### PR TITLE
fix(ria): run the dossier for advisers whose SEC record has no zip

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import secrets
 from typing import Annotated, Any, Literal
 
@@ -36,6 +37,8 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMPolicyError,
     RIAIAMService,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ria", tags=["RIA"])
 
@@ -1044,7 +1047,7 @@ _DOSSIER_MAIL_STATUSES = {
 async def _fetch_own_dossier_row(conn: Any, user_id: str, *, for_update: bool = False) -> Any:
     """Latest dossier row belonging to the caller — never anyone else's."""
     query = """
-        SELECT id, status, result_summary, result_markdown, requested_at,
+        SELECT id, status, scan_id, result_summary, result_markdown, requested_at,
                completed_at, mail_recipient, mail_intended_recipient
         FROM ria_claim_dossiers
         WHERE user_id = $1
@@ -1104,6 +1107,55 @@ def _redispatch_dossier(*, dossier_id: int, user_id: str, context: dict[str, Any
     ria_dossier_service._track_background_task(task)
 
 
+# Dossier rows whose poll this instance is already resuming, so a page that
+# reloads twice does not stack workers on one row.
+_DOSSIER_RESUMING: set[int] = set()
+
+
+async def _resume_stalled_dossier(row: Any, user_id: str) -> None:
+    """Re-enter the poll for a row left mid-scan, if one is stalled.
+
+    The worker is an in-process background task on a CPU-throttled Cloud Run
+    service: once an instance stops receiving requests its CPU is withdrawn,
+    the poll freezes mid-flight, and the row is stranded in `scanning` forever
+    with the scan itself finishing perfectly well upstream. The read that
+    renders the card is a request, so it is also the thing that can revive the
+    poll — the scan id is already durable on the row, so resuming costs one
+    poll rather than a new scan.
+    """
+    if str(row["status"] or "") != "scanning" or row["completed_at"] is not None:
+        return
+    scan_id = str(row["scan_id"] or "").strip()
+    dossier_id = int(row["id"])
+    if not scan_id or dossier_id in _DOSSIER_RESUMING:
+        return
+    context = await _load_dossier_claim_context(user_id)
+    if context is None:
+        return
+
+    from hushh_mcp.services import ria_dossier_service
+
+    metadata_raw = context.get("metadata")
+    metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
+    service = ria_dossier_service.RIADossierService()
+    _DOSSIER_RESUMING.add(dossier_id)
+
+    async def _run() -> None:
+        try:
+            await service._run_worker(
+                dossier_id=dossier_id,
+                user_id=user_id,
+                ria_profile_id=str(context.get("ria_profile_id") or ""),
+                claim_type=str(metadata.get("claim_type") or ""),
+                reference_metadata=metadata,
+                resume_scan_id=scan_id,
+            )
+        finally:
+            _DOSSIER_RESUMING.discard(dossier_id)
+
+    ria_dossier_service._track_background_task(asyncio.create_task(_run()))
+
+
 @router.get("/dossier")
 @limiter.limit("20/minute")
 async def ria_dossier_status(
@@ -1120,6 +1172,10 @@ async def ria_dossier_status(
         row = None
     if row is None:
         raise HTTPException(status_code=404, detail="No dossier yet.")
+    try:
+        await _resume_stalled_dossier(row, firebase_uid)
+    except Exception:  # noqa: BLE001 - reviving the poll never fails the read
+        logger.warning("ria.dossier_resume_failed", exc_info=True)
     return _shape_dossier_row(row)
 
 

--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = httpx.Timeout(10.0, connect=5.0)
 _PLACES_BASE = "https://places.googleapis.com"
 _PLACES_NEARBY_URL = f"{_PLACES_BASE}/v1/places:searchNearby"
+_PLACES_TEXT_URL = f"{_PLACES_BASE}/v1/places:searchText"
 _ROUTES_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
 _GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 _NEARBY_CHECK_IN_RADIUS_METERS = 500.0
@@ -266,6 +267,23 @@ def _country_code_from_components(components: Any) -> str | None:
     return None
 
 
+def _postal_code_from_components(components: Any) -> str:
+    """Read a postal code from Geocoding or Places address components."""
+    if not isinstance(components, list):
+        return ""
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        types = component.get("types") or []
+        if "postal_code" not in types:
+            continue
+        value = component.get("long_name") or component.get("longText")
+        normalized = str(value or "").strip()
+        if normalized:
+            return normalized
+    return ""
+
+
 def _distance_meters(
     *,
     origin_lat: float,
@@ -360,6 +378,43 @@ def _check_in_place_identity(
 
 
 class GoogleMapsService:
+    async def resolve_postal_code(self, *, query: str) -> str:
+        """Best-effort postal code for a free-text place ("FIRM, CITY, STATE").
+
+        Text Search (New), not Geocoding: the Geocoding API is not enabled for
+        this key, and Places already is — the same reason ``reverse_geocode``
+        falls back to a nearby place. Enrichment only, so every failure path
+        (no key, transport, upstream error, no postal component) returns "" and
+        never raises into the caller.
+        """
+        text = str(query or "").strip()
+        if not text or not GOOGLE_MAPS_API_KEY:
+            return ""
+        try:
+            async with _async_client() as client:
+                response = await client.post(
+                    _PLACES_TEXT_URL,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Goog-Api-Key": GOOGLE_MAPS_API_KEY,
+                        "X-Goog-FieldMask": "places.addressComponents",
+                    },
+                    json={"textQuery": text, "maxResultCount": 1},
+                )
+        except httpx.HTTPError as exc:
+            logger.info("maps.resolve_postal_code transport %s", type(exc).__name__)
+            return ""
+        if response.status_code >= 400:
+            logger.info("maps.resolve_postal_code upstream %s", response.status_code)
+            return ""
+        try:
+            places = response.json().get("places") or []
+        except ValueError:
+            return ""
+        if not places or not isinstance(places[0], dict):
+            return ""
+        return _postal_code_from_components(places[0].get("addressComponents"))
+
     async def _nearest_place_address(
         self,
         *,

--- a/consent-protocol/hushh_mcp/services/ria_dossier_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_dossier_service.py
@@ -168,48 +168,61 @@ class RIADossierService:
         ria_profile_id: str,
         claim_type: str,
         reference_metadata: dict[str, Any],
+        resume_scan_id: str = "",
     ) -> None:
         try:
             email = await self._resolve_email(user_id)
             if not email:
                 # Visible on the profile row, not silent.
+                logger.warning("ria.dossier_blocked reason=no_email")
                 await self._update_row(dossier_id, completed=True, status="blocked_no_email")
                 return
 
-            display_name = await self._profile_display_name(ria_profile_id, reference_metadata)
-            payload, payload_error = self._build_scan_payload(
-                claim_type=claim_type,
-                reference_metadata=reference_metadata,
-                email=email,
-                display_name=display_name,
-            )
-            if payload is None:
-                await self._update_row(
-                    dossier_id, completed=True, status="scan_failed", error=payload_error
-                )
-                return
-
-            scan_id, scan_error = await self._start_scan(payload)
+            scan_id = _clean_text(resume_scan_id)
             if not scan_id:
-                await self._update_row(
-                    dossier_id, completed=True, status="scan_failed", error=scan_error
+                display_name = await self._profile_display_name(ria_profile_id, reference_metadata)
+                zip_code, zip_source = await self._resolve_scan_zip(reference_metadata)
+                payload, payload_error = self._build_scan_payload(
+                    claim_type=claim_type,
+                    reference_metadata=reference_metadata,
+                    email=email,
+                    display_name=display_name,
+                    zip_code=zip_code,
                 )
-                return
-            await self._update_row(dossier_id, status="scanning", scan_id=scan_id)
+                if payload is None:
+                    # Every abandoned dossier used to end here with no log line
+                    # at all, which is why a dead lane looked like a quiet one.
+                    logger.warning("ria.dossier_blocked reason=%s", payload_error)
+                    await self._update_row(
+                        dossier_id, completed=True, status="scan_failed", error=payload_error
+                    )
+                    return
+                logger.info("ria.dossier_scan_starting zip_source=%s", zip_source)
+
+                scan_id, scan_error = await self._start_scan(payload)
+                if not scan_id:
+                    logger.warning("ria.dossier_blocked reason=%s", scan_error)
+                    await self._update_row(
+                        dossier_id, completed=True, status="scan_failed", error=scan_error
+                    )
+                    return
+                await self._update_row(dossier_id, status="scanning", scan_id=scan_id)
+            else:
+                display_name = await self._profile_display_name(ria_profile_id, reference_metadata)
 
             scan_result = await self._poll_scan(scan_id)
             if scan_result is None:
+                logger.warning("ria.dossier_blocked reason=scan_did_not_complete")
                 await self._update_row(
                     dossier_id, completed=True, status="scan_failed", error="scan_did_not_complete"
                 )
                 return
             markdown, summary = scan_result
-            await self._update_row(
-                dossier_id,
-                status="generated",
-                result_markdown=markdown,
-                result_summary=summary,
-            )
+            if not await self._claim_generated(dossier_id, markdown=markdown, summary=summary):
+                # A concurrent worker (a resume racing the original) already
+                # took this row past `scanning`; exactly one of us may mail.
+                logger.info("ria.dossier_generate_lost_race")
+                return
 
             await self._queue_mail(
                 dossier_id=dossier_id,
@@ -264,6 +277,75 @@ class RIADossierService:
     # Scan payload (redaction boundary)
     # ------------------------------------------------------------------
 
+    async def _resolve_scan_zip(self, reference_metadata: dict[str, Any]) -> tuple[str, str]:
+        """The scan's required coarse location, as ``(zip, source)``.
+
+        The scan API takes ``zipCode`` OR lat/lng and rejects the body without
+        one, so a missing zip is not a degraded dossier — it is no dossier at
+        all. IAPD publishes plenty of records with a city and state but a null
+        zip (street/zip simply absent), which stranded every such adviser at
+        ``no_location``; the place lookups below recover the zip from the city
+        and state that ARE published.
+
+        Privacy is unchanged from the payload contract: a branch flagged
+        ``private_residence`` is never a location source, at any precision —
+        the firm's own public address stands in. A city-level lookup is used
+        rather than lat/lng on purpose, so the scan records this as the coarse
+        location it actually is instead of a precise one.
+        """
+        firm_raw = reference_metadata.get("firm_record")
+        firm = firm_raw if isinstance(firm_raw, dict) else {}
+        advisor_raw = reference_metadata.get("advisor_record")
+        advisor = advisor_raw if isinstance(advisor_raw, dict) else {}
+        branch_raw = advisor.get("branch")
+        branch = branch_raw if isinstance(branch_raw, dict) else {}
+        branch_is_public = bool(branch) and not branch.get("private_residence")
+
+        if branch_is_public and _clean_text(branch.get("zip")):
+            return _clean_text(branch.get("zip")), "branch"
+        if _clean_text(firm.get("zip")):
+            return _clean_text(firm.get("zip")), "firm"
+
+        # Nothing published. Recover it from the public city/state, firm
+        # listing first (an exact business address) then the city itself.
+        candidates: list[tuple[str, str]] = []
+        firm_name = _clean_text(firm.get("name"))
+        firm_place = ", ".join(
+            part
+            for part in (firm_name, _clean_text(firm.get("city")), _clean_text(firm.get("state")))
+            if part
+        )
+        if firm_name and _clean_text(firm.get("city")):
+            candidates.append((firm_place, "firm_place"))
+        firm_city = ", ".join(
+            part for part in (_clean_text(firm.get("city")), _clean_text(firm.get("state"))) if part
+        )
+        if _clean_text(firm.get("city")):
+            candidates.append((f"{firm_city}, USA", "firm_city"))
+        if branch_is_public and _clean_text(branch.get("city")):
+            branch_city = ", ".join(
+                part
+                for part in (_clean_text(branch.get("city")), _clean_text(branch.get("state")))
+                if part
+            )
+            candidates.append((f"{branch_city}, USA", "branch_city"))
+
+        for query, source in candidates:
+            try:
+                resolved = await self._maps_postal_code(query)
+            except Exception:  # noqa: BLE001 - enrichment never breaks the worker
+                logger.info("ria.dossier_zip_lookup_failed", exc_info=True)
+                continue
+            if resolved:
+                return resolved, source
+        return "", ""
+
+    async def _maps_postal_code(self, query: str) -> str:
+        """Seam for the place lookup so tests never reach the network."""
+        from hushh_mcp.services.google_maps_service import GoogleMapsService
+
+        return await GoogleMapsService().resolve_postal_code(query=query)
+
     @staticmethod
     def _build_scan_payload(
         *,
@@ -271,6 +353,7 @@ class RIADossierService:
         reference_metadata: dict[str, Any],
         email: str,
         display_name: str,
+        zip_code: str,
     ) -> tuple[dict[str, Any] | None, str]:
         """Build the redacted scan body from the claim snapshot.
 
@@ -284,17 +367,9 @@ class RIADossierService:
         firm_record = firm_record_raw if isinstance(firm_record_raw, dict) else {}
         advisor_record_raw = reference_metadata.get("advisor_record")
         advisor_record = advisor_record_raw if isinstance(advisor_record_raw, dict) else {}
-        branch_raw = advisor_record.get("branch")
-        branch = branch_raw if isinstance(branch_raw, dict) else {}
 
         if not display_name:
             return None, "no_name"
-
-        zip_code = ""
-        if branch and not branch.get("private_residence"):
-            zip_code = _clean_text(branch.get("zip"))
-        if not zip_code:
-            zip_code = _clean_text(firm_record.get("zip"))
         if not zip_code:
             return None, "no_location"
 
@@ -503,6 +578,36 @@ class RIADossierService:
             "mail_delivery_mode",
         }
     )
+
+    async def _claim_generated(self, dossier_id: int, *, markdown: str, summary: str) -> bool:
+        """Move `scanning` → `generated`, returning whether THIS worker won.
+
+        A resumed poll can run alongside the original worker, and both would
+        otherwise mail the same dossier. The transition is the lock: only a row
+        still in `scanning` flips, so the loser mails nothing.
+        """
+        pool = await get_pool()
+        try:
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    UPDATE ria_claim_dossiers
+                       SET status = 'generated',
+                           result_markdown = $2,
+                           result_summary = $3
+                     WHERE id = $1
+                       AND status = 'scanning'
+                       AND completed_at IS NULL
+                 RETURNING id
+                    """,
+                    dossier_id,
+                    markdown,
+                    summary,
+                )
+        except asyncpg.UndefinedTableError:
+            logger.warning("ria.dossier_table_missing")
+            return False
+        return row is not None
 
     async def _update_row(self, dossier_id: int, *, completed: bool = False, **fields: Any) -> None:
         assignments: list[str] = []

--- a/consent-protocol/tests/services/test_google_maps_service.py
+++ b/consent-protocol/tests/services/test_google_maps_service.py
@@ -675,3 +675,66 @@ async def test_reverse_geocode_falls_back_to_nearest_place_address(monkeypatch):
         "formattedAddress": "Kasturba Road, Bengaluru, Karnataka 560001, India",
         "countryCode": "IN",
     }
+
+
+# ---------------------------------------------------------------------------
+# Postal-code resolution — Text Search, because the Geocoding API is not
+# enabled for this key (REQUEST_DENIED: "This API is not activated").
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_postal_code_reads_the_places_component(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/places:searchText")
+        assert json.loads(request.content)["textQuery"] == "MENDOCINO, CA, USA"
+        return httpx.Response(
+            200,
+            json={
+                "places": [
+                    {
+                        "addressComponents": [
+                            {"longText": "Mendocino", "types": ["locality", "political"]},
+                            {"longText": "95460", "types": ["postal_code"]},
+                        ]
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    assert await gms.GoogleMapsService().resolve_postal_code(query="MENDOCINO, CA, USA") == "95460"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(200, json={"places": []}),
+        httpx.Response(200, json={"places": [{"addressComponents": []}]}),
+        httpx.Response(403, json={"error": {"message": "denied"}}),
+        httpx.Response(200, content=b"not json"),
+    ],
+    ids=["no-place", "no-postal-component", "upstream-error", "unparseable"],
+)
+async def test_resolve_postal_code_never_raises_into_the_caller(monkeypatch, response):
+    """Enrichment only: a lookup failure must not fail the dossier worker."""
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(lambda _r: response))
+    assert await gms.GoogleMapsService().resolve_postal_code(query="SANDY, UT") == ""
+
+
+@pytest.mark.asyncio
+async def test_resolve_postal_code_without_a_key_makes_no_call(monkeypatch):
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    assert await gms.GoogleMapsService().resolve_postal_code(query="SANDY, UT") == ""
+    assert called is False

--- a/consent-protocol/tests/test_ria_dossier_routes.py
+++ b/consent-protocol/tests/test_ria_dossier_routes.py
@@ -53,6 +53,7 @@ def _row(**overrides: Any) -> dict[str, Any]:
         "id": 1,
         "user_id": _TEST_UID,
         "status": "sent",
+        "scan_id": None,
         "result_summary": "One-line summary.",
         "result_markdown": "# Dossier\n\nBody.",
         "requested_at": datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC),
@@ -91,7 +92,7 @@ class _FakeConn:
 
     async def fetchrow(self, query: str, *args: Any):
         normalized = " ".join(query.split())
-        assert normalized.startswith("SELECT id, status, result_summary"), normalized
+        assert normalized.startswith("SELECT id, status, scan_id, result_summary"), normalized
         assert "WHERE user_id = $1" in normalized
         if normalized.endswith("FOR UPDATE"):
             self._db.for_update_selects += 1
@@ -340,3 +341,120 @@ async def test_redispatch_spawns_worker_with_claim_snapshot(monkeypatch):
             "reference_metadata": context["metadata"],
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# Reviving a stranded scan
+#
+# The worker is an in-process task on a CPU-throttled Cloud Run service: when
+# an instance stops receiving requests its CPU is withdrawn and the poll
+# freezes mid-flight, leaving the row in `scanning` while the scan itself
+# finishes upstream. The read that renders the card is a request, so it is
+# also what can resume the poll.
+# ---------------------------------------------------------------------------
+
+
+def _install_resume_recorder(monkeypatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_resume(row: Any, user_id: str) -> None:
+        calls.append({"id": row["id"], "status": row["status"], "user_id": user_id})
+
+    monkeypatch.setattr(ria_module, "_resume_stalled_dossier", _fake_resume)
+    return calls
+
+
+def test_reading_a_scanning_row_resumes_its_poll(monkeypatch):
+    _install_db(monkeypatch, [_row(status="scanning", scan_id="scan-1", completed_at=None)])
+    _install_claim_context(monkeypatch, _claim_context())
+    workers: list[dict[str, Any]] = []
+
+    async def _fake_worker(self, **kwargs: Any) -> None:
+        workers.append(kwargs)
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_dossier_service.RIADossierService._run_worker", _fake_worker
+    )
+    ria_module._DOSSIER_RESUMING.clear()
+
+    response = TestClient(_build_app()).get("/api/ria/dossier")
+    assert response.status_code == 200
+    assert response.json()["status"] == "scanning"
+    assert len(workers) == 1
+    # Resumed against the stored scan, so no second scan is ever started.
+    assert workers[0]["resume_scan_id"] == "scan-1"
+    assert workers[0]["dossier_id"] == 1
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"status": "sent"},
+        {"status": "scan_failed"},
+        {"status": "queued", "scan_id": None},
+        {"status": "scanning", "scan_id": None},
+        {
+            "status": "scanning",
+            "scan_id": "scan-1",
+            "completed_at": datetime(2026, 8, 8, 12, 30, 0, tzinfo=UTC),
+        },
+    ],
+    ids=["sent", "failed", "queued-no-scan", "scanning-no-scan-id", "already-completed"],
+)
+def test_a_row_that_is_not_mid_scan_is_never_resumed(monkeypatch, overrides):
+    _install_db(monkeypatch, [_row(**overrides)])
+    _install_claim_context(monkeypatch, _claim_context())
+    workers: list[dict[str, Any]] = []
+
+    async def _fake_worker(self, **kwargs: Any) -> None:
+        workers.append(kwargs)
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_dossier_service.RIADossierService._run_worker", _fake_worker
+    )
+    ria_module._DOSSIER_RESUMING.clear()
+
+    assert TestClient(_build_app()).get("/api/ria/dossier").status_code == 200
+    assert workers == []
+
+
+def test_a_failing_resume_never_fails_the_read(monkeypatch):
+    _install_db(monkeypatch, [_row(status="scanning", scan_id="scan-1", completed_at=None)])
+
+    async def _boom(row: Any, user_id: str) -> None:
+        raise RuntimeError("resume exploded")
+
+    monkeypatch.setattr(ria_module, "_resume_stalled_dossier", _boom)
+    response = TestClient(_build_app()).get("/api/ria/dossier")
+    assert response.status_code == 200
+    assert response.json()["status"] == "scanning"
+
+
+@pytest.mark.asyncio
+async def test_a_second_read_does_not_stack_a_second_worker(monkeypatch):
+    """A page that reloads while the poll runs must not double the workers."""
+    _install_claim_context(monkeypatch, _claim_context())
+    starts = 0
+    release = asyncio.Event()
+
+    async def _hanging_worker(self, **kwargs: Any) -> None:
+        nonlocal starts
+        starts += 1
+        await release.wait()
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_dossier_service.RIADossierService._run_worker", _hanging_worker
+    )
+    ria_module._DOSSIER_RESUMING.clear()
+    row = _row(status="scanning", scan_id="scan-1", completed_at=None)
+
+    await ria_module._resume_stalled_dossier(row, _TEST_UID)
+    await ria_module._resume_stalled_dossier(row, _TEST_UID)
+    await asyncio.sleep(0)  # let the spawned workers reach their first await
+
+    assert ria_module._DOSSIER_RESUMING == {1}
+    assert starts == 1
+
+    release.set()
+    await asyncio.sleep(0)
+    assert ria_module._DOSSIER_RESUMING == set()  # released for a later resume

--- a/consent-protocol/tests/test_ria_dossier_service.py
+++ b/consent-protocol/tests/test_ria_dossier_service.py
@@ -37,6 +37,7 @@ class _FakeDossierDb:
         self.claimed: dict[tuple[str, str], int] = {}
         self.rows: dict[int, dict[str, Any]] = {}
         self.insert_attempts = 0
+        self.generate_attempts = 0
         self.next_id = 1
         self.display_name = display_name
 
@@ -61,6 +62,14 @@ class _FakeConn:
             if self._db.display_name is None:
                 return None
             return {"display_name": self._db.display_name}
+        if normalized.startswith("UPDATE ria_claim_dossiers SET status = 'generated'"):
+            # The single-winner transition: only a row still `scanning` flips.
+            row = self._db.rows.setdefault(int(args[0]), {})
+            self._db.generate_attempts += 1
+            if row.get("status") != "scanning" or row.get("completed_at") is not None:
+                return None
+            row.update(status="generated", result_markdown=args[1], result_summary=args[2])
+            return {"id": int(args[0])}
         raise AssertionError(f"unexpected fetchrow: {normalized}")
 
     async def execute(self, query: str, *args: Any) -> str:
@@ -299,6 +308,7 @@ def test_scan_payload_forwards_only_public_facts():
         reference_metadata=_reference_metadata(claim_ticket="ria-claim-ticket.v1:1:abc"),
         email="reg@gmail.com",
         display_name="Reginald Troy Maxfield",
+        zip_code="84094",
     )
     assert error == ""
     assert payload is not None
@@ -327,30 +337,13 @@ def test_scan_payload_forwards_only_public_facts():
     assert payload["socialPreferenceConsent"] is False
 
 
-def test_scan_payload_private_residence_uses_firm_zip():
-    metadata = _reference_metadata()
-    metadata["advisor_record"]["branch"]["private_residence"] = True
+def test_scan_payload_without_a_zip_is_no_location():
     payload, error = RIADossierService._build_scan_payload(
         claim_type="individual",
-        reference_metadata=metadata,
+        reference_metadata=_reference_metadata(),
         email="reg@gmail.com",
         display_name="Reginald Troy Maxfield",
-    )
-    assert error == ""
-    assert payload is not None
-    assert payload["zipCode"] == "84070"
-    assert "84094" not in json.dumps(payload)
-
-
-def test_scan_payload_without_any_zip_is_no_location():
-    metadata = _reference_metadata()
-    metadata["advisor_record"]["branch"]["zip"] = None
-    metadata["firm_record"]["zip"] = None
-    payload, error = RIADossierService._build_scan_payload(
-        claim_type="individual",
-        reference_metadata=metadata,
-        email="reg@gmail.com",
-        display_name="Reginald Troy Maxfield",
+        zip_code="",
     )
     assert payload is None
     assert error == "no_location"
@@ -364,6 +357,7 @@ def test_scan_payload_firm_claim_anchors_on_firm_record():
         reference_metadata=metadata,
         email="reg@gmail.com",
         display_name="Olympus Peaks Financial, LLC",
+        zip_code="84070",
     )
     assert error == ""
     assert payload is not None
@@ -372,6 +366,95 @@ def test_scan_payload_firm_claim_anchors_on_firm_record():
         "https://adviserinfo.sec.gov/firm/summary/283040"
     )
     assert payload["zipCode"] == "84070"
+
+
+# ---------------------------------------------------------------------------
+# Scan location — the scan API rejects a body with neither zipCode nor lat/lng,
+# so this chain is the difference between a dossier and no dossier at all.
+# ---------------------------------------------------------------------------
+
+
+def _zip_service(lookups: dict[str, str] | None = None) -> tuple[RIADossierService, list[str]]:
+    """A service whose place lookup is a recorded dictionary, never the network."""
+    service = RIADossierService()
+    asked: list[str] = []
+    table = lookups or {}
+
+    async def _fake_lookup(query: str) -> str:
+        asked.append(query)
+        return table.get(query, "")
+
+    service._maps_postal_code = _fake_lookup  # type: ignore[method-assign]
+    return service, asked
+
+
+async def test_zip_prefers_the_published_branch_zip():
+    service, asked = _zip_service()
+    zip_code, source = await service._resolve_scan_zip(_reference_metadata())
+    assert (zip_code, source) == ("84094", "branch")
+    assert asked == []  # published data needs no lookup
+
+
+async def test_zip_falls_back_to_the_firm_when_the_branch_is_a_residence():
+    metadata = _reference_metadata()
+    metadata["advisor_record"]["branch"]["private_residence"] = True
+    service, asked = _zip_service()
+    zip_code, source = await service._resolve_scan_zip(metadata)
+    assert (zip_code, source) == ("84070", "firm")
+    assert asked == []
+
+
+def _zipless_metadata() -> dict[str, Any]:
+    """The live failure shape: a published city and state, but a null zip.
+
+    Copied from the record that stranded a real claim at ``no_location`` —
+    CRD 1139833 at CYPRESS POINT CAPITAL MANAGEMENT, whose firm and branch
+    both carry a city and state with street1/street2/zip all null.
+    """
+    metadata = _reference_metadata()
+    metadata["firm_record"].update(
+        name="CYPRESS POINT CAPITAL MANAGEMENT, LLC", city="MENDOCINO", state="CA", zip=None
+    )
+    metadata["advisor_record"]["branch"].update(zip=None)
+    return metadata
+
+
+async def test_zip_is_recovered_from_the_firm_listing_when_iapd_publishes_none():
+    service, asked = _zip_service(
+        {"CYPRESS POINT CAPITAL MANAGEMENT, LLC, MENDOCINO, CA": "95460"},
+    )
+    zip_code, source = await service._resolve_scan_zip(_zipless_metadata())
+    assert (zip_code, source) == ("95460", "firm_place")
+    assert asked == ["CYPRESS POINT CAPITAL MANAGEMENT, LLC, MENDOCINO, CA"]
+
+
+async def test_zip_falls_back_to_the_firm_city_when_the_firm_is_unlisted():
+    service, asked = _zip_service({"MENDOCINO, CA, USA": "95460"})
+    zip_code, source = await service._resolve_scan_zip(_zipless_metadata())
+    assert (zip_code, source) == ("95460", "firm_city")
+    assert len(asked) == 2  # the firm listing was tried first and missed
+
+
+async def test_zip_never_looks_up_a_private_residence_city():
+    """Privacy holds at every precision: a home is not a location source."""
+    metadata = _zipless_metadata()
+    metadata["firm_record"].update(city=None, name=None)
+    metadata["advisor_record"]["branch"].update(city="PARK CITY", private_residence=True)
+    service, asked = _zip_service()
+    zip_code, source = await service._resolve_scan_zip(metadata)
+    assert (zip_code, source) == ("", "")
+    assert not any("PARK CITY" in query for query in asked)
+
+
+async def test_zip_lookup_failure_is_not_a_worker_failure():
+    metadata = _zipless_metadata()
+    service, _asked = _zip_service()
+
+    async def _boom(query: str) -> str:
+        raise RuntimeError("maps down")
+
+    service._maps_postal_code = _boom  # type: ignore[method-assign]
+    assert await service._resolve_scan_zip(metadata) == ("", "")
 
 
 # ---------------------------------------------------------------------------
@@ -428,6 +511,51 @@ async def test_worker_happy_path_persists_markdown_and_mails(monkeypatch):
     assert mail_calls[0]["to_email"] == "reg@gmail.com"
     assert mail_calls[0]["first_name"] == "Reginald Troy Maxfield"
     assert [request.method for request in http_calls] == ["POST", "GET"]
+
+
+async def test_a_resumed_worker_polls_the_existing_scan_instead_of_starting_one(monkeypatch):
+    """Reviving a stranded row must cost one poll, never a second scan."""
+    mail_calls = _install_mail_stub(monkeypatch)
+    _set_scan_env(monkeypatch)
+    http_calls: list[httpx.Request] = []
+    service, db, _identity = _make_service(monkeypatch, handler=_happy_scan_handler(http_calls))
+    db.rows[7] = {"status": "scanning", "user_id": _TEST_UID}
+
+    await service._run_worker(
+        dossier_id=7,
+        user_id=_TEST_UID,
+        ria_profile_id=_PROFILE_ID,
+        claim_type="individual",
+        reference_metadata=_reference_metadata(),
+        resume_scan_id="scan-1",
+    )
+
+    assert [request.method for request in http_calls] == ["GET"]  # no POST: no new scan
+    assert db.rows[7]["status"] == "sent"
+    assert len(mail_calls) == 1
+
+
+async def test_the_worker_that_loses_the_generate_race_mails_nothing(monkeypatch):
+    """Two workers on one row (a resume beside the original) send one email."""
+    mail_calls = _install_mail_stub(monkeypatch)
+    _set_scan_env(monkeypatch)
+    http_calls: list[httpx.Request] = []
+    service, db, _identity = _make_service(monkeypatch, handler=_happy_scan_handler(http_calls))
+    # Already past `scanning` — exactly the state the winner leaves behind.
+    db.rows[7] = {"status": "generated", "user_id": _TEST_UID}
+
+    await service._run_worker(
+        dossier_id=7,
+        user_id=_TEST_UID,
+        ria_profile_id=_PROFILE_ID,
+        claim_type="individual",
+        reference_metadata=_reference_metadata(),
+        resume_scan_id="scan-1",
+    )
+
+    assert db.generate_attempts == 1
+    assert db.rows[7]["status"] == "generated"  # untouched by the loser
+    assert mail_calls == []
 
 
 async def test_worker_blocked_without_email_makes_no_http_call(monkeypatch):

--- a/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
@@ -268,21 +268,27 @@ describe("RiaProfileSection dossier row", () => {
     },
   );
 
-  it.each(["scan_failed", "send_failed", "send_blocked_test_unset"])(
-    "shows the failure grammar with Retry for status %s",
-    async (status) => {
-      await renderWithDossier({ status });
-      await waitFor(() =>
-        expect(screen.getByText("Couldn't send.")).toBeTruthy(),
-      );
-      expect(screen.getByTestId("ria-dossier-retry")).toBeTruthy();
-      expect(screen.queryByTestId("ria-dossier-toggle")).toBeNull();
-    },
-  );
+  // The label names the lane that actually failed. "Couldn't send" on a scan
+  // that never started reads as a mail problem and sends anyone debugging it
+  // to the wrong place — which is exactly what happened on UAT.
+  it.each([
+    ["scan_failed", "Couldn't build it."],
+    ["send_failed", "Couldn't send."],
+    ["send_blocked_test_unset", "Couldn't send."],
+  ])("shows the failure grammar with Retry for status %s", async (status, label) => {
+    await renderWithDossier({ status });
+    await waitFor(() => expect(screen.getByText(label)).toBeTruthy());
+    expect(screen.getByTestId("ria-dossier-retry")).toBeTruthy();
+    expect(screen.queryByTestId("ria-dossier-toggle")).toBeNull();
+  });
 
   it("shows blocked_no_email as a visible failure without Retry", async () => {
     await renderWithDossier({ status: "blocked_no_email" });
-    await waitFor(() => expect(screen.getByText("Couldn't send.")).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.getByText("No email on your account to send it to."),
+      ).toBeTruthy(),
+    );
     expect(screen.queryByTestId("ria-dossier-retry")).toBeNull();
   });
 
@@ -301,7 +307,43 @@ describe("RiaProfileSection dossier row", () => {
     await waitFor(() =>
       expect(screen.getByText("Preparing your dossier…")).toBeTruthy(),
     );
-    expect(screen.queryByText("Couldn't send.")).toBeNull();
+    expect(screen.queryByText("Couldn't build it.")).toBeNull();
+  });
+
+  // The read is also what revives a poll the backend lost when its Cloud Run
+  // instance went idle, so a card left on "Preparing…" must keep reading.
+  it("keeps reading while the scan is in flight, and stops once it lands", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.riaService.getDossier
+        .mockResolvedValueOnce({ status: "scanning" })
+        .mockResolvedValueOnce({ status: "scanning" })
+        .mockResolvedValue({ status: "sent", markdown: DOSSIER_MARKDOWN });
+
+      renderSection();
+      await vi.waitFor(() =>
+        expect(mocks.riaService.getDossier).toHaveBeenCalledTimes(1),
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mocks.riaService.getDossier).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mocks.riaService.getDossier).toHaveBeenCalledTimes(3);
+
+      // Terminal status: no further reads are scheduled.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(mocks.riaService.getDossier).toHaveBeenCalledTimes(3);
+      expect(screen.getByText("Your dossier")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps the failed row and Retry when the retry call itself fails", async () => {

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -533,6 +533,21 @@ function RiaEmailVerifyCard({ onVerified }: { onVerified: () => Promise<void> })
  * above. `blocked_no_email` is visible but not retryable (there is no address
  * to retry against until the user signs in with one).
  */
+/** Scan cadence while the dossier is in flight, and the ceiling for it. */
+const DOSSIER_POLL_INTERVAL_MS = 10_000;
+const DOSSIER_POLL_LIMIT_MS = 35 * 60_000;
+
+/**
+ * What actually failed, in the user's words. "Couldn't send" used to cover a
+ * scan that never started, which reads as a mail problem and sends anyone
+ * debugging it to the wrong lane.
+ */
+function dossierFailureLabel(status: string): string {
+  if (status === "scan_failed") return "Couldn't build it.";
+  if (status === "blocked_no_email") return "No email on your account to send it to.";
+  return "Couldn't send.";
+}
+
 function RiaDossierCard() {
   const { user } = useAuth();
   const [dossier, setDossier] = useState<RiaDossier | null>(null);
@@ -542,17 +557,32 @@ function RiaDossierCard() {
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
-    void (async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let elapsedMs = 0;
+
+    const read = async (): Promise<void> => {
       try {
         const idToken = await user.getIdToken();
         const row = await RiaService.getDossier(idToken);
-        if (!cancelled) setDossier(row);
+        if (cancelled) return;
+        setDossier(row);
+        // Keep reading while the scan is still in flight. The read is also
+        // what revives a poll the backend lost, so stopping early would leave
+        // "Preparing…" on screen forever with nothing driving it.
+        const inFlight = row?.status === "queued" || row?.status === "scanning";
+        if (inFlight && elapsedMs < DOSSIER_POLL_LIMIT_MS) {
+          elapsedMs += DOSSIER_POLL_INTERVAL_MS;
+          timer = setTimeout(() => void read(), DOSSIER_POLL_INTERVAL_MS);
+        }
       } catch {
         // Best-effort surface: an unreadable row renders nothing.
       }
-    })();
+    };
+
+    void read();
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [user]);
 
@@ -616,7 +646,7 @@ function RiaDossierCard() {
           <div className="min-w-0">
             <p className="text-[15px] font-semibold">Your dossier</p>
             <p className="mt-0.5 text-[13px] text-destructive">
-              Couldn&apos;t send.
+              {dossierFailureLabel(dossier.status)}
             </p>
           </div>
           {retryable ? (


### PR DESCRIPTION
## What was wrong

A real claim on UAT never produced a dossier. The row said it all:

| id | status | error | scan_id |
|---|---|---|---|
| 4 | `scan_failed` | **`no_location`** | *(empty)* |

The scan API rejects a body with neither `zipCode` nor lat/lng
(`v1-input.ts`: *"Provide `latitude`+`longitude` or `zipCode`"*), and this
adviser's IAPD record publishes a city and state with street and zip **both
null** — on the firm *and* the branch. Confirmed at source, not inferred:

```
GET /v1/advisors/1139833 → branches[0]: city NEW YORK, state NY, zip None, private_residence True
GET /v1/firms/167195     → address:     city MENDOCINO, state CA, zip None
```

So the payload was refused before it was built, and the intelligence
service's own access log shows **zero** POSTs at the dispatch time — the
scan was never attempted. Every adviser with this record shape was
unreachable by the dossier.

## What this changes

**1. Recover the zip from what IAPD *does* publish.** Firm's Google Places
listing first (an exact business address), then the city. Text Search, not
Geocoding — the Geocoding API is not enabled for this key
(`REQUEST_DENIED: This API is not activated`), the same reason
`reverse_geocode` already falls back to a nearby place. Proven live against
both real firms: Cypress Point → `95460` from its city, Olympus Peaks →
`84094` from its listing (matching the address already on the profile).

Privacy is unchanged: a branch flagged `private_residence` is not a
location source **at any precision**, so the firm's public address stands
in. City-level lookup rather than lat/lng is deliberate — the scan records
a coordinate body as `mode: "precise"`, and a city centroid is not.

**2. Make the failures loud.** `no_name`, `no_location` and a non-202 scan
start all returned without logging a single line, which is why a dead lane
looked like a quiet one. They are warnings now.

**3. Tell the truth on the card.** "Couldn't send." was shown for a scan
that never started — it reads as a mail problem and sends anyone debugging
it to the wrong lane. Scan failures now say "Couldn't build it."

**4. Revive a poll the platform loses.** The worker is an in-process task
on a CPU-throttled Cloud Run service. Once an instance stops receiving
requests its CPU is withdrawn and the poll freezes mid-flight while the
scan finishes fine upstream — instance `001548f729cb` polled every 11s from
17:40:20, stopped dead at 17:43:40, and logged nothing at all until it was
reclaimed at 19:22:45. The read that renders the card is a request, so it
is also what can resume the poll, against the scan id already durable on
the row. The card now keeps reading while a scan is in flight, which both
shows progress and drives the resume.

A `scanning` → `generated` transition is the lock, so a resume racing the
original still mails exactly once — covered by a test that puts a second
worker on an already-`generated` row and asserts it mails nothing.

## Verification

- **Backend:** `backend-check.sh` exit 0 — **831 passed**, ruff/mypy/bandit clean
- **Frontend:** **3106 passed, 0 failed** on Node 24 (CI's version); `tsc --noEmit` and eslint clean
- Local Node 20 shows 5 unrelated SubtleCrypto failures — known toolchain skew, absent on 24
- New tests: the location chain incl. the private-residence rule, the resume path, the mail race, the Places resolver's failure modes, and the polling lifecycle

## Not covered

The underlying fragility — a 35-minute in-process poll on a scale-to-zero,
CPU-throttled service — is mitigated here, not removed. A durable job
runner (Cloud Tasks re-entering by HTTP) is the real fix and is a larger
change than this one.