### PR TITLE
fix(connect): keep connection rows readable on mobile

### DIFF
--- a/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
@@ -19,6 +19,17 @@ describe("Connect page layout contract", () => {
     expect(source).not.toContain('eyebrow="One"');
   });
 
+  it("stacks connection actions below labels on narrow screens", () => {
+    const source = fs.readFileSync(
+      path.join(WEBAPP_ROOT, "app/connect/page-client.tsx"),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /sortedConnections\.map[\s\S]*?<SettingsRow[\s\S]*?stackTrailingOnMobile[\s\S]*?title=\{connection\.displayName \|\| connection\.userId\}/,
+    );
+  });
+
   it("hard-gates Connect and the private agent on live in-memory vault state", () => {
     const connectRoute = fs.readFileSync(
       path.join(WEBAPP_ROOT, "app/one/connect/page.tsx"),

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -521,6 +521,7 @@ export default function ConnectPageClient() {
                     key={connection.connectionId}
                     icon={Users}
                     iconTone="blue"
+                    stackTrailingOnMobile
                     title={connection.displayName || connection.userId}
                     density="compact"
                     trailing={


### PR DESCRIPTION
## Summary

- stack each connection row's Scopes/Remove actions below the label on narrow screens
- preserve the existing inline desktop layout through the shared `SettingsRow` responsive contract
- add a regression contract for the Connect connection-list mobile layout

## UAT reproduction (2/2)

Environment: authenticated Hushh UAT in the existing Chrome profile, viewport 320x568.

1. Start at `/one`.
2. Open **Connect**.
3. Inspect **My connections** rows whose profile name is unavailable and therefore falls back to the connection identifier.

Expected: the identifier remains readable in a compact connection row and the actions do not squeeze the label into a narrow vertical column.

Actual (both runs): the action buttons retained the trailing column while the raw identifier was reduced to 47.8px wide and wrapped to 112.5px tall (`overflow-wrap: anywhere`). No console errors were present.

No request, removal, consent change, or other external side effect was performed.

## Root cause

The connection list used the shared `SettingsRow` with two trailing buttons but omitted its existing `stackTrailingOnMobile` contract. On narrow screens the actions therefore consumed most of the row width and forced long fallback identifiers to wrap every few characters.

## Fix

Enable `stackTrailingOnMobile` only for the existing-connection rows. Mobile gets a full-width label plus an indented action row; `sm` and wider viewports keep the existing inline layout.

## Regression proof

- Before production fix: `connect-page-layout.contract.test.ts` failed, 1 failed / 2 passed.
- After production fix: focused test passed, 3/3.
- Neighboring Connect/shared-row suite: 4 files, 26/26 passed.

## Verification

- `npm test -- --run __tests__/components/connect-page-layout.contract.test.ts __tests__/app/connect/page-client.contract.test.ts __tests__/components/settings-ui.test.tsx __tests__/navigation/connect-nav.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify:design-system`
- `npm run build` with explicit UAT backend and public Firebase build configuration
- `git diff --check`

## Browser verification

- UAT pre-fix reproduction: **2/2 confirmed** at 320x568.
- Fixed local replay: **2/2 passed** using the authenticated existing Chrome session at `http://127.0.0.1:3000`, with the local frontend connected to UAT services.
- Both local runs followed `/one → Connect` without sending a request or mutating connection state.
- Raw UID label after fix: 213.3px wide × 37.5px tall in both runs (pre-fix: 47.8px × 112.5px).
- Row after fix: 279.3px wide × 99.5px tall; Scopes/Remove render on a separate action row.
- The shared row class was verified as `grid-cols-1 ... sm:grid-cols-[minmax(0,1fr)_auto]`, preserving the desktop breakpoint.

## Scope

Frontend-only. Two files, no API/schema/cache/consent changes, and no new dependency.
