### PR TITLE
fix(one-location): allow reopening onboarding location picker

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2247,6 +2247,54 @@ describe("OneLocationAgentPage", () => {
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(2);
   });
 
+  it("reopens the location picker after dismissing it and returning to the feature step", async () => {
+    window.localStorage.removeItem(
+      "one_location_saved_location_prompt_v1:user_a",
+    );
+    window.localStorage.removeItem(
+      "one_location_saved_location_prompt_v2:user_a",
+    );
+
+    mockLoadSavedLocations.mockResolvedValue([]);
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockGetPermissionState.mockResolvedValue({
+      state: "granted",
+      precise: true,
+      background: "foreground-only",
+      locationServicesEnabled: true,
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    await openLocationPermissionsStep();
+
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("save-location-modal")).toBeNull(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Share your location easily with anyone.",
+      }),
+    ).toBeTruthy();
+
+    await openLocationPermissionsStep();
+
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(2);
+  });
   it("retires a legacy skipped outcome and still opens the onboarding picker", async () => {
     window.localStorage.setItem(
       "one_location_saved_location_prompt_v2:user_a",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -6909,6 +6909,9 @@ export function OneLocationAgentPageContent({
   );
 
   const handleSkipSaveOnboardingLocation = useCallback(() => {
+    // Dismissing the saved-place picker must stay reversible during onboarding.
+    // Going back and continuing again should offer the picker again.
+    savedLocationPromptedRef.current = false;
     if (auth.userId) {
       PreVaultSensitiveDraftService.clearSavedLocation(auth.userId);
     }

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -2108,6 +2108,10 @@ export function OneLocationOnboardingFlow({
   };
 
   const backFromFeatures = () => {
+    // A dismissed location picker is reversible. When the owner goes back and
+    // returns to Features, prepare Location again; the parent still suppresses
+    // duplicate work after a confirmed save.
+    locationPreparationCompleteRef.current = false;
     if (startAt === "permissions") {
       void runBack();
       return;


### PR DESCRIPTION
## Problem

During Location onboarding, dismissing the saved-location picker without saving made the action effectively irreversible. Going back and entering Location setup again did not offer the picker again.

## Fix

- Reset the saved-location prompt guard when the picker is dismissed.
- Reset Location preparation when backing out of the Features step.
- Add a behavior regression for dismiss -> back -> re-enter -> picker reopens.

## Verification

- Browser verification after rebase: **2/2 PASS**
- Targeted Bug 7 regression: **PASS**
- TypeScript typecheck: **PASS**
- Targeted ESLint: **PASS**
- Production build: **PASS**
- git diff --check: **PASS**

## Test-suite context

Two pre-existing SMS emergency-number assertions in the broader Location test file were independently reproduced on clean upstream/main and are unrelated to this onboarding change.