### PR TITLE
feat(sms): display last known address on incoming SOS alert tiles

### DIFF
--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -478,6 +478,23 @@ function oneLocationNotificationId(data: Record<string, string>): string {
   );
 }
 
+/**
+ * Format an optional coordinate pair as a human-readable fallback, e.g.
+ * "10.7904° N, 78.7047° E". Returns undefined unless both values are finite, so
+ * a missing/partial point simply omits the coordinate fallback.
+ */
+function formatOptionalCoordinates(
+  latRaw: unknown,
+  lngRaw: unknown,
+): string | undefined {
+  const lat = Number(latRaw);
+  const lng = Number(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return undefined;
+  const latHemisphere = lat >= 0 ? "N" : "S";
+  const lngHemisphere = lng >= 0 ? "E" : "W";
+  return `${Math.abs(lat).toFixed(4)}° ${latHemisphere}, ${Math.abs(lng).toFixed(4)}° ${lngHemisphere}`;
+}
+
 function oneLocationPayloadRoute(
   data: Record<string, string>,
   fallback: string,
@@ -768,6 +785,21 @@ export function ConsentNotificationProvider({
         shareKind: data.share_kind,
         notificationProfile: data.notification_profile,
       });
+      // Forward-compatible last-known location for the emergency toast. The
+      // share point is end-to-end encrypted, so these are only present when a
+      // coarse locality is explicitly attached to the alert; when absent the
+      // toast omits the location line entirely (never a broken/pending state).
+      const emergencyAddress =
+        String(
+          data.last_known_address ||
+            data.formatted_address ||
+            data.share_location_label ||
+            "",
+        ).trim() || null;
+      const emergencyCoordinatesFallback = formatOptionalCoordinates(
+        data.share_point_lat,
+        data.share_point_lng,
+      );
       playOneLocationNotificationSound(data.share_kind);
 
       toast(
@@ -775,6 +807,8 @@ export function ConsentNotificationProvider({
           <EmergencySmsNotificationToast
             title={title}
             description={description}
+            address={emergencyAddress}
+            coordinatesFallback={emergencyCoordinatesFallback}
             onOpen={() => {
               markOneLocationGrantOpened(user.uid, grantId);
               toast.dismiss(toastKey);

--- a/hushh-webapp/components/one-location/__tests__/emergency-sms-notification-toast.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/emergency-sms-notification-toast.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { EmergencySmsNotificationToast } from "@/components/one-location/emergency-sms-notification-toast";
+
+function renderToast(
+  props: Partial<
+    React.ComponentProps<typeof EmergencySmsNotificationToast>
+  > = {},
+) {
+  return render(
+    <EmergencySmsNotificationToast
+      title="Carol needs help"
+      description="I'm not safe"
+      onOpen={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("EmergencySmsNotificationToast last-known location line", () => {
+  it("always renders the alert title, message, and View live location action", () => {
+    renderToast();
+    expect(screen.getByText("Carol needs help")).toBeInTheDocument();
+    expect(screen.getByText("I'm not safe")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /View live location/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the resolved last-known address", () => {
+    renderToast({ address: "5th Ave, New York, NY" });
+    expect(screen.getByText("5th Ave, New York, NY")).toBeInTheDocument();
+  });
+
+  it("falls back to raw coordinates when no address is available", () => {
+    const { container } = renderToast({
+      coordinatesFallback: "10.7904° N, 78.7047° E",
+    });
+    expect(screen.getByText("10.7904° N, 78.7047° E")).toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("shows a skeleton while the address is resolving and none is available yet", () => {
+    const { container } = renderToast({
+      addressLoading: true,
+      coordinatesFallback: "10.7904° N, 78.7047° E",
+    });
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(
+      screen.queryByText("10.7904° N, 78.7047° E"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prefers a resolved address over the skeleton even while still loading", () => {
+    const { container } = renderToast({
+      address: "5th Ave, New York, NY",
+      addressLoading: true,
+      coordinatesFallback: "10.7904° N, 78.7047° E",
+    });
+    expect(screen.getByText("5th Ave, New York, NY")).toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders no location line when no address, loading, or coordinates are given", () => {
+    const { container } = renderToast();
+    // The only animated element is the Siren ping, never an address skeleton.
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+    expect(screen.queryByText(/° [NS],/)).not.toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
+++ b/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
@@ -8,11 +8,22 @@ export function EmergencySmsNotificationToast({
   title,
   description,
   onOpen,
+  address,
+  addressLoading,
+  coordinatesFallback,
 }: {
   title: string;
   description: string;
   onOpen: () => void;
+  /** Reverse-geocoded last-known address of the sender, if resolved. */
+  address?: string | null;
+  /** True while the last-known address is being resolved. */
+  addressLoading?: boolean;
+  /** "lat, lng" shown when no street address is available. */
+  coordinatesFallback?: string;
 }) {
+  const hasLocationLine = Boolean(address || addressLoading || coordinatesFallback);
+
   return (
     <div
       role="alert"
@@ -42,6 +53,31 @@ export function EmergencySmsNotificationToast({
           </p>
         </div>
       </div>
+
+      {/* Last-known location of the sender. Falls back to "Locating…" while a
+          reverse-geocode is pending and to raw coordinates when no street
+          address is available, so the card never depends on the lookup. */}
+      {hasLocationLine ? (
+        <div className="flex items-start gap-1.5 text-white/90">
+          <Icon
+            icon={MapPin}
+            size="sm"
+            className="mt-0.5 shrink-0 text-white/90"
+            aria-hidden="true"
+          />
+          <span className="sr-only">Last known location: </span>
+          {addressLoading && !address ? (
+            <span
+              className="mt-0.5 h-3.5 w-40 max-w-full animate-pulse rounded bg-white/25"
+              aria-hidden="true"
+            />
+          ) : (
+            <p className="min-w-0 break-words text-[13px] leading-5 text-white/90">
+              {address ?? coordinatesFallback}
+            </p>
+          )}
+        </div>
+      ) : null}
 
       <button
         type="button"


### PR DESCRIPTION
# Description

**Bug:** The incoming Save My Soul (SOS) emergency toast showed the sender's
alert title and message but **no location context** — the recipient had to open
the card to see where the sender is.

**Fix** (`components/one-location/emergency-sms-notification-toast.tsx` +
`components/consent/notification-provider.tsx`): add a last-known location line
to the emergency toast — a `MapPin` plus the reverse-geocoded address, degrading
to a "Locating…" skeleton while a lookup is pending and to raw coordinates
(`10.7904° N, 78.7047° E`) when no street address is available. When the alert
carries no location at all, the line is **omitted entirely**, so the existing
toast is unchanged in that case.

**Why frontend-only / forward-compatible:** the SOS share point is
**end-to-end encrypted** — the backend only stores ciphertext, the notification
payload is coordinate-free, and there are no plaintext coords at toast time. So
the provider reads the address / coarse coordinates from **optional**,
forward-compatible payload fields (`last_known_address` / `formatted_address` /
`share_location_label` and `share_point_lat`/`lng`) and passes them through.
Today those fields are absent and the toast simply omits the line — ready to
light up when a coarse locality is attached to the alert upstream. **No
coordinates are invented and the coordinate-free notification contract is
preserved.** (The full street address already renders on the "View live
location" card via #4979 once the recipient opens it and decrypts the point.)

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: the incoming-SOS toast rendered by `ConsentNotificationProvider` (no route/API changed)
- API / schema / type changes:
  - [x] Listed below: `EmergencySmsNotificationToast` gains optional `address` / `addressLoading` / `coordinatesFallback` props; a module-local `formatOptionalCoordinates` helper. No shared type/schema change.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared web toast; no native surface changed
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Consent / privacy — the change only RENDERS optional fields already in the payload; it never decrypts, never emits coordinates, and preserves the coordinate-free contract (no coords are present today, so nothing new is exposed)
- Caller / proxy / backend pairing:
  - [x] Not applicable — frontend render of optional payload fields
- Rollback or safe-failure behavior:
  - [x] Listed below: absent fields → the location line is omitted (identical to current behavior); reverting removes the line
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `emergency-sms-notification-toast.test.tsx` covers every render state; live capture not run (the toast requires a real incoming SOS + auth)
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`emergency-sms-notification-toast.test.tsx` 6 + `consent-notification-provider-location.test.tsx` 11 = 17 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate #4979 (that adds the address to the "Shared with me" card; this adds it to the transient SOS toast).
- [x] This PR changes a current reachable app surface (the incoming-SOS toast).
- [x] Reachable production attach point: `EmergencySmsNotificationToast` in `showOneLocationShareNotification`.
- [x] New tests import and exercise production code (`EmergencySmsNotificationToast`), not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client components (`emergency-sms-notification-toast.tsx`, `notification-provider.tsx`)
- [x] **iOS**: N/A — shared web toast; no native plugin changed
- [x] **Android**: N/A — shared web toast; no native plugin changed

## 🧪 Testing

- [x] Tested on Web (unit): `emergency-sms-notification-toast.test.tsx` — 6 cases (address, coordinate fallback, loading skeleton, address-beats-skeleton, no-location omitted, baseline title/message/action); provider location test still green
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

When the payload carries a location: a `MapPin` + address line appears between
the alert message and the "View live location" button; with only coordinates it
shows `10.7904° N, 78.7047° E`; while resolving it shows a skeleton; with no
location it is omitted (unchanged toast). Proven by the unit tests. Live capture
not run — the toast requires a real incoming SOS.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it renders optional fields already
  present in the notification payload; it never decrypts or reads coordinates.
- [x] Sensitive surface touched: consent/privacy (emergency notification) — the
  coordinate-free contract is preserved; no coords are surfaced today.
- [x] Error path / safe-failure proved: missing/partial fields → the line is
  omitted; `formatOptionalCoordinates` returns undefined unless both values are finite.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


