### PR TITLE
fix(circle): share invite code as direct clickable link

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -1368,6 +1368,29 @@
     },
     {
       "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "none",
+        "refresh_trigger": "none",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": null,
+      "page_file": "app/circle/join/page.tsx",
+      "pathname": "/circle/join",
+      "route_mode": "redirect",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.circle.join"
+      }
+    },
+    {
+      "alias": null,
       "api_dependencies": [
         {
           "backend_endpoint_family": "/api/connected-systems/*",
@@ -4515,13 +4538,13 @@
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "0ea5a55102d495e2486fa7314657b96af58f5bf439939403371873d9bf94955a",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
-    "cache_manifest": "e2a60c9182ecd0503088c3c38fddc7f3890e9c9b54d207699c47583830c8f8ff",
+    "cache_manifest": "53a4bec80f5e2b26de1a00542b8d3ea0566fb891c084038f1ea9f72ec2ae3ed8",
     "data_plane": "270affce3a97bcbde752a465927f065005176f0ddc69aeb9419e6605bbc4f94d",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
-    "route_index": "c1bd9650cf900965dfbacba6be77ea5c0d05ba7a28966585d826cb0160193273",
-    "route_layout": "75b951eb1791e744c015f2817ea92903b7fa803bdbcd499e1168caea95a4ba96",
-    "surface_map": "e83774ac04c9ac4e9deee9b71f2f4c896ac95725bf8ff9b092f200784017a416",
+    "route_index": "467bed8dcd5b094487621fb61f3e049c5938a806ece35319c5ec01a2e4ab3598",
+    "route_layout": "96347a79931c212dc9972c271642ab0ef38202492471e2f8469201d871a47787",
+    "surface_map": "773978b66561ffb6c5b9ec76fa5862e6db357d4f05ad9e82a2e638b44419c92e",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
@@ -4533,7 +4556,7 @@
     "decision_required": 2,
     "in_process_specialists": 3,
     "one_specialist_tools": 5,
-    "physical_routes": 119,
+    "physical_routes": 120,
     "semantic_routes": 14,
     "table_families": 43
   }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -226,6 +226,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/circle/join",
+      "page_file": "app/circle/join/page.tsx",
+      "route_mode": "redirect",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.circle.join",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.circle.join",
+        "purpose": "Help the person understand and use the circle join screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "block_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/__tests__/one-location/circle-join-url.test.ts
+++ b/hushh-webapp/__tests__/one-location/circle-join-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCircleJoinUrl,
+  CIRCLE_JOIN_CODE_PARAM,
+} from "@/lib/one-location/circle-join-url";
+
+describe("buildCircleJoinUrl", () => {
+  it("builds a clickable join link carrying the code query param", () => {
+    expect(
+      buildCircleJoinUrl("https://uat.one.hushh.ai", "96RE-HUNF-KMVX"),
+    ).toBe("https://uat.one.hushh.ai/circle/join?code=96RE-HUNF-KMVX");
+  });
+
+  it("strips a trailing slash from the origin", () => {
+    expect(buildCircleJoinUrl("https://uat.one.hushh.ai/", "ABCD")).toBe(
+      "https://uat.one.hushh.ai/circle/join?code=ABCD",
+    );
+  });
+
+  it("URL-encodes the code", () => {
+    expect(buildCircleJoinUrl("https://x.test", "A B&C")).toBe(
+      "https://x.test/circle/join?code=A%20B%26C",
+    );
+  });
+
+  it("omits the query when no code is given", () => {
+    expect(buildCircleJoinUrl("https://x.test", "")).toBe(
+      "https://x.test/circle/join",
+    );
+  });
+
+  it("exposes the canonical code param name", () => {
+    expect(CIRCLE_JOIN_CODE_PARAM).toBe("code");
+  });
+});

--- a/hushh-webapp/__tests__/one-location/share-circle-code.test.ts
+++ b/hushh-webapp/__tests__/one-location/share-circle-code.test.ts
@@ -82,4 +82,46 @@ describe("Circle code sharing parity", () => {
     expect(copyToClipboard).toHaveBeenCalledWith(payload.text);
     expect(payload.text).not.toContain("http");
   });
+
+  const payloadWithUrl = {
+    ...payload,
+    url: "https://uat.one.hushh.ai/circle/join?code=2345-6789-ABCD",
+  };
+
+  it("passes the join link to the native share sheet when provided", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+
+    await expect(shareNamedCircleCode(payloadWithUrl)).resolves.toBe(
+      "native-share",
+    );
+    expect(Share.share).toHaveBeenCalledWith(payloadWithUrl);
+  });
+
+  it("passes the join link to Web Share when provided", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    const webShare = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: webShare,
+    });
+
+    await expect(shareNamedCircleCode(payloadWithUrl)).resolves.toBe(
+      "web-share",
+    );
+    expect(webShare).toHaveBeenCalledWith({
+      title: payload.title,
+      text: payload.text,
+      url: payloadWithUrl.url,
+    });
+  });
+
+  it("appends the join link to the clipboard fallback when provided", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+    await expect(shareNamedCircleCode(payloadWithUrl)).resolves.toBe("copied");
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      `${payload.text}\n${payloadWithUrl.url}`,
+    );
+  });
 });

--- a/hushh-webapp/app/circle/join/page.tsx
+++ b/hushh-webapp/app/circle/join/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { CIRCLE_JOIN_CODE_PARAM } from "@/lib/one-location/circle-join-url";
+
+/**
+ * Recipient landing for a shared Circle join link (`/circle/join?code=…`).
+ * Forwards into the in-app "Join with code" flow with the code pre-filled, so a
+ * recipient can tap the link instead of copy-pasting the raw code. A client
+ * redirect keeps this working for both the web SSR build and the Capacitor
+ * static export.
+ */
+function CircleJoinRedirect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const code = (searchParams.get(CIRCLE_JOIN_CODE_PARAM) ?? "").trim();
+    const query = new URLSearchParams({ action: "join-circle" });
+    if (code) query.set(CIRCLE_JOIN_CODE_PARAM, code);
+    router.replace(`/one/location?${query.toString()}`);
+  }, [router, searchParams]);
+
+  return null;
+}
+
+export default function CircleJoinPage() {
+  return (
+    <Suspense fallback={null}>
+      <CircleJoinRedirect />
+    </Suspense>
+  );
+}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -200,6 +200,7 @@ import {
   type EmergencyInfo,
   type EmergencyNumberLookupStatus,
 } from "@/lib/one-location/emergency-numbers";
+import { buildCircleJoinUrl } from "@/lib/one-location/circle-join-url";
 import type {
   DriveDestination,
   DriveSharePayload,
@@ -5063,10 +5064,17 @@ export function OneLocationAgentPageContent({
   const handleShareNamedCircleCode = useCallback(
     async (circle: OneLocationCircleDetail, code: string) => {
       try {
+        const joinUrl =
+          typeof window !== "undefined"
+            ? buildCircleJoinUrl(window.location.origin, code)
+            : undefined;
         const delivery = await shareNamedCircleCode({
           title: `Join ${circle.name} on One`,
-          text: `Join my ${circle.name} Circle on One with code ${code}. You'll connect with current and future members, while location and SMS stay private until you choose to share.`,
+          text: joinUrl
+            ? `Join my ${circle.name} Circle on One — tap to join: ${joinUrl} (or enter code ${code}). Location and SMS stay private until you choose to share.`
+            : `Join my ${circle.name} Circle on One with code ${code}. You'll connect with current and future members, while location and SMS stay private until you choose to share.`,
           dialogTitle: "Share Circle code",
+          url: joinUrl,
         });
         if (delivery === "copied") toast.success("Circle code copied.");
       } catch (error) {
@@ -5146,10 +5154,17 @@ export function OneLocationAgentPageContent({
   const handleShareOnboardingCircleInvite = useCallback(
     async (invite: OnboardingCircleInvite) => {
       try {
+        const joinUrl =
+          typeof window !== "undefined"
+            ? buildCircleJoinUrl(window.location.origin, invite.code)
+            : undefined;
         const delivery = await shareNamedCircleCode({
           title: `Join ${invite.circleName} on One`,
-          text: `Join my ${invite.circleName} Circle on One with code ${invite.code}. Set up One, then open Location → People → Join a circle and enter it. Location and SMS stay private until you choose to share.`,
+          text: joinUrl
+            ? `Join my ${invite.circleName} Circle on One — tap to join: ${joinUrl} (or enter code ${invite.code}). Set up One, then the link opens the join screen with the code filled in. Location and SMS stay private until you choose to share.`
+            : `Join my ${invite.circleName} Circle on One with code ${invite.code}. Set up One, then open Location → People → Join a circle and enter it. Location and SMS stay private until you choose to share.`,
           dialogTitle: "Share Circle code",
+          url: joinUrl,
         });
         if (delivery === "copied") toast.success("Circle code copied.");
       } catch (error) {

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,14 +10,14 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 119,
-    "physical_page_count": 119,
-    "route_contract_count": 119,
-    "surface_map_count": 119,
+    "total_screens": 120,
+    "physical_page_count": 0,
+    "route_contract_count": 120,
+    "surface_map_count": 120,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
-      "redirect/alias": 40,
+      "redirect/alias": 41,
       "vault-backed": 42,
       "hidden flow": 13,
       "auth/pre-vault": 6,
@@ -259,6 +259,46 @@
       "findings": [
         "no local cache primitive detected in page/contract source"
       ]
+    },
+    {
+      "route": "/circle/join",
+      "page_file": "app/circle/join/page.tsx",
+      "route_contract_mode": "redirect",
+      "screen_class": "redirect/alias",
+      "cache_policy": "none",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "none",
+      "warm_source": "none",
+      "refresh_trigger": "none",
+      "mutation_invalidator": "none",
+      "best_available_ux_path": [
+        "static render"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/circle/join",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": []
     },
     {
       "route": "/connected-systems",
@@ -5339,5 +5379,5 @@
       ]
     }
   ],
-  "content_sha256": "eced63115b24b5d4401ad450fcfaea2991cb6a8f80155fed42ae32ada063a858"
+  "content_sha256": "301dc38200d0cbb0ce8dfc5d25f6dc2933fed7495c80bcdfb57fb35620f7c427"
 }

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -154,6 +154,21 @@ describe("named Circle flows", () => {
     );
   });
 
+  it("pre-fills the code input from initialCode (a shared /circle/join link)", () => {
+    render(
+      <JoinCircleFlow
+        busy={false}
+        initialCode="2345-6789-ABCD"
+        onResolve={async () => ({}) as OneLocationCircleInvitePreview}
+        onJoin={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByLabelText("Circle invite code")).toHaveValue(
+      "2345-6789-ABCD",
+    );
+  });
+
   it("ignores a stale preview and joins the exact code that was reviewed", async () => {
     let resolveFirst:
       | ((value: OneLocationCircleInvitePreview) => void)

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -475,12 +475,15 @@ export function JoinCircleFlow({
   busy,
   onResolve,
   onJoin,
+  initialCode,
 }: {
   busy: boolean;
   onResolve: (code: string) => Promise<OneLocationCircleInvitePreview>;
   onJoin: (code: string) => Promise<void>;
+  /** Pre-fills the code input when arriving from a `/circle/join?code=` link. */
+  initialCode?: string;
 }) {
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState(initialCode ?? "");
   const [resolved, setResolved] = useState<{
     code: string;
     preview: OneLocationCircleInvitePreview;

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -112,6 +112,7 @@ import type {
   EmergencyNumberLookupStatus,
 } from "@/lib/one-location/emergency-numbers";
 import { ONE_LOCATION_SHARE_NOTE_MAX_LENGTH } from "@/lib/one-location/message-limits";
+import { CIRCLE_JOIN_CODE_PARAM } from "@/lib/one-location/circle-join-url";
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
@@ -915,6 +916,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         ) : flow === "join-circle" ? (
           <JoinCircleFlow
             busy={vm.busy === "namedCircle"}
+            initialCode={
+              searchParams.get(CIRCLE_JOIN_CODE_PARAM)?.trim() || undefined
+            }
             onResolve={vm.onResolveNamedCircleCode}
             onJoin={async (code) => {
               const result = await vm.onJoinNamedCircle(code);

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -226,6 +226,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/circle/join",
+      "page_file": "app/circle/join/page.tsx",
+      "route_mode": "redirect",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.circle.join",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.circle.join",
+        "purpose": "Help the person understand and use the circle join screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "block_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -569,6 +569,55 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/circle/join",
+      "page_file": "app/circle/join/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "redirect",
+        "exemption_reason": "Public Circle join landing route reads the invite code from the query string and redirects into the in-app Join-with-code flow; it owns no signed-in app shell of its own.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.circle.join",
+          "purpose": "Help the person understand and use the circle join screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": null,
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "physical_page_exists": true,
@@ -8047,5 +8096,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "19f043f5cc5034b2034e72bb40fac51fc0047e1b2fb0eac54f6eef5568f28002"
+  "content_sha256": "e9349af4b2a9447e0b87cb0162d6c37634e3ae0c91a4fe3c5f422db819acaf70"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -137,6 +137,33 @@
     }
   },
   {
+    "route": "/circle/join",
+    "mode": "redirect",
+    "exemptionReason": "Public Circle join landing route reads the invite code from the query string and redirects into the in-app Join-with-code flow; it owns no signed-in app shell of its own.",
+    "voicePlaybook": {
+      "playbookId": "route.circle.join",
+      "purpose": "Help the person understand and use the circle join screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
     "route": "/developers",
     "mode": "redirect",
     "exemptionReason": "Compatibility route redirects to the canonical /welcome?tab=developers public workspace.",

--- a/hushh-webapp/lib/one-location/circle-join-url.ts
+++ b/hushh-webapp/lib/one-location/circle-join-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Build a clickable Circle join link that carries the invite code, e.g.
+ * `https://uat.one.hushh.ai/circle/join?code=96RE-HUNF-KMVX`.
+ *
+ * The `/circle/join` route reads the `code` query param and forwards into the
+ * in-app "Join with code" flow with the field pre-filled, so a recipient can tap
+ * the link instead of copy-pasting the raw code.
+ */
+export const CIRCLE_JOIN_CODE_PARAM = "code";
+
+export function buildCircleJoinUrl(origin: string, code: string): string {
+  const base = String(origin || "").replace(/\/+$/, "");
+  const trimmedCode = String(code || "").trim();
+  const query = trimmedCode
+    ? `?${CIRCLE_JOIN_CODE_PARAM}=${encodeURIComponent(trimmedCode)}`
+    : "";
+  return `${base}/circle/join${query}`;
+}

--- a/hushh-webapp/lib/one-location/share-circle-code.ts
+++ b/hushh-webapp/lib/one-location/share-circle-code.ts
@@ -18,17 +18,22 @@ export function isShareCancellationError(error: unknown): boolean {
 }
 
 /**
- * Share a short-lived Circle code without putting it in a URL.
+ * Share a short-lived Circle invite. When a `url` is supplied it is included as
+ * a dedicated, clickable link in the native/web share sheet so the recipient can
+ * tap straight into the join flow; the caller-supplied `text` still carries the
+ * same human-safe consent explanation (and the raw code) as the clipboard/text
+ * fallback for targets that ignore the url field.
  *
  * Capacitor owns the native iOS/Android sheet; browsers use Web Share and then
- * the shared clipboard fallback. The caller supplies the complete, human-safe
- * text so every platform receives the same consent explanation.
+ * the shared clipboard fallback.
  */
 export async function shareNamedCircleCode(params: {
   title: string;
   text: string;
   dialogTitle: string;
+  url?: string;
 }): Promise<CircleCodeShareDelivery> {
+  const url = params.url?.trim() ? params.url.trim() : undefined;
   const { Capacitor } = await import("@capacitor/core");
   if (Capacitor.isNativePlatform()) {
     const { Share } =
@@ -37,6 +42,7 @@ export async function shareNamedCircleCode(params: {
       title: params.title,
       text: params.text,
       dialogTitle: params.dialogTitle,
+      ...(url ? { url } : {}),
     });
     return "native-share";
   }
@@ -45,10 +51,17 @@ export async function shareNamedCircleCode(params: {
     typeof navigator !== "undefined" &&
     typeof navigator.share === "function"
   ) {
-    await navigator.share({ title: params.title, text: params.text });
+    await navigator.share({
+      title: params.title,
+      text: params.text,
+      ...(url ? { url } : {}),
+    });
     return "web-share";
   }
 
-  if (await copyToClipboard(params.text)) return "copied";
+  // Clipboard fallback keeps the link alongside the text so nothing is lost when
+  // neither native nor Web Share is available.
+  const clipboardText = url ? `${params.text}\n${url}` : params.text;
+  if (await copyToClipboard(clipboardText)) return "copied";
   throw new Error("Sharing is not supported on this device.");
 }


### PR DESCRIPTION
# Description

**Bug:** The Circle "Share" button put only the raw code (e.g. `96RE-HUNF-KMVX`)
into the share sheet, so the recipient had to copy it and hand-enter it in the
Join-with-code flow.

**Fix:** share a clickable join link that carries the code and lands the
recipient in the join flow with the field pre-filled.

- `buildCircleJoinUrl(origin, code)` → `${origin}/circle/join?code=<code>` (new pure helper).
- New **`/circle/join`** route reads `?code=` and forwards into the in-app
  "Join with code" flow (`/one/location?action=join-circle&code=…`). A client
  redirect keeps it working on both the web SSR build and the Capacitor static export.
- `JoinCircleFlow` gains an `initialCode` prop; the hub pre-fills it from the
  `code` query param, so the tapped link opens the join screen ready to preview.
- `shareNamedCircleCode` forwards an optional `url` to the native/Web Share sheet
  and appends it to the clipboard fallback; the caller text still carries the raw
  code so nothing is lost on targets that ignore the url field. Both share
  handlers build the link from `window.location.origin`.

**Scope note (design + security):** the app deliberately kept the short-lived
code out of URLs, and a separate token invite link exists — but that token
creates a **generic 1:1 connection**, not membership in the *specific* named
circle (only the code joins that circle). Per maintainer direction, this PR
implements the per-circle `/circle/join?code=` link (the code does travel in the
URL) rather than repurposing the connection token, so the recipient joins the
right circle. The **raw-code path is unchanged when no `url` is supplied**, so
every existing share test still passes.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: new client route `app/circle/join` (redirect only); Share handlers on `/one/location`; `JoinCircleFlow` pre-fill
- API / schema / type changes:
  - [x] Listed below: `shareNamedCircleCode` gains optional `url`; `JoinCircleFlow` gains optional `initialCode`; new `buildCircleJoinUrl` / `CIRCLE_JOIN_CODE_PARAM`. No backend/schema change.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: native share now includes the `url` field (Capacitor Share supports it); `/circle/join` uses a client redirect so it works in the static export
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Consent — the invite code now travels in a shareable URL (previously kept out of URLs by design). It only joins a Circle (still explicit consent to connect); location/SMS remain private until separately shared. Chosen deliberately with maintainer sign-off.
- Caller / proxy / backend pairing:
  - [x] Not applicable — frontend link construction + existing join endpoints unchanged
- Rollback or safe-failure behavior:
  - [x] Listed below: with no `url`, behavior is identical to today; `/circle/join` with no code forwards to the join flow empty; reverting removes the link
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: unit tests cover the URL builder, `url` passthrough on all three delivery paths, and the `initialCode` pre-fill; live browser capture not run (share sheet + auth-gated flow)
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`circle-join-url` + `share-circle-code` + `named-circle-flows` = 30 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass (`/circle/join` route generated)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate the token-invite flow.
- [x] This PR changes a current reachable app surface (Circle share + join).
- [x] Reachable production attach point: `shareNamedCircleCode` handlers + `/circle/join` route + `JoinCircleFlow`.
- [x] New tests import and exercise production code, not test-local mocks.
- [x] New helpers/routes are wired to real callers (share handlers, hub render, join route).
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js route + client components
- [x] **iOS**: Capacitor Share receives the `url` field; `/circle/join` client redirect works in the static export — no native plugin code changed
- [x] **Android**: same as iOS — shared web path; no native plugin changed

## 🧪 Testing

- [x] Tested on Web (unit): URL builder (4), share `url` passthrough native/web/clipboard (3) + existing 4, `initialCode` pre-fill (1) — 30 pass across the three suites
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Share now yields, e.g., `Join my Family Circle on One — tap to join:
https://…/circle/join?code=96RE-HUNF-KMVX (or enter code 96RE-HUNF-KMVX).` and,
where supported, the native/Web Share URL field. Opening the link forwards to the
join screen with the code pre-filled. Live capture not run — share sheet + auth
gated. Behavior proven by the unit tests.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it constructs a share link from the
  code the sharer already holds; no new data access.
- [x] Sensitive surface touched: consent — the join code now appears in a URL
  (deliberate, per maintainer decision); it joins a Circle only, location/SMS
  stay private until separately shared.
- [x] Error path / safe-failure proved: missing url → prior behavior; missing
  code on `/circle/join` → forwards to the empty join flow.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


