### PR TITLE
fix(map): show a loading spinner on the current-location button while it locates

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -994,4 +994,50 @@ describe("LocationImmersiveMap demo experience", () => {
     });
     expect(pushState).not.toHaveBeenCalled();
   });
+
+  it("shows a loading spinner on the Locate button while the position resolves", async () => {
+    render(<LocationImmersiveMap />);
+
+    const locate = await screen.findByTestId("one-location-map-locate");
+    // Any mount-time capture settles first, so the control starts idle.
+    await waitFor(() =>
+      expect(locate).not.toHaveAttribute("aria-busy", "true"),
+    );
+
+    let resolveCapture: (() => void) | undefined;
+    serviceHarness.captureCurrentPosition.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCapture = () =>
+            resolve({
+              latitude: 37.776,
+              longitude: -122.418,
+              accuracyM: 12,
+              capturedAt: "2026-07-23T00:00:00.000Z",
+              sourcePlatform: "ios" as const,
+            });
+        }),
+    );
+
+    fireEvent.click(locate);
+
+    // Immediate feedback: the button disables, reports busy, and swaps the
+    // icon for an animated spinner while the lookup is in flight.
+    await waitFor(() => {
+      expect(locate).toBeDisabled();
+      expect(locate).toHaveAttribute("aria-busy", "true");
+    });
+    expect(locate.querySelector(".animate-spin")).not.toBeNull();
+
+    await act(async () => {
+      resolveCapture?.();
+      await Promise.resolve();
+    });
+
+    // Resolution clears the loading state cleanly.
+    await waitFor(() =>
+      expect(locate).toHaveAttribute("aria-busy", "false"),
+    );
+    expect(locate.querySelector(".animate-spin")).toBeNull();
+  });
 });

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1567,12 +1567,22 @@ export function LocationImmersiveMap() {
         {rendererReady ? (
           <ShellActionSurface
             className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}
-            aria-label="Show my location"
+            aria-label={
+              busy === "locate" ? "Finding your location" : "Show my location"
+            }
+            aria-busy={busy === "locate"}
             data-testid="one-location-map-locate"
             disabled={busy === "locate"}
             onClick={() => void locateMe()}
           >
-            <LocateFixed className="h-5 w-5 stroke-[2.25]" />
+            {busy === "locate" ? (
+              <Loader2
+                className="h-5 w-5 animate-spin stroke-[2.25]"
+                aria-hidden="true"
+              />
+            ) : (
+              <LocateFixed className="h-5 w-5 stroke-[2.25]" />
+            )}
           </ShellActionSurface>
         ) : null}
       </div>


### PR DESCRIPTION
# Description

**Bug:** On the immersive map ("Your map"), tapping the current-location control
had no immediate visual feedback during the geolocation lookup, so it felt
unresponsive.

**Root cause:** the "Show my location" button already disabled itself while
`locateMe` ran (`busy === "locate"`) but kept the static `LocateFixed` icon — no
spinner.

**Fix** (`components/one-location/location-immersive-map.tsx`): swap the icon for
an animated `Loader2` spinner while locating, and set `aria-busy` + a "Finding
your location" label so the loading state reaches assistive tech. The handler
already flips `busy` synchronously on click and clears it in a `finally` on both
success and error (with a graceful error toast), so no state-reset/error change
was needed.

**Latency note (deliberate scope):** the lookup itself is left as-is.
`captureCurrentPosition` is shared with the SOS / Save-My-Soul safety flow and the
web plugin deliberately binds to a **fresh** fix (`maximumAge: 0`); loosening it
to a cached position would be a cross-platform plugin change that weakens accuracy
for safety-critical callers. The bug is "improve latency **or** add a loading
circle" — the spinner gives the immediate feedback without that risk.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: the immersive map (`/one/location/map`) locate control — presentation only
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared web component; geolocation plugin untouched
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — no change to geolocation accuracy, capture, or storage
- Caller / proxy / backend pairing:
  - [x] Not applicable — presentational spinner
- Rollback or safe-failure behavior:
  - [x] Listed below: purely additive icon/state; the existing `finally` already resets the loading state on success/error/timeout
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `location-immersive-map.test.tsx` asserts the spinner/aria-busy on click and its clear on resolve
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`location-immersive-map.test.tsx`, 13 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate.
- [x] This PR changes a current reachable app surface (the map locate control).
- [x] Reachable production attach point: the `one-location-map-locate` control in `LocationImmersiveMap`.
- [x] New test exercises the production component, not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (`location-immersive-map.tsx`)
- [x] **iOS**: N/A — geolocation plugin unchanged
- [x] **Android**: N/A — geolocation plugin unchanged

## 🧪 Testing

- [x] Tested on Web (unit): new spinner test + 12 existing map tests pass
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

On tap, the locate button disables and shows a spinning `Loader2` (with
`aria-busy`) until the position resolves, then returns to the `LocateFixed`
icon. Proven by the unit test. Live capture not run — the map is auth + vault
gated.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — purely a loading indicator; the
  geolocation capture path is unchanged.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


