### PR TITLE
fix(ria): place the office on the map, and fill the zip the SEC omits

### DIFF
--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -378,18 +378,19 @@ def _check_in_place_identity(
 
 
 class GoogleMapsService:
-    async def resolve_postal_code(self, *, query: str) -> str:
-        """Best-effort postal code for a free-text place ("FIRM, CITY, STATE").
+    async def resolve_place(self, *, query: str) -> dict[str, Any]:
+        """Postal code and coordinates for a free-text place ("FIRM, CITY, ST").
 
         Text Search (New), not Geocoding: the Geocoding API is not enabled for
         this key, and Places already is — the same reason ``reverse_geocode``
         falls back to a nearby place. Enrichment only, so every failure path
-        (no key, transport, upstream error, no postal component) returns "" and
+        (no key, transport, upstream error, no match) returns empty values and
         never raises into the caller.
         """
+        empty: dict[str, Any] = {"postal_code": "", "latitude": None, "longitude": None}
         text = str(query or "").strip()
         if not text or not GOOGLE_MAPS_API_KEY:
-            return ""
+            return empty
         try:
             async with _async_client() as client:
                 response = await client.post(
@@ -397,23 +398,36 @@ class GoogleMapsService:
                     headers={
                         "Content-Type": "application/json",
                         "X-Goog-Api-Key": GOOGLE_MAPS_API_KEY,
-                        "X-Goog-FieldMask": "places.addressComponents",
+                        "X-Goog-FieldMask": "places.addressComponents,places.location",
                     },
                     json={"textQuery": text, "maxResultCount": 1},
                 )
         except httpx.HTTPError as exc:
-            logger.info("maps.resolve_postal_code transport %s", type(exc).__name__)
-            return ""
+            logger.info("maps.resolve_place transport %s", type(exc).__name__)
+            return empty
         if response.status_code >= 400:
-            logger.info("maps.resolve_postal_code upstream %s", response.status_code)
-            return ""
+            logger.info("maps.resolve_place upstream %s", response.status_code)
+            return empty
         try:
             places = response.json().get("places") or []
         except ValueError:
-            return ""
+            return empty
         if not places or not isinstance(places[0], dict):
-            return ""
-        return _postal_code_from_components(places[0].get("addressComponents"))
+            return empty
+        place = places[0]
+        location = place.get("location")
+        location = location if isinstance(location, dict) else {}
+        latitude = location.get("latitude")
+        longitude = location.get("longitude")
+        return {
+            "postal_code": _postal_code_from_components(place.get("addressComponents")),
+            "latitude": float(latitude) if isinstance(latitude, int | float) else None,
+            "longitude": float(longitude) if isinstance(longitude, int | float) else None,
+        }
+
+    async def resolve_postal_code(self, *, query: str) -> str:
+        """Just the postal code — see :meth:`resolve_place`."""
+        return str((await self.resolve_place(query=query)).get("postal_code") or "")
 
     async def _nearest_place_address(
         self,

--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -519,6 +519,86 @@ def derive_business_location(reference_metadata: dict[str, Any]) -> dict[str, st
     return _location_from_address(street1="", city="", zip_code="")
 
 
+def public_place_queries(reference_metadata: dict[str, Any]) -> list[tuple[str, str]]:
+    """Free-text lookups for the adviser's PUBLIC office, best first.
+
+    IAPD publishes plenty of records with a city and state but a null street
+    and null zip, which leaves the profile's LOCATION block reading "Not
+    provided" and gives the map nothing to place. These queries recover the
+    rest from the city and state that ARE filed — the firm's own business
+    listing first (an exact address), then the city.
+
+    The privacy rule from :func:`derive_business_location` holds unchanged: a
+    branch the SEC flagged as a private residence is somebody's home and is
+    never a lookup source, at any precision. Returns ``(query, source)`` pairs.
+    """
+    metadata = reference_metadata if isinstance(reference_metadata, dict) else {}
+    firm_raw = metadata.get("firm_record")
+    firm = firm_raw if isinstance(firm_raw, dict) else {}
+    advisor_raw = metadata.get("advisor_record")
+    advisor = advisor_raw if isinstance(advisor_raw, dict) else {}
+    branch_raw = advisor.get("branch")
+    branch = branch_raw if isinstance(branch_raw, dict) else {}
+
+    def _text(value: Any) -> str:
+        return str(value or "").strip()
+
+    def _join(*parts: str) -> str:
+        return ", ".join(part for part in parts if part)
+
+    queries: list[tuple[str, str]] = []
+    firm_city, firm_state = _text(firm.get("city")), _text(firm.get("state"))
+    firm_name = _text(firm.get("name"))
+    if firm_name and firm_city:
+        queries.append((_join(firm_name, firm_city, firm_state), "firm_place"))
+    if firm_city:
+        queries.append((_join(firm_city, firm_state, "USA"), "firm_city"))
+    if branch and not branch.get("private_residence") and _text(branch.get("city")):
+        queries.append(
+            (_join(_text(branch.get("city")), _text(branch.get("state")), "USA"), "branch_city")
+        )
+    return queries
+
+
+async def enrich_business_location(
+    location: dict[str, str], reference_metadata: dict[str, Any]
+) -> dict[str, Any]:
+    """Fill a blank zip and the map's coordinates from the public listing.
+
+    ``derive_business_location`` can only return what the SEC filed, and for a
+    record with a null street and null zip that leaves PIN / ZIP reading "Not
+    provided" and the map with nothing but a bare city name to geocode. This
+    adds what :func:`public_place_queries` can recover, and nothing else: the
+    filed values are never overwritten, and a lookup failure simply leaves the
+    blanks blank.
+    """
+    resolved: dict[str, Any] = dict(location)
+    resolved.setdefault("latitude", None)
+    resolved.setdefault("longitude", None)
+    if str(resolved.get("pin_zip") or "").strip() and resolved.get("latitude") is not None:
+        return resolved
+
+    from hushh_mcp.services.google_maps_service import GoogleMapsService
+
+    service = GoogleMapsService()
+    for query, source in public_place_queries(reference_metadata):
+        try:
+            place = await service.resolve_place(query=query)
+        except Exception:  # noqa: BLE001 - enrichment never fails a claim
+            logger.info("ria.claim_place_lookup_failed", exc_info=True)
+            continue
+        postal = str(place.get("postal_code") or "").strip()
+        if not str(resolved.get("pin_zip") or "").strip() and postal:
+            resolved["pin_zip"] = postal
+        if resolved.get("latitude") is None and place.get("latitude") is not None:
+            resolved["latitude"] = place.get("latitude")
+            resolved["longitude"] = place.get("longitude")
+        if str(resolved.get("pin_zip") or "").strip() and resolved.get("latitude") is not None:
+            logger.info("ria.claim_place_resolved source=%s", source)
+            break
+    return resolved
+
+
 def _shape_candidate(raw: dict[str, Any]) -> dict[str, Any]:
     return {
         "individual_crd": raw.get("individualCrd"),
@@ -797,7 +877,9 @@ class RIAClaimService:
             reference_metadata=reference_metadata,
             # The claimed profile's LOCATION section, filled from the same
             # snapshot rather than left blank for the adviser to retype.
-            business_location=derive_business_location(reference_metadata),
+            business_location=await enrich_business_location(
+                derive_business_location(reference_metadata), reference_metadata
+            ),
             # Regulator facts, straight from the public record.
             regulator="SEC" if firm.get("registration_type") == "sec" else "State",
             regulator_status=firm.get("registration_status"),
@@ -1118,7 +1200,9 @@ class RIAClaimService:
             firm_website=firm.get("website"),
             firm_sec_number=firm.get("sec_number"),
             reference_metadata=reference_metadata,
-            business_location=derive_business_location(reference_metadata),
+            business_location=await enrich_business_location(
+                derive_business_location(reference_metadata), reference_metadata
+            ),
             regulator="SEC" if firm.get("registration_type") == "sec" else "State",
             regulator_status=firm.get("registration_status"),
             disclosures_url=(advisor_record.get("report_url") or firm.get("report_url")),

--- a/consent-protocol/hushh_mcp/services/ria_dossier_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_dossier_service.py
@@ -29,6 +29,7 @@ from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.ria_claim_service import (
     firm_website_host,
     mask_email,
+    public_place_queries,
     title_case_name,
 )
 
@@ -306,31 +307,10 @@ class RIADossierService:
         if _clean_text(firm.get("zip")):
             return _clean_text(firm.get("zip")), "firm"
 
-        # Nothing published. Recover it from the public city/state, firm
-        # listing first (an exact business address) then the city itself.
-        candidates: list[tuple[str, str]] = []
-        firm_name = _clean_text(firm.get("name"))
-        firm_place = ", ".join(
-            part
-            for part in (firm_name, _clean_text(firm.get("city")), _clean_text(firm.get("state")))
-            if part
-        )
-        if firm_name and _clean_text(firm.get("city")):
-            candidates.append((firm_place, "firm_place"))
-        firm_city = ", ".join(
-            part for part in (_clean_text(firm.get("city")), _clean_text(firm.get("state"))) if part
-        )
-        if _clean_text(firm.get("city")):
-            candidates.append((f"{firm_city}, USA", "firm_city"))
-        if branch_is_public and _clean_text(branch.get("city")):
-            branch_city = ", ".join(
-                part
-                for part in (_clean_text(branch.get("city")), _clean_text(branch.get("state")))
-                if part
-            )
-            candidates.append((f"{branch_city}, USA", "branch_city"))
-
-        for query, source in candidates:
+        # Nothing published. Recover it from the public city/state — the same
+        # queries (and the same private-residence rule) the profile's LOCATION
+        # block uses, so the two never disagree about where this adviser is.
+        for query, source in public_place_queries(reference_metadata):
             try:
                 resolved = await self._maps_postal_code(query)
             except Exception:  # noqa: BLE001 - enrichment never breaks the worker

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4566,11 +4566,12 @@ class RIAIAMService:
                     await conn.execute(
                         """
                         INSERT INTO ria_business_contacts (
-                          user_id, phone, city, area_locality, full_street_address, pin_zip
+                          user_id, phone, city, area_locality, full_street_address, pin_zip,
+                          latitude, longitude
                         )
                         VALUES (
                           $1, NULLIF($2, ''), NULLIF($3, ''),
-                          NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, '')
+                          NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''), $7, $8
                         )
                         ON CONFLICT (user_id) DO UPDATE
                         SET
@@ -4579,6 +4580,8 @@ class RIAIAMService:
                           area_locality = COALESCE(NULLIF(EXCLUDED.area_locality, ''), ria_business_contacts.area_locality),
                           full_street_address = COALESCE(NULLIF(EXCLUDED.full_street_address, ''), ria_business_contacts.full_street_address),
                           pin_zip = COALESCE(NULLIF(EXCLUDED.pin_zip, ''), ria_business_contacts.pin_zip),
+                          latitude = COALESCE(ria_business_contacts.latitude, EXCLUDED.latitude),
+                          longitude = COALESCE(ria_business_contacts.longitude, EXCLUDED.longitude),
                           updated_at = NOW()
                         """,
                         normalized_user_id,
@@ -4587,6 +4590,8 @@ class RIAIAMService:
                         str(location.get("area") or "").strip(),
                         str(location.get("address") or "").strip(),
                         str(location.get("pin_zip") or "").strip(),
+                        location.get("latitude"),
+                        location.get("longitude"),
                     )
                 except asyncpg.exceptions.UndefinedTableError:
                     logger.warning(
@@ -5035,6 +5040,7 @@ class RIAIAMService:
                 "business_address": business_location["address"],
                 "business_pin_zip": business_location["pin_zip"],
                 "business_location_source": business_location_source,
+                "business_country_code": business_contact.get("country_code"),
                 "business_latitude": business_contact.get("latitude"),
                 "business_longitude": business_contact.get("longitude"),
                 "contact_email": business_contact.get("email"),

--- a/consent-protocol/tests/test_ria_claim_location.py
+++ b/consent-protocol/tests/test_ria_claim_location.py
@@ -301,9 +301,11 @@ async def test_claim_write_only_fills_blanks_and_never_typed_values(monkeypatch)
             f"{column} = COALESCE(NULLIF(EXCLUDED.{column}, ''), ria_business_contacts.{column})"
         )
         assert guard in normalized, f"{column} may overwrite an adviser-typed value"
-    # The SEC feed carries no coordinates; the claim must not touch them.
-    assert "latitude" not in normalized
-    assert "longitude" not in normalized
+    # Coordinates are recovered for the map when the filing has none, so the
+    # claim now writes them — under the same rule: a stored value always wins.
+    for column in ("latitude", "longitude"):
+        guard = f"{column} = COALESCE(ria_business_contacts.{column}, EXCLUDED.{column})"
+        assert guard in normalized, f"{column} may overwrite an adviser-typed value"
 
 
 async def test_claim_survives_a_missing_business_contacts_table(monkeypatch):
@@ -368,11 +370,15 @@ async def test_completing_a_claim_hands_the_derived_location_to_the_iam_service(
         firm_crd=283040,
     )
 
+    # The filing carries a zip, so nothing is looked up and the coordinate
+    # keys stay empty — enrichment only ever fills what the SEC left blank.
     assert calls[0]["business_location"] == {
         "city": "SANDY",
         "area": "",
         "address": "9539 S PROSPERITY RD, SUITE 200",
         "pin_zip": "84070",
+        "latitude": None,
+        "longitude": None,
     }
 
 
@@ -559,3 +565,127 @@ async def test_wizard_profile_without_a_claim_keeps_reporting_profile(monkeypatc
     assert result["business_city"] == "Draper"
     assert result["business_location_source"] == "profile"
     assert result["business_latitude"] is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_business_location: recovering what the SEC left blank
+#
+# IAPD publishes plenty of records with a city and state but a null street and
+# null zip. That left PIN / ZIP reading "Not provided" and gave the profile map
+# nothing but a bare city name to place — "MENDOCINO" exists on four
+# continents, so the embed drew a whole-world view instead of an office.
+# ---------------------------------------------------------------------------
+
+
+def _zipless_metadata() -> dict[str, Any]:
+    """The live shape: CRD 1139833's firm, city and state only."""
+    return {
+        "firm_record": {
+            "name": "CYPRESS POINT CAPITAL MANAGEMENT, LLC",
+            "city": "MENDOCINO",
+            "state": "CA",
+            "zip": None,
+            "street1": None,
+        },
+        "advisor_record": {
+            "branch": {
+                "city": "NEW YORK",
+                "state": "NY",
+                "zip": None,
+                "street1": None,
+                "private_residence": True,
+            }
+        },
+    }
+
+
+def _install_place_lookup(monkeypatch, table: dict[str, dict[str, Any]]) -> list[str]:
+    from hushh_mcp.services import google_maps_service as gms
+
+    asked: list[str] = []
+
+    async def _fake(self, *, query: str) -> dict[str, Any]:
+        asked.append(query)
+        return table.get(query) or {"postal_code": "", "latitude": None, "longitude": None}
+
+    monkeypatch.setattr(gms.GoogleMapsService, "resolve_place", _fake)
+    return asked
+
+
+async def test_enrichment_recovers_the_zip_and_the_map_position(monkeypatch):
+    from hushh_mcp.services.ria_claim_service import (
+        derive_business_location,
+        enrich_business_location,
+    )
+
+    metadata = _zipless_metadata()
+    asked = _install_place_lookup(
+        monkeypatch,
+        {
+            "CYPRESS POINT CAPITAL MANAGEMENT, LLC, MENDOCINO, CA": {
+                "postal_code": "95460",
+                "latitude": 39.3076744,
+                "longitude": -123.7994591,
+            }
+        },
+    )
+
+    resolved = await enrich_business_location(derive_business_location(metadata), metadata)
+
+    assert resolved["pin_zip"] == "95460"
+    assert resolved["latitude"] == 39.3076744
+    assert resolved["longitude"] == -123.7994591
+    assert resolved["city"] == "MENDOCINO"
+    assert asked == ["CYPRESS POINT CAPITAL MANAGEMENT, LLC, MENDOCINO, CA"]
+
+
+async def test_enrichment_never_overwrites_a_filed_value(monkeypatch):
+    from hushh_mcp.services.ria_claim_service import enrich_business_location
+
+    asked = _install_place_lookup(monkeypatch, {"MENDOCINO, CA, USA": {"postal_code": "99999"}})
+    filed = {"city": "SANDY", "area": "", "address": "9980 S 300 W", "pin_zip": "84070"}
+
+    resolved = await enrich_business_location(filed, _zipless_metadata())
+
+    assert resolved["pin_zip"] == "84070"  # the filing wins, 99999 is discarded
+    assert resolved["address"] == "9980 S 300 W"
+    # The lookup still ran, because the map has no position yet — a filed zip
+    # settles the ZIP row, not where the pin goes.
+    assert asked
+
+
+async def test_enrichment_never_looks_up_a_private_residence(monkeypatch):
+    """Privacy holds at every precision — a home is not a lookup source."""
+    from hushh_mcp.services.ria_claim_service import (
+        derive_business_location,
+        enrich_business_location,
+    )
+
+    metadata = _zipless_metadata()
+    metadata["firm_record"].update(city=None, name=None)
+    asked = _install_place_lookup(monkeypatch, {})
+
+    resolved = await enrich_business_location(derive_business_location(metadata), metadata)
+
+    assert resolved["pin_zip"] == ""
+    assert resolved["latitude"] is None
+    assert not any("NEW YORK" in query for query in asked)
+
+
+async def test_enrichment_failure_never_fails_the_claim(monkeypatch):
+    from hushh_mcp.services import google_maps_service as gms
+    from hushh_mcp.services.ria_claim_service import (
+        derive_business_location,
+        enrich_business_location,
+    )
+
+    async def _boom(self, *, query: str):
+        raise RuntimeError("maps down")
+
+    monkeypatch.setattr(gms.GoogleMapsService, "resolve_place", _boom)
+    metadata = _zipless_metadata()
+
+    resolved = await enrich_business_location(derive_business_location(metadata), metadata)
+
+    assert resolved["pin_zip"] == ""
+    assert resolved["latitude"] is None

--- a/hushh-webapp/__tests__/components/ria/ria-location-map.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-location-map.test.tsx
@@ -192,3 +192,95 @@ describe("RiaLocationMap", () => {
     expect(screen.queryByTestId("ria-location-map-denied")).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// A geocoded office, and a route that would cross an ocean.
+//
+// "MENDOCINO" is a bare city name that exists on four continents, so the
+// embed's own geocoder cannot know which one we mean — and asking Google for
+// driving directions from India to California returns no route at all, which
+// renders as two pins on a whole-world map.
+// ---------------------------------------------------------------------------
+
+const MENDOCINO = {
+  fullStreetAddress: "",
+  areaLocality: "",
+  city: "MENDOCINO",
+  pinZip: "",
+  latitude: 39.3076744,
+  longitude: -123.7994591,
+  countryCode: "US",
+};
+
+/** Bengaluru — ~13,000 km from the Mendocino office. */
+const FAR_AWAY = {
+  status: "ready",
+  permission: "granted",
+  snapshot: {
+    latitude: 12.9716,
+    longitude: 77.5946,
+    accuracyM: 12,
+    capturedAt: "2026-08-08T00:00:00.000Z",
+  },
+};
+
+/** Ukiah — ~50 km from the Mendocino office, an ordinary drive. */
+const NEARBY = {
+  status: "ready",
+  permission: "granted",
+  snapshot: {
+    latitude: 39.1502,
+    longitude: -123.2078,
+    accuracyM: 12,
+    capturedAt: "2026-08-08T00:00:00.000Z",
+  },
+};
+
+describe("RiaLocationMap — geocoded office", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocation();
+  });
+
+  it("places the office by its coordinates, not its ambiguous name", () => {
+    render(<RiaLocationMap {...MENDOCINO} />);
+
+    const src = screen.getByTestId("ria-location-map-office").getAttribute("src") ?? "";
+    expect(src).toContain(encodeURIComponent("39.307674,-123.799459"));
+    expect(src).toContain("z=16");
+    expect(src).not.toContain("MENDOCINO");
+  });
+
+  it("falls back to the address plus its country when no position is stored", () => {
+    render(<RiaLocationMap {...MENDOCINO} latitude={null} longitude={null} />);
+
+    const src = screen.getByTestId("ria-location-map-office").getAttribute("src") ?? "";
+    expect(src).toContain(encodeURIComponent("MENDOCINO, US"));
+  });
+
+  it("shows the office and the real distance instead of a world-spanning route", () => {
+    setLocation(FAR_AWAY);
+    render(<RiaLocationMap {...MENDOCINO} />);
+
+    expect(screen.queryByTestId("ria-location-map-route")).toBeNull();
+    expect(screen.getByTestId("ria-location-map-office")).toBeTruthy();
+    expect(screen.getByTestId("ria-location-map-too-far").textContent).toContain("km from you");
+  });
+
+  it("still draws the route for a viewer who could actually drive there", () => {
+    setLocation(NEARBY);
+    render(<RiaLocationMap {...MENDOCINO} />);
+
+    expect(screen.getByTestId("ria-location-map-route")).toBeTruthy();
+    expect(screen.queryByTestId("ria-location-map-too-far")).toBeNull();
+  });
+
+  it("keeps drawing the route when the office position is unknown", () => {
+    // Unmeasurable distance must never suppress behaviour that already worked.
+    setLocation(FAR_AWAY);
+    render(<RiaLocationMap {...MENDOCINO} latitude={null} longitude={null} />);
+
+    expect(screen.getByTestId("ria-location-map-route")).toBeTruthy();
+    expect(screen.queryByTestId("ria-location-map-too-far")).toBeNull();
+  });
+});

--- a/hushh-webapp/components/ria/profile/ria-location-map.tsx
+++ b/hushh-webapp/components/ria/profile/ria-location-map.tsx
@@ -18,9 +18,11 @@
 import { MapPin } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { haversineMeters } from "@/lib/one-location/marker-interpolation";
 import {
   googleMapsDirectionsEmbedUrl,
   googleMapsLocationEmbedUrl,
+  type MapsPlace,
 } from "@/lib/one-location/maps-urls";
 import { useCurrentLocation } from "@/lib/one-location/use-current-location";
 
@@ -34,11 +36,29 @@ const ADDRESS_FIELD_LABELS = [
 
 const MAP_FRAME_CLASS = "h-[180px] w-full border-0";
 
+/**
+ * Past this, a driving route is crossing an ocean and Google answers with no
+ * route at all — two pins on a whole-world map, which is what a viewer in
+ * India got for an office in California. Coast-to-coast in the US is ~3,940 km,
+ * so this keeps every genuinely drivable route and drops the rest.
+ */
+const ROUTE_MAX_METERS = 5_000_000;
+
+function formatDistance(meters: number): string {
+  const km = Math.round(meters / 1000);
+  return `${km.toLocaleString()} km`;
+}
+
 export interface RiaLocationMapProps {
   city: string;
   areaLocality: string;
   fullStreetAddress: string;
   pinZip: string;
+  /** The office's geocoded position, when the record carries one. */
+  latitude?: number | null;
+  longitude?: number | null;
+  /** Disambiguates a bare city name ("MENDOCINO" exists on four continents). */
+  countryCode?: string | null;
 }
 
 export function RiaLocationMap({
@@ -46,6 +66,9 @@ export function RiaLocationMap({
   areaLocality,
   fullStreetAddress,
   pinZip,
+  latitude,
+  longitude,
+  countryCode,
 }: RiaLocationMapProps) {
   const { status, permission, snapshot, request } = useCurrentLocation();
 
@@ -54,12 +77,36 @@ export function RiaLocationMap({
   const parts = [fullStreetAddress, areaLocality, city, pinZip].map((part) =>
     (part ?? "").trim(),
   );
-  const destination = parts.filter(Boolean).join(", ");
+  const addressText = parts.filter(Boolean).join(", ");
   const missing = ADDRESS_FIELD_LABELS.filter((_, index) => !parts[index]);
+
+  // A stored position beats the words every time: the text form of a
+  // city-only office is ambiguous worldwide, and the embed's own geocoder has
+  // no way to know which continent we meant.
+  const officePoint =
+    typeof latitude === "number" &&
+    typeof longitude === "number" &&
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude)
+      ? { lat: latitude, lng: longitude }
+      : null;
+  const countryText = (countryCode ?? "").trim();
+  const destination: MapsPlace | null =
+    officePoint ??
+    (addressText
+      ? [addressText, countryText].filter(Boolean).join(", ")
+      : null);
 
   const origin = snapshot
     ? { lat: snapshot.latitude, lng: snapshot.longitude }
     : null;
+
+  // Only measurable when we hold both positions; an unknown distance never
+  // suppresses the route, so behaviour is unchanged wherever it always worked.
+  const originToOfficeMeters =
+    origin && officePoint ? haversineMeters(origin, officePoint) : null;
+  const routeIsUnreachable =
+    originToOfficeMeters !== null && originToOfficeMeters > ROUTE_MAX_METERS;
 
   // Denied and unavailable are terminal for this screen: the OS will not
   // re-prompt, so offering a button that cannot work would be a dead control.
@@ -72,7 +119,7 @@ export function RiaLocationMap({
   const locating = status === "locating";
 
   const routeSrc =
-    destination && origin
+    destination && origin && !routeIsUnreachable
       ? googleMapsDirectionsEmbedUrl(origin, destination)
       : "";
   const officeSrc = destination ? googleMapsLocationEmbedUrl(destination) : "";
@@ -110,6 +157,15 @@ export function RiaLocationMap({
           </div>
         )}
       </div>
+
+      {routeIsUnreachable && originToOfficeMeters !== null ? (
+        <p
+          className="mt-3 text-[13px] text-muted-foreground"
+          data-testid="ria-location-map-too-far"
+        >
+          {`About ${formatDistance(originToOfficeMeters)} from you — showing the office.`}
+        </p>
+      ) : null}
 
       {destination && !origin ? (
         <div className="mt-3 flex items-center justify-between gap-3">

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -192,6 +192,9 @@ function RiaRegulatoryProfileSummary({
   profileSource,
   profileSourceUrl,
   profileSourceFiledOn,
+  officeLatitude,
+  officeLongitude,
+  officeCountryCode,
   onEditSection,
   onAskKaiUpdateAnything,
 }: {
@@ -199,6 +202,9 @@ function RiaRegulatoryProfileSummary({
   profileSource?: string | null;
   profileSourceUrl?: string | null;
   profileSourceFiledOn?: string | null;
+  officeLatitude?: number | null;
+  officeLongitude?: number | null;
+  officeCountryCode?: string | null;
   onEditSection: (section: "license" | "services") => void;
   onAskKaiUpdateAnything: () => void;
 }) {
@@ -324,6 +330,9 @@ function RiaRegulatoryProfileSummary({
           areaLocality={reviewProps.areaLocality}
           fullStreetAddress={reviewProps.fullStreetAddress}
           pinZip={reviewProps.pinZip}
+          latitude={officeLatitude}
+          longitude={officeLongitude}
+          countryCode={officeCountryCode}
         />
         <SettingsRow
           icon={Pencil}
@@ -336,6 +345,11 @@ function RiaRegulatoryProfileSummary({
       </SettingsGroup>
     </div>
   );
+}
+
+/** A usable coordinate, or null — the map must never plot NaN at 0,0. */
+function coerceCoordinate(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function asRecord<T>(value: unknown): T | null {
@@ -1042,6 +1056,9 @@ export function RiaProfileSection({
         profileSource={status?.profile_source}
         profileSourceUrl={status?.profile_source_url}
         profileSourceFiledOn={status?.profile_source_filed_on}
+        officeLatitude={coerceCoordinate(status?.business_latitude)}
+        officeLongitude={coerceCoordinate(status?.business_longitude)}
+        officeCountryCode={status?.business_country_code ?? null}
         onEditSection={handleEditSection}
         onAskKaiUpdateAnything={handleAskKai}
       />

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -171,6 +171,8 @@ export interface RiaOnboardingStatus {
   business_pin_zip?: string | null;
   business_latitude?: number | null;
   business_longitude?: number | null;
+  /** ISO country of the office, so a bare city name is not globally ambiguous. */
+  business_country_code?: string | null;
   /**
    * Where the shown address came from: "profile" when the adviser entered it,
    * "sec_record" when any shown value was derived from their claimed SEC


### PR DESCRIPTION
## What was wrong

The LOCATION block read **City MENDOCINO** with **Address** and **PIN / ZIP**
both "Not provided", and the map drew the entire planet — four copies of the
world, a pin on each.

Both come from one fact: IAPD publishes this firm with a city and state and a
**null street and null zip**. `derive_business_location` may only return what
was filed, so it had nothing else to give. That left two consequences:

1. The embed geocoded the bare word `MENDOCINO`, which exists on four
   continents.
2. We asked Google for **driving directions** from the viewer in Bengaluru to
   it. There is no route across the Pacific, so Google returned no route at
   all — two markers, fitted to the globe. That is the world map in the report.

## What this changes

**Recover the rest from the city and state that are filed.** The place lookups
the dossier lane already uses now also fill a blank PIN / ZIP and store the
office's **coordinates**, so the map has an exact point instead of an ambiguous
word. Proven live against the real firm:

```
"CYPRESS POINT CAPITAL MANAGEMENT, LLC, MENDOCINO, CA" → 95460 @ 39.307674,-123.799459
```

The privacy rule is untouched and now lives in **one** place —
`public_place_queries`, shared by the profile and the dossier so the two can
never disagree about where an adviser is. A branch the SEC flagged as a private
residence is never a lookup source, at any precision. Filed values always win,
and a stored coordinate is never overwritten (`COALESCE(existing, new)`).

**Stop drawing a route that is not a route.** With both positions known the
component measures the distance and, past 5,000 km, shows the office and says
how far away it is. US coast-to-coast is ~3,940 km, so every genuinely drivable
route still renders. An unmeasurable distance never suppresses a route, so
nothing that worked before changes.

No redesign: same rows, same groups, same "Show route" flow.

## Verification

- **Backend:** `backend-check.sh` exit 0 — **835 passed**, ruff/mypy/bandit clean
- **Frontend:** **3112 passed** on Node 24; `tsc --noEmit` and eslint clean
- New tests: the recovery chain, the private-residence rule at city precision, a
  filed value surviving enrichment, lookup failure never failing a claim, the
  office placed by coordinates, the country-suffixed text fallback, the distance
  guard both ways, and the unmeasurable-distance case

## Note

Advisers who claimed **before** this ships keep their blank rows until they
re-claim — the enrichment runs on the claim write, not on every profile read
(a lookup per GET would be a network call on every page load).