### PR TITLE
feat(feed): render SMS emergency alerts directly inside activity feed

### DIFF
--- a/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MapPin, Siren } from "lucide-react";
+
+import { FeedActionableRow } from "@/components/feed/feed-actionable-row";
+import type { FeedActionable } from "@/lib/feed/use-feed-actionables";
+
+function actionable(overrides: Partial<FeedActionable> = {}): FeedActionable {
+  return {
+    id: "a-1",
+    icon: MapPin,
+    iconTone: "blue",
+    title: "Row title",
+    description: "Row description",
+    actions: [],
+    sortAt: 0,
+    ...overrides,
+  };
+}
+
+describe("FeedActionableRow", () => {
+  it("wraps an emergency SMS alert in a prominent red alert frame", () => {
+    render(
+      <FeedActionableRow
+        item={actionable({
+          icon: Siren,
+          iconTone: "red",
+          emphasis: "emergency",
+          title: "Mom triggered an SOS",
+          description: "Emergency SMS — sharing live location with you now.",
+          href: "/one/location?grantId=g1&open=1&section=shared",
+          chevron: true,
+        })}
+      />,
+    );
+
+    const frame = screen.getByTestId("feed-sms-emergency");
+    expect(frame).toHaveAttribute("role", "alert");
+    expect(frame).toHaveClass("border-destructive/45");
+    expect(screen.getByText("Mom triggered an SOS")).toBeInTheDocument();
+  });
+
+  it("renders a routine actionable without the emergency frame", () => {
+    render(<FeedActionableRow item={actionable({ title: "Routine row" })} />);
+
+    expect(screen.queryByTestId("feed-sms-emergency")).toBeNull();
+    expect(screen.getByText("Routine row")).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { isIncomingLocationRequestActionable } from "@/lib/feed/use-feed-actionables";
-import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+import {
+  isActiveSmsEmergencyGrant,
+  isIncomingLocationRequestActionable,
+} from "@/lib/feed/use-feed-actionables";
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+} from "@/lib/one-location/types";
 
 const ME = "user-me";
 const CONTACT = "user-contact";
@@ -66,6 +72,46 @@ describe("isIncomingLocationRequestActionable", () => {
         request({ ownerUserId: "user-other", requesterUserId: CONTACT }),
         ME,
       ),
+    ).toBe(false);
+  });
+});
+
+function grant(overrides: Partial<OneLocationGrant>): OneLocationGrant {
+  return {
+    id: "grant-1",
+    ownerUserId: CONTACT,
+    recipientUserId: ME,
+    recipientKeyId: "key-1",
+    status: "active",
+    consentScope: "cap.location.live",
+    capabilityScopes: ["cap.location.live"],
+    durationHours: 1,
+    shareKind: "sos",
+    ...overrides,
+  };
+}
+
+describe("isActiveSmsEmergencyGrant", () => {
+  it("surfaces a live SOS share as an emergency alert", () => {
+    expect(isActiveSmsEmergencyGrant(grant({ shareKind: "sos" }))).toBe(true);
+  });
+
+  it("does NOT surface a plain (non-SOS) share", () => {
+    expect(isActiveSmsEmergencyGrant(grant({ shareKind: "share" }))).toBe(false);
+  });
+
+  it("does NOT surface a friendly check-in", () => {
+    expect(isActiveSmsEmergencyGrant(grant({ shareKind: "check_in" }))).toBe(
+      false,
+    );
+  });
+
+  it("does NOT surface an expired or revoked SOS share", () => {
+    expect(
+      isActiveSmsEmergencyGrant(grant({ shareKind: "sos", status: "expired" })),
+    ).toBe(false);
+    expect(
+      isActiveSmsEmergencyGrant(grant({ shareKind: "sos", status: "revoked" })),
     ).toBe(false);
   });
 });

--- a/hushh-webapp/components/feed/feed-actionable-row.tsx
+++ b/hushh-webapp/components/feed/feed-actionable-row.tsx
@@ -116,19 +116,31 @@ export function FeedActionableRow({ item }: { item: FeedActionable }) {
     trailing: <ActionButtons actions={item.actions} />,
   } as const;
 
-  if (item.href) {
+  const row = item.href ? (
+    <SettingsRow asChild {...shared} chevron={item.chevron}>
+      <Link
+        href={item.href}
+        prefetch={false}
+        aria-label={`${item.title}. ${item.description}`}
+      />
+    </SettingsRow>
+  ) : (
+    <SettingsRow {...shared} chevron={item.chevron} onClick={item.onSelect} />
+  );
+
+  // Emergency SMS alerts get a prominent red frame so a safety alert stands out
+  // from routine "Needs you" rows.
+  if (item.emphasis === "emergency") {
     return (
-      <SettingsRow asChild {...shared} chevron={item.chevron}>
-        <Link
-          href={item.href}
-          prefetch={false}
-          aria-label={`${item.title}. ${item.description}`}
-        />
-      </SettingsRow>
+      <div
+        role="alert"
+        data-testid="feed-sms-emergency"
+        className="overflow-hidden rounded-2xl border border-destructive/45 bg-destructive/[0.06] ring-1 ring-inset ring-destructive/20"
+      >
+        {row}
+      </div>
     );
   }
 
-  return (
-    <SettingsRow {...shared} chevron={item.chevron} onClick={item.onSelect} />
-  );
+  return row;
 }

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
-import { MapPin, ShieldCheck, TrendingUp, UserRound } from "lucide-react";
+import { MapPin, ShieldCheck, Siren, TrendingUp, UserRound } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
 import { useVault } from "@/lib/vault/vault-context";
@@ -42,7 +42,11 @@ import {
   locationConsentSummary,
 } from "@/lib/consent/location-consent";
 import { OneLocationService } from "@/lib/one-location/service";
-import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+} from "@/lib/one-location/types";
+import { buildOneLocationNotificationHref } from "@/lib/one-location/notifications";
 import {
   ConnectionsService,
   type ConnectionRequest,
@@ -86,6 +90,11 @@ export interface FeedActionable {
   chevron?: boolean;
   actions: FeedActionButton[];
   sortAt: number;
+  /**
+   * High-priority visual treatment. "emergency" rows (an incoming SMS · Save My
+   * Soul alert) render with prominent red styling and sort above everything else.
+   */
+  emphasis?: "emergency";
 }
 
 export interface UseFeedActionablesResult {
@@ -133,6 +142,16 @@ export function isIncomingLocationRequestActionable(
     request.ownerUserId === userId &&
     request.requesterUserId !== userId
   );
+}
+
+/**
+ * A received share a contact started as an emergency SOS (SMS · Save My Soul)
+ * that is still live. These surface as pinned, emergency-styled feed cards so a
+ * safety alert is never buried under routine activity. The share point stays
+ * end-to-end encrypted; only the emergency intent (`shareKind`) is read here.
+ */
+export function isActiveSmsEmergencyGrant(grant: OneLocationGrant): boolean {
+  return grant.status === "active" && grant.shareKind === "sos";
 }
 
 export function notifyFeedActionResolved(): void {
@@ -275,6 +294,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
   // returns fresh every render) so the memo below depends on the actual data
   // + the stable refresh callbacks, not the changing wrapper identity.
   const locationRequests = locationResource.data?.requests;
+  const receivedGrants = locationResource.data?.receivedGrants;
   const locationRefresh = locationResource.refresh;
   const connectionRequests = connectionsResource.data;
   const connectionsRefresh = connectionsResource.refresh;
@@ -312,6 +332,30 @@ export function useFeedActionables(): UseFeedActionablesResult {
           sortAt: Date.now(),
         });
       }
+    }
+
+    // SMS · Save My Soul emergency alerts — a live share a contact started as an
+    // SOS. Rendered as pinned, emergency-styled cards at the very top of the feed
+    // so a safety alert is never buried under routine activity.
+    const smsEmergencies = (receivedGrants ?? []).filter(
+      isActiveSmsEmergencyGrant,
+    );
+    for (const grant of smsEmergencies) {
+      const label = grant.ownerDisplayName?.trim() || "A contact";
+      items.push({
+        id: `sms-emergency:${grant.id}`,
+        icon: Siren,
+        iconTone: "red",
+        emphasis: "emergency",
+        title: `${label} triggered an SOS`,
+        description:
+          grant.shareMessage?.trim() ||
+          "Emergency SMS — sharing live location with you now.",
+        href: buildOneLocationNotificationHref(grant.id),
+        chevron: true,
+        actions: [],
+        sortAt: toTimestamp(grant.createdAt) || Date.now(),
+      });
     }
 
     // Location access requests — inline Approve (1h) / Deny. Only requests the
@@ -533,7 +577,14 @@ export function useFeedActionables(): UseFeedActionablesResult {
       });
     }
 
-    return items.sort((a, b) => b.sortAt - a.sortAt);
+    return items.sort((a, b) => {
+      // Emergency SMS alerts pin to the very top, then the rest stays in
+      // descending recency order.
+      const aEmergency = a.emphasis === "emergency" ? 1 : 0;
+      const bEmergency = b.emphasis === "emergency" ? 1 : 0;
+      if (aEmergency !== bEmergency) return bEmergency - aEmergency;
+      return b.sortAt - a.sortAt;
+    });
     // Depend on the resources' `data` + stable `refresh` (not the wrapper
     // objects, which useStaleResource returns fresh every render) so this memo
     // only recomputes when the underlying data actually changes — otherwise a
@@ -545,6 +596,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
     consentItems,
     debateState.tasks,
     locationRequests,
+    receivedGrants,
     locationRefresh,
     openAnalysis,
     pendingConsentCount,


### PR DESCRIPTION
# Description

**Feature:** When a contact triggers a Save My Soul (SMS · SOS) alert, the
incoming live share now surfaces as a **dedicated, emergency-styled card pinned
to the top of the Feed** ("Needs you" zone) — above every routine row — so a
safety alert is never buried under ordinary activity.

- `use-feed-actionables`: read the viewer's active **received grants** and turn
  every live SOS share (`shareKind === "sos"`, status active) into a feed
  actionable — Siren glyph, red tone, sender name, the SOS note (or a clear
  fallback), and a deep link into the shared live-location view. A new
  `emphasis: "emergency"` field marks these, and the sort now pins emergency rows
  to the very top before the usual recency order.
- `feed-actionable-row`: emergency rows render inside a prominent red,
  `role="alert"` frame; all other rows are unchanged.

**Scope (per maintainer direction — frontend-only, "without touching anything
else"):** the chronological feed-event row for a share stores no emergency flag
(only `duration_hours`), so a dedicated *feed-schema* card would need a backend
change. The SOS signal, however, already rides on the received grant
(`shareKind`) that the feed hook loads — so this is implemented **entirely in the
frontend feed layer**, with no feed-schema/backend change and the coordinate-free
contract preserved (only the emergency intent is read; no coordinates).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: the Feed "Needs you" zone (`/one/feed`) — client hook + row renderer only
- API / schema / type changes:
  - [x] Listed below: new exported `isActiveSmsEmergencyGrant` predicate; new optional `emphasis: "emergency"` on `FeedActionable`. No feed schema / backend change.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared web feed components
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Safety (SOS) — surfaces an existing active share more prominently; reads only `shareKind`, never coordinates; no new data access
- Caller / proxy / backend pairing:
  - [x] Not applicable — reads the already-loaded One-Location state
- Rollback or safe-failure behavior:
  - [x] Listed below: additive; a missing/absent SOS grant simply yields no emergency card; reverting removes the pinned card + red frame
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `use-feed-actionables.test.ts` (predicate) + `feed-actionable-row.test.tsx` (emergency frame); live capture not run (feed is auth + vault gated)
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`use-feed-actionables` 9 + `feed-actionable-row` 2 + `feed-action-resolved-events` 1) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate the toast (#5002) or the Shared-with-me card (#4979).
- [x] This PR changes a current reachable app surface (the Feed).
- [x] Reachable production attach point: `useFeedActionables` + `FeedActionableRow`.
- [x] New tests import and exercise production code, not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client hook + component
- [x] **iOS**: N/A — shared web feed; no native surface changed
- [x] **Android**: N/A — shared web feed; no native surface changed

## 🧪 Testing

- [x] Tested on Web (unit): `isActiveSmsEmergencyGrant` (SOS / share / check-in / expired / revoked) + emergency-frame render; existing feed actionables + resolved-events tests still pass
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

An active SOS from a contact appears at the very top of the Feed as a red,
`role="alert"` card with a Siren icon, "<name> triggered an SOS", the SOS note,
and a chevron into the live-location view — above all routine rows. Proven by the
unit tests; live capture not run (feed is auth + vault gated).

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it re-presents an existing received
  share; it reads only `shareKind` (emergency intent), never coordinates.
- [x] Sensitive surface touched: safety (SOS) — coordinate-free contract preserved
- [x] Error path / safe-failure proved: no SOS grant → no card; the predicate is fail-closed on status/kind

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
