### PR TITLE
fix(notifications): route connection request taps

### DIFF
--- a/hushh-webapp/__tests__/notifications/fcm-native-connection-routing.test.ts
+++ b/hushh-webapp/__tests__/notifications/fcm-native-connection-routing.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, (payload: unknown) => void>(),
+  requestInternalAppNavigation: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => "ios",
+  },
+}));
+
+vi.mock("@capacitor-firebase/messaging", () => ({
+  FirebaseMessaging: {
+    addListener: vi.fn(
+      async (eventName: string, listener: (payload: unknown) => void) => {
+        mocks.listeners.set(eventName, listener);
+        return { remove: vi.fn() };
+      },
+    ),
+  },
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    registerPushToken: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/utils/browser-navigation", () => ({
+  assignWindowLocation: vi.fn(),
+  requestInternalAppNavigation: mocks.requestInternalAppNavigation,
+}));
+
+import { prepareFCMListeners } from "@/lib/notifications/fcm-service";
+
+describe("native connection notification actions", () => {
+  beforeEach(() => {
+    mocks.listeners.clear();
+    mocks.requestInternalAppNavigation.mockClear();
+  });
+
+  it("opens the Connections consent view when a connection request is tapped", async () => {
+    await prepareFCMListeners();
+    const onAction = mocks.listeners.get("notificationActionPerformed");
+    expect(onAction).toBeTypeOf("function");
+
+    onAction?.({
+      actionId: "tap",
+      notification: {
+        data: {
+          type: "connection_request",
+          request_url: "/one/consent?tab=connections",
+        },
+      },
+    });
+
+    expect(mocks.requestInternalAppNavigation).toHaveBeenCalledWith({
+      href: "/one/consent?tab=connections",
+      scroll: false,
+    });
+  });
+});

--- a/hushh-webapp/__tests__/notifications/fcm-native-permission-contract.test.ts
+++ b/hushh-webapp/__tests__/notifications/fcm-native-permission-contract.test.ts
@@ -30,7 +30,30 @@ vi.mock("@/lib/services/api-service", () => ({
   },
 }));
 
-import { initializeFCM } from "@/lib/notifications/fcm-service";
+import {
+  initializeFCM,
+  resolveNativeConnectionRequestNotificationHref,
+} from "@/lib/notifications/fcm-service";
+
+describe("native connection notification routing", () => {
+  it("uses the backend-provided Connections route instead of Home", () => {
+    expect(
+      resolveNativeConnectionRequestNotificationHref({
+        type: "connection_request",
+        request_url: "/one/consent?tab=connections",
+      }),
+    ).toBe("/one/consent?tab=connections");
+  });
+
+  it("fails closed to Connections when the payload route is external", () => {
+    expect(
+      resolveNativeConnectionRequestNotificationHref({
+        type: "connection_request",
+        request_url: "https://example.com/untrusted",
+      }),
+    ).toBe("/one/consent?tab=connections");
+  });
+});
 
 describe("native FCM permission ownership", () => {
   beforeEach(() => {

--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -27,6 +27,8 @@ export const FCM_MESSAGE_EVENT = "fcm-message";
 const CONSENT_NOTIFICATION_ACTION_REVIEW = "CONSENT_REVIEW";
 const CONSENT_NOTIFICATION_ACTION_APPROVE = "CONSENT_APPROVE";
 const CONSENT_NOTIFICATION_ACTION_DENY = "CONSENT_DENY";
+const CONNECTION_REQUEST_NOTIFICATION_FALLBACK =
+  `${ROUTES.CONSENTS}?tab=connections`;
 
 export type FCMInitStatus =
   | "push_active"
@@ -43,6 +45,19 @@ export interface FCMInitResult {
 export type FCMInitOptions = {
   requestPermission?: boolean;
 };
+
+export function resolveNativeConnectionRequestNotificationHref(
+  data: Record<string, unknown> | undefined,
+): string {
+  const explicitHref =
+    (typeof data?.request_url === "string" && data.request_url) ||
+    (typeof data?.deep_link === "string" && data.deep_link) ||
+    CONNECTION_REQUEST_NOTIFICATION_FALLBACK;
+  const target = resolveConsentNavigationTarget(explicitHref, "pending");
+  return target.kind === "internal"
+    ? target.href
+    : CONNECTION_REQUEST_NOTIFICATION_FALLBACK;
+}
 
 let nativeListenersConfigured = false;
 let nativeListenersPromise: Promise<void> | null = null;
@@ -874,6 +889,18 @@ function setupNativeListeners(): Promise<void> {
             } else {
               assignWindowLocation(target.href || buildConsentTargetPath(data));
             }
+          } else if (
+            data &&
+            typeof data.type === "string" &&
+            data.type === "connection_request"
+          ) {
+            if (actionId === "dismiss") {
+              return;
+            }
+            requestInternalAppNavigation({
+              href: resolveNativeConnectionRequestNotificationHref(data),
+              scroll: false,
+            });
           } else if (
             data &&
             typeof data.type === "string" &&


### PR DESCRIPTION
# Description

Native notification taps for backend `type=connection_request` payloads fell through to the generic Home route because the native FCM action listener had no connection-request branch. This routes those taps to the existing Connections consent view and fails closed to that same internal route for malformed or external payload links.

## Reproduction and regression proof

- Source payload: backend emits `type=connection_request` with `/one/consent?tab=connections`.
- Before production fix: `fcm-native-permission-contract.test.ts` failed 2/2 with `resolveNativeConnectionRequestNotificationHref is not a function`.
- After fix: the pure route-contract tests pass, and a listener integration test invokes the real `notificationActionPerformed` callback and proves navigation to `/one/consent?tab=connections`.
- Physical iOS/Android notification-tap rehearsal is still required before app-release sign-off; this Windows host has no native device toolchain and no authenticated UAT tab is currently available.

## Impact Map

- Routes touched: `/one/consent?tab=connections` is now the native connection-request tap target.
- API / schema / type changes: None.
- Cache keys touched: None.
- Runtime DB data-plane changes: None.
- World-model domain summary effects: None.
- Mobile parity impacts: iOS and Android share this Capacitor FCM listener.
- Docs updated: None; behavior now matches the existing backend deep-link contract.
- Top-level / devex / config / generated / ignore files touched: None.
- Trust boundary touched: consent navigation only. Payload URLs are normalized through the existing internal-navigation validator; external URLs fail closed to Connections.
- Caller / proxy / backend pairing: `consent-protocol/hushh_mcp/services/push_notifications.py` emits the connection request payload; `hushh-webapp/lib/notifications/fcm-service.ts` consumes it.
- Rollback or safe-failure behavior: revert this commit; invalid or external payload links remain inside the app at Connections.
- UI browser or Playwright proof: not applicable to OS notification action delivery; production listener callback is exercised directly.

## Verification commands executed

- `npm.cmd test -- --run __tests__/notifications/fcm-native-permission-contract.test.ts __tests__/notifications/fcm-native-connection-routing.test.ts __tests__/consent-notification-provider-location.test.tsx __tests__/components/consent-center-page-deeplink.test.tsx __tests__/services/connections-service.test.ts` — 5 files, 51 tests passed on final rebased head.
- `npm.cmd run typecheck` — passed.
- `npm.cmd run lint` — passed.
- targeted ESLint for changed files — passed.
- `npm.cmd run verify:service-boundary` — passed.
- `npm.cmd run verify:capacitor:static` — passed.
- `npm.cmd run build:webpack` with the CI-documented dummy Firebase/backend environment — passed; 144/144 static pages generated.
- `git diff --check` — passed.
- pre-push freshness and consent-protocol checks — passed.

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; no open PR or ahead-of-main branch overlaps `fcm-service.ts`.
- [x] This changes the reachable native FCM listener configured by `prepareFCMListeners()`.
- [x] New tests import and exercise production code.
- [x] Production attach point: `setupNativeListeners()` -> `FirebaseMessaging.addListener(notificationActionPerformed, ...)`.
- [x] Production surface proved by direct listener-callback regression test.
- [x] Commit is DCO signed.
- [x] Maintainer edits enabled by the fork PR default.
- [x] Not a stacked PR.

## Tri-Flow Architecture Check

- [x] Web/Capacitor TypeScript: fixed shared native listener.
- [x] iOS: no Swift change required; the shared listener receives the Firebase action.
- [x] Android: no Kotlin change required; the shared listener receives the Firebase action.

## Testing

- [x] Shared web/Capacitor test and production build.
- [ ] iOS Simulator/Device notification tap — required release follow-up.
- [ ] Android Emulator/Device notification tap — required release follow-up.
- [x] Commits signed off (`git commit -s`).
- [x] No generated files changed.

## Screenshots / Video

Not applicable: this fixes OS notification-action routing and does not change rendered UI. Native device tap evidence remains an explicit app-release gate.

## Privacy & Consent

- [x] Does not add access to user information.
- [x] Sensitive surface: consent navigation.
- [x] Safe failure proved: external payload link resolves to internal Connections route.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.