### PR TITLE
fix(mobile): repair native plugin verifier paths

### DIFF
--- a/hushh-webapp/__tests__/scripts/native-plugin-contracts.test.ts
+++ b/hushh-webapp/__tests__/scripts/native-plugin-contracts.test.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("native plugin contract verifier", () => {
+  it("validates the checked-in iOS and Android plugin trees", () => {
+    const verifierPath = path.join(
+      process.cwd(),
+      "scripts",
+      "native",
+      "verify-native-plugin-contracts.mjs",
+    );
+
+    expect(() =>
+      execFileSync(process.execPath, [verifierPath], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/hushh-webapp/scripts/native/verify-native-plugin-contracts.mjs
+++ b/hushh-webapp/scripts/native/verify-native-plugin-contracts.mjs
@@ -13,9 +13,9 @@ const tsPluginFiles = [
 ];
 
 const iosPluginsDir = path.join(appRoot, "ios/App/App/Plugins");
-const androidPluginsDir = path.join(appRoot, "android/app/src/main/java/com/hushh/app/plugins");
+const androidPluginsDir = path.join(appRoot, "android/app/src/main/java/com/hussh/app/plugins");
 const iosControllerPath = path.join(appRoot, "ios/App/App/MyViewController.swift");
-const androidActivityPath = path.join(appRoot, "android/app/src/main/java/com/hushh/app/MainActivity.kt");
+const androidActivityPath = path.join(appRoot, "android/app/src/main/java/com/hussh/app/MainActivity.kt");
 const iosInfoPlistPath = path.join(appRoot, "ios/App/App/Info.plist");
 const iosEntitlementsPath = path.join(appRoot, "ios/App/App/App.entitlements");
 


### PR DESCRIPTION
# Description

The native plugin parity verifier still scanned the old Android package path (`com/hushh/app`) after the application package moved to `com/hussh/app`. It crashed with `ENOENT` before checking any TypeScript/iOS/Android plugin contract, leaving the app-release gate unusable.

This updates only the Android plugin and `MainActivity` paths and adds a regression test that executes the real verifier against the checked-in native trees.

## Regression proof

- Before fix: the new test failed because the production verifier threw `ENOENT` for `android/app/src/main/java/com/hushh/app/plugins`.
- After fix: `verify:capacitor:plugins` passes and reports 12 native plugins plus 2 classified web-only plugins.

## Impact Map

- Routes touched: None.
- API / schema / type changes: None.
- Cache keys touched: None.
- Runtime DB data-plane changes: None.
- World-model domain summary effects: None.
- Mobile parity impacts: restores the existing cross-platform plugin contract release gate.
- Docs updated: None; the canonical new-feature guide already names `com/hussh/app`.
- Top-level / devex / config / generated / ignore files touched: one existing native verification script and one test.
- Trust boundary touched: None.
- Caller / proxy / backend pairing: Not applicable.
- Rollback or safe-failure behavior: revert this commit; the prior behavior is a deterministic verifier crash.
- UI browser or Playwright proof: Not applicable; no runtime UI changes.

## Verification commands executed

- `npm.cmd test -- --run __tests__/scripts/native-plugin-contracts.test.ts` — 1/1 passed after failing before the production fix.
- `npm.cmd run verify:capacitor:plugins` — passed; 12 native and 2 web-only plugin contracts classified.
- `npm.cmd run verify:capacitor:static` — passed.
- `npm.cmd run typecheck` — passed.
- `npm.cmd run lint` — passed.
- changed-file ESLint — passed.
- `npm.cmd run cap:build` with the CI-documented dummy Firebase/backend environment — passed.
- `git diff --check` — passed.
- pre-push freshness and consent-protocol checks — passed.

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] No active PR or ahead-of-main branch overlaps the verifier script.
- [x] Current app-release verification surface is restored.
- [x] The test executes the production verifier, not a copied helper.
- [x] Production attach point: `npm run verify:capacitor:plugins` and `verify-capacitor-audit.mjs`.
- [x] Commit is DCO signed.
- [x] Maintainer edits enabled by the fork PR default.
- [x] Not a stacked PR.

## Tri-Flow Architecture Check

- [x] Web: TypeScript plugin contracts are inspected by the verifier.
- [x] iOS: Swift plugins and registration are inspected by the verifier.
- [x] Android: Kotlin plugins and registration under `com/hussh/app` are inspected by the verifier.

## Testing

- [x] Cross-platform static plugin contract verifier.
- [x] Capacitor web bundle.
- [x] Commits signed off (`git commit -s`).
- [x] No generated files changed.

## Screenshots / Video

Not applicable: verification tooling only, with no rendered UI change.

## Privacy & Consent

- [x] No user information access or sensitive runtime surface changed.
- [x] Failure behavior is directly covered by the executable regression test.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.