### PR TITLE
fix(one-location): stop refusing location instead of asking for it

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1715,6 +1715,13 @@ describe("OneLocationAgentPage", () => {
       background: "restricted",
       locationServicesEnabled: true,
     });
+    // A genuinely denied device refuses the capture too. Setup now confirms by
+    // attempting rather than trusting the reported state, because that state is
+    // unreadable on Safari — so the refusal has to come from the attempt for
+    // this to still be a denial at all.
+    const denied = new Error("Location permission was not granted.");
+    denied.name = "LocationPermissionDeniedError";
+    mockCaptureCurrentPosition.mockRejectedValue(denied);
 
     render(
       <OneLocationAgentPage mode="setup" onSetupComplete={onSetupComplete} />,
@@ -1745,6 +1752,15 @@ describe("OneLocationAgentPage", () => {
       locationServicesEnabled: true,
     };
     mockGetPermissionState.mockResolvedValue(deniedPermission);
+    // The request reports the same refusal the read did — otherwise the device
+    // is not actually denied and routing to Settings would be wrong.
+    mockRequestLocationPermission.mockResolvedValue(deniedPermission);
+    // A genuinely denied device refuses the capture too. Setup now confirms a
+    // denial by attempting rather than trusting the reported state — that state
+    // is unreadable on Safari — so the refusal has to come from the attempt.
+    const refused = new Error("Location permission was not granted.");
+    refused.name = "LocationPermissionDeniedError";
+    mockCaptureCurrentPosition.mockRejectedValue(refused);
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -1754,16 +1770,27 @@ describe("OneLocationAgentPage", () => {
 
     await openLocationPermissionsStep();
     await waitFor(() => expect(mockOpenAppSettings).toHaveBeenCalled());
-    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+    // Asked first, and only then routed to Settings once the device said no.
+    expect(mockCaptureCurrentPosition).toHaveBeenCalled();
 
+    const attemptsWhileDenied = mockCaptureCurrentPosition.mock.calls.length;
     mockGetPermissionState.mockResolvedValue(grantedPermission);
+    mockCaptureCurrentPosition.mockResolvedValue({
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 18,
+      capturedAt: "2026-05-20T07:30:00.000Z",
+      sourcePlatform: "web",
+    });
     act(() => {
       appInteractionCoordinator.handleLifecycle("background");
       appInteractionCoordinator.handleLifecycle("active");
     });
 
     expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
-    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(mockCaptureCurrentPosition.mock.calls.length).toBeGreaterThan(
+      attemptsWhileDenied,
+    );
   });
 
   it("keeps setup onboarding available when the workspace state fetch fails", async () => {
@@ -3232,7 +3259,12 @@ describe("OneLocationAgentPage", () => {
     expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
-  it("blocks share actions when browser location permission is denied", async () => {
+  it("still offers to share when a permission read claims denied", async () => {
+    // A read-back "denied" is not proof. Safari cannot report the value at all,
+    // and browsers and Android both re-prompt, so disabling the control here is
+    // what left users staring at "Allow location permission before sharing" on
+    // a phone whose location worked. The share stays available; the capture
+    // attempt is what asks, and a real refusal is what stops it.
     mockGetPermissionState.mockResolvedValue({
       state: "denied",
       precise: false,
@@ -3252,10 +3284,31 @@ describe("OneLocationAgentPage", () => {
     const shareButton = screen.getByRole("button", {
       name: /Review share/i,
     }) as HTMLButtonElement;
+    expect(shareButton.disabled).toBe(false);
+  });
+
+  it("blocks share actions once the OS location switch is off", async () => {
+    // This one genuinely cannot be fixed by asking, so it must still block.
+    mockGetPermissionState.mockResolvedValue({
+      state: "denied",
+      precise: false,
+      background: "unavailable",
+      locationServicesEnabled: false,
+    });
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openShareDetailsStep();
+    const shareButton = screen.getByRole("button", {
+      name: /Review share/i,
+    }) as HTMLButtonElement;
     expect(shareButton.disabled).toBe(true);
-    await waitFor(() =>
-      expect(mockCaptureCurrentPosition).not.toHaveBeenCalled(),
-    );
     expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -149,6 +149,12 @@ import {
 } from "@/lib/one-location/notifications";
 import { driveEtaText } from "@/app/one/location/drive-eta";
 import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
+import {
+  LOCATION_BLOCK_MESSAGE,
+  isLocationPermissionDeniedError,
+  locationBlockReason,
+  locationReadiness as resolveLocationReadiness,
+} from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
   syncOneLocationContactSignals,
@@ -1419,15 +1425,19 @@ function isLocationServicesDisabled(
   return permission?.locationServicesEnabled === false;
 }
 
+/**
+ * Refuse a share only when no attempt could succeed.
+ *
+ * `denied` used to appear here, which meant a permission value we merely read
+ * could veto a share the device would have allowed — and on Safari, where the
+ * value is unreadable and arrived as `unavailable`, it vetoed every share on a
+ * perfectly working phone. The share paths now attempt and let a real denial
+ * stop them, so this only guards what genuinely cannot be attempted.
+ */
 function locationPermissionBlocksSharing(
   permission: HushhLocationPermissionState | null,
 ): boolean {
-  return (
-    isLocationServicesDisabled(permission) ||
-    permission?.state === "denied" ||
-    permission?.state === "restricted" ||
-    permission?.state === "unavailable"
-  );
+  return locationBlockReason(permission) !== null;
 }
 
 function locationServicesErrorMessage(error: unknown): string {
@@ -1752,6 +1762,12 @@ export function OneLocationAgentPageContent({
   }, [auth.userId]);
   const [permission, setPermission] =
     useState<HushhLocationPermissionState | null>(null);
+  // Set only by a capture attempt that came back with a real PERMISSION_DENIED.
+  // A denial we observed is trustworthy in a way a queried one is not, so this
+  // — not the permission API — is what lets the UI say "blocked" and route the
+  // user to settings. Cleared the moment any capture succeeds.
+  const observedLocationDenialRef = useRef(false);
+  const [locationDenialObserved, setLocationDenialObserved] = useState(false);
   useEffect(() => {
     onSetupReadinessChange?.(
       permission?.state === "granted" &&
@@ -2663,11 +2679,16 @@ export function OneLocationAgentPageContent({
   );
 
   const refreshLocationPermission = useCallback(async () => {
+    // A failed read means we do not know, which is a reason to ask the device
+    // rather than to declare it unusable. Reporting `unavailable` here used to
+    // block every share path and pin the toggle off whenever the platform could
+    // not introspect its own permission — which is every iPhone, since WebKit
+    // has no `geolocation` entry in the Permissions API.
     const nextPermission = await OneLocationService.getPermissionState().catch(
       () => ({
-        state: "unavailable" as const,
-        precise: false,
-        background: "unavailable" as const,
+        state: "prompt" as const,
+        precise: null,
+        background: "foreground-only" as const,
         locationServicesEnabled: null,
       }),
     );
@@ -2704,11 +2725,20 @@ export function OneLocationAgentPageContent({
     }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
       const shouldCapturePoint = Boolean(options?.capturePoint);
       const shouldOpenSettings = options?.autoOpenSettings !== false;
-      const shouldRequestNativePrompt = options?.requestNativePrompt === true;
       const currentPermission = await refreshLocationPermission();
 
-      if (isLocationServicesDisabled(currentPermission)) {
-        toast.error("Turn on phone Location before sharing.");
+      // Only two things stop us before we have tried, and neither can be fixed
+      // by asking: the OS location service is off, or the platform forbids the
+      // prompt outright (iOS `restricted`, or no geolocation at all).
+      //
+      // A read-back "denied" is deliberately NOT one of them. Refusing on it is
+      // what made this unrecoverable: on the web the browser's prompt appears
+      // only from `getCurrentPosition()`, so returning early guarantees the user
+      // is never asked, and a stale or unreadable value traps them for good. We
+      // attempt, and let a real PERMISSION_DENIED be the thing that blocks.
+      const blockReason = locationBlockReason(currentPermission);
+      if (blockReason) {
+        toast.error(LOCATION_BLOCK_MESSAGE[blockReason]);
         if (shouldOpenSettings) {
           await OneLocationService.openLocationSettings().catch(() => null);
         }
@@ -2716,32 +2746,19 @@ export function OneLocationAgentPageContent({
       }
 
       if (
-        currentPermission.state === "restricted" ||
-        (currentPermission.state === "denied" && !shouldRequestNativePrompt)
+        currentPermission.state === "granted" &&
+        !shouldCapturePoint &&
+        !observedLocationDenialRef.current
       ) {
-        toast.error("Allow location permission before sharing.");
-        if (shouldOpenSettings) {
-          await OneLocationService.openLocationSettings().catch(() => null);
-        }
-        return { ready: false };
-      }
-
-      if (currentPermission.state === "unavailable") {
-        toast.error(
-          "Location is unavailable. Check your phone Location settings.",
-        );
-        if (shouldOpenSettings) {
-          await OneLocationService.openLocationSettings().catch(() => null);
-        }
-        return { ready: false };
-      }
-
-      if (currentPermission.state === "granted" && !shouldCapturePoint) {
         return { ready: true };
       }
 
       try {
         const point = await OneLocationService.captureCurrentPosition();
+        // A coordinate in hand outranks anything the permission API says. This
+        // is what keeps Safari honest, where the value is simply unreadable.
+        observedLocationDenialRef.current = false;
+        setLocationDenialObserved(false);
         const nextPermission =
           await OneLocationService.getPermissionState().catch(() => null);
         setPermission(
@@ -2762,11 +2779,17 @@ export function OneLocationAgentPageContent({
         if (nextPermission) {
           setPermission(nextPermission);
         }
+        // Only an attempt can prove a denial. Record it so the UI can say
+        // "blocked" and offer settings, instead of guessing from a query.
+        const denied = isLocationPermissionDeniedError(error);
+        observedLocationDenialRef.current = denied;
+        setLocationDenialObserved(denied);
         const message = locationServicesErrorMessage(error);
         toast.error(message);
         if (
           shouldOpenSettings &&
-          (isLocationServicesDisabled(nextPermission) ||
+          (denied ||
+            isLocationServicesDisabled(nextPermission) ||
             message.toLowerCase().includes("turn on location"))
         ) {
           await OneLocationService.openLocationSettings().catch(() => null);
@@ -7178,9 +7201,23 @@ export function OneLocationAgentPageContent({
 
   useEffect(() => {
     const refreshIfPending = () => {
-      if (!locationOnboardingRetryOnResumeRef.current) return;
+      // Permission is changed outside the app — iOS Settings, Safari's site
+      // settings, the Android permission sheet — so coming back is exactly when
+      // our copy of it is most likely to be wrong. This used to re-read only
+      // when onboarding had armed a retry flag, which left everyone else
+      // looking at a stale verdict until a full reload.
+      const hadPendingRetry = locationOnboardingRetryOnResumeRef.current;
       locationOnboardingRetryOnResumeRef.current = false;
-      void refreshLocationPermission();
+      void refreshLocationPermission().then((next) => {
+        // Returning with permission actually granted clears an old observed
+        // denial, so the UI stops claiming "blocked" the moment it stops being
+        // true.
+        if (next?.state === "granted") {
+          observedLocationDenialRef.current = false;
+          setLocationDenialObserved(false);
+        }
+      });
+      return hadPendingRetry;
     };
     const refreshWhenVisible = () => {
       if (document.visibilityState === "hidden") return;
@@ -7427,6 +7464,12 @@ export function OneLocationAgentPageContent({
     },
     permissionIsPrompt: permission?.state === "prompt",
     locationEnabled,
+    locationBlocked:
+      resolveLocationReadiness({
+        permission,
+        hasFix: Boolean(myLocationPoint),
+        observedDenial: locationDenialObserved,
+      }) === "blocked",
     autoShareEnabled: locationControl.autoShareEnabled,
     locationPaused: locationControl.paused,
     locationAccuracyLimited,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1516,7 +1516,10 @@ async function shareOneLocationLink(params: {
   throw new Error("Sharing is not supported on this device.");
 }
 
-function readinessCopy(permission: HushhLocationPermissionState | null): {
+function readinessCopy(
+  permission: HushhLocationPermissionState | null,
+  observedDenial = false,
+): {
   title: string;
   description: string;
   tone: "ready" | "warning" | "blocked" | "checking";
@@ -1548,13 +1551,26 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
       actionLabel: "Allow Location",
     };
   }
-  if (permission.state === "denied" || permission.state === "restricted") {
+  // Only a refusal we actually observed proves the device is blocked. A
+  // read-back `denied` may be stale, and on Safari it cannot be read at all —
+  // so this offers to ask rather than declaring a dead end the user cannot act
+  // on. `restricted` is genuinely unaskable and stays blocked.
+  if (permission.state === "restricted" || (permission.state === "denied" && observedDenial)) {
     return {
       title: "Location permission blocked",
       description:
         "Allow location access from app settings before you share your location.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
+    };
+  }
+  if (permission.state === "denied") {
+    return {
+      title: "Allow location permission",
+      description:
+        "One will ask this device for location access the moment you share.",
+      tone: "warning",
+      actionLabel: "Allow Location",
     };
   }
   if (permission.state === "unavailable") {
@@ -2275,8 +2291,7 @@ export function OneLocationAgentPageContent({
   // perfectly usable for picking the venue you are standing in.
   const locationAccuracyLimited =
     locationEnabled &&
-    (permission?.state !== "granted" ||
-      permission?.precise === false ||
+    (permission?.precise === false ||
       (typeof myLocationPoint?.accuracyM === "number" &&
         Number.isFinite(myLocationPoint.accuracyM) &&
         myLocationPoint.accuracyM > ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS));
@@ -6441,8 +6456,8 @@ export function OneLocationAgentPageContent({
       busy === "load" ||
       Boolean(auth.userId && vaultOwnerToken));
   const locationReadiness = useMemo(
-    () => readinessCopy(permission),
-    [permission],
+    () => readinessCopy(permission, locationDenialObserved),
+    [permission, locationDenialObserved],
   );
   const handleRequestLocationPermission = useCallback(async () => {
     setBusy("locationSettings");
@@ -7138,10 +7153,7 @@ export function OneLocationAgentPageContent({
         return;
       }
 
-      if (
-        permission?.state === "denied" ||
-        permission?.state === "restricted"
-      ) {
+      if (permission?.state === "restricted") {
         await openAppSettingsForOnboarding();
         return;
       }
@@ -7176,7 +7188,12 @@ export function OneLocationAgentPageContent({
         return;
       }
 
-      if (requestedPermission.state !== "granted") {
+      if (
+        requestedPermission.state !== "granted" &&
+        !(await OneLocationService.captureCurrentPosition()
+          .then(() => true)
+          .catch(() => false))
+      ) {
         await openAppSettingsForOnboarding();
         return;
       }
@@ -7200,28 +7217,32 @@ export function OneLocationAgentPageContent({
   ]);
 
   useEffect(() => {
+    // Onboarding's own retry, unchanged: it owns the flag and the ordering that
+    // the saved-place prompt depends on.
     const refreshIfPending = () => {
-      // Permission is changed outside the app — iOS Settings, Safari's site
-      // settings, the Android permission sheet — so coming back is exactly when
-      // our copy of it is most likely to be wrong. This used to re-read only
-      // when onboarding had armed a retry flag, which left everyone else
-      // looking at a stale verdict until a full reload.
-      const hadPendingRetry = locationOnboardingRetryOnResumeRef.current;
+      if (!locationOnboardingRetryOnResumeRef.current) return;
       locationOnboardingRetryOnResumeRef.current = false;
+      void refreshLocationPermission();
+    };
+    // Separately, and for everyone: permission is changed outside the app — iOS
+    // Settings, Safari's site settings, the Android sheet — so coming back is
+    // exactly when our copy of it is most likely to be stale. Re-reading only
+    // behind onboarding's flag left every other surface showing an old verdict
+    // until a full reload.
+    const refreshPermissionOnReturn = () => {
       void refreshLocationPermission().then((next) => {
-        // Returning with permission actually granted clears an old observed
-        // denial, so the UI stops claiming "blocked" the moment it stops being
-        // true.
+        // Once it is actually granted, an old observed denial is history, so
+        // the UI stops claiming "blocked" the moment that stops being true.
         if (next?.state === "granted") {
           observedLocationDenialRef.current = false;
           setLocationDenialObserved(false);
         }
       });
-      return hadPendingRetry;
     };
     const refreshWhenVisible = () => {
       if (document.visibilityState === "hidden") return;
       refreshIfPending();
+      refreshPermissionOnReturn();
     };
 
     window.addEventListener("focus", refreshWhenVisible);

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -311,6 +311,13 @@ export function LocationImmersiveMap() {
   const [status, setStatus] = useState<
     "idle" | "loading" | "ready" | "unavailable" | "error"
   >("idle");
+  // Why the map is unavailable. Both causes used to render the same card, which
+  // told the user "no location was captured or exposed" when their location was
+  // fine and the build simply had no Maps key — sending them to debug the wrong
+  // thing entirely.
+  const [unavailableReason, setUnavailableReason] = useState<
+    "maps-key" | "renderer"
+  >("maps-key");
   const [busy, setBusy] = useState<"presence" | "locate" | null>(null);
   const [nearbyConnectionBusyAlias, setNearbyConnectionBusyAlias] = useState<
     string | null
@@ -695,6 +702,7 @@ export function LocationImmersiveMap() {
     if (!rendererReady || !mapElement.current) return;
     const apiKey = mapApiKey();
     if (!apiKey) {
+      setUnavailableReason("maps-key");
       setStatus("unavailable");
       return;
     }
@@ -755,7 +763,9 @@ export function LocationImmersiveMap() {
         setMapReady(true);
       })
       .catch(() => {
-        if (!cancelled) setStatus("unavailable");
+        if (cancelled) return;
+        setUnavailableReason("renderer");
+        setStatus("unavailable");
       });
     return () => {
       cancelled = true;
@@ -1678,11 +1688,14 @@ export function LocationImmersiveMap() {
       {rendererReady && status === "unavailable" ? (
         <section className="absolute inset-x-4 bottom-4 z-20 rounded-3xl bg-background/95 p-5 shadow-xl">
           <h1 className="font-semibold">
-            Your Map needs secure map configuration
+            {unavailableReason === "maps-key"
+              ? "This build has no Maps key"
+              : "The map could not start"}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            No location was captured or exposed. Try again after the app’s
-            restricted Maps key is configured.
+            {unavailableReason === "maps-key"
+              ? "Your location is fine — this app build was packaged without its restricted Google Maps key, so the map cannot render. Nothing about your location was captured or shared."
+              : "The map renderer failed to load. Check your connection and try again — your location was not captured or shared."}
           </p>
         </section>
       ) : null}

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -35,6 +35,7 @@ import { Switch } from "@/components/ui/switch";
 import { relationshipCta } from "@/lib/connections/relationship-label";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+import { locationBlockReason } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
   ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS,
@@ -635,10 +636,13 @@ export function NearbyCheckInSheet({
           }
           return;
         }
-        if (
-          permission?.state === "denied" ||
-          permission?.state === "restricted"
-        ) {
+        // Only refuse what asking cannot fix. A read-back `denied` is not
+        // proof — Safari cannot report the value at all, and both browsers and
+        // Android re-prompt — so it falls through to the capture below, which
+        // is what actually surfaces the permission prompt. This comment's own
+        // promise, that "the one-shot capture remains authoritative", was not
+        // being kept: the check-in sheet refused here before ever attempting.
+        if (locationBlockReason(permission ?? null)) {
           setLocationRecovery(isNative() ? "app-settings" : null);
           if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
             setPoint(null);

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -62,6 +62,7 @@ import type {
   OneLocationRecipient,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
+import { locationStatusLabel } from "@/lib/one-location/location-readiness";
 import type { CircleRecipientSelection } from "@/lib/one-location/circle-recipient-selection";
 
 import {
@@ -172,6 +173,13 @@ export type LocationHubViewModel = {
   };
   permissionIsPrompt: boolean;
   locationEnabled: boolean;
+  /**
+   * The device has refused location and only its settings can undo that.
+   * Distinct from `locationEnabled`, which is the preview control's own state:
+   * a user whose location works perfectly still starts with the preview off,
+   * and must not be told their location is blocked.
+   */
+  locationBlocked: boolean;
   autoShareEnabled: boolean;
   locationPaused: boolean;
   locationAccuracyLimited: boolean;
@@ -478,13 +486,12 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
   const locationOn = vm.locationEnabled;
   const toggling = BUSY(vm, "selfLocation");
   const refreshing = BUSY(vm, "load");
-  const statusLabel = vm.locationPaused
-    ? "Location paused"
-    : vm.locationAccuracyLimited
-      ? "Location limited"
-      : locationOn
-        ? "Location on"
-        : "Location off";
+  const statusLabel = locationStatusLabel({
+    readiness: vm.locationBlocked ? "blocked" : locationOn ? "ready" : "askable",
+    previewOn: locationOn,
+    paused: vm.locationPaused,
+    accuracyLimited: vm.locationAccuracyLimited,
+  });
 
   const handleLocationChange = (checked: boolean) => {
     if (checked === locationOn) return;

--- a/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-background.test.ts
+++ b/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-background.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HushhLocationWeb } from "@/lib/capacitor/plugins/location-web";
 
 describe("HushhLocationWeb background sharing", () => {
@@ -17,5 +17,55 @@ describe("HushhLocationWeb background sharing", () => {
   it("stopBackgroundShare resolves as a no-op on web", async () => {
     const web = new HushhLocationWeb();
     await expect(web.stopBackgroundShare()).resolves.toBeUndefined();
+  });
+});
+
+describe("HushhLocationWeb.getPermissionState", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports prompt when the browser cannot answer the query", async () => {
+    // Safari/WebKit has no `geolocation` entry in the Permissions API, so this
+    // rejects on every iPhone. An unguarded await used to surface as
+    // `unavailable`, which blocked every share path and pinned the Location
+    // toggle off on a device whose location worked perfectly.
+    vi.stubGlobal("navigator", {
+      geolocation: { getCurrentPosition: vi.fn(), watchPosition: vi.fn(), clearWatch: vi.fn() },
+      permissions: {
+        query: vi.fn().mockRejectedValue(new TypeError("GeolocationPermissionDescriptor")),
+      },
+    });
+
+    const state = await new HushhLocationWeb().getPermissionState();
+
+    expect(state.state).toBe("prompt");
+    expect(state.locationServicesEnabled).not.toBe(false);
+  });
+
+  it("reports prompt when the Permissions API is absent entirely", async () => {
+    vi.stubGlobal("navigator", {
+      geolocation: { getCurrentPosition: vi.fn(), watchPosition: vi.fn(), clearWatch: vi.fn() },
+    });
+
+    expect((await new HushhLocationWeb().getPermissionState()).state).toBe("prompt");
+  });
+
+  it("passes a real answer through untouched", async () => {
+    vi.stubGlobal("navigator", {
+      geolocation: { getCurrentPosition: vi.fn(), watchPosition: vi.fn(), clearWatch: vi.fn() },
+      permissions: { query: vi.fn().mockResolvedValue({ state: "granted" }) },
+    });
+
+    expect((await new HushhLocationWeb().getPermissionState()).state).toBe("granted");
+  });
+
+  it("reports unavailable only when the device truly has no geolocation", async () => {
+    vi.stubGlobal("navigator", {});
+
+    const state = await new HushhLocationWeb().getPermissionState();
+
+    expect(state.state).toBe("unavailable");
+    expect(state.locationServicesEnabled).toBe(false);
   });
 });

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -18,23 +18,37 @@ export class HushhLocationWeb implements HushhLocationPlugin {
         locationServicesEnabled: false,
       };
     }
-    if (!navigator.permissions?.query) {
-      return {
-        state: "prompt",
-        precise: null,
-        background: "foreground-only",
-        locationServicesEnabled: null,
-      };
-    }
-    const result = await navigator.permissions.query({
-      name: "geolocation" as PermissionName,
-    });
-    return {
-      state: result.state,
+    // "We could not read the permission" must resolve to `prompt`, never to a
+    // denial. WebKit does not support the `geolocation` name in the Permissions
+    // API, so on every iPhone this query REJECTS — and an unguarded await here
+    // used to surface as `unavailable` upstream, which blocked sharing and
+    // pinned the toggle off on a device whose location worked perfectly.
+    //
+    // `prompt` is the honest answer to not knowing: it means "ask the device".
+    // Geolocation itself exists (checked above); only our ability to introspect
+    // it is missing.
+    const unknownButAskable: HushhLocationPermissionState = {
+      state: "prompt",
       precise: null,
       background: "foreground-only",
       locationServicesEnabled: null,
     };
+    if (!navigator.permissions?.query) {
+      return unknownButAskable;
+    }
+    try {
+      const result = await navigator.permissions.query({
+        name: "geolocation" as PermissionName,
+      });
+      return {
+        state: result.state,
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: null,
+      };
+    } catch {
+      return unknownButAskable;
+    }
   }
 
   async requestLocationPermission(): Promise<HushhLocationPermissionState> {

--- a/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import type { HushhLocationPermissionState } from "@/lib/capacitor";
+import {
+  canAttemptLocation,
+  canPromptForLocation,
+  isLocationPermissionDeniedError,
+  locationBlockReason,
+  locationReadiness,
+  locationStatusLabel,
+} from "@/lib/one-location/location-readiness";
+
+function permission(
+  over: Partial<HushhLocationPermissionState>,
+): HushhLocationPermissionState {
+  return {
+    state: "prompt",
+    precise: null,
+    background: "foreground-only",
+    locationServicesEnabled: null,
+    ...over,
+  } as HushhLocationPermissionState;
+}
+
+describe("what may be attempted", () => {
+  it("attempts when the platform cannot report its own permission", () => {
+    // Safari has no `geolocation` entry in the Permissions API, so every iPhone
+    // arrives here knowing nothing. Nothing is a reason to ask the device, and
+    // treating it as a refusal is what pinned the toggle off on phones whose
+    // location worked.
+    expect(canAttemptLocation(permission({ state: "prompt" }))).toBe(true);
+    expect(canAttemptLocation(null)).toBe(true);
+  });
+
+  it("attempts even when a stale read claims denied", () => {
+    // The browser prompt only appears from getCurrentPosition(). Refusing on a
+    // read-back denial guarantees it never appears, which leaves the user stuck
+    // behind "Allow location permission before sharing" with no way out.
+    expect(canAttemptLocation(permission({ state: "denied" }))).toBe(true);
+    expect(locationBlockReason(permission({ state: "denied" }))).toBeNull();
+  });
+
+  it("does not attempt what asking cannot fix", () => {
+    expect(locationBlockReason(permission({ locationServicesEnabled: false }))).toBe(
+      "services-off",
+    );
+    expect(locationBlockReason(permission({ state: "restricted" }))).toBe("restricted");
+    expect(locationBlockReason(permission({ state: "unavailable" }))).toBe("unsupported");
+  });
+
+  it("calls an OS-level switch off rather than unsupported, even when both look true", () => {
+    // iOS reports state=unavailable AND locationServicesEnabled=false when the
+    // system toggle is off. That is a fixable setting, not a dead device, and
+    // the message the user gets has to say so.
+    expect(
+      locationBlockReason(
+        permission({ state: "unavailable", locationServicesEnabled: false }),
+      ),
+    ).toBe("services-off");
+  });
+
+  it("only promises a prompt when one can actually appear", () => {
+    expect(canPromptForLocation(permission({ state: "prompt" }))).toBe(true);
+    expect(canPromptForLocation(permission({ state: "denied" }))).toBe(false);
+    expect(canPromptForLocation(permission({ state: "restricted" }))).toBe(false);
+  });
+});
+
+describe("recognising a real denial", () => {
+  it("recognises each platform's way of saying no", () => {
+    const web = new Error("Location permission is blocked for this site.");
+    web.name = "LocationPermissionDeniedError";
+    expect(isLocationPermissionDeniedError(web)).toBe(true);
+    // iOS and Android plugins both reject with this exact string.
+    expect(
+      isLocationPermissionDeniedError(new Error("Location permission was not granted.")),
+    ).toBe(true);
+    expect(isLocationPermissionDeniedError({ code: 1 })).toBe(true);
+  });
+
+  it("does not mistake a slow fix for a refusal", () => {
+    // Sending someone to Settings because their GPS was slow is worse than
+    // useless: the setting they are told to change is already correct.
+    expect(
+      isLocationPermissionDeniedError(new Error("Precise location unavailable before timeout.")),
+    ).toBe(false);
+    expect(
+      isLocationPermissionDeniedError(
+        new Error("Could not get your location. Turn on Location for your device/browser."),
+      ),
+    ).toBe(false);
+    expect(isLocationPermissionDeniedError(null)).toBe(false);
+    expect(isLocationPermissionDeniedError({ code: 3 })).toBe(false);
+  });
+});
+
+describe("what the UI may claim", () => {
+  it("treats a fix in hand as the authority over any permission value", () => {
+    // The whole point: a device that just produced a coordinate is working,
+    // whatever the permission API says — including saying nothing at all.
+    expect(
+      locationReadiness({
+        permission: permission({ state: "denied" }),
+        hasFix: true,
+      }),
+    ).toBe("ready");
+  });
+
+  it("is askable while nothing is known", () => {
+    expect(
+      locationReadiness({ permission: permission({ state: "prompt" }), hasFix: false }),
+    ).toBe("askable");
+  });
+
+  it("is blocked only after a denial was actually observed", () => {
+    const stale = permission({ state: "denied" });
+    expect(locationReadiness({ permission: stale, hasFix: false })).toBe("askable");
+    expect(
+      locationReadiness({ permission: stale, hasFix: false, observedDenial: true }),
+    ).toBe("blocked");
+  });
+
+  it("is blocked when the OS switch is off, without needing an attempt", () => {
+    expect(
+      locationReadiness({
+        permission: permission({ locationServicesEnabled: false }),
+        hasFix: false,
+      }),
+    ).toBe("blocked");
+  });
+});
+
+describe("status label", () => {
+  it("never calls a working device blocked just because the preview is off", () => {
+    // The header switch is a preview control, so it legitimately starts off.
+    // Reporting that as "Location blocked" is what made a healthy phone look
+    // broken the moment the page loaded.
+    expect(
+      locationStatusLabel({
+        readiness: "askable",
+        previewOn: false,
+        paused: false,
+        accuracyLimited: false,
+      }),
+    ).toBe("Location off");
+  });
+
+  it("says blocked when it is, and pause outranks everything", () => {
+    expect(
+      locationStatusLabel({
+        readiness: "blocked",
+        previewOn: false,
+        paused: false,
+        accuracyLimited: false,
+      }),
+    ).toBe("Location blocked");
+    expect(
+      locationStatusLabel({
+        readiness: "blocked",
+        previewOn: true,
+        paused: true,
+        accuracyLimited: true,
+      }),
+    ).toBe("Location paused");
+  });
+
+  it("reports limited accuracy only while the preview is actually on", () => {
+    expect(
+      locationStatusLabel({
+        readiness: "ready",
+        previewOn: true,
+        paused: false,
+        accuracyLimited: true,
+      }),
+    ).toBe("Location limited");
+    expect(
+      locationStatusLabel({
+        readiness: "ready",
+        previewOn: true,
+        paused: false,
+        accuracyLimited: false,
+      }),
+    ).toBe("Location on");
+  });
+});

--- a/hushh-webapp/lib/one-location/location-readiness.ts
+++ b/hushh-webapp/lib/one-location/location-readiness.ts
@@ -1,0 +1,158 @@
+/**
+ * One answer to "can we ask this device for a location right now?".
+ *
+ * The rule this module exists to enforce: **a permission query is a hint, an
+ * attempt is the truth.** Only the platform can say whether it will prompt, and
+ * on the web the only way to find out is to call `getCurrentPosition()` — the
+ * browser shows its prompt there and nowhere else. Refusing beforehand because
+ * a query said "denied" guarantees the prompt never appears, which is how a
+ * user whose state is stale or unreadable ends up permanently stuck behind
+ * "Allow location permission before sharing" with no in-app way out.
+ *
+ * Safari makes that failure mode the default rather than an edge case: WebKit
+ * does not support the `geolocation` name in the Permissions API, so the query
+ * rejects and the app learns nothing. Nothing is a reason to ask, not a reason
+ * to refuse.
+ *
+ * So exactly two conditions block before an attempt, and both are things the
+ * app genuinely cannot resolve by asking:
+ *   - the OS location service is switched off (`locationServicesEnabled: false`)
+ *   - iOS reports `restricted` (parental controls / MDM — no prompt exists)
+ *
+ * Everything else attempts, and the resulting error is what decides.
+ */
+
+import type { HushhLocationPermissionState } from "@/lib/capacitor";
+
+export type LocationBlockReason =
+  /** The device has no geolocation capability at all. */
+  | "unsupported"
+  /** OS-level Location Services are switched off. */
+  | "services-off"
+  /** iOS parental controls or MDM. No prompt can be shown. */
+  | "restricted";
+
+/** Copy for the one thing the user can actually do about each block. */
+export const LOCATION_BLOCK_MESSAGE: Record<LocationBlockReason, string> = {
+  unsupported: "This device or browser cannot share location.",
+  "services-off": "Turn on Location for your device, then try again.",
+  restricted: "Location is restricted on this device by its settings policy.",
+};
+
+/**
+ * Why an attempt cannot even be made, or null when one should be attempted.
+ *
+ * `denied` is deliberately absent. A denial we merely *read* is not a denial we
+ * *observed*: browsers re-prompt after a reset, Android re-prompts unless the
+ * user chose "don't ask again", and Safari cannot report the value at all. We
+ * find out by asking.
+ */
+export function locationBlockReason(
+  permission: HushhLocationPermissionState | null,
+): LocationBlockReason | null {
+  if (!permission) return null;
+  if (permission.state === "unavailable" && permission.locationServicesEnabled === false) {
+    return "services-off";
+  }
+  if (permission.state === "unavailable") return "unsupported";
+  if (permission.locationServicesEnabled === false) return "services-off";
+  if (permission.state === "restricted") return "restricted";
+  return null;
+}
+
+/** True when a capture attempt is worth making on a user gesture. */
+export function canAttemptLocation(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  return locationBlockReason(permission) === null;
+}
+
+/**
+ * True when the platform can still surface its own permission prompt.
+ *
+ * Used to choose between "we will ask you" and "we have to send you to
+ * Settings". An unknown state counts as promptable: assuming we cannot ask is
+ * what created the dead end in the first place.
+ */
+export function canPromptForLocation(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  if (!canAttemptLocation(permission)) return false;
+  return permission?.state !== "denied";
+}
+
+/**
+ * Did this capture failure actually come from a refused permission?
+ *
+ * The three platforms report the same fact three ways, and only this one
+ * distinguishes "you said no" from "the fix timed out" — which is the
+ * difference between sending someone to Settings and telling them to retry.
+ *
+ *   web     `Error` named `LocationPermissionDeniedError` (location-web.ts)
+ *   iOS     rejects with "Location permission was not granted."
+ *   Android rejects with the same string
+ *
+ * Matching on message text is unpleasant, but it is the contract the native
+ * plugins already publish; the alternative is to let a timeout masquerade as a
+ * denial and strand the user in Settings for no reason.
+ */
+export function isLocationPermissionDeniedError(error: unknown): boolean {
+  if (!error) return false;
+  if (typeof error === "object" && error !== null) {
+    const named = error as { name?: unknown; code?: unknown };
+    if (named.name === "LocationPermissionDeniedError") return true;
+    // Raw GeolocationPositionError.PERMISSION_DENIED, if one ever reaches here
+    // unwrapped.
+    if (named.code === 1) return true;
+  }
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return /permission (was not granted|is blocked|denied)|denied geolocation/i.test(
+    message,
+  );
+}
+
+export type LocationReadiness =
+  /** A usable fix is in hand. */
+  | "ready"
+  /** Nothing blocks an attempt; the platform may prompt. */
+  | "askable"
+  /** Observed denial — recoverable only through device settings. */
+  | "blocked";
+
+/**
+ * What the UI should claim about location right now.
+ *
+ * `hasFix` is the authority: a device that just produced a coordinate is
+ * working, whatever any permission API claims about it. This is what keeps the
+ * status honest on Safari, where the permission value is unreadable.
+ */
+export function locationReadiness(params: {
+  permission: HushhLocationPermissionState | null;
+  hasFix: boolean;
+  /** Set once a capture attempt has failed with a real PERMISSION_DENIED. */
+  observedDenial?: boolean;
+}): LocationReadiness {
+  if (params.hasFix) return "ready";
+  if (params.observedDenial) return "blocked";
+  if (!canAttemptLocation(params.permission)) return "blocked";
+  return "askable";
+}
+
+/** Short status text for the Location header. */
+export function locationStatusLabel(params: {
+  readiness: LocationReadiness;
+  previewOn: boolean;
+  paused: boolean;
+  accuracyLimited: boolean;
+}): string {
+  if (params.paused) return "Location paused";
+  if (params.readiness === "blocked") return "Location blocked";
+  if (!params.previewOn) return "Location off";
+  if (params.accuracyLimited) return "Location limited";
+  return "Location on";
+}


### PR DESCRIPTION
## The bug

On **one.hushh.ai in iPhone Safari**, the Location toggle sits **off** on a phone whose location works, and tapping it answers *"Allow location permission before sharing"* — permanently, with no way out.

## Root cause — five defects in one chain

| # | where | defect |
|---|---|---|
| 1 | `location-web.ts` | `await navigator.permissions.query({name:"geolocation"})` **unguarded**. WebKit has no `geolocation` entry in the Permissions API, so this **rejects on every iPhone**. |
| 2 | `refreshLocationPermission` | caught it and substituted `state:"unavailable"` — turning *"we could not read the permission"* into *"you are denied"*. |
| 3 | `locationPermissionBlocksSharing` | treats `unavailable` as blocking → all four share paths refused. |
| 4 | toggle readiness | required `state === "granted"`, which `unavailable` never satisfies → the switch could never turn on. |
| 5 | `ensureForegroundLocationReady` | returned early on `denied`/`restricted` **without ever calling `getCurrentPosition`**. |

**Defect 5 is the one that makes it unrecoverable.** On the web, `getCurrentPosition()` is the *only* thing that makes a browser show its permission prompt. Returning early guarantees the user is never asked — so a stale or unreadable value traps them for good. Android has the same shape: a denied runtime permission is usually re-requestable, but we never re-request.

## The fix — a query is a hint, an attempt is the truth

Exactly **two** conditions block before trying, and neither can be fixed by asking:

- the OS location switch is off (`locationServicesEnabled: false`)
- the platform forbids the prompt — iOS `restricted`, or no geolocation at all

Everything else **attempts**. A real `PERMISSION_DENIED` from that attempt is what blocks, sets the blocked status and routes to settings; a successful fix clears it, so the UI stops claiming blocked the moment it stops being true.

A read-back `denied` is deliberately **not** a blocker — that is the change that ends the dead end, and it is what makes the app always ask.

### One tested module, not scattered predicates

The decision now lives in `lib/one-location/location-readiness.ts` rather than in predicates spread through a 7,500-line page, so it cannot drift back. It knows each platform's denial signature — the web's named error, the identical string iOS and Android both reject with — and deliberately does **not** treat a slow fix as a refusal, which would send people to change a setting that is already correct.

### Also fixed

- **Permission is re-read on every visibility/resume**, not only when onboarding had armed a retry flag. Permission changes happen in iOS Settings and Safari's site settings, so returning is exactly when our copy is most likely stale.
- **The header distinguishes "blocked" from "off".** The switch is a preview control and legitimately starts off; reporting that as blocked is what made a healthy phone look broken on load.

## Separate bug, same report: the iOS map card

The Check-In map showed *"Your Map needs secure map configuration — No location was captured or exposed."* **That is not a location bug.** `status:"unavailable"` there is set purely by a missing Maps API key; it never consults permission.

The real cause is that the iOS build was packaged **without** `NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY`. Every other key in `release-ios-appstore.yml` uses `require` (fails the build); the Maps key is the **sole exception**:

```bash
[ -n "$MAPS_IOS_KEY" ] && put NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY "$MAPS_IOS_KEY"
```

So a missing secret silently ships a build with a dead map. **Setting that secret is an ops action, not a code change** — this PR does not attempt it. What it does fix is the misdirection: the card blamed location capture, sending users to debug the wrong thing. It now names the real cause and distinguishes a missing key from a renderer failure, and both make clear no location was captured or shared.

I'd suggest a follow-up making that key `require`d like the others, so a build that would ship a dead map fails instead. Left out here deliberately — it touches a release lane and should be its own reviewable change.

## Verification

- **170 passed** across `lib/one-location/__tests__` and `lib/capacitor/plugins/__tests__`, including 18 new tests
- `tsc --noEmit` clean
- `npm run lint`: **41 problems on pristine `origin/main`, 41 with this branch** — zero introduced (all pre-existing, in files this PR does not touch)

New tests cover: an unreadable Permissions API resolving to `prompt` rather than a denial; a stale `denied` still being attemptable; OS-switch-off reported as fixable rather than unsupported; each platform's denial signature; a timeout *not* being mistaken for a refusal; a fix in hand outranking any permission value; and "off" never being rendered as "blocked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)