### PR TITLE
fix(navigation): let back leave a section by the way the person entered it

### DIFF
--- a/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
+++ b/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveAgentSectionForPath } from "@/lib/navigation/agent-sections";
+import {
+  clearSectionOrigins,
+  isSectionRoot,
+  readSectionOrigin,
+  readSectionOriginsForTest,
+  recordSectionEntry,
+} from "@/lib/navigation/section-back-origin";
+import {
+  navigateTopShellBack,
+  resolveTopShellBackAction,
+} from "@/lib/navigation/top-shell-back";
+
+const KAI = "/one/kai";
+const KAI_ANALYSIS = "/one/kai/analysis";
+const LOCATION = "/one/location";
+const ONE_HOME = "/one";
+
+beforeEach(() => {
+  clearSectionOrigins();
+});
+
+/**
+ * Inside a section the declared parent already climbs correctly and needs no
+ * memory. The hierarchy simply cannot know which section the person crossed in
+ * from, and that is the only case back got wrong: One home is what *contains*
+ * Location, so entering Location from Finance and pressing back landed there.
+ */
+describe("section entry recording", () => {
+  it("stores nothing for a move inside one section", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(KAI_ANALYSIS);
+
+    expect(readSectionOriginsForTest()).toEqual([]);
+  });
+
+  it("stores one entry when crossing between sections", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(KAI_ANALYSIS);
+    recordSectionEntry(LOCATION);
+
+    const stored = readSectionOriginsForTest();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.from).toBe(KAI_ANALYSIS);
+  });
+
+  it("ignores query and hash, so an overlay is never an entry", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(`${LOCATION}?action=share`);
+    recordSectionEntry(`${LOCATION}#map`);
+
+    expect(readSectionOriginsForTest()).toHaveLength(1);
+  });
+
+  it("refuses anything that is not an in-app absolute path", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry("https://example.com/one/location");
+    recordSectionEntry("//evil.example.com");
+
+    expect(readSectionOriginsForTest()).toEqual([]);
+  });
+
+  it("unwinds rather than stacking when a section is re-entered", () => {
+    recordSectionEntry(ONE_HOME);
+    recordSectionEntry(KAI);
+    recordSectionEntry(LOCATION);
+    recordSectionEntry(KAI);
+
+    // Back in Kai, so Location's origin is spent, not kept alongside a second
+    // Kai entry that would grow every time the person moved between two
+    // sections.
+    const ids = readSectionOriginsForTest().map((entry) => entry.sectionId);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(readSectionOrigin(LOCATION)).toBeNull();
+  });
+});
+
+describe("back leaves a section by its origin and climbs inside one", () => {
+  it("returns to the section the person came from", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(LOCATION);
+
+    // Location's declared parent is One home. The person came from Kai.
+    expect(resolveTopShellBackAction({ pathname: LOCATION })).toEqual({
+      href: KAI,
+      mode: "push",
+    });
+  });
+
+  it("climbs the hierarchy inside a section, ignoring the origin", () => {
+    recordSectionEntry(LOCATION);
+    recordSectionEntry(KAI);
+    recordSectionEntry(KAI_ANALYSIS);
+
+    // Analysis is not a section root, so back climbs to its declared parent
+    // rather than jumping out to Location.
+    const action = resolveTopShellBackAction({ pathname: KAI_ANALYSIS });
+    expect(action?.href).not.toBe(LOCATION);
+    expect(isSectionRoot(KAI_ANALYSIS)).toBe(false);
+  });
+
+  it("falls back to the declared parent with no recorded origin", () => {
+    // A deep link, a cold start, a shared invite link. Unchanged behaviour.
+    expect(resolveTopShellBackAction({ pathname: "/ria/onboarding" })).toEqual({
+      href: ONE_HOME,
+      mode: "push",
+    });
+  });
+
+  it("spends the origin so a later visit does not retrace a stale route", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(LOCATION);
+    const navigate = vi.fn();
+
+    navigateTopShellBack({ pathname: LOCATION, navigate });
+    expect(navigate).toHaveBeenCalledWith({ href: KAI, mode: "push" });
+    expect(readSectionOrigin(LOCATION)).toBeNull();
+  });
+
+  it("closes an open action sheet in place instead of leaving the section", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(LOCATION);
+    const navigate = vi.fn();
+
+    navigateTopShellBack({
+      pathname: LOCATION,
+      searchParams: new URLSearchParams("action=share"),
+      navigate,
+    });
+
+    expect(navigate).toHaveBeenCalledWith({ href: LOCATION, mode: "replace" });
+    // The overlay closed; the origin is still owed for when they actually go.
+    expect(readSectionOrigin(LOCATION)).toBe(KAI);
+  });
+
+  it("still reports no back where the shell hides it", () => {
+    recordSectionEntry(KAI);
+    recordSectionEntry(LOCATION);
+
+    // The iOS edge-back gesture enables itself from this returning an action,
+    // so when back exists must not shift.
+    expect(
+      resolveTopShellBackAction({
+        pathname: LOCATION,
+        breadcrumb: { backHref: ONE_HOME, hideBack: true, items: [] },
+      }),
+    ).toBeNull();
+  });
+
+  it("treats a section root as the exit point", () => {
+    expect(isSectionRoot(LOCATION)).toBe(true);
+    expect(resolveAgentSectionForPath(LOCATION)).not.toBeNull();
+  });
+});

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -53,6 +53,7 @@ import {
   useKaiBottomChromeProgressCssVar,
 } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
+import { recordSectionEntry } from "@/lib/navigation/section-back-origin";
 import {
   ROUTES,
   isFoundationPublicRoute,
@@ -86,6 +87,15 @@ function AppShellFrame({ children }: ProvidersProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { isAuthenticated, loading: authLoading } = useAuth();
+  // Section crossings behind the shared back contract. Recorded here because
+  // this frame renders for every route, including chrome-less ones, and a
+  // screen with no top bar can still be the place a section was entered from.
+  // Moves inside a section store nothing. `pathname`, not `shellPathname`:
+  // this is where the person went, not what the shell substituted for an
+  // unauthenticated render.
+  useEffect(() => {
+    recordSectionEntry(pathname || "/");
+  }, [pathname]);
   const isPublicKnowledgeWorkspace =
     pathname === ROUTES.WELCOME &&
     ["research", "blog", "developers"].includes(searchParams?.get("tab") ?? "");

--- a/hushh-webapp/lib/navigation/section-back-origin.ts
+++ b/hushh-webapp/lib/navigation/section-back-origin.ts
@@ -1,0 +1,113 @@
+/**
+ * How the person got *into* the section they are standing in.
+ *
+ * Back is authored: `resolveTopShellBackAction` returns a route's declared
+ * parent. Inside a section that is exactly right -- Analysis climbs to Kai,
+ * Kai climbs to One -- and it needs no memory at all, because the hierarchy is
+ * already declared. The one thing the hierarchy cannot know is which section
+ * you came from when you crossed between two of them, and that is the only
+ * case where back used to dump people on One home: home is what *contains*
+ * Location, so entering Location from Finance and pressing back landed there.
+ *
+ * So this records section entries and nothing else. A move within a section
+ * stores nothing. Only a jump between sections -- Finance to PKM, Kai to
+ * Location -- pushes one entry, and back consumes it at the section root.
+ *
+ * Deliberately not browser history: that stack carries external origins, and
+ * on iOS it would eject the person out of the app. WKWebView has no native
+ * stack for Next routes, and the edge-back gesture shares this same contract.
+ */
+
+import { resolveAgentSectionForPath } from "@/lib/navigation/agent-sections";
+
+type SectionEntry = {
+  sectionId: string;
+  /** The in-app pathname the person was on when they entered this section. */
+  from: string;
+};
+
+/** Bounded by how deeply sections can nest, which is shallow in practice. */
+const MAX_ENTRIES = 8;
+
+let entries: SectionEntry[] = [];
+let currentSectionId: string | null = null;
+let currentPathname: string | null = null;
+
+function normalize(pathname: string | null | undefined): string | null {
+  const clean = String(pathname || "").trim();
+  if (!clean.startsWith("/") || clean.startsWith("//")) return null;
+  return clean.split(/[?#]/)[0] || null;
+}
+
+/**
+ * Note arrival at a pathname. Stores an entry only when the section changed,
+ * so navigating around inside one section costs nothing.
+ */
+export function recordSectionEntry(pathname: string): void {
+  const path = normalize(pathname);
+  if (!path) return;
+  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
+
+  if (sectionId && sectionId !== currentSectionId && currentPathname) {
+    // Returning to a section already on the stack is a retrace, not a new
+    // entry: unwind to it rather than stacking a second origin for it.
+    const existing = entries.findIndex((entry) => entry.sectionId === sectionId);
+    if (existing !== -1) {
+      entries = entries.slice(0, existing + 1);
+    } else {
+      entries.push({ sectionId, from: currentPathname });
+      if (entries.length > MAX_ENTRIES) entries.shift();
+    }
+  }
+
+  currentSectionId = sectionId;
+  currentPathname = path;
+}
+
+/**
+ * Where to leave this section for, or null when the person did not arrive
+ * from another section -- a deep link, a cold start, a shared invite link.
+ * The authored parent is the right answer in those cases.
+ */
+export function readSectionOrigin(pathname: string): string | null {
+  const path = normalize(pathname);
+  if (!path) return null;
+  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
+  if (!sectionId) return null;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry && entry.sectionId === sectionId) return entry.from;
+  }
+  return null;
+}
+
+/** True when this pathname is the section's own root, where back leaves it. */
+export function isSectionRoot(pathname: string): boolean {
+  const path = normalize(pathname);
+  if (!path) return false;
+  const section = resolveAgentSectionForPath(path);
+  if (!section) return false;
+  return normalize(section.href) === path;
+}
+
+/** Drop the entry for this section once back has spent it. */
+export function consumeSectionOrigin(pathname: string): void {
+  const path = normalize(pathname);
+  if (!path) return;
+  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
+  if (!sectionId) return;
+  const index = entries.findIndex((entry) => entry.sectionId === sectionId);
+  if (index !== -1) entries = entries.slice(0, index);
+}
+
+/** Reset point for a sign-out or an account switch. */
+export function clearSectionOrigins(): void {
+  entries = [];
+  currentSectionId = null;
+  currentPathname = null;
+}
+
+/** Test seam: no production caller should read the stack directly. */
+export function readSectionOriginsForTest(): SectionEntry[] {
+  return [...entries];
+}

--- a/hushh-webapp/lib/navigation/top-shell-back.ts
+++ b/hushh-webapp/lib/navigation/top-shell-back.ts
@@ -1,4 +1,9 @@
 import {
+  consumeSectionOrigin,
+  isSectionRoot,
+  readSectionOrigin,
+} from "@/lib/navigation/section-back-origin";
+import {
   resolveTopShellBreadcrumb,
   type TopShellBreadcrumbConfig,
 } from "@/lib/navigation/top-shell-breadcrumbs";
@@ -13,19 +18,37 @@ export type TopShellBackAction = {
 
 /**
  * The one deterministic back action shared by the visible top-bar control and
- * native edge gestures. It intentionally does not use browser history: a
- * nested route's authored parent is more reliable than a transient route
- * stack, and query-only flows must close in place without becoming re-openable
- * OS-back entries.
+ * native edge gestures. It still never uses browser history: that stack carries
+ * external origins (on iOS it would eject the person out of the app, and
+ * WKWebView has no native stack for Next routes at all), and query-only flows
+ * must close in place without becoming re-openable OS-back entries.
+ *
+ * Inside a section the authored parent is already correct and needs no memory:
+ * Analysis climbs to Kai, Kai climbs to One, exactly as declared. The one
+ * thing the hierarchy cannot know is which section the person crossed in from,
+ * and that is where back used to strand them -- One home is what *contains*
+ * Location, so entering Location from Finance and pressing back landed on
+ * home. `?from=` was the only origin signal and almost nothing wrote it, so
+ * whether back retraced depended on the entry point.
+ *
+ * So a section root leaves for its recorded origin, and every other route
+ * climbs. See lib/navigation/section-back-origin.ts.
  */
 export function resolveTopShellBackAction(params: {
   pathname: string;
   searchParams?: SearchParamsLike;
   breadcrumb?: TopShellBreadcrumbConfig | null;
+  /**
+   * Override the recorded section origin. `undefined` reads it, `null` forces
+   * the authored parent. A test seam; production callers pass nothing.
+   */
+  sectionOrigin?: string | null;
 }): TopShellBackAction | null {
   const breadcrumb =
     params.breadcrumb ??
     resolveTopShellBreadcrumb(params.pathname, params.searchParams);
+  // Unchanged on purpose: the iOS edge-back gesture enables itself from whether
+  // this returns an action, so when back exists must not shift.
   if (!breadcrumb || breadcrumb.hideBack) return null;
 
   const profilePanelOpen =
@@ -37,20 +60,42 @@ export function resolveTopShellBackAction(params: {
     params.pathname === ROUTES.ONE_LOCATION &&
     Boolean(params.searchParams?.get("action")?.trim());
 
-  return {
-    href: breadcrumb.backHref,
-    mode: profilePanelOpen || locationActionOpen ? "replace" : "push",
-  };
+  // An open panel or action sheet closes in place. It is a query-only state on
+  // the same screen, never a step in the trail, so it must not retrace.
+  if (profilePanelOpen || locationActionOpen) {
+    return { href: breadcrumb.backHref, mode: "replace" };
+  }
+
+  // Only the section root leaves the section. Everywhere else the declared
+  // parent already climbs the hierarchy correctly, which is why nothing is
+  // stored for moves inside a section.
+  if (!isSectionRoot(params.pathname)) {
+    return { href: breadcrumb.backHref, mode: "push" };
+  }
+
+  const origin =
+    params.sectionOrigin === undefined
+      ? readSectionOrigin(params.pathname)
+      : params.sectionOrigin;
+
+  return { href: origin || breadcrumb.backHref, mode: "push" };
 }
 
 export function navigateTopShellBack(params: {
   pathname: string;
   searchParams?: SearchParamsLike;
   breadcrumb?: TopShellBreadcrumbConfig | null;
+  sectionOrigin?: string | null;
   navigate: (action: TopShellBackAction) => void;
 }): boolean {
   const action = resolveTopShellBackAction(params);
   if (!action) return false;
+  // Leaving a section spends its origin, so a later return records a fresh
+  // one instead of retracing to a route the person has long left. Closing an
+  // overlay is a `replace` on the same screen and spends nothing.
+  if (action.mode === "push" && isSectionRoot(params.pathname)) {
+    consumeSectionOrigin(params.pathname);
+  }
   params.navigate(action);
   return true;
 }


### PR DESCRIPTION
## Summary

**Back inside an agent often landed on One home instead of the previous screen.** Nothing was failing. Back is authored: `resolveTopShellBackAction` returns a route's *declared parent*, and One home is what contains Location. So entering Location from Finance and pressing back went home, correctly and uselessly.

The only origin signal was `?from=`. It is read in nineteen places and written in about five, all hardcoded string interpolations at individual call sites, so whether back retraced depended entirely on which entry point the person used. That is the "sometimes" in the report. The existing Profile test even names an earlier round of this as *"the reported back jumps to the dashboard glitch"*, patched for that one route.

### Why not browser history

`router.back()` is the obvious fix and the wrong one here, for reasons that are specific rather than cautious:

- That stack carries **external** origins, so on iOS back can eject someone out of the app. WKWebView has no native navigation stack for Next routes at all, which is why the app owns its own edge-back gesture.
- Every query-only transition (a Location action sheet, a Profile panel, a tab switch) becomes its own entry, so back re-opens the overlay just closed. Preventing that is what the authored model exists for.

### What this does instead

Inside a section the declared parent already climbs correctly and needs **no memory at all** — Analysis climbs to Kai, Kai climbs to One, exactly as authored. The hierarchy simply cannot know which section the person crossed in from, so that is the only thing recorded:

- **One entry per section crossing.** A move within a section stores nothing.
- **Consumed at the section root**, which is the only place back leaves a section.
- **Unwound, not stacked**, when a section is re-entered, so bouncing between two sections cannot grow the stack.
- Bounded at 8 entries, in memory. Not `sessionStorage`: a stale cross-session trail would be a worse bug than the one being fixed.

Sections come from the existing agent-section registry, so this introduces no new route vocabulary.

With no recorded origin — deep link, cold start, shared invite link — behaviour is **exactly** as before, which is the right answer for precisely those cases. That also means this cannot regress anything currently working.

### iOS / TestFlight

The iOS edge-back gesture shares this resolver deliberately (*"This gesture intentionally invokes the same authored back contract as the visible top-bar button"*), so it retraces too and needed no separate change. **When** back exists is deliberately unchanged: the gesture enables itself from whether the resolver returns an action, and a hidden back stays hidden regardless of what is recorded. Recording happens in `AppShellFrame`, which renders for every route including chrome-less ones, so it behaves identically in the Capacitor static export.

## Test plan

- [x] `tsc --noEmit` clean, `eslint --max-warnings=0` clean on every changed file
- [x] 13 new tests covering: nothing stored within a section, one entry per crossing, query/hash ignored, non-in-app paths refused, re-entry unwinds, back leaves by origin, back climbs inside a section, deep-link fallback, origin spent on use, overlay closes in place without spending it, hidden back stays hidden
- [x] All 4 pre-existing `top-shell-back` contracts pass untouched, 91/91 in `__tests__/navigation`
- [x] Full frontend suite: 3138 passed, 13 failed across 8 files, all pre-existing and in untouched subsystems (marketplace `SubtleCrypto`, two vault tests, an onboarding contract, navbar/top-app-bar/location-page contracts, plus `observability-route-map` which is the `/circle/join` gap already fixed in #5006)
- [ ] Not yet verified on device: iOS edge-back on TestFlight. The resolver is shared and unit-covered, but the gesture itself deserves a real swipe test on a build.

## Reviewer notes

The behaviour change is confined to one branch of one function: a **section root** with a recorded origin now returns that origin instead of its declared parent. Every other path through `resolveTopShellBackAction` is byte-identical to before.
