### PR TITLE
fix(ios): prevent vertical wrapping on Pin / Zip onboarding label

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
@@ -23,7 +23,7 @@ function InfoRow({
 }) {
   return (
     <SettingsRow
-      title={label}
+      title={<span className="whitespace-nowrap">{label}</span>}
       trailing={
         <span className={cn("text-[15px] font-medium text-foreground", numeric && "tabular-nums")}>
           {loading ? <EnrichingPlaceholder /> : value?.trim() || "Not returned"}
@@ -50,7 +50,7 @@ function EditableRow({
 }) {
   return (
     <SettingsRow
-      title={label}
+      title={<span className="whitespace-nowrap">{label}</span>}
       trailing={
         loading ? (
           <EnrichingPlaceholder />


### PR DESCRIPTION
# Description

**Bug (iOS / TestFlight):** On the RIA Onboarding address card, the "Pin / Zip"
field label wrapped onto two lines ("Pin /" over "Zip") on narrow iOS widths,
instead of sitting on one horizontal line next to its value.

**Root cause:** the shared `SettingsRow` title slot uses
`[overflow-wrap:anywhere]`. Once the trailing value/input squeezed the
flex-shrunk label column on a small screen, the label string broke mid-label.

**Fix** (`components/ria/onboarding/onboarding-step-license-details.tsx`): wrap
the label passed from this card's **local** `InfoRow` / `EditableRow` in a
`whitespace-nowrap` span, so every field label ("Pin / Zip", "City", "Advisor"…)
stays on a single line, vertically centered next to its value. The row layout
(`SettingsRow`) already uses `items-center` + `min-w-0`; only the label wrap was
missing.

**Scope:** the shared `SettingsRow` is **untouched** — the change lives entirely
in this card's two local row helpers, so no other settings surface is affected.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: RIA onboarding license-details step — label CSS only
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: fixes the iOS (Capacitor web) label wrap; the same web component renders identically on web
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — presentational label change
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below: two-token CSS change; reverting restores the prior wrap
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: existing `__tests__/app/ria/onboarding-page.test.tsx` still passes (23); wrap is a layout property not asserted in jsdom
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed file, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`ria/onboarding-page.test.tsx`, 23 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate.
- [x] This PR changes a current reachable app surface (RIA onboarding).
- [x] Reachable production attach point: `OnboardingStepLicenseDetails` rows.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (renders inside the iOS Capacitor webview)
- [x] **iOS**: fixed here — same web component; no native plugin changed
- [x] **Android**: N/A — same component; unaffected

## 🧪 Testing

- [x] Tested on Web (unit): existing RIA onboarding page test passes (23)
- [ ] Tested on iOS Simulator/Device — not run in this environment (fix is a CSS `white-space` rule)
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Before: "Pin /" on one line, "Zip" below. After: "Pin / Zip" on a single line,
centered next to its value ("620004"). No jsdom layout assertion is possible for
wrapping; verified by inspection of the `whitespace-nowrap` rule + build.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — label styling only.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed
