### PR TITLE
fix(one-location): reach the device before the tap's activation window closes

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2740,7 +2740,18 @@ export function OneLocationAgentPageContent({
     }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
       const shouldCapturePoint = Boolean(options?.capturePoint);
       const shouldOpenSettings = options?.autoOpenSettings !== false;
-      const currentPermission = await refreshLocationPermission();
+
+      // A user gesture must reach the device before anything else awaits.
+      // Browsers only show the location prompt while the activation window
+      // opened by the tap is still alive, and every `await` before the
+      // geolocation call spends it. Reading permission first — even just to
+      // decide whether to bother — is enough: the capture is then refused with
+      // no prompt ever appearing, which is indistinguishable from a denial.
+      // That is why the toggle still dead-ended after the early return was
+      // removed. The pre-flight below now guards only the non-gesture callers,
+      // which have no activation window to protect.
+      if (!shouldCapturePoint) {
+        const currentPermission = await refreshLocationPermission();
 
       // Only two things stop us before we have tried, and neither can be fixed
       // by asking: the OS location service is off, or the platform forbids the
@@ -2751,21 +2762,21 @@ export function OneLocationAgentPageContent({
       // only from `getCurrentPosition()`, so returning early guarantees the user
       // is never asked, and a stale or unreadable value traps them for good. We
       // attempt, and let a real PERMISSION_DENIED be the thing that blocks.
-      const blockReason = locationBlockReason(currentPermission);
-      if (blockReason) {
-        toast.error(LOCATION_BLOCK_MESSAGE[blockReason]);
-        if (shouldOpenSettings) {
-          await OneLocationService.openLocationSettings().catch(() => null);
+        const blockReason = locationBlockReason(currentPermission);
+        if (blockReason) {
+          toast.error(LOCATION_BLOCK_MESSAGE[blockReason]);
+          if (shouldOpenSettings) {
+            await OneLocationService.openLocationSettings().catch(() => null);
+          }
+          return { ready: false };
         }
-        return { ready: false };
-      }
 
-      if (
-        currentPermission.state === "granted" &&
-        !shouldCapturePoint &&
-        !observedLocationDenialRef.current
-      ) {
-        return { ready: true };
+        if (
+          currentPermission.state === "granted" &&
+          !observedLocationDenialRef.current
+        ) {
+          return { ready: true };
+        }
       }
 
       try {


### PR DESCRIPTION
Follow-up to #5011, which is live on UAT. Safari now prompts and works. **Chrome still does not**, and this is the reason.

## The defect

Browsers show the location prompt **only while the user-activation window opened by the tap is still alive**. `ensureForegroundLocationReady` read permission first:

```js
const currentPermission = await refreshLocationPermission();      // ← spends the window
...
const point = await OneLocationService.captureCurrentPosition();  // ← too late
```

That read is a plugin round-trip. By the time `getCurrentPosition()` runs, the gesture is over, so the browser refuses **without ever showing the prompt** — indistinguishable from a denial.

#5011 removed the *early return*, which was enough for Safari (lenient once an origin is known). It was not enough for a browser that enforces transient activation strictly, so the toggle still answered *"Allow location permission before sharing"* on a phone whose location was on. Same dead end, one layer down.

## The fix

The pre-flight now guards only the **non-gesture** callers, which have no activation window to protect. A user gesture goes straight to the device and explains afterwards — the only ordering that can produce a prompt on a first tap.

## Verified

- **262 passed** across the location, capacitor and agent-page suites
- 2 failures, both the pre-existing emergency-number tests that fail identically on `main`
- `tsc --noEmit` clean

## Related, not fixed here

`HushhLocation` resolves its web implementation through a lazy `import()`:

```js
web: () => import("./plugins/location-web").then((m) => new m.HushhLocationWeb()),
```

The first call must load that module — another `await` ahead of `getCurrentPosition`, which can cost the activation window on the **first** tap and then work on the second. Worth pre-warming on mount, but it is a separate change and I have not verified it on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)