### PR TITLE
fix(connect): distinguish duplicate-name people

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -1744,6 +1744,8 @@ class ConnectionsService:
                     "displayName": p.get("displayName"),
                     "photoUrl": p.get("photoUrl"),
                     "email": p.get("email"),
+                    "maskedEmail": p.get("maskedEmail"),
+                    "maskedPhone": p.get("maskedPhone"),
                     "relationship": relationship(str(p.get("userId") or "")),
                 }
                 for p in people

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import text
 from api.utils.fcm_messages import build_push_message
 from api.utils.firebase_admin import ensure_firebase_admin
 from db.db_client import DatabaseExecutionError, get_db, get_db_connection
+from hushh_mcp.consent.pii_sanitizer import mask_email
 from hushh_mcp.consent.token import issue_token, validate_token
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.operons.location.policy import (
@@ -995,11 +996,13 @@ class OneLocationAgentService:
         if not row:
             return None
         display_name = str(row.get("display_name") or "").strip()
+        email = str(row.get("email") or "").strip()
         masked_phone = _mask_phone(row.get("phone_number"))
         user_id = str(row.get("user_id") or "")
         return {
             "userId": user_id,
             "displayName": display_name or masked_phone or "Verified user",
+            "maskedEmail": mask_email(email) if email else None,
             "maskedPhone": masked_phone,
             "phoneVerified": bool(row.get("phone_verified")),
             "keyId": str(row.get("key_id") or "") or None,
@@ -2952,7 +2955,7 @@ class OneLocationAgentService:
         rows = self._execute_many(
             """
             SELECT
-              a.user_id, a.display_name, a.phone_number, a.phone_verified,
+              a.user_id, a.display_name, a.email, a.phone_number, a.phone_verified,
               k.key_id, k.public_key_jwk, k.algorithm, k.created_at AS key_created_at
             FROM actor_identity_cache a
             LEFT JOIN LATERAL (
@@ -3055,7 +3058,7 @@ class OneLocationAgentService:
         rows = self._execute_many(
             """
             SELECT
-              a.user_id, a.display_name, a.phone_number, a.phone_verified,
+              a.user_id, a.display_name, a.email, a.phone_number, a.phone_verified,
               k.key_id, k.public_key_jwk, k.algorithm, k.created_at AS key_created_at
             FROM actor_identity_cache a
             LEFT JOIN LATERAL (

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -573,7 +573,14 @@ def test_search_directory_delegates_pagination_to_eligible_directory_query():
     def directory_search(owner_user_id: str, **options: object) -> dict[str, object]:
         calls.append((owner_user_id, options))
         return {
-            "items": [{"userId": "user-c", "displayName": "Cara"}],
+            "items": [
+                {
+                    "userId": "user-c",
+                    "displayName": "Cara",
+                    "maskedPhone": "******4455",
+                    "maskedEmail": "c***a@example.com",
+                }
+            ],
             "page": 2,
             "hasMore": True,
         }
@@ -591,6 +598,8 @@ def test_search_directory_delegates_pagination_to_eligible_directory_query():
                 "displayName": "Cara",
                 "photoUrl": None,
                 "email": None,
+                "maskedPhone": "******4455",
+                "maskedEmail": "c***a@example.com",
                 "relationship": "none",
             }
         ],

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2298,6 +2298,22 @@ def test_directory_candidates_query_targets_actor_identity_cache() -> None:
     assert "a.user_id <> :owner_user_id" in service.sql
 
 
+def test_recipient_payload_masks_email_for_directory_disambiguation() -> None:
+    payload = OneLocationAgentService._recipient_payload(
+        {
+            "user_id": "user-b",
+            "display_name": "Abdul Zalil",
+            "email": "abdul.secondary@example.com",
+            "phone_number": "+15550104455",
+            "phone_verified": True,
+        }
+    )
+
+    assert payload is not None
+    assert payload["maskedEmail"] == "a***y@example.com"
+    assert "abdul.secondary@example.com" not in json.dumps(payload)
+
+
 def test_directory_candidate_search_filters_before_pagination(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2317,6 +2333,7 @@ def test_directory_candidate_search_filters_before_pagination(
 
     assert result == {"items": [], "page": 3, "hasMore": False}
     assert "LOWER(COALESCE(a.display_name, '')) LIKE '%' || :query || '%'" in service.sql
+    assert "a.user_id, a.display_name, a.email" in service.sql
     assert "LIMIT :fetch_limit OFFSET :offset" in service.sql
     assert service.params == {
         "owner_user_id": "owner",

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -356,7 +356,7 @@ auth-required response.
 | GET | `/api/ria/picks` | Read the signed-in advisor's encrypted-PKM-backed Picks bootstrap; legacy uploads are intentionally unavailable |
 | POST | `/api/ria/picks` | Sync an already encrypted `ria.advisor_package` projection to currently authorized explicit Picks share artifacts |
 | GET | `/api/kai/market/insights/{user_id}` | Investor market home payload with rights-gated `pick_sources[]` and RIA feed share metadata |
-| GET | `/api/one/connections/directory` | Paginated, privacy-filtered Connect directory; display-name search only |
+| GET | `/api/one/connections/directory` | Paginated, privacy-filtered Connect directory; display-name search only, with masked email/phone labels when available so same-name candidates remain distinguishable without exposing raw identifiers |
 | GET | `/api/one/connections/{counterpart_user_id}/scope-catalog` | Server-authorized metadata and opaque handles available for a bilateral proposal |
 | POST | `/api/one/connections/requests` | Create a connection request with `requested_scope_handles[]` and `offered_scope_handles[]` |
 | POST | `/api/one/connections/requests/{request_id}/cancel` | Requester cancels a pending connection request and its pending proposals |

--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { getDirectoryPersonDescription } from "@/app/connect/directory-person-label";
+
 describe("Connect canonical surface contract", () => {
   it("uses the shared Profile/One header and settings-row geometry", () => {
     const source = readFileSync(
@@ -35,5 +37,34 @@ describe("Connect canonical surface contract", () => {
     expect(source).not.toContain(
       "if (catalog.items.length === 0 && catalog.offerableItems.length === 0)",
     );
+  });
+
+  it("renders a privacy-safe masked identity when duplicate names need disambiguation", () => {
+    const serviceSource = readFileSync(
+      join(process.cwd(), "lib/services/connections-service.ts"),
+      "utf8",
+    );
+
+    expect(serviceSource).toContain("maskedPhone?: string | null");
+    expect(serviceSource).toContain("maskedEmail?: string | null");
+    expect(
+      getDirectoryPersonDescription({
+        displayName: "Abdul Zalil",
+        email: null,
+        maskedEmail: "a***l@example.com",
+        maskedPhone: "******4455",
+      }),
+    ).toBe("a***l@example.com");
+  });
+
+  it("keeps email as the preferred secondary identity", () => {
+    expect(
+      getDirectoryPersonDescription({
+        displayName: "Abdul Zalil",
+        email: "abdul@example.test",
+        maskedEmail: "a***l@example.test",
+        maskedPhone: "******4455",
+      }),
+    ).toBe("abdul@example.test");
   });
 });

--- a/hushh-webapp/app/connect/directory-person-label.ts
+++ b/hushh-webapp/app/connect/directory-person-label.ts
@@ -1,0 +1,13 @@
+import type { DirectoryPerson } from "@/lib/services/connections-service";
+
+type DirectoryPersonIdentity = Pick<
+  DirectoryPerson,
+  "displayName" | "email" | "maskedEmail" | "maskedPhone"
+>;
+
+export function getDirectoryPersonDescription(
+  person: DirectoryPersonIdentity,
+): string | undefined {
+  if (!person.displayName) return undefined;
+  return person.email || person.maskedEmail || person.maskedPhone || undefined;
+}

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -38,6 +38,7 @@ import {
   type DirectoryPerson,
 } from "@/lib/services/connections-service";
 import { relationshipCta } from "@/lib/connections/relationship-label";
+import { getDirectoryPersonDescription } from "./directory-person-label";
 
 type ConnectTab = "people" | "nearby";
 
@@ -661,10 +662,7 @@ export default function ConnectPageClient() {
                     const cta = relationshipCta(person.relationship);
                     const title =
                       person.displayName || person.email || person.userId;
-                    const description =
-                      person.displayName && person.email
-                        ? person.email
-                        : undefined;
+                    const description = getDirectoryPersonDescription(person);
                     return (
                       <SettingsRow
                         key={person.userId}

--- a/hushh-webapp/lib/services/connections-service.ts
+++ b/hushh-webapp/lib/services/connections-service.ts
@@ -8,6 +8,8 @@ export interface DirectoryPerson {
   displayName: string | null;
   photoUrl: string | null;
   email: string | null;
+  maskedEmail?: string | null;
+  maskedPhone?: string | null;
   relationship: ConnectionRelationship;
 }
 


### PR DESCRIPTION
## What changed

- preserve privacy-safe masked email and phone labels from the canonical actor directory through the Connections API
- render email, then masked email, then masked phone as the Connect row's secondary identity
- document the privacy-filtered directory contract
- add backend and frontend regression coverage

## UAT reproduction

Confirmed twice on the existing authenticated UAT session at `https://uat.one.hushh.ai/one/connect` without sending a connection request.

1. Start on Connect > People, search for `Abdul Zalil`, and wait for the directory response.
2. Two separate rows render as `Abdul Zalil` with identical `Connect` actions and no secondary identity.
3. Reconstruct the route through One > Connect and repeat the same search.
4. The two rows remain indistinguishable on the second observation.

Expected: each same-name account has a privacy-safe secondary identity so the user can choose the intended person.

Actual: both rows showed only the same display name. No request or other mutation was performed.

## Root cause

The canonical actor identity cache already contains email and phone identity data, but the eligible directory query omitted email, the Location-safe recipient projection exposed only masked phone, the Connections projection discarded that masked field, and the Connect UI only rendered full email. The two reproduced UAT accounts also share the same masked phone suffix, so phone alone is insufficient.

## Fix

The eligible directory now selects email and converts it to a masked email before it leaves the backend. Connections preserves masked email/phone, and the row prefers full email when already available, otherwise masked email, then masked phone. Raw email, raw phone, and internal user IDs are not newly exposed.

## Regression proof

Before the production fix:

- backend focused regression: 2 failed (`maskedEmail` missing from the recipient and Connections projections)
- frontend focused regression: 1 failed (`maskedEmail` absent from the service contract)

After the fix:

- backend: 106 passed across Connections service/routes and One Location service
- frontend: 18 passed across the Connect page contract, Connections service, and phone-layout contract
- Python typecheck: success, 95 source files
- TypeScript typecheck: passed
- Ruff: passed; formatter clean
- ESLint: passed with zero warnings
- service-boundary, docs, design-system, and accent-token verifiers: passed
- production Next.js webpack build: passed (144 static pages)
- `git diff --check`: passed
- DCO signoff: passed

The full local CI wrapper could not run its `gitleaks` stage because the CLI is not installed on this Windows host; GitHub CI remains authoritative for secret scanning. Its Windows `npm ci` worktree-junction limitation was exercised separately, while the relevant frontend/backend checks above completed successfully.

## Local browser verification

before:
<img width="1279" height="585" alt="image" src="https://github.com/user-attachments/assets/1a327a40-e99d-45cb-85b5-3d56e58a9305" />

after:
<img width="638" height="584" alt="image" src="https://github.com/user-attachments/assets/2d753377-77d5-487f-99d8-cf40cbe43ace" />

Verified twice at phone width on `http://localhost:3000/one/connect`, using the existing authenticated Chrome profile and an isolated local frontend/backend against UAT resources.

1. Search `Abdul Zalil`: the two rows rendered distinct masked emails (`a***l@gmail.com` and `a***l@brilliantmode.com`).
2. Navigate One > Connect in the same unlocked session and repeat: the same two distinct masked identities rendered again.

No connection request was sent. Before/after and both after-fix screenshots were captured during browser verification.
