### PR TITLE
fix(ios): enable return key dismissal and scroll on-drag in Connect screen

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -596,6 +596,34 @@ export default function ConnectPageClient() {
                     placeholder="Search people by name"
                     aria-label="Search people"
                     className="h-10 pl-11"
+                    enterKeyHint="search"
+                    onKeyDown={(event) => {
+                      // iOS soft-keyboard "return" must dismiss the keyboard;
+                      // blurring the field is what actually closes it in the
+                      // Capacitor webview (there is no form submit here).
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        event.currentTarget.blur();
+                      }
+                    }}
+                    onFocus={(event) => {
+                      // Keyboard-dismiss "on drag": the first scroll/drag while
+                      // the field is focused blurs it, so an open keyboard never
+                      // locks the results out of view. Scoped to this field's
+                      // focus lifecycle and cleaned up on blur.
+                      const field = event.currentTarget;
+                      const dismiss = () => field.blur();
+                      window.addEventListener("touchmove", dismiss, {
+                        passive: true,
+                        once: true,
+                      });
+                      field.addEventListener(
+                        "blur",
+                        () =>
+                          window.removeEventListener("touchmove", dismiss),
+                        { once: true },
+                      );
+                    }}
                   />
                 </div>
                 {people.length > 0 && (


### PR DESCRIPTION
# Description

**Bug (iOS / TestFlight):** On the Connect search field ("Search people by
name"):
1. Tapping **return** on the iOS soft keyboard didn't dismiss the keyboard.
2. With the keyboard up, the user couldn't scroll/drag to dismiss it, so results
   and lower controls were blocked.

**Root cause:** the input had no `onKeyDown` handler and isn't inside a `<form>`,
so return was a no-op; nothing dismissed the keyboard on scroll either. (This is
a Capacitor **webview**, not React Native — so the fix uses the web equivalents
of the RN suggestions.)

**Fix** (`app/connect/page-client.tsx`, scoped to this one field):
- `enterKeyHint="search"` + `onKeyDown`: **return** now blurs the field, which is
  what actually closes the iOS webview keyboard.
- `onFocus`: registers a one-shot `touchmove` listener that **blurs on the first
  drag** (the web equivalent of `keyboardDismissMode="on-drag"`), then cleans
  itself up on blur — so an open keyboard never locks the results out of view.
  Scoped strictly to this field's focus lifecycle; no global listeners persist.

No layout, container, or shared-component change — only the Connect people-search
input gains the two handlers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/connect` people-search input only
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: fixes iOS keyboard dismissal; behavior is inert on desktop (no touchmove) and unchanged for typing
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — input UX only
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below: additive handlers; the touchmove listener is `once` + removed on blur, so nothing leaks; reverting restores prior behavior
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: existing Connect contract tests pass; keyboard dismissal is an iOS-webview behavior not reproducible in jsdom
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed file, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`connect/page-client.contract` + `connect-page-layout.contract`, 5 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate.
- [x] This PR changes a current reachable app surface (Connect search).
- [x] Reachable production attach point: the people-search `Input` in `ConnectPageClient`.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (runs inside the iOS Capacitor webview)
- [x] **iOS**: fixed here — webview keyboard dismissal; no native plugin/config changed
- [x] **Android**: unaffected — touchmove drag-dismiss is harmless; return-blur is standard

## 🧪 Testing

- [x] Tested on Web (unit): existing Connect contract tests pass (5)
- [ ] Tested on iOS Simulator/Device — not run here (keyboard dismissal is an iOS-webview behavior)
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Repro: type "Rashid" in the People search → keyboard stayed up, return did
nothing, list couldn't scroll. After: return dismisses the keyboard, and a
drag/scroll dismisses it too, revealing the results and lower controls. Live iOS
capture not run in this environment.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — input keyboard UX only.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


