### PR TITLE
fix(webapp): give every toggle the iOS switch colours

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -595,6 +595,13 @@ textarea {
   --border: oklch(0.92 0.004 264);
   --input: oklch(0.87 0.006 264);
   --ring: var(--app-accent-ring);
+  /* Switch track — the iOS system palette, not a brand colour. A toggle is a
+     platform control before it is ours: users read green-means-on from the OS,
+     so every Switch shares these rather than each surface picking its own
+     approximation (this replaced a one-off emerald on the Location toggle). */
+  --switch-on: #34c759; /* iOS systemGreen, light */
+  --switch-off: #e9e9ea; /* iOS off-track, light */
+  --switch-thumb: #ffffff;
   --chart-1: oklch(0.663 0.096 71.6);
   --chart-2: oklch(0.754 0.085 67.1);
   --chart-3: oklch(0.62 0.19 155);
@@ -2308,6 +2315,11 @@ html.native-ios [data-testid="one-location-onboarding"] {
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: var(--app-accent-ring);
+  /* iOS shifts systemGreen brighter in dark mode and darkens the off-track;
+     the thumb stays white in both appearances. */
+  --switch-on: #30d158; /* iOS systemGreen, dark */
+  --switch-off: #39393d; /* iOS off-track, dark */
+  --switch-thumb: #ffffff;
   /* Chart colors - higher lightness for contrast on dark card */
   --chart-1: oklch(0.797 0.112 76.3);
   --chart-2: oklch(0.663 0.096 71.6);

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -521,10 +521,9 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
           onCheckedChange={handleLocationChange}
           disabled={toggling || refreshing}
           aria-label={locationOn ? "Turn location off" : "Turn location on"}
-          className={cn(
-            "data-[state=checked]:bg-emerald-500 dark:data-[state=checked]:bg-emerald-400",
-            toggling && "animate-pulse",
-          )}
+          // No colour override: the shared Switch already carries the iOS
+          // system green, so this toggle reads the same as every other one.
+          className={cn(toggling && "animate-pulse")}
         />
       </div>
     </div>

--- a/hushh-webapp/components/ui/switch.tsx
+++ b/hushh-webapp/components/ui/switch.tsx
@@ -17,7 +17,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-[var(--switch-on)] data-[state=unchecked]:bg-[var(--switch-off)]",
         className
       )}
       {...props}
@@ -25,7 +25,9 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+          // The knob is white in both appearances on iOS — it never inverts
+          // with the theme, which is why there is no dark: override here.
+          "pointer-events-none block rounded-full bg-[var(--switch-thumb)] shadow-sm ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>


### PR DESCRIPTION
## The bug

> Location on/off toggle should match the actual iOS colour scheme [Broadly every button should use this]

Two things were wrong at once:

- The Location toggle in `location-redesign-hub.tsx` painted its own `bg-emerald-500` / `dark:bg-emerald-400`.
- The shared `Switch` underneath it used `data-[state=checked]:bg-primary` — which resolves to near-black in light mode.

Neither is the colour iOS uses. A toggle is a platform control before it is ours: people read green-means-on from the OS, so a near-black switch reads as decoration rather than state.

## The fix

New tokens in `globals.css` carrying the real iOS system palette:

| token | light | dark |
|---|---|---|
| `--switch-on` | `#34C759` (systemGreen) | `#30D158` |
| `--switch-off` | `#E9E9EA` | `#39393D` |
| `--switch-thumb` | `#FFFFFF` | `#FFFFFF` |

The shared `Switch` now reads those, so **all eleven switches in the app** match rather than each surface approximating it — that is the "broadly every button should use this" part of the report. The knob is white in both appearances on iOS and never inverts with the theme, which is why its `dark:` overrides are gone.

The Location toggle's one-off emerald override is deleted; it inherits the shared colour like everything else.

## Scope note

This covers toggles. It does not restyle other button variants — that would be a much wider visual change than the report describes, and worth its own pass if you want it.

## Verification

- `tsc --noEmit` clean, `eslint` clean on both changed components.
- `vitest` — 66 tests across the one-location redesign and immersive-map suites pass.
- No test asserted the old emerald or `bg-primary` classes, so nothing was written to fit the change.

There is no existing test for `Switch` itself. Worth adding if you want the palette locked down.