### PR TITLE
fix(connect): keep the ZIP box reachable when a nearby search fails

### DIFF
--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -158,6 +158,41 @@ describe("AdvisorsNearby", () => {
     });
   });
 
+  it("still offers the ZIP box after a ZIP search fails", async () => {
+    // The reported dead end: a ZIP that errors leaves "Try again" as the only
+    // control, and that re-runs the ZIP that just failed. Switching tabs and
+    // back was the only way to get the input again, because that remounts the
+    // component and clears the anchor.
+    mocks.locationState = {
+      status: "denied",
+      permission: "denied",
+      snapshot: null,
+      error: "Location is off for Hussh.",
+    };
+    mocks.searchNearby.mockRejectedValueOnce(
+      new Error("That search could not be completed."),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    fireEvent.change(screen.getByTestId("advisors-postal-input"), {
+      target: { value: "00000" },
+    });
+    fireEvent.click(screen.getByText("Search"));
+
+    expect(await screen.findByTestId("advisors-error")).toBeTruthy();
+
+    const retryInput = screen.getByTestId("advisors-postal-input");
+    fireEvent.change(retryInput, { target: { value: "98033" } });
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({
+      postalCode: "98033",
+    });
+    expect(await screen.findByText("Christine Cote")).toBeTruthy();
+  });
+
   it("re-searches when the radius changes", async () => {
     mocks.locationState = {
       status: "ready",

--- a/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
@@ -243,6 +243,39 @@ describe("InsuranceAgentsNearby", () => {
     expect(screen.getByTestId("insurance-agents-postal-input")).toBeTruthy();
   });
 
+  it("still offers the ZIP box after a ZIP search fails", async () => {
+    // A failed ZIP must not strand the reader on a "Try again" that only
+    // re-runs the ZIP that just failed. Mirrors the advisers directory.
+    mocks.locationState = {
+      status: "denied",
+      permission: "denied",
+      snapshot: null,
+      error: "Location is off for Hussh.",
+    };
+    mocks.searchNearby.mockRejectedValueOnce(
+      new Error("That search could not be completed."),
+    );
+
+    render(<InsuranceAgentsNearby getIdToken={getIdToken} />);
+
+    fireEvent.change(screen.getByTestId("insurance-agents-postal-input"), {
+      target: { value: "00000" },
+    });
+    fireEvent.click(screen.getByText("Search"));
+
+    expect(await screen.findByTestId("insurance-agents-error")).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId("insurance-agents-postal-input"), {
+      target: { value: "98033" },
+    });
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({
+      postalCode: "98033",
+    });
+  });
+
   it("re-searches when the radius changes", async () => {
     mocks.locationState = {
       status: "ready",

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -182,16 +182,32 @@ export function AdvisorsNearby({
       ) : null}
 
       {error && !loading ? (
-        <QuietBlock title={error} testId="advisors-error">
-          <Button
-            type="button"
-            variant="none"
-            effect="fill"
-            size="lg"
-            onClick={() => void runSearch(anchor, radiusMi, 0)}
-          >
-            Try again
-          </Button>
+        // A failed search must still offer the ZIP box. "Try again" only
+        // re-runs the anchor that just failed, so on its own it strands anyone
+        // whose ZIP was the problem — the only way out was to leave the tab and
+        // come back, which remounts this component and clears the anchor.
+        <QuietBlock
+          title={error}
+          subtitle="Try again, or search a different ZIP."
+          testId="advisors-error"
+        >
+          <div className="flex w-full flex-col items-center gap-4">
+            <Button
+              type="button"
+              variant="none"
+              effect="fill"
+              size="lg"
+              onClick={() => void runSearch(anchor, radiusMi, 0)}
+            >
+              Try again
+            </Button>
+            <PostalCodeForm
+              busy={loading}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="advisors-postal-input"
+            />
+          </div>
         </QuietBlock>
       ) : null}
 

--- a/hushh-webapp/components/connect/insurance-agents-nearby.tsx
+++ b/hushh-webapp/components/connect/insurance-agents-nearby.tsx
@@ -179,16 +179,30 @@ export function InsuranceAgentsNearby({
       />
 
       {error && !loading ? (
-        <QuietBlock title={error} testId="insurance-agents-error">
-          <Button
-            type="button"
-            variant="none"
-            effect="fill"
-            size="lg"
-            onClick={() => void runSearch(anchor, radiusMi, 0)}
-          >
-            Try again
-          </Button>
+        // Same reasoning as the advisers directory: keep the ZIP box reachable
+        // on a failure, or a bad ZIP is a dead end until the tab is remounted.
+        <QuietBlock
+          title={error}
+          subtitle="Try again, or search a different ZIP."
+          testId="insurance-agents-error"
+        >
+          <div className="flex w-full flex-col items-center gap-4">
+            <Button
+              type="button"
+              variant="none"
+              effect="fill"
+              size="lg"
+              onClick={() => void runSearch(anchor, radiusMi, 0)}
+            >
+              Try again
+            </Button>
+            <PostalCodeForm
+              busy={loading}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="insurance-agents-postal-input"
+            />
+          </div>
         </QuietBlock>
       ) : null}
 


### PR DESCRIPTION
## The bug

> Connect - around you - if you put a zip code and if it fails saying "That search could not be completed.", there is no option to input a new zip code [temp fix, switch to insurance and then back to Advisor to make it reappear]

Reproduced exactly, and the reported workaround explains the mechanism.

On failure, `advisors-nearby.tsx` rendered a `QuietBlock` containing only a **Try again** button:

```tsx
{error && !loading ? (
  <QuietBlock title={error} testId="advisors-error">
    <Button onClick={() => void runSearch(anchor, radiusMi, 0)}>Try again</Button>
  </QuietBlock>
) : null}
```

`runSearch(anchor, ...)` re-runs **the anchor that just failed**. When that anchor was a ZIP, retrying searched the same bad ZIP again, and the ZIP field itself was gone — the empty-state block that owns it is gated on `!error`, so an error hides it.

Switching to Insurance and back worked because it unmounts the component, which resets `anchor` to `null` and brings back the `LocationPrompt` that carries a ZIP field.

## The fix

The ZIP form goes back inside the error block, prefilled with the current code, so a different ZIP can be typed straight away. **Try again** stays for the genuinely transient failures.

Applied to both directories — they fail the same way, and both are US-only registers, so anyone outside the US reaches this state with perfectly good GPS and no results.

## Verification

Two regression tests, one per directory, covering the whole path: a ZIP that errors, then a second, *different* ZIP that searches successfully.

Both were confirmed to **fail without the fix** and pass with it:

```
× still offers the ZIP box after a ZIP search fails   (advisors)
× still offers the ZIP box after a ZIP search fails   (insurance)
```

Full suite for these components: 36 passing. `tsc --noEmit` and `eslint` clean.

No `data-testid` collision is introduced — the error, empty, and location-prompt blocks are mutually exclusive, so only one ZIP input is ever mounted.