### PR TITLE
fix(connect): settle a connection request once it has been answered

### DIFF
--- a/hushh-webapp/__tests__/services/cache-sync-mutation-cascade.test.ts
+++ b/hushh-webapp/__tests__/services/cache-sync-mutation-cascade.test.ts
@@ -88,6 +88,17 @@ describe("CacheSyncService mutation cascades", () => {
     expect(patternArgs).toContain(`ria_clients_${userId}_`);
   });
 
+  it("onConnectionCapabilityMutated also settles the incoming-request list", () => {
+    // Answering a request resolves it, so the list it came from is stale too.
+    // That list is a connections cache, not a consent one, so it does not ride
+    // along on the consent cascade — left behind, the request the user just
+    // accepted keeps rendering as though it were still waiting.
+    CacheSyncService.onConnectionCapabilityMutated(userId);
+
+    const invalidatedKeys = spyInvalidate.mock.calls.map((c) => c[0]);
+    expect(invalidatedKeys).toContain(CACHE_KEYS.CONNECTIONS_INCOMING(userId));
+  });
+
   // ---------- 2. onPersonaStateChanged without preservePersonaState ----------
   it("onPersonaStateChanged invalidates PERSONA_STATE and RIA caches when preservePersonaState is falsy", () => {
     CacheSyncService.onPersonaStateChanged(userId);

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -455,15 +455,20 @@ function filterConsentSurfaceEntries(
   locallyHandledRequestIds: Set<string>,
   locallyRevokedScopes: Set<string>,
 ): ConsentCenterEntry[] {
+  // Both of these surfaces list requests that are still open, so a row the
+  // user just answered has to disappear from either one. Keying this on
+  // "pending" alone kept an accepted connection request on screen, because
+  // connections are a separate surface with their own tab.
+  const listsOpenRequests = surface === "pending" || surface === "connections";
   return source.filter((entry) => {
     if (
-      surface === "pending" &&
+      listsOpenRequests &&
       entry.request_id &&
       locallyHandledRequestIds.has(entry.request_id)
     ) {
       return false;
     }
-    if (surface === "pending" && locallyHandledRequestIds.has(entry.id)) {
+    if (listsOpenRequests && locallyHandledRequestIds.has(entry.id)) {
       return false;
     }
     if (
@@ -1765,6 +1770,34 @@ export function ConsentCenterPage() {
       isMarketplaceConsent(entry.metadata, entry.scope),
     [],
   );
+  /**
+   * Settle a connection request the user has just answered.
+   *
+   * Two separate things have to happen or the row survives its own decision.
+   * The local id retires it from the connections pane straight away, and the
+   * event has to carry `reconcile` — the listener ignores a bare event, so an
+   * accepted request used to sit there looking unanswered until a reload.
+   *
+   * The event deliberately carries no `action`: the optimistic summary maths
+   * behind that field counts consent rows, and a connection request is not
+   * one, so claiming an approve here would knock a real pending consent off
+   * the badge. The forced refetch settles the true counts a moment later.
+   */
+  const markConnectionRequestHandled = useCallback((requestId: string) => {
+    const normalized = requestId.trim();
+    if (normalized) {
+      setLocallyHandledRequestIds((current) => {
+        const next = new Set(current);
+        next.add(normalized);
+        return next;
+      });
+    }
+    window.dispatchEvent(
+      new CustomEvent(CONSENT_ACTION_COMPLETE_EVENT, {
+        detail: { reconcile: true },
+      }),
+    );
+  }, []);
   const approveEntry = useCallback(
     (
       entry: ConsentCenterEntry,
@@ -1777,19 +1810,18 @@ export function ConsentCenterPage() {
       if (isConnectionRequestEntry(entry)) {
         void (async () => {
           if (!user) return;
+          const requestId = entry.request_id || entry.id;
           try {
             const idToken = await user.getIdToken();
             await ConnectionsService.accept({
               idToken,
-              requestId: entry.request_id || entry.id,
+              requestId,
               selectedRequestedScopeHandles:
                 scopeSelection?.requestedScopeHandles,
               selectedOfferedScopeHandles: scopeSelection?.offeredScopeHandles,
             });
             CacheSyncService.onConnectionCapabilityMutated(user.uid);
-            window.dispatchEvent(
-              new CustomEvent(CONSENT_ACTION_COMPLETE_EVENT),
-            );
+            markConnectionRequestHandled(requestId);
           } catch (error) {
             console.error(
               "[ConsentCenter] Couldn't accept the connection request:",
@@ -1815,6 +1847,7 @@ export function ConsentCenterPage() {
       handleMarketplaceApprove,
       isLocationEntry,
       isMarketplaceEntry,
+      markConnectionRequestHandled,
       user,
     ],
   );
@@ -1823,16 +1856,15 @@ export function ConsentCenterPage() {
       if (isConnectionRequestEntry(entry)) {
         void (async () => {
           if (!user) return;
+          const requestId = entry.request_id || entry.id;
           try {
             const idToken = await user.getIdToken();
             await ConnectionsService.reject({
               idToken,
-              requestId: entry.request_id || entry.id,
+              requestId,
             });
             CacheSyncService.onConnectionCapabilityMutated(user.uid);
-            window.dispatchEvent(
-              new CustomEvent(CONSENT_ACTION_COMPLETE_EVENT),
-            );
+            markConnectionRequestHandled(requestId);
           } catch (error) {
             console.error(
               "[ConsentCenter] Couldn't decline the connection request:",
@@ -1858,6 +1890,7 @@ export function ConsentCenterPage() {
       handleMarketplaceDeny,
       isLocationEntry,
       isMarketplaceEntry,
+      markConnectionRequestHandled,
       user,
     ],
   );
@@ -2194,7 +2227,10 @@ export function ConsentCenterPage() {
     () =>
       filterConsentSurfaceEntries(
         tab === "connections" ? connectionItems : listData?.items || [],
-        listSurface,
+        // `listSurface` has no case for the connections tab and falls through
+        // to "active"; naming the surface honestly here is what lets a just-
+        // answered connection request be filtered out of the live pane.
+        tab === "connections" ? "connections" : listSurface,
         locallyHandledRequestIds,
         locallyRevokedScopes,
       ),

--- a/hushh-webapp/lib/cache/cache-sync-service.ts
+++ b/hushh-webapp/lib/cache/cache-sync-service.ts
@@ -619,6 +619,13 @@ export class CacheSyncService {
    */
   static onConnectionCapabilityMutated(userId: string): void {
     this.onConsentMutated(userId);
+    // Accepting or declining a request also settles the incoming-request list,
+    // which is a connections cache rather than a consent one and so survives
+    // the cascade above. Left stale, the request the user just answered keeps
+    // rendering as still-pending until its TTL lapses.
+    CacheService.getInstance().invalidate(
+      CACHE_KEYS.CONNECTIONS_INCOMING(userId),
+    );
   }
 
   /**

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -256,10 +256,16 @@ export function useFeedActionables(): UseFeedActionablesResult {
   });
 
   // ── Incoming connection requests ──
+  // Keyed on the same tick as the consent lanes: a connection request can be
+  // answered from the Consent Center rather than here, and that surface only
+  // announces itself through CONSENT_ACTION_COMPLETE_EVENT. Without the key
+  // this resource never re-runs, so an accepted request stays on the feed as
+  // though it were still waiting.
   const connectionsResource = useStaleResource({
     cacheKey: userId
       ? CACHE_KEYS.CONNECTIONS_INCOMING(userId)
       : "connections_incoming_guest",
+    refreshKey: `connections:${consentTick}`,
     enabled: Boolean(userId),
     load: async () => {
       const idToken = await user?.getIdToken();


### PR DESCRIPTION
## The bug

> Connect - request pop-up shows even after user accepted their request

Three independent faults were holding the row on screen. **Each one alone was enough**, which is why this looked intermittent.

### 1. The incoming-request cache was never invalidated

`CacheSyncService.onConnectionCapabilityMutated` cascades through every consent cache, but `CONNECTIONS_INCOMING` is a *connections* cache and does not ride along:

```ts
static onConnectionCapabilityMutated(userId: string): void {
  this.onConsentMutated(userId);   // ← never touches CONNECTIONS_INCOMING
}
```

The answered request stayed in that cache until its TTL lapsed.

### 2. The refetch signal was a no-op

Accepting dispatched a bare event:

```ts
window.dispatchEvent(new CustomEvent(CONSENT_ACTION_COMPLETE_EVENT));
```

…but the Consent Center listener returns early on `!detail.action && !detail.reconcile`. With no `detail`, `setMutationTick` never fired and the list never refetched.

### 3. The optimistic hide was dead code for connections

`filterConsentSurfaceEntries` only consults `locallyHandledRequestIds` when `surface === "pending"` — but `listSurface` has no case for the connections tab:

```ts
const listSurface =
  tab === "requests" ? "pending" : tab === "history" ? "previous" : "active";
```

Connections fall through to `"active"`, so a handled connection row was never filtered out.

## The fix

All three, plus a `refreshKey` on the feed's connections resource keyed to the consent tick — a request can be answered from the Consent Center, and the feed had no way to hear about it.

**One deliberate choice worth reviewing:** the event carries `reconcile: true` rather than `action: "approve"`. The optimistic summary maths behind `action` runs `counts.pending - 1` unconditionally, and it counts *consent* rows. A connection request is not one, so claiming an approve there would knock a real pending consent off the badge. Instead the row is retired locally by id and the forced refetch settles the true counts.

## Verification

New test in the cascade suite, confirmed to **fail without the fix**:

```
× onConnectionCapabilityMutated also settles the incoming-request list
```

`tsc --noEmit` and `eslint` clean on all four files.

Two unrelated files (`gmail-oauth-popup`, `theme-accent`) fail with `window.localStorage` undefined — verified identical on untouched `origin/main`, so pre-existing and not from this change.