### PR TITLE
fix(connect): offer a bounded suggested set instead of the whole directory

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  searchDirectory: vi.fn(),
+  listConnections: vi.fn(),
+  listRequests: vi.fn(),
+  sendRequest: vi.fn(),
+  cancel: vi.fn(),
+  removeConnection: vi.fn(),
+  getScopeCatalog: vi.fn(),
+  searchInformationScopes: vi.fn(),
+  onConnectionCapabilityMutated: vi.fn(),
+  routerPush: vi.fn(),
+  // The real hook hands back the same user across renders. Rebuilding it per
+  // render would retrigger every effect keyed on it and spin forever, which
+  // would say nothing about the page.
+  user: { uid: "me", getIdToken: async () => "id-token" },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush, replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useRequireAuth: () => ({ user: mocks.user }),
+}));
+
+// The debounce itself is covered by its own hook test; collapsing it here keeps
+// this suite about which request the surface makes, not about timer plumbing.
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
+}));
+
+vi.mock("@/lib/services/connections-service", () => ({
+  ConnectionsService: {
+    searchDirectory: mocks.searchDirectory,
+    listConnections: mocks.listConnections,
+    listRequests: mocks.listRequests,
+    sendRequest: mocks.sendRequest,
+    cancel: mocks.cancel,
+    removeConnection: mocks.removeConnection,
+    getScopeCatalog: mocks.getScopeCatalog,
+    searchInformationScopes: mocks.searchInformationScopes,
+  },
+}));
+
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: {
+    onConnectionCapabilityMutated: mocks.onConnectionCapabilityMutated,
+  },
+}));
+
+// The Around-you tab has its own suite; keep its directory services out of this
+// render so a failure here can only mean the People tab.
+vi.mock("@/components/connect/advisors-nearby", () => ({
+  AdvisorsNearby: () => <div data-testid="advisors-nearby-stub" />,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import ConnectPageClient from "@/app/connect/page-client";
+
+function person(userId: string, displayName: string) {
+  return {
+    userId,
+    displayName,
+    email: `${userId}@example.com`,
+    relationship: "none" as const,
+  };
+}
+
+/** Ten people, so a limit of 8 is visibly a cap rather than the whole set. */
+const EVERYONE = Array.from({ length: 10 }, (_, index) =>
+  person(`u${index}`, `Person ${index}`),
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listConnections.mockResolvedValue([]);
+  mocks.listRequests.mockResolvedValue([]);
+  mocks.searchDirectory.mockResolvedValue({
+    items: EVERYONE.slice(0, 8),
+    hasMore: true,
+    page: 1,
+  });
+});
+
+describe("Connect — People", () => {
+  it("asks for a bounded sample before anyone has searched", async () => {
+    render(<ConnectPageClient />);
+
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+    // The reported problem was the whole register arriving unprompted. The
+    // unsearched surface must ask for a capped set, and no query.
+    expect(mocks.searchDirectory.mock.calls[0][0]).toMatchObject({
+      page: 1,
+      limit: 8,
+    });
+    expect(mocks.searchDirectory.mock.calls[0][0].query).toBe("");
+
+    expect(await screen.findByText("Suggested")).toBeTruthy();
+    expect(screen.getByText("Person 0")).toBeTruthy();
+  });
+
+  it("never offers to page deeper into the sample, whatever the server says", async () => {
+    // hasMore is true in the fixture: a sample that pages is just the register
+    // again, one tap further away.
+    render(<ConnectPageClient />);
+
+    expect(await screen.findByText("Suggested")).toBeTruthy();
+    expect(screen.queryByText("Load more people")).toBeNull();
+  });
+
+  it("opens the full directory once a name is typed", async () => {
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Person 9" },
+    });
+
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+    const searched = mocks.searchDirectory.mock.calls[1][0];
+    expect(searched.query).toBe("Person 9");
+    // No cap on a real search — the reader has said who they are looking for.
+    expect(searched.limit).toBeUndefined();
+
+    // "People" is also the tab label, so the sample heading going away is the
+    // unambiguous signal that this is no longer the bounded surface.
+    await waitFor(() => expect(screen.queryByText("Suggested")).toBeNull());
+    expect(await screen.findByText("Load more people")).toBeTruthy();
+  });
+
+  it("says who was searched for when a search matches nobody", async () => {
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    mocks.searchDirectory.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      page: 1,
+    });
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Nobody" },
+    });
+
+    expect(await screen.findByText('No one matches "Nobody"')).toBeTruthy();
+  });
+
+  it("drops selections the new result set no longer shows", async () => {
+    // "Connect to Selected (N)" counts this set, so an N covering people who
+    // scrolled out of existence is a number the reader cannot reconcile.
+    render(<ConnectPageClient />);
+    expect(await screen.findByText("Person 0")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Select"));
+    fireEvent.click(screen.getByLabelText("Select Person 0"));
+    expect(screen.getByText("Connect to Selected (1)")).toBeTruthy();
+
+    mocks.searchDirectory.mockResolvedValue({
+      items: [person("u9", "Person 9")],
+      hasMore: false,
+      page: 1,
+    });
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Person 9" },
+    });
+
+    expect(await screen.findByText("Person 9")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByText("Connect to Selected (1)")).toBeNull(),
+    );
+  });
+});

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -47,6 +47,15 @@ const CONNECT_TABS = [
   { value: "nearby", label: "Around you" },
 ];
 
+/**
+ * How many people the unsearched People tab offers.
+ *
+ * Deliberately about a screen's worth. It exists so someone who has just joined
+ * and knows nobody's exact name is not staring at an empty surface — not so
+ * they can browse the register, which is the thing that stops scaling.
+ */
+const SUGGESTED_PEOPLE_LIMIT = 8;
+
 export default function ConnectPageClient() {
   const { user } = useRequireAuth();
   const router = useRouter();
@@ -130,6 +139,16 @@ export default function ConnectPageClient() {
     void loadOutgoingRequestIds();
   }, [loadOutgoingRequestIds]);
 
+  // The directory is every account on Hussh, so listing all of it unprompted
+  // stops being useful as soon as sign-ups outgrow a screen or two: the person
+  // you came to connect with is buried among strangers, and paging through them
+  // is the tedious part. Unsearched, this surface therefore shows a short
+  // suggested sample and nothing more — enough that someone who does not yet
+  // know a name has somewhere to start, small enough that it is never the thing
+  // you have to scroll past. Naming a name is what opens the full directory.
+  const trimmedQuery = debouncedQuery.trim();
+  const hasQuery = trimmedQuery.length > 0;
+
   useEffect(() => {
     let cancelled = false;
     async function run() {
@@ -142,13 +161,27 @@ export default function ConnectPageClient() {
         const idToken = await user.getIdToken();
         const page = await ConnectionsService.searchDirectory({
           idToken,
-          query: debouncedQuery,
+          query: trimmedQuery,
           page: 1,
+          ...(hasQuery ? {} : { limit: SUGGESTED_PEOPLE_LIMIT }),
         });
         if (!cancelled) {
           setPeople(page.items);
-          setHasMore(page.hasMore);
+          // A sample is not a directory: never offer to page deeper into it,
+          // whatever the server reports about what else it holds.
+          setHasMore(hasQuery ? page.hasMore : false);
           setCurrentPage(page.page);
+          // Selections are counted on the "Connect to Selected (N)" button, so
+          // drop any that this result set no longer shows — an N the reader
+          // cannot see is a promise the surface can't account for.
+          setSelectedUserIds((current) => {
+            if (current.size === 0) return current;
+            const visible = new Set(page.items.map((person) => person.userId));
+            const next = new Set(
+              [...current].filter((userId) => visible.has(userId)),
+            );
+            return next.size === current.size ? current : next;
+          });
         }
       } catch (loadError) {
         if (!cancelled)
@@ -165,16 +198,16 @@ export default function ConnectPageClient() {
     return () => {
       cancelled = true;
     };
-  }, [user, debouncedQuery]);
+  }, [user, hasQuery, trimmedQuery]);
 
   const loadMorePeople = useCallback(async () => {
-    if (!user || loadingMore || !hasMore) return;
+    if (!user || loadingMore || !hasMore || !hasQuery) return;
     try {
       setLoadingMore(true);
       const idToken = await user.getIdToken();
       const page = await ConnectionsService.searchDirectory({
         idToken,
-        query: debouncedQuery,
+        query: trimmedQuery,
         page: currentPage + 1,
       });
       setPeople((current) => {
@@ -193,7 +226,7 @@ export default function ConnectPageClient() {
     } finally {
       setLoadingMore(false);
     }
-  }, [currentPage, debouncedQuery, hasMore, loadingMore, user]);
+  }, [currentPage, trimmedQuery, hasQuery, hasMore, loadingMore, user]);
 
   const sendConnectionRequest = useCallback(
     async (
@@ -662,8 +695,12 @@ export default function ConnectPageClient() {
                 )}
               </div>
               <SettingsGroup
-                title="People"
-                description="Find people on Hussh and send a connection request."
+                title={hasQuery ? "People" : "Suggested"}
+                description={
+                  hasQuery
+                    ? "Send a connection request to someone you know."
+                    : "A few people on Hussh. Search by name to find someone specific."
+                }
                 separatorInset
               >
                 {loading ? (
@@ -680,11 +717,21 @@ export default function ConnectPageClient() {
                     tone="destructive"
                   />
                 ) : people.length === 0 ? (
-                  <SettingsRow
-                    title="No people found"
-                    density="compact"
-                    disabled
-                  />
+                  hasQuery ? (
+                    <SettingsRow
+                      title={`No one matches "${trimmedQuery}"`}
+                      description="Check the spelling, or try their full name."
+                      density="compact"
+                      disabled
+                    />
+                  ) : (
+                    <SettingsRow
+                      title="No one to suggest yet"
+                      description="Search by name to find someone on Hussh."
+                      density="compact"
+                      disabled
+                    />
+                  )
                 ) : (
                   people.map((person) => {
                     const cta = relationshipCta(person.relationship);


### PR DESCRIPTION
## The bug

> Connect - people - people list listed all the people signed up on hushh, it could increase once active users join, making the process of finding the people we want to connect tedious

With an empty search box the page fetched page 1 of the entire directory. Search already existed and worked — the problem was the unprompted full listing, which is fine today and stops working as sign-ups grow.

## The fix

Unsearched, the surface asks for **eight** people under a **"Suggested"** heading and nothing more. Typing a name opens the full directory with its paging intact.

```ts
const page = await ConnectionsService.searchDirectory({
  idToken,
  query: trimmedQuery,
  page: 1,
  ...(hasQuery ? {} : { limit: SUGGESTED_PEOPLE_LIMIT }),
});
setHasMore(hasQuery ? page.hasMore : false);
```

`hasMore` is forced false for the sample **whatever the server reports** — a sample that pages is just the register again, one tap further away.

### Why a sample rather than requiring a search

My first cut required a search outright and showed nothing until you typed. That breaks the person who has just joined, knows nobody's exact name, and would land on a blank surface. Eight is about a screen's worth: enough to start from, too few to browse. Flagged to the reporter, who asked for this shape.

### Two corrections that follow from it

- The empty state now distinguishes a search that **missed** (`No one matches "…"`) from an instance with **nobody to suggest**. Previously both were "No people found".
- Selections are pruned to the visible set on each result. `Connect to Selected (N)` counts `selectedUserIds`, so without this the button could claim a count covering people no longer on screen.

## Verification

Adds `__tests__/app/connect/page-client.test.tsx` — the **first render test for this page** (it previously had only a source-string contract test). Five cases: bounded request shape, no paging on the sample, full directory once searched, the miss message, and selection pruning.

**Four of the five fail without the change**; the fifth is a characterization test for the searched path.

`tsc --noEmit` and `eslint` clean. The contract test from #5015 still passes — this does not touch the `getDirectoryPersonDescription` row.

## One thing to know before writing more tests here

Mocking `useRequireAuth` to return a fresh `user` object per render sends this page into an infinite fetch loop (2,258 calls before it bailed). The real hook returns a stable reference and the effect already depended on `user` before this change, so it is a harness artifact — but the user object must be hoisted in any future test of this page. Noted in a comment in the fixture.