### PR TITLE
fix(connect): surface failed request decisions

### DIFF
--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -25,6 +25,9 @@ const mocks = vi.hoisted(() => ({
   handleLocationApprove: vi.fn(),
   handleLocationDeny: vi.fn(),
   handleLocationRevoke: vi.fn(),
+  connectionAccept: vi.fn(),
+  connectionReject: vi.fn(),
+  toastError: vi.fn(),
   busyRequestIds: new Set<string>(),
   cacheSubscribers: new Set<
     (event: { type: string; key?: string; keys?: string[] }) => void
@@ -66,6 +69,19 @@ vi.mock("@/lib/vault/vault-context", () => ({
     getVaultOwnerToken: mocks.getVaultOwnerToken,
     isVaultUnlocked: mocks.isVaultUnlocked,
   }),
+}));
+
+vi.mock("@/lib/services/connections-service", () => ({
+  ConnectionsService: {
+    accept: mocks.connectionAccept,
+    reject: mocks.connectionReject,
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+  },
 }));
 
 vi.mock("@/lib/consent", () => ({
@@ -325,6 +341,8 @@ describe("ConsentCenterPage requestId deep links", () => {
     mocks.handleApprove.mockResolvedValue(undefined);
     mocks.handleDeny.mockResolvedValue(undefined);
     mocks.handleRevoke.mockResolvedValue(undefined);
+    mocks.connectionAccept.mockResolvedValue(undefined);
+    mocks.connectionReject.mockResolvedValue(undefined);
     mocks.busyRequestIds = new Set();
     mocks.busyScopes = new Set();
     mocks.cacheSubscribers.clear();
@@ -605,6 +623,59 @@ describe("ConsentCenterPage requestId deep links", () => {
     expect(screen.queryByText("Access duration")).toBeNull();
     expect(screen.queryByText("Requested duration")).toBeNull();
     expect(screen.queryByText("Ends")).toBeNull();
+  });
+
+  it.each([
+    {
+      action: "Accept",
+      errorMessage: "Could not accept the connection request. Try again.",
+      mutate: mocks.connectionAccept,
+    },
+    {
+      action: "Decline",
+      errorMessage: "Could not decline the connection request. Try again.",
+      mutate: mocks.connectionReject,
+    },
+  ])("surfaces a failed $action connection decision", async ({
+    action,
+    errorMessage,
+    mutate,
+  }) => {
+    mocks.search = "tab=pending&requestId=connection-1";
+    mocks.listEntries.mockResolvedValue({
+      ...emptyListResponse(),
+      total: 1,
+      items: [
+        {
+          id: "connection-1",
+          request_id: "connection-1",
+          kind: "connection_request",
+          status: "pending",
+          action: "connection_request",
+          scope: "cap.connections.trusted",
+          scope_description: "Trusted connection",
+          counterpart_type: "investor",
+          counterpart_id: "user-rohan",
+          counterpart_label: "Rohan",
+          issued_at: "2026-07-24T09:00:00.000Z",
+          reason: "Rohan wants to connect with you.",
+          metadata: { request_source: "connection_request" },
+        },
+      ],
+    });
+    mutate.mockRejectedValueOnce(new Error("network unavailable"));
+    installMobileMediaQuery();
+
+    render(<ConsentCenterPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: action }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(errorMessage),
+    );
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "connection-1" }),
+    );
   });
 
   it("shows marketplace requested duration as read-only request context", async () => {

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -22,6 +22,7 @@ import {
   Search,
   UserRound,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   AppPageContentRegion,
   AppPageShell,
@@ -1827,6 +1828,7 @@ export function ConsentCenterPage() {
               "[ConsentCenter] Couldn't accept the connection request:",
               error,
             );
+            toast.error("Could not accept the connection request. Try again.");
           }
         })();
         return;
@@ -1870,6 +1872,7 @@ export function ConsentCenterPage() {
               "[ConsentCenter] Couldn't decline the connection request:",
               error,
             );
+            toast.error("Could not decline the connection request. Try again.");
           }
         })();
         return;


### PR DESCRIPTION
## Summary

When an incoming connection decision failed, the Consent Center closed its detail sheet immediately and logged the error only to the developer console. The person received no recovery feedback and could reasonably assume Accept or Decline succeeded.

This focused fix adds the user-facing error toast already promised by the surrounding component contract:

- Accept failure: `Could not accept the connection request. Try again.`
- Decline failure: `Could not decline the connection request. Try again.`

Successful connection settlement, cache invalidation, and reconciliation are unchanged.

## Reproduction and proof

This is a deterministic source/regression defect, not a claimed UAT mutation reproduction.

- UAT was inspected through the existing authenticated Chrome session at 320 px and 390 px.
- Feed → connection navigation and the non-mutating Connect/Location surfaces behaved as authored.
- The UAT account had no unresolved incoming connection request.
- No real connection request was created and no Accept/Decline mutation was sent.

Before the production fix, the new regression exercised both real Consent Center actions with rejected mutations:

- Accept: console error occurred; expected toast had 0 calls.
- Decline: console error occurred; expected toast had 0 calls.
- Result: 2/2 regression cases failed.

After the fix:

- 3 focused test files passed, 35/35 tests.
- The regression uses the existing 390 px mobile media contract and proves both failure paths.

## Root cause

The connection-specific Accept and Decline branches catch service failures after the sheet is dismissed, but only call `console.error`. Unlike the generic, Location, and Marketplace action paths, they do not surface a recoverable UI error.

## Files changed

- `hushh-webapp/components/consent/consent-center-page.tsx`
- `hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx`

## Verification

- focused Consent Center/connection tests — 35/35 passed
- targeted ESLint on both changed files — passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- CI-equivalent `next build --webpack` with repository dummy env contract — passed; 144/144 static pages generated
- `git diff --check upstream/main...HEAD` — passed
- pre-push freshness hook against canonical `upstream/main` — passed
- DCO sign-off — present

## Impact

- Web: affected; user feedback only.
- iOS/Android: same React Consent Center receives the toast; no native code or bridge contract changes.
- API/schema/cache/consent authority: unchanged.
- Privacy: no information access or mutation semantics changed.
- Rollback: revert the single commit; previous behavior is restored.

## Browser verification limitation

The actual failure toast cannot be safely rehearsed in UAT or local-UAT mode without first creating a real incoming request and then deliberately forcing its mutation to fail. That external mutation was not authorized. The production component regression is therefore the authoritative proof for this failure-only path.