### PR TITLE
fix(feed): show SOS last-known address

### DIFF
--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
@@ -1,0 +1,236 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const serviceHarness = vi.hoisted(() => ({
+  viewEnvelope: vi.fn(),
+  reverseGeocode: vi.fn(),
+}));
+
+const encryptionHarness = vi.hoisted(() => ({
+  decryptLocationEnvelope: vi.fn(),
+  ensureVaultSyncedRecipientKey: vi.fn(),
+}));
+
+const envelope = {
+  ciphertext: "ciphertext",
+  iv: "iv",
+  tag: "tag",
+  algorithm: "AES-GCM",
+  recipientKeyId: "recipient-key",
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => undefined,
+  }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: {
+      uid: "receiver-user",
+      getIdToken: async () => "test-id-token",
+    },
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    vaultKey: "test-vault-key",
+    vaultOwnerToken: "test-vault-token",
+  }),
+}));
+
+vi.mock("@/lib/services/cache-service", () => ({
+  CACHE_KEYS: {
+    CONSENT_CENTER_SUMMARY: (userId: string) =>
+      `consent-summary:${userId}`,
+    CONSENT_CENTER_LIST: (userId: string) =>
+      `consent-list:${userId}`,
+    ONE_LOCATION_STATE: (userId: string) =>
+      `location:${userId}`,
+    CONNECTIONS_INCOMING: (userId: string) =>
+      `connections:${userId}`,
+  },
+  CACHE_TTL: {
+    SHORT: 1,
+  },
+  CacheService: {
+    getInstance: () => ({
+      set: () => undefined,
+    }),
+  },
+}));
+
+vi.mock("@/lib/cache/use-stale-resource", () => ({
+  useStaleResource: ({ cacheKey }: { cacheKey: string }) => {
+    const refresh = async () => undefined;
+
+    if (cacheKey.startsWith("location:")) {
+      return {
+        data: {
+          requests: [],
+          receivedGrants: [
+            {
+              id: "sos-grant-1",
+              ownerUserId: "sender-user",
+              recipientUserId: "receiver-user",
+              ownerDisplayName: "Test contact",
+              status: "active",
+              shareKind: "sos",
+              shareMessage: null,
+              createdAt: "2026-08-10T00:00:00.000Z",
+            },
+          ],
+          myRecipientKey: null,
+        },
+        loading: false,
+        refresh,
+      };
+    }
+
+    if (cacheKey.startsWith("consent-summary:")) {
+      return {
+        data: {
+          counts: {
+            pending: 0,
+          },
+        },
+        loading: false,
+        refresh,
+      };
+    }
+
+    return {
+      data: null,
+      loading: false,
+      refresh,
+    };
+  },
+}));
+
+vi.mock("@/lib/services/debate-run-manager", () => ({
+  DebateRunManagerService: {
+    getState: () => ({
+      tasks: [],
+    }),
+    subscribe: () => () => undefined,
+  },
+}));
+
+vi.mock("@/lib/services/app-background-task-service", () => ({
+  AppBackgroundTaskService: {
+    getState: () => ({
+      tasks: [],
+    }),
+    subscribe: () => () => undefined,
+  },
+  isAppBackgroundTaskVisible: () => false,
+}));
+
+vi.mock("@/lib/services/consent-center-service", () => ({
+  CONSENT_CENTER_PAGE_SIZE: 20,
+  ConsentCenterService: {
+    getSummary: async () => ({
+      counts: {
+        pending: 0,
+      },
+    }),
+    listEntries: async () => ({
+      items: [],
+    }),
+  },
+}));
+
+vi.mock("@/lib/services/connections-service", () => ({
+  ConnectionsService: {
+    listRequests: async () => [],
+  },
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: {
+    getState: async () => ({
+      requests: [],
+      receivedGrants: [],
+    }),
+    viewEnvelope: serviceHarness.viewEnvelope,
+    reverseGeocode: serviceHarness.reverseGeocode,
+  },
+}));
+
+vi.mock("@/lib/one-location/encryption", () => ({
+  RECIPIENT_KEY_UNAVAILABLE_MESSAGE:
+    "Recipient key unavailable for this location share.",
+  decryptLocationEnvelope: encryptionHarness.decryptLocationEnvelope,
+  ensureVaultSyncedRecipientKey:
+    encryptionHarness.ensureVaultSyncedRecipientKey,
+}));
+
+import { useFeedActionables } from "@/lib/feed/use-feed-actionables";
+
+describe("useFeedActionables SOS last-known address", () => {
+  beforeEach(() => {
+    serviceHarness.viewEnvelope.mockReset();
+    serviceHarness.reverseGeocode.mockReset();
+    encryptionHarness.decryptLocationEnvelope.mockReset();
+    encryptionHarness.ensureVaultSyncedRecipientKey.mockReset();
+
+    serviceHarness.viewEnvelope.mockResolvedValue({
+      grant: {
+        id: "sos-grant-1",
+      },
+      envelope,
+    });
+
+    encryptionHarness.decryptLocationEnvelope.mockResolvedValue({
+      latitude: 12.3456,
+      longitude: 78.9012,
+      accuracyM: 18,
+      capturedAt: "2026-08-10T00:00:00.000Z",
+      sourcePlatform: "web",
+    });
+
+    serviceHarness.reverseGeocode.mockResolvedValue({
+      name: "Test Place",
+      formattedAddress: "100 Test Lane, Example City",
+      countryCode: "IN",
+    });
+  });
+
+  it("decrypts an active SOS point and adds its last-known address to the Feed tile", async () => {
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      expect(serviceHarness.viewEnvelope).toHaveBeenCalledWith({
+        vaultOwnerToken: "test-vault-token",
+        grantId: "sos-grant-1",
+      });
+    });
+
+    await waitFor(() => {
+      const emergency = result.current.actionables.find(
+        (item) => item.id === "sms-emergency:sos-grant-1",
+      );
+
+      expect(emergency?.description).toContain(
+        "Last known: 100 Test Lane, Example City",
+      );
+    });
+
+    expect(encryptionHarness.decryptLocationEnvelope).toHaveBeenCalledWith({
+      userId: "receiver-user",
+      envelope,
+    });
+
+    expect(serviceHarness.reverseGeocode).toHaveBeenCalledWith({
+      vaultOwnerToken: "test-vault-token",
+      lat: 12.3456,
+      lng: 78.9012,
+    });
+
+    expect(
+      encryptionHarness.ensureVaultSyncedRecipientKey,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -42,6 +42,11 @@ import {
   locationConsentSummary,
 } from "@/lib/consent/location-consent";
 import { OneLocationService } from "@/lib/one-location/service";
+import {
+  RECIPIENT_KEY_UNAVAILABLE_MESSAGE,
+  decryptLocationEnvelope,
+  ensureVaultSyncedRecipientKey,
+} from "@/lib/one-location/encryption";
 import type {
   OneLocationAccessRequest,
   OneLocationGrant,
@@ -161,8 +166,11 @@ export function notifyFeedActionResolved(): void {
 export function useFeedActionables(): UseFeedActionablesResult {
   const router = useRouter();
   const { user } = useAuth();
-  const { vaultOwnerToken } = useVault();
+  const { vaultKey, vaultOwnerToken } = useVault();
   const userId = user?.uid ?? null;
+  const [smsEmergencyAddresses, setSmsEmergencyAddresses] = useState<
+    Record<string, string>
+  >({});
   const cache = useMemo(() => CacheService.getInstance(), []);
 
   // ── Debate + background-task live stores (in-memory, synchronous) ──
@@ -300,10 +308,104 @@ export function useFeedActionables(): UseFeedActionablesResult {
   // + the stable refresh callbacks, not the changing wrapper identity.
   const locationRequests = locationResource.data?.requests;
   const receivedGrants = locationResource.data?.receivedGrants;
+  const myRecipientKey = locationResource.data?.myRecipientKey;
   const locationRefresh = locationResource.refresh;
   const connectionRequests = connectionsResource.data;
   const connectionsRefresh = connectionsResource.refresh;
   const consentItems = consentListResource.data?.items;
+
+  // SOS location remains end-to-end encrypted at rest. Only active SOS
+  // grants are opened here, while the recipient vault is unlocked. The
+  // decrypted coordinate exists only long enough to reverse-geocode it;
+  // Feed state retains the resulting human-readable address, never the
+  // plaintext point.
+  useEffect(() => {
+    const emergencies = (receivedGrants ?? []).filter(
+      isActiveSmsEmergencyGrant,
+    );
+
+    if (!userId || !vaultOwnerToken || emergencies.length === 0) {
+      setSmsEmergencyAddresses((current) =>
+        Object.keys(current).length === 0 ? current : {},
+      );
+      return;
+    }
+
+    let cancelled = false;
+
+    void Promise.all(
+      emergencies.map(async (grant) => {
+        try {
+          const response = await OneLocationService.viewEnvelope({
+            vaultOwnerToken,
+            grantId: grant.id,
+          });
+
+          let point;
+          try {
+            point = await decryptLocationEnvelope({
+              userId,
+              envelope: response.envelope,
+            });
+          } catch (decryptError) {
+            // Match the Location workspace recovery path: a new device
+            // may need to restore the vault-synced recipient key once.
+            if (
+              decryptError instanceof Error &&
+              decryptError.message === RECIPIENT_KEY_UNAVAILABLE_MESSAGE &&
+              vaultKey &&
+              myRecipientKey?.encryptedPrivateKeyJwk
+            ) {
+              await ensureVaultSyncedRecipientKey({
+                userId,
+                vaultKey,
+                remoteBackup: myRecipientKey,
+              });
+              point = await decryptLocationEnvelope({
+                userId,
+                envelope: response.envelope,
+              });
+            } else {
+              throw decryptError;
+            }
+          }
+
+          const place = await OneLocationService.reverseGeocode({
+            vaultOwnerToken,
+            lat: point.latitude,
+            lng: point.longitude,
+          });
+
+          const address =
+            place.formattedAddress?.trim() || place.name?.trim() || "";
+
+          return [grant.id, address] as const;
+        } catch {
+          // The emergency card must remain useful even while an envelope,
+          // key, or geocoder is temporarily unavailable.
+          return [grant.id, ""] as const;
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) return;
+
+      setSmsEmergencyAddresses(
+        Object.fromEntries(
+          entries.filter(([, address]) => Boolean(address)),
+        ),
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    myRecipientKey,
+    receivedGrants,
+    userId,
+    vaultKey,
+    vaultOwnerToken,
+  ]);
 
   const actionables = useMemo<FeedActionable[]>(() => {
     if (!userId) return [];
@@ -354,15 +456,19 @@ export function useFeedActionables(): UseFeedActionablesResult {
     );
     for (const grant of smsEmergencies) {
       const label = grant.ownerDisplayName?.trim() || "A contact";
+      const emergencyMessage =
+        grant.shareMessage?.trim() ||
+        "Emergency SMS — sharing live location with you now.";
+      const lastKnownAddress = smsEmergencyAddresses[grant.id]?.trim();
       items.push({
         id: `sms-emergency:${grant.id}`,
         icon: Siren,
         iconTone: "red",
         emphasis: "emergency",
         title: `${label} triggered an SOS`,
-        description:
-          grant.shareMessage?.trim() ||
-          "Emergency SMS — sharing live location with you now.",
+        description: lastKnownAddress
+          ? `${emergencyMessage} | Last known: ${lastKnownAddress}`
+          : emergencyMessage,
         href: buildOneLocationNotificationHref(grant.id),
         chevron: true,
         actions: [],
@@ -609,6 +715,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
     debateState.tasks,
     locationRequests,
     receivedGrants,
+    smsEmergencyAddresses,
     locationRefresh,
     openAnalysis,
     pendingConsentCount,


### PR DESCRIPTION
## What

Show the recipient-visible last-known address on active SOS emergency cards in Feed.

## Problem

An incoming SOS Feed card currently tells the receiver that live location is being shared, but does not show the sender's last-known address.

## Fix

- open only active SOS location envelopes while the recipient vault is unlocked
- decrypt the location recipient-side using the existing One Location encryption path
- restore the vault-synced recipient key when needed
- reverse-geocode through the authenticated One Location service
- retain only the human-readable address in Feed state
- preserve the existing emergency message if envelope/decryption/geocoding is temporarily unavailable

Plaintext coordinates are not persisted in Feed state.

## Verification

- original behavior reproduced 2/2
- focused Bug 22 regression passed 2/2
- Feed/emergency regressions: 13/13 passed
- targeted ESLint passed
- TypeScript passed
- real FeedActionableRow browser verification passed 2/2
- 320px and 375px layouts passed without overflow
- accessibility description includes the address
- production build passed
- clean production build retry exited 0
- DCO Signed-off-by verified