### PR TITLE
fix(notifications): dynamically include sender name in connection request push payload

### DIFF
--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -113,18 +113,68 @@ def send_user_data_push(
         return 0
 
 
+_GENERIC_CONNECTION_REQUEST_BODY = "Someone wants to connect with you on hushh."
+
+
+def _connection_request_body(requester_name: str | None) -> str:
+    """Connection-request banner copy. Names the requester when we have one,
+    else falls back to the generic line — never emits ``None``/``undefined``."""
+    name = (requester_name or "").strip()
+    if not name:
+        return _GENERIC_CONNECTION_REQUEST_BODY
+    return f"{name} wants to connect with you on hushh."
+
+
+def _lookup_display_name(user_id: str) -> str:
+    """Best-effort requester display name from the actor identity cache.
+
+    Returns "" on any miss/error, and — mirroring ``send_user_data_push`` —
+    checks Firebase config FIRST so credential-less environments never touch the
+    database. The banner degrades to the generic copy when this returns "".
+    """
+    user_id = (user_id or "").strip()
+    if not user_id:
+        return ""
+    try:
+        from api.utils.firebase_admin import ensure_firebase_admin
+
+        configured, _ = ensure_firebase_admin()
+        if not configured:
+            return ""
+
+        from db.db_client import get_db
+
+        rows = (
+            get_db()
+            .execute_raw(
+                "SELECT display_name FROM actor_identity_cache WHERE user_id = :user_id LIMIT 1",
+                {"user_id": user_id},
+            )
+            .data
+            or []
+        )
+        if not rows:
+            return ""
+        return str(rows[0].get("display_name") or "").strip()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("push.name_lookup_skipped error=%s", exc)
+        return ""
+
+
 def send_connection_request_push(addressee_user_id: str, requester_user_id: str) -> int:
     """Nudge the addressee's client that a new connection request arrived.
 
     The payload's ``type`` drives the client (see notification-provider.tsx):
     on receipt it invalidates the consent-center cache so the incoming request
-    surfaces without a manual refresh. Body is intentionally generic (no
-    requester name lookup on the write hot path)."""
+    surfaces without a manual refresh. The banner names the requester when the
+    identity cache has a display name, and degrades to the generic line
+    otherwise (best-effort; the lookup never blocks or raises)."""
+    requester_name = _lookup_display_name(requester_user_id)
     return send_user_data_push(
         addressee_user_id,
         notification_type="connection_request",
         title="New connection request",
-        body="Someone wants to connect with you on hushh.",
+        body=_connection_request_body(requester_name),
         deep_link="/one/consent?tab=connections",
         notification_tag=f"connection-request:{addressee_user_id}",
         notification_category="ONE_CONNECTIONS",

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -1,0 +1,28 @@
+from hushh_mcp.services.push_notifications import (
+    _GENERIC_CONNECTION_REQUEST_BODY,
+    _connection_request_body,
+)
+
+
+def test_connection_request_body_names_the_requester():
+    assert _connection_request_body("Ankit") == "Ankit wants to connect with you on hushh."
+
+
+def test_connection_request_body_trims_whitespace_around_the_name():
+    assert (
+        _connection_request_body("  Ankit Sharma  ")
+        == "Ankit Sharma wants to connect with you on hushh."
+    )
+
+
+def test_connection_request_body_falls_back_when_name_is_missing():
+    assert _connection_request_body(None) == _GENERIC_CONNECTION_REQUEST_BODY
+    assert _connection_request_body("") == _GENERIC_CONNECTION_REQUEST_BODY
+    assert _connection_request_body("   ") == _GENERIC_CONNECTION_REQUEST_BODY
+
+
+def test_connection_request_body_never_emits_none_or_undefined():
+    for value in (None, "", "   ", "Ankit"):
+        body = _connection_request_body(value)
+        assert "None" not in body
+        assert "undefined" not in body


### PR DESCRIPTION
# Description

**Bug (iOS / APNs):** the incoming connection-request push banner always read
**"Someone wants to connect with you on hushh."**, even when the sender was
known — it never named the requester (e.g. "Ankit wants to connect with you on
hushh.").

**Root cause:** `send_connection_request_push` hard-coded a generic body,
deliberately skipping a name lookup on the write path.

**Fix** (`consent-protocol/hushh_mcp/services/push_notifications.py`):
- `_connection_request_body(name)` — pure formatter: `"<name> wants to connect
  with you on hushh."` when a name is present, else the generic line. Trims
  whitespace and **never emits `None`/`undefined`**.
- `_lookup_display_name(user_id)` — best-effort read from `actor_identity_cache`.
  It checks Firebase config **first** (mirroring `send_user_data_push`) so
  credential-less environments never touch the database, returns `""` on any
  miss/error, and **never raises** — the banner cleanly degrades to the generic
  copy.
- `send_connection_request_push` now resolves the name and passes
  `_connection_request_body(name)` as the body.

Backend-only, additive, and best-effort: if the name can't be resolved the banner
is exactly as before.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None — internal push-notification service only
- API / schema / type changes:
  - [x] None (two new module-private helpers)
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] Listed below: one best-effort read of `actor_identity_cache.display_name` on the push path, gated behind the Firebase-configured check (no write; no-ops in unconfigured envs)
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: fixes the iOS APNs banner copy; same payload benefits Android/FCM
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Listed below: notification copy only; the display name is already shown to the addressee elsewhere (consent center). No new data exposure, no PII beyond the requester's existing display name.
- Caller / proxy / backend pairing:
  - [x] Not applicable — internal notifier; the client `connection_request` handler is unchanged
- Rollback or safe-failure behavior:
  - [x] Listed below: name lookup is best-effort and fail-closed to the generic body; reverting restores the prior generic copy
- UI browser or Playwright proof:
  - [x] Not applicable — server-side push payload; covered by unit tests
- Verification commands executed:
  - [x] `python -m pytest tests/services/test_push_notifications.py` — 4 pass
  - [x] `ruff check` + `ruff format --check` on the changed files — pass
  - [x] Frontend gates not applicable (no `hushh-webapp` files changed; path filters skip the web lanes)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate.
- [x] This changes a current reachable surface (connection-request push).
- [x] Reachable production attach point: `send_connection_request_push` (called by `connections_service._default_notifier`).
- [x] New tests exercise production code (`_connection_request_body`), not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — backend push-service copy
- [x] **iOS**: fixed here — APNs banner now names the sender
- [x] **Android**: benefits from the same payload (FCM)

## 🧪 Testing

- [x] Backend unit: `test_push_notifications.py` — named, whitespace-trimmed, and empty/None/whitespace fallbacks; asserts no `None`/`undefined` leaks
- [ ] iOS device — not run here; verified by the payload formatter unit tests
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Before: "Someone wants to connect with you on hushh." After: "Ankit wants to
connect with you on hushh." (falls back to the generic line when no display name
is cached). Verified by unit tests; iOS banner needs a TestFlight build to see on
device.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It reads the requester's already-visible
  display name from the identity cache to render the banner; no new data class.
- [x] Sensitive surface touched: notifications — best-effort, fail-closed
- [x] Error path proved: any lookup failure → generic body; never raises

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

