### PR TITLE
fix(navigation): let back retrace out of Connect, and keep the tab it left

### DIFF
--- a/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
+++ b/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resolveAgentSectionForPath } from "@/lib/navigation/agent-sections";
 import {
-  clearSectionOrigins,
-  isSectionRoot,
-  readSectionOrigin,
-  readSectionOriginsForTest,
-  recordSectionEntry,
+  clearDestinationOrigins,
+  isDestinationRoot,
+  readDestinationOrigin,
+  readDestinationOriginsForTest,
+  recordDestinationEntry,
+  resolveDestinationId,
 } from "@/lib/navigation/section-back-origin";
 import {
   navigateTopShellBack,
@@ -16,112 +16,124 @@ import {
 const KAI = "/one/kai";
 const KAI_ANALYSIS = "/one/kai/analysis";
 const LOCATION = "/one/location";
+const LOCATION_PEOPLE = "/one/location?view=people";
+const CONNECT = "/one/connect";
 const ONE_HOME = "/one";
 
 beforeEach(() => {
-  clearSectionOrigins();
+  clearDestinationOrigins();
 });
 
 /**
- * Inside a section the declared parent already climbs correctly and needs no
- * memory. The hierarchy simply cannot know which section the person crossed in
- * from, and that is the only case back got wrong: One home is what *contains*
- * Location, so entering Location from Finance and pressing back landed there.
+ * Inside a destination the declared parent already climbs correctly and needs
+ * no memory. What the hierarchy cannot know is which destination the person
+ * crossed in from, and that is the only case back got wrong.
  */
-describe("section entry recording", () => {
-  it("stores nothing for a move inside one section", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(KAI_ANALYSIS);
-
-    expect(readSectionOriginsForTest()).toEqual([]);
+describe("destination identity", () => {
+  it("treats agent sections and shared bottom-nav surfaces alike", () => {
+    expect(resolveDestinationId(LOCATION)).toBeTruthy();
+    // Connect is not an agent capability. Scoping this to sections alone is
+    // what left "Location -> Add Connections -> back" landing on One home.
+    expect(resolveDestinationId(CONNECT)).toBeTruthy();
+    expect(resolveDestinationId(LOCATION)).not.toBe(resolveDestinationId(CONNECT));
   });
 
-  it("stores one entry when crossing between sections", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(KAI_ANALYSIS);
-    recordSectionEntry(LOCATION);
-
-    const stored = readSectionOriginsForTest();
-    expect(stored).toHaveLength(1);
-    expect(stored[0]?.from).toBe(KAI_ANALYSIS);
-  });
-
-  it("ignores query and hash, so an overlay is never an entry", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(`${LOCATION}?action=share`);
-    recordSectionEntry(`${LOCATION}#map`);
-
-    expect(readSectionOriginsForTest()).toHaveLength(1);
-  });
-
-  it("refuses anything that is not an in-app absolute path", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry("https://example.com/one/location");
-    recordSectionEntry("//evil.example.com");
-
-    expect(readSectionOriginsForTest()).toEqual([]);
-  });
-
-  it("unwinds rather than stacking when a section is re-entered", () => {
-    recordSectionEntry(ONE_HOME);
-    recordSectionEntry(KAI);
-    recordSectionEntry(LOCATION);
-    recordSectionEntry(KAI);
-
-    // Back in Kai, so Location's origin is spent, not kept alongside a second
-    // Kai entry that would grow every time the person moved between two
-    // sections.
-    const ids = readSectionOriginsForTest().map((entry) => entry.sectionId);
-    expect(new Set(ids).size).toBe(ids.length);
-    expect(readSectionOrigin(LOCATION)).toBeNull();
+  it("knows which routes are exit points", () => {
+    expect(isDestinationRoot(LOCATION)).toBe(true);
+    expect(isDestinationRoot(CONNECT)).toBe(true);
+    // Deeper routes still climb their declared parents.
+    expect(isDestinationRoot(KAI_ANALYSIS)).toBe(false);
   });
 });
 
-describe("back leaves a section by its origin and climbs inside one", () => {
-  it("returns to the section the person came from", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(LOCATION);
+describe("recording crossings", () => {
+  it("stores nothing for a move inside one destination", () => {
+    recordDestinationEntry(KAI);
+    recordDestinationEntry(KAI_ANALYSIS);
 
-    // Location's declared parent is One home. The person came from Kai.
-    expect(resolveTopShellBackAction({ pathname: LOCATION })).toEqual({
-      href: KAI,
+    expect(readDestinationOriginsForTest()).toEqual([]);
+  });
+
+  it("keeps the query of the screen that was left", () => {
+    recordDestinationEntry(LOCATION_PEOPLE);
+    recordDestinationEntry(CONNECT);
+
+    // Returning to a bare /one/location is the right screen showing the wrong
+    // tab, which is what the report described.
+    expect(readDestinationOrigin(CONNECT)).toBe(LOCATION_PEOPLE);
+  });
+
+  it("does not treat a query-only change as a crossing", () => {
+    recordDestinationEntry(LOCATION);
+    recordDestinationEntry(LOCATION_PEOPLE);
+
+    expect(readDestinationOriginsForTest()).toEqual([]);
+  });
+
+  it("refuses anything that is not an in-app absolute path", () => {
+    recordDestinationEntry(LOCATION);
+    recordDestinationEntry("https://example.com/one/connect");
+    recordDestinationEntry("//evil.example.com");
+
+    expect(readDestinationOriginsForTest()).toEqual([]);
+  });
+
+  it("unwinds rather than stacking when a destination is re-entered", () => {
+    recordDestinationEntry(ONE_HOME);
+    recordDestinationEntry(LOCATION);
+    recordDestinationEntry(CONNECT);
+    recordDestinationEntry(LOCATION);
+
+    const ids = readDestinationOriginsForTest().map((e) => e.destinationId);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(readDestinationOrigin(CONNECT)).toBeNull();
+  });
+});
+
+describe("back leaves a destination by its origin", () => {
+  it("returns from Connect to the exact Location screen it was opened from", () => {
+    recordDestinationEntry(LOCATION_PEOPLE);
+    recordDestinationEntry(CONNECT);
+
+    expect(resolveTopShellBackAction({ pathname: CONNECT })).toEqual({
+      href: LOCATION_PEOPLE,
       mode: "push",
     });
   });
 
-  it("climbs the hierarchy inside a section, ignoring the origin", () => {
-    recordSectionEntry(LOCATION);
-    recordSectionEntry(KAI);
-    recordSectionEntry(KAI_ANALYSIS);
+  it("climbs inside a destination, ignoring the origin", () => {
+    recordDestinationEntry(LOCATION);
+    recordDestinationEntry(KAI);
+    recordDestinationEntry(KAI_ANALYSIS);
 
-    // Analysis is not a section root, so back climbs to its declared parent
-    // rather than jumping out to Location.
     const action = resolveTopShellBackAction({ pathname: KAI_ANALYSIS });
     expect(action?.href).not.toBe(LOCATION);
-    expect(isSectionRoot(KAI_ANALYSIS)).toBe(false);
   });
 
   it("falls back to the declared parent with no recorded origin", () => {
-    // A deep link, a cold start, a shared invite link. Unchanged behaviour.
+    // Deep link, cold start, shared invite link. Unchanged behaviour.
     expect(resolveTopShellBackAction({ pathname: "/ria/onboarding" })).toEqual({
       href: ONE_HOME,
       mode: "push",
     });
   });
 
-  it("spends the origin so a later visit does not retrace a stale route", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(LOCATION);
+  it("spends the origin so a later visit cannot retrace a stale route", () => {
+    recordDestinationEntry(LOCATION_PEOPLE);
+    recordDestinationEntry(CONNECT);
     const navigate = vi.fn();
 
-    navigateTopShellBack({ pathname: LOCATION, navigate });
-    expect(navigate).toHaveBeenCalledWith({ href: KAI, mode: "push" });
-    expect(readSectionOrigin(LOCATION)).toBeNull();
+    navigateTopShellBack({ pathname: CONNECT, navigate });
+    expect(navigate).toHaveBeenCalledWith({
+      href: LOCATION_PEOPLE,
+      mode: "push",
+    });
+    expect(readDestinationOrigin(CONNECT)).toBeNull();
   });
 
-  it("closes an open action sheet in place instead of leaving the section", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(LOCATION);
+  it("closes an open action sheet in place instead of leaving", () => {
+    recordDestinationEntry(KAI);
+    recordDestinationEntry(LOCATION);
     const navigate = vi.fn();
 
     navigateTopShellBack({
@@ -132,25 +144,20 @@ describe("back leaves a section by its origin and climbs inside one", () => {
 
     expect(navigate).toHaveBeenCalledWith({ href: LOCATION, mode: "replace" });
     // The overlay closed; the origin is still owed for when they actually go.
-    expect(readSectionOrigin(LOCATION)).toBe(KAI);
+    expect(readDestinationOrigin(LOCATION)).toBe(KAI);
   });
 
   it("still reports no back where the shell hides it", () => {
-    recordSectionEntry(KAI);
-    recordSectionEntry(LOCATION);
+    recordDestinationEntry(LOCATION);
+    recordDestinationEntry(CONNECT);
 
     // The iOS edge-back gesture enables itself from this returning an action,
     // so when back exists must not shift.
     expect(
       resolveTopShellBackAction({
-        pathname: LOCATION,
+        pathname: CONNECT,
         breadcrumb: { backHref: ONE_HOME, hideBack: true, items: [] },
       }),
     ).toBeNull();
-  });
-
-  it("treats a section root as the exit point", () => {
-    expect(isSectionRoot(LOCATION)).toBe(true);
-    expect(resolveAgentSectionForPath(LOCATION)).not.toBeNull();
   });
 });

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -53,7 +53,7 @@ import {
   useKaiBottomChromeProgressCssVar,
 } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import { recordSectionEntry } from "@/lib/navigation/section-back-origin";
+import { recordDestinationEntry } from "@/lib/navigation/section-back-origin";
 import {
   ROUTES,
   isFoundationPublicRoute,
@@ -87,15 +87,22 @@ function AppShellFrame({ children }: ProvidersProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { isAuthenticated, loading: authLoading } = useAuth();
-  // Section crossings behind the shared back contract. Recorded here because
-  // this frame renders for every route, including chrome-less ones, and a
-  // screen with no top bar can still be the place a section was entered from.
-  // Moves inside a section store nothing. `pathname`, not `shellPathname`:
-  // this is where the person went, not what the shell substituted for an
-  // unauthenticated render.
+  // Destination crossings behind the shared back contract. Recorded here
+  // because this frame renders for every route, including chrome-less ones,
+  // and a screen with no top bar can still be where a destination was entered
+  // from. Moves within a destination store nothing.
+  //
+  // The query is carried deliberately: leaving `/one/location?view=people` for
+  // Connect and coming back has to return to the People tab, not to a bare
+  // `/one/location`, which is the right screen showing the wrong thing.
+  //
+  // `pathname`, not `shellPathname`: this is where the person went, not what
+  // the shell substituted for an unauthenticated render.
+  const search = searchParams?.toString() ?? "";
   useEffect(() => {
-    recordSectionEntry(pathname || "/");
-  }, [pathname]);
+    const base = pathname || "/";
+    recordDestinationEntry(search ? `${base}?${search}` : base);
+  }, [pathname, search]);
   const isPublicKnowledgeWorkspace =
     pathname === ROUTES.WELCOME &&
     ["research", "blog", "developers"].includes(searchParams?.get("tab") ?? "");

--- a/hushh-webapp/lib/navigation/section-back-origin.ts
+++ b/hushh-webapp/lib/navigation/section-back-origin.ts
@@ -1,113 +1,156 @@
 /**
- * How the person got *into* the section they are standing in.
+ * How the person got *into* the destination they are standing in.
  *
  * Back is authored: `resolveTopShellBackAction` returns a route's declared
- * parent. Inside a section that is exactly right -- Analysis climbs to Kai,
- * Kai climbs to One -- and it needs no memory at all, because the hierarchy is
- * already declared. The one thing the hierarchy cannot know is which section
- * you came from when you crossed between two of them, and that is the only
- * case where back used to dump people on One home: home is what *contains*
- * Location, so entering Location from Finance and pressing back landed there.
+ * parent. Inside a destination that is exactly right -- Analysis climbs to Kai,
+ * Kai climbs to One -- and it needs no memory, because the hierarchy is already
+ * declared. What the hierarchy cannot know is which destination you came from
+ * when you crossed between two of them, and that is the only case where back
+ * used to strand people on One home.
  *
- * So this records section entries and nothing else. A move within a section
- * stores nothing. Only a jump between sections -- Finance to PKM, Kai to
- * Location -- pushes one entry, and back consumes it at the section root.
+ * So this records crossings and nothing else. A move within a destination
+ * stores nothing; only a jump between two pushes an entry, consumed when back
+ * leaves at the destination's root.
  *
- * Deliberately not browser history: that stack carries external origins, and
- * on iOS it would eject the person out of the app. WKWebView has no native
- * stack for Next routes, and the edge-back gesture shares this same contract.
+ * A "destination" is an agent section (Location, Kai, PKM...) OR one of the
+ * shared bottom-nav surfaces (Connect, Marketplace, Profile). The second half
+ * matters: Connect is not an agent capability, so scoping this to sections
+ * alone recorded nothing when someone went Location -> Add Connections, and
+ * back fell through to One home -- the original bug, one layer along.
+ *
+ * Deliberately not browser history: that stack carries external origins, and on
+ * iOS it would eject the person out of the app. WKWebView has no native stack
+ * for Next routes, and the edge-back gesture shares this same contract.
  */
 
 import { resolveAgentSectionForPath } from "@/lib/navigation/agent-sections";
+import { isCommonBottomNavRoute } from "@/lib/navigation/app-bottom-nav";
+import { ROUTES } from "@/lib/navigation/routes";
 
-type SectionEntry = {
-  sectionId: string;
-  /** The in-app pathname the person was on when they entered this section. */
+type DestinationEntry = {
+  destinationId: string;
+  /**
+   * The in-app href the person was on when they entered. Keeps its query: the
+   * reported case was `/one/location?view=people`, and returning to a bare
+   * `/one/location` drops them on the wrong tab of the right screen.
+   */
   from: string;
 };
 
-/** Bounded by how deeply sections can nest, which is shallow in practice. */
+/** Bounded by how deeply destinations nest, which is shallow in practice. */
 const MAX_ENTRIES = 8;
 
-let entries: SectionEntry[] = [];
-let currentSectionId: string | null = null;
-let currentPathname: string | null = null;
+/** Shared surfaces that are destinations without being agent sections. */
+const BOTTOM_NAV_ROOTS: readonly string[] = [
+  ROUTES.CONNECT,
+  ROUTES.MARKETPLACE,
+  ROUTES.PROFILE,
+];
 
-function normalize(pathname: string | null | undefined): string | null {
-  const clean = String(pathname || "").trim();
+let entries: DestinationEntry[] = [];
+let currentDestinationId: string | null = null;
+let currentHref: string | null = null;
+
+function pathOf(href: string | null | undefined): string | null {
+  const clean = String(href || "").trim();
   if (!clean.startsWith("/") || clean.startsWith("//")) return null;
-  return clean.split(/[?#]/)[0] || null;
+  return clean.split(/[?#]/)[0]?.replace(/\/$/, "") || "/";
+}
+
+function bottomNavRootFor(path: string): string | null {
+  if (!isCommonBottomNavRoute(path)) return null;
+  return (
+    BOTTOM_NAV_ROOTS.find(
+      (root) => path === root || path.startsWith(`${root}/`),
+    ) ?? null
+  );
+}
+
+/** Which destination a path belongs to, or null when it belongs to none. */
+export function resolveDestinationId(href: string): string | null {
+  const path = pathOf(href);
+  if (!path) return null;
+  const section = resolveAgentSectionForPath(path);
+  if (section) return `section:${section.id}`;
+  const root = bottomNavRootFor(path);
+  return root ? `nav:${root}` : null;
 }
 
 /**
- * Note arrival at a pathname. Stores an entry only when the section changed,
- * so navigating around inside one section costs nothing.
+ * True where back leaves the destination rather than climbing inside it. Only
+ * a destination's own root qualifies; anything deeper still climbs its
+ * declared parents, which is already correct and needs no memory.
  */
-export function recordSectionEntry(pathname: string): void {
-  const path = normalize(pathname);
-  if (!path) return;
-  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
+export function isDestinationRoot(href: string): boolean {
+  const path = pathOf(href);
+  if (!path) return false;
+  const section = resolveAgentSectionForPath(path);
+  if (section) return pathOf(section.href) === path;
+  const root = bottomNavRootFor(path);
+  return root ? root === path : false;
+}
 
-  if (sectionId && sectionId !== currentSectionId && currentPathname) {
-    // Returning to a section already on the stack is a retrace, not a new
+/**
+ * Note arrival. Stores an entry only when the destination changed, so moving
+ * around inside one costs nothing.
+ */
+export function recordDestinationEntry(href: string): void {
+  const path = pathOf(href);
+  if (!path) return;
+  const destinationId = resolveDestinationId(path);
+  const arrivedHref = String(href).trim();
+
+  if (destinationId && destinationId !== currentDestinationId && currentHref) {
+    // Returning to a destination already on the stack is a retrace, not a new
     // entry: unwind to it rather than stacking a second origin for it.
-    const existing = entries.findIndex((entry) => entry.sectionId === sectionId);
+    const existing = entries.findIndex(
+      (entry) => entry.destinationId === destinationId,
+    );
     if (existing !== -1) {
       entries = entries.slice(0, existing + 1);
     } else {
-      entries.push({ sectionId, from: currentPathname });
+      entries.push({ destinationId, from: currentHref });
       if (entries.length > MAX_ENTRIES) entries.shift();
     }
   }
 
-  currentSectionId = sectionId;
-  currentPathname = path;
+  currentDestinationId = destinationId;
+  currentHref = arrivedHref;
 }
 
 /**
- * Where to leave this section for, or null when the person did not arrive
- * from another section -- a deep link, a cold start, a shared invite link.
- * The authored parent is the right answer in those cases.
+ * Where to leave this destination for, or null when the person did not arrive
+ * from another -- a deep link, a cold start, a shared invite link. The declared
+ * parent is the right answer in those cases.
  */
-export function readSectionOrigin(pathname: string): string | null {
-  const path = normalize(pathname);
-  if (!path) return null;
-  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
-  if (!sectionId) return null;
+export function readDestinationOrigin(href: string): string | null {
+  const destinationId = resolveDestinationId(href);
+  if (!destinationId) return null;
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (entry && entry.sectionId === sectionId) return entry.from;
+    if (entry && entry.destinationId === destinationId) return entry.from;
   }
   return null;
 }
 
-/** True when this pathname is the section's own root, where back leaves it. */
-export function isSectionRoot(pathname: string): boolean {
-  const path = normalize(pathname);
-  if (!path) return false;
-  const section = resolveAgentSectionForPath(path);
-  if (!section) return false;
-  return normalize(section.href) === path;
-}
-
-/** Drop the entry for this section once back has spent it. */
-export function consumeSectionOrigin(pathname: string): void {
-  const path = normalize(pathname);
-  if (!path) return;
-  const sectionId = resolveAgentSectionForPath(path)?.id ?? null;
-  if (!sectionId) return;
-  const index = entries.findIndex((entry) => entry.sectionId === sectionId);
+/** Drop the entry for this destination once back has spent it. */
+export function consumeDestinationOrigin(href: string): void {
+  const destinationId = resolveDestinationId(href);
+  if (!destinationId) return;
+  const index = entries.findIndex(
+    (entry) => entry.destinationId === destinationId,
+  );
   if (index !== -1) entries = entries.slice(0, index);
 }
 
 /** Reset point for a sign-out or an account switch. */
-export function clearSectionOrigins(): void {
+export function clearDestinationOrigins(): void {
   entries = [];
-  currentSectionId = null;
-  currentPathname = null;
+  currentDestinationId = null;
+  currentHref = null;
 }
 
 /** Test seam: no production caller should read the stack directly. */
-export function readSectionOriginsForTest(): SectionEntry[] {
+export function readDestinationOriginsForTest(): DestinationEntry[] {
   return [...entries];
 }

--- a/hushh-webapp/lib/navigation/top-shell-back.ts
+++ b/hushh-webapp/lib/navigation/top-shell-back.ts
@@ -1,7 +1,7 @@
 import {
-  consumeSectionOrigin,
-  isSectionRoot,
-  readSectionOrigin,
+  consumeDestinationOrigin,
+  isDestinationRoot,
+  readDestinationOrigin,
 } from "@/lib/navigation/section-back-origin";
 import {
   resolveTopShellBreadcrumb,
@@ -69,13 +69,13 @@ export function resolveTopShellBackAction(params: {
   // Only the section root leaves the section. Everywhere else the declared
   // parent already climbs the hierarchy correctly, which is why nothing is
   // stored for moves inside a section.
-  if (!isSectionRoot(params.pathname)) {
+  if (!isDestinationRoot(params.pathname)) {
     return { href: breadcrumb.backHref, mode: "push" };
   }
 
   const origin =
     params.sectionOrigin === undefined
-      ? readSectionOrigin(params.pathname)
+      ? readDestinationOrigin(params.pathname)
       : params.sectionOrigin;
 
   return { href: origin || breadcrumb.backHref, mode: "push" };
@@ -93,8 +93,8 @@ export function navigateTopShellBack(params: {
   // Leaving a section spends its origin, so a later return records a fresh
   // one instead of retracing to a route the person has long left. Closing an
   // overlay is a `replace` on the same screen and spends nothing.
-  if (action.mode === "push" && isSectionRoot(params.pathname)) {
-    consumeSectionOrigin(params.pathname);
+  if (action.mode === "push" && isDestinationRoot(params.pathname)) {
+    consumeDestinationOrigin(params.pathname);
   }
   params.navigate(action);
   return true;


### PR DESCRIPTION
## Summary

Follow-up to #5012, from a live UAT report: opening **Add Connections** from `/one/location?view=people` and pressing back still landed on **One home**.

Two distinct gaps, both mine:

**Connect was not a "destination".** The origin recorded in #5012 keyed on the agent-section registry, which holds capability surfaces only — `KAI_HOME`, `ONE_LOCATION`, `PKM`, `GMAIL`… Connect is a shared bottom-nav surface, not a capability, so `resolveAgentSectionForPath("/one/connect")` returned `null`. Nothing was recorded on the way in, the route was never an exit point, and back fell through to the declared parent. The original bug, one layer along.

A destination is now an agent section **or** one of the shared bottom-nav surfaces (Connect, Marketplace, Profile). That is deliberately a bounded set rather than "any route that is not a section" — the wider rule would have made every Profile subpage an exit point and broken its climbing.

**The origin dropped its query.** The report came from `/one/location?view=people`; returning to a bare `/one/location` is the right screen showing the wrong tab. Origins now keep their query, while *identity* stays pathname-level — so a query-only change is still not a crossing, and opening a tab cannot become a back step. That constraint is the whole reason the authored model exists.

## Unchanged by design

- Deeper routes climb their declared parents
- No recorded origin → declared parent (deep link, cold start, shared invite link)
- Overlays and action sheets close in place
- A hidden back stays hidden — the iOS edge-back gesture enables itself from whether the resolver returns an action, so *when* back exists must not shift

## Test plan

- [x] `tsc --noEmit` clean, `eslint --max-warnings=0` clean on all changed files
- [x] 92/92 in `__tests__/navigation`, including the reported case end to end: Location?view=people → Connect → back returns to `/one/location?view=people`
- [x] New coverage for identity (sections and bottom-nav alike), exit points, query-only changes not counting as crossings, re-entry unwinding, origin spent on use, overlay closing without spending it
- [x] Full frontend suite: 3209 passed, 20 failed across 10 files — **all pre-existing**, verified by stashing this work and re-running the three suites I had not seen before (`foundation-public-ambient`, `page-sections`, `settings-ui`); they fail identically on clean main
- [ ] Not verified on device: iOS edge-back. Shared resolver, unit-covered, but deserves a real swipe on a build.