### PR TITLE
fix(connect): stop offering bulk selection, keep the machinery

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -151,28 +151,24 @@ describe("Connect — People", () => {
     expect(await screen.findByText('No one matches "Nobody"')).toBeTruthy();
   });
 
-  it("drops selections the new result set no longer shows", async () => {
-    // "Connect to Selected (N)" counts this set, so an N covering people who
-    // scrolled out of existence is a number the reader cannot reconcile.
+  /**
+   * Bulk selection is deliberately unreachable: the entry point was removed
+   * because selecting many people at once was not a clear answer to finding
+   * the right one, and it invited fanning out requests instead of searching.
+   *
+   * This pins the removal rather than the old behaviour. The selection state,
+   * the per-row checkboxes and the bulk request handler are all still in the
+   * component on purpose, so restoring the control is a one-line change -- but
+   * while it is hidden that path has no coverage, and the previous test for it
+   * ("drops selections the new result set no longer shows") went with the
+   * button. Reinstating the control should reinstate that test.
+   */
+  it("does not offer bulk selection", async () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByText("Select"));
-    fireEvent.click(screen.getByLabelText("Select Person 0"));
-    expect(screen.getByText("Connect to Selected (1)")).toBeTruthy();
-
-    mocks.searchDirectory.mockResolvedValue({
-      items: [person("u9", "Person 9")],
-      hasMore: false,
-      page: 1,
-    });
-    fireEvent.change(screen.getByLabelText("Search people"), {
-      target: { value: "Person 9" },
-    });
-
-    expect(await screen.findByText("Person 9")).toBeTruthy();
-    await waitFor(() =>
-      expect(screen.queryByText("Connect to Selected (1)")).toBeNull(),
-    );
+    expect(screen.queryByText("Select")).toBeNull();
+    expect(screen.queryByText("Select All")).toBeNull();
+    expect(screen.queryByLabelText("Select Person 0")).toBeNull();
   });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -660,39 +660,20 @@ export default function ConnectPageClient() {
                     }}
                   />
                 </div>
-                {people.length > 0 && (
-                  <div className="flex shrink-0 items-center gap-1">
-                    {isSelectionMode && (
-                      <Button
-                        type="button"
-                        variant="none"
-                        effect="fade"
-                        onClick={() => {
-                          if (selectedUserIds.size === people.length) {
-                            setSelectedUserIds(new Set());
-                          } else {
-                            setSelectedUserIds(
-                              new Set(people.map((p) => p.userId)),
-                            );
-                          }
-                        }}
-                      >
-                        {selectedUserIds.size === people.length ? "Deselect All" : "Select All"}
-                      </Button>
-                    )}
-                    <Button
-                      type="button"
-                      variant="none"
-                      effect="fade"
-                      onClick={() => {
-                        setIsSelectionMode(!isSelectionMode);
-                        if (isSelectionMode) setSelectedUserIds(new Set());
-                      }}
-                    >
-                      {isSelectionMode ? "Cancel" : "Select"}
-                    </Button>
-                  </div>
-                )}
+                {/*
+                  The Select / Select All controls are intentionally not
+                  rendered. Bulk-selecting people was not a clear answer to the
+                  problem it was reaching for -- finding the right person in a
+                  list that grows with every signup -- and shipping it invited
+                  people to fan out requests rather than helping them search.
+
+                  The machinery below is deliberately left in place: selection
+                  mode, the per-row checkboxes, and the bulk request action all
+                  still work, and `isSelectionMode` simply has no way to become
+                  true from the UI. Restoring the entry point is a one-line
+                  change if a clearer design arrives. Do not delete the state or
+                  the bulk handler on the grounds that they look unreachable.
+                */}
               </div>
               <SettingsGroup
                 title={hasQuery ? "People" : "Suggested"}


### PR DESCRIPTION
## Summary

Removes the **Select** control from Connect → People, per maintainer direction.

Selecting many people at once was not a clear answer to the problem it reached for — finding the right person in a list that grows with every signup — and offering it invited fanning requests out instead of searching. The control is removed rather than reworked, because a better answer has not been decided yet.

**Only the entry point goes.** Selection state, the per-row checkboxes and the bulk request handler all stay exactly as they are, with a comment in place saying why they look unreachable, so restoring the control is a one-line change rather than a rebuild. `isSelectionMode` simply has no way to become true from the UI.

## Trade-off worth naming

The test that drove the bulk flow *through* that button went with it, replaced by one that pins the removal. While the control is hidden, the bulk path has **no coverage** — so reinstating the control should reinstate the test it replaced. That is stated in both the code comment and the test, so it cannot be discovered by surprise later.

## Test plan

- [x] `tsc --noEmit` clean, `eslint --max-warnings=0` clean
- [x] `__tests__/app/connect` 9/9 pass, including the new "does not offer bulk selection"