### PR TITLE
fix(one-location): let the features splash use a wide viewport

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -2227,8 +2227,15 @@ export function OneLocationOnboardingFlow({
       <section
         className={cn(
           "flex h-full min-h-0 w-full flex-col overflow-hidden bg-white dark:bg-[#0c1017]",
+          // Features sizes off viewport HEIGHT so its artwork keeps its
+          // proportions on a short screen, but that left the whole panel a
+          // narrow strip on a wide one: `58dvh` shrinks as the window gets
+          // shorter, and 560px capped it however much room there was. Keep
+          // that behaviour where it earns its place -- phones and short
+          // windows -- and let a genuinely wide viewport use the width, the
+          // same way the SOS panel does.
           screen === "features"
-            ? "max-w-[min(560px,58dvh)] max-[431px]:max-w-none"
+            ? "max-w-[min(560px,58dvh)] max-[431px]:max-w-none lg:max-w-3xl"
             : "max-w-[480px]",
         )}
         data-testid={LOCATION_SCREEN_TEST_IDS[screen]}


### PR DESCRIPTION
## Summary

The second Location onboarding splash sized its panel off viewport **height**:

```
screen === "features" ? "max-w-[min(560px,58dvh)] max-[431px]:max-w-none" : ...
```

So on a wide window it stayed a narrow strip with the room around it unused, and it got *narrower* as the window got shorter — the opposite of what a wide screen wants.

The height coupling earns its place on phones and short windows, where it keeps the artwork in proportion, so it stays. A genuinely wide viewport now gets the width, mirroring how the SOS panel was widened in #4991.

## iOS

Unaffected by construction: an iPhone viewport never reaches the `lg` breakpoint, so the Capacitor build keeps its existing sizing exactly. This is a widen-upward-only change.

## Test plan

- [x] `tsc --noEmit` clean, `eslint --max-warnings=0` clean
- [x] Location component suites: 235 passed; the 3 failures in `one-location-agent-page` are pre-existing (emergency-call link assertions, unrelated to layout)
- [ ] Not verified on device — responsive-only, and the changed breakpoint is above any phone width

## Not included

The companion report that **splash 1 scrolls when it shouldn't** is not addressed here. `WelcomeScreen` is already `overflow-hidden` inside a `fixed inset-0` shell and I could not reproduce a scroller from source — that one needs a repro (device, orientation, screenshot) before I guess at it.