### PR TITLE
feat(connect): page the people directory, with a page size the reader picks

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -106,13 +106,35 @@ describe("Connect — People", () => {
     expect(screen.getByText("Person 0")).toBeTruthy();
   });
 
-  it("never offers to page deeper into the sample, whatever the server says", async () => {
-    // hasMore is true in the fixture: a sample that pages is just the register
-    // again, one tap further away.
+  it("offers paging and a page size, rather than a sample with no way past it", async () => {
+    // A bounded first screenful was the right instinct, but refusing to page
+    // left the rest of the directory unreachable. Both now hold: a screenful
+    // by default, and a way through it.
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("Suggested")).toBeTruthy();
-    expect(screen.queryByText("Load more people")).toBeNull();
+    expect(screen.getByText("Page 1")).toBeTruthy();
+    expect(screen.getByLabelText("People per page")).toBeTruthy();
+    // hasMore is true in the fixture, so forward is offered and back is not.
+    expect(screen.getByText("Next").closest("button")?.disabled).toBe(false);
+    expect(screen.getByText("Previous").closest("button")?.disabled).toBe(true);
+  });
+
+  it("asks the server for the page and size the reader chose", async () => {
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("People per page"), {
+      target: { value: "24" },
+    });
+
+    await waitFor(() => {
+      const latest =
+        mocks.searchDirectory.mock.calls[
+          mocks.searchDirectory.mock.calls.length - 1
+        ][0];
+      expect(latest).toMatchObject({ page: 1, limit: 24 });
+    });
   });
 
   it("opens the full directory once a name is typed", async () => {
@@ -126,13 +148,15 @@ describe("Connect — People", () => {
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
     const searched = mocks.searchDirectory.mock.calls[1][0];
     expect(searched.query).toBe("Person 9");
-    // No cap on a real search — the reader has said who they are looking for.
-    expect(searched.limit).toBeUndefined();
+    // A search is paged like everything else now. Returning the whole matching
+    // set unpaged is the same unbounded list, just filtered.
+    expect(searched.limit).toBe(8);
+    expect(searched.page).toBe(1);
 
     // "People" is also the tab label, so the sample heading going away is the
     // unambiguous signal that this is no longer the bounded surface.
     await waitFor(() => expect(screen.queryByText("Suggested")).toBeNull());
-    expect(await screen.findByText("Load more people")).toBeTruthy();
+    expect(await screen.findByText("Page 1")).toBeTruthy();
   });
 
   it("says who was searched for when a search matches nobody", async () => {

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -56,6 +56,17 @@ const CONNECT_TABS = [
  */
 const SUGGESTED_PEOPLE_LIMIT = 8;
 
+/**
+ * How many people a page shows, and the sizes the reader can pick.
+ *
+ * #5020 answered "the directory is unusably long" with a fixed sample that
+ * deliberately refused to page. That solved the first screenful and left no way
+ * through the rest, so this replaces it with real paging: the default is still
+ * a screenful, and someone who wants to scan more can say so.
+ */
+const PAGE_SIZE_OPTIONS = [8, 16, 24, 50] as const;
+const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
+
 export default function ConnectPageClient() {
   const { user } = useRequireAuth();
   const router = useRouter();
@@ -68,9 +79,9 @@ export default function ConnectPageClient() {
   const [connections, setConnections] = useState<ConnectionSummaryEntry[]>([]);
   const [outgoingRequestIds, setOutgoingRequestIds] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
@@ -149,28 +160,32 @@ export default function ConnectPageClient() {
   const trimmedQuery = debouncedQuery.trim();
   const hasQuery = trimmedQuery.length > 0;
 
+  // A new query, or a new page size, is a new result set: go back to page one
+  // rather than asking for page 4 of something the reader has just redefined.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [trimmedQuery, pageSize]);
+
   useEffect(() => {
     let cancelled = false;
     async function run() {
       if (!user) return;
       try {
         setHasMore(false);
-        setCurrentPage(1);
         setLoading(true);
         setError(null);
         const idToken = await user.getIdToken();
         const page = await ConnectionsService.searchDirectory({
           idToken,
           query: trimmedQuery,
-          page: 1,
-          ...(hasQuery ? {} : { limit: SUGGESTED_PEOPLE_LIMIT }),
+          page: currentPage,
+          limit: pageSize,
         });
         if (!cancelled) {
+          // One page replaces the last. Appending was what made the directory
+          // an endless scroll with no sense of position in it.
           setPeople(page.items);
-          // A sample is not a directory: never offer to page deeper into it,
-          // whatever the server reports about what else it holds.
-          setHasMore(hasQuery ? page.hasMore : false);
-          setCurrentPage(page.page);
+          setHasMore(page.hasMore);
           // Selections are counted on the "Connect to Selected (N)" button, so
           // drop any that this result set no longer shows — an N the reader
           // cannot see is a promise the surface can't account for.
@@ -198,35 +213,18 @@ export default function ConnectPageClient() {
     return () => {
       cancelled = true;
     };
-  }, [user, hasQuery, trimmedQuery]);
+  }, [user, trimmedQuery, currentPage, pageSize]);
 
-  const loadMorePeople = useCallback(async () => {
-    if (!user || loadingMore || !hasMore || !hasQuery) return;
-    try {
-      setLoadingMore(true);
-      const idToken = await user.getIdToken();
-      const page = await ConnectionsService.searchDirectory({
-        idToken,
-        query: trimmedQuery,
-        page: currentPage + 1,
-      });
-      setPeople((current) => {
-        const existing = new Set(current.map((person) => person.userId));
-        return [
-          ...current,
-          ...page.items.filter((person) => !existing.has(person.userId)),
-        ];
-      });
-      setHasMore(page.hasMore);
-      setCurrentPage(page.page);
-    } catch (loadError) {
-      toast.error(
-        loadError instanceof Error ? loadError.message : "Failed to load more people",
-      );
-    } finally {
-      setLoadingMore(false);
-    }
-  }, [currentPage, trimmedQuery, hasQuery, hasMore, loadingMore, user]);
+  const goToPage = useCallback(
+    (next: number) => {
+      if (loading || next < 1) return;
+      // `hasMore` is the only forward signal the directory gives, so a next
+      // page is offered exactly when the server says one exists.
+      if (next > currentPage && !hasMore) return;
+      setCurrentPage(next);
+    },
+    [currentPage, hasMore, loading],
+  );
 
   const sendConnectionRequest = useCallback(
     async (
@@ -789,18 +787,56 @@ export default function ConnectPageClient() {
                     );
                   })
                 )}
-                {hasMore ? (
-                  <div className="flex justify-center px-3 py-2">
-                    <Button
-                      type="button"
-                      variant="none"
-                      effect="fill"
-                      size="sm"
-                      disabled={loadingMore}
-                      onClick={() => void loadMorePeople()}
-                    >
-                      {loadingMore ? "Loading…" : "Load more people"}
-                    </Button>
+                {people.length > 0 || currentPage > 1 ? (
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3">
+                    <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>Per page</span>
+                      <select
+                        value={pageSize}
+                        onChange={(event) =>
+                          setPageSize(Number(event.target.value))
+                        }
+                        aria-label="People per page"
+                        className="h-8 rounded-md border border-[color:var(--app-card-border-standard)] bg-transparent px-2 text-xs"
+                      >
+                        {PAGE_SIZE_OPTIONS.map((size) => (
+                          <option key={size} value={size}>
+                            {size}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="none"
+                        effect="fill"
+                        size="sm"
+                        disabled={loading || currentPage <= 1}
+                        onClick={() => goToPage(currentPage - 1)}
+                      >
+                        Previous
+                      </Button>
+                      {/* The directory reports only whether more exists, never
+                          a total, so this names the page rather than claiming
+                          "3 of 12" — a total the surface cannot stand behind. */}
+                      <span
+                        className="text-xs tabular-nums text-muted-foreground"
+                        aria-live="polite"
+                      >
+                        Page {currentPage}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="none"
+                        effect="fill"
+                        size="sm"
+                        disabled={loading || !hasMore}
+                        onClick={() => goToPage(currentPage + 1)}
+                      >
+                        Next
+                      </Button>
+                    </div>
                   </div>
                 ) : null}
                 {isSelectionMode && selectedUserIds.size > 0 && (


### PR DESCRIPTION
## Summary

**This reverses a deliberate decision in #5020**, at maintainer request — flagging that up front so it is not discovered in a diff.

#5020 answered "the People list shows everyone" with a fixed eight-person sample that explicitly refused to page, on the reasoning that "a sample that pages is just the register again, one tap further away." That fixed the first screenful and left no way through the rest: past those eight, the only route to anyone was knowing their name well enough to search.

Both halves now hold:

- The default page is still **8** — nobody lands in a wall of strangers
- **Previous / Next** plus a **per-page control** (8 / 16 / 24 / 50) make the rest reachable
- A **search is paged on the same terms**; an unpaged search is the same unbounded list, only filtered

### Details worth a reviewer's eye

**A page replaces the previous one** rather than appending. Appending is what made the directory an endless scroll with no sense of position in it — the tedium the original report described.

**The control names the page, not a total.** The directory reports only `hasMore`, never a count, so "Page 3" is honest where "3 of 12" would be a number the surface cannot stand behind.

**Changing query or page size returns to page 1**, since both redefine the result set.

## iOS

No native surface involved: a `<select>` and two buttons inside the existing scroll container, so the Capacitor build behaves as web does. Not verified on device.

## Test plan

- [x] `tsc --noEmit` clean, `eslint --max-warnings=0` clean
- [x] `__tests__/app/connect` **10/10**
- [x] #5020's two tests rewritten rather than deleted — one pins that paging is offered and back is disabled on page 1, the other that the server is asked for the chosen page and size

## Conflict note

#5027 (removing the Select control) touches the same file. Whichever merges second will need a trivial rebase.