### PR TITLE
Polish Location Agent UI spacing

### DIFF
--- a/hushh-webapp/app/one/location/invite/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/invite/[token]/page-client.tsx
@@ -17,7 +17,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/use-auth";
-import { buildPhoneMandateRoute, buildProfileVaultRoute } from "@/lib/navigation/routes";
+import {
+  buildPhoneMandateRoute,
+  buildProfileVaultRoute,
+} from "@/lib/navigation/routes";
 import { bootstrapCurrentUserLocationRecipientKey } from "@/lib/one-location/key-bootstrap";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { OneLocationCircleInvite } from "@/lib/one-location/types";
@@ -217,26 +220,26 @@ export default function OneLocationCircleInvitePageClient() {
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col justify-center px-5 py-10">
-        <div className="space-y-6 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--shadow-xs)] sm:p-7">
+      <div className="mx-auto flex min-h-screen w-full max-w-[720px] flex-col px-5 pb-10 pt-[max(48px,calc(env(safe-area-inset-top)+28px))] sm:px-6 sm:pt-[max(64px,calc(env(safe-area-inset-top)+40px))]">
+        <div className="space-y-6 rounded-[var(--app-card-radius-standard)] bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-none sm:p-6">
           <div className="flex items-start gap-4">
-            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]">
+            <div className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
               {error ? (
-                <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                <AlertTriangle className="h-[17px] w-[17px]" aria-hidden="true" />
               ) : claimed ? (
-                <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+                <CheckCircle2 className="h-[17px] w-[17px]" aria-hidden="true" />
               ) : (
-                <MapPin className="h-5 w-5" aria-hidden="true" />
+                <MapPin className="h-[17px] w-[17px]" aria-hidden="true" />
               )}
             </div>
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--app-accent)]">
+              <div className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                 Location
               </div>
-              <h1 className="mt-2 text-[28px] font-medium leading-[1.12] tracking-normal sm:text-[32px]">
+              <h1 className="mt-1 text-[32px] font-bold leading-[1.08] tracking-normal sm:text-[34px]">
                 Join One
               </h1>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              <p className="mt-3 text-[17px] leading-[24px] text-muted-foreground">
                 {loading
                   ? "Checking Invite to One link."
                   : error
@@ -258,7 +261,7 @@ export default function OneLocationCircleInvitePageClient() {
 
           {!loading && invite ? (
             <div className="space-y-4">
-              <div className="flex flex-wrap items-center gap-2 text-sm">
+              <div className="flex flex-wrap items-center gap-2 text-[13px]">
                 <Badge variant="secondary">
                   Expires {formatDateTime(invite.expiresAt)}
                 </Badge>
@@ -268,19 +271,19 @@ export default function OneLocationCircleInvitePageClient() {
               </div>
 
               {invite.message ? (
-                <div className="rounded-[var(--app-card-radius-standard)] border border-border/70 bg-background p-4 text-sm leading-6 text-muted-foreground">
+                <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-compact)] p-4 text-[15px] leading-5 text-muted-foreground">
                   {invite.message}
                 </div>
               ) : null}
 
-              <div className="rounded-[var(--app-card-radius-standard)] border border-accent-border bg-accent-surface p-4 text-sm leading-6 text-foreground">
+              <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-accent)]/10 p-4 text-[15px] leading-5 text-foreground">
                 Accepting connects both of you on One. Live location still starts only
                 when someone taps Share Location, confirms permission, and sends an
                 encrypted share from Location.
               </div>
 
               {claimError ? (
-                <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-950 dark:text-amber-100">
+                <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-warning)]/10 p-4 text-[15px] leading-5 text-[color:var(--app-warning)]">
                   {claimError}
                 </div>
               ) : null}

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -63,8 +63,8 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
       ? `Accuracy +/- ${Math.round(point.accuracyM)} m`
       : null;
   return (
-    <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-background">
-      <div className="relative h-64 overflow-hidden bg-muted">
+    <div className="overflow-hidden rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)]">
+      <div className="relative h-64 overflow-hidden bg-muted sm:h-72">
         <iframe
           key={`public-location-map:${viewportResetKey}`}
           title="Public location map"
@@ -74,7 +74,7 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
           allowFullScreen
           className="h-full w-full border-0"
         />
-        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full border border-emerald-300/40 bg-emerald-950/75 px-3 py-1.5 text-xs font-semibold text-emerald-50 shadow-lg backdrop-blur-xl">
+        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full bg-[color:var(--app-success)] px-3 py-1.5 text-[12px] font-semibold leading-4 text-white backdrop-blur-xl">
           <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
           Public location
         </div>
@@ -85,26 +85,26 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
           aria-label="Recenter public location map"
           title="Recenter map"
           onClick={() => setViewportResetKey((current) => current + 1)}
-          className="absolute right-3 top-3 z-10 h-11 w-11 rounded-full border border-border/70 bg-background/90 shadow-lg backdrop-blur-xl hover:bg-background sm:h-9 sm:w-9"
+          className="absolute right-3 top-3 z-10 h-11 w-11 rounded-full border border-border/70 bg-background/90 shadow-none backdrop-blur-xl hover:bg-background sm:h-9 sm:w-9"
         >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
-      <div className="space-y-3 p-3">
+      <div className="space-y-3 p-3.5">
         <div className="min-w-0">
-          <p className="text-sm font-semibold">Shared location</p>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="text-[17px] font-normal leading-[22px]">Shared location</p>
+          <p className="mt-0.5 text-[15px] leading-5 text-muted-foreground">
             Updated {capturedAt}
             {accuracy ? ` - ${accuracy}` : ""}
           </p>
         </div>
         {point.drive ? (
-          <div className="rounded-[12px] border border-sky-500/30 bg-sky-500/[0.08] p-3">
-            <p className="flex items-center gap-1.5 text-xs font-semibold text-sky-700 dark:text-sky-300">
+          <div className="rounded-[12px] bg-[color:var(--app-accent)]/10 p-3">
+            <p className="flex items-center gap-1.5 text-[13px] font-semibold leading-[18px] text-[color:var(--app-accent)]">
               <Route className="h-3.5 w-3.5" aria-hidden="true" />
               Driving to {point.drive.destination.label}
             </p>
-            <p className="mt-0.5 text-sm font-semibold">
+            <p className="mt-0.5 text-[15px] font-semibold leading-5">
               {driveEtaText(point.drive.etaSeconds)}
             </p>
           </div>
@@ -176,26 +176,26 @@ export default function PublicLocationRequestPageClient() {
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col justify-center px-5 py-10">
-        <div className="space-y-6 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--shadow-xs)] sm:p-7">
+      <div className="mx-auto flex min-h-screen w-full max-w-[720px] flex-col px-5 pb-10 pt-[max(48px,calc(env(safe-area-inset-top)+28px))] sm:px-6 sm:pt-[max(64px,calc(env(safe-area-inset-top)+40px))]">
+        <div className="space-y-6 rounded-[var(--app-card-radius-standard)] bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-none sm:p-6">
           <div className="flex items-start gap-4">
-            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]">
+            <div className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
               {error ? (
-                <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                <AlertTriangle className="h-[17px] w-[17px]" aria-hidden="true" />
               ) : publicLocation ? (
-                <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+                <CheckCircle2 className="h-[17px] w-[17px]" aria-hidden="true" />
               ) : (
-                <MapPin className="h-5 w-5" aria-hidden="true" />
+                <MapPin className="h-[17px] w-[17px]" aria-hidden="true" />
               )}
             </div>
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--app-accent)]">
+              <div className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                 Location
               </div>
-              <h1 className="mt-2 text-[28px] font-medium leading-[1.12] tracking-normal sm:text-[32px]">
+              <h1 className="mt-1 text-[32px] font-bold leading-[1.08] tracking-normal sm:text-[34px]">
                 View shared location
               </h1>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              <p className="mt-3 text-[17px] leading-[24px] text-muted-foreground">
                 {loading
                   ? "Checking public location link."
                   : error
@@ -217,7 +217,7 @@ export default function PublicLocationRequestPageClient() {
 
           {!loading && invite ? (
             <div className="space-y-4">
-              <div className="flex flex-wrap items-center gap-2 text-sm">
+              <div className="flex flex-wrap items-center gap-2 text-[13px]">
                 <Badge variant="secondary">
                   Expires {formatDateTime(invite.expiresAt)}
                 </Badge>
@@ -228,7 +228,7 @@ export default function PublicLocationRequestPageClient() {
               {publicLocation ? (
                 <PublicLocationMap point={publicLocation} />
               ) : (
-                <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
+                <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-warning)]/10 p-4 text-[15px] leading-5 text-[color:var(--app-warning)]">
                   This link opened correctly, but no public location is attached.
                   Ask the sender to create a fresh public location link.
                 </div>

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -63,26 +63,26 @@ export function LocationOnboardingCompletedScreen({
   return (
     <FullscreenFlowShell
       width="reading"
-      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-center px-[var(--page-inline-gutter-standard)] py-10"
+      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-start px-[var(--page-inline-gutter-standard)] pb-10 pt-[max(56px,calc(env(safe-area-inset-top)+36px))]"
       data-testid="location-onboarding-completed"
     >
       <section
         className="motion-step-enter mx-auto flex w-full max-w-[34rem] flex-col items-center text-center"
         aria-labelledby="location-onboarding-completed-title"
       >
-        <span className="flex size-16 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 sm:size-20">
-          <CheckCircle2 className="size-9 sm:size-11" aria-hidden="true" />
+        <span className="flex h-[52px] w-[52px] items-center justify-center rounded-[16px] bg-[color:var(--app-success)]/12 text-[color:var(--app-success)]">
+          <CheckCircle2 className="h-7 w-7" aria-hidden="true" />
         </span>
-        <p className="mt-6 type-subhead text-muted-foreground">
+        <p className="mt-5 text-[13px] font-normal leading-[18px] text-muted-foreground">
           One · Location
         </p>
         <h1
           id="location-onboarding-completed-title"
-          className="mt-3 max-w-[18ch] text-balance type-display text-foreground"
+          className="mt-2 max-w-[18ch] text-balance text-[32px] font-bold leading-[1.08] tracking-normal text-foreground sm:text-[34px]"
         >
           Your Location onboarding is complete
         </h1>
-        <p className="mt-4 max-w-[34rem] text-pretty type-title3 text-muted-foreground">
+        <p className="mt-3 max-w-[34rem] text-pretty text-[17px] leading-[24px] text-muted-foreground">
           Everything is ready. You can manage Location anytime from One.
         </p>
         <div className="mt-8 w-full max-w-[30rem]">

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -14,6 +14,10 @@ import type {
   OneLocationActivityResponse,
 } from "@/lib/one-location/types";
 import { cn } from "@/lib/utils";
+import {
+  CARD_SURFACE,
+  SUBCARD_SURFACE,
+} from "@/components/one-location/redesign/tokens";
 
 const ACTIVITY_RANGE_OPTIONS: {
   value: OneLocationActivityRange;
@@ -26,7 +30,7 @@ const ACTIVITY_RANGE_OPTIONS: {
 ];
 
 const activityPanelClassName =
-  "w-full min-w-0 max-w-full overflow-hidden rounded-[24px] border border-black/[0.04] bg-white/95 shadow-[0_1px_2px_rgba(0,0,0,0.03),0_14px_34px_rgba(15,23,42,0.06)] backdrop-blur-xl dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.24)]";
+  cn("w-full min-w-0 max-w-full overflow-hidden", CARD_SURFACE);
 
 function activityRangeLabel(range: OneLocationActivityRange): string {
   return (
@@ -37,12 +41,12 @@ function activityRangeLabel(range: OneLocationActivityRange): string {
 
 function activityEventToneClassName(kind: OneLocationActivityKind): string {
   if (kind === "share") {
-    return "bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200";
+    return "bg-[color:var(--app-success)]/12 text-[color:var(--app-success)] dark:bg-[color:var(--app-success)]/15";
   }
   if (kind === "request") {
-    return "bg-[#e7f0fd] text-[color:var(--app-accent)] dark:bg-[color:var(--app-accent)]/15 dark:text-[color:var(--app-accent)]";
+    return "bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)] dark:bg-[color:var(--app-accent)]/15";
   }
-  return "bg-[#fff3e6] text-[#ff9500] dark:bg-orange-400/15 dark:text-orange-200";
+  return "bg-[color:var(--app-warning)]/12 text-[color:var(--app-warning)] dark:bg-[color:var(--app-warning)]/15";
 }
 
 function ActivitySectionLabel({ title }: { title: string }) {
@@ -50,7 +54,7 @@ function ActivitySectionLabel({ title }: { title: string }) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground"
     >
       {title}
     </div>
@@ -67,14 +71,14 @@ function ActivityMetricTile({
   detail: string;
 }) {
   return (
-    <div className="min-w-0 rounded-[18px] border border-black/[0.04] bg-[#f7f7fa] p-3.5 dark:border-white/[0.08] dark:bg-white/[0.07]">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
+    <div className={cn("min-w-0 p-3.5", SUBCARD_SURFACE)}>
+      <p className="text-[12px] font-normal leading-4 tracking-normal text-muted-foreground">
         {label}
       </p>
-      <p className="mt-1 text-[24px] font-semibold leading-none text-[#1c1c1e] dark:text-white">
+      <p className="mt-1 text-[24px] font-semibold leading-none text-foreground">
         {value}
       </p>
-      <p className="mt-1 break-words text-[11px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+      <p className="mt-1 break-words text-[12px] leading-4 text-muted-foreground [overflow-wrap:anywhere]">
         {detail}
       </p>
     </div>
@@ -91,12 +95,12 @@ function EmptyActivityState({
   description: string;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
-      <Icon className="h-5 w-5 text-[#8e8e93]" aria-hidden="true" />
-      <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+    <div className={cn("flex flex-col items-center justify-center gap-2 border-dashed p-5 text-center", SUBCARD_SURFACE)}>
+      <Icon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+      <p className="text-[15px] font-semibold leading-5 text-foreground">
         {title}
       </p>
-      <p className="max-w-[320px] text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+      <p className="max-w-[320px] text-[13px] leading-[18px] text-muted-foreground">
         {description}
       </p>
     </div>
@@ -128,7 +132,7 @@ export function OneLocationActivityDashboard({
       <div className={cn(activityPanelClassName, "space-y-4 p-4")}>
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#e7f0fd] text-[color:var(--app-accent)] dark:bg-[color:var(--app-accent)]/15 dark:text-[color:var(--app-accent)]">
+            <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)] dark:bg-[color:var(--app-accent)]/15">
               {loading ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
@@ -136,10 +140,10 @@ export function OneLocationActivityDashboard({
               )}
             </span>
             <div className="min-w-0">
-              <h3 className="text-[16px] font-semibold tracking-normal text-[#1c1c1e] dark:text-white">
+              <h3 className="text-[17px] font-semibold leading-[22px] tracking-normal text-foreground">
                 Activity history
               </h3>
-              <p className="mt-1 break-words text-[13px] leading-5 text-[#6e6e73] [overflow-wrap:anywhere] dark:text-white/60">
+              <p className="mt-1 break-words text-[15px] leading-5 text-muted-foreground [overflow-wrap:anywhere]">
                 {error ||
                   `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
               </p>
@@ -151,7 +155,7 @@ export function OneLocationActivityDashboard({
               onRangeChange(value as OneLocationActivityRange)
             }
           >
-            <SelectTrigger className="h-9 w-full rounded-[12px] border-black/[0.04] bg-white text-[13px] shadow-sm sm:w-[132px] dark:border-white/[0.08] dark:bg-white/[0.07]">
+            <SelectTrigger className="h-9 w-full rounded-[12px] border-border/60 bg-[color:var(--app-card-surface-compact)] text-[13px] shadow-none sm:w-[132px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -190,7 +194,7 @@ export function OneLocationActivityDashboard({
             aria-label={`Location activity chart for ${activityRangeLabel(
               range,
             )}`}
-            className="min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
+            className={cn("min-w-0 max-w-full overflow-hidden p-3", SUBCARD_SURFACE)}
           >
             <div className="flex h-32 min-w-0 items-end gap-1.5 sm:gap-2">
               {activity.buckets.map((bucket) => {
@@ -202,13 +206,13 @@ export function OneLocationActivityDashboard({
                   >
                     <div className="flex h-24 w-full items-end">
                       <div
-                        className="flex w-full flex-col justify-end overflow-hidden rounded-t-[8px] bg-[#e5e5ea] dark:bg-white/10"
+                        className="flex w-full flex-col justify-end overflow-hidden rounded-t-[8px] bg-[color:var(--app-neutral-fill-strong)] dark:bg-white/10"
                         style={{ height: `${height}%` }}
                         title={`${bucket.label}: ${bucket.total} activities`}
                       >
                         {bucket.publicActivity > 0 ? (
                           <span
-                            className="block bg-[#ff9500]"
+                            className="block bg-[color:var(--app-warning)]"
                             style={{
                               flexGrow: bucket.publicActivity,
                               minHeight: 3,
@@ -223,22 +227,22 @@ export function OneLocationActivityDashboard({
                         ) : null}
                         {bucket.shares > 0 ? (
                           <span
-                            className="block bg-[#34c759]"
+                            className="block bg-[color:var(--app-success)]"
                             style={{ flexGrow: bucket.shares, minHeight: 3 }}
                           />
                         ) : null}
                       </div>
                     </div>
-                    <span className="max-w-full truncate text-[10px] font-semibold text-[#8e8e93] dark:text-white/45">
+                    <span className="max-w-full truncate text-[11px] font-normal leading-4 text-muted-foreground">
                       {bucket.label}
                     </span>
                   </div>
                 );
               })}
             </div>
-            <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-semibold text-[#8e8e93] dark:text-white/50">
+            <div className="mt-3 flex flex-wrap gap-2 text-[12px] font-normal leading-4 text-muted-foreground">
               <span className="inline-flex items-center gap-1">
-                <span className="h-2 w-2 rounded-full bg-[#34c759]" />
+                <span className="h-2 w-2 rounded-full bg-[color:var(--app-success)]" />
                 Shares
               </span>
               <span className="inline-flex items-center gap-1">
@@ -246,7 +250,7 @@ export function OneLocationActivityDashboard({
                 Requests
               </span>
               <span className="inline-flex items-center gap-1">
-                <span className="h-2 w-2 rounded-full bg-[#ff9500]" />
+                <span className="h-2 w-2 rounded-full bg-[color:var(--app-warning)]" />
                 Links
               </span>
             </div>
@@ -261,28 +265,28 @@ export function OneLocationActivityDashboard({
 
         {recentEvents.length ? (
           <div className="space-y-2">
-            <p className="ml-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
+            <p className="ml-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
               Recent history
             </p>
             <div className="min-w-0 space-y-2">
               {recentEvents.map((event) => (
                 <div
                   key={event.id}
-                  className="flex min-w-0 items-start gap-3 overflow-hidden rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
+                  className={cn("flex min-w-0 items-start gap-3 overflow-hidden p-3", SUBCARD_SURFACE)}
                 >
                   <span
                     className={cn(
-                      "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                      "mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
                       activityEventToneClassName(event.kind),
                     )}
                   >
                     <Clock3 className="h-4 w-4" aria-hidden="true" />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <p className="break-words text-[14px] font-semibold text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                    <p className="break-words text-[15px] font-semibold leading-5 text-foreground [overflow-wrap:anywhere]">
                       {event.title}
                     </p>
-                    <p className="mt-0.5 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                    <p className="mt-0.5 break-words text-[13px] leading-[18px] text-muted-foreground [overflow-wrap:anywhere]">
                       {event.detail}
                     </p>
                   </div>

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -29,6 +29,15 @@ import {
   type SavedLocationAddressDetails,
 } from "@/lib/one-location/saved-location-address";
 
+const iconButtonClassName =
+  "press-scale absolute flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill-strong)]/80 disabled:opacity-45";
+
+const controlLabelClassName =
+  "mb-1.5 block text-[13px] font-semibold leading-[18px] text-muted-foreground";
+
+const controlInputClassName =
+  "h-12 w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] px-4 text-[15px] leading-5 text-foreground outline-none transition-colors placeholder:text-[color:var(--app-tertiary-label)] focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent)]/25 disabled:opacity-60";
+
 export type SavedLocationPlaceSuggestion = {
   placeId: string;
   text: string;
@@ -109,7 +118,7 @@ function SavedLocationCategoryPicker({
 }) {
   return (
     <div role="group" aria-label="Saved location category">
-      <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+      <p className={controlLabelClassName}>
         What kind of place is this?
       </p>
       <div className="grid grid-cols-3 gap-2.5">
@@ -123,14 +132,14 @@ function SavedLocationCategoryPicker({
               onClick={() => onChange(category)}
               disabled={disabled}
               className={cn(
-                "press-scale flex min-h-[88px] flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-3 transition-colors disabled:opacity-45",
+                "press-scale flex min-h-[82px] flex-col items-center justify-center gap-2 rounded-[14px] border px-2 py-3 transition-colors disabled:opacity-45",
                 selected
-                  ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
-                  : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
+                  ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)]/10 text-[color:var(--app-accent)]"
+                  : "border-border/70 bg-[color:var(--app-card-surface-default-solid)] text-muted-foreground hover:bg-foreground/[0.03]",
               )}
             >
-              <Icon className="h-6 w-6" strokeWidth={2.1} aria-hidden />
-              <span className="text-[13px] font-bold">{label}</span>
+              <Icon className="h-5 w-5" strokeWidth={1.9} aria-hidden />
+              <span className="text-[13px] font-semibold leading-[18px]">{label}</span>
             </button>
           );
         })}
@@ -396,10 +405,8 @@ export function SaveLocationModal({
         }}
         className={cn(
           "z-[560] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
-          "rounded-b-none rounded-t-[28px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[24px]",
-          "border border-black/[0.06] bg-white p-6 pb-[calc(env(safe-area-inset-bottom,0px)+22px)] sm:pb-6",
-          "shadow-[0_-8px_40px_rgba(16,24,40,0.18)] sm:shadow-[0_20px_60px_rgba(16,24,40,0.24)]",
-          "dark:border-white/[0.08] dark:bg-[#141922]",
+          "rounded-b-none rounded-t-[24px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[20px]",
+          "border border-border/60 bg-[color:var(--app-card-surface-default-solid)] p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] shadow-none sm:p-6 sm:pb-6",
         )}
       >
         {flowStep === "map" && canPickOnMap ? (
@@ -449,7 +456,7 @@ export function SaveLocationModal({
               }
               disabled={interactionBusy}
               aria-label={canPickOnMap ? "Back to map" : "Back"}
-              className="press-scale absolute left-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+              className={cn(iconButtonClassName, "left-4 top-4")}
             >
               <ArrowLeft className="h-4.5 w-4.5" strokeWidth={2.4} />
             </button>
@@ -458,40 +465,40 @@ export function SaveLocationModal({
               onClick={onSkip}
               disabled={interactionBusy}
               aria-label="Close"
-              className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+              className={cn(iconButtonClassName, "right-4 top-4")}
             >
               <X className="h-4.5 w-4.5" strokeWidth={2.4} />
             </button>
 
             <header className="px-9 text-center">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+              <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                 Step 2 of 2
               </p>
               <DialogTitle
                 ref={detailsTitleRef}
                 tabIndex={-1}
-                className="mt-2 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] outline-none dark:text-[#f4f7fb]"
+                className="mt-1 text-[28px] font-bold leading-[1.12] tracking-normal text-foreground outline-none"
               >
                 Add your address details
               </DialogTitle>
               <p
                 id={descriptionId}
-                className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
+                className="mt-2 text-[15px] leading-5 text-muted-foreground"
               >
                 The pin tells One where. These details make the entrance easy to
                 recognise.
               </p>
             </header>
 
-            <div className="flex items-start gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
-              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
-                <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
+            <div className="flex items-start gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
+              <span className="mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
               </span>
               <div className="min-w-0 flex-1">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                   Pinned location
                 </p>
-                <p className="mt-0.5 line-clamp-2 text-[13px] font-semibold leading-[1.35] text-[#111827] dark:text-[#e9eef7]">
+                <p className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-5 text-foreground">
                   {pickedAddress ||
                     resolvedAddress ||
                     "Your selected map point"}
@@ -502,7 +509,7 @@ export function SaveLocationModal({
                   type="button"
                   onClick={() => setFlowStep("map")}
                   disabled={interactionBusy}
-                  className="press-scale shrink-0 rounded-full bg-white px-2.5 py-1.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
+                  className="press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
                 >
                   Edit pin
                 </button>
@@ -513,7 +520,7 @@ export function SaveLocationModal({
               <div>
                 <label
                   htmlFor="saved-location-house-or-flat"
-                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  className={controlLabelClassName}
                 >
                   House, flat, floor or block
                 </label>
@@ -529,7 +536,7 @@ export function SaveLocationModal({
                   maxLength={80}
                   autoComplete={deferredUntilVault ? "off" : "address-line1"}
                   placeholder="e.g. Flat 4B, Tower 2"
-                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  className={controlInputClassName}
                 />
               </div>
 
@@ -537,7 +544,7 @@ export function SaveLocationModal({
                 <div>
                   <label
                     htmlFor="saved-location-building-color"
-                    className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                    className={controlLabelClassName}
                   >
                     Building colour{" "}
                     <span className="font-normal">(optional)</span>
@@ -553,13 +560,13 @@ export function SaveLocationModal({
                     maxLength={40}
                     autoComplete="off"
                     placeholder="e.g. Blue gate"
-                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                    className={controlInputClassName}
                   />
                 </div>
                 <div>
                   <label
                     htmlFor="saved-location-postal-code"
-                    className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                    className={controlLabelClassName}
                   >
                     PIN / postal code
                   </label>
@@ -586,14 +593,17 @@ export function SaveLocationModal({
                       !isValidPostalCode(addressDetails.postalCode)
                     }
                     placeholder="e.g. 560001"
-                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 aria-[invalid=true]:border-[#d92d20] dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                    className={cn(
+                      controlInputClassName,
+                      "aria-[invalid=true]:border-[color:var(--app-destructive)]",
+                    )}
                   />
                   {addressDetails.postalCode.length > 0 &&
                   !isValidPostalCode(addressDetails.postalCode) ? (
                     <p
                       id={postalCodeErrorId}
                       role="alert"
-                      className="mt-1.5 text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
+                      className="mt-1.5 text-[13px] leading-[18px] text-[color:var(--app-destructive)]"
                     >
                       Enter a valid PIN or postal code.
                     </p>
@@ -604,7 +614,7 @@ export function SaveLocationModal({
               <div>
                 <label
                   htmlFor="saved-location-landmark"
-                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  className={controlLabelClassName}
                 >
                   Nearby landmark{" "}
                   <span className="font-normal">(optional)</span>
@@ -620,7 +630,7 @@ export function SaveLocationModal({
                   maxLength={100}
                   autoComplete={deferredUntilVault ? "off" : "address-line2"}
                   placeholder="e.g. Opposite City Mall"
-                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  className={controlInputClassName}
                 />
               </div>
             </div>
@@ -635,7 +645,7 @@ export function SaveLocationModal({
               <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
                 <label
                   htmlFor="saved-location-details-custom-label"
-                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  className={controlLabelClassName}
                 >
                   Give it a name <span className="font-normal">(optional)</span>
                 </label>
@@ -647,26 +657,26 @@ export function SaveLocationModal({
                   disabled={interactionBusy}
                   maxLength={40}
                   placeholder="e.g. Gym, parents' house"
-                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  className={controlInputClassName}
                 />
               </div>
             ) : null}
 
-            <p className="rounded-2xl bg-[#f4f6fa] px-3.5 py-3 text-[12px] leading-[1.45] text-[#5b6472] dark:bg-white/[0.05] dark:text-[#9aa6b6]">
+            <p className="rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3 text-[13px] leading-[18px] text-muted-foreground">
               {deferredUntilVault
                 ? "Kept only for this setup session. One encrypts and saves it after your private vault is ready."
                 : "Saved in your private vault and shared only when you approve location access."}
             </p>
 
-            <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-2xl border-t border-black/[0.06] bg-white/95 px-3 pb-1 pt-3 backdrop-blur dark:border-white/[0.08] dark:bg-[#141922]/95">
+            <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-[18px] border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)]/95 px-3 pb-1 pt-3 backdrop-blur">
               <button
                 type="button"
                 onClick={handleSave}
                 disabled={!canSave || !detailsComplete}
                 aria-busy={saving || undefined}
                 className={cn(
-                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-                  "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+                  "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]",
                 )}
               >
                 {saving ? (
@@ -680,7 +690,7 @@ export function SaveLocationModal({
                 type="button"
                 onClick={onSkip}
                 disabled={interactionBusy}
-                className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+                className="h-11 w-full rounded-full text-[15px] font-semibold text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
               >
                 Skip for now
               </button>
@@ -694,21 +704,21 @@ export function SaveLocationModal({
               onClick={onSkip}
               disabled={interactionBusy}
               aria-label="Close"
-              className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+              className={cn(iconButtonClassName, "right-4 top-4")}
             >
               <X className="h-4.5 w-4.5" strokeWidth={2.4} />
             </button>
 
             <header className="pr-8">
-              <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent,#087ff5)]">
-                <MapPin className="h-6 w-6" strokeWidth={2.2} />
+              <span className="flex h-[34px] w-[34px] items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} />
               </span>
-              <DialogTitle className="mt-3.5 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] dark:text-[#f4f7fb]">
+              <DialogTitle className="mt-3 text-[28px] font-bold leading-[1.12] tracking-normal text-foreground">
                 Save this place
               </DialogTitle>
               <p
                 id={descriptionId}
-                className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
+                className="mt-2 text-[15px] leading-5 text-muted-foreground"
               >
                 Tag where you are so One can personalise your experience. It
                 stays encrypted in your vault and is shared only when you
@@ -716,21 +726,21 @@ export function SaveLocationModal({
               </p>
             </header>
 
-            <div className="flex items-center gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
-                <MapPin className="h-4 w-4" strokeWidth={2.4} />
+            <div className="flex items-center gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
+              <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} />
               </span>
               <div className="min-w-0 flex-1">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                   Current location
                 </p>
                 {loadingAddress ? (
-                  <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+                  <span className="mt-0.5 flex items-center gap-1.5 text-[15px] leading-5 text-muted-foreground">
                     <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding
                     your address…
                   </span>
                 ) : (
-                  <p className="mt-0.5 truncate text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
+                  <p className="mt-0.5 truncate text-[15px] font-semibold leading-5 text-foreground">
                     {resolvedAddress || "Address unavailable"}
                   </p>
                 )}
@@ -745,7 +755,7 @@ export function SaveLocationModal({
                     setPlaceSearchError(null);
                   }}
                   disabled={interactionBusy}
-                  className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-white px-2.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
+                  className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
                   aria-label="Change captured location"
                 >
                   <Pencil className="h-3.5 w-3.5" aria-hidden />
@@ -760,16 +770,16 @@ export function SaveLocationModal({
                 onClick={() => setFlowStep("map")}
                 disabled={interactionBusy}
                 data-testid="save-location-adjust-on-map"
-                className="press-scale flex w-full items-center gap-3 rounded-2xl border border-dashed border-[color:var(--app-accent,#087ff5)]/40 bg-[color:var(--app-accent-tint,#e7f0fd)]/50 px-3.5 py-3 text-left transition-colors hover:bg-[color:var(--app-accent-tint,#e7f0fd)] disabled:opacity-45 dark:border-[color:var(--app-accent,#087ff5)]/30 dark:bg-[color:var(--app-accent,#087ff5)]/10"
+                className="press-scale flex w-full items-center gap-3 rounded-[14px] border border-dashed border-[color:var(--app-accent)]/35 bg-[color:var(--app-accent)]/10 px-3.5 py-3 text-left transition-colors hover:bg-[color:var(--app-accent)]/15 disabled:opacity-45"
               >
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
-                  <MapIcon className="h-4 w-4" strokeWidth={2.2} aria-hidden />
+                <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                  <MapIcon className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="block text-[14px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+                  <span className="block text-[15px] font-semibold leading-5 text-[color:var(--app-accent)]">
                     Pin your entrance on the map
                   </span>
-                  <span className="block text-[12px] leading-[1.4] text-[#5b6472] dark:text-[#9aa6b6]">
+                  <span className="block text-[13px] leading-[18px] text-muted-foreground">
                     GPS can be off by a few meters — drag the pin to your door.
                   </span>
                 </span>
@@ -780,13 +790,13 @@ export function SaveLocationModal({
               <div className="space-y-2.5 [animation:saveLocFadeIn_.2s_ease-out_both]">
                 <label
                   htmlFor="saved-location-place-search"
-                  className="block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  className={controlLabelClassName}
                 >
                   Search for another place
                 </label>
                 <div className="relative">
                   <Search
-                    className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8b93a1]"
+                    className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--app-tertiary-label)]"
                     aria-hidden
                   />
                   <input
@@ -797,11 +807,11 @@ export function SaveLocationModal({
                     disabled={interactionBusy}
                     autoComplete="off"
                     placeholder="Search address or place"
-                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white pl-10 pr-10 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                    className={cn(controlInputClassName, "pl-10 pr-10")}
                   />
                   {placeSearching || changingPlace ? (
                     <Loader2
-                      className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-[#8b93a1]"
+                      className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-[color:var(--app-tertiary-label)]"
                       aria-label="Searching places"
                     />
                   ) : null}
@@ -809,7 +819,7 @@ export function SaveLocationModal({
 
                 {placeSuggestions.length > 0 ? (
                   <div
-                    className="max-h-40 overflow-y-auto rounded-2xl border border-black/[0.08] bg-white p-1 shadow-sm dark:border-white/[0.1] dark:bg-[#1b2230]"
+                    className="max-h-40 overflow-y-auto rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-1 shadow-none"
                     aria-label="Location suggestions"
                   >
                     {placeSuggestions.map((suggestion) => (
@@ -820,10 +830,10 @@ export function SaveLocationModal({
                           void handleSelectPlace(suggestion.placeId)
                         }
                         disabled={interactionBusy}
-                        className="flex min-h-11 w-full items-start gap-2 rounded-xl px-3 py-2.5 text-left text-[14px] font-medium text-[#273142] hover:bg-black/[0.04] disabled:opacity-45 dark:text-[#dce5f2] dark:hover:bg-white/[0.06]"
+                        className="flex min-h-11 w-full items-start gap-2 rounded-[10px] px-3 py-2.5 text-left text-[15px] leading-5 text-foreground hover:bg-foreground/[0.04] disabled:opacity-45"
                       >
                         <MapPin
-                          className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--app-accent,#087ff5)]"
+                          className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--app-accent)]"
                           aria-hidden
                         />
                         <span>{suggestion.text}</span>
@@ -835,7 +845,7 @@ export function SaveLocationModal({
                 {placeSearchError ? (
                   <p
                     role="alert"
-                    className="text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
+                    className="text-[13px] leading-[18px] text-[color:var(--app-destructive)]"
                   >
                     {placeSearchError}
                   </p>
@@ -850,7 +860,7 @@ export function SaveLocationModal({
                     setPlaceSearchError(null);
                   }}
                   disabled={interactionBusy}
-                  className="text-[13px] font-semibold text-[#5b6472] disabled:opacity-45 dark:text-[#9aa6b6]"
+                  className="text-[13px] font-semibold text-muted-foreground disabled:opacity-45"
                 >
                   Keep current location
                 </button>
@@ -867,7 +877,7 @@ export function SaveLocationModal({
               <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
                 <label
                   htmlFor="saved-location-custom-label"
-                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  className={controlLabelClassName}
                 >
                   Give it a name <span className="font-normal">(optional)</span>
                 </label>
@@ -879,7 +889,7 @@ export function SaveLocationModal({
                   disabled={interactionBusy}
                   maxLength={40}
                   placeholder="e.g. Gym, Mom's house, Cafe"
-                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  className={controlInputClassName}
                 />
               </div>
             ) : null}
@@ -891,8 +901,8 @@ export function SaveLocationModal({
                 disabled={!canSave}
                 aria-busy={saving || undefined}
                 className={cn(
-                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-                  "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+                  "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]",
                 )}
               >
                 {saving ? (
@@ -906,7 +916,7 @@ export function SaveLocationModal({
                 type="button"
                 onClick={onSkip}
                 disabled={interactionBusy}
-                className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+                className="h-11 w-full rounded-full text-[15px] font-semibold text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
               >
                 Skip for now
               </button>

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -107,21 +107,20 @@ describe("SmsContactsFlow", () => {
 
     const removeButton = screen.getByRole("button", { name: "Remove" });
     expect(removeButton).toHaveClass(
-      "bg-[#ffe9e9]",
-      "text-[#d70015]",
-      "border-[#ff3b30]/35",
+      "bg-[color:var(--app-destructive)]/10",
+      "text-[color:var(--app-destructive)]",
     );
     fireEvent.click(removeButton);
     expect(onRemove).not.toHaveBeenCalled();
     expect(screen.getByText("Remove Kushal?")).toBeInTheDocument();
 
     const title = screen.getByRole("heading", { name: /Remove Kushal\?/i });
-    expect(title.querySelector("span")).toHaveClass("text-[#17171c]");
+    expect(title.querySelector("span")).toHaveClass("text-foreground");
     expect(
       screen.getByText(
         "They'll no longer be alerted with your live location when you trigger SMS.",
       ),
-    ).toHaveClass("!text-[#17171c]");
+    ).toHaveClass("!text-muted-foreground");
 
     const removeButtons = screen.getAllByRole("button", {
       name: "Remove",
@@ -160,7 +159,7 @@ describe("SmsContactsFlow", () => {
     expect(screen.getByTestId("sms-contacts-screen")).toHaveClass(
       "fixed",
       "inset-0",
-      "bg-[#f2f3f7]",
+      "bg-background",
     );
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
     expect(screen.getByRole("alertdialog")).toHaveClass(

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -76,14 +76,14 @@ export function TrustedPersonCard({
     >
       <Avatar initials={initialsFrom(name)} />
       <div className="min-w-0 flex-1">
-        <p className="break-words text-[13px] font-semibold leading-snug text-foreground [overflow-wrap:anywhere] sm:text-base">
+        <p className="break-words text-[15px] font-semibold leading-5 text-foreground [overflow-wrap:anywhere] sm:text-[17px] sm:leading-[22px]">
           {name}
         </p>
         {subtitle ? (
           <p
             className={cn(
               MUTED_TEXT,
-              "break-words text-[11px] leading-snug [overflow-wrap:anywhere] sm:text-xs",
+              "break-words text-[13px] leading-[18px] [overflow-wrap:anywhere] sm:text-[15px] sm:leading-5",
             )}
           >
             {subtitle}
@@ -205,20 +205,20 @@ export function RequestCard({
   return (
     <div className={cn(SUBCARD_SURFACE, "p-4")}>
       <div className="flex items-center gap-3">
-        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#d8d8de] text-white dark:bg-white/15">
-          <User className="h-5 w-5" />
+        <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)]">
+          <User className="h-[17px] w-[17px]" strokeWidth={1.9} />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-[16px] font-bold text-[#1c1c2e] dark:text-foreground">
+          <p className="text-[17px] font-normal leading-[22px] text-foreground">
             {name}
           </p>
-          <p className="mt-0.5 truncate text-[13px] text-black/50 dark:text-muted-foreground">
+          <p className="mt-0.5 truncate text-[15px] leading-5 text-muted-foreground">
             {promptLine}
           </p>
         </div>
       </div>
       {reason ? (
-        <p className="mt-2.5 rounded-lg bg-black/[0.03] px-2.5 py-1.5 text-xs italic text-black/50 dark:bg-white/5 dark:text-muted-foreground">
+        <p className="mt-2.5 rounded-[10px] bg-[color:var(--app-card-surface-compact)] px-2.5 py-1.5 text-[13px] leading-[18px] text-muted-foreground">
           {reason}
         </p>
       ) : null}
@@ -233,7 +233,7 @@ export function RequestCard({
         <Button
           onClick={onDecline}
           isLoading={declineBusy}
-          className="h-11 flex-1 rounded-full bg-[#ededf2] text-sm font-semibold text-[#1d1d1f] hover:bg-[#e2e2ea] dark:bg-white/10 dark:text-foreground"
+          className="h-11 flex-1 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-sm font-semibold text-foreground hover:bg-[color:var(--app-neutral-fill-strong)]/80 dark:bg-white/10"
         >
           Decline
         </Button>

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -59,7 +59,7 @@ const PRIVATE_CONFIRMATION_MAX_AGE_MS = 10 * 60_000;
 
 /** White surface card — design radius 12px, with a dark-mode variant. */
 const CARD =
-  "rounded-[12px] border border-black/[0.06] bg-white dark:border-white/[0.08] dark:bg-white/[0.05]";
+  "rounded-[var(--app-card-radius-compact)] border border-border/60 bg-[color:var(--app-card-surface-default-solid)]";
 
 // Contact list cap: trusted circles can be long, so show ~4 rows then scroll.
 // A thin, touch-friendly scrollbar keeps it unobtrusive on mobile.
@@ -452,7 +452,7 @@ export function CheckInFlow({
     <div>
       {/* Header — title + Cancel link (no back arrow; Cancel dismisses). */}
       <div className="flex items-start justify-between gap-3">
-        <h1 className="max-w-[250px] text-[23px] font-bold leading-[1.2] tracking-[-0.4px] text-foreground">
+        <h1 className="max-w-[310px] text-[28px] font-bold leading-[1.12] tracking-normal text-foreground">
           Let trusted people know you&apos;re here
         </h1>
         <button
@@ -466,12 +466,12 @@ export function CheckInFlow({
 
       {entrySource === "nearby" ? (
         <section
-          className="mt-4 flex gap-3 rounded-[12px] border border-[var(--app-accent-border)] bg-[var(--app-accent-surface)] p-4"
+          className="mt-4 flex gap-3 rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-accent)]/10 p-4"
           data-testid="nearby-private-share-disclosure"
         >
           <Shield className="mt-0.5 h-5 w-5 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
           <div>
-            <p className="text-sm font-semibold text-foreground">
+            <p className="text-[15px] font-semibold leading-5 text-foreground">
               Nearby and private sharing are separate
             </p>
             <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
@@ -579,20 +579,20 @@ export function CheckInFlow({
                     "bg-[color:var(--app-accent-soft)]",
                 )}
               >
-                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
-                  <UsersRound className="h-4 w-4" />
+                <span className="flex h-[34px] w-[34px] items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                  <UsersRound className="h-[17px] w-[17px]" />
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[15px] font-semibold text-foreground">
+                  <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
                     {circle.name}
                   </span>
-                  <span className="block text-[12px] text-muted-foreground">
+                  <span className="block text-[15px] leading-5 text-muted-foreground">
                     {selected
                       ? `${circleSelection.ready.length} ready now`
                       : `${circle.memberCount} members`}
                   </span>
                 </span>
-                <span className="text-[12px] font-semibold text-[color:var(--app-accent)]">
+                <span className="text-[13px] font-semibold leading-[18px] text-[color:var(--app-accent)]">
                   {circleLoadingId === circle.id
                     ? "Loading…"
                     : selected
@@ -604,7 +604,7 @@ export function CheckInFlow({
           })}
           {circleSelection ? (
             <>
-              <p className="border-t border-black/[0.06] px-4 py-2.5 text-[12px] leading-5 text-muted-foreground dark:border-white/[0.08]">
+              <p className="border-t border-[color:var(--app-separator)] px-4 py-2.5 text-[13px] leading-[18px] text-muted-foreground">
                 Current ready members only. Future members are not added to this
                 check-in.
                 {circleSelection.excluded.filter(
@@ -620,7 +620,7 @@ export function CheckInFlow({
               {/* Grow this Circle in-context: invite an existing connection or
                   share the invite code, so a user can pull loved ones in right
                   before they check in — especially when few members are ready. */}
-              <div className="border-t border-black/[0.06] px-4 py-3 dark:border-white/[0.08]">
+              <div className="border-t border-[color:var(--app-separator)] px-4 py-3">
                 <CircleGrowActions
                   circleId={circleSelection.circle.id}
                   circleName={circleSelection.circle.name}
@@ -647,14 +647,14 @@ export function CheckInFlow({
       <div
         className={cn(CARD, "mb-2 flex items-center gap-2 px-[14px] py-[11px]")}
       >
-        <Search className="h-3.5 w-3.5 shrink-0 text-black/35 dark:text-white/40" />
+        <Search className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-tertiary-label)]" />
         <input
           type="text"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           disabled={retryLocked}
           placeholder="Search contacts…"
-          className="min-w-0 flex-1 bg-transparent text-[15px] text-foreground outline-none placeholder:text-black/35 disabled:cursor-not-allowed dark:placeholder:text-white/40"
+          className="min-w-0 flex-1 bg-transparent text-[15px] leading-5 text-foreground outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
         />
       </div>
       {filtered.length ? (
@@ -702,7 +702,7 @@ export function CheckInFlow({
 
       {/* DURATION — gray segmented control incl. "Until I stop". */}
       <SectionLabel>DURATION</SectionLabel>
-      <div className="flex rounded-[9px] bg-[#ededf2] p-0.5 dark:bg-white/[0.08]">
+      <div className="flex rounded-[10px] bg-[color:var(--app-neutral-fill-strong)] p-0.5">
         {durationOptions.map((option) => (
           <button
             key={option.key}
@@ -713,7 +713,7 @@ export function CheckInFlow({
             className={cn(
               "whitespace-nowrap rounded-[7px] py-[9px] text-center text-[13px] transition-colors",
               option.active
-                ? "bg-white font-bold text-foreground shadow-sm dark:bg-white/[0.16]"
+                ? "bg-[color:var(--app-card-surface-default-solid)] font-semibold text-foreground shadow-none"
                 : "font-normal text-foreground/80",
               retryLocked && "cursor-not-allowed opacity-60",
             )}
@@ -722,7 +722,7 @@ export function CheckInFlow({
           </button>
         ))}
       </div>
-      <p className="mt-2 flex items-center gap-1.5 px-1 text-[12px] text-black/45 dark:text-white/45">
+      <p className="mt-2 flex items-center gap-1.5 px-1 text-[13px] leading-[18px] text-muted-foreground">
         <Shield className="h-3 w-3 shrink-0" strokeWidth={1.5} />
         Sharing stops automatically — no manual revoke needed.
       </p>
@@ -738,13 +738,13 @@ export function CheckInFlow({
           disabled={retryLocked}
           rows={2}
           placeholder={DEFAULT_CHECK_IN_MESSAGE}
-          className="w-full resize-none bg-transparent text-[15px] leading-[1.4] text-foreground outline-none placeholder:text-black/35 disabled:cursor-not-allowed dark:placeholder:text-white/40"
+          className="w-full resize-none bg-transparent text-[15px] leading-5 text-foreground outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
         />
-        <p className="mt-2 text-right text-[12px] text-black/30 dark:text-white/30">
+        <p className="mt-2 text-right text-[12px] text-[color:var(--app-tertiary-label)]">
           {message.length}/{CHECK_IN_MESSAGE_MAX_LENGTH}
         </p>
       </div>
-      <p className="mb-[18px] mt-2 px-1 text-[12px] leading-[1.45] text-black/45 dark:text-white/45">
+      <p className="mb-[18px] mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
         {retryLocked
           ? "Retry keeps the same duration, encrypted message, and reviewed location, and sends only to people who still failed."
           : "This message is encrypted with your location. The notification only says that you shared a check-in."}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -72,6 +72,7 @@ import {
   TrustNoteCard,
   WarningCard,
 } from "./primitives";
+import { SUBCARD_SURFACE } from "./tokens";
 import {
   RequestCard,
   SharedWithMeCard,
@@ -1429,86 +1430,72 @@ function LocationSettingsFlow({
   onManageSmsContacts: () => void;
 }) {
   return (
-    <div>
+    <div className="space-y-5">
       <TaskFlowHeader
         eyebrow="Location"
         title="Settings"
         description="You control who sees your location and when. Change this anytime."
       />
 
-      <p className="mt-6 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
-        Location sharing
-      </p>
-      <div className="mt-2.5 rounded-2xl bg-white px-4 shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
-        <div className="flex items-center gap-3.5 border-b border-black/[0.06] py-4 dark:border-white/10">
-          <div className="flex-1">
-            <p className="text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-              Auto-share my location
-            </p>
-            <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              On — approved shares keep receiving live updates. Off — new shares
-              send only the location you explicitly confirm.
-            </p>
-          </div>
-          <LocationToggle
-            checked={vm.autoShareEnabled}
-            onChange={vm.onAutoShareChange}
-            label="Auto-share my location"
-            disabled={BUSY(vm, "selfLocation")}
-          />
-        </div>
-        <div className="flex items-center gap-3.5 py-4">
-          <div className="flex-1">
-            <p className="text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-              Pause my location
-            </p>
-            <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              Stop new private-share updates and check out from Nearby. Existing
-              shares keep their expiry and may retain your last encrypted point.
-            </p>
-          </div>
-          <LocationToggle
-            checked={vm.locationPaused}
-            onChange={(next) => {
-              if (next) {
-                vm.onHideMyLocation();
-                return;
-              }
-              vm.onResumeMyLocation();
-            }}
-            label="Pause my location"
-            disabled={BUSY(vm, "selfLocation")}
-          />
-        </div>
-      </div>
+      <SettingsGroup title="Location sharing" separatorInset>
+        <SettingsRow
+          title="Auto-share my location"
+          description="On — approved shares keep receiving live updates. Off — new shares send only the location you explicitly confirm."
+          trailing={
+            <LocationToggle
+              checked={vm.autoShareEnabled}
+              onChange={vm.onAutoShareChange}
+              label="Auto-share my location"
+              disabled={BUSY(vm, "selfLocation")}
+            />
+          }
+          density="compact"
+        />
+        <SettingsRow
+          title="Pause my location"
+          description="Stop new private-share updates and check out from Nearby. Existing shares keep their expiry and may retain your last encrypted point."
+          trailing={
+            <LocationToggle
+              checked={vm.locationPaused}
+              onChange={(next) => {
+                if (next) {
+                  vm.onHideMyLocation();
+                  return;
+                }
+                vm.onResumeMyLocation();
+              }}
+              label="Pause my location"
+              disabled={BUSY(vm, "selfLocation")}
+            />
+          }
+          density="compact"
+        />
+      </SettingsGroup>
 
-      <div className="mt-4 flex items-start gap-2.5 px-1">
+      <div className="flex items-start gap-2.5 px-1">
         <Shield className="mt-0.5 h-[15px] w-[15px] shrink-0 text-[color:var(--app-accent)]" />
-        <p className="text-[13px] leading-[1.5] text-black/50 dark:text-muted-foreground">
+        <p className="text-[13px] leading-[18px] text-muted-foreground">
           Private shares stay in your circle. Nearby Check-In is separate and
           only starts after you explicitly agree.
         </p>
       </div>
 
-      <p className="mt-7 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
-        Safety
-      </p>
-      <button
-        type="button"
-        onClick={onManageSmsContacts}
-        className="mt-2.5 flex w-full items-center gap-3 rounded-2xl bg-white p-4 text-left shadow-[0_2px_10px_rgba(0,0,0,0.05)] transition-colors hover:bg-black/[0.02] dark:bg-[color:var(--app-card-surface-default-solid)]"
-        data-testid="one-location-sms-contacts-entry"
-      >
-        <span className="min-w-0 flex-1 text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-          SMS contacts
-        </span>
-        <span className="text-[14px] text-black/40 dark:text-muted-foreground">
-          {smsContactCount}
-        </span>
-        <ChevronRight className="h-4 w-4 shrink-0 text-black/30 dark:text-muted-foreground" />
-      </button>
+      <SettingsGroup title="Safety" separatorInset>
+        <SettingsRow
+          title="SMS contacts"
+          trailing={
+            <span className="text-[15px] leading-5 text-muted-foreground">
+              {smsContactCount}
+            </span>
+          }
+          onClick={onManageSmsContacts}
+          chevron
+          density="compact"
+          testId="one-location-sms-contacts-entry"
+        />
+      </SettingsGroup>
 
-      <div className="mt-7">
+      <div>
         <SavedLocationsSection />
       </div>
     </div>
@@ -1557,26 +1544,26 @@ function PersonRow({
   return (
     <div
       className={cn(
-        "flex items-center gap-3 p-4",
-        !first && "border-t border-black/[0.06] dark:border-white/10",
+        "flex min-h-[60px] items-center gap-3 p-3.5",
+        !first && "border-t border-[color:var(--app-separator)]",
       )}
     >
       <div className="relative shrink-0">
         <span
-          className="flex h-12 w-12 items-center justify-center rounded-full text-sm font-semibold text-white"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-[14px] font-semibold text-white"
           style={{ backgroundColor: tint }}
         >
           {personInitials(name)}
         </span>
         {active ? (
-          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-white bg-[#34c759] dark:border-[color:var(--app-card-surface-default-solid)]" />
+          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-white bg-[color:var(--app-success)] dark:border-[color:var(--app-card-surface-default-solid)]" />
         ) : null}
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[16px] font-bold text-[#1c1c2e] dark:text-foreground">
+        <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
           {name}
         </p>
-        <p className="truncate text-[13px] text-black/50 dark:text-muted-foreground">
+        <p className="truncate text-[15px] leading-5 text-muted-foreground">
           {subtitle}
         </p>
       </div>
@@ -1749,7 +1736,7 @@ function PeopleHub({
       </div>
 
       {filtered.length ? (
-        <div className="overflow-hidden rounded-[20px] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+        <div className={cn("overflow-hidden", SUBCARD_SURFACE)}>
           {filtered.map((r, i) => {
             const grant = vm.activeOwnerGrants.find(
               (g) => g.recipientUserId === r.userId,
@@ -1801,20 +1788,23 @@ function PeopleHub({
       <button
         type="button"
         onClick={onAsk}
-        className="flex w-full items-center gap-3.5 rounded-2xl bg-white p-4 text-left shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-colors hover:bg-black/[0.02] dark:bg-[color:var(--app-card-surface-default-solid)]"
+        className={cn(
+          "flex min-h-[60px] w-full items-center gap-3.5 p-3.5 text-left transition-colors hover:bg-foreground/[0.025]",
+          SUBCARD_SURFACE,
+        )}
       >
-        <span className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-[#e7f0fd] dark:bg-sky-400/15">
-          <Navigation className="h-[18px] w-[18px] text-[color:var(--app-accent)]" />
+        <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12">
+          <Navigation className="h-[17px] w-[17px] text-[color:var(--app-accent)]" />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block text-[15px] font-semibold text-[color:var(--app-accent)]">
+          <span className="block text-[17px] font-normal leading-[22px] text-[color:var(--app-accent)]">
             Ask someone to share
           </span>
-          <span className="block text-[13px] text-black/50 dark:text-muted-foreground">
+          <span className="block text-[15px] leading-5 text-muted-foreground">
             Send a request — they approve first.
           </span>
         </span>
-        <ChevronRight className="h-4 w-4 shrink-0 text-black/35 dark:text-muted-foreground" />
+        <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)]" />
       </button>
 
       {vm.requestedByMe.length ? (
@@ -1863,30 +1853,30 @@ function ActiveLinkRow({
   return (
     <div
       className={cn(
-        "flex items-center gap-3.5 py-4",
-        !first && "border-t border-black/[0.06] dark:border-white/10",
+        "flex min-h-[60px] items-center gap-3.5 py-3.5",
+        !first && "border-t border-[color:var(--app-separator)]",
       )}
     >
       <span
         className={cn(
-          "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl",
+          "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
           tileClass,
         )}
       >
         {icon}
       </span>
       <div className="min-w-0 flex-1">
-        <p className="text-[16px] font-bold text-[#1c1c2e] dark:text-foreground">
+        <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
           {title}
         </p>
-        <p className="mt-0.5 truncate text-[13px] text-black/50 dark:text-muted-foreground">
+        <p className="mt-0.5 truncate text-[15px] leading-5 text-muted-foreground">
           {subtitle}
         </p>
       </div>
       <Button
         variant="outline"
         onClick={onCopy}
-        className="h-9 shrink-0 rounded-full border-[color:var(--app-accent)] px-4 text-sm font-semibold text-[color:var(--app-accent)]"
+        className="h-9 shrink-0 rounded-full border-[color:var(--app-accent)] px-4 text-[14px] font-semibold text-[color:var(--app-accent)]"
       >
         Copy
       </Button>
@@ -1907,17 +1897,17 @@ function LinksHub({
 
   return (
     <div className="space-y-4">
-      <p className="px-1 text-[12px] font-bold uppercase tracking-[0.4px] text-black/40 dark:text-muted-foreground">
+      <p className="px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
         Active links
       </p>
 
       {hasLinks ? (
-        <div className="rounded-[20px] bg-white px-4 shadow-[0_4px_16px_rgba(0,0,0,0.06)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+        <div className={cn("overflow-hidden px-3.5", SUBCARD_SURFACE)}>
           {temp ? (
             <ActiveLinkRow
               first
-              tileClass="bg-[#efe9fb] dark:bg-violet-400/15"
-              icon={<LinkIcon className="h-5 w-5 text-[#7c5cff]" />}
+              tileClass="bg-[color:var(--app-purple)]/12 dark:bg-[color:var(--app-purple)]/15"
+              icon={<LinkIcon className="h-[17px] w-[17px] text-[color:var(--app-purple)]" />}
               title="Live location link"
               subtitle={`${vm.expiresCountdownLabel(temp.expiresAt)} · anyone with the link`}
               onCopy={vm.onCopyPublicInvite}
@@ -1926,8 +1916,8 @@ function LinksHub({
           {invite ? (
             <ActiveLinkRow
               first={!temp}
-              tileClass="bg-[#e5f4ea] dark:bg-emerald-400/15"
-              icon={<ShieldCheck className="h-5 w-5 text-[#2ea44f]" />}
+              tileClass="bg-[color:var(--app-success)]/12 dark:bg-[color:var(--app-success)]/15"
+              icon={<ShieldCheck className="h-[17px] w-[17px] text-[color:var(--app-success)]" />}
               title="Invite link"
               subtitle={`${vm.expiresCountdownLabel(invite.expiresAt)} · one person`}
               onCopy={vm.onCopyCircleInvite}
@@ -1950,8 +1940,8 @@ function LinksHub({
       </Button>
 
       <div className="flex items-start gap-2 px-1">
-        <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-black/40 dark:text-muted-foreground" />
-        <p className="text-[12px] leading-[1.45] text-black/50 dark:text-muted-foreground">
+        <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <p className="text-[13px] leading-[18px] text-muted-foreground">
           Links stop working automatically when they expire. You can revoke any
           link anytime.
         </p>

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -96,10 +96,10 @@ function ContactRow({
         {initials(label)}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[15px] font-semibold text-[#17171c]">
+        <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
           {label}
         </span>
-        <span className="mt-0.5 block truncate text-[12px] text-black/45">
+        <span className="mt-0.5 block truncate text-[15px] leading-5 text-muted-foreground">
           {recipientSubtitle(recipient) || "Connected in One"}
         </span>
       </span>
@@ -108,7 +108,7 @@ function ContactRow({
           type="button"
           onClick={onAskRemove}
           disabled={busy}
-          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full border border-[#ff3b30]/35 bg-[#ffe9e9] px-3 text-[13px] font-semibold text-[#d70015] disabled:opacity-45 disabled:bg-[#f8f8f8]"
+          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full bg-[color:var(--app-destructive)]/10 px-3 text-[13px] font-semibold text-[color:var(--app-destructive)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:opacity-45"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
         </button>
@@ -134,7 +134,7 @@ function ContactRow({
 
 function ContactGroup({ children }: { children: ReactNode }) {
   return (
-    <div className="divide-y divide-black/[0.055] overflow-hidden rounded-[15px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.02)]">
+    <div className="divide-y divide-[color:var(--app-separator)] overflow-hidden rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] shadow-none">
       {children}
     </div>
   );
@@ -185,7 +185,7 @@ export function SmsContactsFlow({
 
   return (
     <section
-      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-[#f2f3f7] text-[#17171c]"
+      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-background text-foreground"
       data-ambient-chrome-ignore
       data-testid="sms-contacts-screen"
     >
@@ -194,22 +194,22 @@ export function SmsContactsFlow({
           type="button"
           onClick={onBack}
           aria-label="Back"
-          className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.045]"
+          className="press-scale flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)]"
         >
           <ChevronLeft className="h-[19px] w-[19px]" />
         </button>
 
-        <h1 className="mt-3 !text-[29px] !font-bold !leading-tight !tracking-[-0.65px]">
+        <h1 className="mt-3 !text-[32px] !font-bold !leading-[1.08] !tracking-normal">
           SMS contacts
         </h1>
-        <p className="mt-1 max-w-[350px] text-[13px] leading-[1.45] text-black/47">
+        <p className="mt-2 max-w-[350px] text-[17px] leading-[24px] text-muted-foreground">
           These people are alerted with your live location the moment you send
           the SMS.
         </p>
 
         {circles.length ? (
           <>
-            <p className="mb-2 mt-6 px-1 text-[11px] font-bold uppercase tracking-[0.35px] text-black/40">
+            <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
               Add a Circle
             </p>
             <ContactGroup>
@@ -221,17 +221,17 @@ export function SmsContactsFlow({
                     className={cn(
                       "flex min-h-[64px] items-center gap-3 px-3.5 py-2.5",
                       index < circles.length - 1 &&
-                        "border-b border-black/[0.055]",
+                        "border-b border-[color:var(--app-separator)]",
                     )}
                   >
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
-                      <UsersRound className="h-[18px] w-[18px]" />
+                    <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                      <UsersRound className="h-[17px] w-[17px]" />
                     </span>
                     <span className="min-w-0 flex-1">
-                      <span className="block truncate text-[15px] font-semibold text-[#17171c]">
+                      <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
                         {circle.name}
                       </span>
-                      <span className="mt-0.5 block text-[12px] text-black/45">
+                      <span className="mt-0.5 block text-[15px] leading-5 text-muted-foreground">
                         Add current ready members · {circle.memberCount} total
                       </span>
                     </span>
@@ -251,7 +251,7 @@ export function SmsContactsFlow({
                 );
               })}
             </ContactGroup>
-            <p className="mt-2 px-1 text-[12px] leading-[1.45] text-black/43">
+            <p className="mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
               This adds a snapshot of current ready members. Anyone who joins
               later is never added to SMS automatically.
             </p>
@@ -260,7 +260,7 @@ export function SmsContactsFlow({
                 contacts. Membership never auto-adds anyone to SMS. */}
             {circles.map((circle) => (
               <div key={`grow-${circle.id}`} className="mt-3 px-1">
-                <p className="mb-1.5 text-[12px] font-semibold text-black/50">
+                <p className="mb-1.5 text-[13px] font-semibold leading-[18px] text-muted-foreground">
                   Grow {circle.name}
                 </p>
                 <CircleGrowActions
@@ -283,7 +283,7 @@ export function SmsContactsFlow({
         ) : null}
 
 
-        <p className="mb-2 mt-6 px-1 text-[11px] font-bold uppercase tracking-[0.35px] text-black/40">
+        <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
           Alerted on SMS
         </p>
         {selected.length ? (
@@ -304,12 +304,12 @@ export function SmsContactsFlow({
             ))}
           </ContactGroup>
         ) : (
-          <div className="rounded-[15px] bg-white px-4 py-5 text-center text-[13px] leading-relaxed text-black/45">
+          <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-5 text-center text-[15px] leading-5 text-muted-foreground">
             No SMS contacts yet. Add someone from your circle below.
           </div>
         )}
 
-        <p className="mb-2 mt-6 px-1 text-[11px] font-bold uppercase tracking-[0.35px] text-black/40">
+        <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
           Add from your circle
         </p>
         {available.length ? (
@@ -330,12 +330,12 @@ export function SmsContactsFlow({
             ))}
           </ContactGroup>
         ) : (
-          <div className="rounded-[15px] bg-white px-4 py-5 text-center text-[13px] text-black/45">
+          <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-5 text-center text-[15px] leading-5 text-muted-foreground">
             Everyone in your ready circle is already selected.
           </div>
         )}
 
-        <p className="mt-4 px-1 text-[12px] leading-[1.45] text-black/43">
+        <p className="mt-4 px-1 text-[13px] leading-[18px] text-muted-foreground">
           Only people in your circle can be SMS contacts. They&apos;re never
           notified unless you send the SMS.
         </p>
@@ -349,24 +349,24 @@ export function SmsContactsFlow({
       >
         <AlertDialogContent
           size="sm"
-          className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-white !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none"
+          className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-[color:var(--app-card-surface-default-solid)] !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none"
         >
           <AlertDialogHeader className="!place-items-center !text-center sm:!place-items-center sm:!text-center">
             <span
-              className="flex h-14 w-14 items-center justify-center rounded-full bg-[#f29918] text-xl font-semibold text-white"
+              className="flex h-[52px] w-[52px] items-center justify-center rounded-[16px] bg-[color:var(--app-warning)] text-xl font-semibold text-white"
               aria-hidden
             >
               {pendingRemoval ? initials(recipientLabel(pendingRemoval)) : "?"}
             </span>
-            <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-bold !leading-tight">
-              <span className="text-[#17171c]">
+            <AlertDialogTitle className="mt-1 !text-center !text-[22px] !font-bold !leading-[1.14]">
+              <span className="text-foreground">
                 Remove{" "}
                 {pendingRemoval
                   ? `${recipientLabel(pendingRemoval).split(/\s+/)[0]}?`
                   : "contact?"}
               </span>
             </AlertDialogTitle>
-            <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[13px] !leading-[1.45] !text-[#17171c]">
+            <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[15px] !leading-5 !text-muted-foreground">
               They&apos;ll no longer be alerted with your live location when you
               trigger SMS.
             </AlertDialogDescription>
@@ -379,7 +379,7 @@ export function SmsContactsFlow({
                 event.preventDefault();
                 void removePending();
               }}
-              className="!h-12 !rounded-full !bg-[#ff3b30] !text-[15px] !font-semibold !text-white hover:!bg-[#ff3b30]/90 disabled:!opacity-60"
+              className="!h-12 !rounded-full !bg-[color:var(--app-destructive)] !text-[15px] !font-semibold !text-white hover:!bg-[color:var(--app-destructive)]/90 disabled:!opacity-60"
             >
               {removing ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -390,7 +390,7 @@ export function SmsContactsFlow({
             <AlertDialogCancel
               variant="secondary"
               disabled={removing}
-              className="!mt-0 !h-12 !rounded-full !border-0 !bg-[#efeff4] !text-[15px] !font-semibold !text-[#17171c] hover:!bg-[#e5e5ea] disabled:!opacity-60"
+              className="!mt-0 !h-12 !rounded-full !border-0 !bg-[color:var(--app-neutral-fill-strong)] !text-[15px] !font-semibold !text-foreground hover:!bg-[color:var(--app-neutral-fill-strong)]/80 disabled:!opacity-60"
             >
               Cancel
             </AlertDialogCancel>

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -308,16 +308,16 @@ export function SosPanel({
           type="button"
           onClick={onClose}
           aria-label="Back to Location"
-          className="press-scale flex h-10 w-10 items-center justify-center rounded-full bg-[#202023] text-white"
+          className="press-scale flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white"
         >
           <ChevronLeft className="h-6 w-6" strokeWidth={2} />
         </button>
 
         <header className="mt-1 px-3 text-center">
-          <h1 className="whitespace-nowrap !text-[28px] !font-bold !leading-[1.15] !tracking-[-0.45px]">
+          <h1 className="whitespace-nowrap !text-[32px] !font-bold !leading-[1.08] !tracking-normal">
             SMS · Save my Soul
           </h1>
-          <p className="mx-auto mt-2 max-w-[290px] text-[14px] leading-[1.45] text-white/70">
+          <p className="mx-auto mt-2 max-w-[310px] text-[17px] leading-[24px] text-white/70">
             Press and hold. An SMS with your live location goes to your people —
             even with no internet.
           </p>
@@ -341,17 +341,17 @@ export function SosPanel({
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[#ff3b30]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
+                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[#ff3b30]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
+                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[#ff3b30]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
+                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
                 />
               </>
             ) : null}
@@ -376,7 +376,7 @@ export function SosPanel({
               onKeyUp={handleKeyUp}
               onContextMenu={(event) => event.preventDefault()}
               className={cn(
-                "relative z-10 flex h-[152px] w-[152px] touch-none select-none flex-col items-center justify-center rounded-full bg-[#ff3b30] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
+                "relative z-10 flex h-[152px] w-[152px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
                 progress > 0 && progress < 1 && "scale-[1.035]",
                 (active || busy) && "[animation:sosCorePulse_2.2s_ease-in-out_infinite]",
                 disabled && "cursor-not-allowed",
@@ -446,7 +446,7 @@ export function SosPanel({
             <button
               type="button"
               onClick={onEditContacts}
-              className="font-semibold text-[#2997ff]"
+              className="font-semibold text-[color:var(--app-accent)]"
             >
               Edit
             </button>
@@ -515,7 +515,7 @@ export function SosPanel({
                     // never runs underneath it.
                     "min-h-[72px] w-full resize-none rounded-2xl border bg-[#1c1c1e] py-3 pl-3.5 pr-14 text-[14px] leading-relaxed text-white outline-none placeholder:text-white/40 focus:border-white/55",
                     customMessageLimitExceeded
-                      ? "border-[#ff453a]"
+                      ? "border-[color:var(--app-destructive)]"
                       : "border-white/10",
                   )}
                 />
@@ -532,7 +532,7 @@ export function SosPanel({
                     "press-scale absolute bottom-2.5 right-2.5 flex h-10 w-10 items-center justify-center rounded-full transition-colors",
                     hardDisabled || !selectedMessage
                       ? "bg-white/10 text-white/35"
-                      : "bg-[#ff3b30] text-white",
+                      : "bg-[color:var(--app-destructive)] text-white",
                   )}
                 >
                   {busy ? (
@@ -547,7 +547,7 @@ export function SosPanel({
                 className={cn(
                   "mt-1 text-right text-[12px]",
                   customMessageLimitExceeded
-                    ? "text-[#ff6961]"
+                    ? "text-[color:var(--app-destructive)]"
                     : "text-white/55",
                 )}
               >
@@ -557,7 +557,7 @@ export function SosPanel({
                 <p
                   id="sos-short-message-error"
                   role="alert"
-                  className="mt-0.5 text-right text-[12px] text-[#ff6961]"
+                  className="mt-0.5 text-right text-[12px] text-[color:var(--app-destructive)]"
                 >
                   character limit exceed
                 </p>
@@ -572,7 +572,7 @@ export function SosPanel({
                   <button
                     type="button"
                     onClick={handleWindowsEmergencyCopy}
-                    className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[#ff3b30] px-3 text-white"
+                    className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[color:var(--app-destructive)] px-3 text-white"
                     aria-label={`Copy ${emergency.number} emergency services (${emergency.countryName})`}
                   >
                     <Phone className="h-4 w-4 fill-current" aria-hidden />
@@ -590,7 +590,7 @@ export function SosPanel({
                     from your phone now.
                   </span>
                   {windowsCopyStatus === "copied" ? (
-                    <span className="mt-1 block text-[11px] leading-tight text-[#35d07f]">
+                    <span className="mt-1 block text-[11px] leading-tight text-[color:var(--app-success)]">
                       Number copied to clipboard.
                     </span>
                   ) : null}
@@ -604,7 +604,7 @@ export function SosPanel({
                 <a
                   href={`tel:${emergency.number}`}
                   aria-label={`Call ${emergency.number} emergency services (${emergency.countryName})`}
-                  className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[#ff3b30] px-3 text-white"
+                  className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[color:var(--app-destructive)] px-3 text-white"
                 >
                   <Phone className="h-4 w-4 fill-current" aria-hidden />
                   <span className="min-w-0 text-left leading-tight">
@@ -629,7 +629,7 @@ export function SosPanel({
                     ? "Retry local emergency number"
                     : "Finding local emergency number"
                 }
-                className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[#ff3b30] px-3 text-white disabled:cursor-wait disabled:opacity-75"
+                className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[color:var(--app-destructive)] px-3 text-white disabled:cursor-wait disabled:opacity-75"
               >
                 {emergencyStatus === "unavailable" ? (
                   <Phone className="h-4 w-4 fill-current" aria-hidden />

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -44,25 +44,26 @@ import type { PlainLocationPoint } from "@/lib/one-location/types";
 import { useOneLocationControlState } from "@/lib/one-location/use-location-control-state";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
+import { SUBCARD_SURFACE } from "@/components/one-location/redesign/tokens";
 
 function CategoryIcon({ category }: { category: SavedLocationCategory }) {
   const Icon =
     category === "home" ? Home : category === "work" ? Briefcase : MapPin;
   const tone =
     category === "home"
-      ? "bg-[#e7f0fd] text-[#087ff5] dark:bg-[#087ff5]/15"
+      ? "bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)] dark:bg-[color:var(--app-accent)]/15"
       : category === "work"
-        ? "bg-[#eef1f5] text-[#5b6472] dark:bg-white/10 dark:text-white/70"
-        : "bg-[#e5f4ea] text-[#2ea44f] dark:bg-emerald-400/15";
+        ? "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)]"
+        : "bg-[color:var(--app-success)]/12 text-[color:var(--app-success)] dark:bg-[color:var(--app-success)]/15";
   return (
     <span
       className={cn(
-        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+        "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
         tone,
       )}
       aria-hidden="true"
     >
-      <Icon className="h-5 w-5" strokeWidth={2.1} />
+      <Icon className="h-[17px] w-[17px]" strokeWidth={1.9} />
     </span>
   );
 }
@@ -549,14 +550,14 @@ export function SavedLocationsSection() {
         data-testid="settings-saved-locations"
       >
         <div className="mb-2.5 flex items-center justify-between gap-3 px-1">
-          <p className="text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
+          <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
             Saved Locations
           </p>
           <button
             type="button"
             onClick={() => void handleAdd()}
             disabled={!hasVaultAccess || locationControl.paused || capturing}
-            className="press-scale inline-flex h-8 items-center gap-1.5 rounded-full bg-[color:var(--app-accent-tint,#e7f0fd)] px-3 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] transition-opacity disabled:cursor-not-allowed disabled:opacity-45"
+            className="press-scale inline-flex h-8 items-center gap-1.5 rounded-full bg-[color:var(--app-accent)]/12 px-3 text-[13px] font-semibold text-[color:var(--app-accent)] transition-opacity disabled:cursor-not-allowed disabled:opacity-45"
           >
             {capturing ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
@@ -567,17 +568,17 @@ export function SavedLocationsSection() {
           </button>
         </div>
 
-        <div className="overflow-hidden rounded-2xl bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+        <div className={cn("overflow-hidden", SUBCARD_SURFACE)}>
           {!hasVaultAccess ? (
-            <div className="flex items-center gap-3.5 p-4">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#eef1f5] text-[#8b93a1] dark:bg-white/10">
-                <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+            <div className="flex min-h-[60px] items-center gap-3.5 p-3.5">
+              <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)]">
+                <ShieldCheck className="h-[17px] w-[17px]" aria-hidden="true" />
               </span>
               <div className="min-w-0">
-                <p className="text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                <p className="text-[17px] font-normal leading-[22px] text-foreground">
                   Unlock your vault to view saved places
                 </p>
-                <p className="mt-0.5 text-[13px] leading-[1.4] text-black/50 dark:text-muted-foreground">
+                <p className="mt-0.5 text-[15px] leading-5 text-muted-foreground">
                   Exact locations stay encrypted and are available only while
                   your vault is unlocked.
                 </p>
@@ -585,35 +586,35 @@ export function SavedLocationsSection() {
             </div>
           ) : loading ? (
             <div
-              className="flex items-center gap-3 p-4 text-[13px] text-black/50 dark:text-muted-foreground"
+              className="flex min-h-[58px] items-center gap-3 p-3.5 text-[15px] leading-5 text-muted-foreground"
               role="status"
             >
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
               Loading saved places…
             </div>
           ) : loadError ? (
-            <div className="flex items-center justify-between gap-3 p-4">
-              <p className="text-[13px] text-[#b42318] dark:text-red-300">
+            <div className="flex min-h-[58px] items-center justify-between gap-3 p-3.5">
+              <p className="text-[15px] leading-5 text-[color:var(--app-destructive)]">
                 {loadError}
               </p>
               <button
                 type="button"
                 onClick={() => void reload()}
-                className="rounded-full px-3 py-1.5 text-[12px] font-bold text-[color:var(--app-accent,#087ff5)]"
+                className="rounded-full px-3 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)]"
               >
                 Retry
               </button>
             </div>
           ) : locations.length === 0 ? (
-            <div className="flex items-center gap-3.5 p-4">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#eef1f5] text-[#8b93a1] dark:bg-white/10">
-                <MapPin className="h-5 w-5" aria-hidden="true" />
+            <div className="flex min-h-[60px] items-center gap-3.5 p-3.5">
+              <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)]">
+                <MapPin className="h-[17px] w-[17px]" aria-hidden="true" />
               </span>
               <div className="min-w-0">
-                <p className="text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                <p className="text-[17px] font-normal leading-[22px] text-foreground">
                   No saved places yet
                 </p>
-                <p className="mt-0.5 text-[13px] leading-[1.4] text-black/50 dark:text-muted-foreground">
+                <p className="mt-0.5 text-[15px] leading-5 text-muted-foreground">
                   Add Home, Work, or another place to see it here.
                 </p>
               </div>
@@ -623,17 +624,17 @@ export function SavedLocationsSection() {
               <div
                 key={location.id}
                 className={cn(
-                  "flex items-center gap-3.5 p-4",
+                  "flex min-h-[60px] items-center gap-3.5 p-3.5",
                   index > 0 &&
-                    "border-t border-black/[0.06] dark:border-white/10",
+                    "border-t border-[color:var(--app-separator)]",
                 )}
               >
                 <CategoryIcon category={location.category} />
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                  <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
                     {location.label}
                   </p>
-                  <p className="mt-0.5 truncate text-[13px] text-black/50 dark:text-muted-foreground">
+                  <p className="mt-0.5 truncate text-[15px] leading-5 text-muted-foreground">
                     {location.address || "Address unavailable"}
                   </p>
                 </div>
@@ -644,7 +645,7 @@ export function SavedLocationsSection() {
                     title="Find address"
                     onClick={() => void handleRepairAddress(location)}
                     disabled={repairingId !== null}
-                    className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-black/[0.05] hover:text-[#087ff5] disabled:opacity-45 dark:text-muted-foreground"
+                    className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-foreground/[0.05] hover:text-[color:var(--app-accent)] disabled:opacity-45"
                   >
                     <RefreshCw
                       className={cn(
@@ -666,7 +667,7 @@ export function SavedLocationsSection() {
                     capturing ||
                     locationControl.paused
                   }
-                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-black/[0.05] hover:text-[#087ff5] disabled:opacity-45 dark:text-muted-foreground"
+                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-foreground/[0.05] hover:text-[color:var(--app-accent)] disabled:opacity-45"
                 >
                   <Pencil className="h-[17px] w-[17px]" strokeWidth={2} />
                 </button>
@@ -675,7 +676,7 @@ export function SavedLocationsSection() {
                   aria-label={`Remove ${location.label}`}
                   onClick={() => void handleRemove(location.id)}
                   disabled={removingId !== null}
-                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-[#ff3b30]/10 hover:text-[#ff3b30] disabled:opacity-45 dark:text-muted-foreground"
+                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-[color:var(--app-destructive)]/10 hover:text-[color:var(--app-destructive)] disabled:opacity-45"
                 >
 
                   {removingId === location.id ? (
@@ -689,7 +690,7 @@ export function SavedLocationsSection() {
           )}
         </div>
         {hasVaultAccess ? (
-          <p className="mt-2 px-1 text-[11px] leading-[1.45] text-black/40 dark:text-muted-foreground">
+          <p className="mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
             {locationControl.paused
               ? "Resume Location before capturing another saved place."
               : "Saved places are encrypted in your vault and shared only when you explicitly approve location access."}


### PR DESCRIPTION
## Summary
- Polish Location Agent spacing, row rhythm, typography, and surface chrome across the main hub, settings, people/links, activity, saved locations, save-location modal, SMS contacts, SOS, check-in, setup completion, and public token screens.
- Keep existing content and behavior intact; only styling/classes and matching visual test assertions changed.
- Preserve Apple-style semantic color: system blue for active/interactive, green for success/share, red for destructive/emergency, neutral grouped surfaces for structure.

## Verification
- npm run test -- components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
- npm run test -- components/one-location/redesign/__tests__/check-in-flow.test.tsx components/one-location/redesign/__tests__/sos-panel.test.tsx __tests__/app/one/location/public-request-page.test.tsx components/one-location/redesign/__tests__/cards-primary-theme.test.tsx components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
- npm run typecheck
- npm run verify:design-system
- npm run lint
- Local browser probe: /one/location and /one/setup/location redirect to login in a fresh unauthenticated browser; /one/location/request/test-token renders with no horizontal overflow.