### PR TITLE
Polish Location agent typography for UAT

### DIFF
--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -83,7 +83,7 @@ export function TrustedPersonCard({
           <p
             className={cn(
               MUTED_TEXT,
-              "break-words text-[13px] leading-[18px] [overflow-wrap:anywhere] sm:text-[15px] sm:leading-5",
+              "break-words [overflow-wrap:anywhere]",
             )}
           >
             {subtitle}
@@ -218,7 +218,7 @@ export function RequestCard({
         </div>
       </div>
       {reason ? (
-        <p className="mt-2.5 rounded-[10px] bg-[color:var(--app-card-surface-compact)] px-2.5 py-1.5 text-[13px] leading-[18px] text-muted-foreground">
+        <p className={cn(MUTED_TEXT, "mt-2.5 rounded-[10px] bg-[color:var(--app-card-surface-compact)] px-2.5 py-1.5")}>
           {reason}
         </p>
       ) : null}

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -179,7 +179,7 @@ function ContactRow({
             Already shared in this check-in
           </span>
         ) : !ready ? (
-          <span className="block truncate text-[12px] text-black/45 dark:text-white/45">
+          <span className="block truncate text-[13px] leading-[18px] text-[#8E8E93]">
             Not ready to receive location
           </span>
         ) : null}
@@ -474,7 +474,7 @@ export function CheckInFlow({
             <p className="text-[15px] font-semibold leading-5 text-foreground">
               Nearby and private sharing are separate
             </p>
-            <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+            <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
               Nearby people can see your name only. People you select below
               receive your encrypted precise location for the duration you
               choose.
@@ -484,7 +484,7 @@ export function CheckInFlow({
       ) : null}
 
       {/* YOUR LOCATION */}
-      <SectionLabel>YOUR LOCATION</SectionLabel>
+      <SectionLabel>Your location</SectionLabel>
       <section className={cn(CARD, "overflow-hidden")}>
         <div className="flex items-center gap-3 px-4 py-[13px]">
           <div className="min-w-0 flex-1">
@@ -497,7 +497,7 @@ export function CheckInFlow({
                     : "Location needs a refresh"
                   : "Location not captured yet"}
             </p>
-            <p className="mt-0.5 text-[13px] text-black/45 dark:text-white/45">
+            <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
               {point
                 ? confirmedPoint
                   ? `${accuracy ?? "Location captured"} · Retrying the exact point you reviewed`
@@ -559,7 +559,7 @@ export function CheckInFlow({
       </section>
 
       {/* WHO SHOULD KNOW? */}
-      <SectionLabel>WHO SHOULD KNOW?</SectionLabel>
+      <SectionLabel>Who should know?</SectionLabel>
       {vm.circles.length ? (
         <div className={cn(CARD, "mb-2 overflow-hidden")}>
           {vm.circles.map((circle, index) => {
@@ -604,7 +604,7 @@ export function CheckInFlow({
           })}
           {circleSelection ? (
             <>
-              <p className="border-t border-[color:var(--app-separator)] px-4 py-2.5 text-[13px] leading-[18px] text-muted-foreground">
+              <p className="border-t border-[color:var(--app-separator)] px-4 py-2.5 text-[15px] leading-[20px] text-[#8E8E93]">
                 Current ready members only. Future members are not added to this
                 check-in.
                 {circleSelection.excluded.filter(
@@ -693,7 +693,7 @@ export function CheckInFlow({
             Shared with {completedRecipientIds.length}{" "}
             {completedRecipientIds.length === 1 ? "person" : "people"} already
           </p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
             They keep the original encrypted location, duration, and message.
             Any edits apply only to people who have not received this check-in.
           </p>
@@ -701,7 +701,7 @@ export function CheckInFlow({
       ) : null}
 
       {/* DURATION — gray segmented control incl. "Until I stop". */}
-      <SectionLabel>DURATION</SectionLabel>
+      <SectionLabel>Duration</SectionLabel>
       <div className="flex rounded-[10px] bg-[color:var(--app-neutral-fill-strong)] p-0.5">
         {durationOptions.map((option) => (
           <button
@@ -722,13 +722,13 @@ export function CheckInFlow({
           </button>
         ))}
       </div>
-      <p className="mt-2 flex items-center gap-1.5 px-1 text-[13px] leading-[18px] text-muted-foreground">
+      <p className="mt-2 flex items-center gap-1.5 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
         <Shield className="h-3 w-3 shrink-0" strokeWidth={1.5} />
         Sharing stops automatically — no manual revoke needed.
       </p>
 
       {/* MESSAGE — encrypted with the reviewed point for selected recipients. */}
-      <SectionLabel>MESSAGE</SectionLabel>
+      <SectionLabel>Message</SectionLabel>
       <div className={cn(CARD, "px-4 py-[14px]")}>
         <textarea
           value={message}
@@ -744,7 +744,7 @@ export function CheckInFlow({
           {message.length}/{CHECK_IN_MESSAGE_MAX_LENGTH}
         </p>
       </div>
-      <p className="mb-[18px] mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
+      <p className="mb-[18px] mt-2 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
         {retryLocked
           ? "Retry keeps the same duration, encrypted message, and reviewed location, and sends only to people who still failed."
           : "This message is encrypted with your location. The notification only says that you shared a check-in."}

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -46,6 +46,7 @@ import {
   TaskFlowHeader,
   TrustNoteCard,
 } from "@/components/one-location/redesign/primitives";
+import { MUTED_TEXT, SECTION_HEADING } from "@/components/one-location/redesign/tokens";
 import type {
   OneLocationCircleDetail,
   OneLocationCircleEligibleConnection,
@@ -168,10 +169,10 @@ export function CirclesSection({
     <div className="space-y-3" data-testid="one-location-named-circles">
       <div className="flex items-center justify-between gap-3 px-1">
         <div>
-          <h2 className="text-[17px] font-semibold leading-[22px] tracking-normal text-foreground">
+          <h2 className={SECTION_HEADING}>
             Your circles
           </h2>
-          <p className="mt-0.5 text-[13px] text-black/50 dark:text-muted-foreground">
+          <p className={cn(MUTED_TEXT, "mt-1")}>
             Family and friends you choose to group together.
           </p>
         </div>
@@ -237,7 +238,7 @@ export function CirclesSection({
                   <p className="truncate text-[15px] font-semibold text-foreground">
                     {invite.circleName}
                   </p>
-                  <p className="text-[13px] leading-5 text-muted-foreground">
+                  <p className={MUTED_TEXT}>
                     Invited by {invite.inviterDisplayName}
                   </p>
                 </div>
@@ -635,7 +636,7 @@ function CircleMemberRow({
           {member.displayName}
           {isCurrentUser ? " (you)" : ""}
         </p>
-        <p className="truncate text-[13px] text-muted-foreground">
+        <p className={cn(MUTED_TEXT, "truncate")}>
           {member.role === "owner"
             ? "Circle owner"
             : member.secureLocationReady
@@ -1107,7 +1108,7 @@ export function CircleDetailFlow({
                   <p className="break-all font-mono text-lg font-bold tracking-[0.08em] text-foreground min-[360px]:text-xl min-[360px]:tracking-[0.12em]">
                     {inviteCode.code}
                   </p>
-                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  <p className={cn(MUTED_TEXT, "mt-2")}>
                     Joining connects Circle members. Location and SMS stay
                     private until each person chooses to share.
                   </p>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -72,7 +72,7 @@ import {
   TrustNoteCard,
   WarningCard,
 } from "./primitives";
-import { SUBCARD_SURFACE } from "./tokens";
+import { MUTED_TEXT, SECTION_HEADING, SUBCARD_SURFACE } from "./tokens";
 import {
   RequestCard,
   SharedWithMeCard,
@@ -1474,7 +1474,7 @@ function LocationSettingsFlow({
 
       <div className="flex items-start gap-2.5 px-1">
         <Shield className="mt-0.5 h-[15px] w-[15px] shrink-0 text-[color:var(--app-accent)]" />
-        <p className="text-[13px] leading-[18px] text-muted-foreground">
+        <p className={MUTED_TEXT}>
           Private shares stay in your circle. Nearby Check-In is separate and
           only starts after you explicitly agree.
         </p>
@@ -1897,7 +1897,7 @@ function LinksHub({
 
   return (
     <div className="space-y-4">
-      <p className="px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+      <p className={cn(SECTION_HEADING, "px-[6px]")}>
         Active links
       </p>
 
@@ -1941,7 +1941,7 @@ function LinksHub({
 
       <div className="flex items-start gap-2 px-1">
         <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        <p className="text-[13px] leading-[18px] text-muted-foreground">
+        <p className={MUTED_TEXT}>
           Links stop working automatically when they expire. You can revoke any
           link anytime.
         </p>
@@ -2215,7 +2215,7 @@ function ShareFlow({
                     <span className="block truncate text-sm font-semibold text-foreground">
                       {circle.name}
                     </span>
-                    <span className="block text-xs text-muted-foreground">
+                    <span className="block text-[13px] leading-[18px] text-[#8E8E93]">
                       {selected
                         ? `${selectedReady.length} ready now`
                         : `${circle.memberCount} ${
@@ -2235,7 +2235,7 @@ function ShareFlow({
             })}
           </div>
           {vm.selectedShareCircleSelection ? (
-            <p className="mt-3 text-xs leading-5 text-muted-foreground">
+            <p className={cn(MUTED_TEXT, "mt-3")}>
               Current ready members only; future members are never added
               automatically.
               {vm.selectedShareCircleSelection.excluded.filter(
@@ -2316,7 +2316,7 @@ function ReviewRow({
 }) {
   return (
     <div className="flex items-start justify-between gap-3 border-b border-border/50 pb-3 last:border-0 last:pb-0">
-      <span className="shrink-0 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+      <span className="shrink-0 text-[15px] font-normal leading-[20px] tracking-[-0.006em] text-[#8E8E93]">
         {label}
       </span>
       <div className="min-w-0 max-w-[70%] text-right text-sm font-medium text-foreground">
@@ -2471,7 +2471,7 @@ function InviteFlow({
               <p className="text-base font-semibold text-foreground">
                 Circle invite
               </p>
-              <p className="text-xs text-muted-foreground">
+              <p className={MUTED_TEXT}>
                 {invite
                   ? vm.expiresLabel(invite.expiresAt)
                   : "Invite expires soon"}

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { SECTION_HEADING } from "./tokens";
+import { MUTED_TEXT, SECTION_HEADING } from "./tokens";
 
 export type QuickActionTone = "green" | "red" | "blue" | "violet" | "slate";
 
@@ -104,7 +104,7 @@ export function QuickActionCard({
         {/* Subtitle spans the full card width (no chevron sharing the row) and
             uses a compact size so the one-line description stays fully visible
             on every device without truncating to an ellipsis. */}
-        <span className="mt-1.5 block truncate text-[11px] leading-tight text-black/50 dark:text-muted-foreground">
+        <span className={cn(MUTED_TEXT, "mt-1.5 block truncate text-[13px] leading-[18px]")}>
           {subtitle}
         </span>
       </div>

--- a/hushh-webapp/components/one-location/redesign/sharing-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/sharing-status-card.tsx
@@ -190,7 +190,7 @@ export function SharingStatusCard({
           <h2 className="mt-3.5 text-[25px] font-bold leading-none tracking-[-0.4px] text-[#1c1c2e] dark:text-white">
             {title}
           </h2>
-          <p className="mt-1.5 max-w-[210px] text-[15px] leading-[1.4] text-black/50 dark:text-white/55">
+          <p className="mt-1.5 max-w-[210px] text-[15px] leading-[20px] text-[#8E8E93]">
             {subtitle}
           </p>
 
@@ -204,7 +204,7 @@ export function SharingStatusCard({
                   {endsLabel ?? "Sharing live"}
                 </span>
                 {startedLabel ? (
-                  <span className="mt-px block text-[13px] text-black/45 dark:text-white/50">
+                  <span className="mt-px block text-[15px] leading-[20px] text-[#8E8E93]">
                     {startedLabel}
                   </span>
                 ) : null}
@@ -226,7 +226,7 @@ export function SharingStatusCard({
       {/* Privacy footer. */}
       <div className="flex items-center gap-[11px] border-t border-black/[0.06] px-[18px] py-3.5 dark:border-white/[0.08]">
         <Lock className="h-[15px] w-[15px] text-black/40 dark:text-white/40" />
-        <span className="text-sm text-black/50 dark:text-white/50">
+        <span className="text-[15px] leading-[20px] text-[#8E8E93]">
           Your location is only visible to your circle.
         </span>
       </div>

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -19,6 +19,7 @@ import type {
   OneLocationRecipient,
 } from "@/lib/one-location/types";
 import { CircleGrowActions } from "@/components/one-location/redesign/circles/circle-grow-actions";
+import { MUTED_TEXT, SECTION_HEADING } from "@/components/one-location/redesign/tokens";
 
 
 const AVATAR_TONES = [
@@ -209,7 +210,7 @@ export function SmsContactsFlow({
 
         {circles.length ? (
           <>
-            <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+            <p className={cn(SECTION_HEADING, "mb-2 mt-6 px-[6px]")}>
               Add a Circle
             </p>
             <ContactGroup>
@@ -251,7 +252,7 @@ export function SmsContactsFlow({
                 );
               })}
             </ContactGroup>
-            <p className="mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
+            <p className={cn(MUTED_TEXT, "mt-2 px-1")}>
               This adds a snapshot of current ready members. Anyone who joins
               later is never added to SMS automatically.
             </p>
@@ -260,7 +261,7 @@ export function SmsContactsFlow({
                 contacts. Membership never auto-adds anyone to SMS. */}
             {circles.map((circle) => (
               <div key={`grow-${circle.id}`} className="mt-3 px-1">
-                <p className="mb-1.5 text-[13px] font-semibold leading-[18px] text-muted-foreground">
+                <p className={cn(SECTION_HEADING, "mb-1.5")}>
                   Grow {circle.name}
                 </p>
                 <CircleGrowActions
@@ -283,7 +284,7 @@ export function SmsContactsFlow({
         ) : null}
 
 
-        <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+        <p className={cn(SECTION_HEADING, "mb-2 mt-6 px-[6px]")}>
           Alerted on SMS
         </p>
         {selected.length ? (
@@ -309,7 +310,7 @@ export function SmsContactsFlow({
           </div>
         )}
 
-        <p className="mb-2 mt-6 px-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+        <p className={cn(SECTION_HEADING, "mb-2 mt-6 px-[6px]")}>
           Add from your circle
         </p>
         {available.length ? (
@@ -335,7 +336,7 @@ export function SmsContactsFlow({
           </div>
         )}
 
-        <p className="mt-4 px-1 text-[13px] leading-[18px] text-muted-foreground">
+        <p className={cn(MUTED_TEXT, "mt-4 px-1")}>
           Only people in your circle can be SMS contacts. They&apos;re never
           notified unless you send the SMS.
         </p>

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -580,22 +580,22 @@ export function SosPanel({
                       <span className="block text-[15px] font-semibold">
                         Copy emergency number
                       </span>
-                      <span className="block truncate text-[10px] text-white/75">
+                      <span className="block truncate text-[12px] text-white/75">
                         {emergency.countryName} · {emergency.number}
                       </span>
                     </span>
                   </button>
-                  <span className="mt-1 block text-[11px] leading-tight text-white/75">
+                  <span className="mt-1 block text-[13px] leading-[18px] text-white/75">
                     Windows browsers cannot open emergency dialers directly. Call {emergency.number}
                     from your phone now.
                   </span>
                   {windowsCopyStatus === "copied" ? (
-                    <span className="mt-1 block text-[11px] leading-tight text-[color:var(--app-success)]">
+                    <span className="mt-1 block text-[13px] leading-[18px] text-[color:var(--app-success)]">
                       Number copied to clipboard.
                     </span>
                   ) : null}
                   {windowsCopyStatus === "error" ? (
-                    <span className="mt-1 block text-[11px] leading-tight text-[#ff9a75]">
+                    <span className="mt-1 block text-[13px] leading-[18px] text-[#ff9a75]">
                       Could not copy. Please open your phone dialer manually.
                     </span>
                   ) : null}

--- a/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
+++ b/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
@@ -30,10 +30,11 @@ export const SECTION_HEADING =
 
 /** Primary screen title (header). */
 export const SCREEN_TITLE =
-  "text-2xl font-semibold leading-tight tracking-tight text-foreground";
+  "font-[family-name:var(--font-app-body)] text-[28px] font-bold leading-[34px] tracking-[-0.022em] text-foreground";
 
 /** Muted secondary copy. */
-export const MUTED_TEXT = "text-sm leading-snug text-muted-foreground";
+export const MUTED_TEXT =
+  "font-[family-name:var(--font-app-body)] text-[15px] font-normal leading-[20px] tracking-[-0.006em] text-[#8E8E93]";
 
 /**
  * Accent utility classes. These follow the active accent preference

--- a/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
@@ -234,7 +234,9 @@ export function WarningCard({
       <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
         <p className="text-sm font-semibold">{title}</p>
-        <p className="text-xs leading-snug opacity-90">{description}</p>
+        <p className="text-[15px] font-normal leading-[20px] opacity-90">
+          {description}
+        </p>
       </div>
     </div>
   );
@@ -263,7 +265,9 @@ export function EmptyState({
       )}
     >
       {icon ? <div className="text-muted-foreground">{icon}</div> : null}
-      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <p className="text-[17px] font-semibold leading-[22px] tracking-[-0.01em] text-foreground">
+        {title}
+      </p>
       {description ? <p className={MUTED_TEXT}>{description}</p> : null}
       {action ? <div className="mt-1">{action}</div> : null}
     </div>


### PR DESCRIPTION
## Summary
- normalize Location agent section labels, subtitles, helper text, and empty states to the shared Apple-style typography scale
- promote shared Morphy muted/title tokens so reused screens inherit consistent 15px secondary copy and 28px task-flow titles
- preserve content, behavior, route structure, colors, and background treatments; casing changes are limited to visible uppercase section labels

## Verification
- npm run verify:design-system
- npm run typecheck
- npm run test -- components/one-location/redesign/__tests__/primitives.test.tsx components/one-location/redesign/__tests__/sharing-status-card.test.tsx components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
- npm run verify:cache
- npm run lint