### PR TITLE
Polish Profile avatar photo picker

### DIFF
--- a/hushh-webapp/__tests__/components/profile-avatar-editor.test.tsx
+++ b/hushh-webapp/__tests__/components/profile-avatar-editor.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileAvatarEditor } from "@/components/profile/profile-avatar-editor";
+import { pickAvatarDataUrl } from "@/lib/profile/avatar-capture";
+import { AccountIdentityService } from "@/lib/services/account-identity-service";
+import { morphyToast } from "@/lib/morphy-ux/morphy";
+
+const testUser = {
+  displayName: "Jhumma Kumari",
+  photoURL: null,
+  uid: "user-1",
+};
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: testUser }),
+}));
+
+vi.mock("@/hooks/use-effective-avatar-url", () => ({
+  useEffectiveAvatarUrl: () => null,
+}));
+
+vi.mock("@/lib/profile/avatar-capture", () => ({
+  pickAvatarDataUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/services/account-identity-service", () => ({
+  AccountIdentityService: {
+    uploadAvatar: vi.fn(),
+    removeAvatar: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: () => false,
+}));
+
+vi.mock("@/lib/morphy-ux/morphy", () => ({
+  morphyToast: {
+    error: vi.fn(),
+    promise: vi.fn(),
+  },
+}));
+
+describe("ProfileAvatarEditor", () => {
+  it("lets the camera badge pick and upload a profile photo directly", async () => {
+    const imageDataUrl = "data:image/jpeg;base64,profile-photo";
+    vi.mocked(pickAvatarDataUrl).mockResolvedValue(imageDataUrl);
+    vi.mocked(AccountIdentityService.uploadAvatar).mockResolvedValue(null);
+
+    render(<ProfileAvatarEditor />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Change profile photo" }),
+    );
+
+    await waitFor(() => {
+      expect(AccountIdentityService.uploadAvatar).toHaveBeenCalledWith(
+        testUser,
+        imageDataUrl,
+      );
+    });
+    expect(morphyToast.promise).toHaveBeenCalledWith(expect.any(Promise), {
+      loading: "Updating photo...",
+      success: "Profile photo updated.",
+      error: expect.any(Function),
+    });
+  });
+
+  it("shows the selected photo immediately while the upload is pending", async () => {
+    const imageDataUrl = "data:image/jpeg;base64,pending-photo";
+    let finishUpload: (() => void) | null = null;
+    vi.mocked(pickAvatarDataUrl).mockResolvedValue(imageDataUrl);
+    vi.mocked(AccountIdentityService.uploadAvatar).mockReturnValue(
+      new Promise((resolve) => {
+        finishUpload = () => resolve(null);
+      }),
+    );
+
+    render(<ProfileAvatarEditor />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Change profile photo" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Jhumma Kumari")).toHaveAttribute(
+        "src",
+        imageDataUrl,
+      );
+    });
+
+    finishUpload?.();
+  });
+});

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1355,14 +1355,38 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
 .profile-home-screen [data-profile-avatar-frame="true"] {
   background: #d1d1d6 !important;
   box-shadow: none !important;
+  display: inline-flex;
   height: 96px !important;
+  justify-content: center;
   padding: 0 !important;
+  position: relative;
   width: 96px !important;
 }
 
-.profile-home-screen [data-profile-avatar-frame="true"] > span {
+.profile-home-screen [data-profile-avatar-display="true"] {
+  overflow: hidden;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    filter 180ms ease;
+}
+
+.profile-home-screen [data-profile-avatar-frame="true"][aria-busy="true"]
+  [data-profile-avatar-display="true"] {
+  filter: saturate(0.92);
+  opacity: 0.82;
+}
+
+.profile-home-screen [data-profile-avatar-camera="true"] {
   background: var(--ios-account-accent) !important;
   box-shadow: none !important;
+  color: var(--ios-account-on-accent) !important;
+  height: 26px !important;
+  width: 26px !important;
+}
+
+.profile-home-screen [data-profile-avatar-camera="true"]:active {
+  transform: scale(0.94);
 }
 
 .profile-home-screen [data-profile-avatar-frame="true"] [data-slot="avatar"],

--- a/hushh-webapp/components/profile/profile-avatar-editor.tsx
+++ b/hushh-webapp/components/profile/profile-avatar-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import {
   Camera as CameraIcon,
   ImagePlus,
@@ -46,41 +47,61 @@ export function ProfileAvatarEditor() {
   const photo = useEffectiveAvatarUrl();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [previewPhoto, setPreviewPhoto] = useState<string | null>(null);
 
   const displayName = user?.displayName || null;
   const fallback = initialsOf(displayName);
+  const shownPhoto = previewPhoto ?? photo;
 
   const handleChange = async () => {
     setSheetOpen(false);
-    if (!user) return;
+    if (!user || busy) return;
+    let dataUrl: string | null = null;
     try {
-      const dataUrl = await pickAvatarDataUrl();
-      if (!dataUrl) return; // user cancelled
-      setBusy(true);
-      await AccountIdentityService.uploadAvatar(user, dataUrl);
-      toast.success("Profile photo updated");
+      dataUrl = await pickAvatarDataUrl();
     } catch (error) {
       toast.error("Could not update photo", {
         description:
           error instanceof Error ? error.message : "Please try again.",
       });
+      return;
+    }
+    if (!dataUrl) return; // user cancelled
+
+    setPreviewPhoto(dataUrl);
+    setBusy(true);
+    const upload = AccountIdentityService.uploadAvatar(user, dataUrl);
+    toast.promise(upload, {
+      loading: "Updating photo...",
+      success: "Profile photo updated.",
+      error: (error) =>
+        error instanceof Error ? error.message : "Could not update photo.",
+    });
+    try {
+      await upload;
+    } catch {
+      setPreviewPhoto(null);
     } finally {
       setBusy(false);
+      setPreviewPhoto(null);
     }
   };
 
   const handleRemove = async () => {
     setSheetOpen(false);
-    if (!user) return;
+    if (!user || busy) return;
     setBusy(true);
+    const removal = AccountIdentityService.removeAvatar(user);
+    toast.promise(removal, {
+      loading: "Removing photo...",
+      success: "Profile photo removed.",
+      error: (error) =>
+        error instanceof Error ? error.message : "Could not remove photo.",
+    });
     try {
-      await AccountIdentityService.removeAvatar(user);
-      toast.success("Profile photo removed");
-    } catch (error) {
-      toast.error("Could not remove photo", {
-        description:
-          error instanceof Error ? error.message : "Please try again.",
-      });
+      await removal;
+    } catch {
+      // The morphing toast owns the user-facing error state.
     } finally {
       setBusy(false);
     }
@@ -91,39 +112,63 @@ export function ProfileAvatarEditor() {
 
   return (
     <>
-      <button
-        type="button"
+      <div
         data-profile-avatar-frame="true"
-        onClick={() => setSheetOpen(true)}
-        disabled={busy}
-        aria-label="Change profile photo"
-        className="group relative h-14 w-14 shrink-0 rounded-full bg-primary/18 p-1 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:h-16 sm:w-16"
+        aria-busy={busy}
+        className="relative h-14 w-14 shrink-0 rounded-full bg-primary/18 p-1 sm:h-16 sm:w-16"
       >
-        {photo ? (
-          <Avatar className="h-full w-full">
-            <AvatarImage src={photo} alt={displayName || "Profile"} />
-            <AvatarFallback className="bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
+        <button
+          type="button"
+          data-profile-avatar-display="true"
+          onClick={() => setSheetOpen(true)}
+          disabled={busy}
+          aria-label="Profile photo options"
+          className="group flex h-full w-full items-center justify-center rounded-full outline-none transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default"
+        >
+          {shownPhoto ? (
+            <Avatar className="h-full w-full">
+              {previewPhoto ? (
+                // A just-picked data URL should appear immediately; the shared
+                // AvatarImage waits for image-load state before replacing the fallback.
+                <Image
+                  src={previewPhoto}
+                  alt={displayName || "Profile"}
+                  data-slot="avatar-image"
+                  fill
+                  sizes="96px"
+                  unoptimized
+                  className="object-cover"
+                />
+              ) : (
+                <AvatarImage src={shownPhoto} alt={displayName || "Profile"} />
+              )}
+              <AvatarFallback className="bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
+                {fallback ?? <UserIcon className="h-8 w-8 sm:h-9 sm:w-9" />}
+              </AvatarFallback>
+            </Avatar>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center rounded-full bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
               {fallback ?? <UserIcon className="h-8 w-8 sm:h-9 sm:w-9" />}
-            </AvatarFallback>
-          </Avatar>
-        ) : (
-          <div className="flex h-full w-full items-center justify-center rounded-full bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
-            {fallback ?? <UserIcon className="h-8 w-8 sm:h-9 sm:w-9" />}
-          </div>
-        )}
-        <span
-          className={cn(
-            "absolute right-0 bottom-0 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background",
+            </div>
           )}
-          aria-hidden="true"
+        </button>
+        <button
+          type="button"
+          data-profile-avatar-camera="true"
+          onClick={handleChange}
+          disabled={busy}
+          aria-label="Change profile photo"
+          className={cn(
+            "absolute right-0 bottom-0 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background transition duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-95 disabled:cursor-default",
+          )}
         >
           {busy ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
           ) : (
-            <CameraIcon className="h-3.5 w-3.5" />
+            <CameraIcon className="h-3.5 w-3.5" aria-hidden="true" />
           )}
-        </span>
-      </button>
+        </button>
+      </div>
 
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
         <SheetContent side="bottom" showCloseButton={false}>
@@ -135,7 +180,7 @@ export function ProfileAvatarEditor() {
               <ImagePlus className="h-5 w-5 text-primary" />
               {isNative() ? "Take photo or choose from library" : "Upload a photo"}
             </button>
-            {photo ? (
+            {shownPhoto ? (
               <button
                 type="button"
                 onClick={handleRemove}


### PR DESCRIPTION
## Summary
- make the Profile camera badge a direct profile-photo picker action
- show a just-selected avatar immediately while upload persists through the existing account identity service
- keep the existing options sheet for secondary photo actions and align feedback to the morphing toast pattern

## Checks
- npm run test -- __tests__/components/profile-avatar-editor.test.tsx
- npm run typecheck
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs
- npm run lint

## Note
- npm run verify:routes was attempted locally but requires REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE in this shell.