### PR TITLE
Normalize shared app typography hierarchy

### DIFF
--- a/docs/ui-migration/final-verification.md
+++ b/docs/ui-migration/final-verification.md
@@ -16,7 +16,12 @@ This file is the visual evidence ledger for the migration. It stays incomplete u
 - Phase 1 visual audit exists: `docs/ui-migration/visual-audit.md`.
 - Agent theme registry audit exists: `docs/ui-migration/agent-theme-registry.md`.
 - Responsive verification matrix exists: `docs/ui-migration/responsive-test-matrix.md`.
-- No UAT deployment has been performed for this migration.
+- Hierarchy audit exists: `docs/ui-migration/hierarchy-audit.md`.
+- Shared typography role primitives have been added.
+- `PageHeader`, `SectionHeader`, `SettingsGroup`, `SettingsRow`, shared field primitives, base `Button`, top shell tabs, breadcrumbs, and Morphy typography constants have been normalized to the shared role classes.
+- `npm run typecheck`, `npm run verify:design-system`, `npm run verify:cache`, `npm run verify:docs`, and `npm run lint` passed after the shared-component pass.
+- `npm run verify:routes` is blocked locally because the maintainer-only reviewer identity environment is missing `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`.
+- No UAT deployment has been performed for this hierarchy pass yet.
 - No route is marked visually complete yet.
 
 ## Final Gate Checklist
@@ -26,8 +31,8 @@ This file is the visual evidence ledger for the migration. It stays incomplete u
 | Every in-scope route inventoried | In progress |
 | Welcome remains excluded/unchanged | Needs verification |
 | Every visible agent traversed | Not started |
-| Shared tokens normalized | Not started |
-| Shared components normalized | Not started |
+| Shared tokens normalized | In progress |
+| Shared components normalized | In progress |
 | Content preserved | Needs verification |
 | Forms and validation preserved | Needs verification |
 | Navigation preserved | Needs verification |
@@ -36,7 +41,7 @@ This file is the visual evidence ledger for the migration. It stays incomplete u
 | Desktop verification complete | Not started |
 | iOS safe-area behavior verified | Not started |
 | Keyboard behavior verified | Not started |
-| Functional tests pass | Not started |
+| Functional tests pass | In progress: typecheck, design-system, cache, docs, and lint passed; route rendering blocked by missing reviewer secrets |
 | UAT deployment complete | Not started |
 | UAT visual recheck complete | Not started |
 

--- a/docs/ui-migration/hierarchy-audit.md
+++ b/docs/ui-migration/hierarchy-audit.md
@@ -1,0 +1,105 @@
+# UAT Global Hierarchy And Spacing Audit
+
+Status: Shared role foundation applied; rendered route verification is still pending.
+
+## Visual Context
+
+Canonical visual owner: [Quality and Design System Index](../reference/quality/README.md).
+
+This file is the product-wide hierarchy evidence ledger for the UAT Apple iOS-first migration. It stays incomplete until every in-scope route has rendered proof across the route matrix and responsive matrix.
+
+## Scope
+
+This audit covers the product-wide Apple iOS-first hierarchy pass requested for UAT. The route inventory currently discovers 123 route files under `hushh-webapp/app`; `welcome` remains explicitly excluded by the migration prompt.
+
+## Shared Typography Roles
+
+Implemented shared semantic role primitives in `hushh-webapp/components/app-ui/typography.tsx`:
+
+| Role | Shared primitive/class |
+| --- | --- |
+| Page title | `PageTitle`, `.ui-text-page-title` |
+| Page subtitle | `PageSubtitle`, `.ui-text-page-subtitle` |
+| Navigation title | `NavigationTitle`, `.ui-text-navigation-title` |
+| Identity/person/agent name | `IdentityName`, `.ui-text-identity-name` |
+| Major section title | `MajorSectionTitle`, `.ui-text-major-section-title` |
+| Group/section label | `SectionLabel`, `.ui-text-section-label` |
+| Card heading | `CardTitle`, `.ui-text-card-title` |
+| Primary row label | `RowLabel`, `.ui-text-row-label` |
+| Row secondary description | `RowDescription`, `.ui-text-row-description` |
+| Trailing informational value | `TrailingValue`, `.ui-text-trailing-value` |
+| Interactive trailing action | `TrailingAction`, `.ui-text-trailing-action` |
+| Form label | `FormLabel`, `.ui-text-form-label` |
+| Helper text | `HelperText`, `.ui-text-helper-text` |
+| Button label | `ButtonLabel`, `.ui-text-button-label` |
+| Tab label | `TabLabel`, `.ui-text-tab-label` |
+
+## Shared Components Updated
+
+| Component | Change |
+| --- | --- |
+| `PageHeader` | Uses `PageTitle`, `PageSubtitle`, and `SectionLabel` instead of local text sizes. |
+| `SectionHeader` | Uses `CardTitle`, `PageSubtitle`, and `SectionLabel`; removed caption-sized title fallback. |
+| `SettingsGroup` | Uses `SectionLabel` for all group headings and `RowDescription` for group descriptions. |
+| `SettingsRow` | Uses `RowLabel` and `RowDescription`; destructive row color remains semantic red through the existing row tone. |
+| `AdaptiveDetailSurface` | Sheet, drawer, and dialog headers now use navigation-title and row-description roles. |
+| `FieldLabel`, `FieldTitle`, `FieldLegend`, `FieldDescription`, `FieldError` | Uses form-label, section-label, helper-text, and error roles. |
+| `Button` | Base button typography now uses the shared button-label role. |
+| `TopShellTabs` | Inactive tab labels use semantic secondary color instead of low opacity. |
+| `TopShellBreadcrumbTrail` | Breadcrumb secondary labels and separators use semantic colors instead of opacity fading. |
+| Morphy surface typography constants | `SCREEN_TITLE`, `SECTION_HEADING`, `MUTED_TEXT`, and `EYEBROW` now point at shared role classes. |
+
+## Global Token Work
+
+Added shared Apple iOS-first typography variables to `hushh-webapp/app/globals.css`, including:
+
+- page title: 28px / 700 / 32px / -0.022em
+- navigation title: 17px / 600 / 22px / -0.01em
+- section label: 15px / 500 / 20px / -0.01em / `#6E6E73`
+- row label: 17px / 400 / 22px
+- row description and trailing value: 15px / 400 / 21px / `#8E8E93`
+- form label: 15px / 500 / 20px
+- helper text: 13px / 400 / 18px
+- button label: 17px / 600 / 22px
+- tab label: 11px / 500 / 13px, reserved for compact tab surfaces
+
+The end-of-file semantic typography guardrail intentionally overrides older `h1`/`h2` and `data-slot` fallback rules so shared role classes win consistently.
+
+## Source Audit Findings
+
+Current source scan still shows route-local tiny and uppercase text usage, especially in dense finance tables, metadata badges, developer docs, Gmail receipts, marketplace cards, and chart labels. These are not all defects: some are true metadata, data-table headings, legal/microcopy, or compact badges. They remain pending until each route is rendered and classified by role.
+
+Known high-risk role mismatches still requiring rendered review:
+
+- RIA picks tables and editor metadata.
+- Gmail receipt/nudge section headings.
+- Kai finance dashboard cards, chart labels, badges, and history widgets.
+- Marketplace metadata and status chips.
+- Developer docs hub labels.
+- One Location map overlays and onboarding sheets.
+
+## Verification
+
+Completed:
+
+- TypeScript check: `npm run typecheck`
+- Design-system check: `npm run verify:design-system`
+- Cache contract tests: `npm run verify:cache`
+- Docs check: `npm run verify:docs`
+- Lint: `npm run lint`
+
+Blocked:
+
+- Signed-in route rendering: `npm run verify:routes` is blocked locally because `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` are not present in the maintainer-only environment.
+
+Pending before this audit can be marked complete:
+
+- `npm run verify:routes` or UAT route verifier with authenticated reviewer context
+- Rendered proof for each route in `docs/ui-migration/route-matrix.md`
+- Viewport proof at 320, 375, 390, 393, 430, 768, 820, 1024, 1280, and 1440 widths
+- iOS Safari safe-area and keyboard proof
+- UAT deployment and UAT visual recheck
+
+## Completion Rule
+
+This audit is not complete yet. It can only be marked complete after every in-scope route has rendered evidence for typography hierarchy, spacing rhythm, semantic color, responsive behavior, iOS safe-area/keyboard behavior, and shared-component conformance.

--- a/docs/ui-migration/responsive-test-matrix.md
+++ b/docs/ui-migration/responsive-test-matrix.md
@@ -1,6 +1,6 @@
 # UAT Responsive Test Matrix
 
-Status: Not started.
+Status: Not complete.
 
 This matrix defines the required verification set for the Apple iOS-first migration. It does not mark any route complete by itself.
 
@@ -46,9 +46,15 @@ For every in-scope route:
 
 | Browser/platform | Status | Notes |
 | --- | --- | --- |
-| Local Chromium via Playwright | Not started | Fast regression baseline. |
+| Local Chromium via Playwright | Pending | Fast regression baseline. |
 | iOS Safari or equivalent device proof | Not started | Required before claiming UAT-complete. |
 | Desktop browser | Not started | Required for whitespace/constrained-column proof. |
+
+## Current Pass Status
+
+The shared typography/component pass is typechecked, but viewport rendering has not yet been completed for the full route matrix. No route should be moved to `Complete` in `route-matrix.md` until rendered proof exists.
+
+Local signed-in route verification attempted with `npm run verify:routes` and stopped before rendering because the required maintainer-only reviewer identity values were not available in this environment.
 
 ## Acceptance Rule
 

--- a/docs/ui-migration/route-matrix.md
+++ b/docs/ui-migration/route-matrix.md
@@ -1,10 +1,12 @@
 # UAT Apple iOS-First Migration Route Matrix
 
-Generated: 2026-08-09T19:57:31.036Z
+Generated: 2026-08-10T00:00:00.000Z
 
 Source inputs: `hushh-webapp/lib/navigation/app-route-layout.contract.json`, `hushh-webapp/app/**/page.*`, and user-supplied Apple iOS-first migration docs.
 
 Status key: `Not started` means inventory only; rendered verification is still required before any route can be marked complete. Welcome is excluded by the migration prompt.
+
+Current shared hierarchy pass: shared typography roles and high-leverage shared components are normalized, but individual routes remain unverified until rendered browser proof is captured.
 
 ## Visual Context
 

--- a/docs/ui-migration/visual-audit.md
+++ b/docs/ui-migration/visual-audit.md
@@ -6,8 +6,9 @@ Scope: `hushh-webapp/app`, `hushh-webapp/components`, and `hushh-webapp/lib`.
 
 Source contract:
 
-- `C:\Users\jhumm\Downloads\APPLE-IOS-FIRST-PRODUCT-DESIGN-SYSTEM-v2.md`
-- `C:\Users\jhumm\Downloads\CODEX-UAT-ALL-SCREENS-MIGRATION-PROMPT (1).md`
+- `C:\Users\jhumm\Downloads\APPLE-IOS-FIRST-PRODUCT-DESIGN-SYSTEM-v2 (1).md`
+- `C:\Users\jhumm\Downloads\CODEX-UAT-ALL-SCREENS-MIGRATION-PROMPT (3).md`
+- `C:\Users\jhumm\Downloads\CODEX-GLOBAL-HIERARCHY-SPACING-AUDIT-PROMPT.md`
 
 Migration boundary:
 
@@ -147,6 +148,22 @@ Implement or normalize centrally before broad page polishing:
 - `AgentIconTile` and `CategoryIconTile`.
 - Button variants, form fields, segmented controls, search fields, status badges.
 - Empty, loading, error, sheet, dialog, toast, and bottom accessory primitives.
+
+## Shared Hierarchy Pass Outcome
+
+The current pass installed shared role primitives and wired the highest-leverage components first:
+
+- `hushh-webapp/components/app-ui/typography.tsx`
+- `hushh-webapp/components/app-ui/page-sections.tsx`
+- `hushh-webapp/components/app-ui/settings-ui.tsx`
+- `hushh-webapp/components/ui/field.tsx`
+- `hushh-webapp/components/ui/button.tsx`
+- `hushh-webapp/components/app-ui/top-shell-tabs.tsx`
+- `hushh-webapp/components/app-ui/top-app-bar.tsx`
+- `hushh-webapp/lib/morphy-ux/tokens/surfaces.ts`
+- `hushh-webapp/app/globals.css`
+
+`npm run typecheck`, `npm run verify:design-system`, `npm run verify:cache`, `npm run verify:docs`, and `npm run lint` passed after these shared changes. `npm run verify:routes` is blocked locally by missing maintainer-only reviewer identity values, so rendered route proof remains pending.
 
 ## Phase 1 Outcome
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -244,6 +244,57 @@ textarea {
   --foundation-caption-size: 0.75rem;
   --foundation-caption-line: 1.333;
   --foundation-caption-weight: 600;
+
+  /* Apple iOS-first semantic type roles. These are the shared source of truth
+     for app UI hierarchy; components opt into roles instead of restating
+     route-specific font sizes. */
+  --type-large-page-title-size: 34px;
+  --type-large-page-title-line: 38px;
+  --type-large-page-title-weight: 700;
+  --type-large-page-title-tracking: -0.028em;
+  --type-page-title-size: 28px;
+  --type-page-title-line: 32px;
+  --type-page-title-weight: 700;
+  --type-page-title-tracking: -0.022em;
+  --type-navigation-title-size: 17px;
+  --type-navigation-title-line: 22px;
+  --type-navigation-title-weight: 600;
+  --type-navigation-title-tracking: -0.01em;
+  --type-major-section-title-size: 22px;
+  --type-major-section-title-line: 26px;
+  --type-major-section-title-weight: 600;
+  --type-major-section-title-tracking: -0.017em;
+  --type-card-title-size: 20px;
+  --type-card-title-line: 24px;
+  --type-card-title-weight: 600;
+  --type-card-title-tracking: -0.014em;
+  --type-section-label-size: 15px;
+  --type-section-label-line: 20px;
+  --type-section-label-weight: 500;
+  --type-section-label-tracking: -0.01em;
+  --type-row-label-size: 17px;
+  --type-row-label-line: 22px;
+  --type-row-label-weight: 400;
+  --type-row-label-emphasis-weight: 600;
+  --type-row-label-tracking: -0.01em;
+  --type-row-description-size: 15px;
+  --type-row-description-line: 21px;
+  --type-row-description-weight: 400;
+  --type-row-description-tracking: -0.006em;
+  --type-form-label-size: 15px;
+  --type-form-label-line: 20px;
+  --type-form-label-weight: 500;
+  --type-form-label-tracking: -0.006em;
+  --type-input-value-size: 17px;
+  --type-input-value-line: 24px;
+  --type-helper-text-size: 13px;
+  --type-helper-text-line: 18px;
+  --type-button-label-size: 17px;
+  --type-button-label-line: 22px;
+  --type-button-label-weight: 600;
+  --type-tab-label-size: 11px;
+  --type-tab-label-line: 13px;
+  --type-tab-label-weight: 500;
   --foundation-caption-tracking: 0.158em;
   --foundation-micro-size: 0.6875rem;
   --foundation-micro-line: 1.273;
@@ -293,6 +344,7 @@ textarea {
   --app-elevated-surface: #ffffff;
   --app-label: #1d1d1f;
   --app-secondary-label: #8e8e93;
+  --app-section-label: #6e6e73;
   --app-tertiary-label: #aeaeb2;
   --app-quaternary-label: #c7c7cc;
   --app-separator: rgba(60, 60, 67, 0.1);
@@ -855,6 +907,7 @@ textarea {
   --app-elevated-surface: #2c2c2e;
   --app-label: #ffffff;
   --app-secondary-label: #98989d;
+  --app-section-label: #98989d;
   --app-tertiary-label: #636366;
   --app-quaternary-label: #48484a;
   --app-separator: rgba(84, 84, 88, 0.65);
@@ -3471,19 +3524,30 @@ html.native-ios [data-testid="one-location-onboarding"] {
      typography instead of inheriting title3 size and semibold weight. */
   [data-slot="settings-row-title"] {
     font-family: var(--font-app-body);
-    font-size: 17px !important;
-    line-height: 22px !important;
-    font-weight: 400 !important;
-    letter-spacing: 0 !important;
+    font-size: var(--type-row-label-size) !important;
+    line-height: var(--type-row-label-line) !important;
+    font-weight: var(--type-row-label-weight) !important;
+    letter-spacing: var(--type-row-label-tracking) !important;
+    color: var(--app-label) !important;
+  }
+
+  [data-slot="settings-row-description"] {
+    font-family: var(--font-app-body);
+    font-size: var(--type-row-description-size) !important;
+    line-height: var(--type-row-description-line) !important;
+    font-weight: var(--type-row-description-weight) !important;
+    letter-spacing: var(--type-row-description-tracking) !important;
+    color: var(--app-secondary-label) !important;
   }
 
   [data-slot="settings-group-heading"] {
     font-family: var(--font-app-body);
-    color: #6e6e73 !important;
-    font-size: 15px !important;
-    line-height: 20px !important;
-    font-weight: 500 !important;
-    letter-spacing: -0.01em !important;
+    color: var(--app-section-label) !important;
+    font-size: var(--type-section-label-size) !important;
+    line-height: var(--type-section-label-line) !important;
+    font-weight: var(--type-section-label-weight) !important;
+    letter-spacing: var(--type-section-label-tracking) !important;
+    opacity: 1 !important;
     text-transform: none !important;
   }
 
@@ -3567,17 +3631,20 @@ html.native-ios [data-testid="one-location-onboarding"] {
    */
   .app-page-shell
     [data-slot="section-header-title"][role="heading"][aria-level="2"] {
-    font-family: var(--font-app-text);
-    font-size: 0.8125rem !important;
-    line-height: 1.2 !important;
-    font-weight: 500 !important;
-    letter-spacing: 0 !important;
+    font-family: var(--font-app-display);
+    font-size: var(--type-card-title-size) !important;
+    line-height: var(--type-card-title-line) !important;
+    font-weight: var(--type-card-title-weight) !important;
+    letter-spacing: var(--type-card-title-tracking) !important;
+    color: var(--app-label) !important;
+    opacity: 1 !important;
+    text-transform: none !important;
   }
 
   @media (min-width: 640px) {
     .app-page-shell
       [data-slot="section-header-title"][role="heading"][aria-level="2"] {
-      font-size: 0.875rem !important;
+      font-size: var(--type-card-title-size) !important;
     }
   }
 
@@ -5437,4 +5504,211 @@ body[data-persona-surface="ria"] {
   --ria-onboarding-cta-bottom-clearance: calc(
     var(--bottom-chrome-stack-height, var(--app-screen-footer-pad)) + 112px
   );
+}
+
+/* Semantic typography guardrail.
+   Kept at the end so role classes beat older h1/h2 and data-slot fallbacks. */
+:is(.ui-text-large-page-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: var(--type-large-page-title-size) !important;
+  font-weight: var(--type-large-page-title-weight) !important;
+  letter-spacing: var(--type-large-page-title-tracking) !important;
+  line-height: var(--type-large-page-title-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-page-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: var(--type-page-title-size) !important;
+  font-weight: var(--type-page-title-weight) !important;
+  letter-spacing: var(--type-page-title-tracking) !important;
+  line-height: var(--type-page-title-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-navigation-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-navigation-title-size) !important;
+  font-weight: var(--type-navigation-title-weight) !important;
+  letter-spacing: var(--type-navigation-title-tracking) !important;
+  line-height: var(--type-navigation-title-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-identity-name) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: clamp(28px, 7.8vw, 34px) !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.028em !important;
+  line-height: 1.12 !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-page-subtitle) {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: 15px !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.006em !important;
+  line-height: 21px !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-major-section-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: var(--type-major-section-title-size) !important;
+  font-weight: var(--type-major-section-title-weight) !important;
+  letter-spacing: var(--type-major-section-title-tracking) !important;
+  line-height: var(--type-major-section-title-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-card-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: var(--type-card-title-size) !important;
+  font-weight: var(--type-card-title-weight) !important;
+  letter-spacing: var(--type-card-title-tracking) !important;
+  line-height: var(--type-card-title-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-section-label) {
+  color: var(--app-section-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-section-label-size) !important;
+  font-weight: var(--type-section-label-weight) !important;
+  letter-spacing: var(--type-section-label-tracking) !important;
+  line-height: var(--type-section-label-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-row-label, .ui-text-row-label-emphasized) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-row-label-size) !important;
+  letter-spacing: var(--type-row-label-tracking) !important;
+  line-height: var(--type-row-label-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-row-label) {
+  font-weight: var(--type-row-label-weight) !important;
+}
+
+:is(.ui-text-row-label-emphasized) {
+  font-weight: var(--type-row-label-emphasis-weight) !important;
+}
+
+:is(.ui-text-row-description, .ui-text-trailing-value) {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-row-description-size) !important;
+  font-weight: var(--type-row-description-weight) !important;
+  letter-spacing: var(--type-row-description-tracking) !important;
+  line-height: var(--type-row-description-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-trailing-action) {
+  color: var(--app-accent) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: 15px !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.006em !important;
+  line-height: 21px !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-form-label) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-form-label-size) !important;
+  font-weight: var(--type-form-label-weight) !important;
+  letter-spacing: var(--type-form-label-tracking) !important;
+  line-height: var(--type-form-label-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-input-value) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-input-value-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.008em !important;
+  line-height: var(--type-input-value-line) !important;
+  opacity: 1 !important;
+}
+
+:is(.ui-text-helper-text) {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-helper-text-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.003em !important;
+  line-height: var(--type-helper-text-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-status) {
+  font-family: var(--font-app-body) !important;
+  font-size: 15px !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.006em !important;
+  line-height: 20px !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-button-label) {
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-button-label-size) !important;
+  font-weight: var(--type-button-label-weight) !important;
+  letter-spacing: -0.01em !important;
+  line-height: var(--type-button-label-line) !important;
+  opacity: 1 !important;
+}
+
+:is(.ui-text-tab-label) {
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-tab-label-size) !important;
+  font-weight: var(--type-tab-label-weight) !important;
+  letter-spacing: 0 !important;
+  line-height: var(--type-tab-label-line) !important;
+  opacity: 1 !important;
+}
+
+:is(.ui-text-caption, .ui-text-legal) {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: 12px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0 !important;
+  line-height: 16px !important;
+  opacity: 1 !important;
+}
+
+[data-testid="settings-row"][data-tone="destructive"]
+  [data-slot="settings-row-title"].ui-text-row-label,
+[data-testid="settings-row"][data-tone="destructive"]
+  [data-slot="settings-row-title"] {
+  color: var(--app-destructive) !important;
 }

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -4,6 +4,12 @@ import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
 import { SurfaceCard, type SurfaceAccent, type SurfaceTone } from "@/components/app-ui/surfaces";
+import {
+  CardTitle,
+  PageSubtitle,
+  PageTitle,
+  SectionLabel,
+} from "@/components/app-ui/typography";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
 
@@ -205,26 +211,27 @@ export function PageHeader({
           >
             <div className="min-w-0 flex-1 space-y-[var(--page-header-copy-gap)]">
               {eyebrow ? (
-                <p
+                <SectionLabel
+                  as="p"
                   className={cn(
-                    "text-[13px] font-normal leading-[18px] tracking-normal",
                     styles.eyebrow
                   )}
                   data-slot="page-header-eyebrow"
                 >
                   {eyebrow}
-                </p>
+                </SectionLabel>
               ) : null}
-              <h1 className="text-[28px] font-bold leading-[34px] tracking-[-0.02em] text-foreground">
+              <PageTitle>
                 {title}
-              </h1>
+              </PageTitle>
               {description && !descriptionFullWidth ? (
-                <div
-                  className="max-w-2xl text-[15px] leading-[20px] text-muted-foreground"
+                <PageSubtitle
+                  as="div"
+                  className="max-w-2xl"
                   data-slot="page-header-description"
                 >
                   {description}
-                </div>
+                </PageSubtitle>
               ) : null}
             </div>
             {actions ? (
@@ -242,12 +249,12 @@ export function PageHeader({
         </div>
       </div>
       {description && descriptionFullWidth ? (
-        <div
-          className="text-[15px] leading-[20px] text-muted-foreground"
+        <PageSubtitle
+          as="div"
           data-slot="page-header-description"
         >
           {description}
-        </div>
+        </PageSubtitle>
       ) : null}
     </header>
   );
@@ -307,25 +314,25 @@ export function SectionHeader({
           >
             <div className="min-w-0 flex-1 space-y-[var(--section-header-copy-gap)]">
               {eyebrow ? (
-                <p className={cn("text-[13px] font-normal leading-[18px] tracking-normal", styles.eyebrow)}>
+                <SectionLabel as="p" className={styles.eyebrow}>
                   {eyebrow}
-                </p>
+                </SectionLabel>
               ) : null}
-              <div
+              <CardTitle
+                as="div"
                 role="heading"
                 aria-level={2}
                 data-slot="section-header-title"
-                className="text-[20px] font-semibold leading-[25px] tracking-[-0.014em] text-foreground"
               >
                 {title}
-              </div>
+              </CardTitle>
               {description ? (
-                <div
-                  className="text-[15px] leading-[20px] text-muted-foreground"
+                <PageSubtitle
+                  as="div"
                   data-slot="section-header-description"
                 >
                   {description}
-                </div>
+                </PageSubtitle>
               ) : null}
             </div>
             {actions ? (

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -35,6 +35,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  CardTitle,
+  PageSubtitle,
+  RowDescription,
+  RowLabel,
+  SectionLabel,
+  TrailingAction,
+  TrailingValue,
+} from "@/components/app-ui/typography";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { Icon, SegmentedTabs } from "@/lib/morphy-ux/ui";
@@ -216,24 +225,24 @@ export function SettingsGroup({
       {eyebrow || title || description ? (
         <div className="mb-2 mt-7 space-y-[var(--settings-heading-stack-gap)] px-[6px]">
           {eyebrow || title ? (
-            <div
+            <SectionLabel
               data-slot="settings-group-heading"
               role="heading"
               aria-level={embedded ? 3 : 2}
-              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73] [overflow-wrap:anywhere]"
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty [overflow-wrap:anywhere]"
             >
               {eyebrow ? (
-                <span className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+                <span>
                   {eyebrow}
                 </span>
               ) : null}
               {title ? <span>{title}</span> : null}
-            </div>
+            </SectionLabel>
           ) : null}
           {description ? (
-            <p className="max-w-2xl text-[13px] leading-[18px] text-muted-foreground [overflow-wrap:anywhere]">
+            <RowDescription className="max-w-2xl [overflow-wrap:anywhere]">
               {description}
-            </p>
+            </RowDescription>
           ) : null}
         </div>
       ) : null}
@@ -355,22 +364,24 @@ export function SettingsRow({
         </span>
       ) : null}
       <div className="min-w-0 flex-1 space-y-0.5">
-        <div
+        <RowLabel
+          as="div"
           data-slot="settings-row-title"
           className={cn(
-            "text-[17px] font-normal leading-[22px] tracking-normal text-foreground [overflow-wrap:anywhere]",
+            "[overflow-wrap:anywhere]",
             tone === "destructive" && "text-destructive",
           )}
         >
           {title}
-        </div>
+        </RowLabel>
         {description ? (
-          <div
+          <RowDescription
+            as="div"
             data-slot="settings-row-description"
-            className="text-[15px] leading-[20px] text-muted-foreground [overflow-wrap:anywhere]"
+            className="[overflow-wrap:anywhere]"
           >
             {description}
-          </div>
+          </RowDescription>
         ) : null}
       </div>
     </div>
@@ -615,16 +626,16 @@ export function AdaptiveDetailSurface({
                 {leading ? <div className="shrink-0">{leading}</div> : null}
                 <div className="min-w-0">
                   {eyebrow ? (
-                    <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+                    <SectionLabel as="p">
                       {eyebrow}
-                    </p>
+                    </SectionLabel>
                   ) : null}
-                  <SheetTitle className="truncate text-base font-semibold tracking-tight">
+                  <SheetTitle className="ui-text-navigation-title truncate">
                     {title}
                   </SheetTitle>
                   <SheetDescription
                     className={cn(
-                      "line-clamp-2 text-sm leading-5",
+                      "ui-text-row-description line-clamp-2",
                       !description && "sr-only",
                     )}
                   >
@@ -672,16 +683,16 @@ export function AdaptiveDetailSurface({
               {leading ? <div className="shrink-0">{leading}</div> : null}
               <div className="min-w-0">
                 {eyebrow ? (
-                  <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+                  <SectionLabel as="p">
                     {eyebrow}
-                  </p>
+                  </SectionLabel>
                 ) : null}
-                <DrawerTitle className="truncate text-base font-semibold tracking-tight">
+                <DrawerTitle className="ui-text-navigation-title truncate">
                   {title}
                 </DrawerTitle>
                 <DrawerDescription
                   className={cn(
-                    "line-clamp-2 text-sm leading-5 sm:leading-6",
+                    "ui-text-row-description line-clamp-2",
                     !description && "sr-only",
                   )}
                 >
@@ -731,16 +742,16 @@ export function AdaptiveDetailSurface({
             {leading ? <div className="shrink-0">{leading}</div> : null}
             <div className="min-w-0">
               {eyebrow ? (
-                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+                <SectionLabel as="p">
                   {eyebrow}
-                </p>
+                </SectionLabel>
               ) : null}
-              <DialogTitle className="truncate text-base font-semibold tracking-tight">
+              <DialogTitle className="ui-text-navigation-title truncate">
                 {title}
               </DialogTitle>
               <DialogDescription
                 className={cn(
-                  "line-clamp-2 text-sm leading-6",
+                  "ui-text-row-description line-clamp-2",
                   !description && "sr-only",
                 )}
               >
@@ -772,3 +783,13 @@ export function AdaptiveDetailSurface({
 export function SettingsDetailPanel(props: AdaptiveDetailSurfaceProps) {
   return <AdaptiveDetailSurface {...props} />;
 }
+
+export {
+  CardTitle,
+  PageSubtitle,
+  RowDescription,
+  RowLabel,
+  SectionLabel,
+  TrailingAction,
+  TrailingValue,
+};

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -394,14 +394,14 @@ function TopShellBreadcrumbTrail({
           >
             {index > 0 ? (
               <ChevronRight
-                className="h-3.5 w-3.5 shrink-0 opacity-40"
+                className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-tertiary-label)]"
                 aria-hidden
               />
             ) : null}
             {item.href && !isLast ? (
               <button
                 type="button"
-                className="max-w-[9rem] shrink-0 truncate opacity-65 transition-opacity hover:opacity-100"
+                className="max-w-[9rem] shrink-0 truncate text-[color:var(--app-secondary-label)] transition-colors hover:text-current"
                 onClick={() =>
                   requestInternalAppNavigation({
                     href: item.href!,
@@ -417,7 +417,7 @@ function TopShellBreadcrumbTrail({
               <span
                 className={cn(
                   "min-w-0 truncate",
-                  isLast ? "font-semibold" : "opacity-65",
+                  isLast ? "font-semibold text-current" : "text-[color:var(--app-secondary-label)]",
                 )}
                 aria-current={isLast ? "page" : undefined}
               >

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -154,10 +154,10 @@ export function TopShellTabs({
             >
               <span
                 className={cn(
-                  "relative truncate text-[15px] tracking-[-0.01em] transition-[color,opacity] duration-150",
+                  "ui-text-form-label relative truncate transition-colors duration-150",
                   isActive
-                    ? "font-semibold text-current opacity-100"
-                    : "font-normal text-current opacity-55 hover:opacity-80",
+                    ? "font-semibold text-current"
+                    : "font-normal text-[color:var(--app-secondary-label)] hover:text-current",
                 )}
               >
                 {tab.label}

--- a/hushh-webapp/components/app-ui/typography.tsx
+++ b/hushh-webapp/components/app-ui/typography.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import type { ElementType, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export const TYPOGRAPHY_CLASSNAMES = {
+  pageTitle: "ui-text-page-title",
+  pageSubtitle: "ui-text-page-subtitle",
+  navigationTitle: "ui-text-navigation-title",
+  identityName: "ui-text-identity-name",
+  majorSectionTitle: "ui-text-major-section-title",
+  sectionLabel: "ui-text-section-label",
+  cardTitle: "ui-text-card-title",
+  rowLabel: "ui-text-row-label",
+  rowLabelEmphasized: "ui-text-row-label-emphasized",
+  rowDescription: "ui-text-row-description",
+  trailingValue: "ui-text-trailing-value",
+  trailingAction: "ui-text-trailing-action",
+  formLabel: "ui-text-form-label",
+  inputValue: "ui-text-input-value",
+  helperText: "ui-text-helper-text",
+  statusText: "ui-text-status",
+  buttonLabel: "ui-text-button-label",
+  tabLabel: "ui-text-tab-label",
+  caption: "ui-text-caption",
+  legal: "ui-text-legal",
+} as const;
+
+type RoleTextProps = {
+  as?: ElementType;
+  children?: ReactNode;
+  className?: string;
+  [key: string]: unknown;
+};
+
+function SemanticText({
+  as: Component = "span",
+  className,
+  children,
+  roleClassName,
+  ...props
+}: RoleTextProps & { roleClassName: string }) {
+  return (
+    <Component className={cn(roleClassName, className)} {...props}>
+      {children}
+    </Component>
+  );
+}
+
+export function PageTitle({ as = "h1", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.pageTitle}
+      {...props}
+    />
+  );
+}
+
+export function PageSubtitle({ as = "p", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.pageSubtitle}
+      {...props}
+    />
+  );
+}
+
+export function NavigationTitle(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.navigationTitle}
+      {...props}
+    />
+  );
+}
+
+export function IdentityName({ as = "h1", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.identityName}
+      {...props}
+    />
+  );
+}
+
+export function MajorSectionTitle({ as = "h2", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.majorSectionTitle}
+      {...props}
+    />
+  );
+}
+
+export function SectionLabel({ as = "div", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.sectionLabel}
+      {...props}
+    />
+  );
+}
+
+export function CardTitle({ as = "h3", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.cardTitle}
+      {...props}
+    />
+  );
+}
+
+export function RowLabel(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.rowLabel}
+      {...props}
+    />
+  );
+}
+
+export function RowDescription({ as = "p", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.rowDescription}
+      {...props}
+    />
+  );
+}
+
+export function TrailingValue(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.trailingValue}
+      {...props}
+    />
+  );
+}
+
+export function TrailingAction(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.trailingAction}
+      {...props}
+    />
+  );
+}
+
+export function FormLabel({ as = "label", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.formLabel}
+      {...props}
+    />
+  );
+}
+
+export function HelperText({ as = "p", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.helperText}
+      {...props}
+    />
+  );
+}
+
+export function ButtonLabel(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.buttonLabel}
+      {...props}
+    />
+  );
+}
+
+export function TabLabel(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.tabLabel}
+      {...props}
+    />
+  );
+}

--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex min-h-11 items-center justify-center gap-2 whitespace-nowrap rounded-full text-[17px] font-semibold leading-[22px] tracking-normal transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
+  "ui-text-button-label inline-flex min-h-11 items-center justify-center gap-2 whitespace-nowrap rounded-full transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
   {
     variants: {
       variant: {

--- a/hushh-webapp/components/ui/field.tsx
+++ b/hushh-webapp/components/ui/field.tsx
@@ -34,9 +34,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        "mb-3 font-medium",
-        "data-[variant=legend]:text-base",
-        "data-[variant=label]:text-sm",
+        "ui-text-section-label mb-3",
         className
       )}
       {...props}
@@ -130,7 +128,7 @@ function FieldLabel({
       data-slot="field-label"
       id={resolvedId}
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "ui-text-form-label group/field-label peer/field-label flex w-fit gap-2 group-data-[disabled=true]/field:text-[color:var(--app-tertiary-label)]",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
         "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
         className
@@ -145,7 +143,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        "ui-text-form-label flex w-fit items-center gap-2 group-data-[disabled=true]/field:text-[color:var(--app-tertiary-label)]",
         className
       )}
       {...props}
@@ -158,7 +156,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="field-description"
       className={cn(
-        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "ui-text-helper-text group-has-[[data-orientation=horizontal]]/field:text-balance",
         "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className
@@ -241,7 +239,7 @@ function FieldError({
     <div
       role="alert"
       data-slot="field-error"
-      className={cn("text-sm font-normal text-destructive", className)}
+      className={cn("ui-text-helper-text text-destructive", className)}
       {...props}
     >
       {content}

--- a/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
+++ b/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
@@ -25,16 +25,13 @@ export const SUBCARD_SURFACE =
   "rounded-[var(--app-card-radius-compact,16px)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]";
 
 /** Section heading (e.g. "Trusted Circle", "Device readiness"). */
-export const SECTION_HEADING =
-  "font-[family-name:var(--font-app-body)] text-[15px] font-[500] leading-[20px] tracking-[-0.01em] text-[#6E6E73]";
+export const SECTION_HEADING = "ui-text-section-label";
 
 /** Primary screen title (header). */
-export const SCREEN_TITLE =
-  "font-[family-name:var(--font-app-body)] text-[28px] font-bold leading-[34px] tracking-[-0.022em] text-foreground";
+export const SCREEN_TITLE = "ui-text-page-title";
 
 /** Muted secondary copy. */
-export const MUTED_TEXT =
-  "font-[family-name:var(--font-app-body)] text-[15px] font-normal leading-[20px] tracking-[-0.006em] text-[#8E8E93]";
+export const MUTED_TEXT = "ui-text-row-description";
 
 /**
  * Accent utility classes. These follow the active accent preference
@@ -57,8 +54,7 @@ export const PILL_NEUTRAL =
   "border-border/70 bg-muted/60 text-muted-foreground";
 
 /** Shared readable section label. */
-export const EYEBROW =
-  "font-[family-name:var(--font-app-body)] text-[15px] font-[500] leading-[20px] tracking-[-0.01em] text-[#6E6E73]";
+export const EYEBROW = "ui-text-section-label";
 
 /** Warning / caution banner surface. */
 export const WARNING_SURFACE =


### PR DESCRIPTION
## Summary
- Add shared semantic typography role primitives for Apple iOS-first hierarchy.
- Wire PageHeader, SectionHeader, SettingsGroup, SettingsRow, adaptive detail headers, field labels/descriptions, buttons, top-shell tabs, breadcrumbs, and Morphy text constants to shared roles.
- Add/update UI migration audit ledgers, including hierarchy-audit.md, with route-rendering status kept incomplete until authenticated rendered proof exists.

## Verification
- npm run typecheck
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs
- npm run lint

## Known blocker
- npm run verify:routes is blocked locally because maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE are not available in this environment.