### PR TITLE
Rename Connect suggested people section

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -681,7 +681,7 @@ export default function ConnectPageClient() {
                 */}
               </div>
               <SettingsGroup
-                title={hasQuery ? "People" : "Suggested"}
+                title="People"
                 description={
                   hasQuery
                     ? "Send a connection request to someone you know."
@@ -712,7 +712,7 @@ export default function ConnectPageClient() {
                     />
                   ) : (
                     <SettingsRow
-                      title="No one to suggest yet"
+                      title="No people yet"
                       description="Search by name to find someone on Hussh."
                       density="compact"
                       disabled


### PR DESCRIPTION
## Summary
- Rename the Connect people directory section from "Suggested" to "People"
- Remove the remaining empty-state use of "suggest" on that section

## Risk area touched
ui

## Verification
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run verify:cache
- cd hushh-webapp && npm run verify:docs