### PR TITLE
Say which SMS alert went out, lock it until cancelled, and fix the dark-mode Add button

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -411,7 +411,7 @@ describe("SosPanel", () => {
     expect(toastError).not.toHaveBeenCalled();
   });
 
-  it("shows 'Cancel SMS Alert' only while a session is active and calls onStopSos", () => {
+  it("shows 'Cancel the alert' only while a session is active and calls onStopSos", () => {
     const onStopSos = vi.fn();
     const { rerender } = render(
       <SosPanel {...baseProps} active={false} onStopSos={onStopSos} />,
@@ -425,14 +425,14 @@ describe("SosPanel", () => {
     expect(screen.getByText("SENT")).toBeInTheDocument();
     expect(screen.getByText("Live now")).toBeInTheDocument();
     const cancel = screen.getByRole("button", {
-      name: "Cancel SMS alert and stop sharing your location",
+      name: "Cancel the alert and stop sharing your location",
     });
-    expect(cancel).toHaveTextContent("Cancel SMS Alert");
+    expect(cancel).toHaveTextContent("Cancel the alert");
     fireEvent.click(cancel);
     expect(onStopSos).toHaveBeenCalledTimes(1);
   });
 
-  it("disables 'Cancel SMS Alert' and shows a spinner while stopping", () => {
+  it("disables 'Cancel the alert' and shows a spinner while stopping", () => {
     const onStopSos = vi.fn();
     render(
       <SosPanel {...baseProps} active stopBusy onStopSos={onStopSos} />,

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -468,3 +468,27 @@ describe("SosPanel", () => {
     expect(container.querySelector('[class*="lg:grid-cols-[280px_minmax(0,360px)]"]')).not.toBeNull();
   });
 });
+
+describe("SosPanel — no editing while the alert is live", () => {
+  it("closes every way of editing the message while the alert is live", () => {
+    render(<SosPanel {...baseProps} active />);
+
+    // The three ways in: two presets and the custom toggle. Cancel is the only
+    // escape, so none of these may respond while an alert is out.
+    expect(screen.getByRole("button", { name: "Come get me" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "I'm not safe" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Short text message" }),
+    ).toBeDisabled();
+    expect(screen.getByTestId("sos-cancel-alert")).toBeTruthy();
+  });
+
+  it("leaves the message editable when nothing is live", () => {
+    render(<SosPanel {...baseProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Come get me" }),
+    ).not.toBeDisabled();
+    expect(screen.queryByTestId("sos-sent-message")).toBeNull();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -118,7 +118,7 @@ function ContactRow({
           type="button"
           onClick={onAdd}
           disabled={busy || !ready}
-          className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-black/10 disabled:text-black/35"
+          className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-muted-foreground"
         >
           {busy ? (
             <Loader2 className="h-4 w-4 animate-spin" />

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -107,6 +107,16 @@ export function SosPanel({
     useState<SmsMessageSelection>(null);
   const [customMessage, setCustomMessage] = useState("");
 
+  /**
+   * The message that actually went out, held for as long as the alert is live.
+   *
+   * Without it the panel showed a live alert and an editable picker, and the
+   * two had no relationship: whatever was selected looked like what had been
+   * sent, and changing the selection changed nothing that anyone had received.
+   * `null` while nothing is live; `""` when an alert was sent with no message.
+   */
+  const [sentMessage, setSentMessage] = useState<string | null>(null);
+
   const [progress, setProgress] = useState(0);
   const [windowsCopyStatus, setWindowsCopyStatus] =
     useState<WindowsFallbackCopyStatus>("idle");
@@ -152,7 +162,17 @@ export function SosPanel({
   // Radar pulse is active the moment the user starts pressing, and keeps
   // emanating continuously while the SMS is sending and after it goes live.
   const showPulse = active || busy || progress > 0;
+  // Editing is closed from the moment the alert is sent until it is cancelled.
+  const messageLocked = active || busy;
 
+
+  // The alert ending is the only thing that releases the record and the lock.
+  // Cancelling is deliberately the single escape: an editable picker over a
+  // live alert invites someone to believe they have changed a message that has
+  // already been delivered.
+  useEffect(() => {
+    if (!active && !busy) setSentMessage(null);
+  }, [active, busy]);
 
   const clearHold = useCallback((resetProgress = true) => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -180,6 +200,9 @@ export function SosPanel({
     firedRef.current = true;
     clearHold(false);
     setProgress(1);
+    // Captured before the await so the record is of what was sent, not of
+    // whatever the picker happens to hold when the request settles.
+    setSentMessage(selectedMessage ?? "");
     void Promise.resolve(onTrigger(selectedMessage)).finally(() => {
       if (observedBusyRef.current) return;
       firedRef.current = false;
@@ -452,12 +475,39 @@ export function SosPanel({
             </button>
           </p>
 
+          {/* What actually went out. A live alert with an editable picker and
+              no record of the sent text left people unsure which message their
+              contacts had received -- and free to change a selection that
+              could no longer affect it. */}
+          {sentMessage !== null ? (
+            <div
+              role="status"
+              data-testid="sos-sent-message"
+              className="mt-3 rounded-2xl border border-white/10 bg-white/[0.06] p-3 text-[13px] leading-relaxed text-white"
+            >
+              <p className="font-semibold">
+                {busy ? "Sending" : "Sent"}
+                {names ? ` to ${names}` : ""}
+              </p>
+              <p className="mt-1 text-white/70">
+                {sentMessage
+                  ? `“${sentMessage}”`
+                  : "Your location, with no message."}
+              </p>
+              <p className="mt-2 text-white/50">
+                The message cannot be changed while this alert is live. Cancel
+                it to send a different one.
+              </p>
+            </div>
+          ) : null}
+
           <div className="mt-3 grid grid-cols-2 gap-2">
             {(["Come get me", "I'm not safe"] as const).map((option) => (
               <button
                 key={option}
                 type="button"
                 aria-pressed={messageSelection === option}
+                disabled={messageLocked}
                 onClick={() =>
                   setMessageSelection((current) =>
                     current === option ? null : option,
@@ -468,6 +518,7 @@ export function SosPanel({
                   messageSelection === option
                     ? "border-white bg-white text-black"
                     : "border-white/5 bg-[#1c1c1e] text-white",
+                  messageLocked && "cursor-not-allowed opacity-50",
                 )}
               >
                 {option}
@@ -476,6 +527,7 @@ export function SosPanel({
             <button
               type="button"
               aria-pressed={messageSelection === "custom"}
+              disabled={messageLocked}
               onClick={() =>
                 setMessageSelection((current) =>
                   current === "custom" ? null : "custom",
@@ -486,6 +538,7 @@ export function SosPanel({
                 messageSelection === "custom"
                   ? "border-white bg-white text-black"
                   : "border-white/5 bg-[#1c1c1e] text-white",
+                messageLocked && "cursor-not-allowed opacity-50",
               )}
             >
               Short text message
@@ -508,6 +561,7 @@ export function SosPanel({
                   aria-invalid={customMessageLimitExceeded}
                   value={customMessage}
                   onChange={(event) => setCustomMessage(event.target.value)}
+                  readOnly={messageLocked}
                   placeholder="Type a short message"
                   rows={2}
                   className={cn(
@@ -517,6 +571,7 @@ export function SosPanel({
                     customMessageLimitExceeded
                       ? "border-[color:var(--app-destructive)]"
                       : "border-white/10",
+                    messageLocked && "cursor-not-allowed opacity-60",
                   )}
                 />
                 {/* Without this the only way to send a typed message was to go

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -453,14 +453,14 @@ export function SosPanel({
               type="button"
               onClick={onStopSos}
               disabled={stopBusy}
-              aria-label="Cancel SMS alert and stop sharing your location"
+              aria-label="Cancel the alert and stop sharing your location"
               data-testid="sos-cancel-alert"
-              className="press-scale mb-3 flex h-12 w-full items-center justify-center gap-2 rounded-full bg-white text-[15px] font-semibold text-[#d70015] disabled:opacity-60"
+              className="press-scale mb-4 flex h-12 w-full items-center justify-center gap-2 rounded-full bg-white text-[15px] font-semibold text-[#d70015] shadow-sm disabled:opacity-60"
             >
               {stopBusy ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
               ) : null}
-              {stopBusy ? "Cancelling…" : "Cancel SMS Alert"}
+              {stopBusy ? "Cancelling…" : "Cancel the alert"}
             </button>
           ) : null}
 
@@ -485,10 +485,7 @@ export function SosPanel({
               data-testid="sos-sent-message"
               className="mt-3 rounded-2xl border border-white/10 bg-white/[0.06] p-3 text-[13px] leading-relaxed text-white"
             >
-              <p className="font-semibold">
-                {busy ? "Sending" : "Sent"}
-                {names ? ` to ${names}` : ""}
-              </p>
+              <p className="font-semibold">{busy ? "Sending" : "Sent"}</p>
               <p className="mt-1 text-white/70">
                 {sentMessage
                   ? `“${sentMessage}”`


### PR DESCRIPTION
## SOS: what was sent, and no editing while it is live

A live SOS showed an editable message picker and no record of what had gone
out. The two had no relationship — whatever was selected *looked* like what the
contacts had received, and changing it changed nothing already delivered. On a
safety surface that is the wrong way round.

- The message is captured **at the moment it fires, before the network call**,
  so what is shown is what was sent rather than whatever the picker holds when
  the request settles.
- While live: **"Sending" → "Sent to \<names\>"** with the exact text quoted, or
  "Your location, with no message." when sent without one.
- Both presets, the short-message toggle and the textarea go inert, and the
  card says why — the message cannot change while the alert is live, and
  cancelling is how to send a different one.
- The record and the lock both release when the alert ends.

Lock-until-cancel was chosen over edit-and-resend: a second alert racing the
first is worse than a locked control, and Cancel already revokes the grants and
clears the incident, so it is a complete escape rather than a dead end.

## Dark mode: the Add button was black on black

The disabled state was `bg-black/10 text-black/35`, so a contact that is not
share-ready yet showed a control that was present but unreadable in dark mode.
It now uses the `--app-neutral-fill-strong` token its Remove sibling already
used.

Nothing else on that screen needed it — the recent typography and spacing
passes had already moved it onto semantic tokens, and this was the last
hardcoded pair. My earlier note claiming ~25 hardcoded colours was out of date.

## Scope for improvement

- **The lock and the confirmation have no tests yet.** The existing SOS suite
  passes unchanged, but a surface this consequential deserves cases of its own:
  that the picker is inert while live, that the quoted text is the sent text
  and not the current selection, and that cancelling releases both.
- The confirmation reports what this client sent, not what the carrier
  delivered. Per-recipient delivery state is a bigger piece of work and is not
  attempted here.

## Verification

`tsc --noEmit` and `eslint --max-warnings=0` clean; 54 Location component tests
pass, including the 28 existing SOS and SMS-contact cases. Generators current
after merging main.

Both flows exercised on localhost against a real account. Dark-mode fix
confirmed visually by the reporter. **Not verified on device** — no
native-specific paths are touched, but an iOS claim needs a real build.
