### PR TITLE
Polish UAT Apple hierarchy system

### DIFF
--- a/docs/ui-migration/final-verification.md
+++ b/docs/ui-migration/final-verification.md
@@ -18,8 +18,12 @@ This file is the visual evidence ledger for the migration. It stays incomplete u
 - Responsive verification matrix exists: `docs/ui-migration/responsive-test-matrix.md`.
 - Hierarchy audit exists: `docs/ui-migration/hierarchy-audit.md`.
 - Shared typography role primitives have been added.
-- `PageHeader`, `SectionHeader`, `SettingsGroup`, `SettingsRow`, shared field primitives, base `Button`, top shell tabs, breadcrumbs, and Morphy typography constants have been normalized to the shared role classes.
-- `npm run typecheck`, `npm run verify:design-system`, `npm run verify:cache`, `npm run verify:docs`, and `npm run lint` passed after the shared-component pass.
+- `PageHeader`, `SectionHeader`, `SettingsGroup`, `SettingsRow`, shared field primitives, base `Button`, top shell tabs, breadcrumbs, Morphy typography constants, base `Input`, base `Label`, shared `TabsTrigger`, segmented controls, Location surface primitives, and One agent roster typography have been normalized to shared role classes.
+- `reading`, `narrow`, and `profile` page shells now cap at `720px`, so desktop space becomes surrounding whitespace instead of larger settings components.
+- Duplicated section-label recipes were removed from Feed, Location Check-In, Location Activity, RIA onboarding, Kai holding details, stream progress, public section kit, and One KYC tokens.
+- Location SMS/SOS desktop composition was tightened without changing the emergency background or behavior.
+- `npm run verify:design-system` now includes `hushh-webapp/scripts/design/verify-apple-hierarchy.mjs`.
+- Latest checks for this pass: `npm run typecheck`, `npm run verify:design-system`, `npm run lint`, `npm run verify:docs`, and `npm run verify:cache` passed.
 - `npm run verify:routes` is blocked locally because the maintainer-only reviewer identity environment is missing `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`.
 - No UAT deployment has been performed for this hierarchy pass yet.
 - No route is marked visually complete yet.
@@ -41,7 +45,7 @@ This file is the visual evidence ledger for the migration. It stays incomplete u
 | Desktop verification complete | Not started |
 | iOS safe-area behavior verified | Not started |
 | Keyboard behavior verified | Not started |
-| Functional tests pass | In progress: typecheck, design-system, cache, docs, and lint passed; route rendering blocked by missing reviewer secrets |
+| Functional tests pass | In progress: typecheck, design-system, lint, docs, and cache passed; route rendering blocked by missing reviewer secrets |
 | UAT deployment complete | Not started |
 | UAT visual recheck complete | Not started |
 

--- a/docs/ui-migration/hierarchy-audit.md
+++ b/docs/ui-migration/hierarchy-audit.md
@@ -1,6 +1,6 @@
 # UAT Global Hierarchy And Spacing Audit
 
-Status: Shared role foundation applied; rendered route verification is still pending.
+Status: Shared role foundation strengthened; rendered route verification is still pending.
 
 ## Visual Context
 
@@ -33,6 +33,10 @@ Implemented shared semantic role primitives in `hushh-webapp/components/app-ui/t
 | Helper text | `HelperText`, `.ui-text-helper-text` |
 | Button label | `ButtonLabel`, `.ui-text-button-label` |
 | Tab label | `TabLabel`, `.ui-text-tab-label` |
+| Input value | `InputValue`, `.ui-text-input-value` |
+| Status text | `StatusText`, `.ui-text-status` |
+| Caption text | `CaptionText`, `.ui-text-caption` |
+| Legal text | `LegalText`, `.ui-text-legal` |
 
 ## Shared Components Updated
 
@@ -47,6 +51,12 @@ Implemented shared semantic role primitives in `hushh-webapp/components/app-ui/t
 | `Button` | Base button typography now uses the shared button-label role. |
 | `TopShellTabs` | Inactive tab labels use semantic secondary color instead of low opacity. |
 | `TopShellBreadcrumbTrail` | Breadcrumb secondary labels and separators use semantic colors instead of opacity fading. |
+| `AppPageShell` | `reading`, `narrow`, and `profile` shells cap at `720px`; wider desktop space now remains surrounding whitespace. |
+| Shared `Input`, `Label`, `TabsTrigger`, `SegmentedTabs`, `SegmentedPill` | Uses semantic input/form/tab roles instead of route-local tiny text utilities. |
+| Location surface primitives | Status pills, privacy cards, trust/warning cards, and quick-path rows now use shared row/status roles. |
+| One agent roster | Uses the shared major section title role, keeps natural lowercase casing, and removes 10px compact metrics. |
+| Location SMS/SOS panel | Desktop composition is capped/tightened and sub-11px emergency metadata was removed without changing the emergency background or behavior. |
+| Feed, Location check-in/activity, RIA onboarding, Kai holding drawer, stream progress, public section kit | Replaced duplicated section-label recipes with the shared role/class. |
 | Morphy surface typography constants | `SCREEN_TITLE`, `SECTION_HEADING`, `MUTED_TEXT`, and `EYEBROW` now point at shared role classes. |
 
 ## Global Token Work
@@ -62,12 +72,13 @@ Added shared Apple iOS-first typography variables to `hushh-webapp/app/globals.c
 - helper text: 13px / 400 / 18px
 - button label: 17px / 600 / 22px
 - tab label: 11px / 500 / 13px, reserved for compact tab surfaces
+- status text: 13px / 600 / 18px, reserved for compact status chips and counters
 
 The end-of-file semantic typography guardrail intentionally overrides older `h1`/`h2` and `data-slot` fallback rules so shared role classes win consistently.
 
 ## Source Audit Findings
 
-Current source scan still shows route-local tiny and uppercase text usage, especially in dense finance tables, metadata badges, developer docs, Gmail receipts, marketplace cards, and chart labels. These are not all defects: some are true metadata, data-table headings, legal/microcopy, or compact badges. They remain pending until each route is rendered and classified by role.
+Current source scan still shows route-local tiny and uppercase text usage, especially in dense finance tables, metadata badges, developer docs, Gmail receipts, marketplace cards, chart labels, legacy Location map overlays, and onboarding microcopy. These are not all defects: some are true metadata, data-table headings, legal/microcopy, codes, initials, or compact badges. They remain pending until each route is rendered and classified by role.
 
 Known high-risk role mismatches still requiring rendered review:
 
@@ -78,17 +89,22 @@ Known high-risk role mismatches still requiring rendered review:
 - Developer docs hub labels.
 - One Location map overlays and onboarding sheets.
 
+Source guardrail added:
+
+- `npm run verify:design-system` now also runs `hushh-webapp/scripts/design/verify-apple-hierarchy.mjs`.
+- The guard verifies semantic role exports, section-label token values, shared/local section-label routing, no duplicated section-label recipe in audited components, no sub-11px text in shared/system UI primitives, and natural casing for the One agent roster heading.
+
 ## Verification
 
 Completed:
 
 - TypeScript check: `npm run typecheck`
 - Design-system check: `npm run verify:design-system`
-- Cache contract tests: `npm run verify:cache`
-- Docs check: `npm run verify:docs`
 - Lint: `npm run lint`
+- Docs check: `npm run verify:docs`
+- Cache contract tests: `npm run verify:cache`
 
-Blocked:
+Attempted:
 
 - Signed-in route rendering: `npm run verify:routes` is blocked locally because `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` are not present in the maintainer-only environment.
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -5670,10 +5670,10 @@ body[data-persona-surface="ria"] {
 
 :is(.ui-text-status) {
   font-family: var(--font-app-body) !important;
-  font-size: 15px !important;
-  font-weight: 500 !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
   letter-spacing: -0.006em !important;
-  line-height: 20px !important;
+  line-height: 18px !important;
   opacity: 1 !important;
   text-transform: none !important;
 }

--- a/hushh-webapp/app/one/kyc/tokens.ts
+++ b/hushh-webapp/app/one/kyc/tokens.ts
@@ -17,12 +17,10 @@ export const SUBCARD_SURFACE =
   "rounded-[var(--app-card-radius-compact,16px)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]";
 
 /** Shared readable section label. */
-export const EYEBROW =
-  "font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]";
+export const EYEBROW = "ui-text-section-label";
 
 /** Shared readable accent section label. */
-export const EYEBROW_ACCENT =
-  "font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]";
+export const EYEBROW_ACCENT = "ui-text-section-label";
 
 /**
  * Primary pill CTA (compact). Solid accent pill, accent-foreground label. Meets

--- a/hushh-webapp/components/app-ui/app-page-shell.tsx
+++ b/hushh-webapp/components/app-ui/app-page-shell.tsx
@@ -22,9 +22,9 @@ export type AppPageDensity = "compact" | "comfortable";
 
 // 2. Mapped directly to Tailwind classes instead of raw string values
 export const APP_SHELL_MAX_WIDTHS: Record<AppPageShellWidth, string> = {
-  reading: "max-w-[54rem]",
-  narrow: "max-w-[54rem]",
-  profile: "max-w-[54rem]",
+  reading: "max-w-[720px]",
+  narrow: "max-w-[720px]",
+  profile: "max-w-[720px]",
   standard: "max-w-[90rem]",
   content: "max-w-[90rem]",
   expanded: "max-w-[96rem]",

--- a/hushh-webapp/components/app-ui/sections.tsx
+++ b/hushh-webapp/components/app-ui/sections.tsx
@@ -61,7 +61,7 @@ export function Hero({
 }) {
   const head = (
     <>
-      <div className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+      <div className="ui-text-section-label">
         {kicker}
       </div>
       <h1
@@ -140,7 +140,7 @@ export function Band({
   const head = (
     <>
       {kicker ? (
-        <div className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+        <div className="ui-text-section-label">
           {kicker}
         </div>
       ) : null}
@@ -227,7 +227,7 @@ export function Card({
         </div>
       ) : null}
       {eyebrow ? (
-        <div className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+        <div className="ui-text-section-label">
           {eyebrow}
         </div>
       ) : null}
@@ -365,7 +365,7 @@ export function Stat({
       <div className="text-[32px] font-semibold leading-none tracking-tight text-foreground sm:text-[40px]">
         {value}
       </div>
-      <div className="mt-2.5 font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+      <div className="ui-text-section-label mt-2.5">
         {label}
       </div>
       {sub ? (

--- a/hushh-webapp/components/app-ui/stream-progress-panel.tsx
+++ b/hushh-webapp/components/app-ui/stream-progress-panel.tsx
@@ -52,7 +52,7 @@ export const AppStreamEventList = memo(function AppStreamEventList({
 }: AppStreamEventListProps) {
   if (items.length === 0) {
     return emptyLabel ? (
-      <div className={cn("px-2.5 py-2 text-xs text-muted-foreground", className)}>
+      <div className={cn("ui-text-caption px-2.5 py-2", className)}>
         {emptyLabel}
       </div>
     ) : null;
@@ -69,9 +69,9 @@ export const AppStreamEventList = memo(function AppStreamEventList({
       {items.map((item) => {
         const status = item.status ?? "running";
         return (
-          <li key={item.id} className="flex gap-2 text-xs">
+          <li key={item.id} className="ui-text-caption flex gap-2">
             {item.badge ? (
-              <span className="mt-0.5 shrink-0 rounded border border-border/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              <span className="mt-0.5 shrink-0 rounded border border-border/50 px-1.5 py-0.5 font-medium text-muted-foreground">
                 {item.badge}
               </span>
             ) : (
@@ -123,7 +123,7 @@ export function AppStreamSection({
         <CollapsibleTrigger asChild>
           <button
             type="button"
-            className="group flex w-full items-center justify-between gap-3 px-[6px] py-2 text-left font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73] transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+            className="ui-text-section-label group flex w-full items-center justify-between gap-3 px-[6px] py-2 text-left transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
           >
             <span className="inline-flex min-w-0 items-center gap-2">
               <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -131,7 +131,7 @@ export function AppStreamSection({
             </span>
             <span className="inline-flex shrink-0 items-center gap-2">
               {typeof count === "number" ? (
-                <span className="rounded-full bg-accent-surface px-2 py-0.5 text-[10px] font-semibold text-accent-strong">
+                <span className="rounded-full bg-accent-surface px-2 py-0.5 text-[12px] font-semibold leading-4 text-accent-strong">
                   {count}
                 </span>
               ) : null}

--- a/hushh-webapp/components/app-ui/typography.tsx
+++ b/hushh-webapp/components/app-ui/typography.tsx
@@ -174,6 +174,24 @@ export function HelperText({ as = "p", ...props }: RoleTextProps) {
   );
 }
 
+export function InputValue(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.inputValue}
+      {...props}
+    />
+  );
+}
+
+export function StatusText(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.statusText}
+      {...props}
+    />
+  );
+}
+
 export function ButtonLabel(props: RoleTextProps) {
   return (
     <SemanticText
@@ -187,6 +205,24 @@ export function TabLabel(props: RoleTextProps) {
   return (
     <SemanticText
       roleClassName={TYPOGRAPHY_CLASSNAMES.tabLabel}
+      {...props}
+    />
+  );
+}
+
+export function CaptionText(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.caption}
+      {...props}
+    />
+  );
+}
+
+export function LegalText(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.legal}
       {...props}
     />
   );

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -7,6 +7,7 @@ import { Grid2X2, List, Search } from "lucide-react";
 import { AgentSectionIcon } from "@/components/app-ui/agent-section-icon";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { MajorSectionTitle } from "@/components/app-ui/typography";
 import {
   getOneSetupCapability,
   isOneCapabilityEnabled,
@@ -385,7 +386,7 @@ function AgentMetricDisplay({
       <span
         className={cn(
           "shrink-0 font-semibold tabular-nums tracking-normal",
-          compact ? "text-[12px]" : "text-[15px]",
+          compact ? "text-[13px]" : "text-[15px]",
           metricClassName(mode),
         )}
       >
@@ -394,7 +395,7 @@ function AgentMetricDisplay({
       <span
         className={cn(
           "min-w-0 truncate font-normal text-muted-foreground",
-          compact ? "text-[10px]" : "text-[13px]",
+          compact ? "text-[12px]" : "text-[13px]",
           isPositiveMetric && "text-emerald-700/80 dark:text-emerald-300/85",
         )}
       >
@@ -575,12 +576,13 @@ export function OneAgentRoster({
       className="mx-auto w-full max-w-[720px]"
     >
       <div className="mb-4 flex items-center justify-between gap-3">
-        <h2
+        <MajorSectionTitle
+          as="h2"
           id="one-agents-heading"
-          className="text-[28px] font-bold leading-[34px] tracking-[-0.01em] text-foreground"
+          className="text-[28px] leading-[34px]"
         >
           agents ({modes.length})
-        </h2>
+        </MajorSectionTitle>
         <AgentRosterViewToggle value={view} onChange={selectView} />
       </div>
       <label className="relative mb-4 block">

--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -14,6 +14,7 @@ import {
   AppPageContentRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
+import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import { Button } from "@/lib/morphy-ux/button";
 import { useAuth } from "@/hooks/use-auth";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
@@ -231,8 +232,11 @@ export function FeedPage() {
 /** Sticky day / section divider that follows the shared readable label scale. */
 function SectionLabel({ children }: { children: ReactNode }) {
   return (
-    <h2 className="sticky top-[var(--top-shell-live-height)] z-10 bg-background/85 px-[6px] pb-2 pt-7 font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73] backdrop-blur-md">
+    <AppSectionLabel
+      as="h2"
+      className="sticky top-[var(--top-shell-live-height)] z-10 bg-background/85 px-[6px] pb-2 pt-7 backdrop-blur-md"
+    >
       {children}
-    </h2>
+    </AppSectionLabel>
   );
 }

--- a/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
+++ b/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { SectionLabel } from "@/components/app-ui/typography";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 import type { HoldingMobileCardViewModel } from "@/components/kai/holdings/holding-mobile-card";
@@ -36,7 +37,7 @@ interface HoldingDetailsDrawerProps {
 function DetailRow({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
   return (
     <div className="rounded-xl border border-border/60 bg-background/70 px-3 py-2.5">
-      <p className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">{label}</p>
+      <SectionLabel as="p">{label}</SectionLabel>
       <p className={cn("app-body-text mt-1 font-semibold text-foreground", valueClassName)}>{value}</p>
     </div>
   );

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -18,6 +18,7 @@ import {
   CARD_SURFACE,
   SUBCARD_SURFACE,
 } from "@/components/one-location/redesign/tokens";
+import { SectionLabel } from "@/components/app-ui/typography";
 
 const ACTIVITY_RANGE_OPTIONS: {
   value: OneLocationActivityRange;
@@ -51,13 +52,14 @@ function activityEventToneClassName(kind: OneLocationActivityKind): string {
 
 function ActivitySectionLabel({ title }: { title: string }) {
   return (
-    <div
+    <SectionLabel
+      as="div"
       role="heading"
       aria-level={2}
-      className="mt-7 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 px-[6px] font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]"
+      className="mt-7 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 px-[6px]"
     >
       {title}
-    </div>
+    </SectionLabel>
   );
 }
 

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -33,6 +33,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
+import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import {
   mergeRecipientsByUserId,
   type CircleRecipientSelection,
@@ -123,9 +124,9 @@ function isFreshReviewedPoint(
 /** Section label that follows the shared readable settings scale. */
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-2 mt-7 px-[6px] font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+    <AppSectionLabel as="p" className="mb-2 mt-7 px-[6px]">
       {children}
-    </p>
+    </AppSectionLabel>
   );
 }
 

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -326,7 +326,7 @@ export function SosPanel({
       data-ambient-chrome-ignore
       data-testid="sms-safety-screen"
     >
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))] lg:max-w-[820px] lg:px-8 lg:pt-[max(48px,env(safe-area-inset-top))]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))] lg:max-w-[720px] lg:px-6 lg:pt-[max(48px,env(safe-area-inset-top))]">
         <button
           type="button"
           onClick={onClose}
@@ -351,9 +351,9 @@ export function SosPanel({
             the space instead of a single narrow strip. Below lg it stays the
             original stacked column, untouched. The <style> block inside is
             display:none and never participates in the flex row. */}
-        <div className="flex flex-1 flex-col justify-center gap-7 pt-6 lg:grid lg:grid-cols-[280px_minmax(0,360px)] lg:items-center lg:justify-center lg:gap-10 lg:pt-2">
+        <div className="flex flex-1 flex-col justify-center gap-7 pt-6 lg:grid lg:grid-cols-[240px_minmax(0,320px)] lg:items-center lg:justify-center lg:gap-8 lg:pt-2">
           <div className="flex items-center justify-center py-4 lg:py-0">
-            <div className="relative flex h-[252px] w-[252px] items-center justify-center">
+            <div className="relative flex h-[224px] w-[224px] items-center justify-center">
             <span className="absolute inset-0 rounded-full border border-white/10" />
             <span className="absolute inset-[24px] rounded-full border border-white/15" />
 
@@ -364,17 +364,17 @@ export function SosPanel({
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
+                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
+                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[152px] w-[152px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
+                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
                 />
               </>
             ) : null}
@@ -399,7 +399,7 @@ export function SosPanel({
               onKeyUp={handleKeyUp}
               onContextMenu={(event) => event.preventDefault()}
               className={cn(
-                "relative z-10 flex h-[152px] w-[152px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
+                "relative z-10 flex h-[136px] w-[136px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
                 progress > 0 && progress < 1 && "scale-[1.035]",
                 (active || busy) && "[animation:sosCorePulse_2.2s_ease-in-out_infinite]",
                 disabled && "cursor-not-allowed",
@@ -443,7 +443,7 @@ export function SosPanel({
         `}</style>
 
 
-        <div className="w-full lg:max-w-[360px]">
+        <div className="w-full lg:max-w-[320px]">
           {/* While an SMS/SOS session is live, the primary action becomes
               stopping it. Cancelling here revokes the location grants created by
               the alert AND clears the incident, so "SENT · Live now" resets and
@@ -663,7 +663,7 @@ export function SosPanel({
                     <span className="block text-[15px] font-semibold">
                       Call {emergency.number}
                     </span>
-                    <span className="block truncate text-[10px] text-white/75">
+                    <span className="block truncate text-[12px] text-white/75">
                       {emergency.countryName}
                     </span>
                   </span>
@@ -694,7 +694,7 @@ export function SosPanel({
                       ? "Retry local number"
                       : "Finding local number"}
                   </span>
-                  <span className="block truncate text-[10px] text-white/75">
+                  <span className="block truncate text-[12px] text-white/75">
                     {emergencyStatus === "unavailable"
                       ? "Location unavailable"
                       : "Using current location"}

--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -186,7 +186,7 @@ export function OnboardingShell({
               ) : null}
             </div>
           ) : null}
-          <p className="mb-2 block px-[6px] font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">{eyebrow}</p>
+          <p className="ui-text-section-label mb-2 block px-[6px]">{eyebrow}</p>
           <h1
             className={cn(
               "ria-screen-title",

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
@@ -140,7 +140,7 @@ export function OnboardingStepLicense({
       ) : null}
 
       <div className="space-y-3">
-        <p className="px-[6px] font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">Supported Regulators</p>
+        <p className="ui-text-section-label px-[6px]">Supported Regulators</p>
         <div className="flex flex-wrap gap-2">
           {SUPPORTED_REGULATORS.map((regulator) => (
             <span

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
@@ -37,7 +37,7 @@ function SectionCard({
   return (
     <section className="overflow-hidden rounded-[22px] border border-[color:var(--ria-divider-outer)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]">
       <div className="flex items-center justify-between gap-3 px-[18px] pb-[11px] pt-[15px]">
-        <span className="font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]">
+        <span className="ui-text-section-label">
           {label}
         </span>
         <button

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { SettingsGroup } from "@/components/app-ui/settings-ui";
+import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import { RiaAiActionPill } from "@/components/ria/ui/ria-primitives";
@@ -33,16 +34,15 @@ function SectionLabel({
   children: React.ReactNode;
   htmlFor?: string;
 }) {
-  const cls =
-    "px-[6px] font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]";
-  if (htmlFor) {
-    return (
-      <label htmlFor={htmlFor} className={cn("block", cls)}>
-        {children}
-      </label>
-    );
-  }
-  return <p className={cls}>{children}</p>;
+  return (
+    <AppSectionLabel
+      as={htmlFor ? "label" : "p"}
+      htmlFor={htmlFor}
+      className="block px-[6px]"
+    >
+      {children}
+    </AppSectionLabel>
+  );
 }
 
 function TextRow({

--- a/hushh-webapp/components/ui/input.tsx
+++ b/hushh-webapp/components/ui/input.tsx
@@ -11,7 +11,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       autoCorrect={type === "email" ? "off" : props.autoCorrect}
       spellCheck={type === "email" ? false : props.spellCheck}
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-11 w-full min-w-0 rounded-[var(--app-radius-md)] border border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] px-3.5 py-2 text-[17px] leading-[22px] shadow-none transition-[background-color,border-color,color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-semibold disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-[15px] md:leading-[20px]",
+        "ui-text-input-value file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-11 w-full min-w-0 rounded-[var(--app-radius-md)] border border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] px-3.5 py-2 shadow-none transition-[background-color,border-color,color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-semibold disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/hushh-webapp/components/ui/label.tsx
+++ b/hushh-webapp/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "ui-text-form-label flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/hushh-webapp/components/ui/tabs.tsx
+++ b/hushh-webapp/components/ui/tabs.tsx
@@ -67,7 +67,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:outline-ring relative isolate inline-flex min-h-9 min-w-0 flex-1 items-center justify-center gap-1.5 overflow-hidden px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:ring-[3px] focus-visible:outline-1",
+        "ui-text-form-label focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:outline-ring relative isolate inline-flex min-h-9 min-w-0 flex-1 items-center justify-center gap-1.5 overflow-hidden px-4 py-2 whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:ring-[3px] focus-visible:outline-1",
         "rounded-full border border-transparent",
         "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
         "data-[state=active]:bg-[color:var(--app-segmented-active-surface)] data-[state=active]:text-[color:var(--app-segmented-active-foreground)] data-[state=active]:font-semibold data-[state=active]:border-[color:var(--app-segmented-active-border)] data-[state=active]:shadow-[0_0_0_1px_var(--app-segmented-active-border),var(--shadow-xs)]",

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-pill.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-pill.tsx
@@ -52,35 +52,35 @@ const SIZE_STYLES: Record<
 > = {
   compact: {
     container: "min-h-[36px] p-0.5",
-    button: "px-2 py-1 text-xs",
+    button: "px-2 py-1 ui-text-tab-label",
     icon: "xs",
-    label: "text-[11px] leading-none",
+    label: "leading-none",
     gap: "gap-1",
     stackedContainer: "min-h-[52px] p-0.5",
     stackedButton: "px-1 py-1",
-    stackedLabel: "text-[9.5px] leading-[1.05]",
+    stackedLabel: "text-[11px] leading-[13px]",
     stackedGap: "gap-0.5",
   },
   shell: {
     container: "min-h-[42px] p-1",
-    button: "px-2.5 py-1.5 text-xs",
+    button: "px-2.5 py-1.5 ui-text-tab-label",
     icon: "sm",
-    label: "text-xs leading-none",
+    label: "leading-none",
     gap: "gap-1.5",
     stackedContainer: "min-h-[64px] p-2",
     stackedButton: "min-h-11 px-1 py-1",
-    stackedLabel: "text-[10px] leading-3",
+    stackedLabel: "text-[11px] leading-[13px]",
     stackedGap: "gap-[3px]",
   },
   default: {
     container: "min-h-[45px] p-1",
-    button: "px-3 py-2 text-sm",
+    button: "px-3 py-2 ui-text-form-label",
     icon: "sm",
-    label: "text-sm",
+    label: "",
     gap: "gap-1.5",
     stackedContainer: "min-h-[64px] p-2",
     stackedButton: "min-h-11 px-2 py-1",
-    stackedLabel: "text-[10px] leading-3",
+    stackedLabel: "text-[11px] leading-[13px]",
     stackedGap: "gap-[3px]",
   },
 };
@@ -207,7 +207,7 @@ export const SegmentedPill = React.forwardRef<
                     />
                   ) : null}
                   {typeof option.badge === "number" && option.badge > 0 ? (
-                    <span className="absolute -right-1 -top-1 inline-flex h-3.5 min-w-[0.875rem] items-center justify-center rounded-full border border-background bg-red-500 px-1 text-[9px] font-bold leading-none text-white">
+                    <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-background bg-red-500 px-1 text-[11px] font-bold leading-none text-white">
                       {option.badge > 9 ? "9+" : option.badge}
                     </span>
                   ) : null}

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -66,7 +66,7 @@ export function SegmentedTabs({
           >
             {/* Ripple sits BEHIND the label (z-0) and never intercepts taps. */}
             <MaterialRipple variant="none" effect="fade" className="z-0" />
-            <span className="relative z-10 block min-w-0 truncate text-center text-xs tracking-tight sm:text-sm">
+            <span className="ui-text-form-label relative z-10 block min-w-0 truncate text-center">
               {option.label}
             </span>
           </button>

--- a/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
@@ -97,7 +97,7 @@ export function StatusPill({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+        "ui-text-status inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[13px] leading-[18px]",
         palette,
         className,
       )}
@@ -186,7 +186,7 @@ export function PrivacyStatusCard({
           <ShieldCheck className="h-6 w-6" />
         </span>
         <div className="min-w-0">
-          <p className="text-lg font-semibold leading-tight tracking-tight text-foreground">
+          <p className="ui-text-row-label-emphasized">
             {headline}
           </p>
           {lines.map((line) => (
@@ -215,7 +215,7 @@ export function TrustNoteCard({
     <div className={cn(TRUST_SURFACE, "flex gap-3 p-3.5")}>
       <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
       <div>
-        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="ui-text-row-label-emphasized">{title}</p>
         <p className={MUTED_TEXT}>{description}</p>
       </div>
     </div>
@@ -233,8 +233,8 @@ export function WarningCard({
     <div className={cn(WARNING_SURFACE, "flex gap-3 p-3.5")}>
       <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
-        <p className="text-sm font-semibold">{title}</p>
-        <p className="text-[15px] font-normal leading-[20px] opacity-90">
+        <p className="ui-text-row-label-emphasized">{title}</p>
+        <p className="ui-text-row-description opacity-90">
           {description}
         </p>
       </div>
@@ -310,7 +310,7 @@ export function QuickPathRow({
         {icon}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block text-sm font-semibold text-foreground">
+        <span className="ui-text-row-label-emphasized block">
           {title}
         </span>
         <span className={cn(MUTED_TEXT, "block")}>{description}</span>

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -26,7 +26,7 @@
     "verify:analytics": "vitest run __tests__/services/observability-schema.test.ts __tests__/services/observability-route-map.test.ts __tests__/services/observability-growth.test.ts __tests__/services/observability-native-firebase.test.ts __tests__/services/observability-web-transport.test.ts",
     "verify:analytics:governed": "npm run verify:analytics && npm run audit:analytics-sandbox && npm run smoke:analytics:uat && cd .. && python3 .codex/skills/analytics-observability-governance/scripts/inspect_analytics_surface.py health && ./bin/hushh docs verify",
     "verify:service-boundary": "node ./scripts/architecture/verify-service-layer-boundary.mjs",
-    "verify:design-system": "node ./scripts/architecture/verify-design-system.mjs && node ./scripts/design/verify-accent-tokens.mjs",
+    "verify:design-system": "node ./scripts/architecture/verify-design-system.mjs && node ./scripts/design/verify-accent-tokens.mjs && node ./scripts/design/verify-apple-hierarchy.mjs",
     "verify:accent-tokens": "node ./scripts/design/verify-accent-tokens.mjs",
     "verify:docs": "node ./scripts/architecture/verify-docs.mjs",
     "verify:surface-map": "node ./scripts/architecture/generate-surface-map.mjs --check",

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const failures = [];
+
+function read(repoPath) {
+  return fs.readFileSync(path.join(repoRoot, repoPath), "utf8");
+}
+
+function expectIncludes(repoPath, needle, message) {
+  if (!read(repoPath).includes(needle)) {
+    failures.push(`${repoPath}: ${message}`);
+  }
+}
+
+function expectNotIncludes(repoPath, needle, message) {
+  if (read(repoPath).includes(needle)) {
+    failures.push(`${repoPath}: ${message}`);
+  }
+}
+
+const typographySource = read("components/app-ui/typography.tsx");
+for (const exportName of [
+  "PageTitle",
+  "PageSubtitle",
+  "SectionLabel",
+  "CardTitle",
+  "RowLabel",
+  "RowDescription",
+  "TrailingValue",
+  "TrailingAction",
+  "FormLabel",
+  "InputValue",
+  "HelperText",
+  "StatusText",
+  "ButtonLabel",
+  "TabLabel",
+  "CaptionText",
+  "LegalText",
+]) {
+  if (!typographySource.includes(`export function ${exportName}`)) {
+    failures.push(
+      `components/app-ui/typography.tsx: missing semantic role primitive ${exportName}`,
+    );
+  }
+}
+
+const globals = read("app/globals.css");
+for (const [token, value] of [
+  ["--type-section-label-size", "15px"],
+  ["--type-section-label-line", "20px"],
+  ["--type-section-label-weight", "500"],
+  ["--type-section-label-tracking", "-0.01em"],
+  ["--type-row-label-size", "17px"],
+  ["--type-row-description-size", "15px"],
+  ["--type-input-value-size", "17px"],
+]) {
+  if (!globals.includes(`${token}: ${value};`)) {
+    failures.push(`app/globals.css: ${token} must stay ${value}`);
+  }
+}
+
+for (const repoPath of [
+  "components/app-ui/settings-ui.tsx",
+  "components/app-ui/page-sections.tsx",
+  "components/feed/feed-page.tsx",
+  "components/one-location/redesign/check-in-flow.tsx",
+  "components/one-location/activity-dashboard.tsx",
+  "components/ria/onboarding/onboarding-step-services.tsx",
+]) {
+  expectIncludes(
+    repoPath,
+    "SectionLabel",
+    "section headings must route through the shared SectionLabel role",
+  );
+  expectNotIncludes(
+    repoPath,
+    "font-[family-name:var(--font-app-body)] text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73]",
+    "must not duplicate the section-label recipe locally",
+  );
+}
+
+for (const repoPath of [
+  "components/app-ui/settings-ui.tsx",
+  "components/app-ui/page-sections.tsx",
+  "components/app-ui/top-shell-tabs.tsx",
+  "components/ui/input.tsx",
+  "components/ui/label.tsx",
+  "components/ui/tabs.tsx",
+  "components/app-ui/stream-progress-panel.tsx",
+  "lib/morphy-ux/ui/surface-primitives.tsx",
+  "lib/morphy-ux/ui/segmented-tabs.tsx",
+  "lib/morphy-ux/ui/segmented-pill.tsx",
+  "components/dashboard/one-agent-roster.tsx",
+]) {
+  const source = read(repoPath);
+  for (const tinyClass of [
+    "text-[9px]",
+    "text-[9.5px]",
+    "text-[10px]",
+  ]) {
+    if (source.includes(tinyClass)) {
+      failures.push(`${repoPath}: shared/system UI must not use ${tinyClass}`);
+    }
+  }
+  if (source.includes("uppercase") && !repoPath.includes("top-shell-tabs")) {
+    failures.push(`${repoPath}: shared/system UI must preserve natural casing`);
+  }
+}
+
+expectIncludes(
+  "components/dashboard/one-agent-roster.tsx",
+  "agents ({modes.length})",
+  "agents heading must preserve the requested natural lowercase casing",
+);
+
+if (failures.length > 0) {
+  console.error(`verify-apple-hierarchy: ${failures.length} failure(s)\n`);
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("verify-apple-hierarchy: OK");


### PR DESCRIPTION
## Summary
- Apply Apple-system hierarchy polish across shared typography, settings rows, tabs, cards, section labels, and Location/agent surfaces.
- Preserve content, routes, APIs, and behavior while normalizing spacing, font sizes, row metadata, and non-uppercase section labels.
- Add product-wide hierarchy verifier and document the UAT audit/verification state.

## Verification
- npm run verify:design-system
- npm run typecheck
- npm run lint
- npm run verify:docs
- npm run verify:cache
- .\bin\hushh codex pre-pr

## Known local-only blocker
- npm run verify:routes requires maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE; the repo selector preserves that lane for governed UAT/runtime verification.