### PR TITLE
feat(one-location): let onboarding be skipped, and ask for a location from the Now tab

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -359,6 +359,23 @@ describe("OneLocationOnboardingFlow", () => {
     expect(screen.queryByText("Connected Person")).toBeNull();
   });
 
+  it("lets Skip leave the add-people screen without choosing anyone", () => {
+    // Skip used to call the Continue handler, which rejects an empty selection
+    // with "Choose at least one contact" -- so the button offered a way out and
+    // then refused to take it. Needing a contact to finish setup is the exact
+    // friction this screen should avoid; contacts can be added later from
+    // Connect.
+    const props = renderFlow();
+    openPeopleScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(props.onSkip).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(props.onSendConnectionRequests).not.toHaveBeenCalled();
+  });
+
+
   it("requests only missing permissions as screen two opens", () => {
     const props = renderFlow();
 
@@ -542,30 +559,6 @@ describe("OneLocationOnboardingFlow", () => {
     expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
   });
 
-  it("does not let people-screen Skip bypass the required contact", () => {
-    const props = renderFlow({
-      people: [people[1]!],
-      connections: [],
-    });
-    openPeopleScreen();
-
-    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
-
-    expect(toast.error).toHaveBeenCalledWith(
-      "Choose at least one contact",
-      {
-        description:
-          "One Location works best with someone in your circle. You can update contacts later from the Connect tab.",
-      },
-    );
-    expect(screen.getByTestId("one-location-onboarding-people")).toBeTruthy();
-    expect(
-      screen.queryByTestId("one-location-onboarding-circle"),
-    ).toBeNull();
-    expect(props.onSkip).not.toHaveBeenCalled();
-    expect(props.onComplete).not.toHaveBeenCalled();
-    expect(props.onSendConnectionRequests).not.toHaveBeenCalled();
-  });
 
   it("sends deliberate requests, shows selected people, and auto-completes after four seconds", async () => {
     vi.useFakeTimers();

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -26,6 +26,29 @@ describe("One Location settings placement", () => {
     expect(nowSource).not.toContain('title="Privacy"');
   });
 
+  it("offers Request Location directly above Settings in the Now hub", () => {
+    // The Now hub listed every way to give a location out -- Share, Map, Active
+    // shares, Shared with me -- and no way to ask for one; asking was reachable
+    // only from the People tab. Placement matters: it belongs with the other
+    // list entries, immediately above Settings, not buried in Quick actions.
+    const nowStart = HUB_SOURCE.indexOf("function NowHub");
+    const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
+    const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
+
+    expect(nowSource).toContain('testId="one-location-request-row"');
+    expect(nowSource).toContain('title="Request Location"');
+
+    const requestIndex = nowSource.indexOf('title="Request Location"');
+    const settingsIndex = nowSource.indexOf('title="Settings"');
+    expect(requestIndex).toBeGreaterThan(-1);
+    expect(settingsIndex).toBeGreaterThan(requestIndex);
+
+    // Reuses the existing ask flow rather than introducing a second one, so
+    // voice and the search bar keep naming a single control.
+    expect(nowSource).toContain('voiceControlId="one-location-action-ask"');
+    expect(HUB_SOURCE).toContain('onRequestLocation={() => openFlow("ask")}');
+  });
+
   it("owns Saved Locations and does not duplicate it in Profile preferences", () => {
     const settingsStart = HUB_SOURCE.indexOf("function LocationSettingsFlow");
     const settingsEnd = HUB_SOURCE.indexOf("/* PEOPLE HUB", settingsStart);

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7630,8 +7630,17 @@ export function OneLocationAgentPageContent({
           onComplete={dismissLocationOnboarding}
           onSkip={skipLocationOnboarding}
           requireLocationToComplete={mode === "setup"}
+          // The circle code is minted server-side and every circle route is
+          // behind `require_vault_owner_token`, so there is nothing to show
+          // before the vault exists. Onboarding runs without one in `setup`
+          // mode, where this used to reach the Invite screen and fail with
+          // "Unlock One before preparing your circle code" -- a dead end during
+          // the very flow that creates the vault. Withholding the callback
+          // makes the flow omit that screen entirely (`inviteScreenEnabled`),
+          // so setup goes features -> people, and the code becomes available
+          // the moment the vault exists and onboarding is re-entered.
           onPrepareOnboardingCircleInvite={
-            handlePrepareOnboardingCircleInvite
+            vaultOwnerToken ? handlePrepareOnboardingCircleInvite : undefined
           }
           onCopyOnboardingCircleCode={handleCopyNamedCircleCode}
           onShareOnboardingCircleCode={handleShareOnboardingCircleInvite}

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -2210,10 +2210,15 @@ export function OneLocationOnboardingFlow({
       });
   };
 
-  // Keep the people-screen Skip path aligned with Continue so neither control
-  // can bypass the minimum-one-contact onboarding requirement.
+  // Skip leaves onboarding without adding anyone. It used to call Continue so
+  // that neither control could bypass a minimum-one-contact requirement, but
+  // that made the button lie: a person with nobody selected tapped Skip and got
+  // "Choose at least one contact" back, with no way forward. Requiring a
+  // contact to finish setup is the friction this screen was meant to avoid, and
+  // contacts can be added later from Connect. Continue still enforces the
+  // minimum, so the choice stays deliberate rather than accidental.
   const handlePeopleSkip = () => {
-    handlePeopleContinue(selectedPeopleIds);
+    void runSkip();
   };
 
   return (

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -4,7 +4,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 
 import { describe, expect, it, vi } from "vitest";
@@ -189,62 +188,26 @@ describe("SmsContactsFlow", () => {
     );
   });
 
-  it("shares the Circle invite code in-context from the grow actions", async () => {
-    const onShareCircleCode = vi.fn().mockResolvedValue(undefined);
-    render(
-      <SmsContactsFlow
-        {...baseProps}
-        onShareCircleCode={onShareCircleCode}
-      />,
-    );
+  it("keeps Circle growth off this screen", () => {
+    // This screen answers one question: who gets the alert. A per-Circle
+    // "Invite people / Share code" block for every Circle pushed the contact
+    // lists below the fold and mixed a membership task into a contact-picking
+    // one. Growing a Circle belongs to the People tab, which owns membership.
+    render(<SmsContactsFlow {...baseProps} />);
 
-    const grow = screen.getByTestId("sms-circle-grow-actions-circle-1");
-    fireEvent.click(within(grow).getByRole("button", { name: /Share code/i }));
+    expect(
+      screen.queryByTestId("sms-circle-grow-actions-circle-1"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Grow /)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Invite people/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Share code/i }),
+    ).not.toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(onShareCircleCode).toHaveBeenCalledWith("circle-1"),
-    );
-  });
-
-  it("invites an existing connection to grow the Circle without leaving SMS", async () => {
-    const onLoadCircleEligibleConnections = vi.fn().mockResolvedValue({
-      eligibleConnections: [
-        {
-          connectionId: "conn-1",
-          userId: "asha-user",
-          displayName: "Asha Meena",
-        },
-      ],
-      pendingInvites: [],
-      remainingCapacity: 1,
-    });
-    const onInviteCircleConnections = vi.fn().mockResolvedValue(undefined);
-
-    render(
-      <SmsContactsFlow
-        {...baseProps}
-        onLoadCircleEligibleConnections={onLoadCircleEligibleConnections}
-        onInviteCircleConnections={onInviteCircleConnections}
-      />,
-    );
-
-    const grow = screen.getByTestId("sms-circle-grow-actions-circle-1");
-    fireEvent.click(
-      within(grow).getByRole("button", { name: /Invite people/i }),
-    );
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: /Asha Meena Connected on One/i,
-      }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
-
-    await waitFor(() =>
-      expect(onInviteCircleConnections).toHaveBeenCalledWith("circle-1", [
-        "asha-user",
-      ]),
-    );
+    // The contact lists it exists for are untouched.
+    expect(screen.getByText("Add a Circle")).toBeInTheDocument();
   });
 });
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -896,12 +896,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             recipientLabel={vm.recipientLabel}
             recipientSubtitle={vm.recipientSubtitle}
             isRecipientShareReady={vm.isRecipientShareReady}
-            onShareCircleCode={vm.onShareNamedCircleCodeById}
-            onLoadCircleEligibleConnections={
-              vm.onLoadNamedCircleEligibleConnections
-            }
-            onInviteCircleConnections={vm.onInviteNamedCircleConnections}
-            onCancelCircleMemberInvite={vm.onCancelNamedCircleMemberInvite}
           />
 
         ) : flow === "create-circle" ? (
@@ -1028,6 +1022,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
               onOpenActiveShares={() => openFlow("active-shares")}
               onOpenSharedWithMe={() => openFlow("shared-with-me")}
               onOpenNeedsReview={() => openFlow("needs-review")}
+              onRequestLocation={() => openFlow("ask")}
               onOpenSettings={() => openFlow("settings")}
             />
           </LocationHubPanel>
@@ -1078,6 +1073,7 @@ function NowHub({
   onOpenActiveShares,
   onOpenSharedWithMe,
   onOpenNeedsReview,
+  onRequestLocation,
   onOpenSettings,
 }: {
   vm: LocationHubViewModel;
@@ -1089,6 +1085,7 @@ function NowHub({
   onOpenActiveShares: () => void;
   onOpenSharedWithMe: () => void;
   onOpenNeedsReview: () => void;
+  onRequestLocation: () => void;
   onOpenSettings: () => void;
 }) {
   return (
@@ -1155,6 +1152,21 @@ function NowHub({
           onClick={onOpenNeedsReview}
           voiceControlId="one-location-action-needs-review"
           voiceActionId="location.open_needs_review"
+        />
+        {/* Asking someone to share was reachable only from the People tab, so
+            the Now tab listed every way to give a location out and none to ask
+            for one. Same flow and same voice control id as that entry -- this
+            is an additional way in, not a second implementation. */}
+        <SettingsRow
+          icon={Send}
+          iconTone="accent"
+          title="Request Location"
+          density="compact"
+          chevron
+          onClick={onRequestLocation}
+          testId="one-location-request-row"
+          voiceControlId="one-location-action-ask"
+          voiceActionId="location.open_ask"
         />
         <SettingsRow
           icon={Lock}

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -14,13 +14,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import type {
-  OneLocationCircleEligibleConnections,
   OneLocationCircleSummary,
   OneLocationRecipient,
 } from "@/lib/one-location/types";
-import { CircleGrowActions } from "@/components/one-location/redesign/circles/circle-grow-actions";
 import { MUTED_TEXT, SECTION_HEADING } from "@/components/one-location/redesign/tokens";
-
 
 const AVATAR_TONES = [
   "bg-[#2f80ed]",
@@ -42,19 +39,7 @@ type SmsContactsFlowProps = {
   recipientLabel: (recipient: OneLocationRecipient) => string;
   recipientSubtitle: (recipient: OneLocationRecipient) => string;
   isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
-  // Grow-this-Circle handlers so a user can invite loved ones or share the
-  // invite code right where they add a Circle to SMS contacts.
-  onShareCircleCode: (circleId: string) => Promise<void>;
-  onLoadCircleEligibleConnections: (
-    circleId: string,
-  ) => Promise<OneLocationCircleEligibleConnections>;
-  onInviteCircleConnections: (
-    circleId: string,
-    inviteeUserIds: string[],
-  ) => Promise<void>;
-  onCancelCircleMemberInvite: (inviteId: string) => Promise<void>;
 };
-
 
 function initials(value: string): string {
   const parts = value.trim().split(/\s+/).filter(Boolean);
@@ -153,12 +138,7 @@ export function SmsContactsFlow({
   recipientLabel,
   recipientSubtitle,
   isRecipientShareReady,
-  onShareCircleCode,
-  onLoadCircleEligibleConnections,
-  onInviteCircleConnections,
-  onCancelCircleMemberInvite,
 }: SmsContactsFlowProps) {
-
   const [pendingRemoval, setPendingRemoval] =
     useState<OneLocationRecipient | null>(null);
   const [removing, setRemoving] = useState(false);
@@ -261,33 +241,12 @@ export function SmsContactsFlow({
               This adds a snapshot of current ready members. Anyone who joins
               later is never added to SMS automatically.
             </p>
-            {/* Grow a Circle in-context: invite an existing connection or share
-                the invite code so loved ones can join before they become SMS
-                contacts. Membership never auto-adds anyone to SMS. */}
-            {circles.map((circle) => (
-              <div
-                key={`grow-${circle.id}`}
-                className="mt-3 px-1 md:max-w-[520px]"
-              >
-                <p className={cn(SECTION_HEADING, "mb-1.5")}>
-                  Grow {circle.name}
-                </p>
-                <CircleGrowActions
-                  circleId={circle.id}
-                  circleName={circle.name}
-                  busy={Boolean(busyKey)}
-                  canInvite={
-                    circle.viewerCapabilities?.canInviteMembers ??
-                    circle.role === "owner"
-                  }
-                  onShareCode={onShareCircleCode}
-                  onLoadEligibleConnections={onLoadCircleEligibleConnections}
-                  onInviteConnections={onInviteCircleConnections}
-                  onCancelMemberInvite={onCancelCircleMemberInvite}
-                  testId={`sms-circle-grow-actions-${circle.id}`}
-                />
-              </div>
-            ))}
+            {/* Growing a Circle deliberately does NOT live here. This screen
+                answers one question -- who gets the alert -- and a per-Circle
+                "Invite people / Share code" block for every Circle pushed that
+                list below the fold and mixed a membership task into a
+                contact-picking one. Growing a Circle stays on the People tab,
+                which owns membership. */}
           </>
         ) : null}
 


### PR DESCRIPTION
# Description

Four changes to the same journey.

## 1. Skip on the add-people screen did not skip

```js
const handlePeopleSkip = () => {
  handlePeopleContinue(selectedPeopleIds);   // ← Continue, not Skip
};
```

`handlePeopleContinue` rejects an empty selection with a toast — *"Choose at least one contact"* — and returns. So the one control that promised a way out refused to take it, and a person with nobody to add was **stuck on the screen**.

That was deliberate once; the old comment said *"so neither control can bypass the minimum-one-contact onboarding requirement."* Requiring a contact to finish setup is exactly the friction this screen should avoid, and it is not how comparable apps behave. Skip now leaves onboarding without adding anyone. Continue still carries a selection forward, so choosing people stays deliberate, and contacts can be added later from Connect.

## 2. The invite screen was a dead end before the vault existed

The circle code is minted server-side and every circle route sits behind `require_vault_owner_token`:

```js
if (!vaultOwnerToken) {
  throw new Error("Unlock One before preparing your circle code.");
}
```

Onboarding runs **without a vault** in `setup` mode:

```js
Boolean(auth.userId && (mode === "setup" || vaultOwnerToken))
```

…so reaching the Invite screen there failed — inside the very flow that creates the vault.

The flow already omits that screen when no prepare handler is supplied (`inviteScreenEnabled`, with an existing test covering it), so this withholds the handler until a vault exists. Setup goes **features → people**, and the code becomes available once the vault does. Same guard `SaveLocationModal` already applies to its own vault-dependent callbacks in this file.

## 3. SMS contacts carried a Circle-growth block

The screen answers one question — who gets the alert — and then rendered "Invite people / Share code" **per Circle**, pushing the contact lists below the fold and mixing a membership task into a contact-picking one. Growing a Circle stays on the People tab, which owns membership. The now-dead props and their call-site wiring are removed rather than left dangling.

## 4. The Now tab had no way to ask for a location

It listed every way to give a location out — Share, Map, Active shares, Shared with me — and none to request one; asking was reachable only from the People tab. Adds a **Request Location** row directly above Settings, opening the **existing** ask flow under the **existing** `one-location-action-ask` voice control id, so it is another way in rather than a second implementation. `Send` + the `accent` tone, the one tone unused in that group and the same accent the People-tab entry already uses.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` (Now hub, SMS contacts flow, onboarding takeover). No new routes.
- API / schema / type changes:
  - [x] Listed below: `SmsContactsFlowProps` loses four now-unused Circle-growth callbacks; `NowHub` gains `onRequestLocation`. No backend, schema or contract change.
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts:
  - [x] Listed below: all four are shared React surfaces, so native inherits them. No plugin change. Change 2 specifically helps native, where setup-mode onboarding is common.
- Docs updated: [x] None — the reasoning is in the code at each site.
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched:
  - [x] Listed below: **consent.** Change 2 stops offering a vault-gated action before the vault exists; it grants nothing new and removes no check. The backend still requires the token.
- Caller / proxy / backend pairing:
  - [x] Listed below: `onPrepareOnboardingCircleInvite` ↔ `require_vault_owner_token` circle routes. Proof: the pre-existing test *"skips the invite screen entirely when no prepare handler is provided"*.
- Rollback or safe-failure behavior:
  - [x] Listed below: each change is independently revertable. Change 2 fails safe in both directions — no vault means no screen, rather than a screen that errors.
- UI browser or Playwright proof:
  - [x] Route/spec listed below: `/one/location`. Covered by `one-location-onboarding-flow.test.tsx`, `sms-contacts-flow.test.tsx` and `one-location-settings-placement.contract.test.ts`. Not driven in a browser — see Testing.
- Verification commands executed:
  - [x] `npm run typecheck` — clean
  - [x] `npx eslint` over all changed files — clean
  - [x] `vitest` across `components/one-location`, `lib/one-location` and the two `__tests__` suites
  - [x] `bash scripts/ci/check-dco-signoff.sh`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation checked; reuses the ask flow and the invite-screen gate rather than adding parallel ones.
- [x] Changes a current reachable app surface.
- [x] Reachable production attach point: `/one/location` — `NowHub`, `SmsContactsFlow`, `OneLocationOnboardingFlow`.
- [x] New tests import and exercise production code.
- [x] New behaviour is wired to existing routes and flows.
- [x] Production surface proved: the skip test fails without the fix; the placement test asserts real source; the SMS test asserts the section is gone.
- [x] Required checks current, commit signed off, mergeable with `main`.
- [x] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: all four changes.
- [x] **iOS** / **Android**: not applicable — shared React surfaces, no plugin change.

## 🧪 Testing

- [x] Commit is signed off (`git commit -s`)
- [x] No generated files changed.

- **Skip fix** — new test verified to **fail without the fix** (`expected onSkip to be called 1 times, but got 0`).
- **SMS removal** — the two tests covering the removed block are replaced by one asserting it stays gone, so the section cannot quietly return.
- **Request Location** — source-contract test asserts the row exists, sits **above** Settings, and reuses the existing ask control id.
- I dropped a second skip test I had drafted: it encoded a guess about `canContinue` that turned out wrong. One accurate test beats two where one is speculation.

**Pre-existing failures, unchanged by this PR** (verified by stashing and re-running on clean `main`): `sos-panel` two-column layout, and three `one-location-agent-page` cases (emergency numbers ×2, approval-first request). A fifth, *"renders the One-owned encrypted location control surface"*, appeared once under full-suite load at 6 s and passes both in isolation and on re-run — a timing flake, not a regression.

`app/one/location/page.tsx` also reports a pre-existing `react-hooks/preserve-manual-memoization` lint error on `main`, untouched here.

## 🛡️ Privacy & Consent

- [x] Accesses no new user data.
- [x] Consent unchanged — no new sharing, and change 2 removes an action that could not have succeeded.
- [x] Sensitive surface: consent.
- [x] Safe-failure proved: skipping sends no connection requests; the invite screen is absent rather than broken without a vault.

## 📜 Licensing

- [x] Apache-2.0 compatible; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)