### PR TITLE
fix(ios): clear Dynamic Island collision on Connect scopes modal

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1803,11 +1803,19 @@ html.native-ios .agent-chat-workspace[data-agent-chat-workspace="page"] {
    html.kb-open + --kb-height on a real on-screen keyboard only). Shrink the
    dialog and shift its center up by half the keyboard height so it stays in the
    band above the keyboard. Only active while kb-open, so desktop is untouched
-   (kb-open is never set there). See mobile-bug-log B21. */
+   (kb-open is never set there). See mobile-bug-log B21.
+
+   This max-height replaces the base rule's, so it repeats the top safe-area
+   subtraction; otherwise a dialog with a search field (e.g. Connect's scopes
+   modal) would lose Dynamic Island clearance the moment its keyboard opened. */
 html.kb-open [data-slot="dialog-content"]:not([data-keyboard-anchor="bottom"]) {
-  max-height: calc(100dvh - 2rem - var(--kb-height, 0px));
+  max-height: calc(
+    100dvh - 2rem - var(--kb-height, 0px) -
+      var(--app-safe-area-top-effective, 0px)
+  );
   margin-top: calc(var(--kb-height, 0px) / -2);
 }
+
 
 .app-page-shell {
   width: 100%;

--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -73,7 +73,15 @@ function DialogContent({
           // (`html.kb-open [data-slot="dialog-content"]`): max-h shrinks by
           // --kb-height and it shifts up by half of it, so it stays in the band
           // above the on-screen keyboard. Inert on desktop (kb-open never set). B21.
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[500] flex w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 flex-col overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[var(--app-card-radius-feature)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-6 shadow-[var(--app-card-shadow-feature)] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] outline-none sm:max-w-lg",
+          //
+          // Safe-area avoidance: the dialog is vertically centered, so a tall
+          // one grows equally up and down. Subtracting the top + bottom insets
+          // from max-height caps that growth, keeping the centered top edge
+          // clear of the iOS Dynamic Island / status bar (which otherwise
+          // clipped the title and close button). `--app-safe-area-top-effective`
+          // is the probe-backed inset (min 44px on iOS native, 0 on desktop),
+          // so this is inert on the web where both insets resolve to 0.
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[500] flex w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem-var(--app-safe-area-top-effective,0px)-env(safe-area-inset-bottom,0px))] min-h-0 flex-col overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[var(--app-card-radius-feature)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-6 shadow-[var(--app-card-shadow-feature)] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] outline-none sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## What & why

On iOS, the Connect screen's **"Available information scopes"** modal opened flush against the top edge, so its title and (X) close button were clipped by the Dynamic Island / status bar. The shared `DialogContent` is vertically centered and clamped to `max-h-[calc(100dvh-2rem)]` with no top safe-area awareness, so a tall modal reached ~1rem from the top on notch devices.

This applies the iOS safe-area inset to the centered dialog's max-height so its top edge always clears the Dynamic Island.

## Scope note (premise-checked against `main`)

The original ticket also asked for **Connect search "return" key dismissal / keyboard-dismiss-on-scroll**. That is **already implemented** on current `main` in `app/connect/page-client.tsx` (search `Input` has `type="search"`, `enterKeyHint="search"`, an `onKeyDown` that blurs on Enter, and an `onFocus` that dismisses the keyboard on first drag). No changes were made there to avoid duplicating shipped behavior. This PR is therefore limited to the modal safe-area fix.

## Changes

- **`components/ui/dialog.tsx`** — `DialogContent` max-height now subtracts the safe insets: `max-h-[calc(100dvh-2rem-var(--app-safe-area-top-effective,0px)-env(safe-area-inset-bottom,0px))]`. Because the dialog is centered, capping growth keeps the top edge clear of the notch.
- **`app/globals.css`** — the `html.kb-open` dialog override replaces max-height, so it repeats the top-inset subtraction; otherwise a dialog with a search field (the scopes modal) would lose Dynamic Island clearance the moment its keyboard opened.

## Platform behavior

Uses the existing `--app-safe-area-top-effective` token (min 44px on iOS native, **0px on desktop/web**), so the change is **inert on web** — `calc(100dvh-2rem-0-0)` equals the previous value — and only shifts layout on iOS. No visual regression on desktop.

## Verification

- ESLint on `components/ui/dialog.tsx`: clean.
- `npm run typecheck`: no new errors introduced by these files (pre-existing environment/module-resolution errors are unrelated; CSS is not typechecked).
- Manual: on iOS, open Connect → tap **Scopes** on a connection → the "Available information scopes" modal title and (X) are fully clear of the Dynamic Island, including when the in-modal search keyboard is open.

## Risk

Low. Single shared component + one scoped CSS override; no API/contract changes; no-op on web.
