### PR TITLE
Fix UAT app typography hierarchy

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -277,6 +277,8 @@ textarea {
   --type-row-label-weight: 400;
   --type-row-label-emphasis-weight: 600;
   --type-row-label-tracking: -0.01em;
+  --type-page-subtitle-size: 16px;
+  --type-page-subtitle-line: 22px;
   --type-row-description-size: 15px;
   --type-row-description-line: 21px;
   --type-row-description-weight: 400;
@@ -5166,11 +5168,12 @@ html[data-accent="gold"].dark {
   }
 
   .type-caption {
-    font-size: var(--foundation-caption-size);
-    font-weight: var(--foundation-caption-weight);
-    line-height: var(--foundation-caption-line);
-    letter-spacing: var(--foundation-caption-tracking);
-    text-transform: uppercase;
+    color: var(--app-secondary-label);
+    font-size: var(--type-helper-text-size);
+    font-weight: 400;
+    line-height: var(--type-helper-text-line);
+    letter-spacing: -0.003em;
+    text-transform: none;
   }
 
   .type-micro {
@@ -5563,10 +5566,10 @@ body[data-persona-surface="ria"] {
 :is(.ui-text-page-subtitle) {
   color: var(--app-secondary-label) !important;
   font-family: var(--font-app-body) !important;
-  font-size: 15px !important;
+  font-size: var(--type-page-subtitle-size) !important;
   font-weight: 400 !important;
   letter-spacing: -0.006em !important;
-  line-height: 21px !important;
+  line-height: var(--type-page-subtitle-line) !important;
   opacity: 1 !important;
   text-transform: none !important;
 }
@@ -5712,6 +5715,40 @@ body[data-persona-surface="ria"] {
   letter-spacing: 0 !important;
   line-height: 16px !important;
   opacity: 1 !important;
+}
+
+.app-page-shell
+  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-xs"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[10px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[11px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[12px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-[#8E8E93]"][class*="text-[12px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-[#96999e]"][class*="text-[12px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-[#5b6472]"][class*="text-[12px]"] {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-helper-text-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.003em !important;
+  line-height: var(--type-helper-text-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+.app-page-shell
+  :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-muted-foreground"],
+.app-page-shell
+  :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-[#96999e]"],
+.app-page-shell
+  :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-[#8b93a1]"] {
+  letter-spacing: 0 !important;
+  text-transform: none !important;
 }
 
 [data-testid="settings-row"][data-tone="destructive"]

--- a/hushh-webapp/components/app-ui/section-toc.tsx
+++ b/hushh-webapp/components/app-ui/section-toc.tsx
@@ -12,6 +12,7 @@ import { Menu } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
+import { RowDescription } from "@/components/app-ui/typography";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Drawer,
@@ -43,14 +44,10 @@ function SectionTocRows({
       {entries.map((entry) => (
         <SettingsRow
           key={entry.id}
-          title={
-            <span className={compact ? "block truncate text-[13px] sm:text-sm" : undefined}>
-              {entry.label}
-            </span>
-          }
+          title={entry.label}
           description={
             showSummaries && entry.summary ? (
-              <span className={compact ? "line-clamp-1 text-[11px] leading-5" : undefined}>
+              <span className={compact ? "line-clamp-1" : undefined}>
                 {entry.summary}
               </span>
             ) : undefined
@@ -85,7 +82,7 @@ export function SectionTocRail({
       >
         <header className="space-y-1 px-3 py-3 sm:px-4">
           <p className="text-sm font-semibold text-foreground">{title}</p>
-          <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+          <RowDescription>{description}</RowDescription>
         </header>
         <ScrollArea className="max-h-[calc(100dvh-var(--top-shell-reserved-height)-9rem)] border-t border-border/60">
           <div className="divide-y divide-border/60">

--- a/hushh-webapp/components/app-ui/stream-progress-panel.tsx
+++ b/hushh-webapp/components/app-ui/stream-progress-panel.tsx
@@ -16,6 +16,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Progress } from "@/components/ui/progress";
+import { HelperText } from "@/components/app-ui/typography";
 import { StreamingCursor } from "@/lib/morphy-ux/streaming-cursor";
 import { cn } from "@/lib/utils";
 
@@ -230,7 +231,7 @@ export function AppStreamPanel({
               )
             ) : null}
             {statusMessage ? (
-              <p className="text-xs text-muted-foreground">{statusMessage}</p>
+              <HelperText>{statusMessage}</HelperText>
             ) : null}
             {progressItems.length > 0 ? (
               <AppStreamSection

--- a/hushh-webapp/components/connect/nearby-directory-ui.tsx
+++ b/hushh-webapp/components/connect/nearby-directory-ui.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  CaptionText,
+  PageSubtitle,
+  RowDescription,
+} from "@/components/app-ui/typography";
 import { Button } from "@/lib/morphy-ux/button";
 
 /**
@@ -124,7 +129,7 @@ export function DirectoryAttributionFooter({
 
   return (
     <footer className="mx-auto max-w-[30rem] text-center" data-testid={testId}>
-      <p className="type-caption text-muted-foreground">
+      <CaptionText as="p">
         <a
           href={attribution.sourceUrl}
           target="_blank"
@@ -159,12 +164,12 @@ export function DirectoryAttributionFooter({
             </a>
           </>
         ) : null}
-      </p>
+      </CaptionText>
       {retrievedLabel ? (
-        <p className="type-caption mt-1 text-muted-foreground/70">
+        <CaptionText as="p" className="mt-1">
           Retrieved {retrievedLabel}
           {stale ? " · cached" : ""}
-        </p>
+        </CaptionText>
       ) : null}
     </footer>
   );
@@ -189,7 +194,7 @@ export function QuietBlock({
     >
       <h2 className="type-title3 text-foreground">{title}</h2>
       {subtitle ? (
-        <p className="mt-2 type-callout text-muted-foreground">{subtitle}</p>
+        <PageSubtitle className="mt-2">{subtitle}</PageSubtitle>
       ) : null}
       {children ? <div className="mt-6 w-full">{children}</div> : null}
     </section>
@@ -231,9 +236,9 @@ export function LocationPrompt({
       <h2 className="type-title2 text-foreground">
         {denied ? "Location is off" : heading}
       </h2>
-      <p className="mt-2 type-callout text-muted-foreground">
+      <PageSubtitle className="mt-2">
         {denied ? "Search by ZIP instead." : "See who's close by."}
-      </p>
+      </PageSubtitle>
 
       {denied ? null : (
         <Button
@@ -265,10 +270,10 @@ export function LocationPrompt({
           variant="none"
           effect="fade"
           size="sm"
-          className="mt-3 text-muted-foreground"
+          className="mt-3"
           onClick={() => setShowPostal(true)}
         >
-          Use a ZIP
+          <RowDescription>Use a ZIP</RowDescription>
         </Button>
       )}
     </section>

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -395,7 +395,7 @@ function AgentMetricDisplay({
       <span
         className={cn(
           "min-w-0 truncate font-normal text-muted-foreground",
-          compact ? "text-[12px]" : "text-[13px]",
+          compact ? "text-[13px]" : "text-[15px] leading-[21px]",
           isPositiveMetric && "text-emerald-700/80 dark:text-emerald-300/85",
         )}
       >

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -18,7 +18,12 @@ import {
   CARD_SURFACE,
   SUBCARD_SURFACE,
 } from "@/components/one-location/redesign/tokens";
-import { SectionLabel } from "@/components/app-ui/typography";
+import {
+  CaptionText,
+  HelperText,
+  RowDescription,
+  SectionLabel,
+} from "@/components/app-ui/typography";
 
 const ACTIVITY_RANGE_OPTIONS: {
   value: OneLocationActivityRange;
@@ -74,15 +79,15 @@ function ActivityMetricTile({
 }) {
   return (
     <div className={cn("min-w-0 p-3.5", SUBCARD_SURFACE)}>
-      <p className="text-[12px] font-normal leading-4 tracking-normal text-muted-foreground">
+      <HelperText>
         {label}
-      </p>
+      </HelperText>
       <p className="mt-1 text-[24px] font-semibold leading-none text-foreground">
         {value}
       </p>
-      <p className="mt-1 break-words text-[12px] leading-4 text-muted-foreground [overflow-wrap:anywhere]">
+      <HelperText className="mt-1 break-words [overflow-wrap:anywhere]">
         {detail}
-      </p>
+      </HelperText>
     </div>
   );
 }
@@ -102,9 +107,9 @@ function EmptyActivityState({
       <p className="text-[15px] font-semibold leading-5 text-foreground">
         {title}
       </p>
-      <p className="max-w-[320px] text-[13px] leading-[18px] text-muted-foreground">
+      <RowDescription className="max-w-[320px]">
         {description}
-      </p>
+      </RowDescription>
     </div>
   );
 }
@@ -235,14 +240,14 @@ export function OneLocationActivityDashboard({
                         ) : null}
                       </div>
                     </div>
-                    <span className="max-w-full truncate text-[11px] font-normal leading-4 text-muted-foreground">
+                    <CaptionText className="max-w-full truncate">
                       {bucket.label}
-                    </span>
+                    </CaptionText>
                   </div>
                 );
               })}
             </div>
-            <div className="mt-3 flex flex-wrap gap-2 text-[12px] font-normal leading-4 text-muted-foreground">
+            <HelperText as="div" className="mt-3 flex flex-wrap gap-2">
               <span className="inline-flex items-center gap-1">
                 <span className="h-2 w-2 rounded-full bg-[color:var(--app-success)]" />
                 Shares
@@ -255,7 +260,7 @@ export function OneLocationActivityDashboard({
                 <span className="h-2 w-2 rounded-full bg-[color:var(--app-warning)]" />
                 Links
               </span>
-            </div>
+            </HelperText>
           </div>
         ) : (
           <EmptyActivityState
@@ -267,9 +272,9 @@ export function OneLocationActivityDashboard({
 
         {recentEvents.length ? (
           <div className="space-y-2">
-            <p className="ml-1 text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+            <SectionLabel as="p" className="ml-1">
               Recent history
-            </p>
+            </SectionLabel>
             <div className="min-w-0 space-y-2">
               {recentEvents.map((event) => (
                 <div
@@ -288,9 +293,9 @@ export function OneLocationActivityDashboard({
                     <p className="break-words text-[15px] font-semibold leading-5 text-foreground [overflow-wrap:anywhere]">
                       {event.title}
                     </p>
-                    <p className="mt-0.5 break-words text-[13px] leading-[18px] text-muted-foreground [overflow-wrap:anywhere]">
+                    <RowDescription className="mt-0.5 break-words [overflow-wrap:anywhere]">
                       {event.detail}
-                    </p>
+                    </RowDescription>
                   </div>
                 </div>
               ))}

--- a/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
@@ -68,7 +68,7 @@ export function TaskFlowHeader({
         {eyebrow ? <p className={EYEBROW}>{eyebrow}</p> : null}
       </div>
       <h1 className={SCREEN_TITLE}>{title}</h1>
-      {description ? <p className={MUTED_TEXT}>{description}</p> : null}
+      {description ? <p className="ui-text-page-subtitle">{description}</p> : null}
     </header>
   );
 }
@@ -234,7 +234,7 @@ export function WarningCard({
       <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
         <p className="ui-text-row-label-emphasized">{title}</p>
-        <p className="ui-text-row-description opacity-90">
+        <p className="ui-text-row-description">
           {description}
         </p>
       </div>

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -55,6 +55,8 @@ for (const exportName of [
 
 const globals = read("app/globals.css");
 for (const [token, value] of [
+  ["--type-page-subtitle-size", "16px"],
+  ["--type-page-subtitle-line", "22px"],
   ["--type-section-label-size", "15px"],
   ["--type-section-label-line", "20px"],
   ["--type-section-label-weight", "500"],
@@ -66,6 +68,14 @@ for (const [token, value] of [
   if (!globals.includes(`${token}: ${value};`)) {
     failures.push(`app/globals.css: ${token} must stay ${value}`);
   }
+}
+
+if (!/\.type-caption\s*\{[^}]*text-transform:\s*none;/s.test(globals)) {
+  failures.push("app/globals.css: legacy type-caption must preserve natural casing");
+}
+
+if (!globals.includes(".app-page-shell")) {
+  failures.push("app/globals.css: app shell must keep scoped readable-text guardrails");
 }
 
 for (const repoPath of [
@@ -96,10 +106,13 @@ for (const repoPath of [
   "components/ui/label.tsx",
   "components/ui/tabs.tsx",
   "components/app-ui/stream-progress-panel.tsx",
+  "components/app-ui/section-toc.tsx",
   "lib/morphy-ux/ui/surface-primitives.tsx",
   "lib/morphy-ux/ui/segmented-tabs.tsx",
   "lib/morphy-ux/ui/segmented-pill.tsx",
   "components/dashboard/one-agent-roster.tsx",
+  "components/connect/nearby-directory-ui.tsx",
+  "components/one-location/activity-dashboard.tsx",
 ]) {
   const source = read(repoPath);
   for (const tinyClass of [


### PR DESCRIPTION
## Summary
- raises the shared page-subtitle role to 16px/22px and removes legacy caption uppercase compression
- adds scoped app-shell guardrails for tiny muted subtitle/description utility classes
- routes Connect, Location activity, stream progress, TOC, and task-flow descriptions through semantic typography roles
- extends Apple hierarchy verification so these rules stay enforced

## Verification
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:cache
- cd hushh-webapp && npm run verify:docs