### PR TITLE
fix(ios): align Consent Center active tab underline on deep-link/route change

### DIFF
--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useRef, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+} from "react";
 import { useRouter } from "next/navigation";
 
 import type { TopShellTabSet } from "@/lib/navigation/top-shell-tabs";
@@ -69,6 +75,21 @@ export function TopShellTabs({
   const tabWidth = `${100 / tabSet.tabs.length}%`;
   const tabSwipeState = useTopShellTabSwipeState(tabSet.id);
   const indicatorTransform = `translate3d(calc(var(${topShellTabSwipePositionVariable(tabSet.id)}, ${activeIndex}) * 100%), 0, 0)`;
+
+  // Keep the shared swipe-position variable in sync with the committed active
+  // tab. Taps go through `selectIndex`, which already snaps the indicator, but
+  // when the active tab changes by any other path -- a deep link like
+  // `?tab=history`, a back/forward navigation, or external route state -- the
+  // persisted position variable can retain the PREVIOUS index. The transform
+  // only falls back to `activeIndex` while that variable is unset, so a stale
+  // value would leave the underline resting under the wrong tab until the next
+  // tap. Re-sync here (never mid-drag) so the resting indicator always matches
+  // the selected tab. Inert during drags and no-op when already aligned.
+  useEffect(() => {
+    if (tabSwipeState.isDragging) return;
+    if (Math.abs(tabSwipeState.position - activeIndex) < 0.001) return;
+    setTopShellTabSwipeState(tabSet.id, activeIndex, false);
+  }, [activeIndex, tabSet.id, tabSwipeState.isDragging, tabSwipeState.position]);
 
   const selectIndex = useCallback(
     (index: number, focus: boolean) => {


### PR DESCRIPTION
## What & why

On the Consent Center tab bar (Requests / Active / History / Connections), the active underline could rest **offset from the selected tab** (reported on "History") on iOS.

Root cause is in the shared `components/app-ui/top-shell-tabs.tsx` indicator. The underline position is driven by a persisted CSS variable (`--top-shell-tab-swipe-<id>-position`) and only falls back to the committed `activeIndex` **while that variable is unset**. Tapping a tab goes through `selectIndex`, which snaps the variable correctly — but when the active tab changes by **any other path** (a deep link like `?tab=history`, back/forward navigation, or external route state), the variable can retain the *previous* index. The transform then keeps the indicator under the old tab until the next tap, which reads as a misaligned/offset underline.

## Fix

Added a small effect in `TopShellTabs` that re-syncs the swipe-position variable to the committed `activeIndex` whenever it changes:

```ts
useEffect(() => {
  if (tabSwipeState.isDragging) return;                 // never fight an active drag
  if (Math.abs(tabSwipeState.position - activeIndex) < 0.001) return; // no-op when aligned
  setTopShellTabSwipeState(tabSet.id, activeIndex, false);
}, [activeIndex, tabSet.id, tabSwipeState.isDragging, tabSwipeState.position]);
```

This is additive and shared-safe:
- The existing `translate3d(calc(var(..., ${activeIndex}) * 100%))` transform is **unchanged** (the `top-app-bar.contract.test.ts` assertion still holds).
- It is **inert during drags** and a **no-op when already aligned**, so the swipe animation and tap-time snap are untouched.
- Because it lives in the shared component, it also hardens Finance / Location / RIA / Public tab strips against the same stale-position case — no per-surface change.

## Scope note (premise-checked)

The ticket suggested switching to `offsetLeft/offsetWidth` measurement, a per-tab `border-b-2`, or Framer Motion `layoutId`. Those don't apply here: the indicator is already dynamic, equal-width (`flex-1`, width `100/tabs.length %`, `justify-center`), and every tab already shares `px-3`. This is not Framer Motion. Rewriting to per-tab measurement/border would fork the shared, contract-tested sliding indicator four other surfaces depend on. This PR fixes the actual defect (stale position variable) without that regression.

## Verification

- ESLint on `top-shell-tabs.tsx`: clean.
- Transform string unchanged → existing `top-app-bar.contract.test.ts` remains valid.
- Manual: deep-link to `?tab=history` (and back/forward between tabs) — the underline now rests under the selected tab immediately, on web and iOS webview.

## Risk

Low. One shared component, additive effect gated on drag/alignment; no transform/markup/contract change.
