### PR TITLE
fix(one-location): give Request Location an icon that is not Share location's

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -49,6 +49,32 @@ describe("One Location settings placement", () => {
     expect(HUB_SOURCE).toContain('onRequestLocation={() => openFlow("ask")}');
   });
 
+  it("gives Request Location an icon distinct from Share location", () => {
+    // These two rows are opposites -- give a location out, ask for one in --
+    // and sit three apart in the same list. `Send` was used first and reads as
+    // the same paper-plane silhouette as `Navigation` at row size, so the pair
+    // looked like one repeated icon.
+    const nowStart = HUB_SOURCE.indexOf("function NowHub");
+    const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
+    const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
+
+    const iconFor = (title: string) => {
+      const titleIndex = nowSource.indexOf(`title="${title}"`);
+      expect(titleIndex).toBeGreaterThan(-1);
+      const rowStart = nowSource.lastIndexOf("<SettingsRow", titleIndex);
+      return /icon=\{(\w+)\}/.exec(nowSource.slice(rowStart, titleIndex))?.[1];
+    };
+
+    const requestIcon = iconFor("Request Location");
+    const shareIcon = iconFor("Share location");
+
+    expect(requestIcon).toBeTruthy();
+    expect(shareIcon).toBeTruthy();
+    expect(requestIcon).not.toBe(shareIcon);
+    // Both plane glyphs are interchangeable at this size; neither belongs here.
+    expect(["Send", "Navigation"]).not.toContain(requestIcon);
+  });
+
   it("owns Saved Locations and does not duplicate it in Profile preferences", () => {
     const settingsStart = HUB_SOURCE.indexOf("function LocationSettingsFlow");
     const settingsEnd = HUB_SOURCE.indexOf("/* PEOPLE HUB", settingsStart);

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -34,6 +34,7 @@ import {
   Lock,
   Map,
   MapPin,
+  MessageCircleQuestionMark,
   Navigation,
   Plus,
   Send,
@@ -1157,8 +1158,15 @@ function NowHub({
             the Now tab listed every way to give a location out and none to ask
             for one. Same flow and same voice control id as that entry -- this
             is an additional way in, not a second implementation. */}
+        {/* Not `Send`: that is the same paper-plane silhouette as `Navigation`
+            on "Share location" two rows up, so at row size the two entries read
+            as the same icon -- and they are opposites. A speech bubble asking a
+            question is distinct at a glance and matches what the flow does:
+            "Requests should explain why. The other person chooses whether to
+            share." Radar and Crosshair were rejected for implying tracking on a
+            surface built around consent. */}
         <SettingsRow
-          icon={Send}
+          icon={MessageCircleQuestionMark}
           iconTone="accent"
           title="Request Location"
           density="compact"


### PR DESCRIPTION
# Description

**Request Location** shipped with `Send`, three rows below **Share location**'s `Navigation`. Both are paper planes, so at row size the two entries read as the same icon — and they are opposites: one gives a location out, the other asks for one in.

Reported by QA as "these look the same".

## The fix

A speech bubble asking a question (`MessageCircleQuestionMark`). Distinct at a glance from every other glyph in that group — `Navigation` (plane), `Map` (folded map), `UsersRound` (people), `MapPin` (pin), `ShieldCheck` (shield), `Lock` (padlock) — and it describes what the flow actually is. The ask screen's own copy:

> *"Requests should explain why. The other person chooses whether to share."*

You are asking a person, not scanning for them.

## Alternatives considered and rejected

| Icon | Why not |
|---|---|
| `Radar`, `Crosshair` | Imply tracking/targeting — wrong connotation on a consent-first surface |
| `HandHelping` | Reads as emergency assistance; would collide with SOS |
| `UserRoundSearch` | Looks like contact search |
| `MapPinPlus` | Means "save a place" |

## Regression guard

The placement contract now extracts the icon identifier for both rows and asserts they differ, and that Request Location uses neither plane glyph:

```ts
expect(requestIcon).not.toBe(shareIcon);
expect(["Send", "Navigation"]).not.toContain(requestIcon);
```

Verified to fail on the old code: `expected [ 'Send', 'Navigation' ] to not include 'Send'`.

## 📌 Impact Map (Required)

- Routes touched: [x] Listed below: `/one/location` Now hub — icon only, no behaviour change.
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] Listed below: shared React surface, so native inherits it. No plugin change.
- Docs updated: [x] None — the reasoning sits at the call site.
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched: [x] None — presentation only.
- Caller / proxy / backend pairing: [x] Not applicable.
- Rollback or safe-failure behavior: [x] Listed below: revert one identifier. No state involved.
- UI browser or Playwright proof: [x] Listed below: `/one/location` Now tab. Asserted by source contract rather than a screenshot, since the defect is which identifier is used.
- Verification commands executed:
  - [x] `npm run typecheck` — clean
  - [x] `npx eslint` on both changed files — clean
  - [x] `vitest` on the placement contract and the redesign suites
  - [x] `bash scripts/ci/check-dco-signoff.sh`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and test describe the same contract.
- [x] Does not duplicate anything open.
- [x] Changes a current reachable app surface.
- [x] Reachable production attach point: `NowHub` at `/one/location`.
- [x] Test exercises production source, not a fixture.
- [x] Production surface proved: the test reads the real component and was verified to fail on the previous icon.
- [x] Required checks current, commit signed off, mergeable with `main`.
- [x] Maintainer edits enabled.
- [x] Predecessor: #5046 (merged).

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: icon on one row.
- [x] **iOS** / **Android**: not applicable — shared surface, no plugin change.

## 🧪 Testing

- [x] Commit is signed off (`git commit -s`)
- [x] No generated files changed.

Placement contract: 5 passed. Redesign suites: 59 passed, with one pre-existing `sos-panel` two-column-layout failure that also fails on clean `main` and is untouched here.

## 🛡️ Privacy & Consent

- [x] Accesses no user data.
- [x] Consent unchanged.
- [x] Sensitive surface: none.
- [x] Safe-failure: presentation-only change.

## 📜 Licensing

- [x] Apache-2.0 compatible; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)