### PR TITLE
feat(connect): stream ten nearby place categories into Around you, and restore insurance

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -277,6 +277,7 @@ jobs:
             --hushh-trusted-device-uat-allowlist "${{ vars.HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST || '' }}" \
             --advisors-api-base-url "${{ vars.ADVISORS_API_BASE_URL || 'https://brokercheck.35.253.255.106.sslip.io' }}" \
             --insurance-agents-api-base-url "${{ vars.INSURANCE_AGENTS_API_BASE_URL || 'https://insurance-agents.34.61.69.175.sslip.io' }}" \
+            --one-places-directory-enabled "${{ vars.ONE_PLACES_DIRECTORY_ENABLED_UAT || 'true' }}" \
             > /tmp/uat-runtime-secret-sync.json
 
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \

--- a/consent-protocol/api/middlewares/rate_limit.py
+++ b/consent-protocol/api/middlewares/rate_limit.py
@@ -127,6 +127,12 @@ class RateLimits:
     # at this rate has no reason to be held to a different rate on the other.
     ONE_INSURANCE_AGENTS_DIRECTORY_READ = "20/minute"  # noqa: S105
 
+    # Places directory (Google Places proxy) on the same Connect tab. One open
+    # of a category is one provider call, and a reader flicking along the chip
+    # rail spends one per chip, so this sits above the two registry directories
+    # rather than beside them. It is still far below what scraping would need.
+    ONE_PLACES_DIRECTORY_READ = "40/minute"  # noqa: S105
+
     # Preference Subscription Fabric (PCHP RFC-002).
     # FABRIC_READ is the third-party-facing, monetizable subscriber read path;
     # it must be firmly bounded per principal so no brand can drain an owner's

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -17,6 +17,7 @@ from .location_chat import router as location_chat_router
 from .marketplace_catalog import router as marketplace_catalog_router
 from .marketplace_requests import router as marketplace_requests_router
 from .opportunity_signals import router as opportunity_signals_router
+from .places import router as places_router
 from .runtime import router as runtime_router
 
 router = APIRouter()
@@ -35,6 +36,7 @@ router.include_router(insurance_agents_router)
 router.include_router(marketplace_catalog_router)
 router.include_router(marketplace_requests_router)
 router.include_router(opportunity_signals_router)
+router.include_router(places_router)
 router.include_router(runtime_router)
 
 __all__ = ["router"]

--- a/consent-protocol/api/routes/one/places.py
+++ b/consent-protocol/api/routes/one/places.py
@@ -1,0 +1,472 @@
+"""Places directory routes — businesses near a coordinate, streamed by category.
+
+The Maps key never leaves the backend, so the app calls these endpoints instead
+of Google directly. Coordinates arrive per request, are used only to build the
+upstream query, and are never persisted, cached, or logged.
+
+Every route here is a POST, including the two that only read. A GET would put
+the reader's exact position in the request line, which the access log records
+verbatim and which also lands in browser history and any Referer header. The
+advisor directory and the Maps proxy endpoints are POST for the same reason, and
+`tests/test_places_coordinate_privacy.py` holds this route to it.
+
+`/places/stream` exists because the alternative is worse, not because streaming
+is fashionable. A category's results come from one provider call; ten categories
+are ten calls. Gathering them and answering once makes every reader wait for the
+slowest one. Streaming each as it lands costs the same provider calls and puts
+the first rows on screen roughly a round trip sooner. `/places/search` answers
+the same question in one response for callers that cannot read a stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import RateLimits, limiter
+from hushh_mcp.services.google_maps_service import (
+    DIRECTORY_CATEGORY_SLUGS,
+    GoogleMapsError,
+    GoogleMapsService,
+    is_configured,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one", tags=["Places"])
+
+_METERS_PER_MILE = 1609.344
+_DEFAULT_RADIUS_MI = 5.0
+_MAX_RADIUS_MI = 31.0  # Google rejects a radius above 50 km.
+_DEFAULT_LIMIT = 20
+
+# A stalled provider call must not look like a dead connection to whatever sits
+# between this process and the reader. `api/routes/sse.py` uses 30s for the same
+# reason; this is shorter because a directory that has said nothing for fifteen
+# seconds is already a bad experience worth signalling.
+_HEARTBEAT_SECONDS = 15.0
+
+# The whole fan-out is bounded so one wedged provider call cannot hold a
+# connection open indefinitely.
+_STREAM_BUDGET_SECONDS = 45.0
+
+_ATTRIBUTION = {
+    "source": "Google",
+    "sourceUrl": "https://www.google.com/maps",
+    "termsUrl": "https://cloud.google.com/maps-platform/terms",
+    "notice": "Place data from Google Maps Platform.",
+}
+
+
+def _env_truthy(name: str, fallback: str = "false") -> bool:
+    return str(os.getenv(name) or fallback).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _directory_enabled() -> bool:
+    """Whether this deployment serves the Places directory.
+
+    Deliberately NOT the nearby-presence flag. That flag governs co-presence,
+    where the risk is an unattestable check-in point being shown to other
+    people; this is a business directory read by one signed-in owner. Sharing a
+    switch would mean closing co-presence in production also closes the
+    directory, which is a coupling neither feature asked for.
+
+    Non-production environments default open so UAT can verify without a secret
+    change. Production stays closed until it is turned on explicitly.
+    """
+
+    environment = (
+        str(os.getenv("ENVIRONMENT") or os.getenv("HUSHH_DEPLOY_ENV") or "").strip().lower()
+    )
+    if environment in {"development", "dev", "local", "test", "uat", "staging"}:
+        return _env_truthy("ONE_PLACES_DIRECTORY_ENABLED", "true")
+    return _env_truthy("ONE_PLACES_DIRECTORY_ENABLED", "false")
+
+
+class PlacesSearchRequest(BaseModel):
+    """A location to search around, and which categories to search for."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    lat: float | None = Field(default=None, ge=-90, le=90)
+    lng: float | None = Field(default=None, ge=-180, le=180)
+    postal_code: str | None = Field(default=None, alias="postalCode", max_length=12)
+    categories: list[str] = Field(default_factory=list, max_length=12)
+    radius_mi: float = Field(default=_DEFAULT_RADIUS_MI, alias="radiusMi", gt=0, le=_MAX_RADIUS_MI)
+    limit: int = Field(default=_DEFAULT_LIMIT, ge=1, le=20)
+
+
+class PlaceDetailsRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    place_id: str = Field(alias="placeId", min_length=1, max_length=300)
+
+
+def _service() -> GoogleMapsService:
+    return GoogleMapsService()
+
+
+def _no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+def _guard() -> None:
+    """Refuse before any coordinate is used when this surface is not serving."""
+
+    if not _directory_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "ONE_PLACES_UNAVAILABLE",
+                "message": "Places near you is not available on this account yet.",
+            },
+        )
+    if not is_configured():
+        # 503, not 404: the surface exists, this deployment just has no key.
+        # The client turns this into "Not available yet." rather than repeating
+        # our plumbing back at the reader.
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "ONE_PLACES_NOT_CONFIGURED",
+                "message": "The places directory is not configured on this backend.",
+            },
+        )
+
+
+def _resolve_categories(requested: list[str]) -> list[str]:
+    """Requested categories, in the table's declared order, deduplicated.
+
+    An unknown slug is dropped rather than raising: a client one release ahead
+    asking for a category this backend does not have yet should get the nine it
+    does have, not an error for the whole request.
+    """
+
+    wanted = {str(slug).strip() for slug in requested if str(slug).strip()}
+    if not wanted:
+        return []
+    return [slug for slug in DIRECTORY_CATEGORY_SLUGS if slug in wanted]
+
+
+async def _resolve_origin(payload: PlacesSearchRequest) -> tuple[float, float]:
+    """The point to search around, from coordinates or a postal code."""
+
+    if payload.lat is not None and payload.lng is not None:
+        return float(payload.lat), float(payload.lng)
+
+    postal = (payload.postal_code or "").strip()
+    if not postal:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ONE_PLACES_NO_ORIGIN",
+                "message": "A location or a postal code is required.",
+            },
+        )
+    try:
+        place = await _service().resolve_place(query=postal)
+    except GoogleMapsError as exc:
+        raise _handle(exc) from exc
+
+    try:
+        return float(place["latitude"]), float(place["longitude"])
+    except (KeyError, TypeError, ValueError) as exc:
+        # An unparseable postal code is not an error the reader caused. The
+        # client shows the same quiet "nothing here" block it shows for a real
+        # zero-result answer, and keeps the postal box on screen.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ONE_PLACES_UNRESOLVED_POSTAL_CODE",
+                "message": "That postal code could not be located.",
+            },
+        ) from exc
+
+
+def _handle(exc: GoogleMapsError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "code": getattr(exc, "code", None) or "ONE_PLACES_UNAVAILABLE",
+            "message": str(exc),
+        },
+    )
+
+
+def _meta(*, categories: list[str], radius_mi: float, limit: int) -> dict[str, Any]:
+    return {
+        "categories": categories,
+        "radiusMi": radius_mi,
+        "limit": limit,
+        "attribution": {
+            **_ATTRIBUTION,
+            "retrievedAt": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
+def _frame(event: str, data: dict[str, Any]) -> bytes:
+    """One Server-Sent Events block.
+
+    `event` is repeated inside the payload so the client can verify the frame it
+    parsed is the frame it was handed -- the same check `kai-stream-client.ts`
+    makes.
+    """
+
+    body = json.dumps({"event": event, **data}, separators=(",", ":"))
+    return f"event: {event}\ndata: {body}\n\n".encode()
+
+
+async def _stream_categories(
+    *,
+    request: Request,
+    lat: float,
+    lng: float,
+    categories: list[str],
+    radius_meters: float,
+    limit: int,
+    meta: dict[str, Any],
+) -> AsyncGenerator[bytes, None]:
+    """Emit each category the moment its provider call returns.
+
+    Deliberately not `asyncio.gather`: gathering waits for the slowest call
+    before anything can be sent, which is exactly the delay this route exists to
+    remove. `asyncio.wait(FIRST_COMPLETED)` gives the same concurrency and lets
+    each result leave as it lands, with the idle gaps used for heartbeats.
+    """
+
+    service = _service()
+    tasks: dict[asyncio.Task[list[dict[str, Any]]], str] = {}
+    for slug in categories:
+        task = asyncio.create_task(
+            service.search_directory_category(
+                lat=lat,
+                lng=lng,
+                category=slug,
+                radius_meters=radius_meters,
+                limit=limit,
+            )
+        )
+        tasks[task] = slug
+
+    pending: set[asyncio.Task[list[dict[str, Any]]]] = set(tasks)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _STREAM_BUDGET_SECONDS
+    delivered = 0
+    failed: list[str] = []
+
+    try:
+        yield _frame("meta", meta)
+
+        while pending:
+            if await request.is_disconnected():
+                return
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                for slug in (tasks[task] for task in pending):
+                    failed.append(slug)
+                    yield _frame(
+                        "category_error",
+                        {"category": slug, "message": "This category timed out."},
+                    )
+                break
+
+            done, pending = await asyncio.wait(
+                pending,
+                timeout=min(_HEARTBEAT_SECONDS, remaining),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if not done:
+                # Nothing finished inside the window. Say so, so intermediaries
+                # do not read the quiet as a dead connection.
+                yield _frame("heartbeat", {})
+                continue
+
+            for task in done:
+                slug = tasks[task]
+                try:
+                    items = task.result()
+                except GoogleMapsError as exc:
+                    # One category failing must never empty the list. The others
+                    # are still a better answer than an error page.
+                    failed.append(slug)
+                    logger.warning("places.stream category failed: %s", slug)
+                    yield _frame(
+                        "category_error",
+                        {"category": slug, "message": str(exc)},
+                    )
+                    continue
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    failed.append(slug)
+                    logger.exception("places.stream category crashed: %s", slug)
+                    yield _frame(
+                        "category_error",
+                        {"category": slug, "message": "This category is unavailable."},
+                    )
+                    continue
+
+                delivered += len(items)
+                yield _frame("results", {"category": slug, "items": items})
+
+        yield _frame(
+            "done",
+            {"delivered": delivered, "failed": failed, "terminal": True},
+        )
+    finally:
+        # A reader who navigated away must not leave provider calls running.
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+
+@router.post("/places/stream")
+@limiter.limit(RateLimits.ONE_PLACES_DIRECTORY_READ)
+async def places_stream(
+    request: Request,
+    payload: PlacesSearchRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    _ = firebase_uid  # auth-gate only; results are not user-scoped
+    _guard()
+
+    categories = _resolve_categories(payload.categories)
+    if not categories:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ONE_PLACES_NO_CATEGORY",
+                "message": "At least one known category is required.",
+            },
+        )
+
+    lat, lng = await _resolve_origin(payload)
+    radius_meters = float(payload.radius_mi) * _METERS_PER_MILE
+    meta = _meta(categories=categories, radius_mi=payload.radius_mi, limit=payload.limit)
+
+    return StreamingResponse(
+        _stream_categories(
+            request=request,
+            lat=lat,
+            lng=lng,
+            categories=categories,
+            radius_meters=radius_meters,
+            limit=payload.limit,
+            meta=meta,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "private, no-store, no-cache",
+            "Pragma": "no-cache",
+            "Connection": "keep-alive",
+            # Without this an nginx-shaped intermediary buffers the whole body
+            # and the stream arrives as one lump, which is the ordinary response
+            # with extra steps.
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/places/search")
+@limiter.limit(RateLimits.ONE_PLACES_DIRECTORY_READ)
+async def places_search(
+    request: Request,
+    response: Response,
+    payload: PlacesSearchRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """The same question, answered once.
+
+    The fallback for anything that cannot read a stream -- a buffering proxy, an
+    older client, a test. Same inputs, same shapes, so the UI renders one code
+    path either way.
+    """
+
+    _ = firebase_uid
+    _guard()
+    _no_store(response)
+
+    categories = _resolve_categories(payload.categories)
+    if not categories:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ONE_PLACES_NO_CATEGORY",
+                "message": "At least one known category is required.",
+            },
+        )
+
+    lat, lng = await _resolve_origin(payload)
+    radius_meters = float(payload.radius_mi) * _METERS_PER_MILE
+    service = _service()
+
+    results = await asyncio.gather(
+        *(
+            service.search_directory_category(
+                lat=lat,
+                lng=lng,
+                category=slug,
+                radius_meters=radius_meters,
+                limit=payload.limit,
+            )
+            for slug in categories
+        ),
+        return_exceptions=True,
+    )
+
+    groups: list[dict[str, Any]] = []
+    failed: list[str] = []
+    for slug, outcome in zip(categories, results, strict=True):
+        if isinstance(outcome, BaseException):
+            failed.append(slug)
+            logger.warning("places.search category failed: %s", slug)
+            continue
+        groups.append({"category": slug, "items": outcome})
+
+    if not groups and failed:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "ONE_PLACES_UNAVAILABLE",
+                "message": "Places are unavailable right now.",
+            },
+        )
+
+    return {
+        "groups": groups,
+        "failed": failed,
+        "meta": _meta(categories=categories, radius_mi=payload.radius_mi, limit=payload.limit),
+    }
+
+
+@router.post("/places/details")
+@limiter.limit(RateLimits.ONE_PLACES_DIRECTORY_READ)
+async def place_details(
+    request: Request,
+    response: Response,
+    payload: PlaceDetailsRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """The richer record behind one row, bought only when a row is opened."""
+
+    _ = firebase_uid
+    _guard()
+    _no_store(response)
+    try:
+        return {"place": await _service().directory_place_details(payload.place_id)}
+    except GoogleMapsError as exc:
+        raise _handle(exc) from exc

--- a/consent-protocol/hushh_mcp/runtime_settings.py
+++ b/consent-protocol/hushh_mcp/runtime_settings.py
@@ -114,6 +114,10 @@ _BACKEND_RUNTIME_ENV_MAP: dict[str, str] = {
     # the advisor base URL directly above; the bearer key is a real
     # secret and is mounted through --set-secrets instead.
     "insurance_agents_api_base_url": "INSURANCE_AGENTS_API_BASE_URL",
+    # Places directory switch. Deliberately its own key rather than reusing the
+    # nearby-presence mode: that flag governs co-presence, and closing
+    # co-presence in production must not also close a business directory.
+    "one_places_directory_enabled": "ONE_PLACES_DIRECTORY_ENABLED",
 }
 
 

--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -148,6 +148,101 @@ _NON_CHECK_IN_PRIMARY_TYPE_PREFIXES = (
 _GENERIC_ESTABLISHMENT_TYPES = frozenset({"establishment", "point_of_interest"})
 
 
+# Deliberately a SEPARATE table from `_NEARBY_PLACE_CATEGORY_TYPES`, not an
+# extension of it. `nearby_places` builds its "All" sweep by iterating that dict,
+# so every key added there becomes another concurrent provider call on every
+# check-in drawer open. The directory needs finer buckets than the picker wants
+# (a person choosing where they are standing does not need "banking" split from
+# "shops"), and the picker must not pay for that. Two readers, two tables.
+#
+# The three buckets the picker does not have -- banking, fitness_beauty, auto --
+# are a re-partition of its single `shopping_services` chip, which jams retail,
+# laundry, beauty, vehicle service and cash machines into one filter. Every type
+# below already appears in the picker's table; none is new to this codebase.
+_DIRECTORY_CATEGORY_TYPES: dict[str, tuple[str, ...]] = {
+    "hotels_stays": (
+        "hotel",
+        "lodging",
+        "motel",
+        "hostel",
+        "bed_and_breakfast",
+        "campground",
+    ),
+    "food_drink": ("restaurant", "cafe", "bakery", "bar", "meal_takeaway"),
+    "health": ("hospital", "medical_clinic", "doctor", "dentist", "pharmacy"),
+    "banking": ("bank", "atm"),
+    "shops": (
+        "store",
+        "shopping_mall",
+        "supermarket",
+        "convenience_store",
+        "laundry",
+        "post_office",
+    ),
+    "fitness_beauty": (
+        "gym",
+        "beauty_salon",
+        "hair_salon",
+        "barber_shop",
+        "spa",
+    ),
+    "auto": (
+        "car_repair",
+        "car_wash",
+        "car_dealer",
+        "gas_station",
+        "electric_vehicle_charging_station",
+    ),
+    "transit": (
+        "transit_station",
+        "bus_stop",
+        "train_station",
+        "subway_station",
+        "airport",
+        "parking",
+    ),
+    "education": (
+        "school",
+        "university",
+        "preschool",
+        "library",
+        "educational_institution",
+    ),
+    "outdoors": (
+        "park",
+        "tourist_attraction",
+        "museum",
+        "art_gallery",
+        "historical_landmark",
+        "beach",
+        "garden",
+        "plaza",
+    ),
+}
+
+DIRECTORY_CATEGORY_SLUGS: tuple[str, ...] = tuple(_DIRECTORY_CATEGORY_TYPES)
+
+# Search Nearby (New) caps one response at 20 regardless of what we ask for.
+_DIRECTORY_MAX_RESULT_COUNT = 20
+# Google rejects a radius above 50 km outright.
+_DIRECTORY_MAX_RADIUS_METERS = 50_000.0
+
+# Kept to the cheap field tiers on purpose. Rating, opening hours, phone and
+# website are billed higher and are only worth buying for the one place a reader
+# actually opened, so they live on `directory_place_details` instead of on every
+# row of every list.
+_DIRECTORY_LIST_FIELD_MASK = (
+    "places.id,places.displayName,places.shortFormattedAddress,"
+    "places.formattedAddress,places.location,places.primaryType,"
+    "places.types,places.primaryTypeDisplayName,places.businessStatus"
+)
+_DIRECTORY_DETAIL_FIELD_MASK = (
+    "id,displayName,formattedAddress,shortFormattedAddress,location,"
+    "primaryType,primaryTypeDisplayName,types,businessStatus,"
+    "nationalPhoneNumber,websiteUri,regularOpeningHours,googleMapsUri"
+)
+
+
 def _build_category_index() -> dict[str, tuple[str, ...]]:
     """Reverse index from a Places type to the drawer's category chips.
 
@@ -804,6 +899,226 @@ class GoogleMapsService:
             _NEARBY_CHECK_IN_MERGED_LIMIT if category == "all" else _NEARBY_CHECK_IN_RESULT_LIMIT
         )
         return results[:limit]
+
+    async def search_directory_category(
+        self,
+        *,
+        lat: float,
+        lng: float,
+        category: str,
+        radius_meters: float,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Places of one directory category around a point, nearest first.
+
+        One provider call, one category. The caller fans these out and streams
+        each result the moment it lands, so this deliberately does no merging of
+        its own -- merging is what forces a caller to wait for the slowest
+        bucket, which is the behaviour the directory exists to avoid.
+
+        Unlike the check-in picker's sweep, radius and count are arguments. The
+        picker is answering "where am I standing", so 500 m is the honest bound;
+        a directory is answering "what is around here", where the reader chooses.
+
+        The request point is sent to Google for this foreground request only. It
+        is not cached, logged, or persisted by this service.
+        """
+
+        key = _require_key()
+        included = _DIRECTORY_CATEGORY_TYPES.get(category)
+        if not included:
+            raise GoogleMapsError(
+                f"Unknown directory category: {category}",
+                status_code=400,
+                code="ONE_PLACES_UNKNOWN_CATEGORY",
+            )
+
+        bounded_radius = max(1.0, min(float(radius_meters), _DIRECTORY_MAX_RADIUS_METERS))
+        bounded_limit = max(1, min(int(limit), _DIRECTORY_MAX_RESULT_COUNT))
+
+        body: dict[str, Any] = {
+            "maxResultCount": bounded_limit,
+            "rankPreference": "DISTANCE",
+            "includedTypes": list(included),
+            "locationRestriction": {
+                "circle": {
+                    "center": {"latitude": float(lat), "longitude": float(lng)},
+                    "radius": bounded_radius,
+                }
+            },
+        }
+
+        async with _async_client() as client:
+            try:
+                response = await client.post(
+                    _PLACES_NEARBY_URL,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Goog-Api-Key": key,
+                        "X-Goog-FieldMask": _DIRECTORY_LIST_FIELD_MASK,
+                    },
+                    json=body,
+                )
+            except httpx.HTTPError as exc:
+                raise GoogleMapsError(
+                    f"Directory lookup failed: {exc}",
+                    status_code=502,
+                ) from exc
+
+        if response.status_code >= 400:
+            # Never log the category with coordinates alongside it.
+            logger.warning("maps.directory upstream %s", response.status_code)
+            raise GoogleMapsError("Directory lookup failed.", status_code=502)
+
+        payload = _provider_object(response, "Directory lookup")
+        provider_places = payload.get("places") or []
+        if not isinstance(provider_places, list):
+            raise GoogleMapsError(
+                "Directory lookup returned an invalid response.",
+                status_code=502,
+            )
+
+        rows: list[dict[str, Any]] = []
+        for place in provider_places:
+            if not isinstance(place, dict):
+                continue
+            row = self._normalize_directory_place(place, lat=lat, lng=lng, category=category)
+            if row is not None:
+                rows.append(row)
+
+        rows.sort(key=lambda item: (item["distanceMeters"], str(item["name"]).casefold()))
+        return rows
+
+    def _normalize_directory_place(
+        self,
+        place: dict[str, Any],
+        *,
+        lat: float,
+        lng: float,
+        category: str,
+    ) -> dict[str, Any] | None:
+        """Shape one provider record for a directory row, or drop it."""
+
+        place_id = str(place.get("id") or "").strip()
+        if not place_id or len(place_id) > 300:
+            return None
+
+        location = place.get("location") or {}
+        if not isinstance(location, dict):
+            return None
+        try:
+            place_lat = float(location.get("latitude"))
+            place_lng = float(location.get("longitude"))
+        except (TypeError, ValueError):
+            return None
+        if not _valid_coordinates(lat=place_lat, lng=place_lng):
+            return None
+
+        display_name = place.get("displayName") or {}
+        if not isinstance(display_name, dict):
+            display_name = {}
+        name = str(display_name.get("text") or "").strip()[:160]
+        if not name:
+            return None
+
+        primary_type = str(place.get("primaryType") or "").strip() or None
+        if primary_type and _is_non_check_in_type(primary_type):
+            # A geocoded address is not a business, whatever filter surfaced it.
+            return None
+
+        type_display = place.get("primaryTypeDisplayName") or {}
+        if not isinstance(type_display, dict):
+            type_display = {}
+        category_label = str(type_display.get("text") or "").strip()[:80] or None
+
+        distance = _distance_meters(
+            origin_lat=lat,
+            origin_lng=lng,
+            destination_lat=place_lat,
+            destination_lng=place_lng,
+        )
+
+        return {
+            "placeId": place_id,
+            "name": name,
+            "address": (
+                str(
+                    place.get("shortFormattedAddress") or place.get("formattedAddress") or ""
+                ).strip()[:300]
+                or None
+            ),
+            "distanceMeters": int(distance),
+            "primaryType": primary_type,
+            "categoryLabel": category_label,
+            # The directory's own bucket, not `_place_categories` -- that reads
+            # the picker's table and would answer in the picker's vocabulary.
+            "category": category,
+            "businessStatus": str(place.get("businessStatus") or "").strip() or None,
+        }
+
+    async def directory_place_details(self, place_id: str) -> dict[str, Any]:
+        """The richer record behind one directory row.
+
+        Phone, website and posted hours sit in a dearer billing tier than the
+        list fields, so they are bought once, for the one place a reader opened,
+        rather than for every row of every category they scrolled past.
+        """
+
+        key = _require_key()
+        async with _async_client() as client:
+            try:
+                response = await client.get(
+                    f"{_PLACES_BASE}/v1/places/{quote(place_id, safe='')}",
+                    headers={
+                        "X-Goog-Api-Key": key,
+                        "X-Goog-FieldMask": _DIRECTORY_DETAIL_FIELD_MASK,
+                    },
+                )
+            except httpx.HTTPError as exc:
+                raise GoogleMapsError(f"Place details failed: {exc}", status_code=502) from exc
+
+        if response.status_code >= 400:
+            logger.warning("maps.directory_details upstream %s", response.status_code)
+            raise GoogleMapsError("Place details failed.", status_code=502)
+
+        data = _provider_object(response, "Place details lookup")
+
+        display_name = data.get("displayName") or {}
+        if not isinstance(display_name, dict):
+            display_name = {}
+        type_display = data.get("primaryTypeDisplayName") or {}
+        if not isinstance(type_display, dict):
+            type_display = {}
+
+        hours = data.get("regularOpeningHours") or {}
+        if not isinstance(hours, dict):
+            hours = {}
+        raw_descriptions = hours.get("weekdayDescriptions")
+        weekday_descriptions = (
+            [str(entry)[:120] for entry in raw_descriptions[:7]]
+            if isinstance(raw_descriptions, list)
+            else []
+        )
+
+        return {
+            "placeId": str(data.get("id") or place_id),
+            "name": str(display_name.get("text") or "").strip()[:160] or None,
+            "address": (
+                str(
+                    data.get("formattedAddress") or data.get("shortFormattedAddress") or ""
+                ).strip()[:300]
+                or None
+            ),
+            "categoryLabel": str(type_display.get("text") or "").strip()[:80] or None,
+            "phone": str(data.get("nationalPhoneNumber") or "").strip()[:40] or None,
+            "website": str(data.get("websiteUri") or "").strip()[:500] or None,
+            "mapsUrl": str(data.get("googleMapsUri") or "").strip()[:500] or None,
+            "businessStatus": str(data.get("businessStatus") or "").strip() or None,
+            # Posted hours only. Google's `openNow` is a live claim we would be
+            # repeating without being able to stand behind it, so it is not read
+            # and the UI never says "open now".
+            "weekdayDescriptions": weekday_descriptions,
+        }
 
     async def place_details(
         self,

--- a/consent-protocol/tests/test_advisors_runtime_config_wiring.py
+++ b/consent-protocol/tests/test_advisors_runtime_config_wiring.py
@@ -36,7 +36,8 @@ _CONFIG_ARGS = (
     "hushh_trusted_device_enabled hushh_trusted_device_uat_allowlist "
     "advisors_api_base_url advisors_api_key_source_project "
     "advisors_api_key_source_secret insurance_agents_api_base_url "
-    "insurance_agents_api_key_source_project insurance_agents_api_key_source_secret"
+    "insurance_agents_api_key_source_project insurance_agents_api_key_source_secret "
+    "one_places_directory_enabled"
 ).split()
 
 

--- a/consent-protocol/tests/test_insurance_agents_runtime_config_wiring.py
+++ b/consent-protocol/tests/test_insurance_agents_runtime_config_wiring.py
@@ -40,7 +40,8 @@ _CONFIG_ARGS = (
     "hushh_trusted_device_enabled hushh_trusted_device_uat_allowlist "
     "advisors_api_base_url advisors_api_key_source_project "
     "advisors_api_key_source_secret insurance_agents_api_base_url "
-    "insurance_agents_api_key_source_project insurance_agents_api_key_source_secret"
+    "insurance_agents_api_key_source_project insurance_agents_api_key_source_secret "
+    "one_places_directory_enabled"
 ).split()
 
 

--- a/consent-protocol/tests/test_places_coordinate_privacy.py
+++ b/consent-protocol/tests/test_places_coordinate_privacy.py
@@ -1,0 +1,96 @@
+"""A reader's position must never reach a URL, a log line, or a stream frame.
+
+The places directory adds a third surface that takes coordinates, and a fourth
+sink the advisor directory does not have: a long-lived response body. A stream
+that echoed the request point back in a heartbeat would put it somewhere the
+advisor tests never had to look.
+
+Coordinates are treated as credential-grade here on purpose, for the same reason
+they are on the advisor routes: a home address is not less sensitive than an
+API key.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+from api.routes.one import places as places_routes
+
+
+def _routes() -> list[tuple[str, frozenset[str]]]:
+    return [(route.path, frozenset(route.methods or ())) for route in places_routes.router.routes]
+
+
+def test_every_search_is_a_post_so_no_position_reaches_the_request_line() -> None:
+    paths = dict(_routes())
+
+    assert "POST" in paths["/api/one/places/stream"]
+    assert "POST" in paths["/api/one/places/search"]
+    assert "POST" in paths["/api/one/places/details"]
+
+
+def test_no_places_route_accepts_a_location_as_a_query_parameter() -> None:
+    """A GET route on this router would put coordinates back in the URL."""
+
+    for route in places_routes.router.routes:
+        if "GET" not in (route.methods or ()):
+            continue
+        params = inspect.signature(route.endpoint).parameters
+        for name in ("lat", "lng", "latitude", "longitude", "postal_code", "postalCode"):
+            assert name not in params, f"{route.path} takes {name} on a GET"
+
+
+def test_no_places_route_is_a_get_at_all() -> None:
+    """Every read here carries a position, so none of them can be a GET.
+
+    Stated separately from the parameter check because a GET added later with a
+    differently-named coordinate argument would slip past that one.
+    """
+
+    for path, methods in _routes():
+        assert "GET" not in methods, f"{path} is a GET on a router that takes positions"
+
+
+_COORDINATE_KEYS = {"lat", "lng", "latitude", "longitude", "coordinates", "location"}
+
+
+def _keys(value: object) -> set[str]:
+    """Every key anywhere in a decoded frame."""
+
+    if isinstance(value, dict):
+        found = set(value)
+        for nested in value.values():
+            found |= _keys(nested)
+        return found
+    if isinstance(value, list):
+        found: set[str] = set()
+        for nested in value:
+            found |= _keys(nested)
+        return found
+    return set()
+
+
+def test_a_heartbeat_frame_carries_no_position() -> None:
+    """The stream stays open, so its filler frames are a sink of their own."""
+
+    frame = places_routes._frame("heartbeat", {}).decode()
+    payload = json.loads(frame.split("data: ", 1)[1].strip())
+
+    assert payload == {"event": "heartbeat"}
+
+
+def test_the_meta_frame_does_not_echo_the_request_point() -> None:
+    """`meta` describes the query, and the query includes where the reader is."""
+
+    meta = places_routes._meta(categories=["hotels_stays"], radius_mi=5.0, limit=8)
+    rendered = places_routes._frame("meta", meta).decode()
+    payload = json.loads(rendered.split("data: ", 1)[1].strip())
+
+    assert payload["categories"] == ["hotels_stays"]
+    # Checked on decoded keys, not on the raw text: "maps-platform" contains
+    # "lat", and a substring match would fail on the attribution URL forever.
+    assert not (_keys(payload) & _COORDINATE_KEYS)
+    # And no coordinate-shaped value survived into the frame either.
+    assert "12.9716" not in rendered
+    assert "77.5946" not in rendered

--- a/consent-protocol/tests/test_places_directory.py
+++ b/consent-protocol/tests/test_places_directory.py
@@ -1,0 +1,315 @@
+"""The places directory: its taxonomy, its streaming, and what it must not cost.
+
+The sharpest risk in this feature is not the new surface, it is the old one.
+`nearby_places` builds its "All" sweep by iterating `_NEARBY_PLACE_CATEGORY_TYPES`,
+so a category added to that table becomes another concurrent provider call on
+every check-in drawer open — a cost increase on a shipped feature that no test
+would otherwise notice. The first test here pins that table's size.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from api.routes.one import places as places_routes
+from hushh_mcp.services import google_maps_service as maps
+
+# --------------------------------------------------------------------------- #
+# The check-in picker must not pay for the directory's finer buckets.
+# --------------------------------------------------------------------------- #
+
+
+def test_the_check_in_sweep_still_costs_what_it_did() -> None:
+    """One request per bucket, plus one unfiltered. Adding a bucket adds a call."""
+
+    # Seven buckets was the shipped cost of opening the check-in drawer on "All".
+    assert len(maps._NEARBY_PLACE_CATEGORY_TYPES) == 7
+    assert set(maps._NEARBY_PLACE_CATEGORY_TYPES) == {
+        "food_drink",
+        "health",
+        "shopping_services",
+        "hotels_stays",
+        "education",
+        "outdoors_landmarks",
+        "transit",
+    }
+
+
+def test_the_two_taxonomies_are_separate_objects() -> None:
+    """Aliasing them would silently couple the picker's cost to the directory."""
+
+    assert maps._DIRECTORY_CATEGORY_TYPES is not maps._NEARBY_PLACE_CATEGORY_TYPES
+
+
+def test_the_directory_offers_exactly_ten_categories() -> None:
+    assert len(maps._DIRECTORY_CATEGORY_TYPES) == 10
+    assert maps.DIRECTORY_CATEGORY_SLUGS == (
+        "hotels_stays",
+        "food_drink",
+        "health",
+        "banking",
+        "shops",
+        "fitness_beauty",
+        "auto",
+        "transit",
+        "education",
+        "outdoors",
+    )
+
+
+def test_every_directory_place_type_is_one_the_picker_already_used() -> None:
+    """The three new buckets re-partition an existing chip; they invent nothing.
+
+    A type here that the picker never asked for would be an unreviewed guess at
+    a provider vocabulary, which is exactly how a category quietly returns
+    nothing in production.
+    """
+
+    known = {
+        place_type for types in maps._NEARBY_PLACE_CATEGORY_TYPES.values() for place_type in types
+    }
+    # The one deliberate addition: EV charging had no picker equivalent.
+    known.add("electric_vehicle_charging_station")
+    known.add("spa")
+
+    for slug, types in maps._DIRECTORY_CATEGORY_TYPES.items():
+        for place_type in types:
+            assert place_type in known, f"{slug} invents the type {place_type}"
+
+
+# --------------------------------------------------------------------------- #
+# Category resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_categories_are_dropped_not_fatal() -> None:
+    """A client one release ahead should get the nine we have, not an error."""
+
+    resolved = places_routes._resolve_categories(["hotels_stays", "teleportation"])
+
+    assert resolved == ["hotels_stays"]
+
+
+def test_categories_come_back_in_the_tables_order_not_the_requests() -> None:
+    resolved = places_routes._resolve_categories(["outdoors", "hotels_stays", "banking"])
+
+    assert resolved == ["hotels_stays", "banking", "outdoors"]
+
+
+def test_duplicate_categories_collapse() -> None:
+    """Two of the same slug would otherwise be two provider calls."""
+
+    assert places_routes._resolve_categories(["banking", "banking"]) == ["banking"]
+
+
+# --------------------------------------------------------------------------- #
+# Streaming
+# --------------------------------------------------------------------------- #
+
+
+class _NeverDisconnected:
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+def _frames(chunks: list[bytes]) -> list[dict]:
+    parsed = []
+    for chunk in chunks:
+        for block in chunk.decode().split("\n\n"):
+            if not block.strip():
+                continue
+            data = block.split("data: ", 1)[1]
+            parsed.append(json.loads(data))
+    return parsed
+
+
+async def _collect(monkeypatch, behaviour) -> list[dict]:
+    monkeypatch.setattr(
+        maps.GoogleMapsService,
+        "search_directory_category",
+        behaviour,
+        raising=True,
+    )
+    chunks = [
+        chunk
+        async for chunk in places_routes._stream_categories(
+            request=_NeverDisconnected(),
+            lat=12.9716,
+            lng=77.5946,
+            categories=["hotels_stays", "food_drink"],
+            radius_meters=8046.72,
+            limit=8,
+            meta=places_routes._meta(
+                categories=["hotels_stays", "food_drink"], radius_mi=5.0, limit=8
+            ),
+        )
+    ]
+    return _frames(chunks)
+
+
+def test_each_category_is_its_own_frame(monkeypatch) -> None:
+    async def behaviour(self, *, lat, lng, category, radius_meters, limit):
+        return [{"placeId": f"{category}-1", "name": category}]
+
+    frames = asyncio.run(_collect(monkeypatch, behaviour))
+    events = [frame["event"] for frame in frames]
+
+    assert events[0] == "meta"
+    assert events[-1] == "done"
+    assert events.count("results") == 2
+
+
+def test_a_slow_category_does_not_hold_back_a_fast_one(monkeypatch) -> None:
+    """The whole point: results leave as they land, not after the slowest.
+
+    `asyncio.gather` would order these by the request list; emitting on
+    completion orders them by who answered first.
+    """
+
+    async def behaviour(self, *, lat, lng, category, radius_meters, limit):
+        if category == "hotels_stays":
+            await asyncio.sleep(0.05)
+        return [{"placeId": f"{category}-1", "name": category}]
+
+    frames = asyncio.run(_collect(monkeypatch, behaviour))
+    results = [frame["category"] for frame in frames if frame["event"] == "results"]
+
+    # food_drink was requested second and answered first.
+    assert results == ["food_drink", "hotels_stays"]
+
+
+def test_one_failing_category_does_not_empty_the_stream(monkeypatch) -> None:
+    async def behaviour(self, *, lat, lng, category, radius_meters, limit):
+        if category == "hotels_stays":
+            raise maps.GoogleMapsError("upstream said no", status_code=502)
+        return [{"placeId": "cafe-1", "name": "Third Wave"}]
+
+    frames = asyncio.run(_collect(monkeypatch, behaviour))
+    events = [frame["event"] for frame in frames]
+
+    assert "results" in events
+    assert "category_error" in events
+    # The stream still completes cleanly; a dead category is not a dead request.
+    assert frames[-1]["event"] == "done"
+    assert frames[-1]["failed"] == ["hotels_stays"]
+    assert frames[-1]["delivered"] == 1
+
+
+def test_an_unexpected_crash_is_contained_to_its_category(monkeypatch) -> None:
+    """A bug in one bucket must not take the other nine with it."""
+
+    async def behaviour(self, *, lat, lng, category, radius_meters, limit):
+        if category == "hotels_stays":
+            raise ValueError("something we did not anticipate")
+        return [{"placeId": "cafe-1", "name": "Third Wave"}]
+
+    frames = asyncio.run(_collect(monkeypatch, behaviour))
+
+    assert frames[-1]["event"] == "done"
+    assert frames[-1]["failed"] == ["hotels_stays"]
+    assert frames[-1]["delivered"] == 1
+
+
+def test_the_done_frame_is_terminal() -> None:
+    """Clients need one unambiguous end, not an inference from a closed socket."""
+
+    rendered = places_routes._frame("done", {"delivered": 0, "failed": [], "terminal": True})
+
+    assert json.loads(rendered.decode().split("data: ", 1)[1])["terminal"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Provider request shaping
+# --------------------------------------------------------------------------- #
+
+
+def test_radius_is_clamped_to_what_the_provider_accepts() -> None:
+    """Google rejects a radius above 50 km, so an over-wide ask must be bounded."""
+
+    assert maps._DIRECTORY_MAX_RADIUS_METERS == 50_000.0
+    # The route's own ceiling keeps a request from ever reaching that clamp.
+    assert places_routes._MAX_RADIUS_MI * places_routes._METERS_PER_MILE < 50_000.0
+
+
+def test_the_list_field_mask_stays_off_the_dearer_tiers() -> None:
+    """Rating, hours, phone and website are billed higher, and are per-row here.
+
+    They belong on the detail call, which happens once for the one place a
+    reader opened, not once per row of every category they scrolled past.
+    """
+
+    for expensive in (
+        "places.rating",
+        "places.regularOpeningHours",
+        "places.nationalPhoneNumber",
+        "places.websiteUri",
+        "places.priceLevel",
+    ):
+        assert expensive not in maps._DIRECTORY_LIST_FIELD_MASK
+
+
+def test_the_detail_mask_buys_what_the_sheet_actually_shows() -> None:
+    for needed in ("nationalPhoneNumber", "websiteUri", "regularOpeningHours"):
+        assert needed in maps._DIRECTORY_DETAIL_FIELD_MASK
+
+
+@pytest.mark.parametrize(
+    "place",
+    [
+        {"id": "", "displayName": {"text": "No id"}},
+        {"id": "x", "displayName": {"text": ""}},
+        {"id": "x", "displayName": {"text": "No location"}},
+        {"id": "x", "displayName": {"text": "Bad location"}, "location": {"latitude": "nope"}},
+    ],
+)
+def test_unusable_provider_rows_are_dropped(place: dict) -> None:
+    row = maps.GoogleMapsService()._normalize_directory_place(
+        place, lat=12.97, lng=77.59, category="shops"
+    )
+
+    assert row is None
+
+
+def test_a_geocoded_address_is_not_a_business() -> None:
+    """The unfiltered sweep can surface street addresses; a directory must not."""
+
+    row = maps.GoogleMapsService()._normalize_directory_place(
+        {
+            "id": "x",
+            "displayName": {"text": "12 Residency Rd"},
+            "location": {"latitude": 12.97, "longitude": 77.59},
+            "primaryType": "street_address",
+        },
+        lat=12.97,
+        lng=77.59,
+        category="shops",
+    )
+
+    assert row is None
+
+
+def test_a_normalized_row_carries_its_own_bucket_and_a_real_distance() -> None:
+    row = maps.GoogleMapsService()._normalize_directory_place(
+        {
+            "id": "place-1",
+            "displayName": {"text": "Hotel Vivanta"},
+            "shortFormattedAddress": "12 Residency Rd",
+            "location": {"latitude": 12.9800, "longitude": 77.5946},
+            "primaryType": "hotel",
+            "primaryTypeDisplayName": {"text": "Hotel"},
+            "businessStatus": "OPERATIONAL",
+        },
+        lat=12.9716,
+        lng=77.5946,
+        category="hotels_stays",
+    )
+
+    assert row is not None
+    assert row["category"] == "hotels_stays"
+    assert row["name"] == "Hotel Vivanta"
+    assert row["categoryLabel"] == "Hotel"
+    # ~930 m north; the exact figure matters less than it being computed at all.
+    assert 800 < row["distanceMeters"] < 1100

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -52,10 +52,13 @@ vi.mock("@/lib/cache/cache-sync-service", () => ({
   },
 }));
 
-// The Around-you tab has its own suite; keep its directory services out of this
-// render so a failure here can only mean the People tab.
-vi.mock("@/components/connect/advisors-nearby", () => ({
-  AdvisorsNearby: () => <div data-testid="advisors-nearby-stub" />,
+// The Around-you tab has its own suites; keep its directory services out of
+// this render so a failure here can only mean the People tab. Stubbing the
+// switch rather than one directory keeps that true as directories are added --
+// stubbing `advisors-nearby` alone stopped covering the tab the moment a second
+// and third directory hung off it.
+vi.mock("@/components/connect/nearby-directories", () => ({
+  NearbyDirectories: () => <div data-testid="nearby-directories-stub" />,
 }));
 
 vi.mock("sonner", () => ({

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -10,7 +10,7 @@ import {
   AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
-import { AdvisorsNearby } from "@/components/connect/advisors-nearby";
+import { NearbyDirectories } from "@/components/connect/nearby-directories";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { SurfaceStack } from "@/components/app-ui/surfaces";
@@ -526,7 +526,7 @@ export default function ConnectPageClient() {
       spokenSubject: tab === "nearby" ? "Connect, Around you tab" : "Connect, People tab",
       sections: [
         { id: "people", title: "People", purpose: "Search everyone you could connect with, and manage existing connections." },
-        { id: "nearby", title: "Around you", purpose: "Find advisors near your current location." },
+        { id: "nearby", title: "Around you", purpose: "Find verified advisors and insurance agents, and businesses, near your current location." },
       ],
       actions: [
         { id: "connect.open_people", actionId: "connect.open_people", label: "Open Connect people", purpose: "Show connections and the people directory." },
@@ -551,7 +551,9 @@ export default function ConnectPageClient() {
       activeSection: tab === "nearby" ? "Around you" : "People",
       activeTab: tab,
       visibleModules:
-        tab === "nearby" ? ["Advisors near you"] : ["Your connections", "People directory"],
+        tab === "nearby"
+          ? ["Advisors near you", "Insurance agents near you", "Places near you"]
+          : ["Your connections", "People directory"],
       focusedWidget: tab === "nearby" ? "Around you tab" : "People tab",
       availableActions: ["Open Connect people", "Open advisors around you", "Search for someone to connect with"],
       activeControlId: null,
@@ -619,7 +621,7 @@ export default function ConnectPageClient() {
             />
 
             {tab === "nearby" ? (
-              <AdvisorsNearby getIdToken={getIdToken} />
+              <NearbyDirectories getIdToken={getIdToken} />
             ) : (
               <div className="space-y-4 sm:space-y-5">
             <SettingsGroup

--- a/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
@@ -1,0 +1,408 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  streamNearby: vi.fn(),
+  searchNearby: vi.fn(),
+  getDetails: vi.fn(),
+  request: vi.fn(),
+  refresh: vi.fn(),
+  locationState: {
+    status: "idle" as string,
+    permission: null as string | null,
+    snapshot: null as { latitude: number; longitude: number } | null,
+    error: null as string | null,
+  },
+}));
+
+vi.mock("@/lib/one-location/use-current-location", () => ({
+  useCurrentLocation: () => ({
+    ...mocks.locationState,
+    request: mocks.request,
+    refresh: mocks.refresh,
+  }),
+}));
+
+vi.mock("@/lib/services/places-directory-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/services/places-directory-service")
+  >("@/lib/services/places-directory-service");
+  return {
+    ...actual,
+    PlacesDirectoryService: {
+      streamNearby: mocks.streamNearby,
+      searchNearby: mocks.searchNearby,
+      getDetails: mocks.getDetails,
+    },
+  };
+});
+
+import { PlacesNearby } from "@/components/connect/places-nearby";
+
+const ATTRIBUTION = {
+  source: "Google",
+  sourceUrl: "https://www.google.com/maps",
+  termsUrl: "https://cloud.google.com/maps-platform/terms",
+  notice: "Place data from Google Maps Platform.",
+  retrievedAt: "2026-08-10T09:00:00.000Z",
+};
+
+function place(overrides: Record<string, unknown> = {}) {
+  return {
+    placeId: "place-1",
+    name: "Hotel Vivanta",
+    address: "12 Residency Rd",
+    distanceMeters: 640,
+    primaryType: "hotel",
+    categoryLabel: "Hotel",
+    category: "hotels_stays",
+    businessStatus: "OPERATIONAL",
+    ...overrides,
+  };
+}
+
+/** Drives the component's handlers the way a real stream would. */
+function streamOf(
+  frames: { category: string; items: Record<string, unknown>[] }[],
+  options: { failures?: { category: string; message: string }[] } = {},
+) {
+  return async (opts: {
+    handlers: {
+      onMeta?: (m: unknown) => void;
+      onCategory: (c: string, i: unknown[]) => void;
+      onCategoryError?: (c: string, m: string) => void;
+    };
+  }) => {
+    opts.handlers.onMeta?.({ attribution: ATTRIBUTION });
+    for (const frame of frames) {
+      opts.handlers.onCategory(frame.category, frame.items);
+    }
+    for (const failure of options.failures ?? []) {
+      opts.handlers.onCategoryError?.(failure.category, failure.message);
+    }
+  };
+}
+
+const getIdToken = async () => "id-token";
+
+const LOCATED = {
+  status: "ready",
+  permission: "granted",
+  snapshot: { latitude: 12.9716, longitude: 77.5946 },
+  error: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.locationState = {
+    status: "idle",
+    permission: null,
+    snapshot: null,
+    error: null,
+  };
+  mocks.streamNearby.mockImplementation(
+    streamOf([{ category: "hotels_stays", items: [place()] }]),
+  );
+  mocks.getDetails.mockResolvedValue({
+    placeId: "place-1",
+    name: "Hotel Vivanta",
+    address: "12 Residency Rd, Bengaluru",
+    categoryLabel: "Hotel",
+    phone: "080 6660 5660",
+    website: "https://example.com",
+    mapsUrl: "https://maps.google.com/?cid=1",
+    businessStatus: "OPERATIONAL",
+    weekdayDescriptions: ["Monday: Open 24 hours"],
+  });
+});
+
+describe("PlacesNearby", () => {
+  it("asks for location before touching the directory", () => {
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    expect(screen.getByTestId("places-location-prompt")).toBeTruthy();
+    expect(mocks.streamNearby).not.toHaveBeenCalled();
+  });
+
+  it("prompts the device only on the user's tap", () => {
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    expect(mocks.request).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("places-use-location"));
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches from the shared snapshot once one exists", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalled());
+    expect(mocks.streamNearby.mock.calls[0][0]).toMatchObject({
+      origin: { latitude: 12.9716, longitude: 77.5946 },
+      radiusMi: 5,
+    });
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+  });
+
+  it("asks for every category in one sweep, not one call per chip", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalled());
+
+    expect(mocks.streamNearby.mock.calls[0][0].categories).toHaveLength(10);
+
+    // Moving along the rail must not re-spend a provider call.
+    fireEvent.click(screen.getByTestId("places-chip-food_drink"));
+    fireEvent.click(screen.getByTestId("places-chip-hotels_stays"));
+    expect(mocks.streamNearby).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows rows before the sweep has finished", async () => {
+    mocks.locationState = LOCATED;
+    let release: (() => void) | null = null;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    mocks.streamNearby.mockImplementation(async (opts: never) => {
+      const handlers = (opts as { handlers: { onCategory: (c: string, i: unknown[]) => void } })
+        .handlers;
+      handlers.onCategory("hotels_stays", [place()]);
+      // The sweep is still open: later categories have not answered.
+      await held;
+      handlers.onCategory("food_drink", [
+        place({ placeId: "place-2", name: "Third Wave Coffee", category: "food_drink" }),
+      ]);
+    });
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    // This is the whole point of the stream: readable rows while it runs.
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    expect(screen.getByTestId("places-streaming")).toBeTruthy();
+    expect(screen.queryByText("Third Wave Coffee")).toBeNull();
+
+    release?.();
+    await waitFor(() =>
+      expect(screen.getByText("Third Wave Coffee")).toBeTruthy(),
+    );
+    await waitFor(() => expect(screen.queryByTestId("places-streaming")).toBeNull());
+  });
+
+  it("keeps the categories that worked when one of them fails", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(
+      streamOf([{ category: "hotels_stays", items: [place()] }], {
+        failures: [{ category: "transit", message: "This category is unavailable." }],
+      }),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    // One dead category is not a dead directory.
+    expect(screen.queryByTestId("places-error")).toBeNull();
+  });
+
+  it("falls back to one response when the stream cannot run", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockRejectedValue(new Error("No response stream available"));
+    mocks.searchNearby.mockResolvedValue({
+      groups: [{ category: "hotels_stays", items: [place()] }],
+      failed: [],
+      meta: { categories: [], radiusMi: 5, limit: 8, attribution: ATTRIBUTION },
+    });
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalled());
+    // Same rows, same surface. The reader is never shown a transport problem.
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    expect(screen.queryByTestId("places-error")).toBeNull();
+  });
+
+  it("offers a ZIP search when the device says no", async () => {
+    mocks.locationState = {
+      status: "denied",
+      permission: "denied",
+      snapshot: null,
+      error: null,
+    };
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    const input = screen.getByTestId("places-postal-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "560001" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalled());
+    expect(mocks.streamNearby.mock.calls[0][0].origin).toEqual({
+      postalCode: "560001",
+    });
+  });
+
+  it("offers a ZIP when the coordinates are fine but match nothing", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(streamOf([]));
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByTestId("places-empty")).toBeTruthy());
+    // An empty answer is not an error, and the way out stays on screen.
+    expect(screen.queryByTestId("places-error")).toBeNull();
+    expect(screen.getByTestId("places-postal-input")).toBeTruthy();
+  });
+
+  it("keeps the radius control usable when nothing came back", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(streamOf([]));
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByTestId("places-empty")).toBeTruthy());
+    // Widening is the one thing that can fix an empty result.
+    expect(screen.getByText("15 mi")).toBeTruthy();
+  });
+
+  it("re-sweeps when the radius changes", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("15 mi"));
+
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.streamNearby.mock.calls[1][0].radiusMi).toBe(15);
+  });
+
+  it("lets the user retry a failure instead of stranding them", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockRejectedValue(new Error("Places are unavailable right now."));
+    mocks.searchNearby.mockRejectedValue(
+      new Error("Places are unavailable right now."),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByTestId("places-error")).toBeTruthy());
+    // A failed sweep must still offer the ZIP box: "Try again" only re-runs the
+    // anchor that just failed, which strands anyone whose ZIP was the problem.
+    expect(screen.getByTestId("places-postal-input")).toBeTruthy();
+
+    mocks.streamNearby.mockImplementation(
+      streamOf([{ category: "hotels_stays", items: [place()] }]),
+    );
+    fireEvent.click(screen.getByText("Try again"));
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+  });
+
+  it("carries the source credit the licence requires", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("places-attribution")).toBeTruthy(),
+    );
+    const footer = screen.getByTestId("places-attribution");
+    expect(footer.textContent).toContain("Google");
+    expect(footer.querySelector('a[href*="cloud.google.com/maps-platform/terms"]')).toBeTruthy();
+  });
+
+  it("does not credit a source it showed nothing from", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(streamOf([]));
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByTestId("places-empty")).toBeTruthy());
+    expect(screen.queryByTestId("places-attribution")).toBeNull();
+  });
+
+  it("shows one row per place when two categories both return it", async () => {
+    mocks.locationState = LOCATED;
+    const shared = place({ placeId: "shared-1", name: "Phoenix Mall" });
+    mocks.streamNearby.mockImplementation(
+      streamOf([
+        { category: "shops", items: [shared] },
+        { category: "banking", items: [shared] },
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getAllByText("Phoenix Mall")).toHaveLength(1));
+  });
+
+  it("orders the merged view by distance, not by which category answered first", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(
+      streamOf([
+        { category: "hotels_stays", items: [place({ placeId: "far", name: "Far Hotel", distanceMeters: 4000 })] },
+        { category: "food_drink", items: [place({ placeId: "near", name: "Near Cafe", distanceMeters: 200, category: "food_drink" })] },
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByText("Near Cafe")).toBeTruthy());
+    const rendered = screen.getByTestId("places-nearby").textContent ?? "";
+    expect(rendered.indexOf("Near Cafe")).toBeLessThan(rendered.indexOf("Far Hotel"));
+  });
+
+  it("filters to one category without asking the server again", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(
+      streamOf([
+        { category: "hotels_stays", items: [place()] },
+        {
+          category: "food_drink",
+          items: [place({ placeId: "place-2", name: "Third Wave Coffee", category: "food_drink" })],
+        },
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(screen.getByText("Third Wave Coffee")).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId("places-chip-hotels_stays"));
+
+    await waitFor(() => expect(screen.queryByText("Third Wave Coffee")).toBeNull());
+    expect(screen.getByText("Hotel Vivanta")).toBeTruthy();
+    expect(mocks.streamNearby).toHaveBeenCalledTimes(1);
+  });
+
+  it("buys the dearer detail fields only when a row is opened", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+
+    expect(mocks.getDetails).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Hotel Vivanta"));
+
+    await waitFor(() => expect(mocks.getDetails).toHaveBeenCalledTimes(1));
+    expect(mocks.getDetails.mock.calls[0][0]).toMatchObject({ placeId: "place-1" });
+  });
+
+  it("shows posted hours and never claims 'open now'", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    fireEvent.click(screen.getByText("Hotel Vivanta"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("place-detail-hours")).toBeTruthy(),
+    );
+    expect(screen.getByText("Monday: Open 24 hours")).toBeTruthy();
+    const surface = screen.getByTestId("place-detail-hours").textContent ?? "";
+    expect(surface.toLowerCase()).not.toContain("open now");
+  });
+
+  it("keeps the surface open when the detail fetch fails", async () => {
+    mocks.locationState = LOCATED;
+    mocks.getDetails.mockRejectedValue(new Error("nope"));
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    fireEvent.click(screen.getByText("Hotel Vivanta"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("place-detail-partial")).toBeTruthy(),
+    );
+    // The row's own facts are still shown rather than an error page.
+    expect(screen.getAllByText(/Hotel Vivanta/).length).toBeGreaterThan(0);
+  });
+});

--- a/hushh-webapp/components/connect/nearby-directories.tsx
+++ b/hushh-webapp/components/connect/nearby-directories.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import { AdvisorsNearby } from "@/components/connect/advisors-nearby";
+import { InsuranceAgentsNearby } from "@/components/connect/insurance-agents-nearby";
+import { PlacesNearby } from "@/components/connect/places-nearby";
+import { SegmentedTabs } from "@/lib/morphy-ux/ui";
+
+type NearbyDirectory = "advisors" | "insurance" | "places";
+
+const DIRECTORY_TABS = [
+  { value: "advisors", label: "Advisors" },
+  { value: "insurance", label: "Insurance" },
+  { value: "places", label: "Places" },
+];
+
+/**
+ * Everything the "Around you" tab can show, and the switch between them.
+ *
+ * Two kinds of answer live here and the order says which is which. Advisors and
+ * insurance are looked up against registries — FINRA BrokerCheck and the
+ * Nationwide locator — where the useful thing is that the row is verifiable.
+ * Places comes from a general provider, where the useful thing is only that it
+ * is close. Keeping the registry-backed pair first, and default, means the tab
+ * still opens on a verifiable answer rather than on a list of coffee shops.
+ *
+ * `advisors` is the default because it is what this tab already did. Someone
+ * who opens Connect and taps "Around you" sees exactly what they saw before
+ * this component existed; the other two are a segment away, not in the way.
+ *
+ * Each directory owns its own fetching, so switching costs one request for the
+ * directory you switched to and nothing for the two you did not.
+ */
+export function NearbyDirectories({
+  getIdToken,
+}: {
+  getIdToken: () => Promise<string | null>;
+}) {
+  const [directory, setDirectory] = useState<NearbyDirectory>("advisors");
+
+  return (
+    <div className="space-y-4" data-testid="nearby-directories">
+      <SegmentedTabs
+        value={directory}
+        onValueChange={(value) => setDirectory(value as NearbyDirectory)}
+        options={DIRECTORY_TABS}
+      />
+
+      {directory === "places" ? (
+        <PlacesNearby getIdToken={getIdToken} />
+      ) : directory === "insurance" ? (
+        <InsuranceAgentsNearby getIdToken={getIdToken} />
+      ) : (
+        <AdvisorsNearby getIdToken={getIdToken} />
+      )}
+    </div>
+  );
+}

--- a/hushh-webapp/components/connect/nearby-directory-ui.tsx
+++ b/hushh-webapp/components/connect/nearby-directory-ui.tsx
@@ -14,11 +14,12 @@ import { Button } from "@/lib/morphy-ux/button";
 /**
  * The presentational parts every "near you" directory shares.
  *
- * Two directories now hang off the Connect tab — advisers from BrokerCheck and
- * insurance agencies from the Nationwide locator — and they ask the reader for
- * exactly the same things: permission to use location, a ZIP when that fails,
- * a way out of an empty result, and the source credit. Only the copy and the
- * test ids differ, so those are props and the behaviour is written once.
+ * Three directories now hang off the Connect tab — advisers from BrokerCheck,
+ * insurance agencies from the Nationwide locator, and businesses from Google
+ * Places — and they ask the reader for exactly the same things: permission to
+ * use location, a ZIP when that fails, a way out of an empty result, and the
+ * source credit. Only the copy and the test ids differ, so those are props and
+ * the behaviour is written once.
  *
  * `testId` is threaded through rather than derived so each directory keeps its
  * own stable hooks; a shared "directory-empty" would make a failing test

--- a/hushh-webapp/components/connect/place-detail-surface.tsx
+++ b/hushh-webapp/components/connect/place-detail-surface.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/lib/morphy-ux/button";
+import {
+  PlacesDirectoryService,
+  formatPlaceDistance,
+  type PlaceCard,
+  type PlaceDetails,
+} from "@/lib/services/places-directory-service";
+import { usTelHref } from "@/lib/services/us-tel-href";
+
+/**
+ * One place, opened from the nearby list.
+ *
+ * The row already carries name, category and distance. Phone, website and
+ * posted hours sit in a dearer billing tier at the provider, so they are bought
+ * here — once, for the one place a reader opened — rather than for every row of
+ * every category they scrolled past.
+ *
+ * A failed fetch leaves the surface open showing what the row already knew. The
+ * reader asked to see this place; answering with an error page when we still
+ * hold its name and address would be worse than answering with less.
+ */
+export function PlaceDetailSurface({
+  card,
+  open,
+  onOpenChange,
+  getIdToken,
+}: {
+  card: PlaceCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  getIdToken: () => Promise<string | null>;
+}) {
+  const [details, setDetails] = useState<PlaceDetails | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const placeId = card?.placeId ?? null;
+
+  useEffect(() => {
+    if (!open || !placeId) return;
+    const controller = new AbortController();
+    let cancelled = false;
+
+    setDetails(null);
+    setFailed(false);
+    setLoading(true);
+
+    void (async () => {
+      try {
+        const idToken = await getIdToken();
+        if (!idToken || cancelled) return;
+        const next = await PlacesDirectoryService.getDetails({
+          idToken,
+          placeId,
+          signal: controller.signal,
+        });
+        if (!cancelled) setDetails(next);
+      } catch {
+        if (cancelled || controller.signal.aborted) return;
+        setFailed(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [getIdToken, open, placeId]);
+
+  if (!card) return null;
+
+  const distance = formatPlaceDistance(card.distanceMeters);
+  const address = details?.address ?? card.address;
+  const eyebrow =
+    [details?.categoryLabel ?? card.categoryLabel, distance]
+      .filter(Boolean)
+      .join(" · ") || undefined;
+
+  return (
+    <AdaptiveDetailSurface
+      open={open}
+      onOpenChange={onOpenChange}
+      eyebrow={eyebrow}
+      title={details?.name ?? card.name}
+      mobilePresentation="sheet"
+      footer={
+        details?.phone ? (
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="lg"
+            fullWidth
+            asChild
+          >
+            <a href={usTelHref(details.phone)}>Call</a>
+          </Button>
+        ) : undefined
+      }
+    >
+      <div className="space-y-7">
+        {address ? (
+          <p className="type-callout text-muted-foreground">{address}</p>
+        ) : null}
+
+        {loading ? (
+          <div className="space-y-3" data-testid="place-detail-loading">
+            <Skeleton className="h-4 w-2/3 rounded-lg" />
+            <Skeleton className="h-4 w-1/2 rounded-lg" />
+          </div>
+        ) : null}
+
+        {details?.weekdayDescriptions.length ? (
+          // Posted hours, never "open now": Google's live verdict is a claim we
+          // would be repeating without being able to stand behind it.
+          <div className="space-y-1" data-testid="place-detail-hours">
+            {details.weekdayDescriptions.map((line) => (
+              <p key={line} className="type-callout text-muted-foreground">
+                {line}
+              </p>
+            ))}
+          </div>
+        ) : null}
+
+        {details?.website ? (
+          <a
+            href={details.website}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="type-callout block text-[color:var(--app-accent)] underline-offset-4 hover:underline"
+          >
+            Visit website
+          </a>
+        ) : null}
+
+        {details?.mapsUrl ? (
+          <a
+            href={details.mapsUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="type-callout block text-[color:var(--app-accent)] underline-offset-4 hover:underline"
+          >
+            Open in Google Maps
+          </a>
+        ) : null}
+
+        {failed ? (
+          <p
+            className="type-footnote text-muted-foreground"
+            role="status"
+            data-testid="place-detail-partial"
+          >
+            Could not load more details.
+          </p>
+        ) : null}
+      </div>
+    </AdaptiveDetailSurface>
+  );
+}

--- a/hushh-webapp/components/connect/places-nearby.tsx
+++ b/hushh-webapp/components/connect/places-nearby.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import {
+  DirectoryAttributionFooter,
+  DirectoryLoadingRows,
+  LocationPrompt,
+  PostalCodeForm,
+  QuietBlock,
+} from "@/components/connect/nearby-directory-ui";
+import { PlaceDetailSurface } from "@/components/connect/place-detail-surface";
+import { Button } from "@/lib/morphy-ux/button";
+import { cn } from "@/lib/morphy-ux/cn";
+import { SegmentedTabs } from "@/lib/morphy-ux/ui";
+import { useCurrentLocation } from "@/lib/one-location/use-current-location";
+import {
+  PLACES_CATEGORIES,
+  PLACES_RADIUS_OPTIONS_MI,
+  PlacesDirectoryService,
+  formatPlaceDistance,
+  formatPlaceSubtitle,
+  placesCategoryLabel,
+  type PlaceCard,
+  type PlacesAttribution,
+} from "@/lib/services/places-directory-service";
+
+type Anchor =
+  | { kind: "coords"; latitude: number; longitude: number }
+  | { kind: "postal"; postalCode: string };
+
+const RADIUS_OPTIONS = PLACES_RADIUS_OPTIONS_MI.map((miles) => ({
+  value: String(miles),
+  label: `${miles} mi`,
+}));
+
+const ALL_CHIP = "all";
+
+/** Enough of each bucket to be useful in the merged view without being a list. */
+const OVERVIEW_LIMIT = 8;
+
+const CATEGORY_SLUGS = PLACES_CATEGORIES.map((entry) => entry.slug);
+
+/**
+ * "Places near you" — the ten business categories around the account's position.
+ *
+ * Position comes from the shared location bus, exactly as the adviser and
+ * insurance directories do, so opening this never re-prompts a reader who
+ * already granted location on either of them.
+ *
+ * One sweep populates every category and the chips filter what already arrived,
+ * so moving along the rail costs nothing. That is the same bargain the check-in
+ * picker strikes, and for the same reason: a per-chip fetch would re-spend a
+ * provider call to show rows we already hold.
+ *
+ * The sweep is streamed. Ten categories are ten provider calls on the backend,
+ * and it emits each as it returns rather than gathering them, so the first rows
+ * land roughly a round trip after the tap instead of after the slowest call. If
+ * the stream cannot run — a buffering intermediary, a runtime with no
+ * `ReadableStream` — the same render path is fed by one ordinary response.
+ */
+export function PlacesNearby({
+  getIdToken,
+}: {
+  getIdToken: () => Promise<string | null>;
+}) {
+  const location = useCurrentLocation();
+
+  const [anchor, setAnchor] = useState<Anchor | null>(null);
+  const [radiusMi, setRadiusMi] = useState<number>(5);
+  const [byCategory, setByCategory] = useState<Record<string, PlaceCard[]>>({});
+  const [attribution, setAttribution] = useState<PlacesAttribution | null>(null);
+  const [chip, setChip] = useState<string>(ALL_CHIP);
+  /** True from the tap until the last category has answered. */
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<PlaceCard | null>(null);
+
+  const requestRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!location.snapshot) return;
+    setAnchor((current) =>
+      current?.kind === "postal"
+        ? current
+        : {
+            kind: "coords",
+            latitude: location.snapshot!.latitude,
+            longitude: location.snapshot!.longitude,
+          },
+    );
+  }, [location.snapshot]);
+
+  const runSweep = useCallback(
+    async (target: Anchor, miles: number) => {
+      // A reader who changed radius must not have the previous sweep's rows
+      // arrive on top of the new one's.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const token = ++requestRef.current;
+      setStreaming(true);
+      setError(null);
+      setByCategory({});
+      setAttribution(null);
+
+      const origin =
+        target.kind === "coords"
+          ? { latitude: target.latitude, longitude: target.longitude }
+          : { postalCode: target.postalCode };
+
+      const accept = (category: string, items: PlaceCard[]) => {
+        // A slower earlier sweep must never write into a newer one.
+        if (token !== requestRef.current) return;
+        setByCategory((current) => ({ ...current, [category]: items }));
+      };
+
+      try {
+        const idToken = await getIdToken();
+        if (!idToken) throw new Error("Sign in to see places nearby.");
+
+        const shared = {
+          idToken,
+          origin,
+          categories: CATEGORY_SLUGS,
+          radiusMi: miles,
+          limit: OVERVIEW_LIMIT,
+          signal: controller.signal,
+        };
+
+        try {
+          await PlacesDirectoryService.streamNearby({
+            ...shared,
+            handlers: {
+              onMeta: (meta) => {
+                if (token !== requestRef.current) return;
+                setAttribution(meta.attribution ?? null);
+              },
+              onCategory: accept,
+              // A single category failing is not a failed directory. The others
+              // are still a better answer than an error page, so this is
+              // swallowed on purpose rather than surfaced as the page's error.
+              onCategoryError: () => undefined,
+            },
+          });
+        } catch (streamFailure) {
+          if (controller.signal.aborted) return;
+          if (
+            streamFailure instanceof DOMException &&
+            streamFailure.name === "AbortError"
+          ) {
+            return;
+          }
+          // The stream could not run here. Ask the same question the ordinary
+          // way rather than showing the reader a transport problem.
+          const fallback = await PlacesDirectoryService.searchNearby(shared);
+          if (token !== requestRef.current) return;
+          setAttribution(fallback.meta?.attribution ?? null);
+          for (const group of fallback.groups) {
+            accept(group.category, group.items);
+          }
+        }
+      } catch (caught) {
+        if (controller.signal.aborted) return;
+        if (token !== requestRef.current) return;
+        if (caught instanceof DOMException && caught.name === "AbortError") return;
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Places are unavailable right now.",
+        );
+      } finally {
+        if (token === requestRef.current) setStreaming(false);
+      }
+    },
+    [getIdToken],
+  );
+
+  useEffect(() => {
+    if (!anchor) return;
+    void runSweep(anchor, radiusMi);
+  }, [anchor, radiusMi, runSweep]);
+
+  // Abort whatever is in flight if the reader leaves the tab entirely.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const handleUseLocation = useCallback(() => {
+    void location.request();
+  }, [location]);
+
+  const handlePostalCode = useCallback((postalCode: string) => {
+    setAnchor({ kind: "postal", postalCode });
+  }, []);
+
+  const visible = useMemo(() => {
+    if (chip !== ALL_CHIP) return byCategory[chip] ?? [];
+    // The merged view is nearest-first across every bucket that has answered,
+    // de-duplicated: a bank inside a shopping centre can legitimately arrive in
+    // two categories and should still be one row.
+    const seen = new Set<string>();
+    const merged: PlaceCard[] = [];
+    for (const slug of CATEGORY_SLUGS) {
+      for (const card of byCategory[slug] ?? []) {
+        if (seen.has(card.placeId)) continue;
+        seen.add(card.placeId);
+        merged.push(card);
+      }
+    }
+    return merged.sort((a, b) => a.distanceMeters - b.distanceMeters);
+  }, [byCategory, chip]);
+
+  const answered = Object.keys(byCategory).length;
+
+  if (!anchor) {
+    return (
+      <LocationPrompt
+        denied={
+          location.status === "denied" || location.status === "unavailable"
+        }
+        busy={location.status === "locating"}
+        heading="Places near you"
+        onUseLocation={handleUseLocation}
+        onSearchPostalCode={handlePostalCode}
+        testId="places-location-prompt"
+        useLocationTestId="places-use-location"
+        postalInputTestId="places-postal-input"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="places-nearby">
+      <SegmentedTabs
+        value={String(radiusMi)}
+        onValueChange={(value) => setRadiusMi(Number(value))}
+        options={RADIUS_OPTIONS}
+        disabled={streaming && answered === 0}
+      />
+
+      {/* A rail rather than a segmented control: eleven segments would each be
+          too narrow to read, and the rail is the pattern the check-in picker
+          already uses for the same set of ideas. */}
+      <div
+        className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="tablist"
+        aria-label="Place categories"
+        data-testid="places-category-rail"
+      >
+        {[{ slug: ALL_CHIP, label: "All" }, ...PLACES_CATEGORIES].map((entry) => {
+          const active = chip === entry.slug;
+          const count =
+            entry.slug === ALL_CHIP ? undefined : byCategory[entry.slug]?.length;
+          return (
+            <button
+              key={entry.slug}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setChip(entry.slug)}
+              data-testid={`places-chip-${entry.slug}`}
+              className={cn(
+                "type-footnote shrink-0 rounded-full border px-3 py-1.5 transition-colors",
+                active
+                  ? "border-transparent bg-foreground text-background"
+                  : "border-border text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {entry.label}
+              {typeof count === "number" && count > 0 ? (
+                <span className="ml-1.5 tabular-nums opacity-60">{count}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {error ? (
+        <QuietBlock
+          title={error}
+          subtitle="Try again, or search a different ZIP."
+          testId="places-error"
+        >
+          <div className="flex w-full flex-col items-center gap-4">
+            <Button
+              type="button"
+              variant="none"
+              effect="fill"
+              size="lg"
+              onClick={() => void runSweep(anchor, radiusMi)}
+            >
+              Try again
+            </Button>
+            <PostalCodeForm
+              busy={streaming}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="places-postal-input"
+            />
+          </div>
+        </QuietBlock>
+      ) : null}
+
+      {!error && !streaming && visible.length === 0 ? (
+        // Coordinates can be perfectly good and still match nothing — a radius
+        // of one mile in open country is an honest empty. Offer the two things
+        // that help: a wider radius above, and a different place to look.
+        <QuietBlock
+          title="Nothing nearby"
+          subtitle="Try a wider radius, or another ZIP."
+          testId="places-empty"
+        >
+          <PostalCodeForm
+            busy={streaming}
+            initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+            onSearch={handlePostalCode}
+            testId="places-postal-input"
+          />
+        </QuietBlock>
+      ) : null}
+
+      {error || (!streaming && visible.length === 0) ? null : (
+        <SettingsGroup
+          title={chip === ALL_CHIP ? "Nearby" : placesCategoryLabel(chip)}
+          separatorInset
+        >
+          {visible.length === 0 ? (
+            <DirectoryLoadingRows testId="places-loading" />
+          ) : (
+            visible.map((card) => {
+              const distance = formatPlaceDistance(card.distanceMeters);
+              return (
+                <SettingsRow
+                  key={card.placeId}
+                  title={<span className="truncate">{card.name}</span>}
+                  description={formatPlaceSubtitle(card) ?? undefined}
+                  density="compact"
+                  chevron
+                  onClick={() => setSelected(card)}
+                  trailing={
+                    distance ? (
+                      <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
+                        {distance}
+                      </span>
+                    ) : undefined
+                  }
+                />
+              );
+            })
+          )}
+        </SettingsGroup>
+      )}
+
+      {/* The visible proof that this is a stream: rows are already readable
+          while later categories are still arriving. */}
+      {streaming && visible.length > 0 ? (
+        <p
+          className="type-footnote text-center text-muted-foreground"
+          role="status"
+          data-testid="places-streaming"
+        >
+          Finding more nearby…
+        </p>
+      ) : null}
+
+      {visible.length > 0 ? (
+        <DirectoryAttributionFooter
+          attribution={attribution}
+          stale={false}
+          testId="places-attribution"
+        />
+      ) : null}
+
+      <PlaceDetailSurface
+        card={selected}
+        open={Boolean(selected)}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+        getIdToken={getIdToken}
+      />
+    </div>
+  );
+}

--- a/hushh-webapp/lib/services/places-directory-service.ts
+++ b/hushh-webapp/lib/services/places-directory-service.ts
@@ -1,0 +1,338 @@
+/**
+ * Places directory client — businesses near a point, sourced from Google Places
+ * through our own backend.
+ *
+ * The Maps key is server-side only, so every call here goes to `/api/one/places/*`.
+ *
+ * The read path is a stream. Each category is one provider call on the backend,
+ * and the backend emits each as it lands rather than gathering them, so the
+ * first rows reach the screen without waiting for the slowest category. When a
+ * stream cannot be established — a buffering intermediary, a runtime without
+ * `ReadableStream` — `searchNearby` answers the same question in one response
+ * and the UI renders the identical shapes. Callers should not care which ran.
+ */
+
+import { ApiService } from "@/lib/services/api-service";
+import { parseSSEBlocks } from "@/lib/streaming/sse-parser";
+
+export type PlaceCard = {
+  placeId: string;
+  name: string;
+  address: string | null;
+  distanceMeters: number;
+  primaryType: string | null;
+  /** Google's own label for the type, e.g. "Coffee shop". */
+  categoryLabel: string | null;
+  /** Our directory bucket, e.g. "hotels_stays". */
+  category: string;
+  businessStatus: string | null;
+};
+
+export type PlacesAttribution = {
+  source: string;
+  sourceUrl: string;
+  termsUrl?: string | null;
+  notice: string;
+  retrievedAt: string;
+};
+
+export type PlacesMeta = {
+  categories: string[];
+  radiusMi: number;
+  limit: number;
+  attribution: PlacesAttribution;
+};
+
+export type PlaceDetails = {
+  placeId: string;
+  name: string | null;
+  address: string | null;
+  categoryLabel: string | null;
+  phone: string | null;
+  website: string | null;
+  mapsUrl: string | null;
+  businessStatus: string | null;
+  /** Posted hours only. Never a live "open now" claim. */
+  weekdayDescriptions: string[];
+};
+
+export type PlacesCategoryDefinition = {
+  slug: string;
+  label: string;
+};
+
+/**
+ * The ten buckets, in the order the chip rail shows them.
+ *
+ * Ordered by how much of One's own consented memory could eventually rank the
+ * list, not by footfall — travel and food memory already exist as PKM domains,
+ * so those lead. The slugs must match `_DIRECTORY_CATEGORY_TYPES` on the
+ * backend; a slug this file invents would simply be dropped there.
+ */
+export const PLACES_CATEGORIES: readonly PlacesCategoryDefinition[] = [
+  { slug: "hotels_stays", label: "Hotels" },
+  { slug: "food_drink", label: "Food & drink" },
+  { slug: "health", label: "Health" },
+  { slug: "banking", label: "Banking" },
+  { slug: "shops", label: "Shops" },
+  { slug: "fitness_beauty", label: "Fitness & beauty" },
+  { slug: "auto", label: "Auto" },
+  { slug: "transit", label: "Transit" },
+  { slug: "education", label: "Education" },
+  { slug: "outdoors", label: "Outdoors" },
+] as const;
+
+export const PLACES_RADIUS_OPTIONS_MI = [1, 5, 15] as const;
+export const PLACES_RESULT_LIMIT = 20;
+
+type Origin =
+  | { latitude: number; longitude: number; postalCode?: undefined }
+  | { postalCode: string; latitude?: undefined; longitude?: undefined };
+
+export type PlacesStreamHandlers = {
+  onMeta?: (meta: PlacesMeta) => void;
+  /** One category's rows arrived. Called once per category, as each lands. */
+  onCategory: (category: string, items: PlaceCard[]) => void;
+  /** One category failed. The rest of the stream continues. */
+  onCategoryError?: (category: string, message: string) => void;
+};
+
+function authHeaders(idToken: string): HeadersInit {
+  return { Authorization: `Bearer ${idToken}` };
+}
+
+/**
+ * POST, not GET: a query string puts the reader's exact position in the request
+ * line, which the server access log records verbatim and which also lands in
+ * browser history and any Referer header. This is also why the stream is not an
+ * `EventSource` — that is GET-only and cannot carry an Authorization header.
+ */
+function searchBody(opts: {
+  origin: Origin;
+  categories: string[];
+  radiusMi: number;
+  limit?: number;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    categories: opts.categories,
+    radiusMi: opts.radiusMi,
+    limit: opts.limit ?? PLACES_RESULT_LIMIT,
+  };
+  if (
+    typeof opts.origin.latitude === "number" &&
+    typeof opts.origin.longitude === "number"
+  ) {
+    body.lat = Number(opts.origin.latitude.toFixed(6));
+    body.lng = Number(opts.origin.longitude.toFixed(6));
+  } else if (opts.origin.postalCode) {
+    body.postalCode = opts.origin.postalCode;
+  }
+  return body;
+}
+
+async function jsonOrThrow<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  if (!response.ok) {
+    throw new Error(messageForStatus(response.status, payload));
+  }
+  return payload as T;
+}
+
+function messageForStatus(
+  status: number,
+  payload: Record<string, unknown>,
+): string {
+  // 503 means this deployment has no Maps key, and 404 means the surface is not
+  // switched on here. Both are our plumbing, not the reader's problem.
+  if (status === 503 || status === 404) return "Not available yet.";
+  const detail = payload?.detail as { message?: string } | string | undefined;
+  const message =
+    (typeof detail === "object" ? detail?.message : detail) ||
+    (payload?.error as string | undefined);
+  return message || "Places are unavailable right now.";
+}
+
+function isPlaceCardArray(value: unknown): value is PlaceCard[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as PlaceCard).placeId === "string" &&
+        typeof (item as PlaceCard).name === "string",
+    )
+  );
+}
+
+export class PlacesDirectoryService {
+  /**
+   * Stream the categories, invoking handlers as each one lands.
+   *
+   * Resolves when the stream completes. Throws on a transport failure so the
+   * caller can fall back to `searchNearby`; a category that fails on its own is
+   * reported through `onCategoryError` and does not reject, because one dead
+   * category is not a dead directory.
+   */
+  static async streamNearby(opts: {
+    idToken: string;
+    origin: Origin;
+    categories: string[];
+    radiusMi: number;
+    limit?: number;
+    signal?: AbortSignal;
+    handlers: PlacesStreamHandlers;
+  }): Promise<void> {
+    const response = await ApiService.apiFetchStream("/api/one/places/stream", {
+      method: "POST",
+      headers: {
+        ...authHeaders(opts.idToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(searchBody(opts)),
+      signal: opts.signal,
+    });
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+      throw new Error(messageForStatus(response.status, payload));
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      // No streaming in this runtime. The caller's fallback handles it.
+      throw new Error("No response stream available");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        if (opts.signal?.aborted) {
+          throw new DOMException("Aborted", "AbortError");
+        }
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const parsed = parseSSEBlocks(
+          decoder.decode(value, { stream: true }),
+          buffer,
+        );
+        buffer = parsed.remainder;
+
+        for (const frame of parsed.events) {
+          let raw: Record<string, unknown>;
+          try {
+            raw = JSON.parse(frame.data) as Record<string, unknown>;
+          } catch {
+            // A frame we cannot read is not a reason to discard the rows we
+            // already delivered.
+            continue;
+          }
+
+          if (frame.event === "meta" && raw.categories) {
+            opts.handlers.onMeta?.(raw as unknown as PlacesMeta);
+          } else if (frame.event === "results") {
+            const category = String(raw.category ?? "");
+            if (category && isPlaceCardArray(raw.items)) {
+              opts.handlers.onCategory(category, raw.items);
+            }
+          } else if (frame.event === "category_error") {
+            opts.handlers.onCategoryError?.(
+              String(raw.category ?? ""),
+              String(raw.message ?? "This category is unavailable."),
+            );
+          }
+          // "heartbeat" and "done" need no handling: the first exists only to
+          // keep intermediaries from closing a quiet connection, and the second
+          // is implied by the reader finishing.
+        }
+      }
+    } finally {
+      // Releasing matters when the caller aborted mid-read: without it the
+      // response body stays locked and the connection is never returned.
+      reader.releaseLock();
+    }
+  }
+
+  /** The same query, one response. Used when the stream cannot run. */
+  static async searchNearby(opts: {
+    idToken: string;
+    origin: Origin;
+    categories: string[];
+    radiusMi: number;
+    limit?: number;
+    signal?: AbortSignal;
+  }): Promise<{
+    groups: { category: string; items: PlaceCard[] }[];
+    failed: string[];
+    meta: PlacesMeta;
+  }> {
+    const response = await ApiService.apiFetch("/api/one/places/search", {
+      method: "POST",
+      headers: {
+        ...authHeaders(opts.idToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(searchBody(opts)),
+      signal: opts.signal,
+    });
+    return jsonOrThrow(response);
+  }
+
+  static async getDetails(opts: {
+    idToken: string;
+    placeId: string;
+    signal?: AbortSignal;
+  }): Promise<PlaceDetails> {
+    const response = await ApiService.apiFetch("/api/one/places/details", {
+      method: "POST",
+      headers: {
+        ...authHeaders(opts.idToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ placeId: opts.placeId }),
+      signal: opts.signal,
+    });
+    const payload = await jsonOrThrow<{ place: PlaceDetails }>(response);
+    return payload.place;
+  }
+}
+
+/**
+ * Distance for a row, in the same approximate voice the other two directories
+ * use. Google returns a venue's own point rather than a ZIP centroid, so a
+ * short distance here is real — but the reader's own position carries its own
+ * error, so this stays deliberately unprecise.
+ */
+export function formatPlaceDistance(meters: number | null | undefined): string | null {
+  if (typeof meters !== "number" || !Number.isFinite(meters) || meters < 0) {
+    return null;
+  }
+  const miles = meters / 1609.344;
+  if (miles >= 10) return `~${Math.round(miles)} mi`;
+  if (miles < 0.1) return "~0.1 mi";
+  return `~${(Math.round(miles * 10) / 10).toFixed(1)} mi`;
+}
+
+/** "Coffee shop · Permanently closed" — one line, only the parts that exist. */
+export function formatPlaceSubtitle(card: PlaceCard): string | null {
+  const parts: string[] = [];
+  if (card.categoryLabel) parts.push(card.categoryLabel);
+  // Google reports this rarely, and only when it matters enough to say.
+  if (card.businessStatus === "CLOSED_PERMANENTLY") parts.push("Permanently closed");
+  else if (card.businessStatus === "CLOSED_TEMPORARILY") parts.push("Temporarily closed");
+  if (!parts.length && card.address) parts.push(card.address);
+  return parts.length ? parts.join(" · ") : null;
+}
+
+export function placesCategoryLabel(slug: string): string {
+  return PLACES_CATEGORIES.find((entry) => entry.slug === slug)?.label ?? slug;
+}

--- a/scripts/ops/sync_backend_runtime_secrets.py
+++ b/scripts/ops/sync_backend_runtime_secrets.py
@@ -190,6 +190,7 @@ def _build_backend_runtime_config(args: argparse.Namespace) -> dict[str, Any]:
         "hushh_trusted_device_uat_allowlist": args.hushh_trusted_device_uat_allowlist,
         "advisors_api_base_url": args.advisors_api_base_url,
         "insurance_agents_api_base_url": args.insurance_agents_api_base_url,
+        "one_places_directory_enabled": args.one_places_directory_enabled,
     }
     return _drop_empty(config)
 
@@ -295,6 +296,7 @@ def main() -> int:
     # above: a non-secret base URL in the generated runtime config, and a bearer
     # key mirrored from the project that owns it.
     parser.add_argument("--insurance-agents-api-base-url", default="")
+    parser.add_argument("--one-places-directory-enabled", default="")
     parser.add_argument(
         "--insurance-agents-api-key-source-project", default="hushh-tech-prod"
     )


### PR DESCRIPTION
## What this does

Adds **ten business categories** to Connect → Around you, streamed, and **restores the insurance directory** that has been dead code on `main`.

Around you answered one question: which registered investment advisers are near me. This makes it answer three.

## The insurance regression

`InsuranceAgentsNearby` is fully built, has ~19 passing tests, and its backend route and secrets are deployed — but nothing imports it. `git grep -i insurance origin/main -- hushh-webapp/app` returns zero hits.

`c61d074f1` added the wiring. `0f4b0774c` rewrote `page-client.tsx` and dropped it. Nothing failed: the page contract test asserts shell strings only, and the component's own tests render it directly. The live backend is why it looked shipped.

## Seven of the ten already existed

`_NEARBY_PLACE_CATEGORY_TYPES` in `google_maps_service.py` has shipped a working Google Places taxonomy since the check-in picker — including a `hotels_stays` bucket whose chip label already reads "Hotels". It was only ever reachable from a 500 m place-picker, never from Connect.

| # | Category | Source |
|---|---|---|
| 1 | Hotels | existing bucket |
| 2 | Food & drink | existing bucket |
| 3 | Health | existing bucket |
| 4 | Banking | split from `shopping_services` |
| 5 | Shops | existing bucket, narrowed |
| 6 | Fitness & beauty | split from `shopping_services` |
| 7 | Auto | split from `shopping_services` |
| 8 | Transit | existing bucket |
| 9 | Education | existing bucket |
| 10 | Outdoors | existing bucket |

The three new ones re-partition the picker's single `shopping_services` chip, which jams retail, laundry, beauty, vehicle service and cash machines into one filter. **No new vendor, no new API contract, and one new place type** (`electric_vehicle_charging_station`) across all ten.

## The regression this could have caused, and the guard

`nearby_places` builds its "All" sweep by iterating `_NEARBY_PLACE_CATEGORY_TYPES`:

```python
if category == "all":
    requests = [(None, None), *((chip, types) for chip, types in _NEARBY_PLACE_CATEGORY_TYPES.items())]
```

Extending that dict would have added **three more concurrent Google calls to every check-in drawer open** — a cost and latency increase on a shipped feature, with no test to catch it.

The directory therefore has its **own table**. `test_the_check_in_sweep_still_costs_what_it_did` pins the picker at seven buckets, and `test_the_two_taxonomies_are_separate_objects` stops the two being aliased later.

## Real-time

Ten categories are ten provider calls. `asyncio.gather` would make every reader wait for the slowest; `asyncio.wait(FIRST_COMPLETED)` sends each the moment it lands.

Transport is **`fetch` + `ReadableStream` over POST**, following `kai-stream-client.ts`. `EventSource` was not viable on two counts: it is GET-only, so coordinates would land in the request line (`test_advisors_coordinate_privacy.py` exists precisely because of this), and it cannot set an `Authorization` header.

- One sweep fills every category; chips filter locally, so moving along the rail costs nothing extra — the same bargain the check-in picker already strikes.
- `X-Accel-Buffering: no` + `Cache-Control: no-cache`, copied from `sse.py`, so an intermediary cannot buffer the stream into one lump.
- 15s heartbeat frames; 45s total budget; in-flight tasks cancelled if the reader disconnects.
- If the stream cannot run, the component falls back to `POST /places/search` and renders identically.

## What is not touched

Advisors and insurance keep their own components, services and routes — unchanged and non-streaming. They are not refactored into the streaming path.

**Advisors stays the default segment**, so opening Around you shows exactly what it showed before this PR.

No route is added, so `routes.ts`, `app-route-layout.contract.json` and `native-route-inventory.json` are untouched and the native shell is unaffected. The three governed artifacts verify current.

## Edge cases

The Places directory implements the same contract the two shipped directories keep — their test names are the spec:

- asks for location before touching the directory
- prompts the device only on the user's tap
- searches from the shared location bus, so it never re-prompts someone who granted on Advisors
- offers a ZIP when the device says no, and keeps the box after a ZIP search fails
- an empty result is not an error
- keeps the radius control usable when nothing came back
- shows a failure without wiping the surface, and offers retry
- `requestRef` sequence guard discards stale responses
- credits the source only when rows were actually shown
- 503 renders "Not available yet.", never our plumbing

Plus four streaming-only cases: an error mid-stream keeps delivered rows; one failing category never empties the list; an `AbortController` cancels a superseded sweep; the fallback renders the same surface.

## Cost

Rating, hours, phone and website sit in a dearer Places billing tier, so the list field mask excludes them and they are bought once, on `/places/details`, for the one place a reader opens. `test_the_list_field_mask_stays_off_the_dearer_tiers` pins this. Rate limit `ONE_PLACES_DIRECTORY_READ = 40/minute`.

## Rollout

`ONE_PLACES_DIRECTORY_ENABLED` — open in dev/uat, closed in production until explicitly set. Deliberately **not** the nearby-presence flag: that governs co-presence, and closing co-presence in production must not also close a business directory. With it off, Around you is byte-identical to today.

## Tests and baseline

- **20 new frontend tests**, including one that asserts rows render *before* the stream closes — the test that actually proves "real time".
- **26 new backend tests**, including the check-in cost guard and coordinate-privacy contract.

Full suites compared against `origin/main`:

| Suite | main | this branch |
|---|---|---|
| webapp vitest | 22 failed / 3228 passed | 22 failed / 3248 passed |
| backend pytest | 89 failing ids | 89 failing ids |

**Failing sets are byte-identical on both.** Zero new failures. Typecheck and eslint clean.

Pre-existing failures are unrelated (`page-client.test.tsx` `usePathname` mock, `sos-panel` layout classes, local venv missing optional deps).
