### PR TITLE
fix(ios): prevent breadcrumb overlap on narrow screens (ancestors shrink+truncate)

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -390,18 +390,25 @@ function TopShellBreadcrumbTrail({
         return (
           <span
             key={`${item.label}-${index}`}
-            className="flex min-w-0 items-center gap-1"
+            className={cn(
+              "flex min-w-0 items-center gap-1",
+              // The last crumb (current page) keeps its full label; earlier
+              // ancestors are allowed to shrink and truncate so a deep trail
+              // like "Profile > Preferences > Gemini" collapses gracefully on
+              // narrow iOS widths instead of colliding/overflowing the header.
+              isLast ? "shrink-0" : "min-w-0 shrink",
+            )}
           >
             {index > 0 ? (
               <ChevronRight
-                className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-tertiary-label)]"
+                className="mx-0.5 h-3.5 w-3.5 shrink-0 text-[color:var(--app-tertiary-label)]"
                 aria-hidden
               />
             ) : null}
             {item.href && !isLast ? (
               <button
                 type="button"
-                className="max-w-[9rem] shrink-0 truncate text-[color:var(--app-secondary-label)] transition-colors hover:text-current"
+                className="min-w-0 max-w-[9rem] shrink truncate text-[color:var(--app-secondary-label)] transition-colors hover:text-current"
                 onClick={() =>
                   requestInternalAppNavigation({
                     href: item.href!,
@@ -416,8 +423,10 @@ function TopShellBreadcrumbTrail({
             ) : (
               <span
                 className={cn(
-                  "min-w-0 truncate",
-                  isLast ? "font-semibold text-current" : "text-[color:var(--app-secondary-label)]",
+                  "truncate",
+                  isLast
+                    ? "min-w-0 shrink-0 font-semibold text-current"
+                    : "min-w-0 shrink text-[color:var(--app-secondary-label)]",
                 )}
                 aria-current={isLast ? "page" : undefined}
               >


### PR DESCRIPTION
## What & why

On nested preference screens (e.g. Gemini preferences) the top-header breadcrumb trail (`Profile > Preferences > Gemini`) could collide/overflow on narrow iOS widths — cramped separators and clipped text like `Profile> Preferences Ge...`.

Root cause in `TopShellBreadcrumbTrail` (`components/app-ui/top-app-bar.tsx`): every crumb — including the ancestors — was `shrink-0`. With a fixed-width chevron between each, a 3+ level trail could not shrink to fit the available header width, so items overlapped/overflowed instead of truncating.

## Fix

`TopShellBreadcrumbTrail` now distributes shrink correctly:
- **Last crumb (current page):** `shrink-0` — always fully visible, never truncated (it's where you are).
- **Ancestor crumbs (links + labels):** `min-w-0 shrink` + existing `truncate` — they collapse gracefully with an ellipsis when space is tight, so a deep trail fits on one line.
- **Separators:** each `ChevronRight` stays `shrink-0` and gains a small `mx-0.5` so the gap between items is consistent and never cramped.

## Scope note (premise-checked)

The trail already used chevron separators, `truncate`, and `gap-1` — so the ticket's suggestions to "add chevrons / add truncate / add gap" were largely already present. The actual defect was the **`shrink-0` on ancestors** preventing collapse. I kept it in the shared trail component (used by every inner route: Kai, Analysis, Connected Systems, Preferences, etc.) rather than adding a per-page breadcrumb, so all deep trails benefit and there's no second breadcrumb implementation. Note: the top-app-bar trail is the real "Profile > Preferences > Gemini" component here; the app also has a separate `components/ui/breadcrumb.tsx` + `dashboard-breadcrumb.tsx`, which are unaffected and already handle their own layout.

## Verification

- ESLint on `top-app-bar.tsx`: clean.
- No contract test pins the trail's classes.
- Manual: open Profile → Preferences → Gemini on a narrow iOS width — the ancestors truncate with clean, evenly-spaced `>` separators and the current page label stays fully visible, no overlap.

## Risk

Low. One shared presentational component; Tailwind class changes only (shrink distribution + separator margin); no data/route/contract change.
