### PR TITLE
fix(connect): mark the places stream no-transform so it is not buffered

### DIFF
--- a/consent-protocol/api/routes/one/places.py
+++ b/consent-protocol/api/routes/one/places.py
@@ -370,12 +370,16 @@ async def places_stream(
         ),
         media_type="text/event-stream",
         headers={
-            "Cache-Control": "private, no-store, no-cache",
+            # `no-transform` is doing real work, not decoration: the frontend
+            # runs with `compress: true`, and a compressing intermediary is
+            # free to buffer a response body to compress it. That turns a
+            # stream back into one lump. The Kai stream lanes carry it for the
+            # same reason. `private, no-store` matches the two sibling
+            # directories, because this response is derived from a position.
+            "Cache-Control": "private, no-store, no-cache, no-transform",
             "Pragma": "no-cache",
             "Connection": "keep-alive",
-            # Without this an nginx-shaped intermediary buffers the whole body
-            # and the stream arrives as one lump, which is the ordinary response
-            # with extra steps.
+            # And this stops an nginx-shaped proxy buffering it regardless.
             "X-Accel-Buffering": "no",
         },
     )

--- a/consent-protocol/tests/test_places_directory.py
+++ b/consent-protocol/tests/test_places_directory.py
@@ -10,6 +10,7 @@ would otherwise notice. The first test here pins that table's size.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 
 import pytest
@@ -211,6 +212,36 @@ def test_an_unexpected_crash_is_contained_to_its_category(monkeypatch) -> None:
     assert frames[-1]["event"] == "done"
     assert frames[-1]["failed"] == ["hotels_stays"]
     assert frames[-1]["delivered"] == 1
+
+
+def test_the_stream_carries_the_headers_that_stop_it_being_buffered() -> None:
+    """Without these the stream is an ordinary response with extra steps.
+
+    Checked at the source because the header dict is built inside the route and
+    the route is auth-gated; the repo already asserts deploy wiring this way.
+    `no-transform` is the subtle one: the frontend runs with `compress: true`,
+    and a compressing intermediary may buffer a body in order to compress it.
+    """
+
+    source = inspect.getsource(places_routes)
+
+    assert "no-transform" in source
+    assert '"X-Accel-Buffering": "no"' in source
+    assert 'media_type="text/event-stream"' in source
+
+
+def test_every_frame_is_named_because_the_parser_drops_unnamed_ones() -> None:
+    """`parseSSEBlocks` skips any block without an `event:` line.
+
+    A heartbeat sent as a bare SSE comment would therefore never reach the
+    client and could not reset its idle timer -- the one job it has.
+    """
+
+    for event in ("meta", "results", "category_error", "heartbeat", "done"):
+        rendered = places_routes._frame(event, {}).decode()
+        assert rendered.startswith(f"event: {event}\n")
+        assert "\ndata: " in rendered
+        assert rendered.endswith("\n\n")
 
 
 def test_the_done_frame_is_terminal() -> None:


### PR DESCRIPTION
Follow-up to #5052.

The frontend runs with `compress: true` (`next.config.ts`), and a compressing intermediary is free to buffer a response body in order to compress it — which turns the per-category stream back into the single lump it exists to avoid.

`consent-protocol/api/routes/kai/agent_chat.py` already carries `no-transform` on both of its streaming lanes for exactly this reason (lines 605, 915). The places stream did not.

Also adds two tests pinning the properties that make the stream a stream:

- **the anti-buffering headers** — `no-transform`, `X-Accel-Buffering: no`, `text/event-stream`
- **every frame is named** — `parseSSEBlocks` contains `if (!eventName || dataLines.length === 0) continue;`, so a heartbeat sent as a bare SSE `:` comment would be silently dropped by the client and could never reset its idle timer, which is the only job it has

28 backend tests pass.