### PR TITLE
fix(ios): hide Talk to One bar over active input on keyboard focus

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1818,6 +1818,23 @@ html.kb-open [data-slot="dialog-content"]:not([data-keyboard-anchor="bottom"]) {
   margin-top: calc(var(--kb-height, 0px) / -2);
 }
 
+/* The fixed "Talk to One" agent launcher lifts above the on-screen keyboard by
+ * --kb-height. On a plain form screen (e.g. Connect's people search) that lands
+ * it directly on top of the focused input, obscuring typed text. While a real
+ * on-screen keyboard is open, hide the FIXED launcher so it can never overlay
+ * the active field. Scoped to layout="fixed": the in-chat slot composer, which
+ * IS the input the person is typing into, keeps its keyboard lift. Inert on
+ * desktop (kb-open never set there). See mobile-bug-log B21. */
+html.kb-open [data-agent-bar-shell][data-agent-bar-layout="fixed"] {
+  opacity: 0;
+  transform: translate3d(0, 1rem, 0);
+  pointer-events: none;
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease;
+}
+
+
 
 .app-page-shell {
   width: 100%;

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1853,6 +1853,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     <div
       ref={agentBarShellRef}
       data-agent-bar-shell
+      data-agent-bar-layout={layout}
       data-ambient-chrome-ignore
       className={cn(
         "pointer-events-none flex flex-col items-center",


### PR DESCRIPTION
## What & why

On the Connect screen (and any plain form screen), tapping into a text input like **"Search people by name"** made the fixed **"Talk to One"** agent launcher lift above the iOS soft keyboard and settle **directly on top of the input**, obscuring typed text.

Root cause: the fixed `AgentBar` (`components/agent/agent-bar.tsx`) is anchored to the bottom and, like every keyboard-anchored surface here, rides up by `--kb-height` when the on-screen keyboard opens (correct for the in-chat composer, wrong for a launcher sitting over an unrelated input).

## Fix

While a real on-screen keyboard is open, **hide the fixed launcher** so it can never overlay the active field:
- Tagged the shell with `data-agent-bar-layout={layout}` in `AgentBar` (one attribute).
- Added a scoped rule in `globals.css`:
  ```css
  html.kb-open [data-agent-bar-shell][data-agent-bar-layout="fixed"] {
    opacity: 0;
    transform: translate3d(0, 1rem, 0);
    pointer-events: none;
    transition: opacity 150ms ease, transform 150ms ease;
  }
  ```

This uses the app's **existing** keyboard mechanism (`KeyboardInsetManager` sets `html.kb-open` + `--kb-height` on native/mobile-web only), so:
- **Desktop is byte-for-byte unchanged** — `kb-open` is never set there.
- Scoped to `layout="fixed"`: the **in-chat slot composer** (`layout="slot"`, which IS the input the person types into) keeps its keyboard lift and is untouched.
- It reuses the same B21 keyboard contract the dialogs/sheets/drawers already rely on — no new listener, no JS, no per-screen change. The bar reappears on blur when the keyboard dismisses.

## Scope note (premise-checked)

The ticket suggested `onFocus/onBlur` on the search input plus `scrollIntoView`. I deliberately fixed it in the **shared** agent bar instead:
- The overlap is caused by the bar (a global fixed sibling of every route), not by the Connect search field, so a per-input handler would only fix one of many screens with this bar + a form.
- `KeyboardInsetManager` already runs a focus-driven `scrollIntoView` (centering) for non-keyboard-anchored inputs, so a second per-field scroll would fight it. Hiding the offending overlay is the minimal, global, non-duplicative fix.

## Verification

- ESLint on `agent-bar.tsx`: clean.
- Desktop unaffected (no `kb-open`).
- Manual: Connect → tap "Search people by name" on iOS — the "Talk to One" bar fades out as the keyboard rises (input fully visible), and returns when the keyboard dismisses. In-chat composer keyboard lift unchanged.

## Risk

Low. One data attribute + one scoped, keyboard-gated CSS rule; inert on desktop; does not touch the chat composer or any route logic.
