### PR TITLE
Polish strict Apple typography for UAT

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -174,12 +174,9 @@ textarea {
 :root {
   /* Centralized app typography variables.
    * Apple-system web pass uses the bundled Inter Variable family only. */
-  --font-app-display:
-    "InterVariable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
-  --font-app-body:
-    "InterVariable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  --font-family-product: "InterVariable", "Inter", system-ui, sans-serif;
+  --font-app-display: var(--font-family-product);
+  --font-app-body: var(--font-family-product);
   --font-app-text: var(--font-app-body);
   --font-app-heading: var(--font-app-display);
   --font-app-mono: var(--font-app-body);
@@ -249,48 +246,51 @@ textarea {
      for app UI hierarchy; components opt into roles instead of restating
      route-specific font sizes. */
   --type-large-page-title-size: 34px;
-  --type-large-page-title-line: 38px;
+  --type-large-page-title-line: 41px;
   --type-large-page-title-weight: 700;
-  --type-large-page-title-tracking: -0.028em;
+  --type-large-page-title-tracking: -0.03em;
   --type-page-title-size: 28px;
-  --type-page-title-line: 32px;
+  --type-page-title-line: 34px;
   --type-page-title-weight: 700;
-  --type-page-title-tracking: -0.022em;
+  --type-page-title-tracking: -0.025em;
   --type-navigation-title-size: 17px;
   --type-navigation-title-line: 22px;
   --type-navigation-title-weight: 600;
   --type-navigation-title-tracking: -0.01em;
   --type-major-section-title-size: 22px;
-  --type-major-section-title-line: 26px;
+  --type-major-section-title-line: 27px;
   --type-major-section-title-weight: 600;
-  --type-major-section-title-tracking: -0.017em;
-  --type-card-title-size: 20px;
-  --type-card-title-line: 24px;
+  --type-major-section-title-tracking: -0.018em;
+  --type-card-title-size: 17px;
+  --type-card-title-line: 22px;
   --type-card-title-weight: 600;
-  --type-card-title-tracking: -0.014em;
+  --type-card-title-tracking: -0.01em;
   --type-section-label-size: 15px;
   --type-section-label-line: 20px;
   --type-section-label-weight: 500;
-  --type-section-label-tracking: -0.01em;
+  --type-section-label-tracking: -0.006em;
   --type-row-label-size: 17px;
   --type-row-label-line: 22px;
   --type-row-label-weight: 400;
   --type-row-label-emphasis-weight: 600;
   --type-row-label-tracking: -0.01em;
-  --type-page-subtitle-size: 16px;
-  --type-page-subtitle-line: 22px;
-  --type-row-description-size: 15px;
-  --type-row-description-line: 21px;
+  --type-page-subtitle-size: 15px;
+  --type-page-subtitle-line: 20px;
+  --type-row-description-size: 13px;
+  --type-row-description-line: 18px;
   --type-row-description-weight: 400;
-  --type-row-description-tracking: -0.006em;
+  --type-row-description-tracking: 0;
   --type-form-label-size: 15px;
   --type-form-label-line: 20px;
   --type-form-label-weight: 500;
   --type-form-label-tracking: -0.006em;
   --type-input-value-size: 17px;
-  --type-input-value-line: 24px;
+  --type-input-value-line: 22px;
   --type-helper-text-size: 13px;
   --type-helper-text-line: 18px;
+  --type-helper-text-tracking: 0;
+  --type-legal-text-size: 11px;
+  --type-legal-text-line: 15px;
   --type-button-label-size: 17px;
   --type-button-label-line: 22px;
   --type-button-label-weight: 600;
@@ -345,11 +345,12 @@ textarea {
   --app-secondary-surface: #f9f9fb;
   --app-elevated-surface: #ffffff;
   --app-label: #1d1d1f;
-  --app-secondary-label: #8e8e93;
+  --app-secondary-label: #6e6e73;
   --app-section-label: #6e6e73;
-  --app-tertiary-label: #aeaeb2;
+  --app-tertiary-label: #8e8e93;
+  --app-disabled-label: #aeaeb2;
   --app-quaternary-label: #c7c7cc;
-  --app-separator: rgba(60, 60, 67, 0.1);
+  --app-separator: rgba(60, 60, 67, 0.12);
   --app-opaque-separator: #e5e5ea;
   --app-neutral-fill: rgba(120, 120, 128, 0.16);
   --app-neutral-fill-strong: rgba(120, 120, 128, 0.2);
@@ -358,6 +359,15 @@ textarea {
   --app-destructive: #ff3b30;
   --app-success: #34c759;
   --app-warning: #ff9500;
+  --text-primary: var(--app-label);
+  --text-secondary: var(--app-secondary-label);
+  --text-tertiary: var(--app-tertiary-label);
+  --text-disabled: var(--app-disabled-label);
+  --chevron: var(--app-quaternary-label);
+  --system-blue: var(--app-accent);
+  --system-green: var(--app-success);
+  --system-red: var(--app-destructive);
+  --system-orange: var(--app-warning);
   --app-purple: #af52de;
   --app-info: var(--app-accent);
   --app-focus-ring: rgba(0, 122, 255, 0.25);
@@ -5555,10 +5565,10 @@ body[data-persona-surface="ria"] {
 :is(.ui-text-identity-name) {
   color: var(--app-label) !important;
   font-family: var(--font-app-display) !important;
-  font-size: clamp(28px, 7.8vw, 34px) !important;
+  font-size: var(--type-page-title-size) !important;
   font-weight: 700 !important;
-  letter-spacing: -0.028em !important;
-  line-height: 1.12 !important;
+  letter-spacing: var(--type-page-title-tracking) !important;
+  line-height: var(--type-page-title-line) !important;
   opacity: 1 !important;
   text-transform: none !important;
 }
@@ -5625,8 +5635,8 @@ body[data-persona-surface="ria"] {
   font-weight: var(--type-row-label-emphasis-weight) !important;
 }
 
-:is(.ui-text-row-description, .ui-text-trailing-value) {
-  color: var(--app-secondary-label) !important;
+:is(.ui-text-row-description) {
+  color: var(--app-tertiary-label) !important;
   font-family: var(--font-app-body) !important;
   font-size: var(--type-row-description-size) !important;
   font-weight: var(--type-row-description-weight) !important;
@@ -5642,7 +5652,7 @@ body[data-persona-surface="ria"] {
   font-size: 15px !important;
   font-weight: 500 !important;
   letter-spacing: -0.006em !important;
-  line-height: 21px !important;
+  line-height: 20px !important;
   opacity: 1 !important;
   text-transform: none !important;
 }
@@ -5663,7 +5673,7 @@ body[data-persona-surface="ria"] {
   font-family: var(--font-app-body) !important;
   font-size: var(--type-input-value-size) !important;
   font-weight: 400 !important;
-  letter-spacing: -0.008em !important;
+  letter-spacing: -0.01em !important;
   line-height: var(--type-input-value-line) !important;
   opacity: 1 !important;
 }
@@ -5673,7 +5683,7 @@ body[data-persona-surface="ria"] {
   font-family: var(--font-app-body) !important;
   font-size: var(--type-helper-text-size) !important;
   font-weight: 400 !important;
-  letter-spacing: -0.003em !important;
+  letter-spacing: var(--type-helper-text-tracking) !important;
   line-height: var(--type-helper-text-line) !important;
   opacity: 1 !important;
   text-transform: none !important;
@@ -5681,10 +5691,10 @@ body[data-persona-surface="ria"] {
 
 :is(.ui-text-status) {
   font-family: var(--font-app-body) !important;
-  font-size: 13px !important;
+  font-size: var(--type-row-label-size) !important;
   font-weight: 600 !important;
-  letter-spacing: -0.006em !important;
-  line-height: 18px !important;
+  letter-spacing: var(--type-row-label-tracking) !important;
+  line-height: var(--type-row-label-line) !important;
   opacity: 1 !important;
   text-transform: none !important;
 }
@@ -5707,14 +5717,25 @@ body[data-persona-surface="ria"] {
   opacity: 1 !important;
 }
 
-:is(.ui-text-caption, .ui-text-legal) {
-  color: var(--app-secondary-label) !important;
+:is(.ui-text-caption) {
+  color: var(--app-tertiary-label) !important;
   font-family: var(--font-app-body) !important;
   font-size: 12px !important;
   font-weight: 400 !important;
   letter-spacing: 0 !important;
   line-height: 16px !important;
   opacity: 1 !important;
+}
+
+:is(.ui-text-legal) {
+  color: var(--app-tertiary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-legal-text-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: 0 !important;
+  line-height: var(--type-legal-text-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
 }
 
 .app-page-shell
@@ -5735,8 +5756,53 @@ body[data-persona-surface="ria"] {
   font-family: var(--font-app-body) !important;
   font-size: var(--type-helper-text-size) !important;
   font-weight: 400 !important;
-  letter-spacing: -0.003em !important;
+  letter-spacing: var(--type-helper-text-tracking) !important;
   line-height: var(--type-helper-text-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+.app-page-shell
+  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[10px]"],
+.app-page-shell
+  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[11px]"],
+.app-page-shell
+  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[12px]"],
+.app-page-shell
+  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg2)]"][class*="text-[12px]"] {
+  color: var(--app-tertiary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-helper-text-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: var(--type-helper-text-tracking) !important;
+  line-height: var(--type-helper-text-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+.app-page-shell
+  :is(p, span, div, label)[class*="text-[color:var(--one-fg2)]"][class*="text-[13px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-[color:var(--one-fg2)]"][class*="text-[14px]"],
+.app-page-shell
+  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-sm"] {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-page-subtitle-size) !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.006em !important;
+  line-height: var(--type-page-subtitle-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+:is(.ui-text-trailing-value) {
+  color: var(--app-tertiary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: 15px !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.006em !important;
+  line-height: 20px !important;
   opacity: 1 !important;
   text-transform: none !important;
 }

--- a/hushh-webapp/components/app-ui/typography.tsx
+++ b/hushh-webapp/components/app-ui/typography.tsx
@@ -5,6 +5,7 @@ import type { ElementType, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 export const TYPOGRAPHY_CLASSNAMES = {
+  largeTitle: "ui-text-large-page-title",
   pageTitle: "ui-text-page-title",
   pageSubtitle: "ui-text-page-subtitle",
   navigationTitle: "ui-text-navigation-title",
@@ -27,6 +28,30 @@ export const TYPOGRAPHY_CLASSNAMES = {
   legal: "ui-text-legal",
 } as const;
 
+const TYPOGRAPHY_ROLE_BY_CLASSNAME: Record<string, string> = {
+  [TYPOGRAPHY_CLASSNAMES.largeTitle]: "large-title",
+  [TYPOGRAPHY_CLASSNAMES.pageTitle]: "page-title",
+  [TYPOGRAPHY_CLASSNAMES.pageSubtitle]: "subtitle",
+  [TYPOGRAPHY_CLASSNAMES.navigationTitle]: "nav-title",
+  [TYPOGRAPHY_CLASSNAMES.identityName]: "identity-title",
+  [TYPOGRAPHY_CLASSNAMES.majorSectionTitle]: "section-title",
+  [TYPOGRAPHY_CLASSNAMES.sectionLabel]: "section-label",
+  [TYPOGRAPHY_CLASSNAMES.cardTitle]: "card-title",
+  [TYPOGRAPHY_CLASSNAMES.rowLabel]: "body",
+  [TYPOGRAPHY_CLASSNAMES.rowLabelEmphasized]: "body-strong",
+  [TYPOGRAPHY_CLASSNAMES.rowDescription]: "row-description",
+  [TYPOGRAPHY_CLASSNAMES.trailingValue]: "trailing-value",
+  [TYPOGRAPHY_CLASSNAMES.trailingAction]: "trailing-action",
+  [TYPOGRAPHY_CLASSNAMES.formLabel]: "form-label",
+  [TYPOGRAPHY_CLASSNAMES.inputValue]: "input-text",
+  [TYPOGRAPHY_CLASSNAMES.helperText]: "helper-text",
+  [TYPOGRAPHY_CLASSNAMES.statusText]: "body-strong",
+  [TYPOGRAPHY_CLASSNAMES.buttonLabel]: "button-label",
+  [TYPOGRAPHY_CLASSNAMES.tabLabel]: "tab-label",
+  [TYPOGRAPHY_CLASSNAMES.caption]: "caption",
+  [TYPOGRAPHY_CLASSNAMES.legal]: "legal-text",
+};
+
 type RoleTextProps = {
   as?: ElementType;
   children?: ReactNode;
@@ -41,10 +66,25 @@ function SemanticText({
   roleClassName,
   ...props
 }: RoleTextProps & { roleClassName: string }) {
+  const uiRole = TYPOGRAPHY_ROLE_BY_CLASSNAME[roleClassName];
   return (
-    <Component className={cn(roleClassName, className)} {...props}>
+    <Component
+      className={cn(roleClassName, className)}
+      data-ui-role={uiRole}
+      {...props}
+    >
       {children}
     </Component>
+  );
+}
+
+export function LargeTitle({ as = "h1", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.largeTitle}
+      {...props}
+    />
   );
 }
 

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircle2, Loader2, Trash2 } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import {
+  CardTitle,
+  FormLabel,
+  HelperText,
+} from "@/components/app-ui/typography";
 import { GeminiLogo } from "@/components/brand/gemini-logo";
 import { RuntimeProviderMark } from "@/components/brand/runtime-provider-mark";
 import { Badge } from "@/components/ui/badge";
@@ -535,28 +540,29 @@ export function GeminiRuntimeSettingsCard({
         {mode === "byok" ? (
           <div className="space-y-2 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
             <div className="flex items-center justify-between gap-3">
-              <p className="text-[13px] font-medium text-foreground">Gemini connection</p>
+              <CardTitle as="p">Gemini connection</CardTitle>
               <Badge variant={hasSavedKey ? "secondary" : "outline"}>
                 {needsVaultCreation ? "Vault needed" : needsUnlock ? "Locked" : hasSavedKey ? "Saved" : "Not set"}
               </Badge>
             </div>
-            <label className="block space-y-1 text-[12px] text-muted-foreground">
+            <FormLabel className="block space-y-1">
               API endpoint
               <select
+                data-ui-role="input-text"
                 value={transport}
                 onChange={(event) => {
                   setTransport(event.target.value as GeminiRuntimeTransport);
                   invalidateCredentialValidation();
                 }}
                 disabled={isSaving || isRemoving || credentialValidation.status === "checking"}
-                className="h-10 w-full rounded-[var(--app-card-radius-compact)] border border-input bg-background px-3 text-[14px] text-foreground"
+                className="ui-text-input-value h-10 w-full rounded-[var(--app-card-radius-compact)] border border-input bg-background px-3"
               >
                 <option value="developer_api">Google AI Studio</option>
                 <option value="vertex_api_key">
                   Google Cloud Vertex API key
                 </option>
               </select>
-            </label>
+            </FormLabel>
             {transport === "vertex_api_key" ? (
               <div className="grid gap-2 sm:grid-cols-2">
                 <Input
@@ -595,8 +601,9 @@ export function GeminiRuntimeSettingsCard({
               disabled={isSaving || isRemoving}
               aria-label="Gemini API key"
             />
-            <div
-              className="min-h-5 text-[12px] leading-5 text-muted-foreground"
+            <HelperText
+              as="div"
+              className="min-h-5"
               role="status"
               aria-live="polite"
             >
@@ -615,7 +622,7 @@ export function GeminiRuntimeSettingsCard({
               ) : (
                 "Validate the key before confirming it."
               )}
-            </div>
+            </HelperText>
             <div className="flex flex-wrap gap-2">
               {credentialValidation.status === "ready" ? (
                 <Button type="button" onClick={() => void saveByok()} disabled={isSaving || isRemoving}>

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -7,7 +7,7 @@ import { Grid2X2, List, Search } from "lucide-react";
 import { AgentSectionIcon } from "@/components/app-ui/agent-section-icon";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
-import { MajorSectionTitle } from "@/components/app-ui/typography";
+import { PageTitle } from "@/components/app-ui/typography";
 import {
   getOneSetupCapability,
   isOneCapabilityEnabled,
@@ -391,24 +391,25 @@ function AgentMetricDisplay({
       )}
     >
       <span
+        data-ui-role="body-strong"
         className={cn(
-          "shrink-0 font-semibold tabular-nums tracking-normal",
-          compact ? "text-[13px]" : "text-[15px]",
+          "ui-text-status shrink-0 tabular-nums",
           metricClassName(mode),
         )}
       >
         {mode.primaryMetric.value}
       </span>
       <span
+        data-ui-role="trailing-value"
         className={cn(
-          "font-normal text-muted-foreground",
           // Grid (compact) wraps and centers so multi-word metrics like
           // "0 requests to review" never clip on narrow iOS. List keeps the
-          // single-line truncating treatment. Font sizes follow the upstream
-          // typography pass (compact 13px, list 15px/21px).
+          // single-line truncating treatment; typography comes from the shared
+          // trailing-value role.
+          "ui-text-trailing-value",
           compact
-            ? "min-w-0 whitespace-normal text-center [overflow-wrap:anywhere] text-[13px]"
-            : "min-w-0 truncate text-[15px] leading-[21px]",
+            ? "min-w-0 whitespace-normal text-center [overflow-wrap:anywhere]"
+            : "min-w-0 truncate",
           isPositiveMetric && "text-emerald-700/80 dark:text-emerald-300/85",
         )}
       >
@@ -450,7 +451,7 @@ function AgentGridItem({
         className="relative z-10"
       />
       <span className="relative z-10 min-w-0">
-        <span className="block truncate text-[15px] font-normal leading-[20px] tracking-normal text-foreground">
+        <span className="ui-text-row-label block truncate" data-ui-role="body">
           {mode.title}
         </span>
         <AgentMetricDisplay mode={mode} compact />
@@ -589,13 +590,12 @@ export function OneAgentRoster({
       className="mx-auto w-full max-w-[720px]"
     >
       <div className="mb-4 flex items-center justify-between gap-3">
-        <MajorSectionTitle
+        <PageTitle
           as="h2"
           id="one-agents-heading"
-          className="text-[28px] leading-[34px]"
         >
-          agents ({modes.length})
-        </MajorSectionTitle>
+          Agents ({modes.length})
+        </PageTitle>
         <AgentRosterViewToggle value={view} onChange={selectView} />
       </div>
       <label className="relative mb-4 block">
@@ -607,10 +607,11 @@ export function OneAgentRoster({
           type="search"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="search agents"
-          aria-label="search agents"
+          placeholder="Search agents"
+          aria-label="Search agents"
+          data-ui-role="input-text"
           data-testid="one-agents-search"
-          className="h-11 w-full rounded-[16px] border-0 bg-[color:var(--app-card-surface-compact)] py-2 pl-11 pr-4 text-[17px] font-normal leading-[22px] tracking-normal text-foreground outline-none ring-1 ring-border/55 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/70"
+          className="ui-text-input-value h-11 w-full rounded-[16px] border-0 bg-[color:var(--app-card-surface-compact)] py-2 pl-11 pr-4 outline-none ring-1 ring-border/55 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/70"
         />
       </label>
       <div

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -1,31 +1,31 @@
 "use client";
 
 export const kaiAppEyebrowClassName =
-  "!font-[family-name:var(--font-app-body)] !text-[15px] !font-medium !leading-[20px] !tracking-[-0.01em] !text-[#6E6E73]";
+  "ui-text-section-label";
 
 export const kaiAppHeroTitleClassName =
-  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
+  "ui-text-large-page-title";
 
 export const kaiAppHeroBodyClassName =
-  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
+  "ui-text-row-label";
 
 export const kaiAppDisplayTitleClassName =
-  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
+  "ui-text-large-page-title";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
+  "ui-text-page-title";
 
 export const kaiAppBodyClassName =
-  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
+  "ui-text-row-label";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
+  "ui-text-major-section-title";
 
 export const kaiAppCardTitleClassName =
-  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
+  "ui-text-card-title";
 
 export const kaiAppCardBodyClassName =
-  "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";
+  "ui-text-page-subtitle";
 
 export const kaiAppHelperClassName =
-  "!text-[12.5px] !font-normal !leading-[1.45] !tracking-normal";
+  "ui-text-helper-text";

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -29,6 +29,7 @@ function expectNotIncludes(repoPath, needle, message) {
 
 const typographySource = read("components/app-ui/typography.tsx");
 for (const exportName of [
+  "LargeTitle",
   "PageTitle",
   "PageSubtitle",
   "SectionLabel",
@@ -55,15 +56,33 @@ for (const exportName of [
 
 const globals = read("app/globals.css");
 for (const [token, value] of [
-  ["--type-page-subtitle-size", "16px"],
-  ["--type-page-subtitle-line", "22px"],
+  ["--type-large-page-title-size", "34px"],
+  ["--type-large-page-title-line", "41px"],
+  ["--type-large-page-title-weight", "700"],
+  ["--type-large-page-title-tracking", "-0.03em"],
+  ["--type-page-title-size", "28px"],
+  ["--type-page-title-line", "34px"],
+  ["--type-page-title-weight", "700"],
+  ["--type-page-title-tracking", "-0.025em"],
+  ["--type-page-subtitle-size", "15px"],
+  ["--type-page-subtitle-line", "20px"],
   ["--type-section-label-size", "15px"],
   ["--type-section-label-line", "20px"],
   ["--type-section-label-weight", "500"],
-  ["--type-section-label-tracking", "-0.01em"],
+  ["--type-section-label-tracking", "-0.006em"],
   ["--type-row-label-size", "17px"],
-  ["--type-row-description-size", "15px"],
+  ["--type-row-label-line", "22px"],
+  ["--type-row-label-tracking", "-0.01em"],
+  ["--type-row-description-size", "13px"],
+  ["--type-row-description-line", "18px"],
+  ["--type-row-description-tracking", "0"],
   ["--type-input-value-size", "17px"],
+  ["--type-input-value-line", "22px"],
+  ["--type-helper-text-size", "13px"],
+  ["--type-helper-text-line", "18px"],
+  ["--type-helper-text-tracking", "0"],
+  ["--type-legal-text-size", "11px"],
+  ["--type-legal-text-line", "15px"],
 ]) {
   if (!globals.includes(`${token}: ${value};`)) {
     failures.push(`app/globals.css: ${token} must stay ${value}`);
@@ -131,9 +150,64 @@ for (const repoPath of [
 
 expectIncludes(
   "components/dashboard/one-agent-roster.tsx",
-  "agents ({modes.length})",
-  "agents heading must preserve the requested natural lowercase casing",
+  "Agents ({modes.length})",
+  "agents heading is the page title and must use title casing",
 );
+
+expectNotIncludes(
+  "components/dashboard/one-agent-roster.tsx",
+  "text-[28px] leading-[34px]",
+  "agents heading must use the shared PageTitle role instead of a route-level arbitrary override",
+);
+
+expectNotIncludes(
+  "components/dashboard/one-agent-roster.tsx",
+  'placeholder="search agents"',
+  "search placeholder must preserve sentence casing",
+);
+
+for (const repoPath of [
+  "components/kai/shared/kai-typography.ts",
+  "components/dashboard/one-agent-roster.tsx",
+]) {
+  const source = read(repoPath);
+  for (const forbidden of [
+    "sm:text-",
+    "md:text-",
+    "lg:text-",
+    "xl:text-",
+    "clamp(",
+    "font-size:",
+    "fontSize:",
+  ]) {
+    if (source.includes(forbidden)) {
+      failures.push(`${repoPath}: strict app typography must not use ${forbidden}`);
+    }
+  }
+}
+
+for (const [key, uiRole] of [
+  ["largeTitle", "large-title"],
+  ["pageTitle", "page-title"],
+  ["pageSubtitle", "subtitle"],
+  ["sectionLabel", "section-label"],
+  ["cardTitle", "card-title"],
+  ["rowLabel", "body"],
+  ["rowDescription", "row-description"],
+  ["trailingValue", "trailing-value"],
+  ["trailingAction", "trailing-action"],
+  ["inputValue", "input-text"],
+  ["helperText", "helper-text"],
+  ["buttonLabel", "button-label"],
+  ["tabLabel", "tab-label"],
+  ["legal", "legal-text"],
+]) {
+  if (!typographySource.includes(`[TYPOGRAPHY_CLASSNAMES.${key}]: "${uiRole}"`)) {
+    failures.push(
+      `components/app-ui/typography.tsx: ${key} must emit data-ui-role="${uiRole}"`,
+    );
+  }
+}
 
 if (failures.length > 0) {
   console.error(`verify-apple-hierarchy: ${failures.length} failure(s)\n`);


### PR DESCRIPTION
## Summary
- lock the app typography tokens to the final strict Apple UI contract
- make the Agents roster page title use shared PageTitle and title casing (`Agents (7)`)
- route Finance/Kai shared typography and CRM runtime settings text through semantic typography roles
- extend the Apple hierarchy verifier to catch the lowercase Agents regression and shared token drift

## Verification
- npm run verify:design-system
- npm run typecheck
- npx eslint components/app-ui/typography.tsx components/connections/gemini-runtime-settings-card.tsx components/dashboard/one-agent-roster.tsx components/kai/shared/kai-typography.ts scripts/design/verify-apple-hierarchy.mjs