### PR TITLE
fix(ci): harden ship-ios TestFlight summary step against special-char notes

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -444,21 +444,36 @@ jobs:
       - name: Job summary
         if: always()
         shell: bash
+        # Untrusted / free-form values (the release SHA and the user-supplied
+        # notes) are passed through `env:` and referenced as quoted shell
+        # variables, never interpolated inline into the script body. Inlining
+        # `${{ github.event.inputs.notes }}` directly meant any quote, paren,
+        # or `>` in the notes produced malformed bash (e.g. `if [ -n ""Build" ]`)
+        # and failed this step with a syntax error AFTER a fully successful
+        # upload. See run 31403438972.
+        env:
+          SUMMARY_SHA: ${{ steps.resolve.outputs.sha }}
+          SUMMARY_BUILD: ${{ steps.build_number.outputs.next_build }}
+          SUMMARY_MODE: ${{ github.event.inputs.dry_run == 'true' && 'dry run (no upload)' || 'upload to TestFlight' }}
+          SUMMARY_NOTES: ${{ github.event.inputs.notes }}
         run: |
           set -euo pipefail
           MARKETING="$(grep -m1 -E 'MARKETING_VERSION[[:space:]]*=' "${PBXPROJ}" | sed -E 's/.*= *([^;]+);.*/\1/' | tr -d ' ')"
+          # Collapse newlines and escape the markdown cell separator so a
+          # multi-line or pipe-containing note cannot break the table row.
+          notes_cell="$(printf '%s' "${SUMMARY_NOTES:-}" | tr '\n' ' ' | sed 's/|/\\|/g')"
           {
             echo "## Ship iOS to TestFlight"
             echo ""
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| SHA | \`${{ steps.resolve.outputs.sha }}\` |"
+            echo "| SHA | \`${SUMMARY_SHA}\` |"
             echo "| Version | ${MARKETING:-unknown} |"
-            echo "| Build | ${{ steps.build_number.outputs.next_build }} |"
+            echo "| Build | ${SUMMARY_BUILD} |"
             echo "| Bundle | ${IOS_BUNDLE_ID} |"
             echo "| Backend | UAT (hushh-pda-uat) |"
-            echo "| Mode | ${{ github.event.inputs.dry_run == 'true' && 'dry run (no upload)' || 'upload to TestFlight' }} |"
-            if [ -n "${{ github.event.inputs.notes }}" ]; then
-              echo "| Notes | ${{ github.event.inputs.notes }} |"
+            echo "| Mode | ${SUMMARY_MODE} |"
+            if [ -n "${notes_cell}" ]; then
+              echo "| Notes | ${notes_cell} |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What & why

The **Ship iOS to TestFlight** workflow's final `Job summary` step failed with a bash syntax error whenever the `notes` input contained a quote, paren, or a greater-than sign — even though the build, signing, upload, and Apple processing all succeeded. This made a fully successful ship (run 31403438972: Archive ok, Export & upload to TestFlight ok, Poll ASC processing ok, artifact `ios-testflight-72` ok) show a red X on the run.

Root cause: the step interpolated `${{ github.event.inputs.notes }}` (and `sha`) **directly into the bash script body**. The run notes produced malformed shell:

```
syntax error near unexpected token `fi'
# from: if [ -n ""Build" ]; then  /  echo "| Notes | "Build |"
```

## Fix

Pass the untrusted / free-form values through `env:` and reference them as **quoted shell variables**, never inline:

```yaml
env:
  SUMMARY_SHA:   ${{ steps.resolve.outputs.sha }}
  SUMMARY_BUILD: ${{ steps.build_number.outputs.next_build }}
  SUMMARY_MODE:  ${{ github.event.inputs.dry_run == 'true' && 'dry run (no upload)' || 'upload to TestFlight' }}
  SUMMARY_NOTES: ${{ github.event.inputs.notes }}
```

```bash
notes_cell="$(printf '%s' "${SUMMARY_NOTES:-}" | tr '\n' ' ' | sed 's/|/\\|/g')"
echo "| SHA | \`${SUMMARY_SHA}\` |"
if [ -n "${notes_cell}" ]; then echo "| Notes | ${notes_cell} |"; fi
```

- No user/free-form value is injected into the script body anymore, so quotes/parens/greater-than/backticks can't break parsing (this also removes a script-injection footgun).
- `notes` is sanitized for the markdown table: newlines collapsed to spaces, the pipe char escaped, so a multi-line or pipe-containing note renders as one clean cell.
- Behavior is otherwise identical: same table, same fields.

## Scope note

This is the summary/reporting step only — it runs **after** upload and never affected the shipped binary. Build 72 is already on TestFlight from run 31403438972; this PR just makes future ships report green instead of a misleading red X, and hardens the step. No build/sign/upload/gate step changed; the governed dispatch gates (actor, ref=main, SHA-on-main, smoke) are untouched.

## Risk

Very low. One reporting step in a manually-dispatched workflow; env-passing is the GitHub-recommended pattern for untrusted inputs.
