### PR TITLE
Let search remember what this person actually does

### DIFF
--- a/hushh-webapp/__tests__/voice/action-usage-memory.test.ts
+++ b/hushh-webapp/__tests__/voice/action-usage-memory.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearActionUsage,
+  readActionUsage,
+  recordActionUse,
+  usageBoostFor,
+} from "@/lib/voice/action-usage-memory";
+
+const USER = "user_1";
+const DAY = 1000 * 60 * 60 * 24;
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("what the palette remembers", () => {
+  it("keeps habits apart per account", () => {
+    // A shared device must not blend one person's habits into another's
+    // suggestions.
+    recordActionUse(USER, "location.open_share");
+    recordActionUse("user_2", "analysis.start");
+
+    expect(readActionUsage(USER).map((entry) => entry.actionId)).toEqual([
+      "location.open_share",
+    ]);
+    expect(readActionUsage("user_2").map((entry) => entry.actionId)).toEqual([
+      "analysis.start",
+    ]);
+  });
+
+  it("records nothing without an account", () => {
+    recordActionUse(null, "location.open_share");
+    recordActionUse("", "location.open_share");
+
+    expect(readActionUsage(null)).toEqual([]);
+  });
+
+  it("puts a daily habit above a one-off burst", () => {
+    // Frequency alone entrenches last month's spike; recency alone forgets the
+    // thing you do every morning. This is the case that separates them.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00Z"));
+    for (let i = 0; i < 6; i += 1) recordActionUse(USER, "analysis.start");
+
+    vi.setSystemTime(new Date("2026-02-05T09:00:00Z"));
+    for (let i = 0; i < 3; i += 1) recordActionUse(USER, "location.open_share");
+
+    expect(readActionUsage(USER)[0].actionId).toBe("location.open_share");
+  });
+
+  it("forgets something used once, long ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00Z"));
+    recordActionUse(USER, "kai.setup.answer_horizon");
+
+    // Beyond the horizon: importing a portfolio once in March should not still
+    // be suggested in August.
+    vi.setSystemTime(new Date("2026-01-01T09:00:00Z").getTime() + 60 * DAY);
+    expect(readActionUsage(USER)).toEqual([]);
+  });
+
+  it("survives corrupt storage rather than throwing", () => {
+    window.localStorage.setItem("hushh.action-usage.v1.user_1", "{not json");
+    expect(readActionUsage(USER)).toEqual([]);
+
+    window.localStorage.setItem("hushh.action-usage.v1.user_1", '[{"nope":1}]');
+    expect(readActionUsage(USER)).toEqual([]);
+  });
+});
+
+describe("how much habit is allowed to matter", () => {
+  it("is a tie-break, never a way to outrank a better answer", () => {
+    for (let i = 0; i < 500; i += 1) recordActionUse(USER, "analysis.start");
+
+    // Capped well below the gap `scoreSearchMatch` puts between a label match
+    // (+8) and a keyword match (+4), so typing "circle" still finds Create a
+    // circle however often you have analysed a stock.
+    expect(usageBoostFor(readActionUsage(USER), "analysis.start")).toBeLessThanOrEqual(3);
+  });
+
+  it("is nothing at all for something never used", () => {
+    recordActionUse(USER, "analysis.start");
+    expect(
+      usageBoostFor(readActionUsage(USER), "location.open_join_circle"),
+    ).toBe(0);
+  });
+});
+
+describe("forgetting on request", () => {
+  it("clears one account without touching another", () => {
+    recordActionUse(USER, "location.open_share");
+    recordActionUse("user_2", "analysis.start");
+
+    clearActionUsage(USER);
+
+    expect(readActionUsage(USER)).toEqual([]);
+    expect(readActionUsage("user_2")).toHaveLength(1);
+  });
+});

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -387,6 +387,7 @@ export function KaiCommandBarGlobal() {
       appRuntimeState={appRuntimeState}
       capabilityState={canonicalAgentRuntime?.capabilityState}
       surfaceMetadata={getVoiceSurfaceMetadata()}
+      userId={userId || null}
       portfolioTickers={portfolioTickers}
     />
   );

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -52,6 +52,13 @@ import type { VoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { KAI_MARKET_PATH, ROUTES } from "@/lib/navigation/routes";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
+import {
+  RECENT_ACTION_LIMIT,
+  readActionUsage,
+  recordActionUse,
+  usageBoostFor,
+  type ActionUsageEntry,
+} from "@/lib/voice/action-usage-memory";
 
 export type KaiCommandPaletteSelection = {
   actionId: string;
@@ -66,6 +73,8 @@ interface KaiCommandPaletteProps {
   appRuntimeState?: AppRuntimeState;
   capabilityState?: VoiceCapabilityStateV1;
   surfaceMetadata?: VoiceSurfaceMetadata | null;
+  /** Scopes usage memory per account; a shared device must not blend habits. */
+  userId?: string | null;
   disabled?: boolean;
   portfolioTickers?: Array<{
     symbol: string;
@@ -279,6 +288,7 @@ export function KaiCommandPalette({
   appRuntimeState,
   capabilityState,
   surfaceMetadata,
+  userId = null,
   disabled = false,
   portfolioTickers = [],
 }: KaiCommandPaletteProps) {
@@ -560,6 +570,8 @@ export function KaiCommandPalette({
     [appRuntimeState, capabilityState, currentScreen, query, surfaceMetadata]
   );
 
+
+
   /**
    * What the screen the person is looking at can actually do, read straight
    * from the action gateway.
@@ -581,10 +593,12 @@ export function KaiCommandPalette({
   const [tappableControlIds, setTappableControlIds] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
   );
+  const [usage, setUsage] = useState<readonly ActionUsageEntry[]>([]);
   useEffect(() => {
     if (!open || typeof document === "undefined") return;
     setTappableControlIds(readTappableControlIds());
-  }, [open]);
+    setUsage(readActionUsage(userId));
+  }, [open, userId]);
 
   const surfaceActions = useMemo(() => {
     const screen = String(appRuntimeState?.route.screen || "").trim();
@@ -646,6 +660,70 @@ export function KaiCommandPalette({
   );
 
   /**
+   * The same matches, with what this person actually uses breaking ties.
+   *
+   * `searchKaiActions` has already ranked by how well each action answers the
+   * query; this only separates entries that answered it equally well. The
+   * boost is capped so a familiar action can never displace a better answer --
+   * typing "circle" must find Create a circle whether or not you have ever
+   * created one.
+   */
+  const rankedActionMatches = useMemo(() => {
+    if (usage.length === 0) return actionMatches;
+    return [...actionMatches].sort(
+      (left, right) =>
+        usageBoostFor(usage, right.action.action_id) -
+        usageBoostFor(usage, left.action.action_id),
+    );
+  }, [actionMatches, usage]);
+
+  /**
+   * What this person reaches for, offered before anything the app guessed.
+   *
+   * Filtered through the same availability and capability rules as every other
+   * group -- a habit is not a reason to offer something that cannot run -- and
+   * excludes whatever is already a button in front of them.
+   */
+  const recentActions = useMemo(() => {
+    if (usage.length === 0) return [];
+    const rows: KaiActionDefinition[] = [];
+    for (const entry of usage) {
+      if (rows.length >= RECENT_ACTION_LIMIT) break;
+      const action = getKaiActionById(entry.actionId);
+      if (!action) continue;
+      if (action.control_ids.some((id) => tappableControlIds.has(id))) continue;
+      if (isLocalHandlerAwayFromItsScreen(action, currentScreen)) continue;
+      const availability = evaluateKaiActionAvailability({
+        action,
+        appRuntimeState,
+        surfaceMetadata,
+      });
+      if (availability.status !== "available") continue;
+      if (
+        capabilityState &&
+        !isDiscoverableCapability(
+          projectKaiActionCapability({
+            actionId: action.action_id,
+            state: capabilityState,
+            surfaceMetadata,
+          }),
+        )
+      ) {
+        continue;
+      }
+      rows.push(action);
+    }
+    return rows;
+  }, [
+    appRuntimeState,
+    capabilityState,
+    currentScreen,
+    surfaceMetadata,
+    tappableControlIds,
+    usage,
+  ]);
+
+  /**
    * What the app has noticed and thinks is worth doing next.
    *
    * The insight comes first: a surface that has published a dead end is
@@ -697,6 +775,10 @@ export function KaiCommandPalette({
 
   function runAction(actionId: string, slots?: Record<string, unknown>) {
     if (disabled) return;
+    // The id only, and only what the person actually chose -- not what was
+    // merely offered, and never the slots that would turn a habit into a
+    // holding.
+    recordActionUse(userId, actionId);
     onOpenChange(false);
     setQuery("");
     // A local handler belonging to another screen cannot run from here: the
@@ -764,6 +846,29 @@ export function KaiCommandPalette({
             this group on screen, full of fuzzy matches, pushing the real
             results below the fold. A group that is not in the tree cannot be
             resurrected. */}
+        {!isFiltering && recentActions.length > 0 ? (
+          <CommandGroup heading="You usually">
+            {recentActions.map((action) => (
+              <CommandItem
+                className={commandItemClass}
+                key={`recent-${action.action_id}`}
+                disabled={disabled}
+                value={action.action_id}
+                onSelect={() => runAction(action.action_id)}
+              >
+                <Icon
+                  icon={History}
+                  size="sm"
+                  className="mr-2 text-muted-foreground"
+                />
+                <span className="min-w-0 truncate font-medium">
+                  {action.label}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ) : null}
+
         {!isFiltering && offScreenActions.length > 0 ? (
           <CommandGroup heading="Elsewhere on this screen">
             {offScreenActions.map(({ action }) => (
@@ -840,13 +945,13 @@ export function KaiCommandPalette({
         <CommandSeparator hidden={!isFiltering} />
 
         <CommandGroup heading="Commands" hidden={!isFiltering}>
-          {actionMatches.length === 0 ? (
+          {rankedActionMatches.length === 0 ? (
             <CommandItem className={commandItemClass} disabled>
               <Icon icon={Compass} size="sm" className="mr-2 text-muted-foreground" />
               No matching Kai actions.
             </CommandItem>
           ) : null}
-          {actionMatches.map(({ action, availability }) => {
+          {rankedActionMatches.map(({ action, availability }) => {
             const actionDisabled =
               disabled ||
               availability.status === "dead" ||

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -28,6 +28,7 @@ export function KaiSearchBar({
   appRuntimeState,
   capabilityState,
   surfaceMetadata,
+  userId = null,
   portfolioTickers = [],
 }: {
   onSelectAction: (selection: KaiCommandPaletteSelection) => void;
@@ -36,6 +37,7 @@ export function KaiSearchBar({
   appRuntimeState?: AppRuntimeState;
   capabilityState?: VoiceCapabilityStateV1;
   surfaceMetadata?: VoiceSurfaceMetadata | null;
+  userId?: string | null;
   portfolioTickers?: Array<{
     symbol: string;
     name?: string;
@@ -67,6 +69,7 @@ export function KaiSearchBar({
       appRuntimeState={appRuntimeState}
       capabilityState={capabilityState}
       surfaceMetadata={surfaceMetadata}
+      userId={userId}
       disabled={disabled}
       portfolioTickers={portfolioTickers}
     />

--- a/hushh-webapp/lib/voice/action-usage-memory.ts
+++ b/hushh-webapp/lib/voice/action-usage-memory.ts
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * What this person actually does, so search can lead with it.
+ *
+ * The gateway knows every action in the app; nothing knew which ones YOU use.
+ * That is the difference between a command palette and something that has met
+ * you before: the same six rows in the same order forever, however many times
+ * you have opened Location and never once opened the RIA workspace.
+ *
+ * Deliberately local and deliberately thin:
+ *
+ * - **Local only.** This is behavioural data about one person. It stays in
+ *   their browser, is keyed per account so a shared device cannot leak one
+ *   person's habits into another's suggestions, and never crosses the voice
+ *   trust boundary -- the model is told what a screen offers, never what its
+ *   owner tends to pick.
+ * - **Ids only.** An action id is a generated, public contract name. No slots,
+ *   no arguments, no query text: "you analysed a stock" is a habit, "you
+ *   analysed NVDA" is a holding.
+ * - **Bounded.** A fixed number of entries, pruned by usefulness, so this
+ *   cannot grow without limit in storage a person never asked to spend.
+ */
+
+const STORAGE_PREFIX = "hushh.action-usage.v1";
+/** Entries kept per account. Beyond this the least useful are dropped. */
+const MAX_ENTRIES = 40;
+/** How many recents the palette offers before it becomes a list of everything. */
+export const RECENT_ACTION_LIMIT = 4;
+/**
+ * A use stops counting toward the habit after this long. Someone who imported
+ * a portfolio once in March should not still be told about it in August.
+ */
+const RECENCY_HORIZON_MS = 1000 * 60 * 60 * 24 * 45;
+
+export type ActionUsageEntry = {
+  actionId: string;
+  count: number;
+  lastUsedAt: number;
+};
+
+function storageKey(userId: string | null | undefined): string | null {
+  const clean = String(userId || "").trim();
+  return clean ? `${STORAGE_PREFIX}.${clean}` : null;
+}
+
+function readAll(userId: string | null | undefined): ActionUsageEntry[] {
+  const key = storageKey(userId);
+  if (!key || typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const entry = item as Partial<ActionUsageEntry>;
+      const actionId = String(entry.actionId || "").trim();
+      const count = Number(entry.count);
+      const lastUsedAt = Number(entry.lastUsedAt);
+      if (!actionId || !Number.isFinite(count) || !Number.isFinite(lastUsedAt)) {
+        return [];
+      }
+      return [{ actionId, count: Math.max(1, count), lastUsedAt }];
+    });
+  } catch {
+    // Corrupt or unavailable storage is not worth an error path here: the
+    // worst case is a palette that has simply not met you yet.
+    return [];
+  }
+}
+
+function writeAll(
+  userId: string | null | undefined,
+  entries: ActionUsageEntry[],
+): void {
+  const key = storageKey(userId);
+  if (!key || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(entries));
+  } catch {
+    /* storage full or blocked; usage memory is an enhancement, never required */
+  }
+}
+
+/**
+ * Usefulness, for both ranking and pruning.
+ *
+ * Frequency alone entrenches whatever you did most last month; recency alone
+ * forgets the thing you do every morning because you happened to do something
+ * else twice today. Multiplying a log-damped count by a linear recency decay
+ * keeps a daily habit ahead of a one-off burst without freezing the list.
+ */
+function usefulness(entry: ActionUsageEntry, now: number): number {
+  const age = Math.max(0, now - entry.lastUsedAt);
+  if (age > RECENCY_HORIZON_MS) return 0;
+  const recency = 1 - age / RECENCY_HORIZON_MS;
+  return Math.log2(entry.count + 1) * recency;
+}
+
+/** Record that the person ran `actionId`. Ids only -- never slots. */
+export function recordActionUse(
+  userId: string | null | undefined,
+  actionId: string,
+): void {
+  const clean = String(actionId || "").trim();
+  if (!storageKey(userId) || !clean) return;
+  const now = Date.now();
+  const entries = readAll(userId);
+  const existing = entries.find((entry) => entry.actionId === clean);
+  if (existing) {
+    existing.count += 1;
+    existing.lastUsedAt = now;
+  } else {
+    entries.push({ actionId: clean, count: 1, lastUsedAt: now });
+  }
+  const pruned = entries
+    .filter((entry) => usefulness(entry, now) > 0 || entry.actionId === clean)
+    .sort((left, right) => usefulness(right, now) - usefulness(left, now))
+    .slice(0, MAX_ENTRIES);
+  writeAll(userId, pruned);
+}
+
+/** The person's habits, most useful first. */
+export function readActionUsage(
+  userId: string | null | undefined,
+): ActionUsageEntry[] {
+  const now = Date.now();
+  return readAll(userId)
+    .filter((entry) => usefulness(entry, now) > 0)
+    .sort((left, right) => usefulness(right, now) - usefulness(left, now));
+}
+
+/**
+ * A small ranking bonus for something this person uses, in the same units as
+ * `scoreSearchMatch`.
+ *
+ * Capped deliberately. Habit is a tie-breaker between things that already
+ * match what was typed, never a way for a familiar action to outrank a better
+ * answer -- typing "circle" must find Create a circle whether or not you have
+ * ever created one.
+ */
+export function usageBoostFor(
+  usage: readonly ActionUsageEntry[],
+  actionId: string,
+): number {
+  const now = Date.now();
+  const entry = usage.find((item) => item.actionId === actionId);
+  if (!entry) return 0;
+  return Math.min(3, usefulness(entry, now));
+}
+
+/** Forget this account's habits. */
+export function clearActionUsage(userId: string | null | undefined): void {
+  const key = storageKey(userId);
+  if (!key || typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    /* nothing to do */
+  }
+}


### PR DESCRIPTION
## What changes

The gateway knows every action in the app; nothing knew which ones *you* use.
Search offered the same rows in the same order forever — however many times you
had opened Location and never once opened the RIA workspace.

- **"You usually"** now leads the unfiltered palette, drawn from what this
  person has actually run.
- **Typed results keep the gateway's ranking**, with habit breaking ties only.

## Two judgement calls worth reviewing

**Habit settles ties; it does not win arguments.** The boost is capped at 3,
well under the gap `scoreSearchMatch` puts between a label match (+8) and a
keyword match (+4). Typing "circle" finds *Create a circle* whether or not you
have ever created one. A palette that quietly reorders itself around what you
did yesterday stops being predictable, and predictable matters more than clever
for something you use with your hands.

**Frequency and recency both, because either alone is wrong.** Frequency alone
entrenches whatever you did most last month. Recency alone forgets the thing
you do every morning because you happened to do something else twice today. A
log-damped count times a linear decay over 45 days keeps a daily habit ahead of
a one-off burst — the case is in the tests.

## What it deliberately does not know

- **Local to the browser**, keyed per account so a shared device cannot blend
  one person's habits into another's suggestions.
- **Never crosses the voice trust boundary.** The model is told what a screen
  offers, never what its owner tends to pick.
- **Action ids only** — a generated, public contract name. No slots, no
  arguments, no query text. "You analysed a stock" is a habit; "you analysed
  NVDA" is a holding, and this stores the first only.
- **Bounded** to 40 entries, pruned by the same usefulness score.

The recents list also passes through the same availability and capability
filters as every other group, and drops anything already a button on screen. A
habit is not a reason to offer something that cannot run.

## Scope for improvement

- **No way to forget from the UI.** `clearActionUsage` exists and is tested,
  but nothing calls it. Someone who wants their palette to stop suggesting
  something has no control for it — that should exist before this is treated as
  finished.
- **Recents are read when the palette opens**, so a run and a reopen inside the
  same session reflect immediately, but two palettes open at once would not
  agree. Not a real scenario today.
- The 45-day horizon and the cap of 3 are judgement, not measurement. They are
  in one file with the reasoning next to them, so they are cheap to revisit
  once there is real usage to look at.

## Verification

`tsc --noEmit` and `eslint --max-warnings=0` clean. 179 voice and palette tests,
including 8 new ones covering per-account separation, the daily-habit-vs-burst
case, expiry past the horizon, the boost cap, and corrupt storage.

Exercised on localhost. Not verified on device, though nothing here is
native-specific — `localStorage` under the Capacitor `App://` scheme behaves as
it does on web.
