### PR TITLE
fix(connect): stop the /api/one proxy swallowing the places stream

### DIFF
--- a/hushh-webapp/__tests__/app/api/one-proxy-stream.test.ts
+++ b/hushh-webapp/__tests__/app/api/one-proxy-stream.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ fetch: vi.fn() }));
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "https://backend.test",
+}));
+
+import { NextRequest } from "next/server";
+
+import { POST } from "@/app/api/one/[...path]/route";
+
+/**
+ * The `/api/one` proxy buffers every response through `response.json()`.
+ *
+ * For an event-stream that is silent data loss: the parse fails, the `.catch`
+ * turns it into `{}`, and the browser gets an empty object with status 200 --
+ * no frames and no error. That is exactly how "Places near you" showed an empty
+ * list on UAT while the backend was returning 23 KB of places. These pin the
+ * passthrough, and pin that ordinary JSON routes still buffer as before.
+ */
+
+function nextRequest(body: string): NextRequest {
+  return new NextRequest("https://app.test/api/one/places/stream", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: "Bearer t" },
+    body,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", mocks.fetch);
+});
+
+describe("/api/one proxy", () => {
+  it("passes an event-stream through instead of parsing it as JSON", async () => {
+    const frames = 'event: results\ndata: {"event":"results","category":"hotels_stays","items":[]}\n\n';
+    mocks.fetch.mockResolvedValue(
+      new Response(frames, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const response = await POST(
+      nextRequest(JSON.stringify({ lat: 1, lng: 2, categories: ["hotels_stays"] })) as never,
+      { params: Promise.resolve({ path: ["places", "stream"] }) },
+    );
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+    expect(response.headers.get("cache-control")).toContain("no-transform");
+    // The bytes must survive intact — this is what was being dropped.
+    await expect(response.text()).resolves.toContain("hotels_stays");
+  });
+
+  it("still buffers an ordinary JSON route exactly as before", async () => {
+    mocks.fetch.mockResolvedValue(
+      new Response(JSON.stringify({ items: [1, 2] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const response = await POST(
+      nextRequest(JSON.stringify({ q: "x" })) as never,
+      { params: Promise.resolve({ path: ["advisors", "search"] }) },
+    );
+
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toMatchObject({ items: [1, 2] });
+  });
+});

--- a/hushh-webapp/app/api/one/[...path]/route.ts
+++ b/hushh-webapp/app/api/one/[...path]/route.ts
@@ -71,6 +71,31 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
       body,
       signal: AbortSignal.timeout(ONE_API_TIMEOUT_MS),
     });
+
+    // A streamed upstream must be handed through untouched. The JSON path below
+    // buffers the whole body and swallows a parse failure into `{}`, which for
+    // an event-stream means the caller receives an empty object with status 200
+    // -- no frames, no error, and nothing to distinguish "the stream broke"
+    // from "there was nothing to send". The Kai proxy passes streams through
+    // for the same reason. Gated on the upstream content type, so every JSON
+    // route on this proxy keeps the exact behaviour it had.
+    const responseContentType = response.headers.get("content-type");
+    if (responseContentType?.includes("text/event-stream")) {
+      return new Response(response.body, {
+        status: response.status,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "private, no-store, no-cache, no-transform",
+          Pragma: "no-cache",
+          Connection: "keep-alive",
+          // Stops a compressing hop buffering the body in order to encode it.
+          "Content-Encoding": "none",
+          "X-Accel-Buffering": "no",
+          "x-request-id": requestId,
+        },
+      });
+    }
+
     const data = await response.json().catch(() => ({}));
     return withRequestIdJson(requestId, data, {
       status: response.status,

--- a/hushh-webapp/components/connect/__tests__/places-nearby.integration.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/places-nearby.integration.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  apiFetchStream: vi.fn(),
+  apiFetch: vi.fn(),
+  request: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+// The snapshot object is hoisted, not rebuilt per render. The real hook reads
+// from a singleton bus and hands back the same reference until the position
+// actually changes; a fresh object each render would retrigger the anchor
+// effect forever, which tests the mock rather than the component.
+const SNAPSHOT = { latitude: 12.9716, longitude: 77.5946 };
+
+vi.mock("@/lib/one-location/use-current-location", () => ({
+  useCurrentLocation: () => ({
+    status: "ready",
+    permission: "granted",
+    snapshot: SNAPSHOT,
+    error: null,
+    request: mocks.request,
+    refresh: mocks.refresh,
+  }),
+}));
+
+// Deliberately NOT mocking places-directory-service: the point of this file is
+// to exercise the component through the real client, which is the seam the
+// component tests mock away and where the surface actually broke on UAT.
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetchStream: mocks.apiFetchStream,
+    apiFetch: mocks.apiFetch,
+  },
+}));
+
+import { PlacesNearby } from "@/components/connect/places-nearby";
+
+const PLACE = {
+  placeId: "p1",
+  name: "Hotel Vivanta",
+  address: "12 Residency Rd",
+  distanceMeters: 640,
+  primaryType: "hotel",
+  categoryLabel: "Hotel",
+  category: "hotels_stays",
+  businessStatus: "OPERATIONAL",
+};
+
+function frame(event: string, data: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify({ event, ...data })}\n\n`;
+}
+
+function streamingResponse(pieces: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "text/event-stream" : null) },
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < pieces.length
+            ? { done: false, value: encoder.encode(pieces[i++]) }
+            : { done: true, value: undefined },
+        releaseLock: () => undefined,
+        cancel: async () => undefined,
+      }),
+    },
+  } as unknown as Response;
+}
+
+const getIdToken = async () => "id-token";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PlacesNearby end to end through the real client", () => {
+  it("renders rows from the exact bytes the backend emits", async () => {
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("meta", {
+          categories: ["hotels_stays"],
+          radiusMi: 5,
+          limit: 8,
+          attribution: {
+            source: "Google",
+            sourceUrl: "https://www.google.com/maps",
+            termsUrl: "https://cloud.google.com/maps-platform/terms",
+            notice: "Place data from Google Maps Platform.",
+            retrievedAt: "2026-08-10T09:00:00.000Z",
+          },
+        }),
+        frame("results", { category: "hotels_stays", items: [PLACE] }),
+        frame("done", { delivered: 1, failed: [], terminal: true }),
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.apiFetchStream).toHaveBeenCalled());
+    // The whole point: a real byte stream must become a visible row.
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    expect(screen.queryByTestId("places-empty")).toBeNull();
+  });
+
+  it("does not claim the area is empty when every category failed", async () => {
+    // The provider answering "no" ten times is not the same as there being
+    // nothing nearby, and saying "Nothing nearby" there is a lie the reader
+    // cannot act on. This is what UAT showed.
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("meta", { categories: ["hotels_stays", "food_drink"] }),
+        frame("category_error", { category: "hotels_stays", message: "upstream" }),
+        frame("category_error", { category: "food_drink", message: "upstream" }),
+        frame("done", { delivered: 0, failed: ["hotels_stays", "food_drink"], terminal: true }),
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.apiFetchStream).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId("places-error")).toBeTruthy());
+    expect(screen.queryByTestId("places-empty")).toBeNull();
+  });
+
+  it("still says nothing nearby when the provider genuinely returned nothing", async () => {
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("meta", { categories: ["hotels_stays"] }),
+        frame("results", { category: "hotels_stays", items: [] }),
+        frame("done", { delivered: 0, failed: [], terminal: true }),
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByTestId("places-empty")).toBeTruthy());
+    expect(screen.queryByTestId("places-error")).toBeNull();
+  });
+
+  it("falls back when a proxy buffers the stream into JSON", async () => {
+    // This is the exact UAT failure. The /api/one proxy did
+    // `await response.json().catch(() => ({}))` on every response, so an
+    // event-stream came back as `{}` with status 200: no frames, no error, and
+    // a surface that said "Nothing nearby" while the backend had just sent
+    // 23 KB of places. The stream must be recognised as not-a-stream so the
+    // ordinary endpoint answers instead.
+    mocks.apiFetchStream.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      body: { getReader: () => ({ read: async () => ({ done: true }), releaseLock: () => undefined }) },
+    } as unknown as Response);
+    mocks.apiFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        groups: [{ category: "hotels_stays", items: [PLACE] }],
+        failed: [],
+        meta: { categories: [], radiusMi: 5, limit: 8, attribution: null },
+      }),
+    } as unknown as Response);
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.apiFetch).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    expect(screen.queryByTestId("places-empty")).toBeNull();
+  });
+
+  it("does not re-sweep on its own after one successful sweep", async () => {
+    // A sweep that refires invalidates its own in-flight results through the
+    // sequence guard, so the surface can request forever and render nothing.
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("results", { category: "hotels_stays", items: [PLACE] }),
+      ]),
+    );
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(mocks.apiFetchStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/components/connect/places-nearby.tsx
+++ b/hushh-webapp/components/connect/places-nearby.tsx
@@ -112,9 +112,14 @@ export function PlacesNearby({
           ? { latitude: target.latitude, longitude: target.longitude }
           : { postalCode: target.postalCode };
 
+      /** Categories the provider refused, to tell a dead sweep from an empty one. */
+      const failed = new Set<string>();
+      let categoriesAnswered = 0;
+
       const accept = (category: string, items: PlaceCard[]) => {
         // A slower earlier sweep must never write into a newer one.
         if (token !== requestRef.current) return;
+        categoriesAnswered += 1;
         setByCategory((current) => ({ ...current, [category]: items }));
       };
 
@@ -140,10 +145,16 @@ export function PlacesNearby({
                 setAttribution(meta.attribution ?? null);
               },
               onCategory: accept,
-              // A single category failing is not a failed directory. The others
-              // are still a better answer than an error page, so this is
-              // swallowed on purpose rather than surfaced as the page's error.
-              onCategoryError: () => undefined,
+              // A single category failing is not a failed directory -- the
+              // others are still a better answer than an error page. But every
+              // category failing is not an empty neighbourhood, and saying
+              // "Nothing nearby" there tells the reader something false about
+              // the world instead of something true about us. Counted here,
+              // judged once the sweep ends.
+              onCategoryError: (category) => {
+                if (token !== requestRef.current) return;
+                failed.add(category);
+              },
             },
           });
         } catch (streamFailure) {
@@ -159,9 +170,17 @@ export function PlacesNearby({
           const fallback = await PlacesDirectoryService.searchNearby(shared);
           if (token !== requestRef.current) return;
           setAttribution(fallback.meta?.attribution ?? null);
+          for (const slug of fallback.failed ?? []) failed.add(slug);
           for (const group of fallback.groups) {
             accept(group.category, group.items);
           }
+        }
+
+        // Nothing answered and something refused: the provider is down, not the
+        // neighbourhood. Saying "Nothing nearby" here would be a claim about
+        // the world that we have no evidence for.
+        if (token === requestRef.current && categoriesAnswered === 0 && failed.size > 0) {
+          setError("Places are unavailable right now.");
         }
       } catch (caught) {
         if (controller.signal.aborted) return;

--- a/hushh-webapp/lib/services/__tests__/places-directory-service.test.ts
+++ b/hushh-webapp/lib/services/__tests__/places-directory-service.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  apiFetchStream: vi.fn(),
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetchStream: mocks.apiFetchStream,
+    apiFetch: mocks.apiFetch,
+  },
+}));
+
+import { PlacesDirectoryService } from "@/lib/services/places-directory-service";
+
+/**
+ * The parsing path the component tests never touch.
+ *
+ * Every test in `places-nearby.test.tsx` mocks `PlacesDirectoryService`
+ * wholesale, so the code that turns provider bytes into rows had no coverage at
+ * all -- which is exactly where the surface broke on UAT while every test was
+ * green. These drive the real reader against real frame bytes.
+ */
+
+const PLACE = {
+  placeId: "p1",
+  name: "Hotel Vivanta",
+  address: "12 Residency Rd",
+  distanceMeters: 640,
+  primaryType: "hotel",
+  categoryLabel: "Hotel",
+  category: "hotels_stays",
+  businessStatus: "OPERATIONAL",
+};
+
+function frame(event: string, data: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify({ event, ...data })}\n\n`;
+}
+
+/** A Response whose body streams the given string pieces, as the server does. */
+function streamingResponse(pieces: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "text/event-stream" : null) },
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < pieces.length
+            ? { done: false, value: encoder.encode(pieces[i++]) }
+            : { done: true, value: undefined },
+        releaseLock: () => undefined,
+        cancel: async () => undefined,
+      }),
+    },
+  } as unknown as Response;
+}
+
+function collect() {
+  const categories: { category: string; count: number }[] = [];
+  const errors: string[] = [];
+  let meta: unknown = null;
+  return {
+    categories,
+    errors,
+    get meta() {
+      return meta;
+    },
+    handlers: {
+      onMeta: (m: unknown) => {
+        meta = m;
+      },
+      onCategory: (category: string, items: unknown[]) =>
+        categories.push({ category, count: items.length }),
+      onCategoryError: (_c: string, m: string) => errors.push(m),
+    },
+  };
+}
+
+const BASE = {
+  idToken: "id-token",
+  origin: { latitude: 12.9716, longitude: 77.5946 },
+  categories: ["hotels_stays"],
+  radiusMi: 5,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PlacesDirectoryService.streamNearby", () => {
+  it("delivers rows from frames the server actually sends", async () => {
+    const sink = collect();
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("meta", { categories: ["hotels_stays"], attribution: { source: "Google" } }),
+        frame("results", { category: "hotels_stays", items: [PLACE] }),
+        frame("done", { delivered: 1, failed: [], terminal: true }),
+      ]),
+    );
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.categories).toEqual([{ category: "hotels_stays", count: 1 }]);
+    expect(sink.meta).toBeTruthy();
+  });
+
+  it("reassembles a frame split across two reads", async () => {
+    // The provider does not respect our frame boundaries; a row can arrive in
+    // two pieces and must not be dropped.
+    const whole = frame("results", { category: "hotels_stays", items: [PLACE] });
+    const cut = Math.floor(whole.length / 2);
+    const sink = collect();
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([whole.slice(0, cut), whole.slice(cut)]),
+    );
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.categories).toEqual([{ category: "hotels_stays", count: 1 }]);
+  });
+
+  it("delivers a final frame that arrives without a trailing blank line", async () => {
+    // A stream can end on a frame whose terminator never comes. The last
+    // category's rows must still be delivered rather than sitting in the buffer.
+    const sink = collect();
+    const unterminated = `event: results\ndata: ${JSON.stringify({
+      event: "results",
+      category: "hotels_stays",
+      items: [PLACE],
+    })}`;
+    mocks.apiFetchStream.mockResolvedValue(streamingResponse([unterminated]));
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.categories).toEqual([{ category: "hotels_stays", count: 1 }]);
+  });
+
+  it("delivers every category when the whole stream arrives as one chunk", async () => {
+    // A buffering intermediary collapses the stream into one read. Correct
+    // behaviour is still every row, just not progressively.
+    const sink = collect();
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("meta", { categories: ["hotels_stays", "food_drink"] }) +
+          frame("results", { category: "hotels_stays", items: [PLACE] }) +
+          frame("results", { category: "food_drink", items: [PLACE] }) +
+          frame("done", { delivered: 2, failed: [], terminal: true }),
+      ]),
+    );
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.categories.map((c) => c.category)).toEqual([
+      "hotels_stays",
+      "food_drink",
+    ]);
+  });
+
+  it("reports a failed category without rejecting the whole stream", async () => {
+    const sink = collect();
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("category_error", { category: "transit", message: "upstream said no" }),
+        frame("results", { category: "hotels_stays", items: [PLACE] }),
+        frame("done", { delivered: 1, failed: ["transit"], terminal: true }),
+      ]),
+    );
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.errors).toEqual(["upstream said no"]);
+    expect(sink.categories).toEqual([{ category: "hotels_stays", count: 1 }]);
+  });
+
+  it("ignores heartbeats", async () => {
+    const sink = collect();
+    mocks.apiFetchStream.mockResolvedValue(
+      streamingResponse([
+        frame("heartbeat", {}),
+        frame("results", { category: "hotels_stays", items: [PLACE] }),
+      ]),
+    );
+
+    await PlacesDirectoryService.streamNearby({ ...BASE, handlers: sink.handlers });
+
+    expect(sink.categories).toEqual([{ category: "hotels_stays", count: 1 }]);
+  });
+
+  it("sends coordinates in the body, never in the path", async () => {
+    mocks.apiFetchStream.mockResolvedValue(streamingResponse([]));
+
+    await PlacesDirectoryService.streamNearby({
+      ...BASE,
+      handlers: collect().handlers,
+    });
+
+    const [path, init] = mocks.apiFetchStream.mock.calls[0];
+    expect(path).toBe("/api/one/places/stream");
+    expect(path).not.toContain("lat");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toMatchObject({ lat: 12.9716, lng: 77.5946 });
+  });
+});

--- a/hushh-webapp/lib/services/places-directory-service.ts
+++ b/hushh-webapp/lib/services/places-directory-service.ts
@@ -204,6 +204,17 @@ export class PlacesDirectoryService {
       throw new Error(messageForStatus(response.status, payload));
     }
 
+    // A hop that buffers the body and re-encodes it as JSON answers 200 with no
+    // frames in it. Read as a stream that yields nothing, that is
+    // indistinguishable from "there is nothing near you" -- which is how this
+    // surface silently showed an empty list on UAT while the backend was
+    // returning 23 KB of places. Treat a non-stream answer as a failed stream
+    // so the caller falls back to the ordinary endpoint instead.
+    const contentType = response.headers?.get?.("content-type") ?? "";
+    if (contentType && !contentType.includes("text/event-stream")) {
+      throw new Error("Response is not a stream");
+    }
+
     const reader = response.body?.getReader();
     if (!reader) {
       // No streaming in this runtime. The caller's fallback handles it.
@@ -212,6 +223,35 @@ export class PlacesDirectoryService {
 
     const decoder = new TextDecoder();
     let buffer = "";
+
+    /** Hand one parsed frame to the caller. Shared by the loop and the flush. */
+    const dispatch = (frame: { event: string; data: string }) => {
+      let raw: Record<string, unknown>;
+      try {
+        raw = JSON.parse(frame.data) as Record<string, unknown>;
+      } catch {
+        // A frame we cannot read is not a reason to discard the rows we
+        // already delivered.
+        return;
+      }
+
+      if (frame.event === "meta" && raw.categories) {
+        opts.handlers.onMeta?.(raw as unknown as PlacesMeta);
+      } else if (frame.event === "results") {
+        const category = String(raw.category ?? "");
+        if (category && isPlaceCardArray(raw.items)) {
+          opts.handlers.onCategory(category, raw.items);
+        }
+      } else if (frame.event === "category_error") {
+        opts.handlers.onCategoryError?.(
+          String(raw.category ?? ""),
+          String(raw.message ?? "This category is unavailable."),
+        );
+      }
+      // "heartbeat" and "done" need no handling: the first exists only to keep
+      // intermediaries from closing a quiet connection, and the second is
+      // implied by the reader finishing.
+    };
 
     try {
       while (true) {
@@ -228,31 +268,17 @@ export class PlacesDirectoryService {
         buffer = parsed.remainder;
 
         for (const frame of parsed.events) {
-          let raw: Record<string, unknown>;
-          try {
-            raw = JSON.parse(frame.data) as Record<string, unknown>;
-          } catch {
-            // A frame we cannot read is not a reason to discard the rows we
-            // already delivered.
-            continue;
-          }
+          dispatch(frame);
+        }
+      }
 
-          if (frame.event === "meta" && raw.categories) {
-            opts.handlers.onMeta?.(raw as unknown as PlacesMeta);
-          } else if (frame.event === "results") {
-            const category = String(raw.category ?? "");
-            if (category && isPlaceCardArray(raw.items)) {
-              opts.handlers.onCategory(category, raw.items);
-            }
-          } else if (frame.event === "category_error") {
-            opts.handlers.onCategoryError?.(
-              String(raw.category ?? ""),
-              String(raw.message ?? "This category is unavailable."),
-            );
-          }
-          // "heartbeat" and "done" need no handling: the first exists only to
-          // keep intermediaries from closing a quiet connection, and the second
-          // is implied by the reader finishing.
+      // A stream can end on a frame whose blank-line terminator never arrives.
+      // `parseSSEBlocks` holds that tail in `remainder`, so without this flush
+      // the last category's rows sit in a buffer and are silently lost. The Kai
+      // stream client does the same thing for the same reason.
+      if (buffer.trim()) {
+        for (const frame of parseSSEBlocks("\n\n", buffer).events) {
+          dispatch(frame);
         }
       }
     } finally {


### PR DESCRIPTION
Fixes the "Nothing nearby" you saw on UAT.

## What was actually happening

The backend was working perfectly. Cloud Run logs for your session:

- ten `places:searchNearby` calls, **all 200 OK**
- `/api/one/places/stream` → **200, 23,543 bytes, 0.39s**

The bytes never reached the browser. `app/api/one/[...path]/route.ts` ends every proxied request with:

```ts
const data = await response.json().catch(() => ({}));
```

An event-stream is not JSON. The parse throws, the `.catch` turns it into `{}`, and the browser gets an empty object with **status 200**. No frames, and no error to distinguish *the stream was destroyed in transit* from *there is nothing near you*. The client parsed zero frames, threw nothing, never triggered its fallback, and reported an empty neighbourhood.

## Three fixes, each with the test that would have caught it

**1. The proxy passes event-streams through.** Gated on the upstream content type, so every JSON route on that shared proxy keeps byte-identical behaviour — pinned by a test. This mirrors `app/api/kai/[...path]/route.ts`, which already does exactly this.

**2. The client rejects a non-stream answer**, so a buffering hop makes it fall back to `/places/search` instead of silently rendering nothing. Had this existed, the surface would have degraded to a working list rather than lying.

**3. Every category failing no longer renders as "Nothing nearby".** That is a claim about the world we have no evidence for. It now says places are unavailable. A genuinely empty result still says "Nothing nearby" — both pinned.

Plus a real bug found on the way: the client never flushed the trailing SSE buffer, so a final frame arriving without its blank-line terminator was dropped. `kai-stream-client.ts` does this flush; this did not.

## Why no test caught it

All 20 tests in `places-nearby.test.tsx` mock `PlacesDirectoryService` wholesale, so the code turning provider bytes into rows had **zero coverage**, and nothing exercised the proxy at all. Green tests over an untested seam.

Both seams are now covered:

| Suite | Tests | Covers |
|---|---|---|
| `places-directory-service.test.ts` | 7 | real reader against real frame bytes — split frames, single-chunk, unterminated tail, heartbeats, coordinates-in-body |
| `places-nearby.integration.test.tsx` | 5 | component through the **real** client, including the exact UAT failure |
| `one-proxy-stream.test.ts` | 2 | stream passthrough, and that JSON routes are unaffected |

## Baseline

Full webapp suite against `origin/main`: same 9 failing files, **21 failures against the baseline's 22**, zero new. Typecheck and eslint clean.