### PR TITLE
fix(connect): Places is worldwide, so stop asking for a US ZIP

### DIFF
--- a/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
@@ -220,6 +220,26 @@ describe("PlacesNearby", () => {
     expect(screen.queryByTestId("places-error")).toBeNull();
   });
 
+  it("asks for a postcode, not a US ZIP, because Places is worldwide", async () => {
+    // BrokerCheck and the Nationwide locator are US registers and correctly say
+    // "ZIP". Google Places is not, so this input must not tell a reader in
+    // Bengaluru or Berlin that the surface is not for them. `inputMode` also
+    // has to allow letters, or a UK postcode cannot be typed on a phone.
+    mocks.locationState = {
+      status: "denied",
+      permission: "denied",
+      snapshot: null,
+      error: null,
+    };
+    render(<PlacesNearby getIdToken={getIdToken} />);
+
+    const input = screen.getByTestId("places-postal-input") as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("Postcode");
+    expect(input.getAttribute("aria-label")).toBe("Postcode");
+    expect(input.getAttribute("inputmode")).toBe("text");
+    expect(screen.queryByText(/ZIP/)).toBeNull();
+  });
+
   it("offers a ZIP search when the device says no", async () => {
     mocks.locationState = {
       status: "denied",

--- a/hushh-webapp/components/connect/nearby-directory-ui.tsx
+++ b/hushh-webapp/components/connect/nearby-directory-ui.tsx
@@ -49,19 +49,30 @@ export function DirectoryLoadingRows({ testId }: { testId: string }) {
 /**
  * The one way in when coordinates cannot answer the question — location was
  * refused, or the coordinates are real but the directory covers nobody there.
- * Both sources are US-only, so anyone outside the US has working GPS and an
- * empty list; a ZIP is the only thing that helps them.
+ *
+ * The label is a prop because the three directories do not share a geography.
+ * BrokerCheck and the Nationwide locator are US registers, so "ZIP" is the
+ * honest word there and anyone outside the US has working GPS and an empty
+ * list. Places is worldwide, so calling its input a ZIP tells a reader in
+ * Bengaluru or Berlin that the surface is not for them, which is false. The
+ * default stays "ZIP" so the two US directories are untouched.
  */
 export function PostalCodeForm({
   busy,
   initialValue = "",
   onSearch,
   testId,
+  label = "ZIP",
+  numericOnly = true,
 }: {
   busy: boolean;
   initialValue?: string;
   onSearch: (postalCode: string) => void;
   testId: string;
+  /** Shown as placeholder and accessible name. "ZIP" for US-only directories. */
+  label?: string;
+  /** US and Indian codes are digits; UK and Canadian ones are not. */
+  numericOnly?: boolean;
 }) {
   const [postalCode, setPostalCode] = useState(initialValue);
 
@@ -77,9 +88,9 @@ export function PostalCodeForm({
       <Input
         value={postalCode}
         onChange={(event) => setPostalCode(event.target.value)}
-        placeholder="ZIP"
-        inputMode="numeric"
-        aria-label="ZIP code"
+        placeholder={label}
+        inputMode={numericOnly ? "numeric" : "text"}
+        aria-label={label}
         className="h-11"
         data-testid={testId}
       />
@@ -212,6 +223,8 @@ export function LocationPrompt({
   testId,
   useLocationTestId,
   postalInputTestId,
+  postalLabel = "ZIP",
+  postalNumericOnly = true,
 }: {
   denied: boolean;
   busy: boolean;
@@ -222,6 +235,9 @@ export function LocationPrompt({
   testId: string;
   useLocationTestId: string;
   postalInputTestId: string;
+  /** See PostalCodeForm: "ZIP" is only honest for the two US registers. */
+  postalLabel?: string;
+  postalNumericOnly?: boolean;
 }) {
   const [showPostal, setShowPostal] = useState(denied);
 
@@ -238,7 +254,7 @@ export function LocationPrompt({
         {denied ? "Location is off" : heading}
       </h2>
       <PageSubtitle className="mt-2">
-        {denied ? "Search by ZIP instead." : "See who's close by."}
+        {denied ? `Search by ${postalLabel.toLowerCase()} instead.` : "See who's close by."}
       </PageSubtitle>
 
       {denied ? null : (
@@ -263,6 +279,8 @@ export function LocationPrompt({
             busy={busy}
             onSearch={onSearchPostalCode}
             testId={postalInputTestId}
+            label={postalLabel}
+            numericOnly={postalNumericOnly}
           />
         </div>
       ) : (

--- a/hushh-webapp/components/connect/places-nearby.tsx
+++ b/hushh-webapp/components/connect/places-nearby.tsx
@@ -246,6 +246,11 @@ export function PlacesNearby({
         testId="places-location-prompt"
         useLocationTestId="places-use-location"
         postalInputTestId="places-postal-input"
+        // Google Places is worldwide. Calling this a ZIP, as the two US
+        // registers correctly do, would tell a reader in Bengaluru the surface
+        // is not for them.
+        postalLabel="Postcode"
+        postalNumericOnly={false}
       />
     );
   }
@@ -299,7 +304,7 @@ export function PlacesNearby({
       {error ? (
         <QuietBlock
           title={error}
-          subtitle="Try again, or search a different ZIP."
+          subtitle="Try again, or search a different area."
           testId="places-error"
         >
           <div className="flex w-full flex-col items-center gap-4">
@@ -317,6 +322,8 @@ export function PlacesNearby({
               initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
               onSearch={handlePostalCode}
               testId="places-postal-input"
+              label="Postcode"
+              numericOnly={false}
             />
           </div>
         </QuietBlock>
@@ -328,7 +335,7 @@ export function PlacesNearby({
         // that help: a wider radius above, and a different place to look.
         <QuietBlock
           title="Nothing nearby"
-          subtitle="Try a wider radius, or another ZIP."
+          subtitle="Try a wider radius, or another postcode."
           testId="places-empty"
         >
           <PostalCodeForm
@@ -336,6 +343,8 @@ export function PlacesNearby({
             initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
             onSearch={handlePostalCode}
             testId="places-postal-input"
+            label="Postcode"
+            numericOnly={false}
           />
         </QuietBlock>
       ) : null}


### PR DESCRIPTION
Google Places answers anywhere. The two directories beside it do not — BrokerCheck and the Nationwide locator are US registers, and "ZIP" is the honest word there.

Places inherited that copy wholesale. A reader in Bengaluru whose location was refused got:

- a box labelled **ZIP**
- "Try a wider radius, or another **ZIP**"
- `inputMode="numeric"`, which cannot type a UK or Canadian postcode at all

Three separate signals that the surface is not for them, none of them true.

## Change

`label` and `numericOnly` are now props on `PostalCodeForm`, threaded through `LocationPrompt` as `postalLabel` / `postalNumericOnly`. **Both default to "ZIP" and numeric**, so the advisor and insurance directories are byte-identical — pinned by their own 39 tests still passing untouched.

Places passes "Postcode" and a text keypad, and its empty and error copy no longer name a US artefact.

## Scope

Copy and input mode only. The data was already worldwide: the search is a coordinate query against Google Places with no country restriction, and the postcode path resolves through a global text search.

91 Connect tests pass. Typecheck and eslint clean.