### PR TITLE
Fix SMS safety panel stacking

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -455,17 +455,18 @@ describe("SosPanel", () => {
     expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
   });
 
-  it("keeps the mobile strip but tightens into a measured two-column layout on large screens", () => {
+  it("keeps the SMS action in one centered stack on large screens", () => {
     const { container } = render(<SosPanel {...baseProps} />);
     const screenEl = screen.getByTestId("sms-safety-screen");
     // Mobile behavior preserved: still the full-screen black overlay.
     expect(screenEl).toHaveClass("fixed", "inset-0", "bg-black");
-    // The inner container keeps the mobile 407px strip and widens only enough
-    // to hold the ring and controls as one centered emergency panel.
+    // The inner container keeps the mobile strip and widens only enough to
+    // keep the emergency action centered beneath the title/subtitle.
     const inner = screenEl.firstElementChild as HTMLElement;
-    expect(inner).toHaveClass("max-w-[407px]", "lg:max-w-[820px]");
-    // The press ring + controls become a measured grid on lg.
-    expect(container.querySelector('[class*="lg:grid-cols-[280px_minmax(0,360px)]"]')).not.toBeNull();
+    expect(inner).toHaveClass("max-w-[407px]", "lg:max-w-[520px]");
+    // The press ring + controls must not split into a desktop grid.
+    expect(container.querySelector('[class*="lg:grid-cols-"]')).toBeNull();
+    expect(container.querySelector('[class*="lg:grid-cols_"]')).toBeNull();
   });
 });
 

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -326,7 +326,7 @@ export function SosPanel({
       data-ambient-chrome-ignore
       data-testid="sms-safety-screen"
     >
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))] lg:max-w-[720px] lg:px-6 lg:pt-[max(48px,env(safe-area-inset-top))]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))] lg:max-w-[520px] lg:px-6 lg:pt-[max(48px,env(safe-area-inset-top))]">
         <button
           type="button"
           onClick={onClose}
@@ -346,13 +346,12 @@ export function SosPanel({
           </p>
         </header>
 
-        {/* On wide viewports (lg+) the primary press ring and the
-            message/controls column sit side by side so the safety screen fills
-            the space instead of a single narrow strip. Below lg it stays the
-            original stacked column, untouched. The <style> block inside is
-            display:none and never participates in the flex row. */}
-        <div className="flex flex-1 flex-col justify-center gap-7 pt-6 lg:grid lg:grid-cols-[240px_minmax(0,320px)] lg:items-center lg:justify-center lg:gap-8 lg:pt-2">
-          <div className="flex items-center justify-center py-4 lg:py-0">
+        {/* The emergency action is one centered stack: title/subtitle, then the
+            hold button immediately beneath it, then the message and recovery
+            controls. Keeping this single column prevents the SMS action from
+            reading like a separate desktop panel. */}
+        <div className="flex flex-1 flex-col items-center gap-5 pt-7 lg:justify-start lg:pt-8">
+          <div className="flex items-center justify-center">
             <div className="relative flex h-[224px] w-[224px] items-center justify-center">
             <span className="absolute inset-0 rounded-full border border-white/10" />
             <span className="absolute inset-[24px] rounded-full border border-white/15" />
@@ -443,7 +442,7 @@ export function SosPanel({
         `}</style>
 
 
-        <div className="w-full lg:max-w-[320px]">
+        <div className="w-full max-w-[360px]">
           {/* While an SMS/SOS session is live, the primary action becomes
               stopping it. Cancelling here revokes the location grants created by
               the alert AND clears the incident, so "SENT · Live now" resets and


### PR DESCRIPTION
## Summary
- Keep the SMS safety screen as one centered Apple-style stack instead of splitting the hold button and controls into separate desktop columns.
- Place the SMS hold action directly beneath the title/subtitle, with message and cancel controls below it.
- Update the focused regression test to block future `lg:grid-cols-*` split layouts for this panel.

## Verification
- `npm run verify:design-system`
- `npx eslint components/one-location/redesign/sos-panel.tsx components/one-location/redesign/__tests__/sos-panel.test.tsx`
- `npx vitest run components/one-location/redesign/__tests__/sos-panel.test.tsx`
- `npm run typecheck`
- `npm run verify:cache`
- `npm run verify:docs`