### PR TITLE
Fix Location Agent visual contract

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -193,12 +193,14 @@ vi.mock("@/lib/morphy-ux/ui/swipe-views", () => ({
     activeValue,
     onSelectionChange,
     viewportMinHeight,
+    heightMode,
   }: {
     children: ReactNode;
     options: readonly { label: string; value: string }[];
     activeValue: string;
     onSelectionChange?: (value: string) => void;
     viewportMinHeight?: string;
+    heightMode?: "max" | "active";
   }) => {
     const activeIndex = options.findIndex(({ value }) => value === activeValue);
     const activeChild = Children.toArray(children)[activeIndex];
@@ -207,6 +209,7 @@ vi.mock("@/lib/morphy-ux/ui/swipe-views", () => ({
       <div
         data-testid="location-swipe-views"
         data-viewport-min-height={viewportMinHeight}
+        data-height-mode={heightMode ?? "max"}
       >
         {options.map(({ label, value }) => (
           <button
@@ -638,6 +641,37 @@ async function skipLocationEntryFlow(options: { expectMain?: boolean } = {}) {
   mockCaptureCurrentPosition.mockClear();
 }
 
+async function expectEmergencyAction(
+  number: string,
+  countryName: string,
+): Promise<HTMLElement> {
+  const linkName = new RegExp(
+    `Call ${number} emergency services \\(${countryName}\\)`,
+    "i",
+  );
+  const copyName = new RegExp(
+    `Copy ${number} emergency services \\(${countryName}\\)`,
+    "i",
+  );
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("link", { name: linkName }) ||
+        screen.queryByRole("button", { name: copyName }),
+    ).not.toBeNull();
+  });
+
+  const link = screen.queryByRole("link", { name: linkName });
+  if (link) {
+    expect(link).toHaveAttribute("href", `tel:${number}`);
+    return link;
+  }
+
+  const copyButton = screen.getByRole("button", { name: copyName });
+  expect(copyButton).toBeEnabled();
+  return copyButton;
+}
+
 async function openLocationPermissionsStep() {
   await openLocationFeatureStep();
 }
@@ -954,6 +988,10 @@ describe("OneLocationAgentPage", () => {
       "data-viewport-min-height",
       "0px",
     );
+    expect(screen.getByTestId("location-swipe-views")).toHaveAttribute(
+      "data-height-mode",
+      "active",
+    );
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.getByRole("button", { name: /Active shares/i })).toBeTruthy();
     expect(
@@ -1003,17 +1041,15 @@ describe("OneLocationAgentPage", () => {
     const headerRow = heading.closest('[data-slot="page-header-row"]');
     expect(headerRow).toBeTruthy();
     expect(headerRow).toHaveClass("flex", "items-start", "justify-between");
-    expect(heading.firstElementChild).toHaveClass(
-      "inline-flex",
-      "h-9",
-      "items-center",
-      "whitespace-nowrap",
-    );
+    expect(heading).toHaveClass("ui-text-agent-title");
     expect(
       headerRow?.contains(
         screen.getByRole("switch", { name: "Turn location on" }),
       ),
     ).toBe(true);
+    expect(
+      screen.getByRole("switch", { name: "Turn location on" }),
+    ).toHaveAttribute("data-size", "ios");
     expect(screen.getByText("Location off").className).toContain("sm:inline");
 
     mockCaptureCurrentPosition.mockClear();
@@ -1508,11 +1544,7 @@ describe("OneLocationAgentPage", () => {
       lat: 28.6139,
       lng: 77.209,
     });
-    expect(
-      await screen.findByRole("link", {
-        name: /Call 112 emergency services \(India\)/i,
-      }),
-    ).toHaveAttribute("href", "tel:112");
+    await expectEmergencyAction("112", "India");
     expect(mockStoreEnvelope).toHaveBeenCalledTimes(envelopeWritesBeforeOpen);
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -1557,11 +1589,7 @@ describe("OneLocationAgentPage", () => {
         countryCode: "US",
       });
     });
-    expect(
-      await screen.findByRole("link", {
-        name: /Call 911 emergency services \(United States\)/i,
-      }),
-    ).toHaveAttribute("href", "tel:911");
+    await expectEmergencyAction("911", "United States");
   });
 
   it("resolves the local emergency number on a direct SOS link and hides unverified numbers", async () => {
@@ -1607,11 +1635,7 @@ describe("OneLocationAgentPage", () => {
       });
     });
 
-    expect(
-      await screen.findByRole("link", {
-        name: /Call 911 emergency services \(United States\)/i,
-      }),
-    ).toHaveAttribute("href", "tel:911");
+    await expectEmergencyAction("911", "United States");
     expect(mockCaptureCurrentPosition).toHaveBeenCalled();
     expect(mockReverseGeocode).toHaveBeenCalledTimes(1);
   });
@@ -3063,7 +3087,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockRequestAccess).toHaveBeenCalledWith({
       vaultOwnerToken: "vault-token",
       ownerUserId: "user_b",
-      message: "Need pickup coordination",
+      message: "Safety check-in — Need pickup coordination",
     });
     expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
     expect(mockStoreEnvelope).not.toHaveBeenCalled();

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -294,8 +294,8 @@ textarea {
   --type-button-label-size: 17px;
   --type-button-label-line: 22px;
   --type-button-label-weight: 600;
-  --type-tab-label-size: 11px;
-  --type-tab-label-line: 13px;
+  --type-tab-label-size: 17px;
+  --type-tab-label-line: 22px;
   --type-tab-label-weight: 500;
   --foundation-caption-tracking: 0.158em;
   --foundation-micro-size: 0.6875rem;
@@ -523,6 +523,9 @@ textarea {
   --kai-command-fixed-ui: 82px;
   --kai-command-bottom-gap: 12px;
   --app-screen-footer-pad: calc(8px + var(--app-bottom-inset));
+  --app-bottom-content-clearance: calc(
+    var(--bottom-chrome-stack-height, var(--app-bottom-inset)) + 24px
+  );
   --app-top-safe-offset: 0px;
   --app-safe-area-top-probe: 0px;
   --app-safe-area-top: var(
@@ -535,13 +538,13 @@ textarea {
     var(--app-safe-area-top-probe)
   );
   --app-top-bar-height: 72px;
-  --kai-route-tabs-height: 42px;
+  --kai-route-tabs-height: 56px;
   --kai-route-tabs-content-gap: 14px;
   /* Global top-shell geometry contract (consumed by providers + top-app-bar).
    * Keep these tokens defined at root so web and native share deterministic spacing. */
   --top-shell-safe-area: var(--app-safe-area-top-effective);
   --top-inset: var(--top-shell-safe-area);
-  --top-bar-h: 44px;
+  --top-bar-h: 56px;
   --top-bar-side-w: 98px;
   --top-tabs-h: var(--kai-route-tabs-height);
   --top-tabs-gap: var(--kai-route-tabs-content-gap);
@@ -554,7 +557,7 @@ textarea {
   /* Single visual clearance between the fixed top shell and the first page block.
    * `--page-top-start` is the body-start gap token designers inspect/tune directly.
    * The actual structural spacer adds reserved shell height on top of this value. */
-  --page-top-start: 40px;
+  --page-top-start: 28px;
   --app-top-body-start-gap: var(--page-top-start);
   --page-top-local-offset: 0px;
   --app-shell-reading: 54rem;
@@ -601,7 +604,7 @@ textarea {
     var(--top-shell-visual-height) + var(--top-subnav-total, 0px) +
       var(--top-content-safe-gap)
   );
-  --page-inline-gutter-standard: 20px;
+  --page-inline-gutter-standard: 16px;
   --page-surface-overscan: 0px;
   --page-surface-gap-standard: 16px;
   --page-surface-gap-compact: 12px;
@@ -729,7 +732,7 @@ textarea {
   --motion-deck-scale-other: 0.84;
   /* Foundation (bible): a bright white canvas carries the ambient wash while
      cards remain legible without reverting the app to an opaque flat page. */
-  --background: #ffffff;
+  --background: #f2f2f7;
   --foreground: oklch(0.232 0.004 286.1);
   --card: #ffffff;
   --card-foreground: oklch(0.232 0.004 286.1);
@@ -807,12 +810,12 @@ textarea {
 
   /* App Background - bright Foundation canvas; the shared ambient layer
      supplies its accent depth rather than a separate route gradient. */
-  --app-bg-start: #ffffff;
-  --app-bg-mid: #ffffff;
-  --app-bg-end: #ffffff;
+  --app-bg-start: #f2f2f7;
+  --app-bg-mid: #f2f2f7;
+  --app-bg-end: #f2f2f7;
   /* The base beneath persistent chrome. Foundation may add its restrained
    * corner ambience over this, but shell material must share the same base. */
-  --app-layout-surface: var(--background);
+  --app-layout-surface: var(--app-grouped-background);
 
   --glass1: #ffffff60 !important;
   --glass2: #6464643b !important;
@@ -4639,100 +4642,15 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
    mirrors the quiet root treatment so public, authenticated, and nested
    routes never drift into separate gradients or opaque chrome bands. */
 .foundation-public-ambient {
-  /* Light mode gets the same four-corner accent wash as dark mode, tuned
-     stronger, not weaker: mixing an accent into near-white at the same
-     percentage as near-black reads as far fainter, because the relative
-     luminance/hue shift off a bright base is much smaller. These percentages
-     are deliberately above dark mode's 6-8% so the corners actually read as
-     an accent glow instead of disappearing into the white canvas. */
+  /* Standard app canvas: a quiet iOS grouped background. */
   --foundation-grain-opacity: 0.1;
-  --foundation-ambient-primary: 12%;
-  --foundation-ambient-secondary: 10%;
-  --foundation-ambient-tertiary: 9%;
-  --foundation-ambient-quaternary: 7%;
-  background-color: var(--app-layout-surface);
-  background-image:
-    radial-gradient(
-      circle at 4% 4%,
-      color-mix(
-        in oklab,
-        var(--app-accent) var(--foundation-ambient-primary),
-        transparent
-      ),
-      transparent 31%
-    ),
-    radial-gradient(
-      circle at 100% 0%,
-      color-mix(
-        in oklab,
-        var(--app-accent-bright) var(--foundation-ambient-secondary),
-        transparent
-      ),
-      transparent 33%
-    ),
-    radial-gradient(
-      circle at 0% 100%,
-      color-mix(
-        in oklab,
-        var(--app-accent) var(--foundation-ambient-tertiary),
-        transparent
-      ),
-      transparent 33%
-    ),
-    radial-gradient(
-      circle at 100% 100%,
-      color-mix(
-        in oklab,
-        var(--app-accent-bright) var(--foundation-ambient-quaternary),
-        transparent
-      ),
-      transparent 31%
-    );
+  background-color: var(--app-grouped-background);
+  background-image: none;
 }
 
 .dark .foundation-public-ambient {
-  --foundation-ambient-primary: 8%;
-  --foundation-ambient-secondary: 7%;
-  --foundation-ambient-tertiary: 6%;
-  --foundation-ambient-quaternary: 6%;
   --foundation-grain-opacity: 0.08;
-  background-image:
-    radial-gradient(
-      circle at 4% 4%,
-      color-mix(
-        in oklab,
-        var(--app-accent) var(--foundation-ambient-primary),
-        transparent
-      ),
-      transparent 31%
-    ),
-    radial-gradient(
-      circle at 100% 0%,
-      color-mix(
-        in oklab,
-        var(--app-accent-bright) var(--foundation-ambient-secondary),
-        transparent
-      ),
-      transparent 33%
-    ),
-    radial-gradient(
-      circle at 0% 100%,
-      color-mix(
-        in oklab,
-        var(--app-accent) var(--foundation-ambient-tertiary),
-        transparent
-      ),
-      transparent 33%
-    ),
-    radial-gradient(
-      circle at 100% 100%,
-      color-mix(
-        in oklab,
-        var(--app-accent-bright) var(--foundation-ambient-quaternary),
-        transparent
-      ),
-      transparent 31%
-    );
+  background-image: none;
 }
 
 /* Custom Scrollbar Styles */
@@ -5568,6 +5486,17 @@ body[data-persona-surface="ria"] {
   text-transform: none !important;
 }
 
+:is(.ui-text-agent-title) {
+  color: var(--app-label) !important;
+  font-family: var(--font-app-display) !important;
+  font-size: 34px !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.03em !important;
+  line-height: 41px !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
 :is(.ui-text-navigation-title) {
   color: var(--app-label) !important;
   font-family: var(--font-app-body) !important;
@@ -5726,12 +5655,21 @@ body[data-persona-surface="ria"] {
 }
 
 :is(.ui-text-tab-label) {
+  color: var(--app-secondary-label) !important;
   font-family: var(--font-app-body) !important;
   font-size: var(--type-tab-label-size) !important;
   font-weight: var(--type-tab-label-weight) !important;
-  letter-spacing: 0 !important;
+  letter-spacing: -0.01em !important;
   line-height: var(--type-tab-label-line) !important;
   opacity: 1 !important;
+}
+
+[role="tab"][aria-selected="true"] :is(.ui-text-tab-label) {
+  color: var(--app-accent) !important;
+}
+
+[role="tab"][aria-selected="false"] :is(.ui-text-tab-label) {
+  color: var(--app-secondary-label) !important;
 }
 
 :is(.ui-text-caption) {

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -512,7 +512,7 @@ function AppShellFrame({ children }: ProvidersProps) {
                             ? "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none overscroll-y-contain touch-pan-y pb-[var(--app-scroll-bottom-pad,var(--onboarding-agent-bar-clearance))] relative z-10 min-h-0"
                             : shouldLockFullscreenRoot
                               ? "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y relative z-10 min-h-0"
-                              : "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y pb-[var(--app-scroll-bottom-pad,var(--app-bottom-inset))] relative z-10 min-h-0"
+                              : "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y pb-[var(--app-scroll-bottom-pad,var(--app-bottom-content-clearance))] relative z-10 min-h-0"
                         }
                       >
                         {!hideGlobalChrome && !shouldLockFullscreenRoot ? (
@@ -576,7 +576,7 @@ function AppShellFrame({ children }: ProvidersProps) {
                             : shouldLockFullscreenRoot
                               ? // Fullscreen flows keep chrome contract, but permit y-scroll for small devices.
                                 "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y relative z-10 min-h-0"
-                              : "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y pb-[var(--app-scroll-bottom-pad,var(--app-bottom-inset))] relative z-10 min-h-0"
+                              : "flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none touch-pan-y pb-[var(--app-scroll-bottom-pad,var(--app-bottom-content-clearance))] relative z-10 min-h-0"
                         }
                       >
                         {!hideGlobalChrome && !shouldLockFullscreenRoot ? (

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -5,6 +5,7 @@ import type { LucideIcon } from "lucide-react";
 
 import { SurfaceCard, type SurfaceAccent, type SurfaceTone } from "@/components/app-ui/surfaces";
 import {
+  AgentTitle,
   CardTitle,
   PageSubtitle,
   PageTitle,
@@ -21,6 +22,7 @@ type SectionAccent =
   | "marketplace"
   | "developers"
   | "research"
+  | "location"
   | "success"
   | "warning"
   | "critical"
@@ -79,6 +81,11 @@ const ACCENT_STYLES: Record<SectionAccent, {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
+    divider: "bg-[color:var(--app-separator)]",
+  },
+  location: {
+    eyebrow: "text-muted-foreground",
+    icon: "bg-[color:var(--app-accent)] text-white shadow-none",
     divider: "bg-[color:var(--app-separator)]",
   },
   success: {
@@ -166,6 +173,7 @@ export function PageHeader({
   icon,
   leading,
   accent = "default",
+  titleRole = "page",
   className,
   testId = "page-header",
 }: {
@@ -178,10 +186,12 @@ export function PageHeader({
   icon?: LucideIcon;
   leading?: ReactNode;
   accent?: SectionAccent;
+  titleRole?: "page" | "agent";
   className?: string;
   testId?: string;
 }) {
   const styles = ACCENT_STYLES[accent];
+  const TitleComponent = titleRole === "agent" ? AgentTitle : PageTitle;
   return (
     <header
       className={cn("space-y-[var(--page-header-stack-gap)]", className)}
@@ -196,7 +206,10 @@ export function PageHeader({
             leading={leading}
             iconSize="lg"
             iconClassName={cn(
-              "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[8px]",
+              "flex shrink-0 items-center justify-center",
+              titleRole === "agent"
+                ? "h-11 w-11 rounded-[10px]"
+                : "h-[34px] w-[34px] rounded-[8px]",
               styles.icon
             )}
           />
@@ -221,9 +234,9 @@ export function PageHeader({
                   {eyebrow}
                 </SectionLabel>
               ) : null}
-              <PageTitle>
+              <TitleComponent>
                 {title}
-              </PageTitle>
+              </TitleComponent>
               {description && !descriptionFullWidth ? (
                 <PageSubtitle
                   as="div"

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -193,7 +193,7 @@ export function SettingsGroup({
       className={cn(
         // Inset settings groups use the compact card radius and flat grouped
         // Apple surfaces; separators inside the card carry the structure.
-        "relative isolate [--settings-group-radius:var(--app-card-radius-compact)] overflow-hidden rounded-[var(--settings-group-radius)]",
+        "relative isolate [--settings-group-radius:22px] overflow-hidden rounded-[var(--settings-group-radius)]",
         "bg-[color:var(--app-card-surface-default-solid)] shadow-none ring-0",
         !embedded && "sm:rounded-[var(--settings-group-radius)]",
         shellClassName,
@@ -321,15 +321,15 @@ export function SettingsRow({
     // need a full-width hairline; otherwise the divider appears arbitrarily cut
     // off, as it did on Connect's plain-text rows.
     icon || leading
-      ? "group-data-[inset-separators=true]/settings-list:after:left-[3.75rem] sm:group-data-[inset-separators=true]/settings-list:after:left-[4.25rem]"
+      ? "group-data-[inset-separators=true]/settings-list:after:left-[62px] sm:group-data-[inset-separators=true]/settings-list:after:left-[62px]"
       : "group-data-[inset-separators=true]/settings-list:after:left-0";
   const rowShellClassName = cn(
-    "group/settings-row relative isolate overflow-hidden bg-[color:var(--app-list-row-surface)] sm:bg-transparent",
-    resolvedDensity === "compact" && "[--settings-row-py:11px]",
+    "group/settings-row relative isolate overflow-hidden bg-transparent",
+    resolvedDensity === "compact" && "[--settings-row-py:13px]",
     // iOS-style separator — active only inside SettingsGroup with
     // separatorInset and hidden on the final row. Its start is derived from
     // whether this row actually has a leading visual.
-    "group-data-[inset-separators=true]/settings-list:after:pointer-events-none group-data-[inset-separators=true]/settings-list:after:absolute group-data-[inset-separators=true]/settings-list:after:bottom-0 group-data-[inset-separators=true]/settings-list:after:right-0 group-data-[inset-separators=true]/settings-list:after:h-px group-data-[inset-separators=true]/settings-list:after:bg-[color:var(--app-separator)] group-data-[inset-separators=true]/settings-list:after:content-[''] last:after:hidden",
+    "group-data-[inset-separators=true]/settings-list:after:pointer-events-none group-data-[inset-separators=true]/settings-list:after:absolute group-data-[inset-separators=true]/settings-list:after:bottom-0 group-data-[inset-separators=true]/settings-list:after:right-4 group-data-[inset-separators=true]/settings-list:after:h-px group-data-[inset-separators=true]/settings-list:after:bg-[color:var(--app-separator)] group-data-[inset-separators=true]/settings-list:after:content-[''] last:after:hidden",
     separatorInsetClassName,
     rowRadiusClassName,
     disabled && "cursor-not-allowed opacity-60",
@@ -354,13 +354,13 @@ export function SettingsRow({
             // Keep settings icons as iOS-style rounded-square utility wells.
             // Agent artwork continues to use AgentSectionIcon, which owns the
             // larger launcher/menu geometry separately.
-            "inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center self-center rounded-[8px]",
+            "inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center self-center rounded-[9px]",
             resolvedDensity !== "compact" &&
-              "sm:h-[34px] sm:w-[34px] sm:rounded-[8px]",
+              "sm:h-[34px] sm:w-[34px] sm:rounded-[9px]",
             SETTINGS_ICON_TONE_CLASSNAME[resolvedIconTone],
           )}
         >
-          <Icon icon={icon} size="md" />
+          <Icon icon={icon} size={19} />
         </span>
       ) : null}
       <div className="min-w-0 flex-1 space-y-0.5">
@@ -386,8 +386,14 @@ export function SettingsRow({
       </div>
     </div>
   );
+  const renderedTrailing =
+    typeof trailing === "string" || typeof trailing === "number" ? (
+      <TrailingValue>{trailing}</TrailingValue>
+    ) : (
+      trailing
+    );
   const trailingContent =
-    trailing || chevron ? (
+    renderedTrailing || chevron ? (
       <div
         className={cn(
           "relative z-0 flex max-w-full shrink-0 items-center justify-end self-center gap-2.5 pr-0.5 sm:pr-1",
@@ -395,7 +401,7 @@ export function SettingsRow({
             "w-full min-w-0 justify-between pl-[var(--settings-row-stack-indent,2.65rem)] pt-1 sm:w-auto sm:justify-end sm:pl-0 sm:pt-0",
         )}
       >
-        {trailing}
+        {renderedTrailing}
         {chevron ? (
           <ChevronRight
             className={cn(
@@ -408,7 +414,7 @@ export function SettingsRow({
     ) : null;
 
   const sharedClassName = cn(
-    "relative isolate grid w-full appearance-none overflow-hidden border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 [-webkit-tap-highlight-color:transparent]",
+    "relative isolate grid min-h-[60px] w-full appearance-none overflow-hidden border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 [-webkit-tap-highlight-color:transparent]",
     shouldStackTrailing
       ? "grid-cols-1 gap-y-[var(--settings-row-stack-gap)] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-x-[var(--settings-row-gap)] sm:gap-y-0"
       : "grid-cols-[minmax(0,1fr)_auto] items-center gap-x-[var(--settings-row-gap)]",
@@ -416,7 +422,7 @@ export function SettingsRow({
       "transition-[border-color,box-shadow] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0",
   );
   const primaryActionClassName = cn(
-    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    "relative isolate min-h-[60px] min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
   );
   const voiceProps = {
     "data-voice-control-id": voiceControlId || undefined,

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -383,7 +383,7 @@ function TopShellBreadcrumbTrail({
     <nav
       aria-label="Breadcrumb"
       data-testid="top-app-bar-breadcrumb-trail"
-      className="top-shell-ambient-ink pointer-events-auto flex min-w-0 items-center gap-1 text-[15px] font-medium text-current"
+      className="ui-text-navigation-title top-shell-ambient-ink pointer-events-auto flex min-w-0 items-center gap-1 text-current"
     >
       {items.map((item, index) => {
         const isLast = index === items.length - 1;

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -175,10 +175,10 @@ export function TopShellTabs({
             >
               <span
                 className={cn(
-                  "ui-text-form-label relative truncate transition-colors duration-150",
+                  "ui-text-tab-label relative truncate transition-colors duration-150",
                   isActive
-                    ? "font-semibold text-current"
-                    : "font-normal text-[color:var(--app-secondary-label)] hover:text-current",
+                    ? "text-[color:var(--app-accent)]"
+                    : "text-[color:var(--app-secondary-label)] hover:text-current",
                 )}
               >
                 {tab.label}

--- a/hushh-webapp/components/app-ui/typography.tsx
+++ b/hushh-webapp/components/app-ui/typography.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 export const TYPOGRAPHY_CLASSNAMES = {
   largeTitle: "ui-text-large-page-title",
   pageTitle: "ui-text-page-title",
+  agentTitle: "ui-text-agent-title",
   pageSubtitle: "ui-text-page-subtitle",
   navigationTitle: "ui-text-navigation-title",
   identityName: "ui-text-identity-name",
@@ -31,6 +32,7 @@ export const TYPOGRAPHY_CLASSNAMES = {
 const TYPOGRAPHY_ROLE_BY_CLASSNAME: Record<string, string> = {
   [TYPOGRAPHY_CLASSNAMES.largeTitle]: "large-title",
   [TYPOGRAPHY_CLASSNAMES.pageTitle]: "page-title",
+  [TYPOGRAPHY_CLASSNAMES.agentTitle]: "agent-title",
   [TYPOGRAPHY_CLASSNAMES.pageSubtitle]: "subtitle",
   [TYPOGRAPHY_CLASSNAMES.navigationTitle]: "nav-title",
   [TYPOGRAPHY_CLASSNAMES.identityName]: "identity-title",
@@ -93,6 +95,16 @@ export function PageTitle({ as = "h1", ...props }: RoleTextProps) {
     <SemanticText
       as={as}
       roleClassName={TYPOGRAPHY_CLASSNAMES.pageTitle}
+      {...props}
+    />
+  );
+}
+
+export function AgentTitle({ as = "h1", ...props }: RoleTextProps) {
+  return (
+    <SemanticText
+      as={as}
+      roleClassName={TYPOGRAPHY_CLASSNAMES.agentTitle}
       {...props}
     />
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -510,14 +510,15 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
       className="ml-auto flex max-w-full shrink-0 items-center justify-end"
       data-testid="one-location-header-actions"
     >
-      <div className="flex h-9 shrink-0 items-center gap-0 rounded-full bg-black/[0.05] px-2 text-[13px] font-semibold text-foreground sm:gap-2 sm:px-3 dark:bg-white/[0.07]">
+      <div className="flex min-h-[31px] shrink-0 items-center gap-2 rounded-full bg-[color:var(--app-neutral-fill)] pl-3 pr-0">
         <span
-          className="hidden whitespace-nowrap sm:inline"
+          className="ui-text-helper-text hidden whitespace-nowrap text-[color:var(--app-label)] sm:inline"
           aria-hidden="true"
         >
           {statusLabel}
         </span>
         <Switch
+          size="ios"
           checked={locationOn}
           onCheckedChange={handleLocationChange}
           disabled={toggling || refreshing}
@@ -980,15 +981,12 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   /* Hub (Now | People | Links)                                        */
   /* ----------------------------------------------------------------- */
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <PageHeader
-        title={
-          <span className="inline-flex h-9 items-center whitespace-nowrap">
-            Location Agent
-          </span>
-        }
+        title="Location Agent"
         icon={MapPin}
-        accent="neutral"
+        accent="location"
+        titleRole="agent"
         actionsInlineMobile
         actions={<LocationHeaderActions vm={vm} />}
       />
@@ -1001,6 +999,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           options={LOCATION_SWIPE_OPTIONS}
           onSelectionChange={(value) => setTab(value as LocationHubTab)}
           viewportMinHeight="0px"
+          heightMode="active"
         >
           <LocationHubPanel>
             <NowHub
@@ -1089,7 +1088,7 @@ function NowHub({
   onOpenSettings: () => void;
 }) {
   return (
-    <div className="space-y-3" data-testid="one-location-now-hub">
+    <div className="space-y-4" data-testid="one-location-now-hub">
       {/* Every row and tile below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
@@ -1181,24 +1180,26 @@ function NowHub({
         />
       </SettingsGroup>
 
-      <QuickActionsSection title="Quick actions" columns={2}>
-        <QuickActionCard
-          tone="green"
-          icon={<ShieldCheck className="h-5 w-5" />}
-          title="Check-In"
-          subtitle={checkInSubtitle}
-          onClick={onCheckIn}
-          controlId="one-location-action-check-in"
-        />
-        <QuickActionCard
-          tone="red"
-          icon={<Shield className="h-5 w-5" />}
-          title="SMS"
-          subtitle={vm.sosActive ? "Live now" : "Save my soul"}
-          onClick={onSos}
-          controlId="one-location-action-sos"
-        />
-      </QuickActionsSection>
+      <div className="pt-3">
+        <QuickActionsSection title="Quick actions" columns={2}>
+          <QuickActionCard
+            tone="green"
+            icon={<ShieldCheck />}
+            title="Check-In"
+            subtitle={checkInSubtitle}
+            onClick={onCheckIn}
+            controlId="one-location-action-check-in"
+          />
+          <QuickActionCard
+            tone="red"
+            icon={<Shield />}
+            title="SMS"
+            subtitle={vm.sosActive ? "Live now" : "Save my soul"}
+            onClick={onSos}
+            controlId="one-location-action-sos"
+          />
+        </QuickActionsSection>
+      </div>
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -5,43 +5,46 @@
  *
  * PRESENTATION ONLY. A single reusable `QuickActionCard` renders every tile in
  * the "Quick actions" block so Check-In and Alert stay equal, responsive
- * controls. Each card is a 44px tinted icon circle + bold title + a footer row
- * (subtitle + circular chevron). Cards are prop-driven and delegate taps to the
- * hub.
+ * controls. Each card uses the shared typography roles and iOS grouped-card
+ * geometry. Cards are prop-driven and delegate taps to the hub.
  */
 
 import type { ReactNode } from "react";
 import { ChevronRight } from "lucide-react";
 
+import {
+  CardTitle,
+  MajorSectionTitle,
+  RowDescription,
+} from "@/components/app-ui/typography";
 import { cn } from "@/lib/utils";
-import { MUTED_TEXT, SECTION_HEADING } from "./tokens";
 
 export type QuickActionTone = "green" | "red" | "blue" | "violet" | "slate";
 
 /**
- * Per-tone icon-circle palette, using the design's exact soft tints + saturated
- * foregrounds (with sensible dark-mode fallbacks).
+ * Per-tone semantic icon palette. The tile owns service/action color; labels
+ * stay neutral through the shared typography roles.
  */
 const TONE_STYLES: Record<QuickActionTone, { tile: string; icon: string }> = {
   green: {
-    tile: "bg-[#e5f4ea] dark:bg-emerald-400/15",
-    icon: "text-[#2ea44f] dark:text-emerald-300",
+    tile: "bg-[color:var(--app-success)]",
+    icon: "text-white",
   },
   red: {
-    tile: "bg-[#fdeeec] dark:bg-red-400/15",
-    icon: "text-[#e0342c] dark:text-red-300",
+    tile: "bg-[color:var(--app-destructive)]",
+    icon: "text-white",
   },
   blue: {
-    tile: "bg-[#e7f0fd] dark:bg-sky-400/15",
-    icon: "text-[#2f7cf6] dark:text-sky-300",
+    tile: "bg-[color:var(--app-accent)]",
+    icon: "text-white",
   },
   violet: {
-    tile: "bg-[#efeafc] dark:bg-violet-400/15",
-    icon: "text-[#7b5cf0] dark:text-violet-300",
+    tile: "bg-[color:var(--app-purple)]",
+    icon: "text-white",
   },
   slate: {
-    tile: "bg-[#eeeef2] dark:bg-white/10",
-    icon: "text-[#6b6b76] dark:text-slate-300",
+    tile: "bg-[color:var(--app-icon-tile-background)]",
+    icon: "text-white",
   },
 };
 
@@ -84,7 +87,7 @@ export function QuickActionCard({
       aria-disabled={!interactive}
       data-voice-control-id={controlId}
       className={cn(
-        "group flex h-full w-full min-w-0 flex-col gap-3 rounded-2xl bg-white p-3 text-left shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all duration-200 dark:bg-[color:var(--app-card-surface-default-solid)]",
+        "group flex min-h-[120px] w-full min-w-0 flex-col gap-3 rounded-[22px] bg-white p-4 text-left shadow-none transition-all duration-200 dark:bg-[color:var(--app-card-surface-default-solid)]",
         interactive
           ? "cursor-pointer hover:-translate-y-0.5 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
           : "cursor-not-allowed",
@@ -93,7 +96,7 @@ export function QuickActionCard({
       <div className="flex w-full items-start justify-between gap-2">
         <span
           className={cn(
-            "flex h-11 w-11 items-center justify-center rounded-full",
+            "flex h-[34px] w-[34px] items-center justify-center rounded-[9px] [&_svg]:h-[19px] [&_svg]:w-[19px]",
             palette.tile,
             palette.icon,
           )}
@@ -106,15 +109,12 @@ export function QuickActionCard({
       </div>
 
       <div className="mt-auto w-full min-w-0">
-        <p className="truncate text-[15px] font-bold leading-tight text-[#1c1c2e] dark:text-foreground">
+        <CardTitle as="p" className="truncate">
           {title}
-        </p>
-        {/* Subtitle spans the full card width (no chevron sharing the row) and
-            uses a compact size so the one-line description stays fully visible
-            on every device without truncating to an ellipsis. */}
-        <span className={cn(MUTED_TEXT, "mt-1.5 block truncate text-[13px] leading-[18px]")}>
+        </CardTitle>
+        <RowDescription as="span" className="mt-1 block truncate">
           {subtitle}
-        </span>
+        </RowDescription>
       </div>
     </button>
   );
@@ -125,19 +125,21 @@ export function QuickActionsSection({
   title = "Quick actions",
   children,
   columns = 3,
+  className,
 }: {
   title?: string;
   children: ReactNode;
   columns?: 2 | 3;
+  className?: string;
 }) {
   return (
-    <section className="space-y-3">
+    <section className={cn("space-y-4", className)}>
       <div className="flex items-center px-1">
-        <h2 className={SECTION_HEADING}>{title}</h2>
+        <MajorSectionTitle>{title}</MajorSectionTitle>
       </div>
       <div
         className={cn(
-          "grid auto-rows-fr gap-2.5",
+          "grid auto-rows-fr gap-3",
           columns === 2 ? "grid-cols-2" : "grid-cols-3",
         )}
       >

--- a/hushh-webapp/components/ui/switch.tsx
+++ b/hushh-webapp/components/ui/switch.tsx
@@ -10,14 +10,14 @@ function Switch({
   size = "default",
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default" | "ios"
 }) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-[var(--switch-on)] data-[state=unchecked]:bg-[var(--switch-off)]",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[size=ios]:h-[31px] data-[size=ios]:w-[51px] data-[state=checked]:bg-[var(--switch-on)] data-[state=unchecked]:bg-[var(--switch-off)]",
         className
       )}
       {...props}
@@ -27,7 +27,7 @@ function Switch({
         className={cn(
           // The knob is white in both appearances on iOS — it never inverts
           // with the theme, which is why there is no dark: override here.
-          "pointer-events-none block rounded-full bg-[var(--switch-thumb)] shadow-sm ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0"
+          "pointer-events-none block rounded-full bg-[var(--switch-thumb)] shadow-sm ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=ios]/switch:size-[27px] group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 group-data-[size=ios]/switch:data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>

--- a/hushh-webapp/e2e/location-agent-now-ui.spec.ts
+++ b/hushh-webapp/e2e/location-agent-now-ui.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const REQUIRED_VALUES = ["REVIEWER_UID", "REVIEWER_VAULT_PASSPHRASE"] as const;
+
+function hasReviewerAuthority() {
+  return REQUIRED_VALUES.every((key) => Boolean(process.env[key]?.trim()));
+}
+
+async function openReviewerLocation(page: Page) {
+  await page.goto(`/login?redirect=${encodeURIComponent("/one/location")}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  const reviewerButton = page.getByRole("button", {
+    name: /continue as reviewer/i,
+  });
+  await reviewerButton.waitFor({ state: "visible", timeout: 60_000 });
+  await reviewerButton.click();
+
+  const unlockInput = page.locator("#unlock-passphrase");
+  await unlockInput
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .catch(() => {});
+  if (await unlockInput.isVisible().catch(() => false)) {
+    await unlockInput.fill(process.env.REVIEWER_VAULT_PASSPHRASE ?? "");
+    await page
+      .getByRole("button", { name: /unlock with passphrase/i })
+      .first()
+      .click({ noWaitAfter: true });
+  }
+
+  await page.goto("/one/location", { waitUntil: "domcontentloaded" });
+  await page.getByRole("heading", { name: "Location Agent" }).waitFor({
+    state: "visible",
+    timeout: 90_000,
+  });
+}
+
+async function expectTypography(
+  locator: Locator,
+  expected: {
+    fontSize: string;
+    fontWeight: string;
+    lineHeight: string;
+    color?: string;
+  },
+) {
+  await expect(locator).toHaveCSS("font-size", expected.fontSize);
+  await expect(locator).toHaveCSS("font-weight", expected.fontWeight);
+  await expect(locator).toHaveCSS("line-height", expected.lineHeight);
+  if (expected.color) {
+    await expect(locator).toHaveCSS("color", expected.color);
+  }
+}
+
+test.describe("Location Agent Now visual contract", () => {
+  test.skip(!hasReviewerAuthority(), "reviewer UAT authority is required");
+
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true });
+
+  test("matches the strict Apple typography and background contract", async ({
+    page,
+  }) => {
+    await openReviewerLocation(page);
+
+    await expectTypography(
+      page.getByRole("heading", { name: "Location Agent" }),
+      {
+        fontSize: "34px",
+        fontWeight: "700",
+        lineHeight: "41px",
+        color: "rgb(29, 29, 31)",
+      },
+    );
+
+    await expectTypography(page.getByRole("heading", { name: "Quick actions" }), {
+      fontSize: "22px",
+      fontWeight: "600",
+      lineHeight: "27px",
+      color: "rgb(29, 29, 31)",
+    });
+
+    const rowLabels = page.locator(
+      '[data-testid^="one-location-now"] [data-slot="settings-row-title"]',
+    );
+    const rowCount = await rowLabels.count();
+    expect(rowCount).toBeGreaterThanOrEqual(7);
+    for (let index = 0; index < rowCount; index += 1) {
+      await expectTypography(rowLabels.nth(index), {
+        fontSize: "17px",
+        fontWeight: "400",
+        lineHeight: "22px",
+        color: "rgb(29, 29, 31)",
+      });
+    }
+
+    const cardTitles = page.locator(
+      '[data-voice-control-id^="one-location-action-"] .ui-text-card-title',
+    );
+    await expectTypography(cardTitles.filter({ hasText: "Check-In" }), {
+      fontSize: "17px",
+      fontWeight: "600",
+      lineHeight: "22px",
+      color: "rgb(29, 29, 31)",
+    });
+    await expectTypography(cardTitles.filter({ hasText: "SMS" }), {
+      fontSize: "17px",
+      fontWeight: "600",
+      lineHeight: "22px",
+      color: "rgb(29, 29, 31)",
+    });
+
+    const cardDescriptions = page.locator(
+      '[data-voice-control-id^="one-location-action-"] .ui-text-row-description',
+    );
+    const descriptionCount = await cardDescriptions.count();
+    expect(descriptionCount).toBeGreaterThanOrEqual(2);
+    for (let index = 0; index < descriptionCount; index += 1) {
+      await expectTypography(cardDescriptions.nth(index), {
+        fontSize: "13px",
+        fontWeight: "400",
+        lineHeight: "18px",
+        color: "rgb(142, 142, 147)",
+      });
+    }
+
+    await expect(page.locator("body")).toHaveCSS(
+      "background-color",
+      "rgb(242, 242, 247)",
+    );
+    await expect(page.locator("body")).toHaveCSS("background-image", "none");
+    await expect(page.locator(".foundation-public-ambient")).toHaveCSS(
+      "background-image",
+      "none",
+    );
+  });
+});

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EmblaCarouselType } from "embla-carousel";
 import useEmblaCarousel from "embla-carousel-react";
 
@@ -165,6 +165,11 @@ interface SwipeViewsProps {
    * when their toolbar and pagination live outside the scrollable row rail.
    */
   viewportMinHeight?: string;
+  /**
+   * Defaults to max content height so mounted panes can keep their existing
+   * layout. Compact task panes can opt into the active pane's measured height.
+   */
+  heightMode?: "max" | "active";
   className?: string;
 }
 
@@ -177,6 +182,7 @@ export function SwipeViews({
   onSelectionCommit,
   panelInset = "none",
   viewportMinHeight = SWIPE_VIEWPORT_MIN_HEIGHT,
+  heightMode = "max",
   className,
 }: SwipeViewsProps) {
   const watchDrag = useCallback(
@@ -220,6 +226,8 @@ export function SwipeViews({
     0,
     options.findIndex((option) => option.value === activeValue),
   );
+  const panelNodesRef = useRef<Record<string, HTMLDivElement | null>>({});
+  const [activePanelHeight, setActivePanelHeight] = useState<number | null>(null);
   const isDraggingRef = useRef(false);
   const hasMovedSincePointerDownRef = useRef(false);
   const lastReportedValueRef = useRef(activeValue);
@@ -233,6 +241,45 @@ export function SwipeViews({
     activeValueRef.current = activeValue;
     optionsRef.current = options;
   }, [activeValue, options]);
+
+  useEffect(() => {
+    if (heightMode !== "active") {
+      setActivePanelHeight(null);
+      return;
+    }
+
+    const activeNode = panelNodesRef.current[activeValue];
+    if (!activeNode) return;
+
+    let frame = 0;
+    const measure = () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        const nextHeight = Math.ceil(activeNode.scrollHeight);
+        setActivePanelHeight((current) =>
+          current === nextHeight ? current : nextHeight,
+        );
+      });
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure, { passive: true });
+      return () => {
+        if (frame) window.cancelAnimationFrame(frame);
+        window.removeEventListener("resize", measure);
+      };
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(activeNode);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [activeValue, heightMode]);
 
   // Embla measures the container and slides synchronously at init, but only
   // attaches its own ResizeObserver a frame later. A width change inside that
@@ -516,13 +563,22 @@ export function SwipeViews({
   return (
     <div
       data-swipe-views-root="true"
+      data-swipe-views-height-mode={heightMode}
       data-no-auto-fade="true"
       className={cn("w-full min-h-0 overflow-hidden", className)}
       ref={emblaRef}
-      style={{ minHeight: viewportMinHeight }}
+      style={{
+        minHeight: viewportMinHeight,
+        ...(heightMode === "active" && activePanelHeight !== null
+          ? { height: activePanelHeight }
+          : null),
+      }}
     >
       <div
-        className="flex w-full min-h-0 touch-pan-y transform-gpu will-change-transform"
+        className={cn(
+          "flex w-full min-h-0 touch-pan-y transform-gpu will-change-transform",
+          heightMode === "active" && "items-start",
+        )}
         style={{ minHeight: "inherit" }}
       >
         {options.map((option, index) => {
@@ -531,6 +587,9 @@ export function SwipeViews({
           return (
             <div
               key={option.value}
+              ref={(node) => {
+                panelNodesRef.current[option.value] = node;
+              }}
               id={`top-shell-${tabSetId}-panel-${safeValue}`}
               role="tabpanel"
               aria-labelledby={`top-shell-${tabSetId}-tab-${safeValue}`}
@@ -538,7 +597,8 @@ export function SwipeViews({
               tabIndex={isActive ? 0 : -1}
               data-swipe-panel-inset={panelInset}
               className={cn(
-                "h-full flex-[0_0_100%] min-h-0 min-w-0 max-w-full",
+                "flex-[0_0_100%] min-h-0 min-w-0 max-w-full",
+                heightMode === "active" ? "h-auto" : "h-full",
                 panelInset === "page" &&
                   "px-[var(--page-inline-gutter-standard)]",
               )}


### PR DESCRIPTION
## Summary
- applies the strict Location Agent Now visual contract through shared app-ui typography, settings rows, tab labels, switch sizing, shell background, and bottom clearance
- removes the Location Now route's old heading wrapper/quick-action typography overrides and switches the page background away from the ambient dotted/radial texture
- adds an exact Playwright visual-contract spec for Location Agent Now typography and background

## Verification
- `git diff --check`
- `cd hushh-webapp; npx eslint components/ui/switch.tsx components/app-ui/typography.tsx components/app-ui/page-sections.tsx components/app-ui/settings-ui.tsx components/app-ui/top-shell-tabs.tsx components/app-ui/top-app-bar.tsx components/one-location/redesign/quick-actions.tsx components/one-location/redesign/location-redesign-hub.tsx lib/morphy-ux/ui/swipe-views.tsx app/providers.tsx e2e/location-agent-now-ui.spec.ts __tests__/components/one-location-agent-page.test.tsx`
- `cd hushh-webapp; npm run verify:design-system`
- `cd hushh-webapp; npm run verify:cache`
- `cd hushh-webapp; npm run verify:docs`
- `cd hushh-webapp; npm run typecheck`
- `cd hushh-webapp; npx vitest run __tests__/components/swipe-views.test.tsx`
- `cd hushh-webapp; npx vitest run __tests__/components/one-location-agent-page.test.tsx`
- `cd hushh-webapp; npx playwright test e2e/location-agent-now-ui.spec.ts --project=chromium` (skipped locally because reviewer UAT env vars are not present)