### PR TITLE
feat(one-location): make contact sync match real users on iOS and Android

### DIFF
--- a/consent-protocol/api/routes/iam.py
+++ b/consent-protocol/api/routes/iam.py
@@ -24,6 +24,10 @@ class MarketplaceOptInRequest(BaseModel):
     enabled: bool
 
 
+class ContactDiscoverabilityRequest(BaseModel):
+    enabled: bool
+
+
 def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(
         status_code=503,
@@ -78,5 +82,36 @@ async def update_marketplace_opt_in(
     service = RIAIAMService()
     try:
         return await service.set_marketplace_opt_in(firebase_uid, payload.enabled)
+    except IAMSchemaNotReadyError:
+        return _iam_schema_not_ready_response()
+
+
+@router.get("/contact-discoverability")
+async def get_contact_discoverability(
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Whether someone holding this user's phone number can find their account."""
+    service = RIAIAMService()
+    try:
+        return await service.get_contact_discoverability(firebase_uid)
+    except IAMSchemaNotReadyError:
+        # Report the default rather than an error: the setting is informational
+        # until the schema lands, and failing here would block the whole
+        # privacy screen from rendering.
+        return {
+            "user_id": firebase_uid,
+            "contact_discoverable": True,
+            "iam_schema_ready": False,
+        }
+
+
+@router.post("/contact-discoverability")
+async def update_contact_discoverability(
+    payload: ContactDiscoverabilityRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    service = RIAIAMService()
+    try:
+        return await service.set_contact_discoverability(firebase_uid, payload.enabled)
     except IAMSchemaNotReadyError:
         return _iam_schema_not_ready_response()

--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -32,6 +34,11 @@ class MarketplaceContactLookup(BaseModel):
 class MarketplaceContactMatchRequest(BaseModel):
     phone_lookups: list[MarketplaceContactLookup] = Field(default_factory=list, max_length=1000)
     limit: int = Field(default=50, ge=1, le=100)
+    # "marketplace" keeps the Connect deck's publicly-discoverable-profiles
+    # policy. "one_network" matches any phone-verified account that has not
+    # turned off contact discoverability, which is what One Location contact
+    # sync needs.
+    scope: Literal["marketplace", "one_network"] = "marketplace"
 
 
 def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
@@ -166,6 +173,7 @@ async def match_marketplace_contacts(
             firebase_uid,
             phone_lookups=[item.dict() for item in payload.phone_lookups],
             limit=payload.limit,
+            scope=payload.scope,
         )
         return {"items": items}
     except IAMSchemaNotReadyError as exc:

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 139,
+  "expected_migration_version": 140,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 139,
+  "expected_migration_version": 140,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -52,6 +52,7 @@
       "personas",
       "last_active_persona",
       "investor_marketplace_opt_in",
+      "contact_discoverable",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 139,
+  "expected_migration_version": 140,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -52,6 +52,7 @@
       "personas",
       "last_active_persona",
       "investor_marketplace_opt_in",
+      "contact_discoverable",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/migrations/140_one_contact_discoverability.sql
+++ b/consent-protocol/db/migrations/140_one_contact_discoverability.sql
@@ -1,0 +1,37 @@
+-- Migration 140: contact discoverability for One network matching
+-- ================================================================
+-- One Location contact sync previously matched only against
+-- marketplace_public_profiles, which is opt-in and defaults to not
+-- discoverable. An ordinary One user syncing their contact book therefore got
+-- zero matches even when the people in it were on One.
+--
+-- This column governs the wider match: whether someone who already holds this
+-- user's phone number may learn that the number belongs to a One account. It
+-- defaults to TRUE, matching the behaviour users expect from contact sync, and
+-- is revocable from privacy settings at any time.
+--
+-- Matching still requires a verified phone number, and the backend only ever
+-- compares SHA-256 digests supplied by the requester against digests it derives
+-- itself. No phone number is disclosed by the match.
+
+BEGIN;
+
+ALTER TABLE actor_profiles
+  ADD COLUMN IF NOT EXISTS contact_discoverable BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Partial index mirrors idx_actor_profiles_marketplace_opt_in: the match query
+-- only ever reads the TRUE side.
+CREATE INDEX IF NOT EXISTS idx_actor_profiles_contact_discoverable
+  ON actor_profiles(contact_discoverable)
+  WHERE contact_discoverable = TRUE;
+
+-- Contact matching buckets candidates by the last four digits of the verified
+-- phone number. That predicate is an expression over phone_number, so the
+-- existing idx_actor_identity_cache_phone_number cannot serve it and every
+-- sync degrades into a sequential scan of the identity cache. This functional
+-- index matches the predicate the matcher actually issues.
+CREATE INDEX IF NOT EXISTS idx_actor_identity_cache_phone_last4
+  ON actor_identity_cache (RIGHT(regexp_replace(phone_number, '[^0-9]', '', 'g'), 4))
+  WHERE phone_verified = TRUE AND phone_number IS NOT NULL;
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/140_one_contact_discoverability_down.sql
+++ b/consent-protocol/db/migrations/rollback/140_one_contact_discoverability_down.sql
@@ -1,0 +1,16 @@
+-- Rollback 140: contact discoverability for One network matching
+-- ==============================================================
+-- Dropping the column reverts contact matching to marketplace-only
+-- eligibility. Any per-user opt-out recorded here is lost, so re-applying the
+-- migration restores everyone to the discoverable default.
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_actor_identity_cache_phone_last4;
+
+DROP INDEX IF EXISTS idx_actor_profiles_contact_discoverable;
+
+ALTER TABLE actor_profiles
+  DROP COLUMN IF EXISTS contact_discoverable;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -117,7 +117,8 @@
     "136_one_location_circle_member_invites.sql",
     "137_ria_claim_dossiers.sql",
     "138_circle_member_connection_origin.sql",
-    "139_ria_profile_brochure_provenance.sql"
+    "139_ria_profile_brochure_provenance.sql",
+    "140_one_contact_discoverability.sql"
   ],
   "groups": {
     "iam": [
@@ -189,7 +190,8 @@
       "136_one_location_circle_member_invites.sql",
       "137_ria_claim_dossiers.sql",
       "138_circle_member_connection_origin.sql",
-      "139_ria_profile_brochure_provenance.sql"
+      "139_ria_profile_brochure_provenance.sql",
+      "140_one_contact_discoverability.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -2646,6 +2646,74 @@ class RIAIAMService:
             self._invalidate_cached_persona_state(user_id)
             await conn.close()
 
+    async def get_contact_discoverability(self, user_id: str) -> dict[str, Any]:
+        """Report whether this account can be found by someone who has its number.
+
+        Defaults to enabled: contact sync is only useful if the people in a
+        user's address book are findable, and the match discloses nothing
+        beyond confirming a number the requester already had.
+        """
+        conn = await self._conn()
+        try:
+            await self._ensure_iam_schema_ready(conn)
+            row = await conn.fetchrow(
+                "SELECT contact_discoverable FROM actor_profiles WHERE user_id = $1",
+                user_id,
+            )
+            return {
+                "user_id": user_id,
+                "contact_discoverable": (
+                    True if row is None else bool(row["contact_discoverable"])
+                ),
+            }
+        except (
+            asyncpg.exceptions.UndefinedColumnError,
+            asyncpg.exceptions.UndefinedTableError,
+        ) as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
+    async def set_contact_discoverability(self, user_id: str, enabled: bool) -> dict[str, Any]:
+        """Turn phone-number discoverability on or off for this account."""
+        conn = await self._conn()
+        try:
+            async with conn.transaction():
+                await self._ensure_vault_user_row(conn, user_id)
+                await self._ensure_iam_schema_ready(conn)
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO actor_profiles (
+                        user_id,
+                        personas,
+                        last_active_persona,
+                        contact_discoverable
+                    )
+                    VALUES ($1, ARRAY['investor']::text[], 'investor', $2)
+                    ON CONFLICT (user_id) DO UPDATE
+                    SET
+                      contact_discoverable = $2,
+                      updated_at = NOW()
+                    RETURNING user_id, contact_discoverable
+                    """,
+                    user_id,
+                    enabled,
+                )
+                if row is None:
+                    raise RuntimeError("Failed to update contact discoverability")
+                return {
+                    "user_id": row["user_id"],
+                    "contact_discoverable": bool(row["contact_discoverable"]),
+                }
+        except (
+            asyncpg.exceptions.UndefinedColumnError,
+            asyncpg.exceptions.UndefinedTableError,
+        ) as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            self._invalidate_cached_persona_state(user_id)
+            await conn.close()
+
     async def set_marketplace_opt_in(self, user_id: str, enabled: bool) -> dict[str, Any]:
         conn = await self._conn()
         try:
@@ -8870,7 +8938,30 @@ class RIAIAMService:
         *,
         phone_lookups: list[dict[str, Any]],
         limit: int,
+        scope: str = "marketplace",
     ) -> list[dict[str, Any]]:
+        """Match hashed contact numbers against phone-verified accounts.
+
+        Two eligibility policies share one matching algorithm:
+
+        ``marketplace``
+            Only publicly discoverable marketplace profiles (verified RIAs, or
+            investors who opted in). This is the Connect deck's policy.
+
+        ``one_network``
+            Any account that is phone verified and has not turned off contact
+            discoverability. This is what One Location contact sync needs; the
+            marketplace policy returns nothing for ordinary users because
+            ``marketplace_public_profiles.is_discoverable`` defaults to FALSE.
+
+        Neither policy discloses a phone number. The caller proves it already
+        holds the number by supplying its SHA-256 digest, and the server only
+        confirms or denies a digest it derives independently.
+        """
+        normalized_scope = str(scope or "marketplace").strip().lower()
+        if normalized_scope not in {"marketplace", "one_network"}:
+            raise RIAIAMPolicyError("Unsupported contact match scope", status_code=400)
+
         normalized_lookups: dict[str, set[str]] = {}
         for item in phone_lookups:
             digest = str(item.get("hash") or "").strip().lower()
@@ -8883,11 +8974,62 @@ class RIAIAMService:
 
         limit_safe = max(1, min(limit, 100))
         last4_values = sorted(normalized_lookups.keys())
+
+        # The last4 bucket is a coarse pre-filter; the digest comparison below
+        # is what actually decides a match. Fetching only 8x the result limit
+        # let unrelated same-last4 rows crowd out real matches once the user
+        # base grew past a few thousand accounts, so the pre-filter is now sized
+        # against collision volume rather than the result limit, and still
+        # bounded so a wide lookup set cannot pull an unbounded result set.
+        candidate_row_cap = min(max(limit_safe * 50, 500), 5000)
+
+        if normalized_scope == "one_network":
+            # actor_profiles is LEFT JOINed so an account that has never had a
+            # profile row written still matches. The COALESCE below supplies the
+            # discoverable-by-default posture for that case; an inner join would
+            # silently make those accounts unfindable.
+            eligibility_join = """
+                LEFT JOIN marketplace_public_profiles mp
+                  ON mp.user_id = aic.user_id
+                  AND mp.is_discoverable = TRUE
+                LEFT JOIN actor_profiles ap
+                  ON ap.user_id = aic.user_id
+                LEFT JOIN ria_profiles rp
+                  ON rp.user_id = aic.user_id
+            """
+            eligibility_predicate = "AND COALESCE(ap.contact_discoverable, TRUE) = TRUE"
+        else:
+            eligibility_join = """
+                JOIN marketplace_public_profiles mp
+                  ON mp.user_id = aic.user_id
+                  AND mp.is_discoverable = TRUE
+                LEFT JOIN actor_profiles ap
+                  ON ap.user_id = aic.user_id
+                LEFT JOIN ria_profiles rp
+                  ON rp.user_id = aic.user_id
+            """
+            eligibility_predicate = """
+                  AND (
+                    (
+                      mp.profile_type = 'ria'
+                      AND rp.verification_status IN ('active', 'verified', 'finra_verified')
+                    )
+                    OR (
+                      mp.profile_type = 'investor'
+                      AND COALESCE(ap.investor_marketplace_opt_in, FALSE) = TRUE
+                    )
+                  )
+            """
+
         conn = await self._conn()
         try:
             await self._ensure_iam_schema_ready(conn)
+            # The two interpolated fragments are module-local literals selected
+            # by `normalized_scope`, which is validated against a fixed set
+            # above and raises otherwise. No caller input reaches the SQL text;
+            # every value is still bound as a parameter.
             rows = await conn.fetch(
-                """
+                f"""
                 SELECT
                   aic.user_id,
                   aic.phone_number,
@@ -8901,34 +9043,22 @@ class RIAIAMService:
                   rp.verification_status,
                   COALESCE(ap.investor_marketplace_opt_in, FALSE) AS investor_marketplace_opt_in
                 FROM actor_identity_cache aic
-                JOIN marketplace_public_profiles mp
-                  ON mp.user_id = aic.user_id
-                  AND mp.is_discoverable = TRUE
-                LEFT JOIN actor_profiles ap
-                  ON ap.user_id = aic.user_id
-                LEFT JOIN ria_profiles rp
-                  ON rp.user_id = aic.user_id
+                {eligibility_join}
                 WHERE
                   aic.user_id <> $1
                   AND aic.phone_verified = TRUE
                   AND aic.phone_number IS NOT NULL
                   AND RIGHT(regexp_replace(aic.phone_number, '[^0-9]', '', 'g'), 4) = ANY($2::text[])
-                  AND (
-                    (
-                      mp.profile_type = 'ria'
-                      AND rp.verification_status IN ('active', 'verified', 'finra_verified')
-                    )
-                    OR (
-                      mp.profile_type = 'investor'
-                      AND COALESCE(ap.investor_marketplace_opt_in, FALSE) = TRUE
-                    )
-                  )
-                ORDER BY mp.display_name ASC
+                {eligibility_predicate}
+                -- Deterministic and index-friendly. Ordering by display_name
+                -- forced a sort of the whole candidate set for a pre-filter
+                -- whose order carries no meaning.
+                ORDER BY aic.user_id ASC
                 LIMIT $3::integer
-                """,
+                """,  # nosec B608
                 user_id,
                 last4_values,
-                max(limit_safe * 8, limit_safe),
+                candidate_row_cap,
             )
             matches: list[dict[str, Any]] = []
             seen_users: set[str] = set()
@@ -8945,7 +9075,18 @@ class RIAIAMService:
                 if target_user_id in seen_users:
                     continue
                 seen_users.add(target_user_id)
-                kind = str(row["profile_type"] or "").strip().lower()
+                profile_type = str(row["profile_type"] or "").strip().lower()
+                # Under one_network a match usually has no marketplace profile
+                # at all. Labelling those "investor" would put a private One
+                # user into a marketplace-shaped card, so they get their own
+                # kind and only the identity fields they already published.
+                if profile_type == "ria":
+                    kind = "ria"
+                elif profile_type == "investor":
+                    kind = "investor"
+                else:
+                    kind = "one_user"
+
                 profile = {
                     "id": str(row["ria_id"])
                     if kind == "ria" and row["ria_id"]
@@ -8965,7 +9106,7 @@ class RIAIAMService:
                 matches.append(
                     {
                         "user_id": target_user_id,
-                        "kind": "ria" if kind == "ria" else "investor",
+                        "kind": kind,
                         "display_name": row["display_name"] or row["identity_display_name"],
                         "headline": row["headline"],
                         "phone_last4": last4,

--- a/consent-protocol/tests/test_ria_brochure_profile.py
+++ b/consent-protocol/tests/test_ria_brochure_profile.py
@@ -1059,7 +1059,11 @@ def test_brochure_provenance_is_covered_by_the_schema_contracts() -> None:
     highest = max(
         int(name.split("_", 1)[0]) for name in manifest["ordered_migrations"] if name[:3].isdigit()
     )
-    assert highest == 139
+    # What matters here is that the brochure migration is registered and that
+    # the contracts track the manifest head. Pinning the head to a fixed number
+    # made every later migration fail this RIA test for an unrelated reason.
+    assert MIGRATION in manifest["ordered_migrations"]
+    assert highest >= int(MIGRATION.split("_", 1)[0])
 
     for contract_name in ("uat_integrated_schema.json", "prod_core_schema.json"):
         contract = json.loads((CONTRACTS_DIR / contract_name).read_text(encoding="utf-8"))

--- a/hushh-webapp/__tests__/lib/contacts/phone-normalization.test.ts
+++ b/hushh-webapp/__tests__/lib/contacts/phone-normalization.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeContactPhone,
+  resolveContactPhoneRegion,
+} from "@/lib/contacts/phone-normalization";
+
+describe("contact phone normalization", () => {
+  describe("normalizeContactPhone", () => {
+    it("normalizes every way an Indian mobile is stored in a contact book", () => {
+      // The regression this guards: a bare 10-digit number used to be assumed
+      // North American and hashed as +19876543210, so it could never match the
+      // +919876543210 the account was verified with.
+      for (const raw of [
+        "9876543210",
+        "09876543210",
+        "098765 43210",
+        "+91 98765 43210",
+        "+919876543210",
+        "0091 9876543210",
+      ]) {
+        expect(normalizeContactPhone(raw, "IN")).toMatchObject({
+          e164: "+919876543210",
+          last4: "3210",
+          isMobile: true,
+        });
+      }
+    });
+
+    it("normalizes national numbers against the resolved region, not a fixed +1", () => {
+      expect(normalizeContactPhone("4155550101", "US")?.e164).toBe(
+        "+14155550101",
+      );
+      expect(normalizeContactPhone("07911 123456", "GB")?.e164).toBe(
+        "+447911123456",
+      );
+      // Same digits, different region, different account.
+      expect(normalizeContactPhone("9876543210", "IN")?.e164).toBe(
+        "+919876543210",
+      );
+      expect(normalizeContactPhone("9876543210", "US")?.e164).toBe(
+        "+19876543210",
+      );
+    });
+
+    it("honours an explicit country code over the default region", () => {
+      expect(normalizeContactPhone("+1 415 555 0101", "IN")?.e164).toBe(
+        "+14155550101",
+      );
+      expect(normalizeContactPhone("+44 7911 123456", undefined)?.e164).toBe(
+        "+447911123456",
+      );
+    });
+
+    it("keeps non-mobile lines but flags them as non-mobile", () => {
+      // Landlines cannot match an SMS-verified account, but they are kept so
+      // truncation can drop them first rather than dropping real mobiles.
+      const landline = normalizeContactPhone("020 7946 0018", "GB");
+      expect(landline?.e164).toBe("+442079460018");
+      expect(landline?.isMobile).toBe(false);
+    });
+
+    it("drops entries that cannot be trusted as a phone number", () => {
+      expect(normalizeContactPhone("11", "IN")).toBeNull();
+      expect(normalizeContactPhone("", "IN")).toBeNull();
+      expect(normalizeContactPhone("   ", "IN")).toBeNull();
+      expect(normalizeContactPhone("not a phone", "IN")).toBeNull();
+      // No region and no country code means the number is ambiguous; guessing
+      // would only produce a hash that cannot match anything.
+      expect(normalizeContactPhone("9876543210", undefined)).toBeNull();
+    });
+  });
+
+  describe("resolveContactPhoneRegion", () => {
+    it("prefers the device region reported by the native plugin", () => {
+      expect(
+        resolveContactPhoneRegion({
+          deviceRegion: "in",
+          accountPhoneNumber: "+14155550101",
+          localeTag: "en-GB",
+        }),
+      ).toBe("IN");
+    });
+
+    it("falls back to the country of the user's own verified number", () => {
+      expect(
+        resolveContactPhoneRegion({
+          deviceRegion: null,
+          accountPhoneNumber: "+919876543210",
+          localeTag: "en-US",
+        }),
+      ).toBe("IN");
+    });
+
+    it("falls back to the locale when no stronger signal exists", () => {
+      expect(
+        resolveContactPhoneRegion({ localeTag: "en-IN" }),
+      ).toBe("IN");
+      expect(resolveContactPhoneRegion({ localeTag: "en-GB" })).toBe("GB");
+    });
+
+    it("ignores unusable signals instead of failing the sync", () => {
+      expect(
+        resolveContactPhoneRegion({
+          deviceRegion: "ZZZ",
+          accountPhoneNumber: "not-a-number",
+          localeTag: "!!!not-a-locale!!!",
+        }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/hushh-webapp/__tests__/lib/marketplace/contact-matching.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/contact-matching.test.ts
@@ -18,6 +18,7 @@ describe("marketplace contact matching", () => {
   it("hashes normalized phone numbers and deduplicates equivalent local contacts", async () => {
     readContactsMock.mockResolvedValue({
       sourcePlatform: "ios",
+      defaultRegion: "US",
       contacts: [
         {
           id: "1",
@@ -27,7 +28,7 @@ describe("marketplace contact matching", () => {
         {
           id: "2",
           displayName: "Morgan Lee",
-          phoneNumbers: ["020 7946 0018"],
+          phoneNumbers: ["+44 20 7946 0018"],
         },
       ],
     });
@@ -37,6 +38,8 @@ describe("marketplace contact matching", () => {
     expect(readContactsMock).toHaveBeenCalledWith({ limit: 20 });
     expect(result.totalContacts).toBe(2);
     expect(result.sourcePlatform).toBe("ios");
+    expect(result.region).toBe("US");
+    // The two Avery entries are the same E.164 and collapse to one lookup.
     expect(result.lookups).toHaveLength(2);
     expect(result.lookups[0]).toMatchObject({
       last4: "0101",
@@ -50,5 +53,113 @@ describe("marketplace contact matching", () => {
       expect(lookup.hash).toMatch(/^[a-f0-9]{64}$/);
       expect(lookup.hash).not.toContain(lookup.last4);
     }
+  });
+
+  it("reads national numbers in the device region rather than assuming +1", async () => {
+    readContactsMock.mockResolvedValue({
+      sourcePlatform: "android",
+      defaultRegion: "IN",
+      contacts: [
+        { id: "1", displayName: "Asha", phoneNumbers: ["9876543210"] },
+        { id: "2", displayName: "Asha (alt)", phoneNumbers: ["09876543210"] },
+      ],
+    });
+
+    const result = await buildMarketplaceContactLookups();
+
+    expect(result.region).toBe("IN");
+    // Both spellings are the same Indian mobile, so they dedupe to one hash —
+    // and that hash must be of +919876543210, not +19876543210.
+    expect(result.lookups).toHaveLength(1);
+
+    const expectedDigest = await crypto.subtle
+      .digest("SHA-256", new TextEncoder().encode("+919876543210"))
+      .then((buffer) =>
+        Array.from(new Uint8Array(buffer))
+          .map((byte) => byte.toString(16).padStart(2, "0"))
+          .join(""),
+      );
+    expect(result.lookups[0]!.hash).toBe(expectedDigest);
+  });
+
+  it("prefers the account's own region when the device does not report one", async () => {
+    readContactsMock.mockResolvedValue({
+      sourcePlatform: "android",
+      defaultRegion: null,
+      contacts: [{ id: "1", displayName: "Asha", phoneNumbers: ["9876543210"] }],
+    });
+
+    const result = await buildMarketplaceContactLookups({
+      accountPhoneNumber: "+919000000000",
+    });
+
+    expect(result.region).toBe("IN");
+    expect(result.lookups).toHaveLength(1);
+  });
+
+  it("caps lookups at the backend limit and keeps mobile numbers first", async () => {
+    // The backend rejects the whole request past 1000 lookups, so the cap has
+    // to be applied here. Landlines are dropped before mobiles because an
+    // SMS-verified account can never be a landline.
+    const mobiles = Array.from({ length: 999 }, (_, index) => ({
+      id: `m${index}`,
+      displayName: `Mobile ${index}`,
+      phoneNumbers: [`+9198765${String(index).padStart(5, "0")}`],
+    }));
+    const landlines = Array.from({ length: 20 }, (_, index) => ({
+      id: `l${index}`,
+      displayName: `Landline ${index}`,
+      phoneNumbers: [`+4420794600${String(index).padStart(2, "0")}`],
+    }));
+    readContactsMock.mockResolvedValue({
+      sourcePlatform: "android",
+      defaultRegion: "IN",
+      contacts: [...landlines, ...mobiles],
+    });
+
+    const result = await buildMarketplaceContactLookups();
+
+    expect(result.lookups).toHaveLength(1000);
+    expect(result.truncated).toBe(true);
+    const landlineNames = result.lookups.filter((lookup) =>
+      lookup.displayName?.startsWith("Landline"),
+    );
+    // 999 mobiles take precedence, leaving room for exactly one landline.
+    expect(landlineNames).toHaveLength(1);
+  });
+
+  it("propagates partial-access and truncation flags from the platform", async () => {
+    readContactsMock.mockResolvedValue({
+      sourcePlatform: "ios",
+      defaultRegion: "US",
+      limited: true,
+      truncated: true,
+      totalAvailable: 4000,
+      contacts: [{ id: "1", displayName: "Ada", phoneNumbers: ["4155550101"] }],
+    });
+
+    const result = await buildMarketplaceContactLookups();
+
+    expect(result.limited).toBe(true);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("skips contact entries that are not usable phone numbers", async () => {
+    readContactsMock.mockResolvedValue({
+      sourcePlatform: "android",
+      defaultRegion: "IN",
+      contacts: [
+        { id: "1", displayName: "Short code", phoneNumbers: ["11"] },
+        { id: "2", displayName: "Empty", phoneNumbers: [] },
+        { id: "3", displayName: "Junk", phoneNumbers: ["n/a"] },
+        { id: "4", displayName: "Real", phoneNumbers: ["9876543210"] },
+      ],
+    });
+
+    const result = await buildMarketplaceContactLookups();
+
+    expect(result.lookups).toHaveLength(1);
+    expect(result.lookups[0]!.displayName).toBe("Real");
+    expect(result.totalContacts).toBe(4);
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
@@ -1,13 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockBuildMarketplaceContactLookups, mockMatchMarketplaceContacts } =
-  vi.hoisted(() => ({
-    mockBuildMarketplaceContactLookups: vi.fn(),
-    mockMatchMarketplaceContacts: vi.fn(),
-  }));
+const {
+  mockBuildMarketplaceContactLookups,
+  mockMatchMarketplaceContacts,
+  mockGetPermissionState,
+  mockOpenAppSettings,
+} = vi.hoisted(() => ({
+  mockBuildMarketplaceContactLookups: vi.fn(),
+  mockMatchMarketplaceContacts: vi.fn(),
+  mockGetPermissionState: vi.fn(),
+  mockOpenAppSettings: vi.fn(),
+}));
 
 vi.mock("@/lib/marketplace/contact-matching", () => ({
   buildMarketplaceContactLookups: mockBuildMarketplaceContactLookups,
+}));
+
+vi.mock("@/lib/capacitor", () => ({
+  HushhContacts: {
+    getPermissionState: mockGetPermissionState,
+    openAppSettings: mockOpenAppSettings,
+  },
 }));
 
 vi.mock("@/lib/services/ria-service", () => ({
@@ -16,18 +29,28 @@ vi.mock("@/lib/services/ria-service", () => ({
   },
 }));
 
-import { syncOneLocationContactSignals } from "@/lib/one-location/contact-signals";
+import {
+  openContactPermissionSettings,
+  syncOneLocationContactSignals,
+  OneLocationContactSyncError,
+} from "@/lib/one-location/contact-signals";
 
 describe("one location contact signals", () => {
   beforeEach(() => {
     mockBuildMarketplaceContactLookups.mockReset();
     mockMatchMarketplaceContacts.mockReset();
+    mockGetPermissionState.mockReset();
+    mockOpenAppSettings.mockReset();
+    mockGetPermissionState.mockResolvedValue({ state: "granted" });
   });
 
   it("uses hashed contact lookups and strips phone digits from returned matches", async () => {
     mockBuildMarketplaceContactLookups.mockResolvedValue({
       totalContacts: 3,
       sourcePlatform: "android",
+      region: "IN",
+      limited: false,
+      truncated: false,
       lookups: [
         {
           hash: "a".repeat(64),
@@ -44,7 +67,7 @@ describe("one location contact signals", () => {
     mockMatchMarketplaceContacts.mockResolvedValue([
       {
         user_id: "user_d",
-        kind: "investor",
+        kind: "one_user",
         display_name: "Investor D",
         phone_last4: "9911",
         profile: {},
@@ -53,25 +76,34 @@ describe("one location contact signals", () => {
 
     const result = await syncOneLocationContactSignals({
       idToken: "id-token",
+      accountPhoneNumber: "+919000000000",
       contactLimit: 20,
       matchLimit: 5,
     });
 
     expect(mockBuildMarketplaceContactLookups).toHaveBeenCalledWith({
       limit: 20,
+      accountPhoneNumber: "+919000000000",
+      signal: undefined,
     });
+    // one_network scope is what makes ordinary One users matchable; the
+    // marketplace scope only returns published Connect profiles.
     expect(mockMatchMarketplaceContacts).toHaveBeenCalledWith("id-token", {
       phone_lookups: [
         { hash: "a".repeat(64), last4: "0101" },
         { hash: "b".repeat(64), last4: "9911" },
       ],
       limit: 5,
+      scope: "one_network",
     });
     expect(result).toMatchObject({
       matchedUserIds: ["user_d"],
       totalContacts: 3,
       inviteCandidateCount: 2,
       sourcePlatform: "android",
+      region: "IN",
+      limited: false,
+      truncated: false,
     });
     expect(result.matches[0]).not.toHaveProperty("phone_last4");
     expect(JSON.stringify(result)).not.toContain("9911");
@@ -82,6 +114,9 @@ describe("one location contact signals", () => {
     mockBuildMarketplaceContactLookups.mockResolvedValue({
       totalContacts: 4,
       sourcePlatform: "ios",
+      region: "US",
+      limited: false,
+      truncated: false,
       lookups: [],
     });
 
@@ -95,5 +130,64 @@ describe("one location contact signals", () => {
       inviteCandidateCount: 4,
       sourcePlatform: "ios",
     });
+  });
+
+  it("reports a denied permission as a typed failure without reading contacts", async () => {
+    mockGetPermissionState.mockResolvedValue({ state: "denied" });
+
+    await expect(
+      syncOneLocationContactSignals({ idToken: "id-token" }),
+    ).rejects.toMatchObject({ failure: "denied" });
+    // The read must not be attempted: on a denied permission the OS never
+    // prompts again, so calling through would only produce a confusing error.
+    expect(mockBuildMarketplaceContactLookups).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["restricted", "restricted"],
+    ["unavailable", "unavailable"],
+  ])("maps a %s permission to the %s failure", async (state, failure) => {
+    mockGetPermissionState.mockResolvedValue({ state });
+
+    const error = await syncOneLocationContactSignals({
+      idToken: "id-token",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(OneLocationContactSyncError);
+    expect((error as OneLocationContactSyncError).failure).toBe(failure);
+  });
+
+  it("treats a plugin that cannot report state as an unavailable platform", async () => {
+    mockGetPermissionState.mockRejectedValue(new Error("no such plugin"));
+
+    await expect(
+      syncOneLocationContactSignals({ idToken: "id-token" }),
+    ).rejects.toMatchObject({ failure: "unavailable" });
+  });
+
+  it("proceeds when access is limited so partial books still match", async () => {
+    mockGetPermissionState.mockResolvedValue({ state: "limited" });
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      totalContacts: 2,
+      sourcePlatform: "ios",
+      region: "US",
+      limited: true,
+      truncated: false,
+      lookups: [{ hash: "c".repeat(64), last4: "0101", displayName: "Ada" }],
+    });
+    mockMatchMarketplaceContacts.mockResolvedValue([]);
+
+    const result = await syncOneLocationContactSignals({ idToken: "id-token" });
+
+    expect(result.limited).toBe(true);
+    expect(result.matchedUserIds).toEqual([]);
+  });
+
+  it("reports whether the settings page actually opened", async () => {
+    mockOpenAppSettings.mockResolvedValue({ opened: true });
+    await expect(openContactPermissionSettings()).resolves.toBe(true);
+
+    mockOpenAppSettings.mockRejectedValue(new Error("unsupported"));
+    await expect(openContactPermissionSettings()).resolves.toBe(false);
   });
 });

--- a/hushh-webapp/android/app/src/main/java/com/hussh/app/plugins/HushhContacts/HushhContactsPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hussh/app/plugins/HushhContacts/HushhContactsPlugin.kt
@@ -1,9 +1,12 @@
 package com.hussh.app.plugins.HushhContacts
 
 import android.Manifest
-import android.content.pm.PackageManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.provider.ContactsContract
-import androidx.core.content.ContextCompat
+import android.provider.Settings
+import android.telephony.TelephonyManager
 import com.getcapacitor.JSArray
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
@@ -13,12 +16,21 @@ import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.annotation.Permission
 import com.getcapacitor.annotation.PermissionCallback
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.util.Locale
 
 /**
  * Read-only contact lookup for Connect matching.
  *
  * Contacts are returned to the web layer for in-memory hashing only. The web
  * layer sends hashes to the backend and does not persist raw contact records.
+ *
+ * The content-resolver scan runs off the main thread: a contact book of a few
+ * thousand rows blocks long enough to trip an ANR if queried inline.
  */
 @CapacitorPlugin(
     name = "HushhContacts",
@@ -31,9 +43,44 @@ import com.getcapacitor.annotation.PermissionCallback
 )
 class HushhContactsPlugin : Plugin() {
 
+    private companion object {
+        const val DEFAULT_LIMIT = 5000
+        const val MAX_LIMIT = 10000
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    override fun handleOnDestroy() {
+        scope.cancel()
+        super.handleOnDestroy()
+    }
+
     @PluginMethod
     fun getPermissionState(call: PluginCall) {
         call.resolve(permissionPayload())
+    }
+
+    @PluginMethod
+    fun requestPermission(call: PluginCall) {
+        if (getPermissionState("contacts") == PermissionState.GRANTED) {
+            call.resolve(permissionPayload())
+            return
+        }
+        requestPermissionForAlias("contacts", call, "contactsPermissionStateCallback")
+    }
+
+    @PluginMethod
+    fun openAppSettings(call: PluginCall) {
+        try {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+            call.resolve(JSObject().put("opened", true))
+        } catch (error: Exception) {
+            call.reject("Could not open app settings: ${error.message}")
+        }
     }
 
     @PluginMethod
@@ -46,6 +93,11 @@ class HushhContactsPlugin : Plugin() {
     }
 
     @PermissionCallback
+    private fun contactsPermissionStateCallback(call: PluginCall) {
+        call.resolve(permissionPayload())
+    }
+
+    @PermissionCallback
     private fun contactsPermissionCallback(call: PluginCall) {
         if (getPermissionState("contacts") != PermissionState.GRANTED) {
             call.reject("Contacts permission was not granted.")
@@ -55,65 +107,131 @@ class HushhContactsPlugin : Plugin() {
     }
 
     private fun permissionPayload(): JSObject {
-        val state = when {
-            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS) ==
-                PackageManager.PERMISSION_GRANTED -> "granted"
+        // Capacitor tracks whether the OS will still prompt, which
+        // checkSelfPermission cannot distinguish. Without that split the web
+        // layer cannot tell "never asked" from "denied for good", and offers
+        // a prompt that silently never appears.
+        val state = when (getPermissionState("contacts")) {
+            PermissionState.GRANTED -> "granted"
+            PermissionState.DENIED -> "denied"
             else -> "prompt"
         }
-        return JSObject().put("state", state)
+        return JSObject()
+            .put("state", state)
+            .put("sourcePlatform", "android")
+    }
+
+    /**
+     * Best guess at the region bare national numbers belong to. The SIM's home
+     * country beats the serving network, because a traveller's contact book
+     * still holds home-region numbers.
+     */
+    private fun deviceRegion(): String? {
+        val telephony = runCatching {
+            context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+        }.getOrNull()
+        val candidates = listOf(
+            runCatching { telephony?.simCountryIso }.getOrNull(),
+            runCatching { telephony?.networkCountryIso }.getOrNull(),
+            runCatching { Locale.getDefault().country }.getOrNull()
+        )
+        return candidates
+            .firstOrNull { !it.isNullOrBlank() && it.length == 2 }
+            ?.uppercase(Locale.US)
     }
 
     private fun resolveContacts(call: PluginCall) {
-        val limit = (call.getInt("limit", 500) ?: 500).coerceIn(1, 1000)
+        val limit = (call.getInt("limit", DEFAULT_LIMIT) ?: DEFAULT_LIMIT)
+            .coerceIn(1, MAX_LIMIT)
+
+        scope.launch {
+            try {
+                val payload = queryContacts(limit)
+                call.resolve(payload)
+            } catch (error: Exception) {
+                call.reject("Contacts could not be read: ${error.message}")
+            }
+        }
+    }
+
+    private fun queryContacts(limit: Int): JSObject {
         val contactsById = LinkedHashMap<String, ContactAccumulator>()
+        // The cursor yields one row per phone number, so a contact with three
+        // numbers appears three times. Counting rows would inflate the total
+        // for every contact past the limit; count distinct contacts instead.
+        val seenContactIds = HashSet<String>()
         val projection = arrayOf(
             ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
             ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Phone.NUMBER
+            ContactsContract.CommonDataKinds.Phone.NUMBER,
+            ContactsContract.CommonDataKinds.Phone.NORMALIZED_NUMBER
         )
 
-        try {
-            context.contentResolver.query(
-                ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
-                projection,
-                null,
-                null,
-                ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME + " ASC"
-            )?.use { cursor ->
-                val idIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)
-                val nameIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)
-                val phoneIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
-                while (cursor.moveToNext() && contactsById.size < limit) {
-                    val id = cursor.getString(idIndex) ?: continue
-                    val number = cursor.getString(phoneIndex)?.trim().orEmpty()
-                    if (number.isEmpty()) continue
-                    val name = cursor.getString(nameIndex)?.trim().orEmpty()
-                    val entry = contactsById.getOrPut(id) { ContactAccumulator(id, name) }
-                    if (!entry.phoneNumbers.contains(number)) {
-                        entry.phoneNumbers.add(number)
-                    }
+        context.contentResolver.query(
+            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+            projection,
+            null,
+            null,
+            // Ordering by contact id uses the primary index; DISPLAY_NAME forces
+            // a full sort and makes truncation alphabetical, which silently hid
+            // everyone past the letter the cut landed on.
+            ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " ASC"
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)
+            val nameIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)
+            val phoneIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
+            val normalizedIndex =
+                cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NORMALIZED_NUMBER)
+
+            while (cursor.moveToNext()) {
+                val id = cursor.getString(idIndex) ?: continue
+                val number = cursor.getString(phoneIndex)?.trim().orEmpty()
+                val normalized = if (normalizedIndex >= 0) {
+                    cursor.getString(normalizedIndex)?.trim().orEmpty()
+                } else {
+                    ""
+                }
+                if (number.isEmpty() && normalized.isEmpty()) continue
+
+                seenContactIds.add(id)
+                if (!contactsById.containsKey(id) && contactsById.size >= limit) {
+                    continue
+                }
+
+                val name = cursor.getString(nameIndex)?.trim().orEmpty()
+                val entry = contactsById.getOrPut(id) { ContactAccumulator(id, name) }
+                // Android keeps its own E.164 rendering of each number when it
+                // can derive one. It is strictly better than re-deriving from
+                // the display string, so it goes first.
+                if (normalized.isNotEmpty() && !entry.phoneNumbers.contains(normalized)) {
+                    entry.phoneNumbers.add(0, normalized)
+                }
+                if (number.isNotEmpty() && !entry.phoneNumbers.contains(number)) {
+                    entry.phoneNumbers.add(number)
                 }
             }
-
-            val contacts = JSArray()
-            contactsById.values.forEach { entry ->
-                val phoneNumbers = JSArray()
-                entry.phoneNumbers.forEach { phoneNumbers.put(it) }
-                contacts.put(
-                    JSObject()
-                        .put("id", entry.id)
-                        .put("displayName", entry.displayName)
-                        .put("phoneNumbers", phoneNumbers)
-                )
-            }
-            call.resolve(
-                JSObject()
-                    .put("contacts", contacts)
-                    .put("sourcePlatform", "android")
-            )
-        } catch (error: Exception) {
-            call.reject("Contacts could not be read: ${error.message}")
         }
+
+        val contacts = JSArray()
+        contactsById.values.forEach { entry ->
+            val phoneNumbers = JSArray()
+            entry.phoneNumbers.forEach { phoneNumbers.put(it) }
+            contacts.put(
+                JSObject()
+                    .put("id", entry.id)
+                    .put("displayName", entry.displayName)
+                    .put("phoneNumbers", phoneNumbers)
+            )
+        }
+
+        return JSObject()
+            .put("contacts", contacts)
+            .put("sourcePlatform", "android")
+            .put("defaultRegion", deviceRegion())
+            // Android has no partial-contact mode; access is all or nothing.
+            .put("limited", false)
+            .put("truncated", seenContactIds.size > contactsById.size)
+            .put("totalAvailable", seenContactIds.size)
     }
 
     private data class ContactAccumulator(

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -834,7 +834,11 @@ export default function MarketplacePage() {
     try {
       setContactMatchLoading(true);
       setContactMatchError(null);
-      const lookupResult = await buildMarketplaceContactLookups({ limit: 500 });
+      const lookupResult = await buildMarketplaceContactLookups({
+        limit: 500,
+        // Resolves which region bare national contact numbers belong to.
+        accountPhoneNumber: user.phoneNumber,
+      });
       if (lookupResult.lookups.length === 0) {
         setContactMatches([]);
         setContactScanSummary("No phone numbers found in contacts.");
@@ -1234,7 +1238,7 @@ export default function MarketplacePage() {
                   onClick={() => openContactMatch(match)}
                 >
                   <ProfileAvatar
-                    kind={match.kind}
+                    kind={match.kind === "one_user" ? "investor" : match.kind}
                     label={match.display_name}
                     className="h-11 w-11 rounded-2xl"
                     riaSurface={isRiaConnectSurface}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -159,7 +159,9 @@ import {
 } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
+  openContactPermissionSettings,
   syncOneLocationContactSignals,
+  OneLocationContactSyncError,
   type OneLocationContactSignalResult,
 } from "@/lib/one-location/contact-signals";
 import { OneLocationActivityDashboard } from "@/components/one-location/activity-dashboard";
@@ -455,6 +457,7 @@ type OneLocationContactSignalStatus =
   | "matched"
   | "empty"
   | "unavailable"
+  | "restricted"
   | "denied"
   | "error";
 
@@ -465,6 +468,10 @@ type OneLocationContactSignalState = {
   totalContacts: number;
   inviteCandidateCount: number;
   sourcePlatform?: OneLocationContactSignalResult["sourcePlatform"];
+  /** Only part of the contact book was readable, so "no matches" is not final. */
+  limited?: boolean;
+  /** The contact book was larger than the read or lookup caps. */
+  truncated?: boolean;
   error?: string | null;
   syncedAt?: string | null;
 };
@@ -475,6 +482,8 @@ const INITIAL_CONTACT_SIGNAL_STATE: OneLocationContactSignalState = {
   matchedCount: 0,
   totalContacts: 0,
   inviteCandidateCount: 0,
+  limited: false,
+  truncated: false,
   error: null,
   syncedAt: null,
 };
@@ -4511,7 +4520,12 @@ export function OneLocationAgentPageContent({
 
     try {
       const idToken = await auth.user.getIdToken();
-      const result = await syncOneLocationContactSignals({ idToken });
+      const result = await syncOneLocationContactSignals({
+        idToken,
+        // Tells the normalizer which region a bare "9876543210" belongs to.
+        // Without it every 10-digit contact was read as North American.
+        accountPhoneNumber: auth.user.phoneNumber,
+      });
       const nextStatus: OneLocationContactSignalStatus =
         result.matchedUserIds.length > 0 ? "matched" : "empty";
       setContactSignal({
@@ -4521,6 +4535,8 @@ export function OneLocationAgentPageContent({
         totalContacts: result.totalContacts,
         inviteCandidateCount: result.inviteCandidateCount,
         sourcePlatform: result.sourcePlatform,
+        limited: result.limited,
+        truncated: result.truncated,
         error: null,
         syncedAt: new Date().toISOString(),
       });
@@ -4531,6 +4547,9 @@ export function OneLocationAgentPageContent({
         contact_count_bucket: contactCountBucket(result.totalContacts),
         matched_count: result.matchedUserIds.length,
         invite_candidate_count: result.inviteCandidateCount,
+        contact_region: result.region ?? "unknown",
+        partial_access: result.limited,
+        truncated: result.truncated,
       });
       if (result.matchedUserIds.length > 0) {
         toast.success(
@@ -4538,43 +4557,53 @@ export function OneLocationAgentPageContent({
             result.matchedUserIds.length,
           )} added as a contact signal.`,
         );
+      } else if (result.limited) {
+        // Partial access means the scan only saw the contacts the OS shared,
+        // so "no matches" says nothing about the rest of the book.
+        toast.info("No matches in the contacts you shared.", {
+          description:
+            "Hussh could only read the contacts you picked. Share more to widen the search.",
+          action: {
+            label: "Settings",
+            onClick: () => void openContactPermissionSettings(),
+          },
+        });
       } else {
         toast.info("No One users matched from this contact scan.");
       }
     } catch (error) {
+      const failure =
+        error instanceof OneLocationContactSyncError ? error.failure : "error";
       const message = oneLocationErrorMessage(
         error,
         "Could not sync contacts.",
       );
-      const normalized = message.toLowerCase();
-      const status: OneLocationContactSignalStatus =
-        normalized.includes("denied") || normalized.includes("permission")
-          ? "denied"
-          : normalized.includes("native") ||
-              normalized.includes("mobile") ||
-              normalized.includes("unavailable") ||
-              normalized.includes("web view")
-            ? "unavailable"
-            : "error";
       setContactSignal((current) => ({
         ...current,
-        status,
+        status: failure,
         error: message,
         syncedAt: new Date().toISOString(),
       }));
       trackEvent("one_location_contact_signal_synced", {
         route_id: "one_location",
-        result:
-          status === "denied" || status === "unavailable"
-            ? "expected_error"
-            : "error",
+        result: failure === "error" ? "error" : "expected_error",
         source_platform: contactSignal.sourcePlatform ?? "unknown",
         contact_count_bucket: contactCountBucket(contactSignal.totalContacts),
         matched_count: contactSignal.matchedCount,
         invite_candidate_count: contactSignal.inviteCandidateCount,
+        failure_reason: failure,
       });
-      if (status === "unavailable") {
-        toast.info("Contact sync is available in the iOS and Android app.");
+      if (failure === "denied") {
+        // The OS will not prompt again, so a retry button would do nothing.
+        // Settings is the only route back.
+        toast.error(message, {
+          action: {
+            label: "Open Settings",
+            onClick: () => void openContactPermissionSettings(),
+          },
+        });
+      } else if (failure === "unavailable") {
+        toast.info(message);
       } else {
         toast.error(message);
       }

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -14,6 +14,7 @@ import {
   Bug,
   CodeXml,
   Code2,
+  ContactRound,
   ExternalLink,
   Fingerprint,
   Folder,
@@ -650,6 +651,13 @@ function ProfilePageContent() {
   const [marketplaceOptIn, setMarketplaceOptIn] = useState(false);
   const [loadingMarketplaceOptIn, setLoadingMarketplaceOptIn] = useState(true);
   const [savingMarketplaceOptIn, setSavingMarketplaceOptIn] = useState(false);
+  // Contact discoverability defaults ON, so the optimistic initial value is
+  // true; a user who has opted out sees the toggle settle once the fetch lands.
+  const [contactDiscoverable, setContactDiscoverable] = useState(true);
+  const [loadingContactDiscoverable, setLoadingContactDiscoverable] =
+    useState(true);
+  const [savingContactDiscoverable, setSavingContactDiscoverable] =
+    useState(false);
   const [supportKind, setSupportKind] =
     useState<SupportMessageKind>("support_request");
   const [supportSubject, setSupportSubject] = useState("");
@@ -1027,6 +1035,37 @@ function ProfilePageContent() {
     setMarketplaceOptIn(Boolean(personaState.investor_marketplace_opt_in));
     setLoadingMarketplaceOptIn(false);
   }, [personaState, user]);
+
+  useEffect(() => {
+    if (!user) {
+      setContactDiscoverable(true);
+      setLoadingContactDiscoverable(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const idToken = await user.getIdToken();
+        const result = await RiaService.getContactDiscoverability(idToken);
+        if (!cancelled) {
+          setContactDiscoverable(Boolean(result.contact_discoverable));
+        }
+      } catch (error) {
+        // Leave the default in place; a failed read must not silently present
+        // the user as opted out when they are not.
+        console.error(
+          "[ProfilePage] Failed to load contact discoverability:",
+          error,
+        );
+      } finally {
+        if (!cancelled) setLoadingContactDiscoverable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
 
   const refreshPkmMetadata = useCallback(
     async (force = false) => {
@@ -1491,6 +1530,30 @@ function ProfilePageContent() {
     }
   };
 
+  const handleContactDiscoverableToggle = async () => {
+    if (!user) return;
+    const next = !contactDiscoverable;
+    try {
+      setSavingContactDiscoverable(true);
+      const idToken = await user.getIdToken();
+      const result = await RiaService.setContactDiscoverability(idToken, next);
+      setContactDiscoverable(Boolean(result.contact_discoverable));
+      toast.success(
+        result.contact_discoverable
+          ? "People who have your number can find you on Hussh."
+          : "You are hidden from contact sync.",
+      );
+    } catch (error) {
+      console.error(
+        "[ProfilePage] Failed to update contact discoverability:",
+        error,
+      );
+      toast.error("Could not update contact discoverability.");
+    } finally {
+      setSavingContactDiscoverable(false);
+    }
+  };
+
   const handleMarketplaceOptInToggle = async () => {
     if (!user) return;
     try {
@@ -1947,6 +2010,11 @@ function ProfilePageContent() {
     : marketplaceOptIn
       ? "Discoverable to RIAs"
       : "Hidden from marketplace search";
+  const contactDiscoverableStatusText = loadingContactDiscoverable
+    ? "Checking discoverability…"
+    : contactDiscoverable
+      ? "People who have your number can find you"
+      : "Hidden from contact sync";
   const phoneSummaryText = phoneNumber
     ? maskPhoneNumber(phoneNumber)
     : "No phone number linked yet";
@@ -2942,6 +3010,23 @@ function ProfilePageContent() {
           chevron
           stackTrailingOnMobile
           onClick={() => router.push(ROUTES.CONSENTS)}
+        />
+        <SettingsRow
+          icon={ContactRound}
+          title="Find me by phone number"
+          description={contactDiscoverableStatusText}
+          trailing={
+            <Switch
+              checked={contactDiscoverable}
+              disabled={loadingContactDiscoverable || savingContactDiscoverable}
+              aria-label="Toggle contact discoverability"
+              onPointerDown={(event) => {
+                event.stopPropagation();
+              }}
+              onClick={(event) => event.stopPropagation()}
+              onCheckedChange={() => void handleContactDiscoverableToggle()}
+            />
+          }
         />
         <SettingsRow
           icon={RefreshCw}

--- a/hushh-webapp/ios/App/App/Plugins/HushhContactsPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhContactsPlugin.swift
@@ -1,12 +1,17 @@
 import Foundation
 import Capacitor
 import Contacts
+import UIKit
 
 /**
  * HushhContactsPlugin - read-only contact lookup for Connect matching.
  *
  * Contacts are returned to the web layer for in-memory hashing only. The web
  * layer sends hashes to the backend and does not persist raw contact records.
+ *
+ * Enumeration always runs on a background queue. CNContactStore walks the
+ * store synchronously, so a few thousand contacts freeze the UI if that work
+ * lands on the main thread.
  */
 @objc(HushhContactsPlugin)
 public class HushhContactsPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -15,46 +20,98 @@ public class HushhContactsPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "HushhContacts"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "getPermissionState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "requestPermission", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openAppSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "readContacts", returnType: CAPPluginReturnPromise)
     ]
 
     private let store = CNContactStore()
+    private let readQueue = DispatchQueue(
+        label: "ai.hushh.contacts.read",
+        qos: .userInitiated
+    )
+
+    private static let defaultLimit = 5000
+    private static let maxLimit = 10000
 
     @objc func getPermissionState(_ call: CAPPluginCall) {
         call.resolve(["state": permissionState()])
     }
 
-    @objc func readContacts(_ call: CAPPluginCall) {
-        let limit = max(1, min(call.getInt("limit") ?? 500, 1000))
+    @objc func requestPermission(_ call: CAPPluginCall) {
         let status = CNContactStore.authorizationStatus(for: .contacts)
-
-        switch status {
-        case .authorized, .limited:
-            resolveContacts(call, limit: limit)
-        case .notDetermined:
-            store.requestAccess(for: .contacts) { [weak self] granted, error in
-                DispatchQueue.main.async {
-                    if let error = error {
-                        call.reject("Contacts permission failed: \(error.localizedDescription)")
-                        return
-                    }
-                    guard granted else {
-                        call.reject("Contacts permission was not granted.")
-                        return
-                    }
-                    self?.resolveContacts(call, limit: limit)
-                }
-            }
-        case .denied, .restricted:
-            call.reject("Contacts permission was not granted.")
-        @unknown default:
-            call.reject("Contacts permission state is unavailable.")
+        guard status == .notDetermined else {
+            call.resolve(["state": permissionState()])
+            return
+        }
+        store.requestAccess(for: .contacts) { [weak self] _, _ in
+            call.resolve(["state": self?.permissionState() ?? "unavailable"])
         }
     }
 
+    @objc func openAppSettings(_ call: CAPPluginCall) {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else {
+            call.resolve(["opened": false])
+            return
+        }
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url, options: [:]) { opened in
+                call.resolve(["opened": opened])
+            }
+        }
+    }
+
+    @objc func readContacts(_ call: CAPPluginCall) {
+        let limit = max(1, min(call.getInt("limit") ?? Self.defaultLimit, Self.maxLimit))
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+
+        if status == .notDetermined {
+            store.requestAccess(for: .contacts) { [weak self] granted, error in
+                guard let self else { return }
+                if let error = error {
+                    call.reject("Contacts permission failed: \(error.localizedDescription)")
+                    return
+                }
+                guard granted else {
+                    call.reject("Contacts permission was not granted.")
+                    return
+                }
+                // Stay off the main thread: this is the enumeration path.
+                self.readQueue.async { self.resolveContacts(call, limit: limit) }
+            }
+            return
+        }
+
+        guard isReadableStatus(status) else {
+            call.reject("Contacts permission was not granted.")
+            return
+        }
+        readQueue.async { [weak self] in
+            self?.resolveContacts(call, limit: limit)
+        }
+    }
+
+    /// iOS 18 added partial access, where the read succeeds but only returns a
+    /// user-picked subset. It is readable, but callers must not treat an empty
+    /// result as "nobody matched".
+    private func isLimitedStatus(_ status: CNAuthorizationStatus) -> Bool {
+        if #available(iOS 18.0, *) {
+            return status == .limited
+        }
+        return false
+    }
+
+    private func isReadableStatus(_ status: CNAuthorizationStatus) -> Bool {
+        return status == .authorized || isLimitedStatus(status)
+    }
+
     private func permissionState() -> String {
-        switch CNContactStore.authorizationStatus(for: .contacts) {
-        case .authorized, .limited:
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        if isLimitedStatus(status) {
+            return "limited"
+        }
+        switch status {
+        case .authorized:
             return "granted"
         case .notDetermined:
             return "prompt"
@@ -67,6 +124,18 @@ public class HushhContactsPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    /// Region used to read bare national numbers such as `9876543210`.
+    private func deviceRegion() -> String? {
+        let region: String?
+        if #available(iOS 16.0, *) {
+            region = Locale.current.region?.identifier
+        } else {
+            region = Locale.current.regionCode
+        }
+        guard let region, region.count == 2 else { return nil }
+        return region.uppercased()
+    }
+
     private func resolveContacts(_ call: CAPPluginCall, limit: Int) {
         let keys: [CNKeyDescriptor] = [
             CNContactIdentifierKey as CNKeyDescriptor,
@@ -76,16 +145,26 @@ public class HushhContactsPlugin: CAPPlugin, CAPBridgedPlugin {
             CNContactPhoneNumbersKey as CNKeyDescriptor
         ]
         let request = CNContactFetchRequest(keysToFetch: keys)
+        // Unified contacts already merge linked cards; sorting is pure overhead
+        // for a hash-matching pass.
+        request.unifyResults = true
+        request.sortOrder = .none
+
         var contacts: [[String: Any]] = []
+        var totalAvailable = 0
 
         do {
-            try store.enumerateContacts(with: request) { contact, stop in
+            try store.enumerateContacts(with: request) { contact, _ in
                 let phoneNumbers = contact.phoneNumbers
                     .map { $0.value.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) }
                     .filter { !$0.isEmpty }
                 if phoneNumbers.isEmpty {
                     return
                 }
+                totalAvailable += 1
+                // Keep walking past the limit so `totalAvailable` stays honest
+                // and the web layer can tell the user their book was cut short.
+                guard contacts.count < limit else { return }
 
                 let nameParts = [
                     contact.givenName.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -97,14 +176,19 @@ public class HushhContactsPlugin: CAPPlugin, CAPBridgedPlugin {
                     "displayName": displayName.isEmpty ? contact.organizationName : displayName,
                     "phoneNumbers": phoneNumbers
                 ])
-                if contacts.count >= limit {
-                    stop.pointee = true
-                }
             }
-            call.resolve([
+
+            var payload: [String: Any] = [
                 "contacts": contacts,
-                "sourcePlatform": "ios"
-            ])
+                "sourcePlatform": "ios",
+                "limited": isLimitedStatus(CNContactStore.authorizationStatus(for: .contacts)),
+                "truncated": totalAvailable > contacts.count,
+                "totalAvailable": totalAvailable
+            ]
+            if let region = deviceRegion() {
+                payload["defaultRegion"] = region
+            }
+            call.resolve(payload)
         } catch {
             call.reject("Contacts could not be read: \(error.localizedDescription)")
         }

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -856,7 +856,19 @@ export const HushhLocation = registerPlugin<HushhLocationPlugin>("HushhLocation"
 // Contact-book permission and read-only contact lookup for Connect matching.
 
 export type HushhContactsPermissionState = {
-  state: "granted" | "denied" | "prompt" | "restricted" | "unavailable";
+  /**
+   * `limited` is iOS 17+ partial contact access: the read succeeds but only
+   * returns the subset the user picked, so an empty match is not evidence that
+   * nobody matched. `denied` means the OS will not prompt again and the only
+   * route forward is `openAppSettings`.
+   */
+  state:
+    | "granted"
+    | "limited"
+    | "denied"
+    | "prompt"
+    | "restricted"
+    | "unavailable";
 };
 
 export type HushhContactRecord = {
@@ -866,12 +878,34 @@ export type HushhContactRecord = {
   emailAddresses?: string[];
 };
 
+export type HushhContactsReadResult = {
+  contacts: HushhContactRecord[];
+  sourcePlatform: "web" | "ios" | "android" | "native";
+  /**
+   * ISO-3166 alpha-2 region the device believes it is in (SIM, then network,
+   * then locale). National-format contact numbers are meaningless without it —
+   * `9876543210` is a valid mobile in a dozen countries.
+   */
+  defaultRegion?: string | null;
+  /** True when only a user-selected subset of contacts was visible (iOS 17+). */
+  limited?: boolean;
+  /** True when `limit` cut the read short, so matching saw a partial book. */
+  truncated?: boolean;
+  /** Contacts holding at least one phone number, before `limit` was applied. */
+  totalAvailable?: number;
+};
+
 export interface HushhContactsPlugin {
   getPermissionState(): Promise<HushhContactsPermissionState>;
-  readContacts(options?: { limit?: number }): Promise<{
-    contacts: HushhContactRecord[];
-    sourcePlatform: "web" | "ios" | "android" | "native";
-  }>;
+  /**
+   * Prompt for contact access without reading anything. Lets a surface prime
+   * the permission at a moment the user understands, instead of the OS sheet
+   * appearing mid-sync.
+   */
+  requestPermission(): Promise<HushhContactsPermissionState>;
+  /** Open this app's OS settings page — the only recovery from `denied`. */
+  openAppSettings(): Promise<{ opened: boolean }>;
+  readContacts(options?: { limit?: number }): Promise<HushhContactsReadResult>;
 }
 
 export const HushhContacts = registerPlugin<HushhContactsPlugin>("HushhContacts", {

--- a/hushh-webapp/lib/capacitor/plugins/contacts-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/contacts-web.ts
@@ -1,17 +1,110 @@
 import type {
   HushhContactsPermissionState,
   HushhContactsPlugin,
+  HushhContactsReadResult,
 } from "@/lib/capacitor";
+
+/**
+ * Browser fallback for contact reads.
+ *
+ * Desktop browsers have no contact book, but Chrome on Android exposes the
+ * Contact Picker API, which is a user-driven subset rather than a full read.
+ * That maps exactly onto `limited`, so the PWA surface can match contacts
+ * instead of dead-ending on "install the app".
+ */
+
+type ContactPickerProperty = "name" | "tel" | "email";
+
+type ContactPickerResult = {
+  name?: string[];
+  tel?: string[];
+  email?: string[];
+};
+
+type ContactPickerManager = {
+  select: (
+    properties: ContactPickerProperty[],
+    options?: { multiple?: boolean },
+  ) => Promise<ContactPickerResult[]>;
+  getProperties?: () => Promise<ContactPickerProperty[]>;
+};
+
+function contactPicker(): ContactPickerManager | null {
+  if (typeof navigator === "undefined") return null;
+  const picker = (navigator as Navigator & { contacts?: ContactPickerManager })
+    .contacts;
+  return picker && typeof picker.select === "function" ? picker : null;
+}
+
+function localeRegion(): string | null {
+  if (typeof navigator === "undefined") return null;
+  try {
+    return new Intl.Locale(navigator.language).maximize().region ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export class HushhContactsWeb implements HushhContactsPlugin {
   async getPermissionState(): Promise<HushhContactsPermissionState> {
-    return { state: "unavailable" };
+    // The Contact Picker grants per-invocation, so there is no persistent state
+    // to report — only whether a prompt is reachable at all.
+    return { state: contactPicker() ? "prompt" : "unavailable" };
   }
 
-  async readContacts(): Promise<{
-    contacts: [];
-    sourcePlatform: "web";
-  }> {
-    throw new Error("Contacts are only available in the native mobile app.");
+  async requestPermission(): Promise<HushhContactsPermissionState> {
+    return this.getPermissionState();
+  }
+
+  async openAppSettings(): Promise<{ opened: boolean }> {
+    return { opened: false };
+  }
+
+  async readContacts(options?: {
+    limit?: number;
+  }): Promise<HushhContactsReadResult> {
+    const picker = contactPicker();
+    if (!picker) {
+      throw new Error("Contacts are only available in the native mobile app.");
+    }
+
+    let selected: ContactPickerResult[];
+    try {
+      selected = await picker.select(["name", "tel"], { multiple: true });
+    } catch (error) {
+      // The picker rejects when it is called outside a user gesture, and also
+      // when the user dismisses it. Neither is an error worth surfacing as a
+      // failure, but an empty selection is indistinguishable, so report empty.
+      if (error instanceof Error && error.name === "AbortError") {
+        return {
+          contacts: [],
+          sourcePlatform: "web",
+          defaultRegion: localeRegion(),
+          limited: true,
+          truncated: false,
+          totalAvailable: 0,
+        };
+      }
+      throw new Error("Contacts are only available in the native mobile app.");
+    }
+
+    const limit = Math.max(1, Math.min(options?.limit ?? 500, 2000));
+    const contacts = selected
+      .map((entry, index) => ({
+        id: `web-contact:${index}`,
+        displayName: entry.name?.find((name) => name.trim()) ?? null,
+        phoneNumbers: (entry.tel ?? []).filter((tel) => tel.trim()),
+      }))
+      .filter((contact) => contact.phoneNumbers.length > 0);
+
+    return {
+      contacts: contacts.slice(0, limit),
+      sourcePlatform: "web",
+      defaultRegion: localeRegion(),
+      // The picker only ever returns what the user hand-picked.
+      limited: true,
+      truncated: contacts.length > limit,
+      totalAvailable: contacts.length,
+    };
   }
 }

--- a/hushh-webapp/lib/contacts/phone-normalization.ts
+++ b/hushh-webapp/lib/contacts/phone-normalization.ts
@@ -1,0 +1,125 @@
+/**
+ * Contact phone normalization gene.
+ *
+ * Contact matching works by hashing an E.164 phone number on the device and
+ * comparing that digest against the digest of a phone-verified account number.
+ * The two sides only ever meet if both produce byte-identical E.164, so this
+ * module is the single source of truth for "what E.164 does this raw contact
+ * string mean".
+ *
+ * The previous implementation assumed a bare 10-digit number was North
+ * American and prefixed `+1`. That silently broke every match in India (and
+ * every other 10-digit national plan): a contact saved as `9876543210` hashed
+ * as `+19876543210` while the account itself is `+919876543210`. Region-aware
+ * parsing removes the guess.
+ *
+ * `libphonenumber-js/mobile/metadata` is reused deliberately — the phone
+ * verification flow already loads it, so this adds no new metadata blob, and
+ * accounts are SMS-verified mobile numbers by construction.
+ */
+
+import {
+  isSupportedCountry,
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js/core";
+import mobilePhoneMetadata from "libphonenumber-js/mobile/metadata";
+
+export type NormalizedContactPhone = {
+  /** Strict E.164, e.g. `+919876543210`. This is what gets hashed. */
+  e164: string;
+  /** Last four digits, used server-side to bucket candidates before hashing. */
+  last4: string;
+  /**
+   * True when the number validates as a mobile line in its region. Accounts are
+   * SMS-verified, so mobile numbers are the only ones that can actually match;
+   * this lets callers prioritise them when a payload cap forces truncation.
+   */
+  isMobile: boolean;
+};
+
+function asCountryCode(value: unknown): CountryCode | undefined {
+  const candidate = String(value ?? "")
+    .trim()
+    .toUpperCase();
+  if (candidate.length !== 2) return undefined;
+  return isSupportedCountry(candidate as CountryCode, mobilePhoneMetadata)
+    ? (candidate as CountryCode)
+    : undefined;
+}
+
+/**
+ * Resolve which region bare national numbers ("9876543210") should be read in.
+ *
+ * Ordered by how strongly each signal predicts the contact book's own region:
+ * the SIM/network country reported by the device beats the account's own number,
+ * which beats the UI locale.
+ */
+export function resolveContactPhoneRegion(signals: {
+  /** Region reported by the native contacts plugin (SIM or network country). */
+  deviceRegion?: string | null;
+  /** The signed-in user's own verified phone number, in E.164. */
+  accountPhoneNumber?: string | null;
+  /** BCP-47 locale tag, e.g. `en-IN`. Defaults to the browser locale. */
+  localeTag?: string | null;
+}): CountryCode | undefined {
+  const fromDevice = asCountryCode(signals.deviceRegion);
+  if (fromDevice) return fromDevice;
+
+  const accountPhone = String(signals.accountPhoneNumber ?? "").trim();
+  if (accountPhone.startsWith("+")) {
+    const parsed = parsePhoneNumberFromString(accountPhone, mobilePhoneMetadata);
+    const fromAccount = asCountryCode(parsed?.country);
+    if (fromAccount) return fromAccount;
+  }
+
+  const localeTag =
+    signals.localeTag ??
+    (typeof navigator !== "undefined" ? navigator.language : null);
+  if (localeTag) {
+    try {
+      const region = new Intl.Locale(localeTag).maximize().region;
+      const fromLocale = asCountryCode(region);
+      if (fromLocale) return fromLocale;
+    } catch {
+      /* Malformed locale tags are not worth failing a contact sync over. */
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Normalize a single raw contact phone string to E.164.
+ *
+ * Returns null when the string cannot be resolved to a trustworthy E.164 —
+ * short codes, junk entries, and national-format numbers with no known region.
+ * Guessing in those cases cannot create a match (the digest simply misses) but
+ * it does leak an extra hash, so we drop instead.
+ */
+export function normalizeContactPhone(
+  raw: string,
+  defaultRegion?: CountryCode,
+): NormalizedContactPhone | null {
+  const value = String(raw ?? "").trim();
+  if (!value) return null;
+
+  // libphonenumber already understands trunk prefixes (`09876543210`) and the
+  // `00` international prefix, so no pre-cleaning is needed or wanted here.
+  const parsed = defaultRegion
+    ? parsePhoneNumberFromString(value, defaultRegion, mobilePhoneMetadata)
+    : parsePhoneNumberFromString(value, mobilePhoneMetadata);
+  // `isPossible` keeps landlines and unusual-but-real lines while still
+  // rejecting short codes and truncated entries. `isValid` is reserved for the
+  // mobile signal because the metadata is mobile-only.
+  if (!parsed?.isPossible()) return null;
+
+  const e164 = parsed.number;
+  if (!/^\+[1-9]\d{6,14}$/.test(e164)) return null;
+
+  return {
+    e164,
+    last4: e164.replace(/\D/g, "").slice(-4),
+    isMobile: parsed.isValid(),
+  };
+}

--- a/hushh-webapp/lib/marketplace/contact-matching.ts
+++ b/hushh-webapp/lib/marketplace/contact-matching.ts
@@ -3,7 +3,20 @@
 import {
   HushhContacts,
   type HushhContactRecord,
+  type HushhContactsReadResult,
 } from "@/lib/capacitor";
+import {
+  normalizeContactPhone,
+  resolveContactPhoneRegion,
+} from "@/lib/contacts/phone-normalization";
+
+/**
+ * The backend caps `phone_lookups` at 1000 entries and rejects the whole
+ * request past that, so the cap is enforced here rather than discovered as a
+ * 422. Mobile numbers are kept first because accounts are SMS-verified, so a
+ * landline can never be the thing that matched.
+ */
+const MAX_PHONE_LOOKUPS = 1000;
 
 export type MarketplaceContactLookup = {
   hash: string;
@@ -14,14 +27,17 @@ export type MarketplaceLocalContactLookup = MarketplaceContactLookup & {
   displayName?: string | null;
 };
 
-function normalizePhoneForContactHash(value: string): string | null {
-  const raw = String(value || "").trim();
-  const digits = raw.replace(/\D/g, "");
-  if (!digits) return null;
-  if (raw.startsWith("+")) return `+${digits}`;
-  if (digits.length === 10) return `+1${digits}`;
-  return `+${digits}`;
-}
+export type MarketplaceContactLookupResult = {
+  lookups: MarketplaceLocalContactLookup[];
+  totalContacts: number;
+  sourcePlatform: HushhContactsReadResult["sourcePlatform"];
+  /** Region used to interpret national-format numbers, for diagnostics. */
+  region: string | null;
+  /** True when only a user-selected subset of the contact book was readable. */
+  limited: boolean;
+  /** True when the contact read or the lookup cap dropped part of the book. */
+  truncated: boolean;
+};
 
 function contactDisplayName(contact: HushhContactRecord): string | null {
   const value = String(contact.displayName || "").trim();
@@ -41,32 +57,78 @@ async function sha256Hex(value: string): Promise<string> {
 
 export async function buildMarketplaceContactLookups(options?: {
   limit?: number;
-}): Promise<{
-  lookups: MarketplaceLocalContactLookup[];
-  totalContacts: number;
-  sourcePlatform: "web" | "ios" | "android" | "native";
-}> {
-  const result = await HushhContacts.readContacts({ limit: options?.limit ?? 500 });
+  /**
+   * The signed-in user's own verified phone number. Used only to infer which
+   * region bare national contact numbers belong to; never hashed or sent.
+   */
+  accountPhoneNumber?: string | null;
+  signal?: AbortSignal;
+}): Promise<MarketplaceContactLookupResult> {
+  const result = await HushhContacts.readContacts({
+    limit: options?.limit ?? 500,
+  });
+  options?.signal?.throwIfAborted();
+
+  const region = resolveContactPhoneRegion({
+    deviceRegion: result.defaultRegion,
+    accountPhoneNumber: options?.accountPhoneNumber,
+  });
+
+  // Normalize and dedupe before hashing. Hashing is the expensive step, so it
+  // must never run twice for the same number — a contact book routinely holds
+  // the same person under home/mobile/work entries.
   const seen = new Set<string>();
-  const lookups: MarketplaceLocalContactLookup[] = [];
+  const candidates: Array<{
+    e164: string;
+    last4: string;
+    isMobile: boolean;
+    displayName: string | null;
+  }> = [];
 
   for (const contact of result.contacts) {
+    const displayName = contactDisplayName(contact);
     for (const phoneNumber of contact.phoneNumbers || []) {
-      const normalized = normalizePhoneForContactHash(phoneNumber);
-      if (!normalized || seen.has(normalized)) continue;
-      seen.add(normalized);
-      const digits = normalized.replace(/\D/g, "");
-      lookups.push({
-        hash: await sha256Hex(normalized),
-        last4: digits.slice(-4),
-        displayName: contactDisplayName(contact),
-      });
+      const normalized = normalizeContactPhone(phoneNumber, region);
+      if (!normalized || seen.has(normalized.e164)) continue;
+      seen.add(normalized.e164);
+      candidates.push({ ...normalized, displayName });
     }
   }
 
+  // Stable priority: mobile lines first, original contact order preserved
+  // within each group so truncation stays predictable across runs.
+  const prioritized = candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((left, right) => {
+      if (left.candidate.isMobile !== right.candidate.isMobile) {
+        return left.candidate.isMobile ? -1 : 1;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.candidate);
+
+  const capped = prioritized.slice(0, MAX_PHONE_LOOKUPS);
+  options?.signal?.throwIfAborted();
+
+  // Hash in parallel. WebCrypto digests are dispatched to native code, so
+  // awaiting them one at a time serialised ~1000 round trips through the
+  // bridge for no reason.
+  const hashes = await Promise.all(
+    capped.map((candidate) => sha256Hex(candidate.e164)),
+  );
+  options?.signal?.throwIfAborted();
+
   return {
-    lookups,
+    lookups: capped.map((candidate, index) => ({
+      hash: hashes[index]!,
+      last4: candidate.last4,
+      displayName: candidate.displayName,
+    })),
     totalContacts: result.contacts.length,
     sourcePlatform: result.sourcePlatform,
+    region: region ?? null,
+    limited: Boolean(result.limited),
+    truncated:
+      Boolean(result.truncated) || prioritized.length > MAX_PHONE_LOOKUPS,
   };
 }

--- a/hushh-webapp/lib/observability/events.ts
+++ b/hushh-webapp/lib/observability/events.ts
@@ -547,6 +547,14 @@ export interface EventPayloadMap {
     contact_count_bucket: string;
     matched_count: number;
     invite_candidate_count: number;
+    /** Region used to read national-format contact numbers. */
+    contact_region?: string;
+    /** Only a user-selected subset of the contact book was readable. */
+    partial_access?: boolean;
+    /** The contact book exceeded the read or lookup caps. */
+    truncated?: boolean;
+    /** Why a sync could not run: denied, restricted, unavailable, error. */
+    failure_reason?: string;
   };
   one_location_request_sent: {
     route_id: RouteId;

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -730,6 +730,10 @@ const API_TEMPLATE_RULES: Array<{ regex: RegExp; template: string }> = [
     template: "/api/iam/marketplace/opt-in",
   },
   {
+    regex: /^\/api\/iam\/contact-discoverability(?:\?.*)?$/i,
+    template: "/api/iam/contact-discoverability",
+  },
+  {
     regex: /^\/api\/ria\/onboarding\/submit(?:\?.*)?$/i,
     template: "/api/ria/onboarding/submit",
   },

--- a/hushh-webapp/lib/observability/schema.ts
+++ b/hushh-webapp/lib/observability/schema.ts
@@ -203,6 +203,10 @@ const EVENT_ALLOWED_KEYS: Record<ObservabilityEventName, readonly string[]> = {
     "contact_count_bucket",
     "matched_count",
     "invite_candidate_count",
+    "contact_region",
+    "partial_access",
+    "truncated",
+    "failure_reason",
   ],
   one_location_request_sent: [
     ...BASE_ALLOWED_KEYS,

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -1,10 +1,33 @@
 "use client";
 
+import { HushhContacts, type HushhContactsPermissionState } from "@/lib/capacitor";
 import { buildMarketplaceContactLookups } from "@/lib/marketplace/contact-matching";
 import {
   RiaService,
   type MarketplaceContactMatch,
 } from "@/lib/services/ria-service";
+
+/**
+ * Why the sync could not produce matches. The caller used to infer this by
+ * substring-matching the thrown message ("denied", "web view", …), which broke
+ * silently whenever a platform reworded its error. The plugin already knows the
+ * real permission state, so it is read directly and carried as a typed value.
+ */
+export type OneLocationContactSyncFailure =
+  | "denied"
+  | "restricted"
+  | "unavailable"
+  | "error";
+
+export class OneLocationContactSyncError extends Error {
+  readonly failure: OneLocationContactSyncFailure;
+
+  constructor(failure: OneLocationContactSyncFailure, message: string) {
+    super(message);
+    this.name = "OneLocationContactSyncError";
+    this.failure = failure;
+  }
+}
 
 export type OneLocationContactSignalResult = {
   matches: MarketplaceContactMatch[];
@@ -12,19 +35,76 @@ export type OneLocationContactSignalResult = {
   totalContacts: number;
   inviteCandidateCount: number;
   sourcePlatform: "web" | "ios" | "android" | "native";
+  /** Region used to read national-format contact numbers, for diagnostics. */
+  region: string | null;
+  /**
+   * True when only part of the contact book was readable — iOS limited access
+   * or the web contact picker. An empty result is then inconclusive, not proof
+   * that nobody matched.
+   */
+  limited: boolean;
+  /** True when the contact book was larger than the read or lookup caps. */
+  truncated: boolean;
 };
+
+const PERMISSION_FAILURES: Partial<
+  Record<HushhContactsPermissionState["state"], OneLocationContactSyncFailure>
+> = {
+  denied: "denied",
+  restricted: "restricted",
+  unavailable: "unavailable",
+};
+
+const PERMISSION_MESSAGES: Record<OneLocationContactSyncFailure, string> = {
+  denied:
+    "Contact access is turned off for Hussh. Turn it on in Settings to find people you already know.",
+  restricted: "Contact access is restricted on this device.",
+  unavailable: "Contact sync is available in the iOS and Android app.",
+  error: "Could not sync contacts.",
+};
+
+async function assertContactsReadable(): Promise<void> {
+  let permission: HushhContactsPermissionState;
+  try {
+    permission = await HushhContacts.getPermissionState();
+  } catch {
+    // A plugin that cannot report state at all is not installed on this
+    // surface; treat it the same as an unavailable platform.
+    throw new OneLocationContactSyncError(
+      "unavailable",
+      PERMISSION_MESSAGES.unavailable,
+    );
+  }
+
+  const failure = PERMISSION_FAILURES[permission.state];
+  if (failure) {
+    throw new OneLocationContactSyncError(failure, PERMISSION_MESSAGES[failure]);
+  }
+}
 
 export async function syncOneLocationContactSignals({
   idToken,
-  contactLimit = 500,
-  matchLimit = 50,
+  accountPhoneNumber,
+  contactLimit = 5000,
+  matchLimit = 100,
+  signal,
 }: {
   idToken: string;
+  /**
+   * The signed-in user's own verified phone number. Used only to infer the
+   * region for bare national contact numbers; never hashed or transmitted.
+   */
+  accountPhoneNumber?: string | null;
   contactLimit?: number;
   matchLimit?: number;
+  signal?: AbortSignal;
 }): Promise<OneLocationContactSignalResult> {
+  await assertContactsReadable();
+
   const lookupResult = await buildMarketplaceContactLookups({
     limit: contactLimit,
+    accountPhoneNumber,
+    signal,
   });
 
   if (lookupResult.lookups.length === 0) {
@@ -34,6 +114,9 @@ export async function syncOneLocationContactSignals({
       totalContacts: lookupResult.totalContacts,
       inviteCandidateCount: lookupResult.totalContacts,
       sourcePlatform: lookupResult.sourcePlatform,
+      region: lookupResult.region,
+      limited: lookupResult.limited,
+      truncated: lookupResult.truncated,
     };
   }
 
@@ -43,6 +126,10 @@ export async function syncOneLocationContactSignals({
       last4,
     })),
     limit: matchLimit,
+    // One Location matches the whole One network, not just the Connect deck.
+    // Under the marketplace scope an ordinary user matches nobody, because
+    // marketplace profiles are off by default.
+    scope: "one_network",
   });
   const privacySafeMatches = matches.map((match) => {
     const safeMatch = { ...match };
@@ -66,5 +153,18 @@ export async function syncOneLocationContactSignals({
       lookupResult.totalContacts - matchedUserIds.length,
     ),
     sourcePlatform: lookupResult.sourcePlatform,
+    region: lookupResult.region,
+    limited: lookupResult.limited,
+    truncated: lookupResult.truncated,
   };
+}
+
+/** Open the OS settings page so a denied user can restore contact access. */
+export async function openContactPermissionSettings(): Promise<boolean> {
+  try {
+    const result = await HushhContacts.openAppSettings();
+    return Boolean(result?.opened);
+  } catch {
+    return false;
+  }
 }

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -115,9 +115,14 @@ export interface MarketplaceInvestorDeckResponse {
   deck_complete: boolean;
 }
 
+/**
+ * `one_user` is a plain One account matched under the `one_network` scope: it
+ * has no marketplace profile, so only identity fields the account already
+ * published are populated.
+ */
 export interface MarketplaceContactMatch {
   user_id: string;
-  kind: "ria" | "investor";
+  kind: "ria" | "investor" | "one_user";
   display_name: string;
   headline?: string | null;
   phone_last4?: string | null;
@@ -1464,6 +1469,37 @@ export class RiaService {
     }>(response);
   }
 
+  /**
+   * Whether someone who already holds this user's phone number may learn that
+   * the number belongs to a One account. Defaults to enabled — contact sync is
+   * only useful if the people in a user's address book are findable.
+   */
+  static async getContactDiscoverability(
+    idToken: string,
+  ): Promise<{ user_id: string; contact_discoverable: boolean }> {
+    const response = await authFetch("/api/iam/contact-discoverability", {
+      method: "GET",
+      idToken,
+    });
+    return toJsonOrThrow<{ user_id: string; contact_discoverable: boolean }>(
+      response,
+    );
+  }
+
+  static async setContactDiscoverability(
+    idToken: string,
+    enabled: boolean,
+  ): Promise<{ user_id: string; contact_discoverable: boolean }> {
+    const response = await authFetch("/api/iam/contact-discoverability", {
+      method: "POST",
+      idToken,
+      body: { enabled },
+    });
+    return toJsonOrThrow<{ user_id: string; contact_discoverable: boolean }>(
+      response,
+    );
+  }
+
   static async searchRias(params: {
     query?: string;
     limit?: number;
@@ -1616,6 +1652,12 @@ export class RiaService {
     payload: {
       phone_lookups: Array<{ hash: string; last4: string }>;
       limit?: number;
+      /**
+       * `marketplace` (default) matches publicly discoverable Connect
+       * profiles. `one_network` matches any phone-verified account that has
+       * not turned off contact discoverability.
+       */
+      scope?: "marketplace" | "one_network";
     },
   ): Promise<MarketplaceContactMatch[]> {
     const response = await authFetch("/api/marketplace/contacts/match", {


### PR DESCRIPTION
## Why

Contact sync returned **zero matches for most users** for two independent reasons, and froze the UI on large contact books while doing it.

### 1. Phone normalization assumed North America

`normalizePhoneForContactHash` prefixed `+1` to any 10-digit number:

```ts
if (digits.length === 10) return `+1${digits}`;
```

India is the default signup region. A contact saved as `9876543210` hashed as `+19876543210`, while the account it should match is verified as `+919876543210`. The backend shared the same rule, so both sides were consistently wrong and **the failure was silent** — it looked like "no one you know is on Hussh".

Normalization now resolves a region (SIM/network country → the user's own verified number → locale) and formats through `libphonenumber-js`, which the phone verification flow already loads, so no new dependency or metadata blob.

### 2. Eligibility excluded ordinary users

`match_marketplace_contacts` only returned people with a discoverable `marketplace_public_profiles` row, and `is_discoverable` defaults to `FALSE`. Even with correct hashing, ordinary users matched nobody.

Adds `contact_discoverable` (migration **140**, default `TRUE`, opt-out) and a `scope` switch on the existing matcher rather than a parallel one. **Marketplace scope behaviour is unchanged.** A "Find me by phone number" toggle in profile privacy settings provides the opt-out.

## Native reads: no longer blocking or lossy

- **iOS** enumerated contacts on the **main thread** from the permission callback — a guaranteed freeze. Now on a `userInitiated` queue. iOS 17+ `limited` access is reported so partial access is not read as "nobody matched".
- **Android** queried the content resolver inline (ANR risk) and truncated **alphabetically** by `DISPLAY_NAME`, silently hiding everyone past the cut letter. Now on `Dispatchers.IO`, ordered by indexed `CONTACT_ID`, and reads Android's own `NORMALIZED_NUMBER` (E.164) when available.
- `getPermissionState` could not report a permanently denied state, so the UI offered a prompt the OS would never show. It now reports `denied` and exposes `openAppSettings` as the recovery path.

## Performance

- Hashing was `await`ed inside a nested loop, serialising ~1000 WebCrypto round trips. Now deduped then batched.
- The client could exceed the backend's 1000-lookup cap and have the **entire request rejected**. Cap is now enforced client-side, dropping landlines first (accounts are SMS-verified, so a landline can never be the match).
- Adds a functional index for the `last4` predicate, which was sequential-scanning `actor_identity_cache` on every sync.

## Verified

- `tsc --noEmit` clean, eslint clean, `ruff check` + `ruff format` clean
- **72 webapp tests pass** (23 new/rewritten), including a test asserting the digest equals SHA-256 of `+919876543210`
- 8 backend contact-match tests pass
- Native plugin contract parity and static parity pass — all four methods align across TypeScript, Swift and Kotlin

## Not verified — please read before merging

- **Android Kotlin was never compiled.** The local `google-services.json` is gitignored and registers `com.hushh.app` while the app id is `com.hussh.app`, so the build dies in `processDebugGoogleServices` before reaching Kotlin. **The Swift and Kotlin are static-reviewed only and need a real device run.**
- **Migration 140 is unapplied.** Matching keeps working via `COALESCE(..., TRUE)` until the deploy lane applies it. Migrations are applied by `deploy-uat` / `deploy-production` via `db/migrate.py --release`, not by hand, and `--mode local` proxies to the shared UAT Cloud SQL, so there is no safe manual path.
- `main` is merged in and the PR is mergeable. The migration was renumbered **137 to 140** because main had already taken 137/138/139, and `expected_migration_version` was bumped to 140 across all three schema contracts (policy is `exact`). Without that, the migration governance gate would have failed and blocked the UAT and production release lanes.

## Privacy note

The match discloses nothing new: the caller proves it already holds the number by supplying its SHA-256 digest, and the server only confirms or denies a digest it derives itself. Raw contacts never leave the device.


