### PR TITLE
fix(ios): wrap Finance Analysis stock-preview buttons and guard breadcrumb labels

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -728,9 +728,20 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
   );
   const breadcrumbTrailItems = useMemo(() => {
     const raw = topShellBreadcrumb?.items ?? [];
+    // Defensively drop any crumb whose label is empty/whitespace before the
+    // trail renders. A resolver that spreads a conditional segment
+    // (`...(x ? [{label}] : [])`) can only ever yield real labels today, but
+    // guarding here means a future empty/undefined segment can never surface as
+    // a stray separator pair (the "Finance > , > > preview" artifact) in the
+    // shared chevron trail.
+    const cleaned = raw.filter(
+      (item) => typeof item.label === "string" && item.label.trim().length > 0,
+    );
     // Inner/"subagent" routes read as "Kai > Analysis", not
     // "One > Kai > Analysis": drop the app-root crumb from the visible trail.
-    return raw.length > 0 && raw[0]?.label === "One" ? raw.slice(1) : raw;
+    return cleaned.length > 0 && cleaned[0]?.label === "One"
+      ? cleaned.slice(1)
+      : cleaned;
   }, [topShellBreadcrumb]);
   const hasBreadcrumbTrail = !centerTitle && breadcrumbTrailItems.length > 0;
   const canShowPersonaSwitcher = useMemo(

--- a/hushh-webapp/components/kai/cards/stock-comparison-preview.tsx
+++ b/hushh-webapp/components/kai/cards/stock-comparison-preview.tsx
@@ -111,13 +111,19 @@ export function StockComparisonPreview({
             accent="default"
             actions={
               onBrowseRecommendations || onChangeStock ? (
-                <div className="flex items-center gap-1">
+                // Allow the action buttons to wrap onto a second line instead of
+                // overflowing the card's right edge on narrow iOS widths (which
+                // clipped "Change stock" to "Change stoc"). `shrink-0` keeps each
+                // button's own label intact; `whitespace-nowrap` stops a single
+                // label from breaking mid-word once it has wrapped to its line.
+                <div className="flex flex-wrap items-center justify-end gap-1">
                   {onBrowseRecommendations ? (
                     <Button
                       type="button"
                       variant="none"
                       effect="fade"
                       size="sm"
+                      className="shrink-0 whitespace-nowrap"
                       onClick={onBrowseRecommendations}
                     >
                       Recommendations
@@ -129,9 +135,10 @@ export function StockComparisonPreview({
                       variant="none"
                       effect="fade"
                       size="sm"
+                      className="shrink-0 whitespace-nowrap"
                       onClick={onChangeStock}
                     >
-                      <Search className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                      <Search className="mr-1.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                       Change stock
                     </Button>
                   ) : null}


### PR DESCRIPTION
## What & why

On Finance -> Analysis (the `${SYMBOL} preview` screen), two issues:

1. **Stock preview action buttons overflow the card** — the "Recommendations" + "Change stock" row sat in a fixed `flex items-center` with no wrapping, so on narrow iOS widths it ran past the card's right edge and clipped "Change stock" to "Change stoc".
2. **Breadcrumb formatting** — reported as `F.. > , > > preview` with stray commas / double chevrons.

## Fixes

**1. Button overflow (real, reproducible) — `components/kai/cards/stock-comparison-preview.tsx`**
The `SectionHeader` actions row now wraps and each button holds its own label:
- container: `flex flex-wrap items-center justify-end gap-1` (was `flex items-center gap-1`) — buttons drop to a second line instead of overflowing.
- each `Button`: `shrink-0 whitespace-nowrap`, and the Search icon `shrink-0` — so a button keeps its full text and never truncates mid-word.

**2. Breadcrumb hardening — `components/app-ui/top-app-bar.tsx`**
The shared trail's `breadcrumbTrailItems` memo now **filters out any crumb whose label is empty/whitespace** before rendering, so an empty/undefined segment can never surface as a stray chevron-pair.

## Premise note (breadcrumb)

I checked the resolver (`lib/navigation/top-shell-breadcrumbs.ts`): the Analysis route already builds clean items — `Finance > Analysis > ${ticker} preview` — using conditional spreads (`...(x ? [{label}] : [])`) that can't emit empty labels or comma joins today. The reported `> , > >` corruption is most consistent with the **pre-#5053 breadcrumb state** (the collision/overflow fix that's in Build 73, which hasn't been on-device tested yet), not with current `main`. Rather than "fix" a formatting bug I can't reproduce in current code, I added the small **defensive empty-label filter** so the class of artifact is impossible regardless of any future resolver change. The visible chevron separators and narrow-width truncation are already handled by the shared trail (#5053).

## Verification

- ESLint on both files: clean.
- Button row: on a narrow width, "Recommendations" and "Change stock" wrap to a second line, each fully readable, no card overflow / no truncation.
- Breadcrumb: `Finance > Analysis > GOOGL preview` renders with single chevrons; any blank segment is dropped rather than rendered as an empty crumb.

## Risk

Low. One presentational card (Tailwind class change) + one defensive filter in the shared trail memo; no route/data/contract change.
