### PR TITLE
fix(ios): stop deep-analysis tab bounce and show full agent labels

### DIFF
--- a/hushh-webapp/components/kai/views/round-tabs-card.tsx
+++ b/hushh-webapp/components/kai/views/round-tabs-card.tsx
@@ -84,18 +84,29 @@ export function RoundTabsCard({
   className,
 }: RoundTabsCardProps) {
   const [currentTab, setCurrentTab] = useState<string>(activeAgent || "fundamental");
+  // Once the user manually taps a tab, honor THEIR selection instead of the
+  // live stream's `activeAgent`. Without this, tapping "Sentiment" while the
+  // fundamental agent is still streaming was ignored (handleTabChange returned
+  // early) and the next `activeAgent` prop from polling snapped the tab back --
+  // the "bounce". The pin auto-follows again only until the first manual tap.
+  const [userPinned, setUserPinned] = useState(false);
 
   useEffect(() => {
-    if (activeAgent && activeAgent !== currentTab) {
+    // Auto-advance to the live agent only while the user has not taken manual
+    // control of the tabs.
+    if (!userPinned && activeAgent && activeAgent !== currentTab) {
       setCurrentTab(activeAgent);
     }
-  }, [activeAgent, currentTab]);
+  }, [activeAgent, currentTab, userPinned]);
+
+  // The displayed tab: the user's pinned choice wins; otherwise follow the
+  // live agent, then the local default.
+  const selectedTab = userPinned ? currentTab : activeAgent || currentTab;
 
   const handleTabChange = (val: string) => {
-    if (activeAgent) {
-      onTabChange?.(val);
-      return;
-    }
+    // A tap always wins and pins, whether or not a live run is streaming, so
+    // the selection can never revert under the user.
+    setUserPinned(true);
     setCurrentTab(val);
     onTabChange?.(val);
   };
@@ -169,7 +180,7 @@ export function RoundTabsCard({
 
       {!isCollapsed && (
         <MorphyCardContent>
-          <Tabs value={activeAgent || currentTab} onValueChange={handleTabChange} className="w-full">
+          <Tabs value={selectedTab} onValueChange={handleTabChange} className="w-full">
             <TabsList className="mb-4 grid h-10 w-full grid-cols-3 items-stretch gap-1">
               {AGENT_ORDER.map((agent) => {
                 const config = AGENT_CONFIG[agent];
@@ -178,32 +189,43 @@ export function RoundTabsCard({
                 const isAgentActive = state?.stage === "active";
                 const isAgentError = state?.stage === "error";
 
+                const hasStatusIndicator =
+                  isAgentComplete || isAgentError || isAgentActive;
+
                 return (
                   <TabsTrigger
                     key={agent}
                     value={agent}
                     className={cn(
                       // Center reliably inside the fixed grid cell and keep the
-                      // layout stable between active/inactive. min-w-0 + the
-                      // grid cell handle responsiveness on narrow iPhones.
-                      "flex h-8 min-h-0 w-full min-w-0 items-center justify-center gap-1 px-1.5 text-center text-[11px] leading-none sm:text-xs",
+                      // layout stable between active/inactive. `whitespace-nowrap`
+                      // keeps each label ("Fundamental"/"Sentiment"/"Valuation")
+                      // on one line; the tighter padding + 11px size fit all
+                      // three full labels across a 3-col grid on narrow iPhones
+                      // instead of the previous mid-word "Funda…" truncation.
+                      "flex h-8 min-h-0 w-full min-w-0 items-center justify-center gap-1 whitespace-nowrap px-1 text-center text-[11px] leading-none sm:text-xs",
                       isAgentComplete &&
                         "data-[state=active]:text-emerald-700 dark:data-[state=active]:text-emerald-300"
                     )}
                   >
                     <span className="min-w-0 truncate">{config.label}</span>
-                    <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center">
-                      {isAgentComplete ? (
-                        <Icon icon={CheckCircle2} size="xs" className="text-emerald-500" />
-                      ) : isAgentError ? (
-                        <Icon icon={AlertCircle} size="xs" className="text-red-500" />
-                      ) : isAgentActive ? (
-                        <span className="relative flex h-2 w-2">
-                          <span className={cn("animate-ping absolute inline-flex h-full w-full rounded-full opacity-75", config.bgDot)} />
-                          <span className={cn("relative inline-flex rounded-full h-2 w-2", config.bgDot)} />
-                        </span>
-                      ) : null}
-                    </span>
+                    {/* Only reserve the status glyph's width when a status
+                        actually exists, so an idle tab gives its full width to
+                        the label instead of a permanently empty 12px gutter. */}
+                    {hasStatusIndicator ? (
+                      <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center">
+                        {isAgentComplete ? (
+                          <Icon icon={CheckCircle2} size="xs" className="text-emerald-500" />
+                        ) : isAgentError ? (
+                          <Icon icon={AlertCircle} size="xs" className="text-red-500" />
+                        ) : (
+                          <span className="relative flex h-2 w-2">
+                            <span className={cn("animate-ping absolute inline-flex h-full w-full rounded-full opacity-75", config.bgDot)} />
+                            <span className={cn("relative inline-flex rounded-full h-2 w-2", config.bgDot)} />
+                          </span>
+                        )}
+                      </span>
+                    ) : null}
                   </TabsTrigger>
                 );
               })}


### PR DESCRIPTION
## What & why

On Finance -> Analysis live (`Initial Deep Analysis`, `RoundTabsCard`), two issues in the Fundamental / Sentiment / Valuation tab group:

1. **Tab selection bounced back.** Tapping a tab while a live run was streaming reverted to the streaming agent.
2. **Labels truncated** on mobile ("Funda…", "Sentim…", "Valuati…").

## Root cause

`components/kai/views/round-tabs-card.tsx`:
- The Tabs were controlled by `value={activeAgent || currentTab}`, and `handleTabChange` did `if (activeAgent) { onTabChange?.(val); return; }` — i.e. while a run was live it **ignored the user's tap** and kept following `activeAgent`, which the parent re-supplies from polling → the tab snapped back (the "bounce").
- Each trigger rendered a `truncate` label plus a **status-icon span that always reserved ~12px** (even when idle), so three labels + three gutters didn't fit a 3-col grid on narrow iPhones and clipped.

## Fixes (one file)

**Bounce — user tap wins:**
- Added `userPinned` state. A tap now always `setUserPinned(true)` + `setCurrentTab(val)` and never early-returns, so the selection can't revert.
- `selectedTab = userPinned ? currentTab : (activeAgent || currentTab)` drives `value` — auto-follow the live agent until the user takes control, then honor their choice.
- The auto-advance effect is gated on `!userPinned`.

**Truncation — full labels:**
- Trigger is `whitespace-nowrap` with tighter `px-1` (keeps 11px / sm:xs), so "Fundamental" / "Sentiment" / "Valuation" fit across the 3-col grid.
- The status glyph span is now rendered **only when a status exists** (`isAgentComplete || isAgentError || isAgentActive`), so an idle tab gives its full width to the label instead of a permanent empty gutter.

Radix Tabs already `e.preventDefault()`s its triggers, so no extra event handling was needed — the bounce was pure state logic, not event propagation.

## Verification

- ESLint on `round-tabs-card.tsx`: clean.
- Bounce: tapping Sentiment/Valuation mid-stream stays put; before any tap it still auto-advances with the live agent.
- Labels: all three render in full on a narrow width; the check/active/error indicator still appears (and only then reserves its width).

## Risk

Low. One presentational/stateful card; no API/route/contract change. Auto-follow behavior preserved until the first manual tap.
