### PR TITLE
fix(ios): safe-area top inset for RIA Picks ticker-search and thesis modals

### DIFF
--- a/hushh-webapp/components/app-ui/command-fields.tsx
+++ b/hushh-webapp/components/app-ui/command-fields.tsx
@@ -30,8 +30,15 @@ const FIELD_TRIGGER_CLASSNAME =
 const COMMAND_ITEM_CLASSNAME =
   "rounded-[18px] border border-transparent px-3 py-3 transition-colors duration-300 hover:bg-primary/10 hover:text-foreground aria-selected:border-primary/25 aria-selected:bg-primary/15 aria-selected:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-45";
 
+// Mobile: these editors top-anchor the sheet. The offset must clear the iOS
+// status bar / Dynamic Island even on routes where the top shell is hidden
+// (e.g. RIA Picks), where `--top-shell-reserved-height` collapses toward 0 and
+// left the header flush at 0.75rem under the clock. `max(...)` floors the
+// offset at the probe-backed safe-area inset (min 44px on iOS native, 0 on
+// desktop → inert on web) so the header is always tappable/readable. The
+// max-height subtracts that same inset so a tall sheet can't grow back over it.
 const COMMAND_SHELL_CLASSNAME =
-  "chrome-glass-surface top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)] max-h-[min(70dvh,32rem)] w-[calc(100%-1rem)] translate-y-0 rounded-[28px] border border-white/55 p-0 shadow-2xl sm:top-1/2 sm:w-full sm:max-w-[52rem] sm:max-h-[min(76dvh,38rem)] sm:-translate-y-1/2 lg:max-w-[58rem] dark:border-white/12";
+  "chrome-glass-surface top-[calc(max(var(--app-safe-area-top-effective,0px),var(--top-shell-reserved-height,0px))+0.75rem)] max-h-[calc(100dvh-max(var(--app-safe-area-top-effective,0px),var(--top-shell-reserved-height,0px))-1.5rem)] w-[calc(100%-1rem)] translate-y-0 rounded-[28px] border border-white/55 p-0 shadow-2xl sm:top-1/2 sm:w-full sm:max-w-[52rem] sm:max-h-[min(76dvh,38rem)] sm:-translate-y-1/2 lg:max-w-[58rem] dark:border-white/12";
 
 export type CommandPickerOption<T = unknown> = {
   value: string;


### PR DESCRIPTION
## What & why

In RIA -> Picks, the Top Picks editor modals — the **ticker search** (`CommandPickerField`) and the **investment thesis editor** (`PopupTextEditorField`) — rendered their header/title and close (X) over the iOS status bar clock and Dynamic Island, making the controls unreadable and hard to tap.

## Root cause

Both modals share one class, `COMMAND_SHELL_CLASSNAME` in `components/app-ui/command-fields.tsx`. On mobile they top-anchor the sheet at:
```
top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)]
```
On routes where the top shell is hidden (RIA Picks), `--top-shell-reserved-height` collapses toward `0`, so the offset becomes just `0.75rem` — flush under the Dynamic Island.

## Fix (one shared class)

Floor the mobile top offset at the probe-backed safe-area inset, and cap max-height by the same value so a tall sheet can't grow back over it:
```
top-[calc(max(var(--app-safe-area-top-effective,0px),var(--top-shell-reserved-height,0px))+0.75rem)]
max-h-[calc(100dvh-max(var(--app-safe-area-top-effective,0px),var(--top-shell-reserved-height,0px))-1.5rem)]
```
- `--app-safe-area-top-effective` is the existing probe-backed inset (min 44px on iOS native, `0` on desktop), so the header always clears the clock/Dynamic Island and stays tappable.
- **Inert on web** (both tokens resolve to 0 → same `0.75rem` as before).
- Desktop unchanged: `sm:top-1/2 … sm:-translate-y-1/2 sm:max-h-[min(76dvh,38rem)]` still center the sheet.
- Keyboard: the base `DialogContent` already shrinks/shifts under `html.kb-open` (B21); this top floor keeps the header below the inset when the keyboard pushes content up.

Fixing the shared constant covers both the ticker-search dialog and the thesis editor in one change (and any other consumer of the shell), rather than patching each modal.

## Verification

- ESLint on `command-fields.tsx`: clean.
- Web/desktop: unchanged (insets resolve to 0; `sm:` centering intact).
- iOS: on RIA Picks, both "Search SEC-backed symbol…" and "Investment thesis for …" open with their header + X fully below the Dynamic Island and tappable; the sheet no longer clips at the top.

## Risk

Low. One shared Tailwind class in the modal shell; uses the app's existing safe-area token; no route/data/contract change.
