### PR TITLE
Enforce Apple UI hierarchy across UAT app shell

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -294,9 +294,14 @@ textarea {
   --type-button-label-size: 17px;
   --type-button-label-line: 22px;
   --type-button-label-weight: 600;
-  --type-tab-label-size: 17px;
-  --type-tab-label-line: 22px;
+  --type-tab-label-size: 11px;
+  --type-tab-label-line: 13px;
   --type-tab-label-weight: 500;
+  --type-tab-label-tracking: 0;
+  --type-agent-tab-label-size: 17px;
+  --type-agent-tab-label-line: 22px;
+  --type-agent-tab-label-weight: 500;
+  --type-agent-tab-label-tracking: -0.01em;
   --foundation-caption-tracking: 0.158em;
   --foundation-micro-size: 0.6875rem;
   --foundation-micro-line: 1.273;
@@ -1918,9 +1923,9 @@ html.kb-open [data-agent-bar-shell][data-agent-bar-layout="fixed"] {
   --surface-card-content-pb: 14px;
   --surface-inset-p: 12px;
   --settings-group-stack-gap: 6px;
-  --settings-row-px: 12px;
-  --settings-row-py: 12px;
-  --settings-row-gap: 10px;
+  --settings-row-px: 16px;
+  --settings-row-py: 10px;
+  --settings-row-gap: 12px;
   --settings-row-stack-gap: 10px;
   --data-table-controls-gap: 12px;
   --data-table-cell-px: 10px;
@@ -1947,8 +1952,8 @@ html.kb-open [data-agent-bar-shell][data-agent-bar-layout="fixed"] {
     --surface-card-content-pb: 16px;
     --surface-inset-p: 14px;
     --settings-group-stack-gap: 8px;
-    --settings-row-px: 14px;
-    --settings-row-py: 14px;
+    --settings-row-px: 16px;
+    --settings-row-py: 10px;
     --settings-row-gap: 12px;
     --settings-row-stack-gap: 12px;
     --data-table-controls-gap: 14px;
@@ -4420,10 +4425,10 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
-  font-size: var(--ios-account-tab-label-size, 10px);
+  font-size: var(--ios-account-tab-label-size, var(--type-tab-label-size));
   font-weight: 500;
-  line-height: var(--ios-account-tab-label-line, 12px);
-  letter-spacing: 0;
+  line-height: var(--ios-account-tab-label-line, var(--type-tab-label-line));
+  letter-spacing: var(--type-tab-label-tracking);
   text-wrap: nowrap;
   opacity: 0.92;
 }
@@ -5464,6 +5469,10 @@ body[data-persona-surface="ria"] {
 
 /* Semantic typography guardrail.
    Kept at the end so role classes beat older h1/h2 and data-slot fallbacks. */
+[data-slot="settings-row-icon"] svg {
+  stroke-width: 1.65 !important;
+}
+
 :is(.ui-text-large-page-title) {
   color: var(--app-label) !important;
   font-family: var(--font-app-display) !important;
@@ -5489,10 +5498,10 @@ body[data-persona-surface="ria"] {
 :is(.ui-text-agent-title) {
   color: var(--app-label) !important;
   font-family: var(--font-app-display) !important;
-  font-size: 34px !important;
-  font-weight: 700 !important;
-  letter-spacing: -0.03em !important;
-  line-height: 41px !important;
+  font-size: var(--type-large-page-title-size) !important;
+  font-weight: var(--type-large-page-title-weight) !important;
+  letter-spacing: var(--type-large-page-title-tracking) !important;
+  line-height: var(--type-large-page-title-line) !important;
   opacity: 1 !important;
   text-transform: none !important;
 }
@@ -5659,7 +5668,7 @@ body[data-persona-surface="ria"] {
   font-family: var(--font-app-body) !important;
   font-size: var(--type-tab-label-size) !important;
   font-weight: var(--type-tab-label-weight) !important;
-  letter-spacing: -0.01em !important;
+  letter-spacing: var(--type-tab-label-tracking) !important;
   line-height: var(--type-tab-label-line) !important;
   opacity: 1 !important;
 }
@@ -5669,6 +5678,25 @@ body[data-persona-surface="ria"] {
 }
 
 [role="tab"][aria-selected="false"] :is(.ui-text-tab-label) {
+  color: var(--app-secondary-label) !important;
+}
+
+:is(.ui-text-agent-tab-label) {
+  color: var(--app-secondary-label) !important;
+  font-family: var(--font-app-body) !important;
+  font-size: var(--type-agent-tab-label-size) !important;
+  font-weight: var(--type-agent-tab-label-weight) !important;
+  letter-spacing: var(--type-agent-tab-label-tracking) !important;
+  line-height: var(--type-agent-tab-label-line) !important;
+  opacity: 1 !important;
+  text-transform: none !important;
+}
+
+[role="tab"][aria-selected="true"] :is(.ui-text-agent-tab-label) {
+  color: var(--app-accent) !important;
+}
+
+[role="tab"][aria-selected="false"] :is(.ui-text-agent-tab-label) {
   color: var(--app-secondary-label) !important;
 }
 

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -6,7 +6,7 @@ import type { LucideIcon } from "lucide-react";
 import { SurfaceCard, type SurfaceAccent, type SurfaceTone } from "@/components/app-ui/surfaces";
 import {
   AgentTitle,
-  CardTitle,
+  MajorSectionTitle,
   PageSubtitle,
   PageTitle,
   SectionLabel,
@@ -36,19 +36,16 @@ type SectionAccent =
 const ACCENT_STYLES: Record<SectionAccent, {
   eyebrow: string;
   icon: string;
-  divider: string;
 }> = {
   neutral: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   kai: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   ria: {
     // RIA sub-agent = Apple-clean gold. Var-driven so it flips to the DS gold
@@ -57,83 +54,68 @@ const ACCENT_STYLES: Record<SectionAccent, {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   consent: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   marketplace: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   developers: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   research: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   location: {
     eyebrow: "text-muted-foreground",
     icon: "bg-[color:var(--app-accent)] text-white shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   success: {
     eyebrow: "text-emerald-700 dark:text-emerald-300",
     icon: "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-200",
-    divider: "bg-emerald-300/50 dark:bg-emerald-400/30",
   },
   warning: {
     eyebrow: "text-amber-700 dark:text-amber-300",
     icon: "bg-amber-500/10 text-amber-700 dark:bg-amber-400/10 dark:text-amber-200",
-    divider: "bg-amber-300/50 dark:bg-amber-400/30",
   },
   critical: {
     eyebrow: "text-rose-700 dark:text-rose-300",
     icon: "bg-rose-500/10 text-rose-700 dark:bg-rose-400/10 dark:text-rose-200",
-    divider: "bg-rose-300/50 dark:bg-rose-400/30",
   },
   default: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   sky: {
     eyebrow: "text-muted-foreground",
     icon:
       "bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)] shadow-none",
-    divider: "bg-[color:var(--app-separator)]",
   },
   emerald: {
     eyebrow: "text-emerald-700 dark:text-emerald-300",
     icon: "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-200",
-    divider: "bg-emerald-300/50 dark:bg-emerald-400/30",
   },
   amber: {
     eyebrow: "text-amber-700 dark:text-amber-300",
     icon: "bg-amber-500/10 text-amber-700 dark:bg-amber-400/10 dark:text-amber-200",
-    divider: "bg-amber-300/50 dark:bg-amber-400/30",
   },
   rose: {
     eyebrow: "text-rose-700 dark:text-rose-300",
     icon: "bg-rose-500/10 text-rose-700 dark:bg-rose-400/10 dark:text-rose-200",
-    divider: "bg-rose-300/50 dark:bg-rose-400/30",
   },
   violet: {
     eyebrow: "text-violet-700 dark:text-violet-300",
     icon: "bg-violet-500/10 text-violet-700 dark:bg-violet-400/10 dark:text-violet-200",
-    divider: "bg-violet-300/50 dark:bg-violet-400/30",
   },
 };
 
@@ -331,14 +313,14 @@ export function SectionHeader({
                   {eyebrow}
                 </SectionLabel>
               ) : null}
-              <CardTitle
+              <MajorSectionTitle
                 as="div"
                 role="heading"
                 aria-level={2}
                 data-slot="section-header-title"
               >
                 {title}
-              </CardTitle>
+              </MajorSectionTitle>
               {description ? (
                 <PageSubtitle
                   as="div"
@@ -359,7 +341,6 @@ export function SectionHeader({
           </div>
         </div>
       </div>
-      <div className={cn("h-px w-full", styles.divider)} aria-hidden="true" />
     </div>
   );
 }

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -325,7 +325,7 @@ export function SettingsRow({
       : "group-data-[inset-separators=true]/settings-list:after:left-0";
   const rowShellClassName = cn(
     "group/settings-row relative isolate overflow-hidden bg-transparent",
-    resolvedDensity === "compact" && "[--settings-row-py:13px]",
+    resolvedDensity === "compact" && "[--settings-row-py:10px]",
     // iOS-style separator — active only inside SettingsGroup with
     // separatorInset and hidden on the final row. Its start is derived from
     // whether this row actually has a leading visual.

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -174,8 +174,9 @@ export function TopShellTabs({
               }}
             >
               <span
+                data-ui-role="agent-tab-label"
                 className={cn(
-                  "ui-text-tab-label relative truncate transition-colors duration-150",
+                  "ui-text-agent-tab-label relative truncate transition-colors duration-150",
                   isActive
                     ? "text-[color:var(--app-accent)]"
                     : "text-[color:var(--app-secondary-label)] hover:text-current",
@@ -201,7 +202,7 @@ export function TopShellTabs({
               width: tabWidth,
             }}
           >
-            <span className="h-[2.5px] w-[max(28px,calc(100%-2rem))] rounded-full bg-[var(--app-accent)]" />
+            <span className="h-[3px] w-[max(28px,calc(100%-2rem))] rounded-full bg-[var(--app-accent)]" />
           </div>
         ) : null}
       </div>

--- a/hushh-webapp/components/app-ui/typography.tsx
+++ b/hushh-webapp/components/app-ui/typography.tsx
@@ -25,6 +25,7 @@ export const TYPOGRAPHY_CLASSNAMES = {
   statusText: "ui-text-status",
   buttonLabel: "ui-text-button-label",
   tabLabel: "ui-text-tab-label",
+  agentTabLabel: "ui-text-agent-tab-label",
   caption: "ui-text-caption",
   legal: "ui-text-legal",
 } as const;
@@ -32,7 +33,7 @@ export const TYPOGRAPHY_CLASSNAMES = {
 const TYPOGRAPHY_ROLE_BY_CLASSNAME: Record<string, string> = {
   [TYPOGRAPHY_CLASSNAMES.largeTitle]: "large-title",
   [TYPOGRAPHY_CLASSNAMES.pageTitle]: "page-title",
-  [TYPOGRAPHY_CLASSNAMES.agentTitle]: "agent-title",
+  [TYPOGRAPHY_CLASSNAMES.agentTitle]: "large-title",
   [TYPOGRAPHY_CLASSNAMES.pageSubtitle]: "subtitle",
   [TYPOGRAPHY_CLASSNAMES.navigationTitle]: "nav-title",
   [TYPOGRAPHY_CLASSNAMES.identityName]: "identity-title",
@@ -50,6 +51,7 @@ const TYPOGRAPHY_ROLE_BY_CLASSNAME: Record<string, string> = {
   [TYPOGRAPHY_CLASSNAMES.statusText]: "body-strong",
   [TYPOGRAPHY_CLASSNAMES.buttonLabel]: "button-label",
   [TYPOGRAPHY_CLASSNAMES.tabLabel]: "tab-label",
+  [TYPOGRAPHY_CLASSNAMES.agentTabLabel]: "agent-tab-label",
   [TYPOGRAPHY_CLASSNAMES.caption]: "caption",
   [TYPOGRAPHY_CLASSNAMES.legal]: "legal-text",
 };
@@ -257,6 +259,15 @@ export function TabLabel(props: RoleTextProps) {
   return (
     <SemanticText
       roleClassName={TYPOGRAPHY_CLASSNAMES.tabLabel}
+      {...props}
+    />
+  );
+}
+
+export function AgentTabLabel(props: RoleTextProps) {
+  return (
+    <SemanticText
+      roleClassName={TYPOGRAPHY_CLASSNAMES.agentTabLabel}
       {...props}
     />
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1089,7 +1089,7 @@ function NowHub({
   onOpenSettings: () => void;
 }) {
   return (
-    <div className="space-y-4" data-testid="one-location-now-hub">
+    <div data-testid="one-location-now-hub">
       {/* Every row and tile below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
@@ -1119,7 +1119,11 @@ function NowHub({
         />
       </SettingsGroup>
 
-      <SettingsGroup separatorInset testId="one-location-now-status">
+      <SettingsGroup
+        separatorInset
+        className="mt-4"
+        testId="one-location-now-status"
+      >
         <SettingsRow
           icon={UsersRound}
           iconTone="purple"
@@ -1188,7 +1192,7 @@ function NowHub({
         />
       </SettingsGroup>
 
-      <div className="pt-3">
+      <div className="mt-7">
         <QuickActionsSection title="Quick actions" columns={2}>
           <QuickActionCard
             tone="green"

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -89,7 +89,7 @@ export function QuickActionCard({
       className={cn(
         "group flex min-h-[120px] w-full min-w-0 flex-col gap-3 rounded-[22px] bg-white p-4 text-left shadow-none transition-all duration-200 dark:bg-[color:var(--app-card-surface-default-solid)]",
         interactive
-          ? "cursor-pointer hover:-translate-y-0.5 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
+          ? "cursor-pointer active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
           : "cursor-not-allowed",
       )}
     >
@@ -103,8 +103,8 @@ export function QuickActionCard({
         >
           {icon}
         </span>
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#eef2f8] dark:bg-white/10">
-          <ChevronRight className="h-3 w-3 text-black/40 dark:text-muted-foreground" />
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill)] dark:bg-white/10">
+          <ChevronRight className="h-3 w-3 text-[color:var(--app-tertiary-label)]" />
         </span>
       </div>
 

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -44,6 +44,7 @@ for (const exportName of [
   "StatusText",
   "ButtonLabel",
   "TabLabel",
+  "AgentTabLabel",
   "CaptionText",
   "LegalText",
 ]) {
@@ -83,6 +84,12 @@ for (const [token, value] of [
   ["--type-helper-text-tracking", "0"],
   ["--type-legal-text-size", "11px"],
   ["--type-legal-text-line", "15px"],
+  ["--type-tab-label-size", "11px"],
+  ["--type-tab-label-line", "13px"],
+  ["--type-tab-label-weight", "500"],
+  ["--type-agent-tab-label-size", "17px"],
+  ["--type-agent-tab-label-line", "22px"],
+  ["--type-agent-tab-label-weight", "500"],
 ]) {
   if (!globals.includes(`${token}: ${value};`)) {
     failures.push(`app/globals.css: ${token} must stay ${value}`);
@@ -200,6 +207,7 @@ for (const [key, uiRole] of [
   ["helperText", "helper-text"],
   ["buttonLabel", "button-label"],
   ["tabLabel", "tab-label"],
+  ["agentTabLabel", "agent-tab-label"],
   ["legal", "legal-text"],
 ]) {
   if (!typographySource.includes(`[TYPOGRAPHY_CLASSNAMES.${key}]: "${uiRole}"`)) {


### PR DESCRIPTION
## Summary
- split top agent tabs from bottom-tab typography so each uses the Apple contract size
- normalize shared section headers, settings row density, icon stroke weight, and Location Now spacing
- keep Check-In and SMS differentiated through semantic icon tiles while labels stay neutral
- extend the Apple hierarchy verifier to lock the new tab role and tab tokens

## Verification
- npm run verify:design-system
- npm run typecheck
- npx eslint components/app-ui/typography.tsx components/app-ui/top-shell-tabs.tsx components/app-ui/page-sections.tsx components/app-ui/settings-ui.tsx components/one-location/redesign/quick-actions.tsx components/one-location/redesign/location-redesign-hub.tsx scripts/design/verify-apple-hierarchy.mjs --max-warnings=0
- npx playwright test e2e/location-agent-now-ui.spec.ts e2e/one-agent-directory-ui.spec.ts --project=chromium (skipped: reviewer auth env unavailable locally)