### PR TITLE
fix(ios): hide bottom nav and agent bar when keyboard is open

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1852,6 +1852,21 @@ html.kb-open [data-agent-bar-shell][data-agent-bar-layout="fixed"] {
     transform 150ms ease;
 }
 
+/* Same keyboard-avoidance for the persistent bottom shell (bottom nav + the
+ * in-slot "Talk to One" bar) and its ambient fade. That stack lifts by
+ * --kb-height when the on-screen keyboard opens, which rode it UP directly over
+ * a focused bottom input (e.g. Connect's people search, Share location). Hide
+ * the whole bottom chrome while a real keyboard is open so the input is never
+ * occluded; it returns on blur. Only active under html.kb-open (native +
+ * mobile web) → byte-for-byte inert on desktop. See mobile-bug-log B21. */
+html.kb-open [data-app-bottom-shell],
+html.kb-open .ambient-chrome-mask--bottom {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease;
+}
+
+
 
 
 .app-page-shell {


### PR DESCRIPTION
## What & why

On pages with a bottom text/search input (Connect people search, Share location), tapping the field opened the iOS keyboard while the persistent bottom chrome — the bottom nav **and** the in-slot "Talk to One" bar — stayed fixed directly above the keyboard, obscuring the active input.

## Root cause

The bottom shell's motion stack (`components/app-ui/app-bottom-shell.tsx`) lifts by `--kb-height`:
```
translate3d(0, calc((var(--kb-height,0px) * -1) + …), 0)
```
When the keyboard opens, that rides the whole nav + slot AgentBar UP, landing it over a focused bottom input. My earlier fix (#5055) only hid the **fixed** AgentBar (`layout="fixed"`); the bottom-shell bar is the **slot** variant, so it wasn't covered.

## Fix (globals.css, keyboard-gated)

Extend the same keyboard-avoidance to the whole bottom chrome while a real keyboard is open:
```css
html.kb-open [data-app-bottom-shell],
html.kb-open .ambient-chrome-mask--bottom {
  opacity: 0;
  pointer-events: none;
  transition: opacity 150ms ease;
}
```
- Uses the app's existing keyboard signal (`KeyboardInsetManager` sets `html.kb-open` + `--kb-height`), native/mobile-web only → **byte-for-byte inert on desktop**.
- Hides the bottom nav + slot "Talk to One" bar + its ambient bottom fade so the focused input is never occluded; everything returns on blur.
- Consistent with #5055 (fixed AgentBar) and the B21 dialog/sheet/drawer keyboard contract — no new JS listener.

Viewport scrolling of the focused input above the keyboard is already handled by `KeyboardInsetManager`'s focus `scrollIntoView` + `--kb-height` padding, so no per-page container change is needed.

## Verification

- `app/globals.css` is CSS (not ESLint-linted); no TS/type impact.
- Desktop unaffected (`kb-open` never set).
- iOS: Connect people search / Share location — on focus the bottom nav + Talk-to-One fade out and the input is fully visible above the keyboard; both reappear on blur.

## Risk

Low. One scoped, keyboard-gated CSS rule on the shared bottom shell; inert on desktop; no route/data/JS change.
