### PR TITLE
fix(ios): bake the browser Maps key into native builds

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -219,10 +219,16 @@ jobs:
 
           FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID)"
           MAPS_IOS_KEY="$(get NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY)"
+          # The immersive "Your Map" uses the native SDK (iOS key), but the
+          # onboarding location picker and LiveMap render Maps JS inside the
+          # WKWebView and read the BROWSER key. Without it the webview map has no
+          # key at all and silently degrades to the iframe embed.
+          MAPS_BROWSER_KEY="$(get NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY)"
 
           echo "::add-mask::$FB_API_KEY"
           echo "::add-mask::$FB_VAPID"
           [ -n "$MAPS_IOS_KEY" ] && echo "::add-mask::$MAPS_IOS_KEY"
+          [ -n "$MAPS_BROWSER_KEY" ] && echo "::add-mask::$MAPS_BROWSER_KEY"
 
           put APP_RUNTIME_PROFILE "uat"
           put NEXT_PUBLIC_APP_ENV "uat"
@@ -238,6 +244,7 @@ jobs:
           put NEXT_PUBLIC_FIREBASE_VAPID_KEY "$FB_VAPID"
           [ -n "$FB_MEASUREMENT" ] && put NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID "$FB_MEASUREMENT"
           [ -n "$MAPS_IOS_KEY" ] && put NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY "$MAPS_IOS_KEY"
+          [ -n "$MAPS_BROWSER_KEY" ] && put NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY "$MAPS_BROWSER_KEY"
           put NEXT_PUBLIC_OBSERVABILITY_ENABLED "true"
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -181,10 +181,19 @@ jobs:
           [ -n "$FB_MEASUREMENT" ] || FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_UAT)"
           [ -n "$FB_MEASUREMENT" ] || FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_STAGING)"
 
+          # Maps credentials. The immersive "Your Map" uses the native SDK (iOS
+          # key); the onboarding location picker and LiveMap render Maps JS
+          # inside the WKWebView and read the BROWSER key. Omitting either one
+          # degrades that surface to the iframe embed with no error.
+          MAPS_IOS_KEY="$(get NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY)"
+          MAPS_BROWSER_KEY="$(get NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY)"
+
           # NEXT_PUBLIC_* are public build values (baked into the client bundle),
           # but keep the API/VAPID keys out of the log for hygiene.
           echo "::add-mask::$FB_API_KEY"
           echo "::add-mask::$FB_VAPID"
+          [ -n "$MAPS_IOS_KEY" ] && echo "::add-mask::$MAPS_IOS_KEY"
+          [ -n "$MAPS_BROWSER_KEY" ] && echo "::add-mask::$MAPS_BROWSER_KEY"
 
           put APP_RUNTIME_PROFILE "uat"
           put NEXT_PUBLIC_APP_ENV "uat"
@@ -199,6 +208,8 @@ jobs:
           put NEXT_PUBLIC_FIREBASE_APP_ID "$FB_APP_ID"
           put NEXT_PUBLIC_FIREBASE_VAPID_KEY "$FB_VAPID"
           [ -n "$FB_MEASUREMENT" ] && put NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID "$FB_MEASUREMENT"
+          [ -n "$MAPS_IOS_KEY" ] && put NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY "$MAPS_IOS_KEY"
+          [ -n "$MAPS_BROWSER_KEY" ] && put NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY "$MAPS_BROWSER_KEY"
           put NEXT_PUBLIC_OBSERVABILITY_ENABLED "true"
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"


### PR DESCRIPTION
## What was blocked

The UAT Maps Platform keys and Secret Manager entries already existed (created 2026-07-23), but maps were still dead inside the iOS app. Two separate causes:

**1. Browser key restrictions (fixed in GCP, no code)** — `hushh-uat-one-location-browser` was API-restricted to `maps-backend.googleapis.com` only, and its referrer list had no Capacitor origin. So in the WKWebView (origin `App://localhost`, per `iosScheme: "App"`) it failed with `RefererNotAllowedMapError` — the exact error [`use-google-maps.ts:21-25`](../blob/main/hushh-webapp/lib/one-location/use-google-maps.ts#L21-L25) documents — and `places.Place.searchNearby()` was blocked outright.

Now widened to `maps-backend` + `places` + `routes`, with referrers `https://uat.one.hushh.ai/*`, `http://localhost:3000/*`, `App://localhost/*`, `capacitor://localhost/*`, `http://localhost/*`, `https://localhost/*`. Verified live: Maps JS `200`, Places `searchNearby` and Routes `computeRoutes` both return data from the `App://localhost` referrer.

**2. The key was never baked into the build (this PR)**

`getBrowserMapsApiKey()` reads `NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY`. Neither iOS workflow wrote it into `.env.local`, so on device it returned `""`, `loadGoogleMaps()` rejected with `maps-not-configured`, and every Maps JS surface degraded to the iframe embed. `ship-ios-testflight.yml` was missing the **iOS** key too, so the native immersive map had no credential either.

| surface | renderer | key | before |
|---|---|---|---|
| "Your Map" immersive | `@capacitor/google-maps` native SDK | iOS | app-store: OK · testflight: **missing** |
| Onboarding location picker | Maps JS in webview | browser | **missing in both** |
| LiveMap | Maps JS in webview | browser | **missing in both** |

## Verification

- Both workflows parse as YAML.
- The added `[ -n "$X" ] && put …` lines simulated under `set -euo pipefail` for all three cases (both keys present / both absent / only iOS): step completes `rc=0` and writes exactly the expected env lines. Matches the existing `FB_MEASUREMENT` pattern, so an absent secret stays non-fatal.
- Both keys masked in logs.

## Notes

Keys stay optional rather than `require`d, so a project without the secret still builds — consistent with how `FB_MEASUREMENT` and the existing iOS key are handled. UAT has both secrets, and the UAT CI service account already holds project-level `secretmanager.secretAccessor`.