### PR TITLE
fix(ios): gate bottom-nav hide on committed scroll distance to stop slow-scroll drift

### DIFF
--- a/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
+++ b/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
@@ -2,8 +2,16 @@ import { useEffect, useSyncExternalStore } from "react";
 
 const MIN_SCROLL_Y_FOR_SHOW = 10;
 const JITTER_DELTA_PX = 1.5;
+// Cumulative displacement (px) the gesture must travel in a single direction
+// before the bottom chrome starts hiding/revealing. Per-frame deltas above the
+// jitter floor but below this threshold (slow "micro-scroll" gestures on iOS)
+// previously nudged progress 1:1 every frame, so the bar drifted down / collapsed
+// prematurely while barely scrolling. We accumulate directional distance and only
+// begin moving once it clears this commit threshold; direction reversals reset it.
+const MIN_SCROLL_THRESHOLD_PX = 15;
 const PROGRESS_EPSILON = 0.001;
 const SCROLL_TRAVEL_PX = 84;
+
 const APP_SCROLL_ROOT_SELECTOR = '[data-app-scroll-root="true"]';
 
 type Listener = () => void;
@@ -134,10 +142,26 @@ export function onScroll(y: number): void {
   }
 
   const direction = delta > 0 ? 1 : -1;
-  state.direction = direction;
+  // A direction reversal restarts the commit budget so the bar responds
+  // promptly when the user changes scroll direction, but a fresh slow drag in
+  // one direction must still travel MIN_SCROLL_THRESHOLD_PX before anything moves.
+  if (direction !== state.direction) {
+    state.direction = direction;
+    state.directionalDistance = 0;
+  }
   state.directionalDistance += Math.abs(delta);
-  // Follow the thumb directly. This avoids an iOS-only lag window where the
-  // gesture has ended but the fixed controls are still animating under a tap.
+
+  // Velocity/displacement gate: hold the bar pinned until the gesture has
+  // committed enough distance in this direction. Without this, slow
+  // micro-scrolls (each frame just over the jitter floor) nudged progress 1:1
+  // every frame and the bar drifted/collapsed prematurely.
+  if (state.directionalDistance < MIN_SCROLL_THRESHOLD_PX) {
+    return;
+  }
+
+  // Once committed, follow the thumb directly. This avoids an iOS-only lag
+  // window where the gesture has ended but the fixed controls are still
+  // animating under a tap.
   setTargetProgress(state.progress + delta / SCROLL_TRAVEL_PX);
 }
 


### PR DESCRIPTION
## What & why

On scrollable pages (e.g. Location → Settings), scrolling **slowly** made the bottom chrome (bottom nav + "Talk to One" bar) drift down / collapse prematurely. Each per-frame scroll delta above the 1.5px jitter floor nudged the hide progress 1:1 immediately, so a slow micro-scroll accumulated into visible movement while the user had barely scrolled.

## Root cause

`lib/navigation/kai-bottom-chrome-visibility.ts → onScroll`: after the jitter check it went straight to `setTargetProgress(progress + delta / SCROLL_TRAVEL_PX)` on every qualifying frame — no minimum committed displacement before the bar starts moving.

## Fix — scroll-distance commit gate

- Added `MIN_SCROLL_THRESHOLD_PX = 15`.
- `onScroll` now accumulates `directionalDistance` per direction and **holds the bar pinned until the gesture commits ≥15px in one direction** before translating progress.
- A **direction reversal resets** the accumulator, so reversing scroll still responds promptly (the bar reveals/hides as soon as the new direction commits 15px), while a fresh slow drag must clear the threshold first.
- The jitter floor (`< 1.5px` ignored) and top-reset (`≤10px → shown`) behavior are unchanged. Reused the already-present `directionalDistance`/`direction` state fields (previously tracked but unused in the gate).

## Position pinning

Already satisfied: the bottom shell is `fixed inset-x-0 bottom-0` (`components/app-ui/app-bottom-shell.tsx`) and moves only via a `translate3d(... --bottom-chrome-progress ...)` transform, not by flowing in the scroll container. No change needed there; this PR only removes the premature progress movement.

## Verification

- ESLint on the file: clean.
- Reviewed `__tests__/lib/kai-bottom-chrome-visibility.test.ts`: every case scrolls in large jumps (120/160/200px) that clear the 15px threshold, so hide-on-down / show-on-up, snap, re-sync, and root-rebind expectations are all preserved. (Local `vitest` run couldn't load `@testing-library/jest-dom` — a missing local dev dep, unrelated to this change; CI's Web Core job runs the suite.)

## Risk

Low. One leaf hook, additive threshold gate; fast scrolls behave exactly as before, slow scrolls no longer drift. No route/data/contract change; desktop unaffected.
