### PR TITLE
fix(ui): center loading spinner in shared button component

### DIFF
--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -64,13 +64,24 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     // When using asChild, we must ensure only one child is passed to Slot.
     // If loading, we handle the content inside a single span.
-    const content = (
-      <>
-        {isLoading && (
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-        )}
-        {isLoading ? <span className="opacity-0">{children}</span> : children}
-      </>
+    //
+    // While loading, keep the original label in the flow but invisible so the
+    // button preserves its width, and overlay the spinner absolutely centered
+    // over it. The previous approach put the spinner inline with `mr-2` beside
+    // the hidden label, so the whole group centered as a block and the spinner
+    // rendered left of the button's true center. Absolute centering pins it to
+    // the exact middle regardless of label width.
+    const content = isLoading ? (
+      <span className="relative inline-flex items-center justify-center">
+        <span aria-hidden="true" className="opacity-0">
+          {children}
+        </span>
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        </span>
+      </span>
+    ) : (
+      children
     )
 
     return (


### PR DESCRIPTION
## What & why

When the shared stock `Button` (`components/ui/button.tsx`) enters its `isLoading` state (e.g. the Share Location consent-check button), the spinner rendered **left of center** instead of centered.

## Root cause

The loading content placed the spinner inline with a right margin next to a width-preserving hidden label:
```tsx
{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
{isLoading ? <span className="opacity-0">{children}</span> : children}
```
The button centers its content as a group, so `[spinner + mr-2 + hidden label]` centered as one block — pushing the visible spinner to the left of the button's true center.

## Fix

Keep the label in flow but invisible (preserves button width), and **overlay the spinner absolutely centered** over it:
```tsx
const content = isLoading ? (
  <span className="relative inline-flex items-center justify-center">
    <span aria-hidden className="opacity-0">{children}</span>
    <span className="absolute inset-0 flex items-center justify-center">
      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
    </span>
  </span>
) : children;
```
- Dropped the asymmetric `mr-2` so the spinner is no longer offset.
- Spinner is pinned to the exact middle regardless of label width; the button keeps its resting width so it doesn't resize when toggling loading.
- `asChild` path is unchanged (it already renders `React.Children.only(children)` and doesn't use this content).

## Verification

- ESLint on `components/ui/button.tsx`: clean.
- Loading state now shows a perfectly centered spinner; non-loading render is byte-identical to before; button width is preserved during the transition.
- Shared component, so this corrects every `isLoading` consumer (Share Location consent check and others) in one place.

## Risk

Low. One shared presentational component; only the loading-state markup changed (spinner centering), no API/prop/behavior change; `asChild` untouched.
