### PR TITLE
fix(ios): resolve Add Place map infinite loading (mount deadlock + 5s fallback)

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -132,6 +132,10 @@ export function LocationPickerMap({
   const [hasInteracted, setHasInteracted] = useState(false);
   const [locating, setLocating] = useState(false);
   const [locationError, setLocationError] = useState<string | null>(null);
+  // Safety net: if the map never reaches "ready" within this window, fall back
+  // to the captured-point flow so the owner is never blocked behind an infinite
+  // "Loading map…". See the timeout effect below.
+  const [timedOut, setTimedOut] = useState(false);
 
 
   useEffect(() => {
@@ -415,6 +419,19 @@ export function LocationPickerMap({
     setResolving(false);
   }, [status]);
 
+  // Timeout fallback: if the map hasn't reached "ready" within 5s, stop showing
+  // the infinite "Loading map…" and switch to the captured-point flow so the
+  // owner can still Confirm. Clears itself the moment the map becomes ready.
+  useEffect(() => {
+    if (status === "ready") {
+      setTimedOut(false);
+      return;
+    }
+    if (status === "error") return;
+    const timer = window.setTimeout(() => setTimedOut(true), 5000);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
   const handleLocateMe = useCallback(async () => {
     if (!onLocateMe || locating) return;
     setLocating(true);
@@ -473,7 +490,10 @@ export function LocationPickerMap({
     onConfirm({ latitude: lat, longitude: lng, address });
   }, [address, onConfirm]);
 
-  const unavailable = status === "error";
+  // Treat a hard SDK error OR the 5s load timeout as "unavailable" so the owner
+  // is never trapped behind an infinite "Loading map…"; both fall back to the
+  // captured-point confirm flow below.
+  const unavailable = status === "error" || timedOut;
 
   const accuracyHint = unavailable
     ? "Review the captured point, then complete the address details on the next step."
@@ -513,6 +533,22 @@ export function LocationPickerMap({
         )}
       >
 
+        {/* NATIVE: the @capacitor/google-maps element must be mounted BEFORE
+            GoogleMap.create runs (create needs a real element). Gating it behind
+            status==="ready" deadlocked the picker — the element only mounted
+            once ready, but ready only arrives after create succeeds against the
+            element — which is what left it stuck on "Loading map…". So on native
+            we always mount the element (unless the map is truly unavailable) and
+            overlay the loader on top until it's ready. */}
+        {native && !unavailable ? (
+          <capacitor-google-map
+            ref={(element: HTMLElement | null) => {
+              nativeMapElementRef.current = element;
+            }}
+            className="block h-full w-full bg-transparent"
+          />
+        ) : null}
+
         {unavailable ? (
           <div
             role="status"
@@ -534,20 +570,16 @@ export function LocationPickerMap({
             </p>
           </div>
         ) : status !== "ready" ? (
-          <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+          // Overlay (not a replacement): on native the map element stays mounted
+          // underneath so create() can resolve; this loader simply covers it
+          // until ready.
+          <div className="absolute inset-0 flex h-full items-center justify-center gap-2 bg-[#eef2f7] text-[13px] text-[#5b6472] dark:bg-[#10151d] dark:text-[#9aa6b6]">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading
             map…
           </div>
         ) : (
           <>
-            {native ? (
-              <capacitor-google-map
-                ref={(element: HTMLElement | null) => {
-                  nativeMapElementRef.current = element;
-                }}
-                className="block h-full w-full bg-transparent"
-              />
-            ) : (
+            {native ? null : (
               <div
                 key={colorScheme}
                 ref={containerRef}


### PR DESCRIPTION
## What & why

Opening "+ Add place" → "Pin your entrance on the map" hung forever on **"Loading map…"** on iOS, even with valid coordinates.

## Root cause — a mount deadlock (not a resize/key problem)

In `location-picker-map.tsx`, the native `<capacitor-google-map>` element was only rendered inside the `status === "ready"` branch. But on native, `nativeStatus` only becomes `"ready"` **after** `GoogleMap.create({ element })` succeeds — and `element` (`nativeMapElementRef`) is `null` until that element is actually mounted:

- element mounts only when `status === "ready"`
- `status` becomes `"ready"` only after `create()` runs against the element

→ neither ever happens → permanent "Loading map…". (The API key path was already correct: native uses the bundle-restricted `getNativeMapsApiKey`; if that key is missing it now shows the unavailable fallback instead of spinning.)

## Fix

1. **Break the deadlock:** always mount the native map element (unless the map is truly unavailable) and render the "Loading map…" state as an **overlay on top** of it, instead of gating the element behind `ready`. Now `create()` gets a real element, resolves, flips to `ready`, and the overlay clears. Web is unchanged (its `status` is independent of element mount).
2. **5-second timeout fallback (per ticket):** new `timedOut` state; if the map hasn't reached `ready` within 5s, it folds into the existing `unavailable` path — the **captured-point** flow with an interactive centre pin and a working **"Use captured point"** confirm — so the owner is never blocked. The timer clears the instant the map becomes ready.

## Verification

- ESLint on the file: clean. (Local `google`/`@capacitor/google-maps` TS "cannot find" noise is a missing-local-types artifact, not from this change; CI's Web Core typechecks with full deps.)
- Native: element mounts immediately → `GoogleMap.create` resolves → map shows; if create stalls >5s or the key is missing, the captured-point fallback lets the user Confirm.
- Web: unchanged behavior.

## Risk

Low. One component; the change is render-ordering (always-mount element + overlay loader) plus an additive timeout that only ever *unblocks* a stuck state. No API/prop/contract change; existing error + confirm paths reused.
