### PR TITLE
fix(native): assert the Android package the app actually builds as

### DIFF
--- a/hushh-webapp/scripts/native/sync-native-firebase-configs.mjs
+++ b/hushh-webapp/scripts/native/sync-native-firebase-configs.mjs
@@ -81,10 +81,14 @@ export function syncNativeFirebaseConfigs({
     );
   }
 
+  // Android ships as com.hussh.app; only iOS is com.hushh.app. This check used
+  // the iOS bundle id, so it accepted a google-services.json with no client for
+  // the package Android actually builds as, and Gradle then failed at
+  // processDebugGoogleServices with "No matching client found".
   const packages = androidPackageNames(androidSource);
-  if (!packages.has("com.hushh.app")) {
+  if (!packages.has("com.hussh.app")) {
     throw new Error(
-      "Android Firebase config does not contain package_name com.hushh.app."
+      "Android Firebase config does not contain package_name com.hussh.app."
     );
   }
 


### PR DESCRIPTION
## Why

`sync-native-firebase-configs.mjs` validated the Android `google-services.json` against **`com.hushh.app`** — which is the **iOS** bundle id.

Verified from source:

| Platform | Id | Source |
|---|---|---|
| iOS | `com.hushh.app` | `PRODUCT_BUNDLE_IDENTIFIER` in `project.pbxproj` |
| Android | `com.hussh.app` | `applicationId` in `android/app/build.gradle` |

The iOS assertion in that file is correct. Only the Android one had the iOS id copied into it — the "copied idiom" class that `safe-changes` R14 exists for.

**Consequence:** the script accepts a `google-services.json` containing no client for the package Android actually builds as, then Gradle fails:

```
No matching client found for package name 'com.hussh.app'
```

That is a real, reproducible Android build failure.

## Scope

This fixes the **validation only**. A `google-services.json` that actually contains a `com.hussh.app` Android client still has to be generated from the Firebase project and placed at the monorepo root before Android can build.

## Possibly related, not touched here

`NEXT_PUBLIC_ANDROID_APP_ID` feeds `.well-known/assetlinks.json` (Android App Links / passkey domain association) and is sourced from Secret Manager. If it also holds `com.hushh.app`, Android passkey association points at a package that does not exist. I could not read the secret to check. Worth confirming in the console.
