### PR TITLE
chore(skills): add client-env-parity and enforce it in Governance

### DIFF
--- a/.claude/skills/client-env-parity/SKILL.md
+++ b/.claude/skills/client-env-parity/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: client-env-parity
+description: Prevents a client credential from existing in Secret Manager yet never reaching the app that needs it, and prevents an API key from rejecting an origin the app really runs at. Use BEFORE shipping any iOS/TestFlight/App Store or web build, when adding or changing any NEXT_PUBLIC_* value, when adding a build lane, when a feature works on web but not in the app (or the reverse), and whenever a map, embed, analytics tag, or third-party widget renders as a blank box, a placeholder, or a static fallback with no error in the console.
+---
+
+# Client env parity
+
+**A credential that exists is not a credential that shipped.**
+
+Two independent things must both be true before a client credential works. Each fails
+silently on its own. Both failed at once on 2026-08-11, which is why this skill exists.
+
+1. **The value reaches the build.** Every `NEXT_PUBLIC_*` is baked in at build time.
+   Each lane copies its own explicit list, so a value can be perfect in Secret Manager
+   and simply absent from one lane's build.
+2. **The key accepts the origin.** A referrer-restricted key must list every origin the
+   app actually runs at — and the app runs at more origins than the hosted domain.
+
+Neither failure throws. The client reads `""`, or the provider returns a refusal the
+UI already has a fallback for, and the feature degrades into something that looks
+merely plain. A blank map is not an error state anyone reports.
+
+---
+
+## Run both checks
+
+```bash
+.claude/skills/client-env-parity/check.sh                       # value reaches every lane
+.claude/skills/client-env-parity/check-key-origins.sh hushh-pda-uat   # key accepts every origin
+```
+
+Both exit non-zero on a gap and print exactly what is missing. `check.sh` is offline and
+fast — put it in front of any release. `check-key-origins.sh` is read-only and needs
+`gcloud`; it never modifies a key.
+
+Verified to catch the real bug: run `check.sh` against `main` at
+`34eb56b02d6734b0ecfa8455f009f0f66db7eac3` and it reports all three genuine gaps that
+shipped. A guard that cannot fail is not a guard — re-prove it this way after editing it.
+
+---
+
+## The lanes, and why parity is not automatic
+
+| Lane | File | How it passes values |
+|---|---|---|
+| web | `deploy/frontend.cloudbuild.yaml` | `--build-arg NEXT_PUBLIC_X=…` + `availableSecrets` |
+| ios-testflight | `.github/workflows/ship-ios-testflight.yml` | `put NEXT_PUBLIC_X "$VAL"` → `.env.local` |
+| ios-appstore | `.github/workflows/release-ios-appstore.yml` | `put NEXT_PUBLIC_X "$VAL"` → `.env.local` |
+
+There is no shared list. Adding a value to the web lane does **not** add it to the iOS
+lanes. `check.sh` compares `required-client-env.tsv` against all three.
+
+**When you add a client credential, add a row to `required-client-env.tsv`.** That row —
+not good intentions — is what makes the check protect it. Keep local-only and test-only
+vars out; a noisy check gets ignored, which is precisely how the original bug survived.
+
+---
+
+## Origins this app runs at
+
+From `hushh-webapp/capacitor.config.ts`:
+
+```ts
+ios:    { scheme: "App" }          // webview origin: App://localhost
+server: { iosScheme: "App",
+          androidScheme: "https" } // webview origin: https://localhost
+```
+
+So a browser key restricted to the hosted domain alone is rejected inside the app with
+`RefererNotAllowedMapError`. The required list:
+
+| Origin | Where it comes from |
+|---|---|
+| `https://<hosted-host>/*` | the real site |
+| `http://localhost:3000/*` | `npm run dev` |
+| `App://localhost/*` | **iOS app webview** — the one everyone forgets |
+| `capacitor://localhost/*` | Capacitor's default if `iosScheme` is ever removed |
+| `https://localhost/*` | Android app webview |
+| `http://localhost/*` | Capacitor fallback |
+
+Scheme matching is case-insensitive — `app://`, `App://`, and `APP://` all match a single
+entry. Verified against Google directly, not assumed.
+
+`gcloud services api-keys update` **replaces** the restriction lists; it does not append.
+Always pass the complete desired set or you will silently drop the origins you meant to keep.
+
+After widening a key, confirm it is still restricted:
+
+```bash
+curl -s -X POST "https://places.googleapis.com/v1/places:searchNearby" \
+  -H "X-Goog-Api-Key: $KEY" -H "Referer: https://evil.example.com/" \
+  -H "Content-Type: application/json" -H "X-Goog-FieldMask: places.id" \
+  -d '{"includedTypes":["cafe"],"maxResultCount":1,"locationRestriction":{"circle":{"center":{"latitude":19.076,"longitude":72.877},"radius":500}}}'
+# must return 403 "Requests from referer ... are blocked"
+```
+
+Widening is not the same as opening. Prove the difference.
+
+---
+
+## One key is rarely enough
+
+A Capacitor app draws maps two different ways, and they need different keys:
+
+| Surface | Renderer | Key |
+|---|---|---|
+| "Your Map" immersive | `@capacitor/google-maps` native SDK | `NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY` |
+| Onboarding location picker, LiveMap | Maps **JS** in the WKWebView | `NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY` |
+
+"It is the iPhone app, so the iOS key covers it" is the wrong instinct and cost this
+incident. Read `hushh-webapp/lib/one-location/maps-config.ts` before assuming which key a
+surface uses.
+
+Restrict each key to only the services its surface calls. The browser key needs
+`maps-backend` (Maps JS), `places` (the picker's `Place.searchNearby` nearest-place
+lookup — this key deliberately has no classic Geocoding API), and `routes`.
+
+---
+
+## Verifying a native build for real
+
+A green workflow does not prove a credential landed in the app. Grep the built bundle:
+
+```bash
+KEY="$(gcloud secrets versions access latest \
+  --secret=NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY --project=hushh-pda-uat)"
+grep -rlF "$KEY" hushh-webapp/ios/App/App/public/ || echo "NOT IN THE BUILD"
+```
+
+To run it on a simulator use the `run-ios-sim` skill. Two things that will bite:
+
+- `ios/App/App/GoogleService-Info.plist` is gitignored, so a local build fails with
+  `Build input file cannot be found`. Fetch it the way the release workflow does, then
+  **delete it again** when finished:
+  ```bash
+  gcloud secrets versions access latest --secret=IOS_GOOGLESERVICE_INFO_PLIST_B64 \
+    --project=hushh-pda-uat | openssl base64 -d -A > hushh-webapp/ios/App/App/GoogleService-Info.plist
+  ```
+- The app is auth + vault gated. An agent can prove the build, the launch, the backend,
+  and the absence of key errors in the log — it cannot reach a gated screen. Say so
+  plainly instead of implying a screen was seen.
+
+---
+
+## What "verified" means here
+
+Do not report a client credential as fixed on the strength of the secret existing. Show:
+
+- the value is present in each lane that needs it (`check.sh`);
+- the key accepts each origin and service (`check-key-origins.sh`);
+- the key still rejects an unknown origin (the 403 above);
+- the value is physically inside the built bundle (the grep above);
+- for a native change, that the next build is what carries it — Capacitor has no
+  over-the-air update, so a merged fix reaches a tester only through a new build.
+
+Related: `run-ios-sim`, `mobile-bug-log`, `safe-changes`, `hushh-research-ship`.

--- a/.claude/skills/client-env-parity/check-key-origins.sh
+++ b/.claude/skills/client-env-parity/check-key-origins.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Verifies the browser Google Maps key accepts every origin this app actually
+# runs at, and permits every Maps service the client calls.
+#
+# Usage:  .claude/skills/client-env-parity/check-key-origins.sh [GCP_PROJECT]
+#         (default project: hushh-pda-uat)
+#
+# Needs: gcloud authenticated. Read-only — it never modifies a key.
+set -uo pipefail
+
+PROJECT="${1:-hushh-pda-uat}"
+SECRET="NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY"
+
+# Origins the app runs at. Derived from hushh-webapp/capacitor.config.ts:
+#   ios.scheme / server.iosScheme = "App"   -> App://localhost
+#   server.androidScheme = "https"          -> https://localhost
+# plus the hosted site and local dev. A key missing any of these fails ONLY on
+# that surface, and fails silently (the map degrades to an iframe embed).
+REQUIRED_REFERRERS=(
+  "App://localhost/*"
+  "capacitor://localhost/*"
+  "http://localhost/*"
+  "https://localhost/*"
+)
+# Services the browser bundle calls: Maps JS draws the map, Places powers the
+# onboarding picker's nearest-place lookup, Routes is used by route previews.
+REQUIRED_SERVICES=(
+  "maps-backend.googleapis.com"
+  "places.googleapis.com"
+  "routes.googleapis.com"
+)
+
+KEY_STRING="$(gcloud secrets versions access latest --secret="$SECRET" --project="$PROJECT" 2>/dev/null)"
+if [ -z "$KEY_STRING" ]; then
+  echo "FAIL — cannot read secret $SECRET in $PROJECT." >&2
+  exit 1
+fi
+
+# Resolve the key by matching its actual key string, not by display name —
+# display names drift, and a renamed key would silently pass a name-based check.
+KEY_NAME=""
+while read -r uid; do
+  [ -n "$uid" ] || continue
+  ks="$(gcloud services api-keys get-key-string "$uid" --project="$PROJECT" --format='value(keyString)' 2>/dev/null)"
+  if [ "$ks" = "$KEY_STRING" ]; then KEY_NAME="$uid"; break; fi
+done < <(gcloud services api-keys list --project="$PROJECT" --format='value(uid)' 2>/dev/null)
+
+if [ -z "$KEY_NAME" ]; then
+  echo "FAIL — the value in $SECRET matches no API key in $PROJECT." >&2
+  echo "       The secret and the key have drifted apart." >&2
+  exit 1
+fi
+
+DESC="$(gcloud services api-keys describe "$KEY_NAME" --project="$PROJECT" --format=json 2>/dev/null)"
+REFERRERS="$(printf '%s' "$DESC" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(d.get("restrictions",{}).get("browserKeyRestrictions",{}).get("allowedReferrers",[])))')"
+SERVICES="$(printf '%s' "$DESC" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(t["service"] for t in d.get("restrictions",{}).get("apiTargets",[])))')"
+
+fail=0
+
+# An empty referrer list means "any site may use this key" — not a pass.
+if [ -z "$REFERRERS" ]; then
+  echo "FAIL  the key has NO referrer restriction at all (usable from any site)"
+  fail=1
+else
+  for want in "${REQUIRED_REFERRERS[@]}"; do
+    printf '%s\n' "$REFERRERS" | grep -qixF "$want" \
+      || { echo "MISSING referrer  $want"; fail=1; }
+  done
+fi
+
+if [ -z "$SERVICES" ]; then
+  echo "WARN  no API restriction — the key may call any Google API"
+else
+  for want in "${REQUIRED_SERVICES[@]}"; do
+    printf '%s\n' "$SERVICES" | grep -qxF "$want" \
+      || { echo "MISSING service   $want"; fail=1; }
+  done
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "OK — browser maps key in $PROJECT accepts every app origin and service."
+else
+  echo "FAIL — the browser maps key rejects a surface the app really runs on."
+  echo "Widen it with the FULL list (update replaces, it does not append):"
+  echo "  gcloud services api-keys update <KEY_ID> --project=$PROJECT \\"
+  for s in "${REQUIRED_SERVICES[@]}"; do echo "    --api-target=service=$s \\"; done
+  echo "    --allowed-referrers='https://<host>/*','http://localhost:3000/*',$(printf "'%s'," "${REQUIRED_REFERRERS[@]}" | sed 's/,$//')"
+fi
+exit "$fail"

--- a/.claude/skills/client-env-parity/check.sh
+++ b/.claude/skills/client-env-parity/check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fails when a required NEXT_PUBLIC_* credential is missing from a build lane.
+#
+# Usage:  .claude/skills/client-env-parity/check.sh
+# Exit:   0 = every required var is written by every lane that needs it
+#         1 = at least one gap (printed)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MANIFEST="${ROOT}/.claude/skills/client-env-parity/required-client-env.tsv"
+
+WEB_LANE="${ROOT}/deploy/frontend.cloudbuild.yaml"
+TF_LANE="${ROOT}/.github/workflows/ship-ios-testflight.yml"
+AS_LANE="${ROOT}/.github/workflows/release-ios-appstore.yml"
+
+for f in "$MANIFEST" "$WEB_LANE" "$TF_LANE" "$AS_LANE"; do
+  [ -f "$f" ] || { echo "MISSING FILE: $f" >&2; exit 1; }
+done
+
+# A lane "provides" a var when it passes it as a Docker build argument (web) or
+# writes it into the build env with the `put` helper (native). Both are the
+# real mechanisms; grepping for the bare name would match comments and pass
+# a lane that only mentions the var.
+web_provides()  { grep -qE "build-arg[[:space:]]+$1=" "$WEB_LANE"; }
+tf_provides()   { grep -qE "put[[:space:]]+$1[[:space:]]" "$TF_LANE"; }
+as_provides()   { grep -qE "put[[:space:]]+$1[[:space:]]" "$AS_LANE"; }
+
+fail=0
+checked=0
+
+while IFS=$'\t' read -r var lanes why; do
+  case "$var" in ''|\#*) continue ;; esac
+  [ -n "${lanes:-}" ] || continue
+  checked=$((checked + 1))
+  [ "$lanes" = "all" ] && lanes="web,ios-testflight,ios-appstore"
+
+  IFS=',' read -ra want <<< "$lanes"
+  for lane in "${want[@]}"; do
+    case "$lane" in
+      web)            web_provides "$var" || { echo "GAP  web             $var"; echo "       why: $why"; fail=1; } ;;
+      ios-testflight) tf_provides  "$var" || { echo "GAP  ios-testflight  $var"; echo "       why: $why"; fail=1; } ;;
+      ios-appstore)   as_provides  "$var" || { echo "GAP  ios-appstore    $var"; echo "       why: $why"; fail=1; } ;;
+      *)              echo "UNKNOWN LANE '$lane' for $var (manifest error)"; fail=1 ;;
+    esac
+  done
+done < "$MANIFEST"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "OK — $checked required client credentials reach every lane that needs them."
+else
+  echo "FAIL — a required credential is missing from a build lane."
+  echo "A gap here ships a build where the feature is silently dead, not broken."
+fi
+exit "$fail"

--- a/.claude/skills/client-env-parity/required-client-env.tsv
+++ b/.claude/skills/client-env-parity/required-client-env.tsv
@@ -1,0 +1,31 @@
+# Client credentials that MUST reach a shipping build.
+#
+# Every NEXT_PUBLIC_* value is baked in at BUILD time. Each lane copies its own
+# explicit list, so a value can be correct in Secret Manager and still be absent
+# from one lane's build. That absence is silent — the client reads "" and the
+# feature degrades instead of erroring.
+#
+# Columns (tab-separated):
+#   VAR <TAB> LANES <TAB> WHY
+#
+# LANES is a comma-separated subset of: web, ios-testflight, ios-appstore
+# Use "all" for every lane.
+#
+# Add a row whenever the client starts reading a new NEXT_PUBLIC_* that a real
+# user journey depends on. The row is the thing that makes check.sh protect it.
+# Do NOT add local-only or test-only vars — they would make this file noisy and
+# the check ignorable, which is how the original bug survived.
+
+NEXT_PUBLIC_BACKEND_URL	all	Without it the app cannot reach the vault; every screen dies.
+NEXT_PUBLIC_APP_ENV	all	Selects runtime profile; wrong value points a build at the wrong environment.
+NEXT_PUBLIC_APP_URL	all	Absolute links, deep links, and redirect targets.
+NEXT_PUBLIC_FIREBASE_API_KEY	all	Sign-in fails entirely without it.
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN	all	Sign-in fails entirely without it.
+NEXT_PUBLIC_FIREBASE_PROJECT_ID	all	Sign-in fails entirely without it.
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET	all	File and media reads fail.
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID	all	Push registration fails.
+NEXT_PUBLIC_FIREBASE_APP_ID	all	Sign-in fails entirely without it.
+NEXT_PUBLIC_FIREBASE_VAPID_KEY	all	Web push token cannot be minted.
+NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY	all	Maps JS in the WKWebView (onboarding location picker, LiveMap). Missing = silent iframe fallback. This is the 2026-08-11 incident.
+NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY	ios-testflight,ios-appstore	Native Maps SDK for the "Your Map" immersive view.
+NEXT_PUBLIC_OBSERVABILITY_ENABLED	all	Without it a broken build reports nothing and the failure stays invisible.

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -35,5 +35,9 @@ python3 .codex/skills/codex-skill-authoring/scripts/test_trigger_evals.py
 python3 .codex/skills/codex-skill-authoring/scripts/compact_kernel_smoke.py
 python3 .claude/skills/codex-bridge/scripts/route.py --check
 python3 .claude/skills/codex-bridge/scripts/test_route_hook.py
+# Fails when a required NEXT_PUBLIC_* credential is missing from a build lane.
+# Offline and fast. The origin-restriction half of this skill needs gcloud and
+# stays out of CI on purpose — run it from the skill before a release.
+bash .claude/skills/client-env-parity/check.sh
 ./bin/hushh db verify-release-contract
 ./bin/hushh db report-prod-posture


### PR DESCRIPTION
## Why

Yesterday's Maps failure (PR #5074) was not one bug, it was two — and both were **silent**. The keys were correct in Secret Manager the whole time.

1. **The value never reached the build.** Every `NEXT_PUBLIC_*` is baked in at build time, and each lane copies its own explicit list. Neither iOS workflow copied `NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY`, so on device the client read `""` and every Maps JS surface degraded to the iframe fallback. No error, no crash — the screen just looked plain.
2. **The key rejected the origin.** The browser key's referrer list had only the hosted domain and `localhost:3000`. The iOS webview runs at `App://localhost` (from `capacitor.config.ts` `iosScheme: "App"`), so Google refused it. Its API list also omitted Places and Routes.

Nothing in CI could have caught either one.

## What this adds

`.claude/skills/client-env-parity/` — the failure class, the origin list, the two-key split, and two runnable guards.

**`check.sh`** compares `required-client-env.tsv` against all three build lanes (web cloudbuild, TestFlight, App Store). Offline and fast, so it is wired into `scripts/ci/repo-governance-check.sh` — **a PR that drops a required credential from a lane now fails Governance.**

Proven to catch the real bug, not just to pass:

```
$ git checkout 34eb56b0 -- .github/workflows/ship-ios-testflight.yml .github/workflows/release-ios-appstore.yml
$ .claude/skills/client-env-parity/check.sh
GAP  ios-testflight  NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY
GAP  ios-appstore    NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY
GAP  ios-testflight  NEXT_PUBLIC_GOOGLE_MAPS_IOS_API_KEY
FAIL — a required credential is missing from a build lane.
exit=1
```

All three are the genuine gaps that shipped. On current `main` it exits `0`.

**`check-key-origins.sh`** resolves the live key by matching the secret's key string (not its display name, which drifts), then asserts every app origin and Maps service is allowed. It needs `gcloud`, so it deliberately stays **out** of CI and is run from the skill before a release. Read-only — it never modifies a key.

## Design note

The manifest is curated, not auto-derived. The client reads 59 distinct `NEXT_PUBLIC_*` values; most are local- or test-only. Requiring all of them would make the check noisy, and a noisy check gets ignored — which is exactly how the original bug survived. Adding a client credential now means adding a manifest row, and that row is what makes the guard protect it.

## Verification

- `check.sh` from repo root (how Governance invokes it): `OK — 13 required client credentials reach every lane that needs them.`
- `skill_lint.py`: `Skill lint passed. Validated 47 skills…`
- `verify-protected-pipeline-edits.py`: passes (`scripts/ci/` is protected, actor-gated, PR-enforced).