### PR TITLE
Refine agent workspace typography and chrome

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -245,10 +245,10 @@ textarea {
   /* Apple iOS-first semantic type roles. These are the shared source of truth
      for app UI hierarchy; components opt into roles instead of restating
      route-specific font sizes. */
-  --type-large-page-title-size: 34px;
-  --type-large-page-title-line: 41px;
+  --type-large-page-title-size: 28px;
+  --type-large-page-title-line: 34px;
   --type-large-page-title-weight: 700;
-  --type-large-page-title-tracking: -0.03em;
+  --type-large-page-title-tracking: -0.025em;
   --type-page-title-size: 28px;
   --type-page-title-line: 34px;
   --type-page-title-weight: 700;
@@ -257,10 +257,10 @@ textarea {
   --type-navigation-title-line: 22px;
   --type-navigation-title-weight: 600;
   --type-navigation-title-tracking: -0.01em;
-  --type-major-section-title-size: 22px;
-  --type-major-section-title-line: 27px;
+  --type-major-section-title-size: 20px;
+  --type-major-section-title-line: 25px;
   --type-major-section-title-weight: 600;
-  --type-major-section-title-tracking: -0.018em;
+  --type-major-section-title-tracking: -0.016em;
   --type-card-title-size: 17px;
   --type-card-title-line: 22px;
   --type-card-title-weight: 600;
@@ -275,7 +275,7 @@ textarea {
   --type-row-label-emphasis-weight: 600;
   --type-row-label-tracking: -0.01em;
   --type-page-subtitle-size: 15px;
-  --type-page-subtitle-line: 21px;
+  --type-page-subtitle-line: 20px;
   --type-row-description-size: 13px;
   --type-row-description-line: 18px;
   --type-row-description-weight: 400;
@@ -298,10 +298,10 @@ textarea {
   --type-tab-label-line: 13px;
   --type-tab-label-weight: 500;
   --type-tab-label-tracking: 0;
-  --type-agent-tab-label-size: 17px;
-  --type-agent-tab-label-line: 22px;
+  --type-agent-tab-label-size: 15px;
+  --type-agent-tab-label-line: 20px;
   --type-agent-tab-label-weight: 500;
-  --type-agent-tab-label-tracking: -0.01em;
+  --type-agent-tab-label-tracking: -0.006em;
   --foundation-caption-tracking: 0.158em;
   --foundation-micro-size: 0.6875rem;
   --foundation-micro-line: 1.273;
@@ -566,7 +566,7 @@ textarea {
   --app-top-body-start-gap: var(--page-top-start);
   --page-top-local-offset: 0px;
   --app-shell-reading: 54rem;
-  --app-shell-agent: 65rem;
+  --app-shell-agent: 55rem;
   --app-shell-standard: 90rem;
   --app-shell-expanded: 96rem;
   --top-systembar-row-gap: 4px;
@@ -875,8 +875,8 @@ textarea {
   /* Shared app card contract */
   --theme-color-boxShadow: rgba(120, 120, 128, 0.16);
   --app-card-radius-compact: 20px;
-  --app-card-radius-standard: 22px;
-  --app-card-radius-feature: 24px;
+  --app-card-radius-standard: 20px;
+  --app-card-radius-feature: 20px;
   --app-card-surface-data: #f7f7fa;
   --app-card-surface-compact: #fcfcfd;
   --app-card-surface-default: #ffffff;
@@ -3401,8 +3401,8 @@ html.native-ios [data-testid="one-location-onboarding"] {
   /* Dark: shared app card contract */
   --theme-color-boxShadow: rgba(0, 0, 0, 0.65);
   --app-card-radius-compact: 20px;
-  --app-card-radius-standard: 22px;
-  --app-card-radius-feature: 24px;
+  --app-card-radius-standard: 20px;
+  --app-card-radius-feature: 20px;
   --app-card-surface-data: #2c2c2e;
   --app-card-surface-compact: #2c2c2e;
   --app-card-surface-default: #2c2c2e;

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1148,7 +1148,7 @@ export function KaiAnalysisPageContent() {
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[20px] font-medium leading-tight tracking-normal text-foreground sm:text-[22px]"
+                    className="ui-text-major-section-title"
                   >
                     {activeTicker}
                   </div>

--- a/hushh-webapp/app/one/location/invite/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/invite/[token]/page-client.tsx
@@ -236,10 +236,10 @@ export default function OneLocationCircleInvitePageClient() {
               <div className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                 Location
               </div>
-              <h1 className="mt-1 text-[32px] font-bold leading-[1.08] tracking-normal sm:text-[34px]">
+              <h1 className="ui-text-agent-title mt-1">
                 Join One
               </h1>
-              <p className="mt-3 text-[17px] leading-[24px] text-muted-foreground">
+              <p className="mt-3 text-[15px] font-normal leading-[20px] text-muted-foreground">
                 {loading
                   ? "Checking Invite to One link."
                   : error

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -192,10 +192,10 @@ export default function PublicLocationRequestPageClient() {
               <div className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
                 Location
               </div>
-              <h1 className="mt-1 text-[32px] font-bold leading-[1.08] tracking-normal sm:text-[34px]">
+              <h1 className="ui-text-agent-title mt-1">
                 View shared location
               </h1>
-              <p className="mt-3 text-[17px] leading-[24px] text-muted-foreground">
+              <p className="mt-3 text-[15px] font-normal leading-[20px] text-muted-foreground">
                 {loading
                   ? "Checking public location link."
                   : error

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -78,11 +78,11 @@ export function LocationOnboardingCompletedScreen({
         </p>
         <h1
           id="location-onboarding-completed-title"
-          className="mt-2 max-w-[18ch] text-balance text-[32px] font-bold leading-[1.08] tracking-normal text-foreground sm:text-[34px]"
+          className="ui-text-agent-title mt-2 max-w-[18ch] text-balance"
         >
           Your Location onboarding is complete
         </h1>
-        <p className="mt-3 max-w-[34rem] text-pretty text-[17px] leading-[24px] text-muted-foreground">
+        <p className="mt-3 max-w-[34rem] text-pretty text-[15px] font-normal leading-[20px] text-muted-foreground">
           Everything is ready. You can manage Location anytime from One.
         </p>
         <div className="mt-8 w-full max-w-[30rem]">

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -3995,7 +3995,7 @@ function ProfilePageContent() {
         >
           <ProfileAvatarEditor />
           <div className="profile-home-copy min-w-0 max-w-full space-y-1.5">
-            <h1 className="profile-home-name text-[28px] font-medium leading-[1.08] tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[34px]">
+            <h1 className="profile-home-name ui-text-identity-name [overflow-wrap:anywhere]">
               {user.displayName || "User"}
             </h1>
             <div

--- a/hushh-webapp/components/app-ui/agent-section-icon.tsx
+++ b/hushh-webapp/components/app-ui/agent-section-icon.tsx
@@ -60,12 +60,12 @@ const ICON_SIZE_CLASS = {
     pixels: 40,
   },
   roster: {
-    surface: "h-10 w-10",
-    lucideSurface: "h-10 w-10 rounded-[10px]",
+    surface: "h-9 w-9",
+    lucideSurface: "h-9 w-9 rounded-[9px]",
     imageSurface: "rounded-[10px]",
-    lucide: "h-5 w-5",
+    lucide: "h-[17px] w-[17px]",
     image: "h-full w-full object-contain",
-    pixels: 40,
+    pixels: 36,
   },
 } as const;
 
@@ -74,7 +74,7 @@ const PROFILE_ICON_RADIUS_CLASS: Record<AgentSectionIconSize, string> = {
   launcher: "rounded-[17px] sm:rounded-[20px]",
   topbar: "rounded-[10px]",
   menu: "rounded-[11px]",
-  roster: "rounded-[10px]",
+  roster: "rounded-[9px]",
 };
 
 type AgentSectionIconSize = keyof typeof ICON_SIZE_CLASS;
@@ -154,7 +154,7 @@ export function AgentSectionIcon({
         <Icon
           className={cn(
             classes.lucide,
-            "[stroke-width:1.8]",
+            size === "roster" ? "[stroke-width:1.7]" : "[stroke-width:1.8]",
             active
               ? glyphContrast === "inverted"
                 ? "!text-white dark:!text-[#1d1d1f]"

--- a/hushh-webapp/components/app-ui/app-page-shell.tsx
+++ b/hushh-webapp/components/app-ui/app-page-shell.tsx
@@ -24,7 +24,7 @@ export type AppPageDensity = "compact" | "comfortable";
 // 2. Mapped directly to Tailwind classes instead of raw string values
 export const APP_SHELL_MAX_WIDTHS: Record<AppPageShellWidth, string> = {
   reading: "max-w-[720px]",
-  agent: "max-w-[1040px]",
+  agent: "max-w-[880px]",
   narrow: "max-w-[720px]",
   profile: "max-w-[720px]",
   standard: "max-w-[90rem]",

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -411,7 +411,7 @@ function AgentMetric({
     <span
       data-testid={isTopWinner ? "one-finance-top-winner-kpi" : undefined}
       className={cn(
-        "inline-flex w-full min-w-0 items-baseline gap-[5px] text-right",
+        "inline-flex w-full min-w-0 items-baseline gap-1 text-right",
         compact
           ? "max-w-full flex-wrap justify-center"
           : "justify-end whitespace-nowrap",
@@ -420,7 +420,9 @@ function AgentMetric({
       <span
         data-ui-role="body-strong"
         className={cn(
-          "shrink-0 tabular-nums text-[15px] font-semibold leading-5 tracking-[-0.006em]",
+          compact
+            ? "shrink-0 tabular-nums text-[15px] font-semibold leading-5 tracking-[-0.006em]"
+            : "shrink-0 tabular-nums text-[15px] font-semibold leading-5 tracking-[-0.006em]",
           metricValueClassName(valueTone),
         )}
       >
@@ -429,7 +431,9 @@ function AgentMetric({
       <span
         data-ui-role="trailing-value"
         className={cn(
-          "min-w-0 text-[15px] font-normal leading-5 tracking-[-0.006em]",
+          compact
+            ? "min-w-0 text-[15px] font-normal leading-5 tracking-[-0.006em]"
+            : "min-w-0 text-[15px] font-normal leading-5 tracking-[-0.006em]",
           compact
             ? "min-w-0 whitespace-normal text-center [overflow-wrap:anywhere]"
             : "truncate",
@@ -474,7 +478,10 @@ function AgentGridItem({
         className="relative z-10"
       />
       <span className="relative z-10 min-w-0">
-        <span className="ui-text-row-label block truncate" data-ui-role="body">
+        <span
+          className="block truncate text-[17px] font-normal leading-[22px] tracking-[-0.006em] text-[#1D1D1F] dark:text-[#F5F5F7]"
+          data-ui-role="body"
+        >
           {mode.title}
         </span>
         <AgentMetric mode={mode} compact />
@@ -492,11 +499,11 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
       title={mode.description}
       data-testid={`one-agent-list-row-${mode.id}`}
       className={cn(
-        "group/agent-row relative grid min-h-16 w-full grid-cols-[40px_minmax(0,1fr)_minmax(120px,160px)_16px] items-center gap-x-[14px] overflow-hidden px-4 text-left outline-none",
+        "group/agent-row relative grid min-h-[60px] w-full grid-cols-[36px_minmax(0,1fr)_minmax(108px,150px)_16px] items-center gap-x-3 overflow-hidden px-4 text-left outline-none",
         "transition-colors duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
         "hover:bg-[rgba(120,120,128,.08)] active:bg-[rgba(120,120,128,.12)]",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-        "sm:grid-cols-[40px_minmax(0,1fr)_minmax(170px,220px)_16px]",
+        "sm:grid-cols-[36px_minmax(0,1fr)_minmax(160px,210px)_16px]",
       )}
     >
       <span className="relative z-10 flex items-center justify-center">
@@ -513,7 +520,7 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
       </span>
       <span
         data-ui-role="row-label"
-        className="relative z-10 min-w-0 truncate text-[17px] font-medium leading-[22px] tracking-[-0.01em] text-[#1D1D1F] dark:text-[#F5F5F7]"
+        className="relative z-10 min-w-0 truncate text-[17px] font-normal leading-[22px] tracking-[-0.006em] text-[#1D1D1F] dark:text-[#F5F5F7]"
       >
         {mode.title}
       </span>
@@ -522,11 +529,11 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
       </span>
       <ChevronRight
         aria-hidden
-        className="relative z-10 h-4 w-4 text-[#C7C7CC] [stroke-width:1.8]"
+        className="relative z-10 h-4 w-4 text-[#C7C7CC] [stroke-width:1.7]"
       />
       <span
         aria-hidden
-        className="pointer-events-none absolute bottom-0 left-[68px] right-4 h-px bg-[rgba(60,60,67,.12)] group-last/agent-list:hidden"
+        className="pointer-events-none absolute bottom-0 left-16 right-4 h-px bg-[rgba(60,60,67,.12)] group-last/agent-list:hidden"
       />
       <MaterialRipple variant="blue" effect="fade" className="z-0" />
     </Link>
@@ -632,15 +639,13 @@ export function OneAgentRoster({
       <div className="mb-5 flex items-center justify-between gap-3">
         <h2
           id="one-agents-heading"
-          aria-label={`Agents (${modes.length})`}
-          className="flex min-w-0 items-baseline gap-2"
+          className="min-w-0"
         >
-          {/* Agents ({modes.length}) is split visually so the count can stay subordinate. */}
-          <span className="text-[34px] font-bold leading-[41px] tracking-[-0.03em] text-[#1D1D1F] dark:text-[#F5F5F7]">
-            Agents
-          </span>
-          <span className="text-[17px] font-medium leading-[22px] text-[#8E8E93]">
-            ({modes.length})
+          <span
+            className="ui-text-page-title block truncate"
+            data-ui-role="page-title"
+          >
+            Agents ({modes.length})
           </span>
         </h2>
         <AgentRosterViewToggle value={view} onChange={selectView} />

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -460,7 +460,7 @@ export const Navbar = ({
           ? "flex w-full justify-center"
           : "fixed inset-x-0 flex justify-center px-4 transform-gpu",
         layout === "fixed" && (isVaultUnlocked ? "z-[120]" : "z-[505]"),
-        "pointer-events-none",
+        "pointer-events-none lg:hidden",
       )}
       style={
         layout === "fixed"

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -678,7 +678,7 @@ export function LocationPickerMap({
           <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+          <p className="text-[13px] font-normal leading-[18px] tracking-normal text-[#8b93a1] dark:text-[#7f8a99]">
             Selected spot
           </p>
           {resolving ? (

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -429,7 +429,7 @@ function WelcomeScreen({
       />
       <div className="relative z-10 flex min-h-0 flex-1 flex-col">
         <div className="shrink-0 text-center">
-          <p className="inline-flex items-center gap-2 text-[19px] font-bold">
+          <p className="inline-flex items-center gap-2 text-[17px] font-semibold leading-[22px]">
             <MapPin
               className="h-5 w-5"
               strokeWidth={2.5}
@@ -438,7 +438,7 @@ function WelcomeScreen({
             Location Agent
           </p>
           <h1
-            className="mx-auto mt-7 max-w-[410px] text-[38px] font-bold leading-[1.08] tracking-normal"
+            className="mx-auto mt-7 max-w-[410px] text-[28px] font-bold leading-[34px] tracking-[-0.025em]"
             data-one-welcome-heading
           >
             Share your location
@@ -913,13 +913,13 @@ function FeaturesScreen({
       >
         <header className="mt-3 shrink-0" data-one-feature-header>
           <h1
-            className="text-[36px] font-bold leading-none tracking-[-0.025em] text-[#111823] dark:text-[#f6f8fc]"
+            className="ui-text-agent-title text-[#111823] dark:!text-[#f6f8fc]"
             data-one-feature-heading
           >
             Stay connected
           </h1>
           <p
-            className="mt-4 text-[17px] leading-[26px] text-[#737a84] dark:text-[#aeb8c7]"
+            className="mt-3 text-[15px] font-normal leading-[20px] text-[#737a84] dark:text-[#aeb8c7]"
             data-one-feature-subtitle
           >
             For everyday plans, meetups, and emergencies.
@@ -1419,16 +1419,16 @@ function InviteScreen({
         <span className="mt-2 flex h-14 w-14 items-center justify-center rounded-2xl bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
           <Users className="h-7 w-7" strokeWidth={2} />
         </span>
-        <h1 className="mt-4 text-[32px] font-bold leading-[1.08] text-[#151b26] dark:text-[#f5f7fb]">
+        <h1 className="ui-text-agent-title mt-4 text-[#151b26] dark:!text-[#f5f7fb]">
           Share your circle code
         </h1>
-        <p className="mt-2 text-[16px] leading-6 text-[#73777f] dark:text-[#b5bfcc]">
+        <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[#b5bfcc]">
           Send this code to your loved ones. When they set up One, they enter it
           under &ldquo;Join a circle&rdquo; to connect with you.
         </p>
 
         <div
-          className="mt-7 rounded-[24px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center shadow-[0_10px_30px_rgba(29,45,68,0.08)] dark:border-white/[0.08] dark:bg-[#1c212a] dark:shadow-[0_10px_30px_rgba(0,0,0,0.22)]"
+          className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center shadow-none dark:border-white/[0.08] dark:bg-[#1c212a]"
           data-testid="one-location-onboarding-invite-card"
         >
           {loading ? (
@@ -1451,7 +1451,7 @@ function InviteScreen({
             </div>
           ) : invite ? (
             <>
-              <p className="text-[13px] font-semibold uppercase tracking-[0.08em] text-[#96999e] dark:text-[#8d99a8]">
+              <p className="text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73] dark:text-[#aeb8c7]">
                 {invite.circleName}
               </p>
               <p
@@ -1607,13 +1607,13 @@ function PeopleScreen({
         className="px-5 pt-2"
       />
       <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
-        <h1 className="mt-3 text-[34px] font-bold leading-[1.06] text-[#151b26] dark:text-[#f5f7fb]">
+        <h1 className="ui-text-agent-title mt-3 text-[#151b26] dark:!text-[#f5f7fb]">
           Add people
         </h1>
-        <p className="mt-2 text-[16px] leading-6 text-[#73777f] dark:text-[#b5bfcc]">
+        <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[#b5bfcc]">
           Invite the people you want to keep connected with.
         </p>
-        <h2 className="mt-8 text-[13px] font-semibold tracking-[0.02em] text-[#96999e] dark:text-[#8d99a8]">
+        <h2 className="mt-7 text-[15px] font-medium leading-[20px] tracking-[-0.01em] text-[#6E6E73] dark:text-[#aeb8c7]">
           Contacts
         </h2>
         <div className="mt-3 overflow-hidden rounded-[24px] bg-[#f8f9fb] px-4 shadow-[0_10px_30px_rgba(29,45,68,0.08)] dark:bg-[#1c212a] dark:shadow-[0_10px_30px_rgba(0,0,0,0.22)]">
@@ -1775,10 +1775,10 @@ function CircleScreen({
         busy={leaving}
       />
       <div className="shrink-0 pt-3 text-left" data-one-circle-heading>
-        <h1 className="text-[36px] font-bold leading-[1.05] text-[#111823] dark:text-[#f5f7fb]">
+        <h1 className="ui-text-agent-title text-[#111823] dark:!text-[#f5f7fb]">
           Your circle is ready.
         </h1>
-        <p className="mt-3 min-h-12 max-w-[410px] text-[16px] leading-6 text-[#777d86] dark:text-[#aeb8c7]">
+        <p className="mt-3 min-h-12 max-w-[410px] text-[15px] font-normal leading-[20px] text-[#777d86] dark:text-[#aeb8c7]">
           {subtitle}
         </p>
       </div>

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -420,7 +420,7 @@ export function SaveLocationModal({
                 : "Review how Google Maps uses the selected point before opening the map."}
             </p>
             {collectAddressDetails ? (
-              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+              <p className="text-[13px] font-normal leading-[18px] tracking-normal text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
                 Step 1 of 2
               </p>
             ) : null}

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -88,7 +88,7 @@ export function QuickActionCard({
       aria-disabled={!interactive}
       data-voice-control-id={controlId}
       className={cn(
-        "group flex min-h-[120px] w-full min-w-0 flex-col gap-3 rounded-[22px] bg-white p-4 text-left shadow-none transition-all duration-200 dark:bg-[color:var(--app-card-surface-default-solid)]",
+        "group flex min-h-[120px] w-full min-w-0 flex-col gap-3 rounded-[20px] bg-white p-4 text-left shadow-none transition-all duration-200 dark:bg-[color:var(--app-card-surface-default-solid)]",
         interactive
           ? "cursor-pointer active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
           : "cursor-not-allowed",

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -185,10 +185,10 @@ export function SmsContactsFlow({
           <ChevronLeft className="h-[19px] w-[19px]" />
         </button>
 
-        <h1 className="mt-3 !text-[32px] !font-bold !leading-[1.08] !tracking-normal">
+        <h1 className="mt-3 !text-[28px] !font-bold !leading-[34px] !tracking-[-0.025em]">
           SMS contacts
         </h1>
-        <p className="mt-2 max-w-[350px] text-[17px] leading-[24px] text-muted-foreground">
+        <p className="mt-2 max-w-[350px] text-[15px] font-normal leading-[20px] text-muted-foreground">
           These people are alerted with your live location the moment you send
           the SMS.
         </p>
@@ -341,7 +341,7 @@ export function SmsContactsFlow({
             >
               {pendingRemoval ? initials(recipientLabel(pendingRemoval)) : "?"}
             </span>
-            <AlertDialogTitle className="mt-1 !text-center !text-[22px] !font-bold !leading-[1.14]">
+            <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-semibold !leading-[25px] !tracking-[-0.016em]">
               <span className="text-foreground">
                 Remove{" "}
                 {pendingRemoval

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -337,10 +337,10 @@ export function SosPanel({
         </button>
 
         <header className="mt-4 px-3 text-center lg:mt-1">
-          <h1 className="whitespace-nowrap !text-[32px] !font-bold !leading-[1.08] !tracking-normal">
+          <h1 className="whitespace-nowrap !text-[28px] !font-bold !leading-[34px] !tracking-[-0.025em]">
             SMS · Save my Soul
           </h1>
-          <p className="mx-auto mt-2 max-w-[310px] text-[17px] leading-[24px] text-white/70">
+          <p className="mx-auto mt-2 max-w-[310px] text-[15px] font-normal leading-[20px] text-white/70">
             Press and hold. An SMS with your live location goes to your people —
             even with no internet.
           </p>
@@ -350,9 +350,9 @@ export function SosPanel({
             hold button immediately beneath it, then the message and recovery
             controls. Keeping this single column prevents the SMS action from
             reading like a separate desktop panel. */}
-        <div className="flex flex-1 flex-col items-center gap-5 pt-7 lg:justify-start lg:pt-8">
+        <div className="flex flex-col items-center gap-4 pt-5 lg:pt-5">
           <div className="flex items-center justify-center">
-            <div className="relative flex h-[224px] w-[224px] items-center justify-center">
+            <div className="relative flex h-[204px] w-[204px] items-center justify-center">
             <span className="absolute inset-0 rounded-full border border-white/10" />
             <span className="absolute inset-[24px] rounded-full border border-white/15" />
 
@@ -363,17 +363,17 @@ export function SosPanel({
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
+                  className="absolute h-[128px] w-[128px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
+                  className="absolute h-[128px] w-[128px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:0.73s]"
                 />
                 <span
                   aria-hidden="true"
                   data-sos-pulse
-                  className="absolute h-[136px] w-[136px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
+                  className="absolute h-[128px] w-[128px] rounded-full bg-[color:var(--app-destructive)]/40 [animation:sosRadarPulse_2.2s_ease-out_infinite] [animation-delay:1.46s]"
                 />
               </>
             ) : null}
@@ -398,7 +398,7 @@ export function SosPanel({
               onKeyUp={handleKeyUp}
               onContextMenu={(event) => event.preventDefault()}
               className={cn(
-                "relative z-10 flex h-[136px] w-[136px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
+                "relative z-10 flex h-[128px] w-[128px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
                 progress > 0 && progress < 1 && "scale-[1.035]",
                 (active || busy) && "[animation:sosCorePulse_2.2s_ease-in-out_infinite]",
                 disabled && "cursor-not-allowed",
@@ -410,7 +410,7 @@ export function SosPanel({
                     : undefined,
               }}
             >
-              <span className="text-[31px] font-bold leading-none">
+              <span className="text-[28px] font-bold leading-[34px] tracking-[-0.025em]">
                 {active ? "SENT" : "SMS"}
               </span>
               <span className="mt-1.5 text-[12px] text-white/85">

--- a/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
+++ b/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
@@ -18,11 +18,11 @@
 
 /** Standard rounded card surface — matches SurfaceCard (app-card tokens). */
 export const CARD_SURFACE =
-  "rounded-[22px] border-0 bg-[color:var(--app-card-surface-default-solid)] shadow-none";
+  "rounded-[20px] border-0 bg-[color:var(--app-card-surface-default-solid)] shadow-none";
 
 /** Soft inset surface used for sub-cards / list rows inside a card. */
 export const SUBCARD_SURFACE =
-  "rounded-[22px] border-0 bg-[color:var(--app-card-surface-default-solid)] shadow-none";
+  "rounded-[20px] border-0 bg-[color:var(--app-card-surface-default-solid)] shadow-none";
 
 /** Section heading (e.g. "Trusted Circle", "Device readiness"). */
 export const SECTION_HEADING = "ui-text-section-label";

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -58,16 +58,20 @@ for (const exportName of [
 
 const globals = read("app/globals.css");
 for (const [token, value] of [
-  ["--type-large-page-title-size", "34px"],
-  ["--type-large-page-title-line", "41px"],
+  ["--type-large-page-title-size", "28px"],
+  ["--type-large-page-title-line", "34px"],
   ["--type-large-page-title-weight", "700"],
-  ["--type-large-page-title-tracking", "-0.03em"],
+  ["--type-large-page-title-tracking", "-0.025em"],
   ["--type-page-title-size", "28px"],
   ["--type-page-title-line", "34px"],
   ["--type-page-title-weight", "700"],
   ["--type-page-title-tracking", "-0.025em"],
+  ["--type-major-section-title-size", "20px"],
+  ["--type-major-section-title-line", "25px"],
+  ["--type-major-section-title-weight", "600"],
+  ["--type-major-section-title-tracking", "-0.016em"],
   ["--type-page-subtitle-size", "15px"],
-  ["--type-page-subtitle-line", "21px"],
+  ["--type-page-subtitle-line", "20px"],
   ["--type-section-label-size", "15px"],
   ["--type-section-label-line", "20px"],
   ["--type-section-label-weight", "500"],
@@ -88,8 +92,8 @@ for (const [token, value] of [
   ["--type-tab-label-size", "11px"],
   ["--type-tab-label-line", "13px"],
   ["--type-tab-label-weight", "500"],
-  ["--type-agent-tab-label-size", "17px"],
-  ["--type-agent-tab-label-line", "22px"],
+  ["--type-agent-tab-label-size", "15px"],
+  ["--type-agent-tab-label-line", "20px"],
   ["--type-agent-tab-label-weight", "500"],
 ]) {
   if (!globals.includes(`${token}: ${value};`)) {


### PR DESCRIPTION
## Summary
- replace the previous Settings-clone typography with the final Apple-native multi-agent workspace scale
- tighten Location/SMS/Profile/Kai in-app typography, card radius, agent roster icon sizing, and desktop bottom-nav behavior
- update the design verifier so CI enforces the new exact contract instead of the old 34px large-title contract

## Verification
- npm run verify:design-system
- npm run typecheck
- npm run lint
- npm run verify:cache
- npm run verify:docs
- npm run build
- python .codex/skills/codex-skill-authoring/scripts/skill_lint.py