### PR TITLE
fix(profile): prevent compact email orphan wrapping

### DIFF
--- a/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
@@ -32,4 +32,26 @@ describe("Profile canonical page layout", () => {
     );
     expect(source).not.toContain('<UserIcon className="h-12 w-12" />');
   });
+  it("gives account metadata the full compact header width", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/profile/profile-workspace-page.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      'className="profile-home-copy w-full min-w-0 max-w-full',
+    );
+    expect(source).toContain(
+      'gap-2.5 px-0 text-center sm:px-6',
+    );
+    expect(source).not.toContain(
+      'gap-2.5 px-4 text-center sm:px-6',
+    );
+    expect(source).toContain(
+      'className="profile-home-meta flex w-full min-w-0 items-center justify-center',
+    );
+    expect(source).not.toContain(
+      'className="profile-home-meta inline-flex max-w-full',
+    );
+  });
 });

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -3989,17 +3989,17 @@ function ProfilePageContent() {
     <div className="profile-home-screen">
       <AppPageHeaderRegion>
         <header
-          className="profile-home-hero flex w-full min-w-0 flex-col items-center gap-2.5 px-4 text-center sm:px-6"
+          className="profile-home-hero flex w-full min-w-0 flex-col items-center gap-2.5 px-0 text-center sm:px-6"
           data-slot="page-header"
           data-page-primary="true"
         >
           <ProfileAvatarEditor />
-          <div className="profile-home-copy min-w-0 max-w-full space-y-1.5">
+          <div className="profile-home-copy w-full min-w-0 max-w-full space-y-1.5">
             <h1 className="profile-home-name ui-text-identity-name [overflow-wrap:anywhere]">
               {user.displayName || "User"}
             </h1>
             <div
-              className="profile-home-meta inline-flex max-w-full items-center justify-center gap-2 text-sm text-muted-foreground"
+              className="profile-home-meta flex w-full min-w-0 items-center justify-center gap-2 text-sm text-muted-foreground"
               title={provider.name}
             >
               <ProviderIcon providerId={provider.id} />


### PR DESCRIPTION
## Summary

Fixes the compact Profile header so the signed-in account email does not wrap its last characters onto an orphan line at phone widths.

## UAT observation

Reproduced twice on `https://uat.one.hushh.ai/one/profile?from=%2Fone` at 320×568.

- Starting state: authenticated, Vault unlocked, Profile root open
- Action: open Profile and inspect the Google provider/email row
- Expected: the signed-in test account email remains readable on one line
- Actual: its final two characters wrapped onto a second line
- Both observations showed the metadata content constrained to about 232px inside the compact header

No information was changed and no share/action was sent.

## Root cause

`AppPageHeaderRegion` already supplies the compact page gutter, while the Profile hero added another `px-4` inset. The metadata copy also remained shrink-wrapped. Together those constraints left too little width for the provider icon, gap, and email.

## Fix

- Remove only the redundant compact horizontal inset while preserving `sm:px-6`
- Give the Profile copy and metadata row the available width
- Preserve current-main's `ui-text-identity-name` typography contract

## Regression proof

Added a source contract covering all three required width constraints.

- Before production fix: new regression assertion failed
- After fix: exact regression passes, 1 passed / 2 skipped
- The complete contract file currently has a separate upstream avatar assertion failure (`photo` vs `shownPhoto`). The same failure was executed and reproduced in an untouched detached `upstream/main` worktree; its failing line is outside this PR diff.

## Local browser verification

Existing authenticated Chrome profile, local frontend with UAT services, 320×568:

1. Profile pass 1: email rendered as one line (225.55px text range inside 264.67px metadata row)
2. One → Profile round trip: email again rendered as one line

No new login session was created and the Vault key remained memory-only.

## Checks

- Exact regression: pass
- Typecheck: pass on final rebased head
- Targeted ESLint: pass on final rebased head
- Design-system verification: pass
- `git diff --check`: pass
- Production webpack build: pass; 145/145 static pages generated on the same patch before the final two-commit main rebase
- Final rebase preserved current-main typography; exact regression, typecheck, and lint were rerun afterward
- DCO: signed off with the developer's linked GitHub identity

## Impact map

- Route: `/one/profile`
- Production file: `hushh-webapp/app/profile/profile-workspace-page.tsx`
- Test file: `hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts`
- API/schema/cache/trust-boundary changes: none
- Mobile impact: compact web/Capacitor Profile layout only
- Rollback: revert the single commit
