### PR TITLE
fix(location): preserve selected circle members

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -559,6 +559,56 @@ describe("OneLocationOnboardingFlow", () => {
     expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
   });
 
+  it("keeps a selected person visible when their connection request fails", async () => {
+    renderFlow({
+      people: [people[1]!],
+      connections: [],
+      onSendConnectionRequests: vi.fn().mockResolvedValue({
+        sentUserIds: [],
+        failedUserIds: ["new_user"],
+      }),
+    });
+    openPeopleScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add New Person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "1 invitation could not be sent. You can retry it later from Connect.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByText("New")).toBeTruthy();
+    expect(screen.getByText("Not sent")).toBeTruthy();
+  });
+
+  it("preserves an already-selected person when their relationship settles to pending", async () => {
+    const props = renderFlow({
+      people: [people[1]!],
+      connections: [],
+    });
+    openPeopleScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Add New Person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Go back" })).toBeEnabled(),
+    );
+    props.rerenderFlow({
+      people: [{ ...people[1]!, relationship: "pending_outgoing" }],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
+    expect(screen.getByText("1 selected")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
+    expect(screen.getByText("New")).toBeTruthy();
+  });
+
 
   it("sends deliberate requests, shows selected people, and auto-completes after four seconds", async () => {
     vi.useFakeTimers();

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -67,7 +67,7 @@ type CircleMember = {
   userId: string;
   displayName: string;
   photoUrl: string | null;
-  status: "connected" | "pending";
+  status: "connected" | "pending" | "failed";
 };
 
 type OneLocationOnboardingFlowProps = {
@@ -1828,10 +1828,16 @@ function CircleScreen({
                   "mt-0.5 text-[10px] font-semibold",
                   member.status === "connected"
                     ? "text-[#23a64d]"
+                    : member.status === "failed"
+                      ? "text-[#c2413b] dark:text-[#ff8b83]"
                     : "text-[#8b919a] dark:text-[#8f9bab]",
                 )}
               >
-                {member.status === "connected" ? "Joined" : "Invited"}
+                {member.status === "connected"
+                  ? "Joined"
+                  : member.status === "failed"
+                    ? "Not sent"
+                    : "Invited"}
               </span>
             </span>
           ))}
@@ -2132,11 +2138,8 @@ export function OneLocationOnboardingFlow({
   };
 
   const handlePeopleContinue = (selectedIds: string[]) => {
-    const selectedPeople = people.filter(
-      (person) =>
-        selectedIds.includes(person.userId) &&
-        person.relationship !== "pending_incoming" &&
-        person.relationship !== "pending_outgoing",
+    const selectedPeople = people.filter((person) =>
+      selectedIds.includes(person.userId),
     );
     if (selectedPeople.length === 0) {
       toast.error("Choose at least one contact", {
@@ -2187,11 +2190,12 @@ export function OneLocationOnboardingFlow({
           requestedConnectionIdsRef.current.delete(userId),
         );
         if (requestBatchRef.current !== batchId) return;
-        const sentIds = new Set(result.sentUserIds);
+        const failedIds = new Set(result.failedUserIds);
         setCircleMembers(
-          optimisticMembers.filter(
-            (member) =>
-              member.status === "connected" || sentIds.has(member.userId),
+          optimisticMembers.map((member) =>
+            failedIds.has(member.userId)
+              ? { ...member, status: "failed" as const }
+              : member,
           ),
         );
         setFailedRequestCount(result.failedUserIds.length);
@@ -2202,8 +2206,13 @@ export function OneLocationOnboardingFlow({
           requestedConnectionIdsRef.current.delete(userId),
         );
         if (requestBatchRef.current !== batchId) return;
+        const failedIds = new Set(requestIds);
         setCircleMembers(
-          optimisticMembers.filter((member) => member.status === "connected"),
+          optimisticMembers.map((member) =>
+            failedIds.has(member.userId)
+              ? { ...member, status: "failed" as const }
+              : member,
+          ),
         );
         setFailedRequestCount(requestIds.length);
         setRequestsSending(false);


### PR DESCRIPTION
## Summary

Preserve the people a user selected while One Location settles connection requests.

## Root cause

The Circle screen initially received the selected people optimistically, but the request callback replaced that state with only connected users and successfully sent requests. A failed request therefore removed the selected person entirely. The Continue handler also discarded an already-selected person once their relationship refreshed to `pending_incoming` or `pending_outgoing`.

## Fix

- Keep every deliberate selection in Circle state.
- Mark a failed request as `Not sent` instead of deleting the person.
- Keep already-selected pending relationships without sending a duplicate request.
- Preserve existing retry guidance and connection-request behavior.

## Regression proof

Before the production fix, both new tests failed:
- failed request removed the only selected person from Circle
- pending relationship refresh caused Continue to reject the existing selection

After the fix:
- `npm test -- __tests__/components/one-location-onboarding-flow.test.tsx -t "keeps a selected person visible|preserves an already-selected person"` — 2 passed
- full component file — 27 passed, 1 failed on the existing `mt-4` vs `mt-3` spacing assertion
- the same spacing assertion was run on clean base `3a72e436c` and failed identically

## Checks

- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run verify:docs` — passed
- `git diff --check` — passed
- DCO signoff — passed
- pre-push freshness/backend quick lint — passed
- production build compiled and completed TypeScript; the combined local run timed out during static generation, so this is not claimed as a local build pass
- signed-in route verification/local browser flow was blocked because localhost had no authenticated session and no existing UAT tab was open; no second login or real share was created

## Impact

- Frontend-only One Location onboarding state and presentation
- No API, schema, consent, vault, or backend changes
- No real location share or connection request was sent
