### PR TITLE
fix(finance): keep setup state capability-scoped

### DIFF
--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -57,17 +57,26 @@ vi.mock("@/lib/morphy-ux/button", () => ({
 }));
 
 vi.mock("@/lib/navigation/routes", () => ({
-  ROUTES: { ONE_SETUP: "/one/setup", ONE_HOME: "/one", PROFILE: "/one/profile" },
+  ROUTES: {
+    ONE_SETUP: "/one/setup",
+    ONE_SETUP_FINANCE: "/one/setup/finance",
+    ONE_HOME: "/one",
+    PROFILE: "/one/profile",
+  },
   buildOneSetupRoute: ({ returnTo }: { returnTo: string }) =>
     `/one/setup?return_to=${encodeURIComponent(returnTo)}`,
   isCapabilityOnboardingRoute: () => false,
   isOnboardingAdmissionExemptRoute: () => false,
+  normalizeStaticExportPathname: (pathname: string) =>
+    pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") || "/",
 
   isOneSetupRoute: (pathname: string) =>
     pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") ===
     "/one/setup",
   isOneSetupSurfaceRoute: (pathname: string) =>
-    pathname === "/one/setup" || pathname === "/one/setup/connections",
+    pathname === "/one/setup" ||
+    pathname === "/one/setup/connections" ||
+    pathname === "/one/setup/finance",
 }));
 
 vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
@@ -201,6 +210,25 @@ describe("OnboardingJourneyGuard", () => {
       expect(replace).toHaveBeenCalledWith("/one");
     });
     expect(screen.queryByText("hub")).toBeNull();
+  });
+
+  it("admits unfinished Finance setup after root onboarding resolves", async () => {
+    pathnameValue = "/one/setup/finance";
+    window.history.replaceState(null, "", pathnameValue);
+    isPersistentSetupResolvedMock.mockReturnValue(true);
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>finance setup</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("finance setup")).toBeTruthy();
+    expect(replace).not.toHaveBeenCalled();
+    expect(bootstrapStateMock).not.toHaveBeenCalled();
   });
 
   it("admits a setup surface during first onboarding (not dismissed)", async () => {

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -49,7 +49,7 @@ describe("OneDashboardPage", () => {
     window.localStorage.clear();
   });
 
-  it("routes home tiles to the product surface once onboarding is dismissed", () => {
+  it("keeps unfinished Finance actionable after root onboarding is dismissed", () => {
     const userId = "dashboard-dismissed-user";
     OneSetupCompletionHintService.markResolved(userId); // dismissed
 
@@ -63,12 +63,12 @@ describe("OneDashboardPage", () => {
       />,
     );
 
-    // Profile-only: a not-configured tile opens the capability's own screen,
-    // never /one/setup/* (which the guard would eject a dismissed user from).
+    // Root onboarding completion is not Finance completion. The resolver's
+    // actionable state must still lead to the bounded Finance setup workspace.
     const financeLink = screen.getByRole("link", { name: "Open Finance" });
-    const href = financeLink.getAttribute("href") ?? "";
-    expect(href).not.toBe(buildOneSetupCapabilityRoute("finance"));
-    expect(href.startsWith("/one/setup")).toBe(false);
+    expect(financeLink.getAttribute("href")).toBe(
+      buildOneSetupCapabilityRoute("finance"),
+    );
   });
 
   it("renders the primary One agent modes with route targets", () => {

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -274,6 +274,11 @@ function buildModes(
 
     const isActionable =
       "isActionable" in display ? (display as any).isActionable : true;
+    const opensSetup = Boolean(
+      setupCapability &&
+        isActionable &&
+        (!setupDismissed || capability.id === "finance"),
+    );
 
     const primaryMetric =
       cachedMetrics[capability.id] ??
@@ -286,14 +291,12 @@ function buildModes(
       id: capability.id,
       title: capability.title,
       description: capability.description,
-      // Once onboarding is dismissed, a home tile for a not-yet-configured
-      // capability opens the capability's OWN screen — never the setup hub.
-      // Setup is reachable only via Profile → "Set Up One" (post-onboarding),
-      // and routing a tile into a setup surface would be ejected by the guard.
-      href:
-        !setupDismissed && setupCapability && isActionable
-          ? buildOneSetupCapabilityRoute(capability.id)
-          : capability.href,
+      // Root onboarding dismissal normally opens the product workspace.
+      // Finance remains an exception while its own resolver says setup is
+      // actionable: root completion or Skip is not Finance completion.
+      href: opensSetup
+        ? buildOneSetupCapabilityRoute(capability.id)
+        : capability.href,
       icon: capability.icon,
       statusTone: display.tone,
       primaryMetric,

--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -13,6 +13,7 @@ import {
   isOnboardingAdmissionExemptRoute,
   isOneSetupRoute,
   isOneSetupSurfaceRoute,
+  normalizeStaticExportPathname,
   ROUTES,
 } from "@/lib/navigation/routes";
 import {
@@ -123,8 +124,13 @@ export function OnboardingJourneyGuard({
     persistentSetupResolved ||
       (cachedState && PreVaultUserStateService.isSetupResolved(cachedState)),
   );
+  // Finance setup remains a valid, bounded capability entry after the one-time
+  // root journey is dismissed. Root completion (including Skip) is not the
+  // durable Finance completion signal.
+  const isPostRootFinanceSetup =
+    normalizeStaticExportPathname(pathname) === ROUTES.ONE_SETUP_FINANCE;
   const shouldEjectSetupSurface = Boolean(
-    setupSurface && setupDismissed,
+    setupSurface && setupDismissed && !isPostRootFinanceSetup,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Keep Finance setup governed by Finance’s durable capability state after root onboarding is skipped or completed.

## Root cause

The shared resolver correctly reported unfinished Finance as actionable, but the One roster deliberately routed every tile straight to its product workspace once root onboarding was dismissed. The onboarding guard also ejected every post-root setup route, including `/one/setup/finance`. Together those older root-level shortcuts bypassed the capability resolver and made unfinished Finance behave as already configured.

## Fix

- Route actionable Finance to `/one/setup/finance` even after root onboarding is dismissed.
- Admit only the bounded Finance setup route post-root.
- Preserve the one-time root setup hub ejection and all non-Finance capability behavior.

## Regression proof

Before the fix:
- the dismissed-root dashboard test got `/one/kai?tab=market` instead of `/one/setup/finance`
- the guard contract now models `/one/setup/finance` as a real setup surface

After the fix:
- focused post-rebase regression tests — 2 passed
- Finance neighborhood suites — 63 passed

## Checks

- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run verify:docs` — passed
- `git diff --check` — passed
- DCO signoff — passed
- pre-push freshness/backend quick lint — passed
- production build compiled and completed TypeScript; the combined local run timed out during static generation, so this is not claimed as a local build pass
- signed-in route verification/local browser flow was blocked because localhost had no authenticated session and no existing UAT tab was open

## Impact

- Frontend-only One dashboard and onboarding admission
- No API, schema, vault, consent, or backend changes
- Root onboarding completion remains distinct from Finance capability completion
