### PR TITLE
fix(webapp): restore the bottom nav above the lg breakpoint

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -79,7 +79,7 @@ describe("Navbar bottom chrome contract", () => {
     const bottomChromeMotion = read(
       "lib/navigation/kai-bottom-chrome-visibility.ts",
     );
-    expect(bottomChromeMotion).toContain("Follow the thumb directly");
+    expect(bottomChromeMotion).toContain("follow the thumb directly");
     expect(agentBar).not.toContain('aria-label="Talk to your agent"');
     expect(agentBar).not.toContain("<Mic");
 

--- a/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
+++ b/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
@@ -146,6 +146,21 @@ describe("Navbar bottom utilities", () => {
     );
   });
 
+  // Regression: a `lg:hidden` was added to the nav root in a chrome-polish pass,
+  // which removed the primary navigation entirely above 1024px. Nothing renders
+  // One / Connect / Feed / Search at desktop widths, so the bar must never be
+  // gated behind a viewport breakpoint.
+  it.each(["fixed", "slot"] as const)(
+    "renders the %s bottom nav at every viewport width",
+    (layout) => {
+      const { container } = render(<Navbar layout={layout} />);
+      const nav = container.querySelector("[data-app-bottom-nav]");
+
+      expect(nav).not.toBeNull();
+      expect(nav?.className).not.toMatch(/(^|\s|:)hidden(\s|$)/);
+    },
+  );
+
   it("places pending consent and unread Feed counts on Feed, not One", () => {
     notificationMock.pendingConsents = 3;
     notificationMock.feedUnreadCount = 2;

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -460,7 +460,11 @@ export const Navbar = ({
           ? "flex w-full justify-center"
           : "fixed inset-x-0 flex justify-center px-4 transform-gpu",
         layout === "fixed" && (isVaultUnlocked ? "z-[120]" : "z-[505]"),
-        "pointer-events-none lg:hidden",
+        // No breakpoint gate here. The bottom pill IS the primary navigation on
+        // every viewport — there is no desktop/sidebar nav that takes over at
+        // `lg`, so hiding it above 1024px leaves signed-in users with no way to
+        // reach One / Connect / Feed / Search at all.
+        "pointer-events-none",
       )}
       style={
         layout === "fixed"


### PR DESCRIPTION
## Symptom

The bottom navigation disappears on `uat.one.hushh.ai` when the browser is maximised / fullscreen, and comes back when the window is made smaller. Reported against `/one`, but it affects every signed-in route.

## Root cause

`e902f86e4` ("Refine agent workspace typography and chrome") added `lg:hidden` to the bottom nav root in `components/navbar.tsx`:

```diff
-        "pointer-events-none",
+        "pointer-events-none lg:hidden",
```

That was a one-line change inside a 12-file typography pass, and it landed with no companion desktop navigation. There is no sidebar and no top-shell nav that renders `One / Connect / Feed / Search` — `AppBottomShell` (mounted once in `app/providers.tsx`) is the only primary-navigation surface in the app. Above Tailwind's `lg` (1024px) the class removes it outright, so signed-in users on desktop web have no way to change section at all.

Because the class sits outside the `layout === "fixed" | "slot"` conditional it applied to both layouts, including the persistent shell slot.

It went unnoticed because the Capacitor shell and every phone viewport sit below `lg`. Only desktop web crosses the breakpoint — precisely where it was reported.

## Fix

Remove the breakpoint gate, with a comment recording why one must not be reintroduced without a desktop nav to hand off to.

Regression coverage in `navbar-bottom-nav.test.tsx` asserts the nav root carries no viewport-hiding class, across both the `fixed` and `slot` layouts. Verified as a real guard: reintroducing `lg:hidden` fails both cases; removing it passes.

## Also in this PR

`__tests__/components/navbar-agent-trigger.contract.test.ts` was **already failing on `main`** before this branch. It pins the literal comment text of `lib/navigation/kai-bottom-chrome-visibility.ts`, and `50dc4370c` reworded `"Follow the thumb directly"` into `"Once committed, follow the thumb directly"` without updating the assertion. One-word fix, same subsystem, included so this PR can go green.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run __tests__/components __tests__/navigation` — 123 files.
  - Baseline on clean `main`: **11 files failing**.
  - With this branch: **10 files failing** — the same set minus `navbar-agent-trigger`, which this PR fixes.
  - **No new failures introduced.**

The other 10 failing files are pre-existing breakage on `main` (`one-dashboard-page`, `capability-cinematic-intro`, `top-app-bar.contract`, `settings-ui`, `theme-toggle`, and others) and are untouched here — worth a separate pass.

## Reviewer note

Desktop web now shows the same bottom pill as mobile. If the intent behind `lg:hidden` was in fact to move desktop onto a different navigation pattern, that pattern still needs to be built — this restores working navigation in the meantime rather than leaving desktop with none.