### PR TITLE
fix(location): destroy native map on teardown so Your Map re-renders on re-open

### DIFF
--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -828,6 +828,16 @@ export function LocationImmersiveMap({
     return () => {
       cancelled = true;
       setMapReady(false);
+      // Destroy the native map instance and drop the ref on teardown. Without
+      // this, closing Your Map left the @capacitor/google-maps instance
+      // (registered under MAP_ID) alive; re-opening then raced a fresh create()
+      // against the stale instance and rendered a blank canvas the second time.
+      // Nulling the ref also stops the unmount effect from double-destroying it.
+      const staleMap = mapRef.current;
+      mapRef.current = null;
+      markerIdsRef.current = [];
+      markerByMapIdRef.current.clear();
+      void staleMap?.destroy();
     };
   }, [auth.userId, rendererReady]);
 


### PR DESCRIPTION
## What & why

Opening **Your Map a second time** showed a blank canvas — the native Google Map didn't re-render because the previous instance was never torn down when the map screen closed.

## Root cause

In `location-immersive-map.tsx`, the `GoogleMap.create` effect's cleanup only did:
```tsx
return () => { cancelled = true; setMapReady(false); };
```
It never destroyed the created map or nulled `mapRef.current`. The `@capacitor/google-maps` instance is registered under a fixed `MAP_ID`; leaving it alive meant the next mount's `create()` raced a stale instance for the same id → blank map on re-open. (The prior `closeMap` fix destroyed the map on the close tap, but a route/unmount that didn't go through that path still leaked.)

## Fix

The create-effect cleanup now tears the instance down and drops the ref:
```tsx
return () => {
  cancelled = true;
  setMapReady(false);
  const staleMap = mapRef.current;
  mapRef.current = null;          // also stops the unmount effect double-destroying
  markerIdsRef.current = [];
  markerByMapIdRef.current.clear();
  void staleMap?.destroy();
};
```
So every teardown (close, route change, unmount) destroys the map and clears marker refs; the next open builds a fresh instance and renders reliably.

## Close (X) button

Already hardened in the prior merged fix (`closeMap` destroys the native map + has a guaranteed hard-nav fallback, and the X is a `pointer-events-auto` / `touch-manipulation` control at z-20 with an `onPointerUp` touch handler). Nulling the ref here additionally prevents a stale-ref double-destroy, which is what could leave the button feeling "locked" on a re-open. No further change needed there.

## Verification

- ESLint clean. (Local `@capacitor/google-maps`/`google` TS "cannot find" noise is missing-local-types only; CI Web Core typechecks with full deps.)
- Open → close → re-open Your Map repeatedly now re-creates and renders the map each time; refs no longer leak between mounts.

## Risk

Low — one effect-cleanup block in one component; strictly adds teardown (destroy + null + clear), no API/route/data/contract change. Idempotent with the existing unmount destroy (ref is nulled first).
