### PR TITLE
fix(ios): keep stock-preview action pills on one row instead of stacking

### DIFF
--- a/hushh-webapp/components/kai/cards/stock-comparison-preview.tsx
+++ b/hushh-webapp/components/kai/cards/stock-comparison-preview.tsx
@@ -111,19 +111,19 @@ export function StockComparisonPreview({
             accent="default"
             actions={
               onBrowseRecommendations || onChangeStock ? (
-                // Allow the action buttons to wrap onto a second line instead of
-                // overflowing the card's right edge on narrow iOS widths (which
-                // clipped "Change stock" to "Change stoc"). `shrink-0` keeps each
-                // button's own label intact; `whitespace-nowrap` stops a single
-                // label from breaking mid-word once it has wrapped to its line.
-                <div className="flex flex-wrap items-center justify-end gap-1">
+                // Keep both action pills on ONE horizontal line (they were
+                // wrapping/stacking on narrow iOS widths). `flex-nowrap` + a
+                // shared `min-w-0` and compact padding/label sizing let both
+                // fit at 375px without clipping "Change stock" or overflowing
+                // the card's right edge.
+                <div className="flex flex-nowrap items-center justify-end gap-1.5">
                   {onBrowseRecommendations ? (
                     <Button
                       type="button"
                       variant="none"
                       effect="fade"
                       size="sm"
-                      className="shrink-0 whitespace-nowrap"
+                      className="min-w-0 shrink whitespace-nowrap px-2.5 text-xs sm:text-sm"
                       onClick={onBrowseRecommendations}
                     >
                       Recommendations
@@ -135,10 +135,10 @@ export function StockComparisonPreview({
                       variant="none"
                       effect="fade"
                       size="sm"
-                      className="shrink-0 whitespace-nowrap"
+                      className="min-w-0 shrink whitespace-nowrap px-2.5 text-xs sm:text-sm"
                       onClick={onChangeStock}
                     >
-                      <Search className="mr-1.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      <Search className="mr-1 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                       Change stock
                     </Button>
                   ) : null}


### PR DESCRIPTION
## What & why

In the **Stock preview** card (Analysis tab), the **Recommendations** and **Change stock** pill buttons were stacking vertically (right-aligned) on narrow iOS widths instead of sitting side-by-side.

## Root cause

The prior fix (#5068) used `flex flex-wrap` to avoid clipping "Change stock" → on 375–390px the two pills no longer fit, so `flex-wrap` pushed them onto separate lines (the stacking).

## Fix

Keep both pills on **one horizontal row** and make them fit instead of wrapping (`hushh-webapp/components/kai/cards/stock-comparison-preview.tsx`):
- Container: `flex flex-wrap` → **`flex flex-nowrap`**, `items-center justify-end gap-1.5`.
- Each `Button`: `min-w-0 shrink whitespace-nowrap px-2.5 text-xs sm:text-sm` — compact horizontal padding + smaller mobile label so both fit at 375px without clipping; `whitespace-nowrap` keeps each label intact; `sm:text-sm` restores full size on wider screens.
- Trimmed the Search icon margin (`mr-1.5` → `mr-1`).

## Verification

- ESLint clean.
- At 375 / 390 / 428px the two pills render side-by-side within the card, no wrap, no "Change stoc" clipping; on ≥sm they return to normal label size. Uses the existing Morphy `Button` (`size="sm"`), so styling/behavior is otherwise unchanged.

## Risk

Low — pure CSS-class layout change in one card's action slot; no props, data, or behavior changes.
