### PR TITLE
fix(ria-setup): center onboarding hero and raise eyebrow contrast

### DIFF
--- a/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
@@ -163,7 +163,7 @@ export function CapabilityCinematicIntroGate({
 
   const content = (
     <section
-      className="motion-step-enter relative mx-auto flex w-full max-w-[36rem] flex-col items-start"
+      className="motion-step-enter relative mx-auto flex min-h-[calc(100dvh-16rem)] w-full max-w-[36rem] flex-col items-center justify-center text-center"
       aria-labelledby={`capability-intro-${capabilityId}`}
       data-capability-cinematic-intro={capabilityId}
     >
@@ -197,7 +197,13 @@ export function CapabilityCinematicIntroGate({
           ))}
         </ul>
       ) : null}
-      <p className="type-subhead text-muted-foreground">One · {copy.title}</p>
+      {/* Eyebrow was `text-muted-foreground`, which reads as heavily faded /
+          low-contrast on the light onboarding background. Use the primary
+          foreground token at reduced weight so it stays legible in both themes
+          without hardcoding a slate color that would break dark mode. */}
+      <p className="type-subhead font-medium text-foreground/80">
+        One · {copy.title}
+      </p>
       <h1
         id={`capability-intro-${capabilityId}`}
         className="mt-4 max-w-[16ch] text-balance type-display text-foreground"


### PR DESCRIPTION
## What & why

On the RIA setup / capability intro screen (`One · RIA` hero):
1. The eyebrow `One · {title}` was faded/low-contrast on the light theme.
2. The hero (eyebrow, heading, subtitle, Continue) was top-anchored and left-aligned, leaving a large empty gap at the bottom.

Both live in the shared prologue `components/onboarding/setup/capability-cinematic-intro.tsx` (drives RIA, connections, and other capability intros).

## Fix

- **Eyebrow contrast:** `text-muted-foreground` → **`font-medium text-foreground/80`** — legible in both light and dark themes. (Kept the design-token color rather than a hardcoded `slate-600`, which would break dark mode; same intent as the ticket's contrast request, theme-safe.)
- **Vertical + horizontal centering:** the hero `<section>` now `flex min-h-[calc(100dvh-16rem)] flex-col items-center justify-center text-center` (was `items-start`, top-anchored). It fills the available height between header and bottom bar and centers the content, removing the bottom dead space. Existing `max-w` constraints + centered Continue button are preserved.

## Scope note

This is the shared capability intro, so the centering + eyebrow contrast improve every capability prologue (RIA, AI access/connections, etc.), not just RIA — consistent, and each already used the same copy structure.

## Verification

- ESLint clean.
- Centered layout balances the hero on mobile + desktop; eyebrow now clearly readable on the light background and still correct in dark mode. Copy, actions, session-latch/OAuth-resume logic all unchanged.

## Risk

Low — presentational classes only in one shared intro component; no copy, action, routing, or state changes.
