### PR TITLE
fix(connect): cap bulk connection requests

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -357,24 +357,70 @@ describe("Connect — People", () => {
     expect(await screen.findByText('No one matches "Nobody"')).toBeTruthy();
   });
 
-  /**
-   * Bulk selection is deliberately unreachable: the entry point was removed
-   * because selecting many people at once was not a clear answer to finding
-   * the right one, and it invited fanning out requests instead of searching.
-   *
-   * This pins the removal rather than the old behaviour. The selection state,
-   * the per-row checkboxes and the bulk request handler are all still in the
-   * component on purpose, so restoring the control is a one-line change -- but
-   * while it is hidden that path has no coverage, and the previous test for it
-   * ("drops selections the new result set no longer shows") went with the
-   * button. Reinstating the control should reinstate that test.
-   */
-  it("does not offer bulk selection", async () => {
+  it("caps bulk connection requests at 20 people", async () => {
+    const bulkPeople = Array.from({ length: 21 }, (_, index) =>
+      person(`bulk-${index}`, `Bulk person ${index}`),
+    );
+    mocks.searchDirectory.mockResolvedValue({
+      items: bulkPeople,
+      hasMore: false,
+      page: 1,
+    });
+    mocks.sendRequest.mockResolvedValue({ id: "request" });
+    render(<ConnectPageClient />);
+    expect(await screen.findByText("Bulk person 0")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
+
+    for (let index = 0; index < 20; index += 1) {
+      fireEvent.click(screen.getByLabelText(`Select Bulk person ${index}`));
+    }
+
+    expect(screen.getByText("Connect to Selected (20/20)")).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Select Bulk person 20") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
+    expect(
+      (screen.getByLabelText("Select Bulk person 20") as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect to Selected (20/20)" }));
+
+    await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(20));
+
+    expect(mocks.sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ addresseeUserId: "bulk-0" }),
+    );
+    expect(mocks.sendRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ addresseeUserId: "bulk-20" }),
+    );
+  });
+
+  it("drops a selection that is no longer visible in the directory", async () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
-    expect(screen.queryByText("Select")).toBeNull();
-    expect(screen.queryByText("Select All")).toBeNull();
-    expect(screen.queryByLabelText("Select Person 0")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
+    fireEvent.click(screen.getByLabelText("Select Person 0"));
+    expect(screen.getByText("Connect to Selected (1/20)")).toBeTruthy();
+
+    mocks.searchDirectory.mockResolvedValue({
+      items: [person("u9", "Person 9")],
+      hasMore: false,
+      page: 1,
+    });
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Person 9" },
+    });
+
+    expect(await screen.findByText("Person 9")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByText("Connect to Selected (1/20)")).toBeNull(),
+    );
   });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -76,6 +76,9 @@ const SUGGESTED_PEOPLE_LIMIT = 8;
 const PAGE_SIZE_OPTIONS = [8, 16, 24, 50] as const;
 const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
 
+/** Maximum number of connection requests the People bulk action can send. */
+const MAX_BULK_CONNECTION_REQUESTS = 20;
+
 /**
  * Bounds on resolving ONE spoken name against the directory.
  *
@@ -502,9 +505,18 @@ export default function ConnectPageClient() {
 
   const handleConnectMultiple = useCallback(async () => {
     if (!user || selectedUserIds.size === 0) return;
+    const selectedPeople = people.filter((p) => selectedUserIds.has(p.userId));
+
+    // Keep the dispatch boundary bounded even if selection state is restored or
+    // changed outside the row controls.
+    if (selectedPeople.length > MAX_BULK_CONNECTION_REQUESTS) {
+      toast.error(`Select no more than ${MAX_BULK_CONNECTION_REQUESTS} people at a time.`);
+      return;
+    }
+
     setIsConnectingMultiple(true);
     let successCount = 0;
-    const selectedPeople = people.filter((p) => selectedUserIds.has(p.userId));
+    const successfulUserIds = new Set<string>();
     
     try {
       const idToken = await user.getIdToken();
@@ -521,6 +533,7 @@ export default function ConnectPageClient() {
               ...current,
               [person.userId]: request.id,
             }));
+            successfulUserIds.add(person.userId);
             successCount++;
           } catch (_err) {
             console.error(`Failed to send request to ${person.userId}`, _err);
@@ -530,7 +543,7 @@ export default function ConnectPageClient() {
       
       setPeople((prev) =>
         prev.map((p) =>
-          selectedUserIds.has(p.userId) && p.relationship === "none"
+          successfulUserIds.has(p.userId) && p.relationship === "none"
             ? { ...p, relationship: "pending_outgoing" }
             : p,
         ),
@@ -1089,25 +1102,30 @@ export default function ConnectPageClient() {
                     }}
                   />
                 </div>
-                {/*
-                  The Select / Select All controls are intentionally not
-                  rendered. Bulk-selecting people was not a clear answer to the
-                  problem it was reaching for -- finding the right person in a
-                  list that grows with every signup -- and shipping it invited
-                  people to fan out requests rather than helping them search.
-
-                  The machinery below is deliberately left in place: selection
-                  mode, the per-row checkboxes, and the bulk request action all
-                  still work, and `isSelectionMode` simply has no way to become
-                  true from the UI. Restoring the entry point is a one-line
-                  change if a clearer design arrives. Do not delete the state or
-                  the bulk handler on the grounds that they look unreachable.
-                */}
+                <Button
+                  type="button"
+                  variant="none"
+                  effect="fill"
+                  size="sm"
+                  disabled={loading || people.length === 0}
+                  onClick={() => {
+                    setIsSelectionMode((current) => !current);
+                    setSelectedUserIds(new Set());
+                  }}
+                >
+                  {isSelectionMode ? "Cancel selection" : "Select people"}
+                </Button>
               </div>
               <SettingsGroup
                 title="People"
                 description={
-                  hasQuery
+                  isSelectionMode
+                    ? (
+                        <span id="connect-selection-limit">
+                          Select up to {MAX_BULK_CONNECTION_REQUESTS} people to send connection requests.
+                        </span>
+                      )
+                    : hasQuery
                     ? "Send a connection request to someone you know."
                     : "A few people on Hussh. Search by name to find someone specific."
                 }
@@ -1148,6 +1166,9 @@ export default function ConnectPageClient() {
                     const title =
                       person.displayName || person.email || person.userId;
                     const description = getDirectoryPersonDescription(person);
+                    const isSelected = selectedUserIds.has(person.userId);
+                    const selectionLimitReached =
+                      selectedUserIds.size >= MAX_BULK_CONNECTION_REQUESTS;
                     return (
                       <SettingsRow
                         key={person.userId}
@@ -1159,13 +1180,25 @@ export default function ConnectPageClient() {
                         trailing={
                           isSelectionMode ? (
                             <Checkbox
-                              checked={selectedUserIds.has(person.userId)}
-                              disabled={person.relationship !== "none"}
+                              checked={isSelected}
+                              disabled={
+                                person.relationship !== "none" ||
+                                (!isSelected && selectionLimitReached)
+                              }
+                              aria-describedby="connect-selection-limit"
                               onCheckedChange={(checked) => {
-                                const next = new Set(selectedUserIds);
-                                if (checked) next.add(person.userId);
-                                else next.delete(person.userId);
-                                setSelectedUserIds(next);
+                                setSelectedUserIds((current) => {
+                                  const next = new Set(current);
+                                  if (checked) {
+                                    if (next.size >= MAX_BULK_CONNECTION_REQUESTS) {
+                                      return current;
+                                    }
+                                    next.add(person.userId);
+                                  } else {
+                                    next.delete(person.userId);
+                                  }
+                                  return next;
+                                });
                               }}
                               aria-label={`Select ${title}`}
                             />
@@ -1272,7 +1305,7 @@ export default function ConnectPageClient() {
                     >
                       {isConnectingMultiple
                         ? "Sending requests…"
-                        : `Connect to Selected (${selectedUserIds.size})`}
+                        : `Connect to Selected (${selectedUserIds.size}/${MAX_BULK_CONNECTION_REQUESTS})`}
                     </Button>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- restore the Connect People selection entry point with a 20-person maximum
- guard bulk dispatch at the same limit and retain failed rows as retryable
- cover the cap and visible-result selection reset

## Verification
- npm run test -- __tests__/app/connect/page-client.test.tsx
- npm run typecheck
- npm run lint
- npm run verify:service-boundary
- npm run verify:docs
- ./bin/hushh codex pre-pr

This is a client-side per-batch cap; it does not add a time-window API rate limiter.