### PR TITLE
fix(finance-setup): stop ejecting portfolio-import route to home after questionnaire

### DIFF
--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -126,9 +126,15 @@ export function OnboardingJourneyGuard({
   );
   // Finance setup remains a valid, bounded capability entry after the one-time
   // root journey is dismissed. Root completion (including Skip) is not the
-  // durable Finance completion signal.
+  // durable Finance completion signal. This covers BOTH the Finance
+  // questionnaire route AND its portfolio-import terminal: completing the
+  // questionnaire redirects to `/one/setup/finance/import`, and without that
+  // route in the allowlist a root-resolved user was ejected to ONE_HOME
+  // ("Opening One…" → main dashboard) instead of reaching the import step.
+  const normalizedGuardPathname = normalizeStaticExportPathname(pathname);
   const isPostRootFinanceSetup =
-    normalizeStaticExportPathname(pathname) === ROUTES.ONE_SETUP_FINANCE;
+    normalizedGuardPathname === ROUTES.ONE_SETUP_FINANCE ||
+    normalizedGuardPathname === ROUTES.ONE_SETUP_FINANCE_IMPORT;
   const shouldEjectSetupSurface = Boolean(
     setupSurface && setupDismissed && !isPostRootFinanceSetup,
   );


### PR DESCRIPTION
## What & why

After completing the 3-step Finance questionnaire and clicking "Continue Finance Setup", the app showed "Opening One…" and landed on the **main agents dashboard** instead of the Finance portfolio-import step — and re-opening Finance restarted the questionnaire at step 1 (completion never recorded).

## Root cause

The completion handler was actually correct — it persists `activeCapability="finance"` and `router.replace('/one/setup/finance/import')`. The eject happened one layer up, in **`OnboardingJourneyGuard`**:

- `/one/setup/finance/import` **is** a setup surface (`isOneSetupSurfaceRoute` includes it).
- For a root-resolved ("dismissed") user, the guard ejects any setup surface to `ONE_HOME` unless it's on the post-root Finance allowlist.
- That allowlist (`isPostRootFinanceSetup`) only matched **`/one/setup/finance`** — **not** `/one/setup/finance/import`.

So the redirect to the import route was immediately caught by the guard → `shouldEjectSetupSurface` → `router.replace(ONE_HOME)` ("Opening One…" → dashboard). Because the terminal import step never ran, Finance completion was never marked, so re-entry looped back to step 1.

## Fix

Extend the guard's post-root Finance allowlist to include the import terminal (`components/onboarding/onboarding-journey-guard.tsx`):
```tsx
const normalizedGuardPathname = normalizeStaticExportPathname(pathname);
const isPostRootFinanceSetup =
  normalizedGuardPathname === ROUTES.ONE_SETUP_FINANCE ||
  normalizedGuardPathname === ROUTES.ONE_SETUP_FINANCE_IMPORT;
```
Now a root-resolved user who finishes the questionnaire reaches the portfolio-source step (Plaid / statement / later) instead of being bounced home, the terminal marks Finance complete, and re-entry resumes correctly rather than restarting step 1.

## Scope / why this is the right seam

- The wizard→import redirect and the import route's own `activeCapability === "finance"` admission were already correct; the only gap was this guard allowlist. Minimal, single-line-of-logic change.
- Non-Finance setup surfaces still eject as before (only the two Finance setup routes are allowlisted). First-run (unresolved) users are unaffected.

## Verification

- ESLint clean.
- `ROUTES.ONE_SETUP_FINANCE_IMPORT` is already treated as a setup surface (routes.ts), so the guard evaluates it — the allowlist entry is what lets it through.
- Reproduced-on-UAT symptom (dashboard bounce + step-1 loop) is explained and closed by this change.

## Risk

Low — one boolean allowlist in the admission guard; widens passage only to the already-canonical Finance import route.
