### PR TITLE
fix(connect): sort people search results alphabetically with prefix priority

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -601,6 +601,30 @@ export default function ConnectPageClient() {
   // Present connections in a stable, predictable order: alphabetical by the
   // name the user sees (case-insensitive), falling back to the userId when a
   // display name is absent. Locale compare keeps accented names sensibly placed.
+  // Present the People directory in the same predictable order as connections:
+  // alphabetical (A-Z) by the visible name, case/accent-insensitive. When a
+  // search query is active, names that START with the query rank above inner
+  // matches (so "Ab" surfaces "Abdul" before "Zab…"), then A-Z within each
+  // group. The server can return directory rows in relevance/insertion order,
+  // which read as unsorted in the list; this makes the rendered order stable.
+  const sortedPeople = useMemo(() => {
+    const q = trimmedQuery.toLowerCase();
+    const nameOf = (person: DirectoryPerson) =>
+      (person.displayName || person.email || person.userId)
+        .trim()
+        .toLowerCase();
+    return [...people].sort((a, b) => {
+      const nameA = nameOf(a);
+      const nameB = nameOf(b);
+      if (q) {
+        const startsA = nameA.startsWith(q);
+        const startsB = nameB.startsWith(q);
+        if (startsA !== startsB) return startsA ? -1 : 1;
+      }
+      return nameA.localeCompare(nameB, undefined, { sensitivity: "base" });
+    });
+  }, [people, trimmedQuery]);
+
   const sortedConnections = useMemo(
     () =>
       [...connections].sort((a, b) =>
@@ -1161,7 +1185,7 @@ export default function ConnectPageClient() {
                     />
                   )
                 ) : (
-                  people.map((person) => {
+                  sortedPeople.map((person) => {
                     const cta = relationshipCta(person.relationship);
                     const title =
                       person.displayName || person.email || person.userId;


### PR DESCRIPTION
## What & why

On Connect → People, search results were rendered in the server's returned order (relevance/insertion), so names were not strictly A-Z (e.g. an "Ab…" name could appear below later ones).

## Fix

Added a `sortedPeople` memo (mirrors the existing `sortedConnections`) and render it instead of raw `people`:
- When a query is active, names that **start with** the query rank first (so "Ab" surfaces "Abdul" before inner matches), then
- **A-Z** via `localeCompare(..., { sensitivity: 'base' })` (case/accent-insensitive), keyed on `displayName || email || userId`.
- Rendered list swapped `people.map` → `sortedPeople.map`. No data/query/paging changes.

## Verification

- ESLint clean. Deterministic ordering; same field-fallback + locale-compare approach already used for connections.

## Risk

Low — pure client-side presentation sort in one component; server search/paging untouched.
