### PR TITLE
fix(location): exclude self/owner from circle member count display

### DIFF
--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -837,6 +837,20 @@ export function CircleDetailFlow({
     circle?.inviteCodeNeedsOwnerRotation,
   );
   const members = useMemo(() => circle?.members ?? [], [circle?.members]);
+  // The Circle Detail subtitle counts OTHER people in the circle, not the
+  // viewer. `circle.memberCount` from the backend includes the owner/self, so a
+  // brand-new circle with only its creator read "· 1 members". Exclude the
+  // owner role and the current user so an empty circle shows "0 members" and
+  // the count only reflects people who have actually joined.
+  const externalMembersCount = useMemo(
+    () =>
+      members.filter(
+        (member) =>
+          member.role !== "owner" && member.userId !== currentUserId,
+      ).length,
+    [members, currentUserId],
+  );
+
   const filteredEligibleConnections = useMemo(() => {
     const query = peopleSearch.trim().toLocaleLowerCase();
     if (!query) return eligibleConnections;
@@ -1017,7 +1031,9 @@ export function CircleDetailFlow({
         title={circle?.name ?? "Circle"}
         description={
           circle
-            ? `${circleKindLabel(circle.kind)} · ${circle.memberCount} members`
+            ? `${circleKindLabel(circle.kind)} · ${externalMembersCount} ${
+                externalMembersCount === 1 ? "member" : "members"
+              }`
             : "Loading Circle…"
         }
       />


### PR DESCRIPTION
## What & why

In **Location → Circle Detail**, a circle containing only its creator showed "Friends · 1 members" — the subtitle counted the owner/self. The count should reflect **other** people who've joined, so an empty circle reads "0 members" and only increments when external users join.

## Fix (`components/one-location/redesign/circles/named-circle-flows.tsx`)

Added a derived `externalMembersCount` in `CircleDetailFlow` that filters the already-available `members` list by **role and self**, and used it in the header subtitle:
```tsx
const externalMembersCount = useMemo(
  () => members.filter(
    (m) => m.role !== "owner" && m.userId !== currentUserId,
  ).length,
  [members, currentUserId],
);
// subtitle: `${circleKindLabel(circle.kind)} · ${externalMembersCount} ${externalMembersCount === 1 ? "member" : "members"}`
```
- Excludes both the `owner` role **and** the current user id (belt-and-suspenders — the creator is the owner, but this also covers a viewer who is a non-owner member appearing in their own list).
- Correct singular/plural ("1 member" / "0 members" / "2 members").
- Uses the local `members` array (already loaded for the member list), so no extra fetch and no backend change.

## Scope note

Only the **Circle Detail** subtitle is changed, matching the ticket. The Circles **list** row and the Join-preview still show the backend `memberCount` (total incl. owner) — those are different surfaces the ticket didn't cover, and changing list rows would need the members array per row (not loaded there). Left intentionally untouched.

## Verification

- ESLint clean.
- Creator-only circle → "0 members"; one external member → "1 member"; two → "2 members".

## Risk

Low — one derived count + subtitle string in one component; no data/API/backend changes.
