### PR TITLE
fix(db): make migration 141's CHECK constraint survive a replay

### DIFF
--- a/consent-protocol/db/migrations/141_crm_zk_v1.sql
+++ b/consent-protocol/db/migrations/141_crm_zk_v1.sql
@@ -68,6 +68,15 @@ ALTER TABLE connected_system_intents
   ADD COLUMN IF NOT EXISTS client_operation_id TEXT,
   ADD COLUMN IF NOT EXISTS approval_challenge_id TEXT;
 
+-- UAT and production run migrations with --migration-mode replay, so every
+-- statement here has to survive a second application. Everything else in this
+-- file already does (IF NOT EXISTS on every table, index and column); this
+-- ALTER did not, and Postgres has no ADD CONSTRAINT IF NOT EXISTS. The first
+-- replay after this migration landed failed the whole UAT deploy with
+-- DuplicateObjectError, which blocks the release before anything ships.
+ALTER TABLE connected_system_intents
+  DROP CONSTRAINT IF EXISTS connected_system_intents_crm_zk_shape;
+
 ALTER TABLE connected_system_intents
   ADD CONSTRAINT connected_system_intents_crm_zk_shape CHECK (
     delivery_mode <> 'crm-zk.v1'


### PR DESCRIPTION
## UAT deploys are blocked right now

`deploy-uat.yml` applies migrations with `--migration-mode replay`, so every statement has to survive a second application. `141_crm_zk_v1.sql` is written that way throughout — `IF NOT EXISTS` on every table, index and column — except for one bare `ALTER TABLE ... ADD CONSTRAINT`. Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so that one line is not replay-safe.

The result: the migration succeeded the first time it ran (UAT deploy 31479267161, 09:47) and then poisoned the next release. The following deploy (31484014725) failed the predeploy schema gate with:

```
asyncpg.exceptions.DuplicateObjectError: constraint
"connected_system_intents_crm_zk_shape" for relation
"connected_system_intents" already exists
```

That gate runs **before** anything is built or deployed, so it blocks the whole release rather than degrading it — no image, no revision, nothing ships. Every UAT deploy would have failed identically until this was fixed.

## The fix

Guarded with the `DROP CONSTRAINT IF EXISTS` pattern this repo already uses for exactly this case — `019_vault_placeholder_user_state.sql`, `024_kai_plaid_refresh_cancel_status.sql`, `027_relationship_disconnect_status.sql` and others.

The constraint is a `CHECK`, so dropping and re-adding it re-validates existing rows in the same transaction rather than weakening anything.

## Scope check

I swept every other migration for the same hazard:

- `085_developer_partner_apps.sql` looks similar but is already guarded, via `information_schema.table_constraints` inside a `DO` block.
- `142_source_library_scope_retirement.sql` adds no constraints.

141 was the only one.

Found while deploying #5100 — that deploy never shipped because of this.
