### PR TITLE
fix(agent-setup): clear iOS safe-area so setup hero isn't pinned under the native header

### DIFF
--- a/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
@@ -163,7 +163,14 @@ export function CapabilityCinematicIntroGate({
 
   const content = (
     <section
-      className="motion-step-enter relative mx-auto flex min-h-[calc(100dvh-16rem)] w-full max-w-[36rem] flex-col items-center justify-center text-center"
+      // Centered hero. On the iOS Capacitor webview `100dvh` does NOT subtract
+      // the native top bar / status-bar safe area, so a purely centered block
+      // rode up under the header and the copy sat too close to the back arrow
+      // (web was already correct). Add the top safe-area inset as padding AND
+      // subtract it from the min-height so the block clears the native header
+      // while staying vertically balanced. `env(safe-area-inset-top)` is 0 on
+      // web/desktop, so this is a no-op there and only affects notched/native.
+      className="motion-step-enter relative mx-auto flex min-h-[calc(100dvh-16rem-env(safe-area-inset-top))] w-full max-w-[36rem] flex-col items-center justify-center pt-[max(2rem,env(safe-area-inset-top))] text-center"
       aria-labelledby={`capability-intro-${capabilityId}`}
       data-capability-cinematic-intro={capabilityId}
     >


### PR DESCRIPTION
## What & why

The agent-setup hero (RIA / Finance / KYC / connections) is correct on **web/UAT** after #5093, but on **iOS native** the same screen still sat too close to the top back-arrow header (and the eyebrow read cramped against it).

## Root cause

#5093 centers the hero with `min-h-[calc(100dvh-16rem)]` + `justify-center`. On the **iOS Capacitor webview**, `100dvh` does **not** subtract the native top bar / status-bar safe area, so the centered block rides up under the header. Web/desktop was already fine because there's no native header and the inset is 0.

## Fix (`components/onboarding/setup/capability-cinematic-intro.tsx`)

Make the shared intro safe-area aware — one class change on the hero `<section>`:
- Add top padding for the inset: `pt-[max(2rem,env(safe-area-inset-top))]`
- Subtract the same inset from the min-height so vertical centering stays balanced: `min-h-[calc(100dvh-16rem-env(safe-area-inset-top))]`

`env(safe-area-inset-top)` is **0 on web/desktop**, so this is a no-op there and only affects notched/native iOS — the hero now clears the native header on all three setup screens (RIA, Finance, KYC), matching web.

Since all three render through this one component, the fix applies uniformly; the eyebrow contrast (`font-medium text-foreground/80`) from #5093 is unchanged and already identical across them.

## Verification

- ESLint clean. Web layout unchanged (inset 0); iOS gains the top clearance.

## Risk

Low — one Tailwind class string in the shared intro; purely additive safe-area handling, no behavior/logic change.

## Note (separate, flagged)

The last UAT deploy failed on a **backend** step (`141_crm_zk_v1` migration — duplicate constraint), not frontend — an upstream branch `fix/migration-141-replay-idempotent` appears to already address it.
