### PR TITLE
fix(location): keep compact actions visually compact

### DIFF
--- a/hushh-webapp/__tests__/components/button-compact-typography.test.tsx
+++ b/hushh-webapp/__tests__/components/button-compact-typography.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TrustedPersonCard } from "@/components/one-location/redesign/cards";
+import { buttonVariants } from "@/components/ui/button";
+
+describe("Button compact typography", () => {
+  it("keeps the full-size label role off compact action sizes", () => {
+    for (const size of ["xs", "sm"] as const) {
+      expect(buttonVariants({ size })).not.toContain("ui-text-button-label");
+      expect(buttonVariants({ size })).not.toContain("min-h-[50px]");
+    }
+  });
+
+  it("keeps the Location trusted-person action compact", () => {
+    render(
+      <TrustedPersonCard
+        name="Smirthi"
+        actionLabel="Share"
+        onAction={() => {}}
+      />,
+    );
+
+    const shareButton = screen.getByRole("button", { name: "Share" });
+    expect(shareButton.className).toContain("min-h-9");
+    expect(shareButton.className).toContain("text-sm");
+    expect(shareButton.className).not.toContain("ui-text-button-label");
+    expect(shareButton.className).not.toContain("min-h-[50px]");
+  });
+
+  it("retains the full-size label role for standard call-to-action sizes", () => {
+    expect(buttonVariants({ size: "default" })).toContain(
+      "ui-text-button-label",
+    );
+    expect(buttonVariants({ size: "default" })).toContain("min-h-[50px]");
+    expect(buttonVariants({ size: "lg" })).toContain("ui-text-button-label");
+    expect(buttonVariants({ size: "lg" })).toContain("min-h-[50px]");
+  });
+});

--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "ui-text-button-label inline-flex min-h-[50px] items-center justify-center gap-2 whitespace-nowrap rounded-full transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
   {
     variants: {
       variant: {
@@ -22,10 +22,11 @@ const buttonVariants = cva(
         link: "min-h-0 rounded-none text-[color:var(--app-accent)] underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-[50px] px-4 py-3 has-[>svg]:px-3",
+        default:
+          "ui-text-button-label min-h-[50px] h-[50px] px-4 py-3 has-[>svg]:px-3",
         xs: "min-h-7 h-7 gap-1 rounded-[var(--app-radius-sm)] px-2 text-[13px] font-semibold leading-[18px] has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "min-h-9 h-9 rounded-[var(--app-radius-md)] gap-1.5 px-3 text-[15px] font-semibold leading-[20px] has-[>svg]:px-2.5",
-        lg: "h-[50px] rounded-full px-6 has-[>svg]:px-4",
+        lg: "ui-text-button-label min-h-[50px] h-[50px] rounded-full px-6 has-[>svg]:px-4",
         icon: "size-9 rounded-full",
         "icon-xs": "size-6 rounded-full [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",


### PR DESCRIPTION
## Description

Location Agent compact actions inherited the full-size button label role and 50px minimum height. On UAT, the trusted-person **Share** action rendered at 17px / 600 weight / 22px line-height and 50px high even though it uses the compact `sm` size.

### UAT reproduction

Observed twice in the existing authenticated Chrome session at `/one/location?view=people` without sending a share:

1. Open Location > People and inspect a trusted-person Share action.
2. Expected: compact action typography and height.
3. Actual (2/2): 17px / 600 / 22px and 50px high.

### Root cause and fix

`Button` applied `ui-text-button-label` and `min-h-[50px]` in its shared base classes. The semantic label rule uses `!important`, so it overrode compact `xs` / `sm` typography, while the base minimum height overrode compact heights.

This moves the full-size semantic label role and 50px minimum height to only `default` and `lg`, preserving compact typography and dimensions for `xs` and `sm`.

## 📌 Impact Map

- Routes touched: `/one/location?view=people` (shared Button consumer; no route file changed)
- API / schema / type changes: None
- Cache keys touched: None
- Runtime DB data-plane changes: None
- World-model domain summary effects: None
- Mobile parity impacts: Compact shared actions now use the intended 36px `sm` contract on responsive web/native-web surfaces
- Docs updated: None; existing design-system contract is restored
- Top-level / devex / config / generated / ignore files touched: None
- Trust boundary touched: None
- Caller / proxy / backend pairing: Not applicable
- Rollback / safe failure: Revert this commit; standard and large CTA sizing is explicitly regression-tested
- UI proof: UAT `/one/location?view=people`; fixed local `/one/connect` desktop and 390×844 mobile; local Location People checked at 390px

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; no exact overlap. PR #5094 does not modify `components/ui/button.tsx`.
- [x] Reachable production attach point: shared `Button` used by Location `TrustedPersonCard`.
- [x] New test imports and renders production code.
- [x] Production surface proved by rendering the real Location Share action.
- [x] DCO signoff passed and GitHub reports the branch mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] Not a stacked PR.

## 🧪 Regression proof and checks

Before the production fix, the focused regression failed because compact sizes contained `ui-text-button-label`.

Passed locally:

- [x] `npm.cmd exec vitest -- run __tests__/components/button-compact-typography.test.tsx --reporter=verbose --pool=threads --maxWorkers=1` — 3/3
- [x] focused ESLint
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run verify:design-system`
- [x] `npm run verify:cache` — 57 tests
- [x] `npm run verify:docs`
- [x] `npm run build` — 145 static pages
- [x] `git diff --check`
- [x] DCO signoff check

Neighbor Location page suite: 57 passed; 2 failures reproduce unchanged on clean `upstream/main` and are outside this two-file diff.

## Browser verification

- Desktop compact Connect action: 15px / 600 / 20px, 36px high
- 390×844 mobile compact Connect action: 15px / 600 / 20px, 36px high
- Location People at 390px: no horizontal overflow

The local authenticated account had no trusted-person Share row, so the exact Share row could not be exercised locally without creating another auth session. The component regression directly renders that Location Share control. No location share or connection request was sent.

## Tri-Flow Architecture Check

- [x] Web: shared frontend Button contract
- [x] iOS: no native plugin change; shared Capacitor web UI consumes the same Button
- [x] Android: no native plugin change; shared Capacitor web UI consumes the same Button

## Privacy, consent, and licensing

- [x] Does not change access to user information
- [x] Sensitive surface: none
- [x] No dependency or third-party notice change
- [x] First-party changes remain Apache-2.0 compatible