### PR TITLE
fix(one-location): send Emergency contacts back where it was opened from

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-back-flow.test.ts
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-back-flow.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSmsContactsBackFlow } from "@/components/one-location/redesign/location-redesign-hub";
+
+/**
+ * Emergency contacts has two openers, Settings and SOS, and one back arrow.
+ *
+ * It was hardcoded to Settings on the reasoning that contacts were "only ever
+ * opened from Settings". The SOS entry point was added later and the assumption
+ * was never revisited, so editing contacts mid-emergency dropped the person out
+ * of the SOS flow entirely. These cases exist so a third opener cannot repeat
+ * that quietly.
+ */
+describe("resolveSmsContactsBackFlow", () => {
+  it("returns to SOS when SOS opened it", () => {
+    expect(resolveSmsContactsBackFlow("sos")).toBe("sos");
+  });
+
+  it("returns to Settings for every other opener", () => {
+    expect(resolveSmsContactsBackFlow("settings")).toBe("settings");
+    expect(resolveSmsContactsBackFlow("nearby")).toBe("settings");
+  });
+
+  it("falls back to Settings when no source is recorded", () => {
+    // A direct link or a refresh carries no source. Settings is the safe
+    // default because every other entry point lives there.
+    expect(resolveSmsContactsBackFlow(null)).toBe("settings");
+    expect(resolveSmsContactsBackFlow(undefined)).toBe("settings");
+    expect(resolveSmsContactsBackFlow("")).toBe("settings");
+  });
+
+  it("does not treat a near-miss source as SOS", () => {
+    // The value is compared exactly, so a stale or spoofed param cannot land
+    // someone in a flow they never opened.
+    expect(resolveSmsContactsBackFlow("SOS")).toBe("settings");
+    expect(resolveSmsContactsBackFlow("sos-panel")).toBe("settings");
+    expect(resolveSmsContactsBackFlow(" sos")).toBe("settings");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -398,6 +398,10 @@ const FLOW_ACTION_PARAM = "action";
 const FLOW_SOURCE_PARAM = "source";
 const PRIVATE_CHECK_IN_ACTION = "private-check-in";
 const NEARBY_CHECK_IN_SOURCE = "nearby";
+// Emergency contacts is reachable from Settings AND from SOS, so its back arrow
+// cannot be a constant. Recording the opener in the URL keeps the in-content
+// arrow agreeing with the chrome and OS back buttons, which follow real history.
+const SOS_FLOW_SOURCE = "sos";
 
 const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
   share: "share",
@@ -415,6 +419,24 @@ const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
   "shared-with-me": "shared-with-me",
   "needs-review": "needs-review",
 };
+
+/**
+ * Where the Emergency-contacts back arrow goes.
+ *
+ * It has two openers -- Settings and SOS -- so a fixed target is wrong for one
+ * of them. This used to be hardcoded to Settings on the reasoning that contacts
+ * were "only ever opened from Settings"; the SOS entry point was added later and
+ * the assumption was never revisited, so anyone editing contacts mid-emergency
+ * was dropped out of the SOS flow.
+ *
+ * Settings stays the default: an unknown or absent source means the person did
+ * not arrive from SOS, and Settings is where the rest of the entry points live.
+ */
+export function resolveSmsContactsBackFlow(
+  source: string | null | undefined,
+): "sos" | "settings" {
+  return source === SOS_FLOW_SOURCE ? "sos" : "settings";
+}
 
 const RETIRED_ACTIONS = new Set([
   "drive-to",
@@ -558,6 +580,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const nearbyPrivateCheckIn =
     searchParams.get(FLOW_ACTION_PARAM) === PRIVATE_CHECK_IN_ACTION &&
     searchParams.get(FLOW_SOURCE_PARAM) === NEARBY_CHECK_IN_SOURCE;
+  const smsContactsBackFlow = resolveSmsContactsBackFlow(
+    searchParams.get(FLOW_ACTION_PARAM) === FLOW_TO_ACTION["sms-contacts"]
+      ? searchParams.get(FLOW_SOURCE_PARAM)
+      : null,
+  );
   const nearbyReturnToken = searchParams.get(NEARBY_PRIVATE_RETURN_TOKEN_PARAM);
   const nearbyCheckInReturnHref =
     nearbyPrivateCheckIn && isNearbyPrivateReturnToken(nearbyReturnToken)
@@ -667,12 +694,18 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   // been removed from the flows — each action screen shows exactly one back
   // affordance plus its own Cancel/Done control.
   const openFlow = useCallback(
-    (next: Exclude<FlowKind, "none">) => {
+    (next: Exclude<FlowKind, "none">, source?: string) => {
       setFlow(next);
       activeFlowRef.current = next;
       pendingFlowRef.current = next;
       const params = new URLSearchParams(searchParams.toString());
-      params.delete(FLOW_SOURCE_PARAM);
+      // Carrying no source is the normal case and must clear a stale one,
+      // otherwise the previous flow's opener would be inherited by the next.
+      if (source) {
+        params.set(FLOW_SOURCE_PARAM, source);
+      } else {
+        params.delete(FLOW_SOURCE_PARAM);
+      }
       params.set(FLOW_ACTION_PARAM, FLOW_TO_ACTION[next]);
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     },
@@ -899,7 +932,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <SosFlow
             vm={vm}
             onClose={() => closeFlow("now")}
-            onEditContacts={() => openFlow("sms-contacts")}
+            onEditContacts={() => openFlow("sms-contacts", SOS_FLOW_SOURCE)}
           />
         ) : flow === "sms-contacts" ? (
           <SmsContactsFlow
@@ -907,10 +940,12 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             circles={vm.circles}
             selectedUserIds={vm.smsContactUserIds}
             busyKey={vm.busy}
-            // SMS contacts is only ever opened from Settings, so its in-content
-            // back arrow returns to Settings (not the default "Now" tab), which
-            // matches the chrome/OS back button behavior.
-            onBack={() => openFlow("settings")}
+            // Emergency contacts is opened from Settings and from SOS, so the
+            // back arrow follows whoever opened it rather than a fixed target.
+            // Sending someone from SOS back to Settings drops them out of the
+            // emergency flow they were in the middle of, which is the worst
+            // moment to make them find their way back.
+            onBack={() => openFlow(smsContactsBackFlow)}
             onAdd={vm.onAddSmsContact}
             onAddCircle={vm.onAddSmsCircle}
             onRemove={vm.onRemoveSmsContact}


### PR DESCRIPTION
## The bug

Open SOS → tap Edit contacts → press back. You land on **Location settings**, not SOS — dropped out of the emergency flow you were in the middle of. That is the worst possible moment to make someone find their own way back.

## Why

Emergency contacts has two openers, Settings and SOS, and one back arrow. The arrow was hardcoded to Settings, under this comment:

```
// SMS contacts is only ever opened from Settings, so its in-content
// back arrow returns to Settings (not the default "Now" tab), which
// matches the chrome/OS back button behavior.
```

That was true when it was written. The SOS entry point (`onEditContacts`) was added later and the assumption was never revisited, so the arrow kept pointing somewhere half the callers had not come from.

Worth noting the comment's own justification had already stopped holding: the chrome and OS back buttons follow real history, so from SOS they returned to SOS correctly while the in-content arrow did not. The two had silently diverged.

## The fix

The opener is recorded in the existing `source` query param rather than in new state — `NEARBY_CHECK_IN_SOURCE` already uses it for exactly this purpose. Keeping it in the URL means a refresh or a shared link resolves the same way a live navigation does.

`openFlow` now takes an optional source and still clears a stale one when none is given, so the previous flow's opener cannot be inherited by the next.

The decision is a named pure function, `resolveSmsContactsBackFlow`, rather than an inline ternary — the original defect was an implicit assumption nobody revisited when a second caller appeared, so the rule is now stated once and tested. Settings remains the default: an absent or unrecognized source means the person did not arrive from SOS.

## Verification

`typecheck`, `lint`, `verify:design-system`, `verify:voice-gateway`, `verify:surface-map` all green.

New unit tests cover the SOS case, the Settings case, a missing source (direct link or refresh), and near-miss values (`"SOS"`, `"sos-panel"`, `" sos"`) so a stale or spoofed param cannot land someone in a flow they never opened.

One **pre-existing** failure in `sos-panel.test.tsx` ("keeps the SMS action in one centered stack on large screens") is unrelated to this change — it fails identically with these changes stashed, and it is a CSS-layout assertion on a component this PR does not touch. CI does not run vitest.
