### PR TITLE
fix(one-location): stop reporting a partial contact read as a whole one

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { describeContactSyncOutcome } from "@/lib/one-location/contact-signals";
+
+/**
+ * A partial contact read must never be reported as a whole one.
+ *
+ * The web Contact Picker and iOS limited access both return only a hand-picked
+ * subset. Phrasing that as "3 people added as a contact signal" tells the user
+ * their whole address book was searched, which is the wrong conclusion to draw
+ * about who is and is not on Hushh.
+ */
+const base = {
+  matchedUserIds: [] as string[],
+  totalContacts: 0,
+  sourcePlatform: "android" as const,
+  limited: false,
+  truncated: false,
+};
+
+describe("describeContactSyncOutcome", () => {
+  it("reports a full read as a plain count with no remedy", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a", "b", "c"],
+      totalContacts: 400,
+    });
+    expect(outcome.title).toBe("3 people added as a contact signal.");
+    expect(outcome.remedy).toBeNull();
+    expect(outcome.description).toBeUndefined();
+  });
+
+  it("says how many of the shared contacts matched when access was partial", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a", "b", "c"],
+      totalContacts: 40,
+      sourcePlatform: "web",
+      limited: true,
+    });
+    // The count must be scoped to what was actually checked.
+    expect(outcome.title).toBe("3 of the 40 contacts you shared are on Hushh");
+    expect(outcome.description).toContain("not your whole address book");
+  });
+
+  it("offers the picker again on web, never a settings page that cannot help", () => {
+    // openAppSettings resolves false in a browser, so a Settings action there
+    // is a button that silently does nothing.
+    const web = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 10,
+      sourcePlatform: "web",
+      limited: true,
+    });
+    expect(web.remedy).toBe("pick_more");
+  });
+
+  it("offers settings on iOS limited access, where the subset is sticky", () => {
+    const ios = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a"],
+      totalContacts: 12,
+      sourcePlatform: "ios",
+      limited: true,
+    });
+    expect(ios.remedy).toBe("open_settings");
+    expect(ios.description).toContain("shared with Hushh");
+  });
+
+  it("does not claim nobody matched when only a subset was searched", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 25,
+      sourcePlatform: "web",
+      limited: true,
+    });
+    expect(outcome.title).toBe(
+      "None of the 25 contacts you shared are on Hushh yet",
+    );
+    expect(outcome.title).not.toContain("No One users matched");
+  });
+
+  it("still reports a genuine empty result plainly on a full read", () => {
+    const outcome = describeContactSyncOutcome({ ...base, totalContacts: 300 });
+    expect(outcome.title).toBe("No One users matched from this contact scan.");
+    expect(outcome.remedy).toBeNull();
+  });
+
+  it("flags a truncated book, which is partial for a different reason", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a"],
+      totalContacts: 5000,
+      truncated: true,
+    });
+    expect(outcome.title).toBe("1 person added as a contact signal.");
+    expect(outcome.description).toContain("larger than the sync limit");
+  });
+
+  it("uses singular wording for a single contact and a single match", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a"],
+      totalContacts: 1,
+      sourcePlatform: "web",
+      limited: true,
+    });
+    expect(outcome.title).toBe("1 of the 1 contact you shared is on Hushh");
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -162,6 +162,7 @@ import {
 } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
+  describeContactSyncOutcome,
   openContactPermissionSettings,
   syncOneLocationContactSignals,
   OneLocationContactSyncError,
@@ -4665,6 +4666,10 @@ export function OneLocationAgentPageContent({
     }
   }, [refresh, sosIncident, vaultOwnerToken]);
 
+  // Lets the "Check more" remedy re-run the sync (and so reopen the web
+  // Contact Picker) without the callback having to reference itself.
+  const handleSyncContactSignalRef = useRef<(() => Promise<void>) | null>(null);
+
   const handleSyncContactSignal = useCallback(async () => {
     if (!auth.user?.getIdToken) {
       const message = "Sign in before syncing contacts.";
@@ -4717,25 +4722,34 @@ export function OneLocationAgentPageContent({
         partial_access: result.limited,
         truncated: result.truncated,
       });
+      // A partial read must never be reported as a whole one. The web Contact
+      // Picker and iOS limited access both return only a hand-picked subset,
+      // so "3 people added" would claim the whole address book was searched.
+      const outcome = describeContactSyncOutcome(result);
+      const outcomeOptions = {
+        description: outcome.description,
+        ...(outcome.remedy === "pick_more"
+          ? {
+              action: {
+                label: "Check more",
+                // Re-running the sync reopens the picker. There is no settings
+                // page to send a browser to; openAppSettings resolves false.
+                onClick: () => void handleSyncContactSignalRef.current?.(),
+              },
+            }
+          : outcome.remedy === "open_settings"
+            ? {
+                action: {
+                  label: "Open Settings",
+                  onClick: () => void openContactPermissionSettings(),
+                },
+              }
+            : {}),
+      };
       if (result.matchedUserIds.length > 0) {
-        toast.success(
-          `${peopleCountLabel(
-            result.matchedUserIds.length,
-          )} added as a contact signal.`,
-        );
-      } else if (result.limited) {
-        // Partial access means the scan only saw the contacts the OS shared,
-        // so "no matches" says nothing about the rest of the book.
-        toast.info("No matches in the contacts you shared.", {
-          description:
-            "Hussh could only read the contacts you picked. Share more to widen the search.",
-          action: {
-            label: "Settings",
-            onClick: () => void openContactPermissionSettings(),
-          },
-        });
+        toast.success(outcome.title, outcomeOptions);
       } else {
-        toast.info("No One users matched from this contact scan.");
+        toast.info(outcome.title, outcomeOptions);
       }
     } catch (error) {
       const failure =
@@ -4777,6 +4791,10 @@ export function OneLocationAgentPageContent({
       setBusy(null);
     }
   }, [auth.user, contactSignal]);
+
+  useEffect(() => {
+    handleSyncContactSignalRef.current = handleSyncContactSignal;
+  }, [handleSyncContactSignal]);
 
   const handleRequestAccess = useCallback(async (reason?: string | null) => {
     if (!vaultOwnerToken || !selectedRequestOwners.length) return;

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -168,3 +168,84 @@ export async function openContactPermissionSettings(): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * How a completed sync should be reported, and what the user can do about it.
+ *
+ * Kept pure and separate from the toast so the wording is testable. It exists
+ * because a partial read was being reported as if it were a whole one: the web
+ * Contact Picker and iOS limited access both return only a hand-picked subset,
+ * yet a match count phrased as "3 people added" reads as though the entire
+ * address book was searched.
+ */
+export type ContactSyncRemedy =
+  /** Re-run the picker so more contacts can be included (web). */
+  | "pick_more"
+  /** Open OS settings to widen contact access (iOS limited access). */
+  | "open_settings"
+  | null;
+
+export type ContactSyncOutcome = {
+  title: string;
+  description?: string;
+  remedy: ContactSyncRemedy;
+};
+
+function peopleLabel(count: number): string {
+  return count === 1 ? "1 person" : `${count} people`;
+}
+
+function contactsLabel(count: number): string {
+  return count === 1 ? "1 contact" : `${count} contacts`;
+}
+
+export function describeContactSyncOutcome(
+  result: Pick<
+    OneLocationContactSignalResult,
+    "matchedUserIds" | "totalContacts" | "sourcePlatform" | "limited" | "truncated"
+  >,
+): ContactSyncOutcome {
+  const matched = result.matchedUserIds.length;
+
+  // The picker grants per-invocation and has no settings page to open, so
+  // offering "Settings" there sends the user somewhere that cannot help —
+  // openAppSettings resolves false on web. Re-running the picker is the only
+  // real remedy. iOS limited access is the opposite: the subset is sticky
+  // until it is widened in Settings.
+  const remedy: ContactSyncRemedy = !result.limited
+    ? null
+    : result.sourcePlatform === "web"
+      ? "pick_more"
+      : "open_settings";
+
+  if (result.limited) {
+    const scanned = contactsLabel(result.totalContacts);
+    return {
+      title: matched
+        ? `${matched} of the ${scanned} you shared ${matched === 1 ? "is" : "are"} on Hushh`
+        : `None of the ${scanned} you shared are on Hushh yet`,
+      description:
+        remedy === "pick_more"
+          ? "Only the contacts you picked were checked, not your whole address book."
+          : "Only the contacts you shared with Hushh were checked.",
+      remedy,
+    };
+  }
+
+  if (!matched) {
+    return {
+      title: "No One users matched from this contact scan.",
+      remedy: null,
+    };
+  }
+
+  return {
+    title: `${peopleLabel(matched)} added as a contact signal.`,
+    // A truncated read is still a partial answer, just for a different reason:
+    // the book was larger than the caps rather than deliberately narrowed.
+    description: result.truncated
+      ? "Your address book was larger than the sync limit, so some contacts were not checked."
+      : undefined,
+    remedy: null,
+  };
+}


### PR DESCRIPTION
## Why

Found while testing contact sync on Chrome for Android. The web Contact Picker asks the user to pick contacts, then returns **only those** — never the address book. Same for iOS limited access. The success toast ignored that:

> "3 people added as a contact signal."

That reads as though the whole address book was searched, so *"nobody else I know is on Hushh"* is a wrong conclusion a user could reasonably draw from it. The `limited` flag was already plumbed all the way through from the plugin and was only consulted on the **empty-result** branch.

## What changes

Partial reads now say what was actually checked:

| | before | after |
|---|---|---|
| picker, 3 matched of 40 picked | `3 people added as a contact signal.` | `3 of the 40 contacts you shared are on Hushh` |
| picker, 0 matched of 25 picked | `No matches in the contacts you shared.` | `None of the 25 contacts you shared are on Hushh yet` |
| full native read | `3 people added as a contact signal.` | unchanged |

## A remedy that could not work

The partial-result toast offered **"Settings"** on every platform. On web, `openAppSettings` resolves `false` and there is no per-site contacts page to open — the button silently did nothing.

- **web** → "Check more", which re-runs the sync and reopens the picker
- **iOS limited access** → keeps "Open Settings", where the subset genuinely is sticky

## Shape

The wording lives in a pure `describeContactSyncOutcome` helper so the distinction is unit-testable rather than asserted through a toast. Also surfaces `truncated` (address book larger than the sync caps) on the success path, which was likewise being reported as a complete read.

## Verified

- 8 new unit tests, including singular/plural and each platform's remedy
- `tsc --noEmit` → exit **0** (real compiler exit code, not a piped status)
- 128 passing across the contact and one-location suites

Two failures in `one-location-agent-page.test.tsx` and 5 eslint errors in `page.tsx` reproduce identically on clean `origin/main` with none of these changes applied — pre-existing, not introduced here.

## Note

This only affects the browser and iOS-limited paths. The full native read on iOS/Android is unchanged and still cannot be exercised until a mobile build ships with a `google-services.json` carrying a `com.hussh.app` client.
