### PR TITLE
fix(location): gate Send request on explicit isFormValid (recipient+duration+reason)

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2512,17 +2512,34 @@ function AskFlow({
         description="They approve, decline, or ignore."
       />
 
-      <Button
-        onClick={() => {
-          vm.onSendRequest(reason);
-          onClose();
-        }}
-        disabled={!vm.selectedRequestOwnerIds.length}
-        isLoading={vm.busy === "request"}
-        className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:opacity-50"
-      >
-        Send request
-      </Button>
+      {/* Single source of truth for whether the request can be sent: at least
+          one recipient AND a duration AND a reason must be chosen. Previously
+          the button only checked the recipient count, so it could look/act
+          submittable before every required selection existed. */}
+      {(() => {
+        const isFormValid =
+          vm.selectedRequestOwnerIds.length > 0 &&
+          Boolean(vm.durationHours) &&
+          Boolean(reason);
+        const sending = vm.busy === "request";
+        return (
+          <Button
+            onClick={() => {
+              // Never submit an incomplete form even if the click somehow
+              // reaches the handler (e.g. keyboard/AT), and never double-fire.
+              if (!isFormValid || sending) return;
+              vm.onSendRequest(reason);
+              onClose();
+            }}
+            disabled={!isFormValid || sending}
+            aria-disabled={!isFormValid || sending}
+            isLoading={sending}
+            className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:opacity-50"
+          >
+            Send request
+          </Button>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## What & why

In the Location "Ask / Request" flow, the **Send request** button could look/act submittable before every required selection existed — it only checked the recipient count. This adds a single, explicit `isFormValid` and binds the button to it.

## Fix (`components/one-location/redesign/location-redesign-hub.tsx`, `AskFlow`)

- **Centralized validity:**
  ```tsx
  const isFormValid =
    vm.selectedRequestOwnerIds.length > 0 &&  // recipient
    Boolean(vm.durationHours) &&              // duration
    Boolean(reason);                          // reason
  ```
- **Button bound to it:** `disabled={!isFormValid || sending}`, `aria-disabled` set to match, `disabled:opacity-50` (dim) **and `disabled:pointer-events-none`** so it's visually and interactively inert until valid.
- **No incomplete / double submit:** the click handler early-returns `if (!isFormValid || sending)` before calling `vm.onSendRequest`, so keyboard/AT activation or a double-tap can't fire an incomplete or duplicate request.

Duration and reason already default to sensible values, so in normal use the button enables once a recipient is picked; the change makes the guarantee explicit and covers the edge cases (deselecting everyone, a future non-defaulted reason/duration).

## Routing note

Success routing was already correct: `onSendRequest` runs, then `onClose()` strips the `?action=` param and returns to the Location hub (the shared route effect handles this). No orphaned/loading state. Auto-share `CLLocationManager` re-registration in the ticket is native-only and not applicable to this Capacitor web layer.

## Verification

- ESLint clean. Web + iOS both benefit (same component).

## Risk

Low — one button's gating + a guard clause in one flow; no data/API change.
