### PR TITLE
fix(shell): add touch-manipulation to top-bar controls to kill iOS double-tap delay

### DIFF
--- a/hushh-webapp/components/app-ui/shell-action-surface.tsx
+++ b/hushh-webapp/components/app-ui/shell-action-surface.tsx
@@ -16,7 +16,10 @@ import { cn } from "@/lib/utils";
 // carry the muted eyebrow tone on the stroke and warm to full foreground on
 // hover; pill controls add horizontal padding + label text.
 const shellActionSurfaceVariants = cva(
-  "shell-action-surface group/shell-action relative isolate inline-flex overflow-hidden rounded-full border border-[color:var(--app-glass-border)] bg-[color:var(--app-glass-surface)] shadow-[var(--app-glass-shadow)] transition-[color,background-color,transform] duration-200 hover:bg-[color:var(--app-shell-surface-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-60",
+  // `touch-manipulation` removes the iOS ~300ms double-tap delay that made the
+  // top-bar back/close controls feel like they needed a second tap. Kept on the
+  // base so every shell control (back, close, theme, profile) gets it.
+  "shell-action-surface group/shell-action relative isolate inline-flex touch-manipulation overflow-hidden rounded-full border border-[color:var(--app-glass-border)] bg-[color:var(--app-glass-surface)] shadow-[var(--app-glass-shadow)] transition-[color,background-color,transform] duration-200 hover:bg-[color:var(--app-shell-surface-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-60",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## What & why

Top-bar back / close / action controls (`ShellActionSurface` — the shared back arrow, close X, profile, theme, etc.) often felt like they needed a second tap on iOS. Root cause: the control had no `touch-manipulation`, so the WebKit ~300ms double-tap-to-zoom delay sat in front of every tap.

## Fix (`components/app-ui/shell-action-surface.tsx`)

Add `touch-manipulation` to the shared base class of `ShellActionSurface`. This disables the double-tap-zoom gesture on these controls so a single tap registers immediately — the web/Capacitor equivalent of the ticket's "dismiss on the main thread / expand hit target" intent.

- Applied on the **base** variant, so it covers every top-bar control (back, close, theme toggle, profile, account menu, vault unlock) in one place.
- `overflow-hidden` is preserved (the MaterialRipple relies on it), so there's no visual change and no ripple bleed.

## Premise notes (translated from the native-worded ticket)

- The back button wrapper is already `h-11 w-11` (44pt) and uses `router.back()`/`navigateTopShellBack` — no main-thread blocking exists in this web layer.
- The **Map overlay close (X)** z-index / pointer-events and the native-map gesture interception were already fixed earlier (#5081 / #5082 / #5090).
- `interactivePopGestureRecognizer` / `DispatchQueue.main.async` are native UIKit APIs with no analog in this Next.js + Capacitor shell.

This PR is the one genuinely-unshipped, cross-cutting piece: the missing tap-delay suppression, which is exactly what makes taps feel like they "need a second press."

## Verification

- ESLint clean. No visual/layout change; behavior-only (removes tap latency).

## Risk

Very low — one Tailwind utility on a shared control class; additive, no logic change.
