### PR TITLE
fix(location): raise Your Map top controls above overlay so close X stays tappable

### DIFF
--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1598,7 +1598,12 @@ export function LocationImmersiveMap({
       />
       <div
         ref={topControlsRef}
-        className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-3 p-4 pt-[max(1rem,env(safe-area-inset-top))]"
+        // z-30 (above the z-20 map loading/error overlay and people tray): at
+        // equal z-index the later-in-DOM full-screen overlay painted on top of
+        // the close X and could swallow the tap that dismisses the map. Keeping
+        // the controls strictly above every map layer guarantees the back/X and
+        // locate buttons stay tappable in every state (loading, error, tray open).
+        className="pointer-events-none absolute inset-x-0 top-0 z-30 flex items-center justify-between gap-3 p-4 pt-[max(1rem,env(safe-area-inset-top))]"
       >
         <ShellActionSurface
           className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}


### PR DESCRIPTION
## What & why

On Your Map, the top-right close (**X**) — and the Locate control — could fail to register a tap in certain states. Root cause: the top-controls bar was `z-20`, the **same** z-index as the full-screen map **loading/error overlay** (`absolute inset-0 z-20`) and the people tray. At equal z-index the later-in-DOM full-screen overlay paints on top of the controls and swallows the tap that should dismiss the map — matching the "X does nothing / needs multiple taps" report, especially while the map is still loading or when the Maps renderer is unavailable.

## Fix (`components/one-location/location-immersive-map.tsx`)

Raise the top-controls container from `z-20` → **`z-30`**, so the back/close X and Locate button sit strictly above every map layer (native canvas, loading/error overlay, people tray, legends) in **every** state — loading, ready, error/unavailable, and tray-open.

This complements the existing hardening already in this component (immediate native-map `destroy()` + `disableTouch()` on close, `touch-manipulation`, `onPointerUp` touch fallback, 56px `!h-14 !w-14` targets, and the 1.2s hard-navigation guaranteed-exit).

## Verification

- ESLint clean on the file. Behavior-only, one Tailwind class; no layout/visual change (the controls already rendered above the map — this only guarantees they also sit above the equal-z overlay).
- Note: 4 pre-existing TS "cannot find module '@capacitor/google-maps'" errors show locally because that native dep isn't installed in this checkout; they're unrelated to this one-line change and resolve in CI where deps are installed.

## Risk

Very low — single z-index bump on the controls layer; strictly raises tap priority of the close/locate buttons.
