### PR TITLE
feat(crm): add encrypted UAT compatibility profile

### DIFF
--- a/consent-protocol/api/routes/connected_systems.py
+++ b/consent-protocol/api/routes/connected_systems.py
@@ -127,6 +127,42 @@ class CrmZkApprovalProofRequest(BaseModel):
     )
 
 
+class CrmZkUatSearchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    object_type: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("objectType", "object_type"),
+        max_length=80,
+    )
+    return_fields: list[str] = Field(
+        validation_alias=AliasChoices("returnFields", "return_fields"),
+        min_length=1,
+        max_length=128,
+    )
+    encrypted_fields: dict[str, Any] = Field(
+        validation_alias=AliasChoices("encryptedFields", "encrypted_fields")
+    )
+
+
+class CrmZkUatUpdateIntentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    object_type: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("objectType", "object_type"),
+        max_length=80,
+    )
+    field_names: list[str] = Field(
+        validation_alias=AliasChoices("fieldNames", "field_names"),
+        min_length=1,
+        max_length=128,
+    )
+    encrypted_fields: dict[str, Any] = Field(
+        validation_alias=AliasChoices("encryptedFields", "encrypted_fields")
+    )
+
+
 class CrmDeleteRequest(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -443,6 +479,69 @@ async def update_connected_system_record_intent_crm_zk(
         _raise_connected_system_error(error)
 
 
+@router.get("/{system_id}/crm-zk-uat/config")
+async def get_connected_system_crm_zk_uat_config(
+    system_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _ = _user_id(token_data)
+    try:
+        return get_connected_systems_service().crm_zk_uat_configuration(system_id=system_id)
+    except ConnectedSystemsError as error:
+        _raise_connected_system_error(error)
+
+
+@router.post("/{system_id}/records/search-zk-uat")
+async def search_connected_system_record_crm_zk_uat(
+    body: CrmZkUatSearchRequest,
+    system_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    service = get_connected_systems_service()
+    try:
+        mapping = await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
+        search_field_names = [
+            str(mapping[name])
+            for name in ("email", "phone")
+            if str(mapping.get(name) or "").strip()
+        ]
+        return await service.search_record_crm_zk_uat(
+            user_id=_user_id(token_data),
+            system_id=system_id,
+            object_type=body.object_type,
+            return_fields=body.return_fields,
+            search_field_names=search_field_names,
+            encrypted_fields=body.encrypted_fields,
+        )
+    except ConnectedSystemsError as error:
+        _raise_connected_system_error(error)
+
+
+@router.post("/{system_id}/records/update-intents-zk-uat")
+async def update_connected_system_record_intent_crm_zk_uat(
+    body: CrmZkUatUpdateIntentRequest,
+    system_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    service = get_connected_systems_service()
+    try:
+        mapping = await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
+        return await service.create_crm_zk_uat_update_intent(
+            user_id=_user_id(token_data),
+            system_id=system_id,
+            object_type=body.object_type,
+            field_names=body.field_names,
+            encrypted_fields=body.encrypted_fields,
+            locked_field_names=set(mapping.values()),
+        )
+    except ConnectedSystemsError as error:
+        _raise_connected_system_error(error)
+
+
 @router.delete("/{system_id}/record-binding")
 async def disconnect_connected_system_record_binding(
     system_id: str = Path(..., min_length=1, max_length=128),
@@ -662,6 +761,20 @@ async def approve_connected_system_crm_zk_intent(
             system_id=system_id,
             intent_id=intent_id,
             approval_proof=body.approval_proof,
+        )
+    except ConnectedSystemsError as error:
+        _raise_connected_system_error(error)
+
+
+@router.post("/{system_id}/intents/{intent_id}/approve-zk-uat")
+async def approve_connected_system_crm_zk_uat_intent(
+    system_id: str = Path(..., min_length=1, max_length=128),
+    intent_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return await get_connected_systems_service().approve_crm_zk_uat_intent(
+            user_id=_user_id(token_data), system_id=system_id, intent_id=intent_id
         )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)

--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -1002,9 +1002,7 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 # re-ran work it had already completed -- the share landed, the
                 # composer cleared, and every retry found nothing selected.
                 if settlement["status"] in {"succeeded", "started", "noop"}:
-                    record_completed_action(
-                        session_id, settlement["action_id"], settled_slots
-                    )
+                    record_completed_action(session_id, settlement["action_id"], settled_slots)
                 raw_settlement = raw_settlement if isinstance(raw_settlement, dict) else {}
                 receipt = _bounded_text(raw_settlement.get("receipt"), 256)
                 try:
@@ -1127,9 +1125,7 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                     # no second publish. The live snapshot is already
                     # sanitized and `continue_app_goal` will still verify its
                     # fresh revision before issuing the destination action.
-                    if _goal_continuation_is_already_ready(
-                        latest_context, continuation_screen
-                    ):
+                    if _goal_continuation_is_already_ready(latest_context, continuation_screen):
                         awaiting_goal_context.pop(goal_id, None)
                         continuation_ready_now = True
                         logger.info(

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 142,
+  "expected_migration_version": 143,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 142,
+  "expected_migration_version": 143,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1040,6 +1040,7 @@
       "configuration_revision",
       "validated_at",
       "crm_zk_v1_enabled",
+      "crm_zk_uat_v1_enabled",
       "mulesoft_connector_ref"
     ],
     "crm_operation_endpoints": [
@@ -1051,7 +1052,8 @@
       "description",
       "mcp_endpoint",
       "response_contract",
-      "crm_zk_tool_name"
+      "crm_zk_tool_name",
+      "crm_zk_uat_tool_name"
     ],
     "crm_zk_recipient_keys": [
       "crm_id",
@@ -1062,6 +1064,19 @@
       "response_signing_key_id",
       "response_signing_key_fingerprint",
       "profile",
+      "environment",
+      "status",
+      "activated_at",
+      "retires_at",
+      "retired_at",
+      "created_at",
+      "updated_at"
+    ],
+    "crm_zk_uat_recipient_keys": [
+      "crm_id",
+      "key_id",
+      "public_key",
+      "public_key_fingerprint",
       "environment",
       "status",
       "activated_at",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 142,
+  "expected_migration_version": 143,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1040,6 +1040,7 @@
       "configuration_revision",
       "validated_at",
       "crm_zk_v1_enabled",
+      "crm_zk_uat_v1_enabled",
       "mulesoft_connector_ref"
     ],
     "crm_operation_endpoints": [
@@ -1051,7 +1052,8 @@
       "description",
       "mcp_endpoint",
       "response_contract",
-      "crm_zk_tool_name"
+      "crm_zk_tool_name",
+      "crm_zk_uat_tool_name"
     ],
     "crm_zk_recipient_keys": [
       "crm_id",
@@ -1062,6 +1064,19 @@
       "response_signing_key_id",
       "response_signing_key_fingerprint",
       "profile",
+      "environment",
+      "status",
+      "activated_at",
+      "retires_at",
+      "retired_at",
+      "created_at",
+      "updated_at"
+    ],
+    "crm_zk_uat_recipient_keys": [
+      "crm_id",
+      "key_id",
+      "public_key",
+      "public_key_fingerprint",
       "environment",
       "status",
       "activated_at",

--- a/consent-protocol/db/migrations/143_crm_zk_uat_v1.sql
+++ b/consent-protocol/db/migrations/143_crm_zk_uat_v1.sql
@@ -1,0 +1,71 @@
+-- CRM ZK UAT v1: isolated confidentiality-only compatibility profile.
+--
+-- Full crm-zk.v1 remains unchanged. This profile is default-off and may be
+-- enabled only for a MuleSoft sandbox connector after conformance testing.
+
+BEGIN;
+
+ALTER TABLE enterprise_crm_registry
+  ADD COLUMN IF NOT EXISTS crm_zk_uat_v1_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE enterprise_crm_registry
+  DROP CONSTRAINT IF EXISTS enterprise_crm_registry_crm_zk_profile_exclusive;
+
+ALTER TABLE enterprise_crm_registry
+  ADD CONSTRAINT enterprise_crm_registry_crm_zk_profile_exclusive CHECK (
+    NOT (crm_zk_v1_enabled AND crm_zk_uat_v1_enabled)
+  );
+
+ALTER TABLE crm_operation_endpoints
+  ADD COLUMN IF NOT EXISTS crm_zk_uat_tool_name TEXT;
+
+CREATE TABLE IF NOT EXISTS crm_zk_uat_recipient_keys (
+  crm_id TEXT NOT NULL REFERENCES enterprise_crm_registry(crm_id) ON DELETE CASCADE,
+  key_id TEXT NOT NULL,
+  public_key TEXT NOT NULL,
+  public_key_fingerprint TEXT NOT NULL,
+  environment TEXT NOT NULL CHECK (environment = 'sandbox'),
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'retiring', 'retired', 'revoked')),
+  activated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  retires_at TIMESTAMPTZ,
+  retired_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (crm_id, key_id),
+  CHECK (public_key_fingerprint ~ '^sha256:[0-9a-f]{64}$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_zk_uat_recipient_keys_one_active
+  ON crm_zk_uat_recipient_keys (crm_id)
+  WHERE status = 'active';
+
+ALTER TABLE connected_system_intents
+  DROP CONSTRAINT IF EXISTS connected_system_intents_delivery_mode_check;
+
+ALTER TABLE connected_system_intents
+  ADD CONSTRAINT connected_system_intents_delivery_mode_check CHECK (
+    delivery_mode IN ('legacy', 'crm-zk.v1', 'crm-zk-uat.v1')
+  );
+
+ALTER TABLE connected_system_intents
+  DROP CONSTRAINT IF EXISTS connected_system_intents_crm_zk_uat_shape;
+
+ALTER TABLE connected_system_intents
+  ADD CONSTRAINT connected_system_intents_crm_zk_uat_shape CHECK (
+    delivery_mode <> 'crm-zk-uat.v1'
+    OR (
+      encrypted_fields_json IS NOT NULL
+      AND zk_metadata_json IS NOT NULL
+      AND request_payload_json = '{}'::jsonb
+      AND readback_payload_json = '{}'::jsonb
+      AND envelope_digest ~ '^sha256:[0-9a-f]{64}$'
+      AND client_operation_id IS NOT NULL
+    )
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_connected_system_intents_zk_uat_client_operation
+  ON connected_system_intents (user_id, system_id, action, client_operation_id)
+  WHERE delivery_mode = 'crm-zk-uat.v1';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/143_crm_zk_uat_v1.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/143_crm_zk_uat_v1.rollback.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM connected_system_intents
+    WHERE delivery_mode = 'crm-zk-uat.v1'
+  ) THEN
+    RAISE EXCEPTION
+      'Migration 143 rollback requires zero crm-zk-uat.v1 intents; disable the feature and retain audit rows instead';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_connected_system_intents_zk_uat_client_operation;
+
+ALTER TABLE connected_system_intents
+  DROP CONSTRAINT IF EXISTS connected_system_intents_crm_zk_uat_shape;
+
+ALTER TABLE connected_system_intents
+  DROP CONSTRAINT IF EXISTS connected_system_intents_delivery_mode_check;
+
+ALTER TABLE connected_system_intents
+  ADD CONSTRAINT connected_system_intents_delivery_mode_check CHECK (
+    delivery_mode IN ('legacy', 'crm-zk.v1')
+  );
+
+DROP TABLE IF EXISTS crm_zk_uat_recipient_keys;
+
+ALTER TABLE crm_operation_endpoints
+  DROP COLUMN IF EXISTS crm_zk_uat_tool_name;
+
+ALTER TABLE enterprise_crm_registry
+  DROP CONSTRAINT IF EXISTS enterprise_crm_registry_crm_zk_profile_exclusive;
+
+ALTER TABLE enterprise_crm_registry
+  DROP COLUMN IF EXISTS crm_zk_uat_v1_enabled;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -120,7 +120,8 @@
     "139_ria_profile_brochure_provenance.sql",
     "140_one_contact_discoverability.sql",
     "141_crm_zk_v1.sql",
-    "142_source_library_scope_retirement.sql"
+    "142_source_library_scope_retirement.sql",
+    "143_crm_zk_uat_v1.sql"
   ],
   "groups": {
     "iam": [
@@ -195,7 +196,8 @@
       "139_ria_profile_brochure_provenance.sql",
       "140_one_contact_discoverability.sql",
       "141_crm_zk_v1.sql",
-      "142_source_library_scope_retirement.sql"
+      "142_source_library_scope_retirement.sql",
+      "143_crm_zk_uat_v1.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
+++ b/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
@@ -27,12 +27,19 @@ experience, but it is not required for decryption when MuleSoft owns that
 boundary.
 
 The existing MuleSoft-backed Connected Systems plaintext create/delete and
-legacy mutation path is current. Every MuleSoft CRM operation now identifies
-only a server-owned `connectorRef`; MuleSoft resolves connection details from
-its own secret store. The repository contains a feature-gated `crm-zk.v1`
+legacy mutation path is current. Normal MuleSoft CRM operations identify only
+a server-owned `connectorRef`; MuleSoft resolves connection details from its
+own secret store. The repository contains a feature-gated `crm-zk.v1`
 bound-read/update contract, but no connector is enabled until its MuleSoft
 conformance vectors, keys, server context-signing key, and UAT proof are
 registered. This is code readiness, not partner-production evidence.
+
+For partner UAT, the repository also carries a separate, default-off
+`crm-zk-uat.v1` compatibility profile. It does not change consent/PCHP and does
+not weaken `crm-zk.v1`. Its only claim is that Hussh cannot decrypt CRM field
+values on the gated read/update path. It deliberately omits HKDF, AAD, P-256
+signatures, MuleSoft approval-proof validation, and signed responses. Those
+omissions make it a transport-trusting sandbox profile, not production ZK.
 
 ```mermaid
 flowchart LR
@@ -125,6 +132,41 @@ The precise cross-language canonicalization and browser contract live in
 `hushh-webapp/lib/connected-systems/crm-zk-v1.ts`. Java/MuleSoft must use the
 same normalized snake_case signed-envelope form, raw 64-byte P-256 P1363
 signatures, exact base64 byte lengths, and zero-salt HKDF vector before enable.
+
+## CRM encrypted UAT v1: MuleSoft compatibility profile
+
+`crm-zk-uat.v1` is mutually exclusive with `crm-zk.v1` and may be enabled only
+for an allowlisted sandbox CRM with a pinned static X25519 `key_id` and public
+key. The browser creates a fresh ephemeral X25519 key, random payload key, and
+fresh 12-byte IVs for every operation; each envelope expires within five
+minutes. The wrapping key is
+`SHA-256(X25519 shared secret)`. Both AES-256-GCM operations omit AAD.
+
+- READ requires an existing owner binding. Hussh sends its backend-resolved
+  record ID, plaintext `objectType`, expected lookup/return field names, and
+  `encryptedFields`; its ciphertext decrypts only at MuleSoft to
+  `{ "searchFields": { ... } }`. MuleSoft returns plaintext status/count and
+  the same matched record ID as verification metadata, plus `encryptedFields`
+  decrypting in browser memory to `{ "returnFields": { ... } }`. This profile
+  never creates a binding from opaque browser lookup values; UAT bindings must
+  be established beforehand with safe synthetic fixtures.
+- UPDATE sends the backend-resolved bound record ID and allowlisted field names
+  only after the browser has reviewed the diff locally. `encryptedFields`
+  decrypts at MuleSoft to `{ "additionalFields": { ... } }`. Hussh persists an
+  opaque pending intent and its ordinary owner approval is the UAT authority.
+  MuleSoft returns only an allowlisted plaintext status/correlation
+  acknowledgement—never values or readback.
+- CREATE and DELETE remain on the existing plaintext lifecycle.
+
+Hussh sends no CRM URL, OAuth credential, token endpoint, arbitrary target, or
+browser-selected record ID. The compatibility call replaces registry tool
+arguments instead of merging secrets or a `connectorRef`; the selected Omni
+Gateway route/application must therefore resolve its fixed sandbox connection.
+MuleSoft must reject a decrypted key set that differs from the plaintext
+`searchFieldNames` or `fieldNames` allowlist supplied by Hussh.
+The backend also rejects this profile unless the runtime environment is exactly
+`uat`. No plaintext fallback is allowed when this profile is enabled. Production
+promotion requires returning to the full `crm-zk.v1` conformance gate.
 
 ## Connector identity and key custody
 

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -194,9 +194,7 @@ def _directive_flags(entry: dict[str, Any] | None) -> dict[str, bool]:
             "needsConfirmation": True,
             "trustedActivationRequired": True,
         }
-    trusted_activation = (
-        str(entry.get("activation_policy") or "") == "trusted_activation_required"
-    )
+    trusted_activation = str(entry.get("activation_policy") or "") == "trusted_activation_required"
     # Voice does not ask. `confirm_required` no longer raises a card, because
     # being asked "are you sure?" after saying a thing out loud is the thing
     # people find most tiring about talking to this app -- and a spoken yes to

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -13,10 +13,15 @@ import secrets
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from db.db_client import DatabaseExecutionError, get_db
+from hushh_mcp.services.crm_zk_uat_v1 import (
+    CRM_ZK_UAT_V1_PROFILE,
+    CrmZkUatEncryptedFields,
+    validate_crm_zk_uat_envelope,
+)
 from hushh_mcp.services.crm_zk_v1 import (
     CRM_ZK_V1_PROFILE,
     CrmZkApprovalProof,
@@ -45,6 +50,56 @@ REGISTRY_MCP_ENDPOINT = (
     "https://hussh-og-nonprod-ingress-a3e0me.y4rjsf.usa-e2.cloudhub.io/crm-connect/v1/mcp"
 )
 TERMINAL_INTENT_STATUSES = frozenset({"rejected", "succeeded", "partial", "failed"})
+_CRM_ZK_UAT_ACK_STATUSES = frozenset({"accepted", "success", "succeeded"})
+_OPAQUE_PARTNER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$")
+
+
+def _crm_zk_uat_runtime_enabled() -> bool:
+    """Fail closed outside the hosted UAT runtime, even if a DB flag drifts."""
+    return (
+        str(os.getenv("ENVIRONMENT") or os.getenv("HUSHH_DEPLOY_ENV") or "").strip().lower()
+        == "uat"
+    )
+
+
+def _normalize_crm_zk_uat_ack(payload: Any) -> dict[str, Any]:
+    """Return the only plaintext partner metadata that may be persisted."""
+    raw = _ensure_dict(payload)
+    if set(raw) - {"status", "accepted", "operationId", "correlationId", "idempotent"}:
+        raise ConnectedSystemConfigurationError(
+            "The CRM partner returned an unsafe acknowledgement.",
+            code="CONNECTED_SYSTEM_CRM_ZK_UAT_ACK_INVALID",
+            status_code=502,
+        )
+    status = str(raw.get("status") or "").strip().lower()
+    if status not in _CRM_ZK_UAT_ACK_STATUSES or raw.get("accepted") is not True:
+        raise ConnectedSystemsError(
+            "The CRM partner did not accept the update.",
+            code="CONNECTED_SYSTEM_CRM_ZK_UAT_UPDATE_UNCONFIRMED",
+            status_code=502,
+        )
+    normalized: dict[str, Any] = {"status": status, "accepted": True}
+    if "idempotent" in raw:
+        if not isinstance(raw["idempotent"], bool):
+            raise ConnectedSystemConfigurationError(
+                "The CRM partner returned an unsafe acknowledgement.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_ACK_INVALID",
+                status_code=502,
+            )
+        normalized["idempotent"] = raw["idempotent"]
+    for key in ("operationId", "correlationId"):
+        if key not in raw:
+            continue
+        value = raw[key]
+        if not isinstance(value, str) or not _OPAQUE_PARTNER_ID.fullmatch(value):
+            raise ConnectedSystemConfigurationError(
+                "The CRM partner returned an unsafe acknowledgement.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_ACK_INVALID",
+                status_code=502,
+            )
+        normalized[key] = value
+    return normalized
+
 
 EXTERNAL_CRM_TOOL_CATALOG = (
     {
@@ -1016,6 +1071,10 @@ class ConnectedSystemDefinition:
     crm_zk_v1_enabled: bool = False
     mulesoft_connector_ref: str | None = None
     crm_zk_recipient_key: dict[str, Any] | None = None
+    # UAT-only compatibility profile. It is intentionally independent from
+    # the stronger crm-zk.v1 profile and must never be enabled at the same time.
+    crm_zk_uat_v1_enabled: bool = False
+    crm_zk_uat_recipient_key: dict[str, Any] | None = None
 
     def operation(self, operation: str) -> dict[str, Any] | None:
         return next(
@@ -1047,6 +1106,27 @@ class ConnectedSystemDefinition:
             and key.get("responseSigningPublicKey")
             and key.get("responseSigningKeyFingerprint")
         )
+
+    def crm_zk_uat_ready(self, operation: str) -> bool:
+        key = self.crm_zk_uat_recipient_key or {}
+        return bool(
+            self.crm_zk_uat_v1_enabled
+            and not self.crm_zk_v1_enabled
+            and _crm_zk_uat_runtime_enabled()
+            and operation in {"read", "update"}
+            and self.crm_zk_uat_tool_name(operation)
+            and key.get("keyId")
+            and key.get("publicKey")
+            and key.get("publicKeyFingerprint")
+            and key.get("environment") == "sandbox"
+        )
+
+    def crm_zk_uat_tool_name(self, operation: str) -> str | None:
+        if not self.crm_zk_uat_v1_enabled or operation not in {"read", "update"}:
+            return None
+        tool = self.operation(operation) or {}
+        name = str(tool.get("crmZkUatToolName") or "").strip()
+        return name or None
 
     def operation_endpoint(self, operation: str) -> str | None:
         tool = self.operation(operation) or {}
@@ -1122,10 +1202,24 @@ class ConnectedSystemDefinition:
                 "version": "crm-operation-contract.v1",
             },
             "crmZk": {
-                "enabled": self.crm_zk_v1_enabled,
-                "profile": "crm-zk.v1" if self.crm_zk_v1_enabled else None,
-                "readReady": self.crm_zk_ready("read"),
-                "updateReady": self.crm_zk_ready("update"),
+                "enabled": self.crm_zk_v1_enabled or self.crm_zk_uat_v1_enabled,
+                "profile": (
+                    "crm-zk.v1"
+                    if self.crm_zk_v1_enabled
+                    else CRM_ZK_UAT_V1_PROFILE
+                    if self.crm_zk_uat_v1_enabled
+                    else None
+                ),
+                "readReady": (
+                    self.crm_zk_ready("read")
+                    if self.crm_zk_v1_enabled
+                    else self.crm_zk_uat_ready("read")
+                ),
+                "updateReady": (
+                    self.crm_zk_ready("update")
+                    if self.crm_zk_v1_enabled
+                    else self.crm_zk_uat_ready("update")
+                ),
             },
         }
 
@@ -1426,7 +1520,12 @@ class ConnectedSystemIntentStore:
         raise NotImplementedError
 
     def get_zk_intent_by_client_operation(
-        self, *, user_id: str, system_id: str, client_operation_id: str
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        delivery_mode: str,
+        client_operation_id: str,
     ) -> dict[str, Any] | None:
         raise NotImplementedError
 
@@ -1530,7 +1629,12 @@ class InMemoryConnectedSystemIntentStore(ConnectedSystemIntentStore):
         return _deepcopy_json(intent)
 
     def get_zk_intent_by_client_operation(
-        self, *, user_id: str, system_id: str, client_operation_id: str
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        delivery_mode: str,
+        client_operation_id: str,
     ) -> dict[str, Any] | None:
         return next(
             (
@@ -1538,7 +1642,7 @@ class InMemoryConnectedSystemIntentStore(ConnectedSystemIntentStore):
                 for intent in self.intents.values()
                 if intent.get("user_id") == user_id
                 and intent.get("system_id") == system_id
-                and intent.get("delivery_mode") == "crm-zk.v1"
+                and intent.get("delivery_mode") == delivery_mode
                 and intent.get("client_operation_id") == client_operation_id
             ),
             None,
@@ -1823,18 +1927,25 @@ class DatabaseConnectedSystemIntentStore(ConnectedSystemIntentStore):
         return _intent_from_db_row(rows[0]) if rows else None
 
     def get_zk_intent_by_client_operation(
-        self, *, user_id: str, system_id: str, client_operation_id: str
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        delivery_mode: str,
+        client_operation_id: str,
     ) -> dict[str, Any] | None:
         rows = self.db.execute_raw(
             """
             SELECT * FROM connected_system_intents
             WHERE user_id = :user_id AND system_id = :system_id
-              AND delivery_mode = 'crm-zk.v1' AND client_operation_id = :client_operation_id
+              AND delivery_mode = :delivery_mode
+              AND client_operation_id = :client_operation_id
             LIMIT 1
             """,
             {
                 "user_id": user_id,
                 "system_id": system_id,
+                "delivery_mode": delivery_mode,
                 "client_operation_id": client_operation_id,
             },
         ).data
@@ -2494,7 +2605,9 @@ class ConnectedSystemsService:
         config = self._require_operation(system, operation)
         adapter = self._adapter_for_system(system)
         effective_payload = _deepcopy_json(payload)
-        if system.mulesoft_connector_ref and not replace_tool_arguments:
+        if (
+            system.mulesoft_connector_ref or system.crm_zk_uat_v1_enabled
+        ) and not replace_tool_arguments:
             # Every MuleSoft connector owns target/connection selection through
             # connectorRef. Never forward a backend target label as tool input,
             # including for the current plaintext create/delete compatibility
@@ -2956,6 +3069,7 @@ class ConnectedSystemsService:
             self.store.get_zk_intent_by_client_operation,
             user_id=user_id,
             system_id=system_id,
+            delivery_mode=CRM_ZK_V1_PROFILE,
             client_operation_id=binding.client_operation_id,
         )
         if existing:
@@ -2973,6 +3087,7 @@ class ConnectedSystemsService:
                 self.store.get_zk_intent_by_client_operation,
                 user_id=user_id,
                 system_id=system_id,
+                delivery_mode=CRM_ZK_V1_PROFILE,
                 client_operation_id=binding.client_operation_id,
             )
             if existing:
@@ -3332,6 +3447,406 @@ class ConnectedSystemsService:
             "responseSignerKeyId": response.response_signer_key_id,
             "responseSignature": response.response_signature,
         }
+
+    def _require_crm_zk_uat_system(
+        self, *, system_id: str, operation: str
+    ) -> ConnectedSystemDefinition:
+        system = self.get_system(system_id)
+        if not system.crm_zk_uat_ready(operation):
+            raise ConnectedSystemConfigurationError(
+                "This connected system is not configured for the CRM encrypted UAT profile.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_UNAVAILABLE",
+            )
+        return system
+
+    def crm_zk_uat_configuration(self, *, system_id: str) -> dict[str, Any]:
+        system = self._require_crm_zk_uat_system(system_id=system_id, operation="read")
+        if not system.crm_zk_uat_ready("update"):
+            raise ConnectedSystemConfigurationError(
+                "CRM encrypted UAT update is not configured for this connected system.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_UPDATE_UNAVAILABLE",
+            )
+        key = system.crm_zk_uat_recipient_key or {}
+        return {
+            "profile": CRM_ZK_UAT_V1_PROFILE,
+            "configurationRevision": system.configuration_revision,
+            "recipientKey": {"keyId": key["keyId"], "publicKey": key["publicKey"]},
+            "keyDerivation": "SHA-256(X25519 shared secret)",
+            "aad": False,
+        }
+
+    def _validated_crm_zk_uat_envelope(
+        self,
+        *,
+        system: ConnectedSystemDefinition,
+        encrypted_fields: dict[str, Any],
+        direction: Literal["read_request", "read_response", "update_request"],
+    ) -> CrmZkUatEncryptedFields:
+        key = system.crm_zk_uat_recipient_key or {}
+        try:
+            return validate_crm_zk_uat_envelope(
+                encrypted_fields,
+                expected_direction=direction,
+                expected_key_id=str(key.get("keyId") or ""),
+                now_ms=int(time.time() * 1000),
+            )
+        except Exception as error:
+            raise ConnectedSystemValidationError(
+                "The encrypted CRM UAT envelope is invalid or expired.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_ENVELOPE_INVALID",
+            ) from error
+
+    async def search_record_crm_zk_uat(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str | None,
+        return_fields: list[str],
+        search_field_names: list[str],
+        encrypted_fields: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Relay an opaque verified-profile lookup and bind transport metadata."""
+        system = self._require_crm_zk_uat_system(system_id=system_id, operation="read")
+        object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
+        record_id = self._require_bound_record_id(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+            supplied_record_id=None,
+        )
+        binding = self._store_call(
+            self.store.get_binding,
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+        )
+        schema = await self.get_schema(
+            system_id=system_id, object_type=object_type_value, require_fresh=True
+        )
+        self._require_schema_action(schema, "read")
+        allowed_return = self._crm_zk_allowed_field_names(
+            schema=schema, operation="read", requested=return_fields, locked_field_names=set()
+        )
+        if len(search_field_names) != 2 or len(set(search_field_names)) != 2:
+            raise ConnectedSystemConfigurationError(
+                "Verified CRM lookup fields are not configured.",
+                code="CONNECTED_SYSTEM_PROFILE_FIELD_MAPPING_UNAVAILABLE",
+            )
+        schema_names = {str(field.get("key") or "") for field in schema.get("fields") or []}
+        if any(name not in schema_names for name in search_field_names):
+            raise ConnectedSystemConfigurationError(
+                "Verified CRM lookup fields do not match the current schema.",
+                code="CONNECTED_SYSTEM_PROFILE_FIELD_MAPPING_UNAVAILABLE",
+            )
+        envelope = self._validated_crm_zk_uat_envelope(
+            system=system, encrypted_fields=encrypted_fields, direction="read_request"
+        )
+        result = await self._call_crm_zk_uat_partner(
+            system=system,
+            operation="read",
+            payload={
+                "profile": CRM_ZK_UAT_V1_PROFILE,
+                "operation": "read",
+                "objectType": object_type_value,
+                "id": record_id,
+                "searchFieldNames": search_field_names,
+                "returnFields": allowed_return,
+                "encryptedFields": envelope.model_dump(mode="json"),
+            },
+        )
+        payload = _ensure_dict(result.get("payload"))
+        try:
+            total_size = int(payload.get("totalSize") or 0)
+        except (TypeError, ValueError):
+            total_size = -1
+        if total_size < 0 or total_size > 1:
+            raise ConnectedSystemBlockedError(
+                "The encrypted CRM lookup did not resolve exactly one safe result.",
+                code="CONNECTED_SYSTEM_RECORD_MATCH_AMBIGUOUS",
+                status_code=409,
+            )
+        response_fields = payload.get("encryptedFields")
+        if not isinstance(response_fields, dict):
+            raise ConnectedSystemConfigurationError(
+                "The CRM partner returned no encrypted field response.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_RESPONSE_INVALID",
+                status_code=502,
+            )
+        response_envelope = self._validated_crm_zk_uat_envelope(
+            system=system, encrypted_fields=response_fields, direction="read_response"
+        )
+        if (
+            response_envelope.client_operation_id != envelope.client_operation_id
+            or response_envelope.client_public_key != envelope.client_public_key
+        ):
+            raise ConnectedSystemConfigurationError(
+                "The encrypted CRM response does not match this request.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_RESPONSE_INVALID",
+                status_code=502,
+            )
+        returned_record_id = _clean_text(
+            payload.get("recordId") or payload.get("id"), max_length=128
+        )
+        if returned_record_id and returned_record_id != record_id:
+            raise ConnectedSystemConfigurationError(
+                "The CRM partner returned a different record than the owner binding.",
+                code="CONNECTED_SYSTEM_BOUND_RECORD_MISMATCH",
+                status_code=502,
+            )
+        response_status = str(payload.get("status") or "succeeded").strip().lower()
+        if response_status not in {"success", "succeeded"}:
+            raise ConnectedSystemConfigurationError(
+                "The CRM partner returned an invalid read status.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_RESPONSE_INVALID",
+                status_code=502,
+            )
+        self._audit(
+            user_id=user_id,
+            system_id=system_id,
+            action="read",
+            object_type=object_type_value,
+            record_id=record_id,
+            field_names=allowed_return,
+            mcp_result_class="succeeded",
+            readback_result_class="encrypted_response_returned",
+            status="succeeded",
+            metadata={"profile": CRM_ZK_UAT_V1_PROFILE, "total_size": total_size},
+        )
+        return {
+            "profile": CRM_ZK_UAT_V1_PROFILE,
+            "systemId": system_id,
+            "objectType": object_type_value,
+            "status": response_status,
+            "totalSize": total_size,
+            "recordId": record_id,
+            "bindingStatus": "active",
+            "binding": self._public_binding(binding),
+            "encryptedFields": response_envelope.model_dump(mode="json", by_alias=True),
+        }
+
+    async def create_crm_zk_uat_update_intent(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str | None,
+        field_names: list[str],
+        encrypted_fields: dict[str, Any],
+        locked_field_names: set[str],
+    ) -> dict[str, Any]:
+        system = self._require_crm_zk_uat_system(system_id=system_id, operation="update")
+        object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
+        record_id = self._require_bound_record_id(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+            supplied_record_id=None,
+        )
+        schema = await self.get_schema(
+            system_id=system_id, object_type=object_type_value, require_fresh=True
+        )
+        self._require_schema_action(schema, "update")
+        allowed_fields = self._crm_zk_allowed_field_names(
+            schema=schema,
+            operation="update",
+            requested=field_names,
+            locked_field_names=locked_field_names,
+        )
+        envelope = self._validated_crm_zk_uat_envelope(
+            system=system, encrypted_fields=encrypted_fields, direction="update_request"
+        )
+        existing = self._store_call(
+            self.store.get_zk_intent_by_client_operation,
+            user_id=user_id,
+            system_id=system_id,
+            delivery_mode=CRM_ZK_UAT_V1_PROFILE,
+            client_operation_id=envelope.client_operation_id,
+        )
+        if existing:
+            if existing.get("delivery_mode") != CRM_ZK_UAT_V1_PROFILE:
+                raise ConnectedSystemValidationError(
+                    "The encrypted CRM operation id is already in use.",
+                    code="CONNECTED_SYSTEM_CRM_ZK_UAT_REPLAYED",
+                )
+            return self._public_intent(existing)
+        return self._create_intent(
+            user_id=user_id,
+            system=system,
+            action="update",
+            object_type=object_type_value,
+            request_payload={},
+            readback_payload={},
+            field_names=allowed_fields,
+            record_id=record_id,
+            delivery_mode=CRM_ZK_UAT_V1_PROFILE,
+            encrypted_fields=envelope.model_dump(mode="json", by_alias=True),
+            zk_metadata={
+                "profile": CRM_ZK_UAT_V1_PROFILE,
+                "recipientKeyId": envelope.recipient_key_id,
+                "configurationRevision": system.configuration_revision,
+                "expiresAtMs": envelope.expires_at_ms,
+            },
+            envelope_digest=envelope.digest(),
+            client_operation_id=envelope.client_operation_id,
+        )
+
+    async def approve_crm_zk_uat_intent(
+        self, *, user_id: str, system_id: str, intent_id: str
+    ) -> dict[str, Any]:
+        system = self._require_crm_zk_uat_system(system_id=system_id, operation="update")
+        existing = self._store_call(
+            self.store.get_intent, user_id=user_id, system_id=system_id, intent_id=intent_id
+        )
+        if not existing:
+            raise ConnectedSystemNotFoundError("CRM intent was not found.")
+        if existing.get("delivery_mode") != CRM_ZK_UAT_V1_PROFILE:
+            raise ConnectedSystemValidationError(
+                "This approval route accepts only CRM encrypted UAT intents.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_INTENT_REQUIRED",
+            )
+        if existing.get("status") in TERMINAL_INTENT_STATUSES:
+            return self._public_intent(existing)
+        if existing.get("status") == "pending":
+            approval = _approval_id()
+            intent = self._store_call(
+                self.store.claim_pending_intent, intent_id=intent_id, approval_id=approval
+            )
+        elif existing.get("status") == "approved" and existing.get("approval_id"):
+            approval = str(existing["approval_id"])
+            intent = existing
+        else:
+            return self._public_intent(existing)
+        if intent.get("approval_id") != approval:
+            return self._public_intent(intent)
+        partner_attempted = False
+        try:
+            record_id = self._require_bound_record_id(
+                user_id=user_id,
+                system_id=system_id,
+                object_type=str(intent.get("object_type") or ""),
+                supplied_record_id=str(intent.get("record_id") or ""),
+            )
+            metadata = _ensure_dict(intent.get("zk_metadata"))
+            if metadata.get("configurationRevision") != system.configuration_revision:
+                raise ConnectedSystemValidationError(
+                    "The CRM connector changed. Review and submit a fresh update.",
+                    code="CONNECTED_SYSTEM_CRM_ZK_UAT_CONFIGURATION_STALE",
+                )
+            envelope = self._validated_crm_zk_uat_envelope(
+                system=system,
+                encrypted_fields=_ensure_dict(intent.get("encrypted_fields")),
+                direction="update_request",
+            )
+            schema = await self.get_schema(
+                system_id=system_id,
+                object_type=str(intent.get("object_type") or ""),
+                require_fresh=True,
+            )
+            self._require_schema_action(schema, "update")
+            partner_attempted = True
+            result = await self._call_crm_zk_uat_partner(
+                system=system,
+                operation="update",
+                payload={
+                    "profile": CRM_ZK_UAT_V1_PROFILE,
+                    "operation": "update",
+                    "objectType": intent["object_type"],
+                    "id": record_id,
+                    "fieldNames": intent.get("field_names") or [],
+                    "intentId": intent_id,
+                    "approvalId": approval,
+                    "clientOperationId": envelope.client_operation_id,
+                    "encryptedFields": envelope.model_dump(mode="json"),
+                },
+            )
+            normalized_ack = _normalize_crm_zk_uat_ack(result.get("payload"))
+            updated = self._store_call(
+                self.store.update_intent,
+                intent_id=intent_id,
+                updates={
+                    "status": "succeeded",
+                    "approval_id": approval,
+                    "result_class": "succeeded",
+                    "result_payload": normalized_ack,
+                    "readback_result": {"resultClass": "metadata_acknowledged"},
+                    "error_code": None,
+                    "error_message": None,
+                },
+            )
+            self._audit_for_intent(
+                updated,
+                mcp_result_class="succeeded",
+                readback_result_class="metadata_acknowledged",
+                status="succeeded",
+                metadata={"profile": CRM_ZK_UAT_V1_PROFILE},
+            )
+            return self._public_intent(updated)
+        except Exception as error:
+            updated = self._store_call(
+                self.store.update_intent,
+                intent_id=intent_id,
+                updates={
+                    "status": "approved" if partner_attempted else "failed",
+                    "approval_id": approval,
+                    "error_code": getattr(
+                        error, "code", "CONNECTED_SYSTEM_CRM_ZK_UAT_APPROVAL_FAILED"
+                    ),
+                    "error_message": "CRM encrypted UAT approval could not be completed.",
+                },
+            )
+            self._audit_for_intent(
+                updated,
+                mcp_result_class="failed",
+                readback_result_class=None,
+                status="retry_pending" if partner_attempted else "failed",
+                metadata={
+                    "profile": CRM_ZK_UAT_V1_PROFILE,
+                    "error_code": updated.get("error_code"),
+                },
+            )
+            if isinstance(error, ConnectedSystemsError):
+                raise
+            raise ConnectedSystemsError(
+                "CRM encrypted UAT approval failed.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_APPROVAL_FAILED",
+            ) from error
+
+    async def _call_crm_zk_uat_partner(
+        self,
+        *,
+        system: ConnectedSystemDefinition,
+        operation: Literal["read", "update"],
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Call the registered UAT tool without merging connector configuration."""
+        tool_name = system.crm_zk_uat_tool_name(operation)
+        if not tool_name:
+            raise ConnectedSystemConfigurationError(
+                "CRM encrypted UAT partner routing is not configured.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_UNAVAILABLE",
+            )
+        try:
+            result = await self._call_operation(
+                system=system,
+                operation=operation,
+                payload=payload,
+                tool_name=tool_name,
+                replace_tool_arguments=True,
+            )
+            if bool(result.get("isError")):
+                raise ConnectedSystemsError(
+                    "CRM encrypted UAT partner request failed.",
+                    code="CONNECTED_SYSTEM_CRM_ZK_UAT_PARTNER_FAILED",
+                    status_code=502,
+                )
+            return result
+        except ConnectedSystemsError as error:
+            raise ConnectedSystemsError(
+                "CRM encrypted UAT partner request failed.",
+                code="CONNECTED_SYSTEM_CRM_ZK_UAT_PARTNER_FAILED",
+                status_code=502,
+            ) from error
 
     def list_record_binding_statuses(self, *, user_id: str) -> dict[str, Any]:
         """Return safe owner-scoped binding states without CRM ids or values."""
@@ -3995,9 +4510,9 @@ class ConnectedSystemsService:
         locked_field_names: set[str] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
-        if system.crm_zk_v1_enabled:
+        if system.crm_zk_v1_enabled or system.crm_zk_uat_v1_enabled:
             raise ConnectedSystemBlockedError(
-                "This CRM requires the crm-zk.v1 update protocol.",
+                "This CRM requires its configured encrypted update protocol.",
                 code="CONNECTED_SYSTEM_CRM_ZK_UPDATE_REQUIRED",
             )
         self._require_operation(system, "update")
@@ -4255,9 +4770,9 @@ class ConnectedSystemsService:
         return_fields: list[str] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
-        if system.crm_zk_v1_enabled:
+        if system.crm_zk_v1_enabled or system.crm_zk_uat_v1_enabled:
             raise ConnectedSystemBlockedError(
-                "This CRM requires the crm-zk.v1 bound-read protocol.",
+                "This CRM requires its configured encrypted read protocol.",
                 code="CONNECTED_SYSTEM_CRM_ZK_READ_REQUIRED",
             )
         object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
@@ -4373,6 +4888,12 @@ class ConnectedSystemsService:
         force_refresh: bool = False,
     ) -> dict[str, Any]:
         """Find a record using only the authenticated owner's verified identity."""
+        system = self.get_system(system_id)
+        if system.crm_zk_uat_v1_enabled:
+            raise ConnectedSystemBlockedError(
+                "This CRM requires the encrypted UAT search protocol.",
+                code="CONNECTED_SYSTEM_CRM_ZK_READ_REQUIRED",
+            )
         profile = await self._verified_user_crm_profile(user_id=user_id)
         return await self.search_record(
             user_id=user_id,
@@ -4701,6 +5222,11 @@ class ConnectedSystemsService:
         )
         if not existing:
             raise ConnectedSystemNotFoundError("CRM intent was not found.")
+        if str(existing.get("delivery_mode") or "legacy") != "legacy":
+            raise ConnectedSystemValidationError(
+                "This approval route accepts only standard CRM intents.",
+                code="CONNECTED_SYSTEM_LEGACY_INTENT_REQUIRED",
+            )
         if existing.get("status") in TERMINAL_INTENT_STATUSES:
             # Retry-safe: callers receive the stored terminal result and never
             # cause a second MCP mutation.
@@ -5175,6 +5701,11 @@ def _payload_summary(intent: dict[str, Any]) -> dict[str, Any]:
         return {
             "profile": "crm-zk.v1",
             "contextId": metadata.get("contextId"),
+            "fieldNames": intent.get("field_names") or [],
+        }
+    if intent.get("delivery_mode") == CRM_ZK_UAT_V1_PROFILE:
+        return {
+            "profile": CRM_ZK_UAT_V1_PROFILE,
             "fieldNames": intent.get("field_names") or [],
         }
     payload = intent.get("request_payload") or {}

--- a/consent-protocol/hushh_mcp/services/crm_registry_repo.py
+++ b/consent-protocol/hushh_mcp/services/crm_registry_repo.py
@@ -12,6 +12,8 @@ request path.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
 import threading
@@ -130,7 +132,8 @@ def _public_system_id(row: dict[str, Any]) -> str:
 def _tool_catalog(row_crm_id: str, database: Any) -> tuple[dict[str, Any], ...]:
     operation_rows = database.execute_raw(
         """
-        SELECT operation, tool_name, crm_zk_tool_name, http_method, path, description, mcp_endpoint, response_contract
+        SELECT operation, tool_name, crm_zk_tool_name, crm_zk_uat_tool_name,
+               http_method, path, description, mcp_endpoint, response_contract
         FROM crm_operation_endpoints
         WHERE crm_id = :crm_id
         """,
@@ -180,6 +183,47 @@ def _active_crm_zk_key(row_crm_id: str, database: Any) -> dict[str, Any] | None:
     }
 
 
+def _active_crm_zk_uat_key(row_crm_id: str, database: Any) -> dict[str, Any] | None:
+    """Return the pinned UAT X25519 public key; no request may choose it."""
+    rows = database.execute_raw(
+        """
+        SELECT key_id, public_key, public_key_fingerprint, environment, status
+        FROM crm_zk_uat_recipient_keys
+        WHERE crm_id = :crm_id
+          AND status = 'active'
+          AND (retires_at IS NULL OR retires_at > NOW())
+        ORDER BY activated_at DESC
+        LIMIT 1
+        """,
+        {"crm_id": row_crm_id},
+    ).data
+    if not rows:
+        return None
+    key = rows[0]
+    try:
+        public_key = str(key.get("public_key") or "")
+        decoded_public_key = base64.b64decode(public_key, validate=True)
+        if len(decoded_public_key) != 32:
+            raise ValueError("wrong X25519 key length")
+    except (ValueError, base64.binascii.Error) as error:
+        raise ConnectedSystemConfigurationError(
+            "CRM encrypted UAT recipient key is invalid.",
+            code="CONNECTED_SYSTEM_REGISTRY_INCOMPLETE",
+        ) from error
+    fingerprint = f"sha256:{hashlib.sha256(decoded_public_key).hexdigest()}"
+    if fingerprint != str(key.get("public_key_fingerprint") or ""):
+        raise ConnectedSystemConfigurationError(
+            "CRM encrypted UAT recipient key fingerprint is invalid.",
+            code="CONNECTED_SYSTEM_REGISTRY_INCOMPLETE",
+        )
+    return {
+        "keyId": str(key.get("key_id") or ""),
+        "publicKey": public_key,
+        "publicKeyFingerprint": fingerprint,
+        "environment": str(key.get("environment") or ""),
+    }
+
+
 def _definition_from_row(
     *,
     requested_crm_id: str,
@@ -189,7 +233,13 @@ def _definition_from_row(
     transport_headers: tuple[tuple[str, str], ...] = (),
     transport_tool_arguments: dict[str, Any] | None = None,
     crm_zk_recipient_key: dict[str, Any] | None = None,
+    crm_zk_uat_recipient_key: dict[str, Any] | None = None,
 ) -> ConnectedSystemDefinition:
+    if bool(row.get("crm_zk_v1_enabled")) and bool(row.get("crm_zk_uat_v1_enabled")):
+        raise ConnectedSystemConfigurationError(
+            "A CRM connector cannot enable both encrypted profiles.",
+            code="CONNECTED_SYSTEM_REGISTRY_INCOMPLETE",
+        )
     return ConnectedSystemDefinition(
         system_id=requested_crm_id,
         registry_id=str(row.get("crm_id") or requested_crm_id),
@@ -225,6 +275,8 @@ def _definition_from_row(
         crm_zk_v1_enabled=bool(row.get("crm_zk_v1_enabled")),
         mulesoft_connector_ref=str(row.get("mulesoft_connector_ref") or "").strip() or None,
         crm_zk_recipient_key=crm_zk_recipient_key,
+        crm_zk_uat_v1_enabled=bool(row.get("crm_zk_uat_v1_enabled")),
+        crm_zk_uat_recipient_key=crm_zk_uat_recipient_key,
     )
 
 
@@ -243,6 +295,11 @@ def _definition_from_row_without_decrypt(
         transport_headers=get_omnigateway_transport_headers() if mulesoft_managed_auth else (),
         crm_zk_recipient_key=(
             _active_crm_zk_key(row_crm_id, database) if bool(row.get("crm_zk_v1_enabled")) else None
+        ),
+        crm_zk_uat_recipient_key=(
+            _active_crm_zk_uat_key(row_crm_id, database)
+            if bool(row.get("crm_zk_uat_v1_enabled"))
+            else None
         ),
     )
 
@@ -360,6 +417,7 @@ def _tool_catalog_from_rows(rows: list[dict[str, Any]]) -> tuple[dict[str, Any],
                 "description": str(row.get("description") or "").strip(),
                 "mcpEndpoint": str(row.get("mcp_endpoint") or "").strip() or None,
                 "crmZkToolName": str(row.get("crm_zk_tool_name") or "").strip() or None,
+                "crmZkUatToolName": str(row.get("crm_zk_uat_tool_name") or "").strip() or None,
                 # This is non-secret registry metadata. It controls how the
                 # backend decodes a tool response and is never supplied by a
                 # browser request.
@@ -407,12 +465,12 @@ def load_active_definition(
     if mulesoft_managed_auth:
         transport_headers = get_omnigateway_transport_headers()
         connector_ref = str(row.get("mulesoft_connector_ref") or "").strip()
-        if not connector_ref:
+        if not connector_ref and not bool(row.get("crm_zk_uat_v1_enabled")):
             raise ConnectedSystemConfigurationError(
                 "MuleSoft CRM registry row is missing mulesoft_connector_ref.",
                 code="CONNECTED_SYSTEM_REGISTRY_INCOMPLETE",
             )
-        transport_tool_arguments = {"connectorRef": connector_ref}
+        transport_tool_arguments = {"connectorRef": connector_ref} if connector_ref else None
     else:
         # Decrypt credentials only for legacy header-auth rows.
         client_id, client_secret = _decrypt_credentials(row)
@@ -446,6 +504,11 @@ def load_active_definition(
         transport_tool_arguments=transport_tool_arguments,
         crm_zk_recipient_key=(
             _active_crm_zk_key(row_crm_id, database) if bool(row.get("crm_zk_v1_enabled")) else None
+        ),
+        crm_zk_uat_recipient_key=(
+            _active_crm_zk_uat_key(row_crm_id, database)
+            if bool(row.get("crm_zk_uat_v1_enabled"))
+            else None
         ),
     )
 

--- a/consent-protocol/hushh_mcp/services/crm_zk_uat_v1.py
+++ b/consent-protocol/hushh_mcp/services/crm_zk_uat_v1.py
@@ -1,0 +1,143 @@
+"""Strict wire validation for the isolated ``crm-zk-uat.v1`` profile.
+
+This compatibility profile is intentionally narrower than ``crm-zk.v1``. It
+provides field-value confidentiality for a gated MuleSoft UAT connector using
+X25519, SHA-256 of the shared secret, and AES-256-GCM without AAD. Hussh never
+decrypts the envelope. Transport authentication and Hussh's owner approval are
+the UAT authority; this module must not be presented as production-grade ZK.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any, Literal
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+
+CRM_ZK_UAT_V1_PROFILE = "crm-zk-uat.v1"
+CRM_ZK_UAT_V1_MAX_CIPHERTEXT_BYTES = 1_000_000
+CRM_ZK_UAT_V1_MAX_TTL_MS = 5 * 60 * 1000
+_B64_MAX = 1_400_000
+
+
+class CrmZkUatValidationError(ValueError):
+    """Value-free validation failure safe to map to a public error code."""
+
+
+def _decode(value: str, *, name: str, expected_bytes: int | None = None) -> bytes:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, base64.binascii.Error) as exc:
+        raise CrmZkUatValidationError(f"crm_zk_uat_invalid_{name}") from exc
+    if expected_bytes is not None and len(decoded) != expected_bytes:
+        raise CrmZkUatValidationError(f"crm_zk_uat_invalid_{name}")
+    return decoded
+
+
+class CrmZkUatEncryptedFields(BaseModel):
+    """Opaque value envelope shared by browser, Hussh, and MuleSoft."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    profile: Literal["crm-zk-uat.v1"] = CRM_ZK_UAT_V1_PROFILE
+    direction: Literal["read_request", "read_response", "update_request"]
+    recipient_key_id: str = Field(
+        validation_alias=AliasChoices("recipientKeyId", "recipient_key_id"),
+        serialization_alias="recipientKeyId",
+        min_length=1,
+        max_length=160,
+    )
+    client_operation_id: str = Field(
+        validation_alias=AliasChoices("clientOperationId", "client_operation_id"),
+        serialization_alias="clientOperationId",
+        min_length=16,
+        max_length=160,
+    )
+    expires_at_ms: int = Field(
+        validation_alias=AliasChoices("expiresAtMs", "expires_at_ms"),
+        serialization_alias="expiresAtMs",
+        gt=0,
+    )
+    client_public_key: str = Field(
+        validation_alias=AliasChoices("clientPublicKey", "client_public_key"),
+        serialization_alias="clientPublicKey",
+        min_length=1,
+        max_length=128,
+    )
+    wrapped_payload_key: str = Field(
+        validation_alias=AliasChoices("wrappedPayloadKey", "wrapped_payload_key"),
+        serialization_alias="wrappedPayloadKey",
+        min_length=1,
+        max_length=256,
+    )
+    wrapped_key_iv: str = Field(
+        validation_alias=AliasChoices("wrappedKeyIv", "wrapped_key_iv"),
+        serialization_alias="wrappedKeyIv",
+        min_length=1,
+        max_length=64,
+    )
+    wrapped_key_tag: str = Field(
+        validation_alias=AliasChoices("wrappedKeyTag", "wrapped_key_tag"),
+        serialization_alias="wrappedKeyTag",
+        min_length=1,
+        max_length=64,
+    )
+    payload_iv: str = Field(
+        validation_alias=AliasChoices("payloadIv", "payload_iv"),
+        serialization_alias="payloadIv",
+        min_length=1,
+        max_length=64,
+    )
+    payload_tag: str = Field(
+        validation_alias=AliasChoices("payloadTag", "payload_tag"),
+        serialization_alias="payloadTag",
+        min_length=1,
+        max_length=64,
+    )
+    ciphertext: str = Field(min_length=1, max_length=_B64_MAX)
+
+    @model_validator(mode="after")
+    def _validate_binary_shape(self) -> "CrmZkUatEncryptedFields":
+        _decode(self.client_public_key, name="client_public_key", expected_bytes=32)
+        _decode(self.wrapped_payload_key, name="wrapped_payload_key", expected_bytes=32)
+        _decode(self.wrapped_key_iv, name="wrapped_key_iv", expected_bytes=12)
+        _decode(self.wrapped_key_tag, name="wrapped_key_tag", expected_bytes=16)
+        _decode(self.payload_iv, name="payload_iv", expected_bytes=12)
+        _decode(self.payload_tag, name="payload_tag", expected_bytes=16)
+        ciphertext = _decode(self.ciphertext, name="ciphertext")
+        if not ciphertext or len(ciphertext) > CRM_ZK_UAT_V1_MAX_CIPHERTEXT_BYTES:
+            raise CrmZkUatValidationError("crm_zk_uat_invalid_ciphertext")
+        return self
+
+    def digest(self) -> str:
+        encoded = json.dumps(
+            self.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def validate_crm_zk_uat_envelope(
+    value: CrmZkUatEncryptedFields | dict[str, Any],
+    *,
+    expected_direction: Literal["read_request", "read_response", "update_request"],
+    expected_key_id: str,
+    now_ms: int,
+) -> CrmZkUatEncryptedFields:
+    envelope = (
+        value
+        if isinstance(value, CrmZkUatEncryptedFields)
+        else CrmZkUatEncryptedFields.model_validate(value)
+    )
+    if envelope.direction != expected_direction:
+        raise CrmZkUatValidationError("crm_zk_uat_direction_mismatch")
+    if envelope.recipient_key_id != expected_key_id:
+        raise CrmZkUatValidationError("crm_zk_uat_recipient_key_mismatch")
+    if envelope.expires_at_ms <= now_ms:
+        raise CrmZkUatValidationError("crm_zk_uat_envelope_expired")
+    if envelope.expires_at_ms > now_ms + CRM_ZK_UAT_V1_MAX_TTL_MS:
+        raise CrmZkUatValidationError("crm_zk_uat_expiry_too_far")
+    return envelope

--- a/consent-protocol/tests/test_connected_systems_routes.py
+++ b/consent-protocol/tests/test_connected_systems_routes.py
@@ -25,6 +25,7 @@ class FakeConnectedSystemsService:
         self.search_payload = None
         self.disconnected_payload = None
         self.schema_calls = 0
+        self.crm_zk_uat_payload = None
 
     def list_systems(self):
         return [
@@ -140,6 +141,49 @@ class FakeConnectedSystemsService:
             "action": "update",
             "status": "pending",
             "fieldNames": ["MailingCity"],
+        }
+
+    def crm_zk_uat_configuration(self, **kwargs):
+        self.crm_zk_uat_payload = kwargs
+        return {
+            "profile": "crm-zk-uat.v1",
+            "configurationRevision": 1,
+            "recipientKey": {"keyId": "uat-key", "publicKey": "public"},
+            "keyDerivation": "SHA-256(X25519 shared secret)",
+            "aad": False,
+        }
+
+    async def search_record_crm_zk_uat(self, **kwargs):
+        self.crm_zk_uat_payload = kwargs
+        return {
+            "profile": "crm-zk-uat.v1",
+            "systemId": kwargs["system_id"],
+            "objectType": kwargs["object_type"],
+            "status": "succeeded",
+            "totalSize": 1,
+            "recordId": "003gK00000demoQAA",
+            "bindingStatus": "active",
+            "encryptedFields": kwargs["encrypted_fields"],
+        }
+
+    async def create_crm_zk_uat_update_intent(self, **kwargs):
+        self.crm_zk_uat_payload = kwargs
+        return {
+            "intentId": "csi_zk_uat",
+            "systemId": kwargs["system_id"],
+            "action": "update",
+            "status": "pending",
+            "fieldNames": kwargs["field_names"],
+        }
+
+    async def approve_crm_zk_uat_intent(self, **kwargs):
+        self.crm_zk_uat_payload = kwargs
+        return {
+            "intentId": kwargs["intent_id"],
+            "systemId": kwargs["system_id"],
+            "action": "update",
+            "status": "succeeded",
+            "fieldNames": ["Title"],
         }
 
     def create_delete_intent(self, **kwargs):
@@ -425,6 +469,77 @@ def test_search_route_uses_verified_owner_identity(monkeypatch):
         "return_fields": ["LeadSource", "MailingCity"],
         "force_refresh": False,
     }
+
+
+def test_crm_zk_uat_search_route_accepts_only_opaque_values(monkeypatch):
+    service = FakeConnectedSystemsService()
+    monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
+    client = TestClient(_build_app())
+    encrypted_fields = {"profile": "crm-zk-uat.v1", "ciphertext": "opaque"}
+
+    response = client.post(
+        "/api/connected-systems/salesforce-fsc-customer0/records/search-zk-uat",
+        headers={"Authorization": "Bearer HCT:test"},
+        json={
+            "objectType": "Contact",
+            "returnFields": ["FirstName", "LastName"],
+            "encryptedFields": encrypted_fields,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.crm_zk_uat_payload == {
+        "user_id": "user_123",
+        "system_id": "salesforce-fsc-customer0",
+        "object_type": "Contact",
+        "return_fields": ["FirstName", "LastName"],
+        "search_field_names": ["Email", "Phone"],
+        "encrypted_fields": encrypted_fields,
+    }
+
+    rejected = client.post(
+        "/api/connected-systems/salesforce-fsc-customer0/records/search-zk-uat",
+        headers={"Authorization": "Bearer HCT:test"},
+        json={
+            "objectType": "Contact",
+            "returnFields": ["FirstName"],
+            "searchFields": {"Email": "must-not-cross-hussh"},
+            "encryptedFields": encrypted_fields,
+        },
+    )
+    assert rejected.status_code == 422
+
+
+def test_crm_zk_uat_update_and_approval_routes_keep_values_opaque(monkeypatch):
+    service = FakeConnectedSystemsService()
+    monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
+    client = TestClient(_build_app())
+    encrypted_fields = {"profile": "crm-zk-uat.v1", "ciphertext": "opaque"}
+
+    prepared = client.post(
+        "/api/connected-systems/salesforce-fsc-customer0/records/update-intents-zk-uat",
+        headers={"Authorization": "Bearer HCT:test"},
+        json={
+            "objectType": "Contact",
+            "fieldNames": ["Title"],
+            "encryptedFields": encrypted_fields,
+        },
+    )
+    assert prepared.status_code == 200
+    assert service.crm_zk_uat_payload["encrypted_fields"] == encrypted_fields
+    assert service.crm_zk_uat_payload["locked_field_names"] == {
+        "Email",
+        "Phone",
+        "FirstName",
+        "LastName",
+    }
+
+    approved = client.post(
+        "/api/connected-systems/salesforce-fsc-customer0/intents/csi_zk_uat/approve-zk-uat",
+        headers={"Authorization": "Bearer HCT:test"},
+    )
+    assert approved.status_code == 200
+    assert approved.json()["status"] == "succeeded"
 
 
 def test_update_intent_route_resolves_bound_record_id(monkeypatch):

--- a/consent-protocol/tests/test_crm_registry_repo.py
+++ b/consent-protocol/tests/test_crm_registry_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 
 import pytest
@@ -71,6 +72,7 @@ def _operation_rows() -> list[dict]:
             "crm_id": "salesforce-fsc-customer0",
             "operation": "read",
             "tool_name": "read-crm-record",
+            "crm_zk_uat_tool_name": "read-crm-record-zk-uat",
             "http_method": None,
             "path": None,
             "description": "Read by email/phone.",
@@ -89,6 +91,7 @@ def _operation_rows() -> list[dict]:
             "crm_id": "salesforce-fsc-customer0",
             "operation": "update",
             "tool_name": "update-crm-record",
+            "crm_zk_uat_tool_name": "update-crm-record-zk-uat",
             "http_method": None,
             "path": None,
             "description": "Update by id.",
@@ -299,6 +302,46 @@ def test_bearer_row_without_connector_ref_fails_closed(monkeypatch):
 
     with pytest.raises(ConnectedSystemConfigurationError, match="mulesoft_connector_ref"):
         crm_registry_repo.load_active_definition("salesforce-fsc-customer0", db=db)
+
+
+def test_uat_bearer_row_uses_pinned_key_without_connector_ref(monkeypatch):
+    row = _pbkdf2_row()
+    row["auth_header_style"] = "Bearer"
+    row["crm_zk_uat_v1_enabled"] = True
+    row["crm_zk_v1_enabled"] = False
+    row["mulesoft_connector_ref"] = None
+    key = {
+        "key_id": "mulesoft-uat-static-1",
+        "public_key": "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=",
+        "public_key_fingerprint": f"sha256:{hashlib.sha256(bytes([2]) * 32).hexdigest()}",
+        "environment": "sandbox",
+        "status": "active",
+    }
+
+    class UatDb(_FakeDb):
+        def execute_raw(self, sql, params=None):
+            self.queries.append((sql, params))
+            if "crm_zk_uat_recipient_keys" in sql:
+                return _FakeQueryResult([key])
+            if "crm_operation_endpoints" in sql:
+                return _FakeQueryResult(list(self._operation_rows))
+            return _FakeQueryResult(list(self._registry_rows))
+
+    monkeypatch.setenv("OMNIGATEWAY_CLIENT_ID", "gateway-client")
+    monkeypatch.setenv("OMNIGATEWAY_CLIENT_SECRET", "gateway-secret")
+    definition = crm_registry_repo.load_active_definition(
+        "salesforce-fsc-customer0", db=UatDb([row], _operation_rows())
+    )
+
+    assert definition is not None
+    assert definition.crm_zk_uat_v1_enabled is True
+    assert definition.crm_zk_uat_recipient_key == {
+        "keyId": key["key_id"],
+        "publicKey": key["public_key"],
+        "publicKeyFingerprint": key["public_key_fingerprint"],
+        "environment": "sandbox",
+    }
+    assert definition.transport_tool_arguments is None
 
 
 def test_load_active_definitions_lists_all_active_rows_without_decrypt(monkeypatch):

--- a/consent-protocol/tests/test_crm_zk_uat_v1.py
+++ b/consent-protocol/tests/test_crm_zk_uat_v1.py
@@ -1,0 +1,417 @@
+"""Contract checks for the isolated CRM encrypted UAT profile."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from hushh_mcp.services.connected_systems_service import (
+    ConnectedSystemBlockedError,
+    ConnectedSystemDefinition,
+    ConnectedSystemsError,
+    ConnectedSystemsService,
+    InMemoryConnectedSystemIntentStore,
+    _normalize_crm_zk_uat_ack,
+)
+from hushh_mcp.services.crm_zk_uat_v1 import (
+    CRM_ZK_UAT_V1_PROFILE,
+    CrmZkUatEncryptedFields,
+    CrmZkUatValidationError,
+    validate_crm_zk_uat_envelope,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True)
+def _uat_runtime(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "uat")
+
+
+def _b64(size: int, byte: int = 1) -> str:
+    return base64.b64encode(bytes([byte]) * size).decode("ascii")
+
+
+def _fingerprint(byte: int = 1) -> str:
+    return f"sha256:{hashlib.sha256(bytes([byte]) * 32).hexdigest()}"
+
+
+def _envelope(*, direction: str = "update_request", key_id: str = "mulesoft-uat-1") -> dict:
+    return {
+        "profile": CRM_ZK_UAT_V1_PROFILE,
+        "direction": direction,
+        "recipientKeyId": key_id,
+        "clientOperationId": "czku_" + "a" * 32,
+        "expiresAtMs": int(time.time() * 1000) + 4 * 60 * 1000,
+        "clientPublicKey": _b64(32, 2),
+        "wrappedPayloadKey": _b64(32, 3),
+        "wrappedKeyIv": _b64(12, 4),
+        "wrappedKeyTag": _b64(16, 5),
+        "payloadIv": _b64(12, 6),
+        "payloadTag": _b64(16, 7),
+        "ciphertext": _b64(8, 8),
+    }
+
+
+def test_uat_envelope_accepts_only_exact_binary_shape_key_and_direction() -> None:
+    value = _envelope()
+    parsed = validate_crm_zk_uat_envelope(
+        value,
+        expected_direction="update_request",
+        expected_key_id="mulesoft-uat-1",
+        now_ms=value["expiresAtMs"] - 1,
+    )
+    assert parsed.digest().startswith("sha256:")
+    assert parsed.model_dump(mode="json", by_alias=True)["clientPublicKey"] == _b64(32, 2)
+
+    wrong_key = _envelope(key_id="untrusted")
+    with pytest.raises(CrmZkUatValidationError, match="recipient_key_mismatch"):
+        validate_crm_zk_uat_envelope(
+            wrong_key,
+            expected_direction="update_request",
+            expected_key_id="mulesoft-uat-1",
+            now_ms=wrong_key["expiresAtMs"] - 1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("clientPublicKey", _b64(31)),
+        ("wrappedPayloadKey", _b64(31)),
+        ("wrappedKeyIv", _b64(11)),
+        ("wrappedKeyTag", _b64(15)),
+        ("payloadIv", _b64(13)),
+        ("payloadTag", _b64(15)),
+        ("ciphertext", "not-base64"),
+    ],
+)
+def test_uat_envelope_rejects_malformed_crypto_fields(field: str, value: str) -> None:
+    with pytest.raises(ValidationError):
+        CrmZkUatEncryptedFields.model_validate({**_envelope(), field: value})
+
+
+@pytest.mark.asyncio
+async def test_uat_partner_call_replaces_registry_arguments_and_sends_no_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system = ConnectedSystemDefinition(
+        system_id="crm-uat",
+        display_name="CRM UAT",
+        customer_display_name="CRM UAT",
+        system_type="CRM",
+        system_name="CRM",
+        target="must-not-leave-hussh",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-uat",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {
+                "operation": "update",
+                "name": "update-crm-record",
+                "crmZkUatToolName": "update-crm-record-zk-uat",
+            },
+        ),
+        transport_tool_arguments={"connectorRef": "must-not-be-merged"},
+        crm_zk_uat_v1_enabled=True,
+        crm_zk_uat_recipient_key={
+            "keyId": "mulesoft-uat-1",
+            "publicKey": _b64(32),
+            "publicKeyFingerprint": _fingerprint(),
+            "environment": "sandbox",
+        },
+    )
+    service = ConnectedSystemsService(
+        registry=(system,), store=InMemoryConnectedSystemIntentStore()
+    )
+    captured: dict = {}
+
+    async def fake_call_operation(**kwargs):
+        captured.update(kwargs)
+        return {"isError": False, "payload": {"status": "accepted", "accepted": True}}
+
+    monkeypatch.setattr(service, "_call_operation", fake_call_operation)
+    payload = {
+        "profile": CRM_ZK_UAT_V1_PROFILE,
+        "operation": "update",
+        "objectType": "Contact",
+        "id": "backend-bound",
+        "fieldNames": ["Title"],
+        "encryptedFields": _envelope(),
+    }
+    await service._call_crm_zk_uat_partner(system=system, operation="update", payload=payload)
+
+    assert captured["replace_tool_arguments"] is True
+    assert captured["payload"] == payload
+    assert not (
+        {
+            "connectorRef",
+            "target",
+            "crmBaseUrl",
+            "crmMcpEndpoint",
+            "clientId",
+            "clientSecret",
+            "crmTokenUrl",
+        }
+        & captured["payload"].keys()
+    )
+
+
+def test_uat_profile_migration_is_release_managed_and_default_off() -> None:
+    migration = (ROOT / "db/migrations/143_crm_zk_uat_v1.sql").read_text("utf-8")
+    manifest = json.loads((ROOT / "db/release_migration_manifest.json").read_text("utf-8"))
+
+    assert "143_crm_zk_uat_v1.sql" in manifest["ordered_migrations"]
+    assert "crm_zk_uat_v1_enabled BOOLEAN NOT NULL DEFAULT FALSE" in migration
+    assert "NOT (crm_zk_v1_enabled AND crm_zk_uat_v1_enabled)" in migration
+    assert "environment = 'sandbox'" in migration
+    assert "crm-zk-uat.v1" in migration
+
+
+def test_uat_profile_fails_closed_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    system = ConnectedSystemDefinition(
+        system_id="crm-uat",
+        display_name="CRM UAT",
+        customer_display_name="CRM UAT",
+        system_type="CRM",
+        system_name="CRM",
+        target="private-target",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-uat",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {
+                "operation": "read",
+                "name": "read-crm-record",
+                "crmZkUatToolName": "read-crm-record-zk-uat",
+            },
+        ),
+        crm_zk_uat_v1_enabled=True,
+        crm_zk_uat_recipient_key={
+            "keyId": "mulesoft-uat-1",
+            "publicKey": _b64(32),
+            "publicKeyFingerprint": _fingerprint(),
+            "environment": "sandbox",
+        },
+    )
+
+    assert system.crm_zk_uat_ready("read") is False
+
+
+@pytest.mark.asyncio
+async def test_uat_update_is_ciphertext_only_and_approval_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system = ConnectedSystemDefinition(
+        system_id="crm-uat",
+        display_name="CRM UAT",
+        customer_display_name="CRM UAT",
+        system_type="CRM",
+        system_name="CRM",
+        target="private-target",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-uat",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {"operation": "schema", "name": "object-schema"},
+            {
+                "operation": "read",
+                "name": "read-crm-record",
+                "crmZkUatToolName": "read-crm-record-zk-uat",
+            },
+            {
+                "operation": "update",
+                "name": "update-crm-record",
+                "crmZkUatToolName": "update-crm-record-zk-uat",
+            },
+        ),
+        crm_zk_uat_v1_enabled=True,
+        crm_zk_uat_recipient_key={
+            "keyId": "mulesoft-uat-1",
+            "publicKey": _b64(32),
+            "publicKeyFingerprint": _fingerprint(),
+            "environment": "sandbox",
+        },
+    )
+    store = InMemoryConnectedSystemIntentStore()
+    store.upsert_binding(
+        {
+            "binding_id": "binding-1",
+            "user_id": "owner-1",
+            "system_id": "crm-uat",
+            "target": "private-target",
+            "object_type": "Contact",
+            "record_id": "backend-bound-record",
+            "created_intent_id": None,
+            "last_intent_id": None,
+        }
+    )
+    service = ConnectedSystemsService(registry=(system,), store=store)
+
+    async def fake_schema(**_kwargs):
+        return {
+            "objectType": "Contact",
+            "effectiveActions": {"read": True, "update": True},
+            "fields": [
+                {
+                    "key": "Title",
+                    "readable": True,
+                    "updateable": True,
+                    "writable": True,
+                    "immutable": False,
+                }
+            ],
+        }
+
+    partner_calls: list[dict] = []
+
+    async def fake_partner(**kwargs):
+        partner_calls.append(kwargs)
+        if len(partner_calls) == 1:
+            raise ConnectedSystemsError("ack lost", code="PARTNER_ACK_LOST", status_code=502)
+        return {
+            "isError": False,
+            "payload": {"status": "accepted", "accepted": True, "operationId": "op-1"},
+        }
+
+    monkeypatch.setattr(service, "get_schema", fake_schema)
+    monkeypatch.setattr(service, "_call_crm_zk_uat_partner", fake_partner)
+
+    prepared = await service.create_crm_zk_uat_update_intent(
+        user_id="owner-1",
+        system_id="crm-uat",
+        object_type="Contact",
+        field_names=["Title"],
+        encrypted_fields=_envelope(),
+        locked_field_names=set(),
+    )
+    stored = store.get_intent(
+        user_id="owner-1", system_id="crm-uat", intent_id=prepared["intentId"]
+    )
+    assert stored is not None
+    assert stored["request_payload"] == {}
+    assert stored["readback_payload"] == {}
+    assert stored["encrypted_fields"]["ciphertext"] == _b64(8, 8)
+    assert "additionalFields" not in str(stored)
+
+    with pytest.raises(ConnectedSystemsError, match="ack lost"):
+        await service.approve_crm_zk_uat_intent(
+            user_id="owner-1", system_id="crm-uat", intent_id=prepared["intentId"]
+        )
+    retryable = store.get_intent(
+        user_id="owner-1", system_id="crm-uat", intent_id=prepared["intentId"]
+    )
+    assert retryable is not None and retryable["status"] == "approved"
+    first = await service.approve_crm_zk_uat_intent(
+        user_id="owner-1", system_id="crm-uat", intent_id=prepared["intentId"]
+    )
+    second = await service.approve_crm_zk_uat_intent(
+        user_id="owner-1", system_id="crm-uat", intent_id=prepared["intentId"]
+    )
+    assert first["status"] == second["status"] == "succeeded"
+    assert len(partner_calls) == 2
+    assert (
+        partner_calls[0]["payload"]["clientOperationId"]
+        == partner_calls[1]["payload"]["clientOperationId"]
+    )
+    assert partner_calls[1]["payload"]["id"] == "backend-bound-record"
+    assert partner_calls[1]["payload"]["fieldNames"] == ["Title"]
+
+
+@pytest.mark.parametrize(
+    "unsafe_ack",
+    [
+        {"status": "Jane Doe", "accepted": True},
+        {"status": "accepted", "accepted": True, "operationId": "Jane Doe"},
+        {"status": "accepted", "accepted": "true"},
+        {"status": "accepted", "accepted": True, "idempotent": "true"},
+    ],
+)
+def test_uat_ack_rejects_plaintext_smuggling(unsafe_ack: dict) -> None:
+    with pytest.raises(ConnectedSystemsError):
+        _normalize_crm_zk_uat_ack(unsafe_ack)
+
+
+@pytest.mark.asyncio
+async def test_legacy_approval_cannot_consume_an_encrypted_intent() -> None:
+    system = ConnectedSystemDefinition(
+        system_id="crm-uat",
+        display_name="CRM UAT",
+        customer_display_name="CRM UAT",
+        system_type="CRM",
+        system_name="CRM",
+        target="private-target",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-uat",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(),
+    )
+    store = InMemoryConnectedSystemIntentStore()
+    store.create_intent(
+        {
+            "intent_id": "intent-zk-uat",
+            "user_id": "owner-1",
+            "system_id": "crm-uat",
+            "status": "pending",
+            "delivery_mode": CRM_ZK_UAT_V1_PROFILE,
+        }
+    )
+    service = ConnectedSystemsService(registry=(system,), store=store)
+
+    with pytest.raises(ConnectedSystemsError, match="standard CRM intents"):
+        await service.approve_intent(
+            user_id="owner-1", system_id="crm-uat", intent_id="intent-zk-uat"
+        )
+    stored = store.get_intent(user_id="owner-1", system_id="crm-uat", intent_id="intent-zk-uat")
+    assert stored is not None and stored["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_uat_profile_rejects_legacy_verified_search_before_loading_plaintext() -> None:
+    system = ConnectedSystemDefinition(
+        system_id="crm-uat",
+        display_name="CRM UAT",
+        customer_display_name="CRM UAT",
+        system_type="CRM",
+        system_name="CRM",
+        target="private-target",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-uat",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=({"operation": "read", "name": "read-crm-record"},),
+        crm_zk_uat_v1_enabled=True,
+        crm_zk_uat_recipient_key={
+            "keyId": "mulesoft-uat-1",
+            "publicKey": _b64(32),
+            "environment": "sandbox",
+        },
+    )
+
+    class ExplodingIdentity:
+        async def get_actor_identity(self, **_kwargs):
+            raise AssertionError("legacy identity lookup must not run")
+
+    service = ConnectedSystemsService(
+        registry=(system,),
+        store=InMemoryConnectedSystemIntentStore(),
+        identity_service=ExplodingIdentity(),
+    )
+    with pytest.raises(ConnectedSystemBlockedError, match="encrypted UAT search"):
+        await service.search_verified_record(
+            user_id="owner-1",
+            system_id="crm-uat",
+            object_type="Contact",
+            return_fields=["Title"],
+        )

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -875,9 +875,7 @@ class TestSettledActionJourneys:
         continued = await continue_app_goal(_tool_context(state))
 
         assert continued["status"] == "preview_started"
-        select = state[
-            f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"
-        ]["payload"]
+        select = state[f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"]["payload"]
         assert select["actionId"] == "location.select_share_recipient"
         assert select["needsConfirmation"] is False
         assert select["trustedActivationRequired"] is False
@@ -916,9 +914,7 @@ class TestSettledActionJourneys:
         continued = await continue_app_goal(_tool_context(state))
 
         assert continued["status"] == "preview_started"
-        search = state[
-            f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"
-        ]["payload"]
+        search = state[f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"]["payload"]
         assert search["actionId"] == "connect.search_people"
         assert search["slots"] == {"person": "Avery"}
         assert search["needsConfirmation"] is False
@@ -962,9 +958,7 @@ class TestSettledActionJourneys:
         continued = await continue_app_goal(_tool_context(state))
 
         assert continued["status"] == "preview_started"
-        request = state[
-            f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"
-        ]["payload"]
+        request = state[f"{_STATE_PENDING_DIRECTIVE}:goal:{started['goal_id']}:preview"]["payload"]
         assert request["actionId"] == "connect.send_request"
         assert request["needsConfirmation"] is False
         assert request["trustedActivationRequired"] is False
@@ -1520,7 +1514,7 @@ class TestNavigationActionMembership:
 
 
 class TestNamedShareChain:
-    """"Share my location with Sarah" is navigate-first, ask-second.
+    """The named location-share journey is navigate-first, ask-second.
 
     The single question exists to catch a MIS-HEARD name, so it is worth
     nothing unless it says the name the app matched. One does not have that

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -531,14 +531,18 @@ def test_a_journey_waits_for_the_screen_its_own_run_names():
     # and nothing happen on it, which is indistinguishable from success.
     run = _navigation_run("goal.location.select_share_recipient", "one_location")
 
-    assert _navigation_continuation_screen(
-        "goal.location.select_share_recipient", run, "succeeded"
-    ) == "one_location"
-    assert _navigation_continuation_screen(
-        "goal.analysis.start_debate",
-        _navigation_run("goal.analysis.start_debate", "kai_analysis"),
-        "started",
-    ) == "kai_analysis"
+    assert (
+        _navigation_continuation_screen("goal.location.select_share_recipient", run, "succeeded")
+        == "one_location"
+    )
+    assert (
+        _navigation_continuation_screen(
+            "goal.analysis.start_debate",
+            _navigation_run("goal.analysis.start_debate", "kai_analysis"),
+            "started",
+        )
+        == "kai_analysis"
+    )
 
 
 def test_a_journey_releases_when_destination_context_precedes_route_settlement():
@@ -546,12 +550,8 @@ def test_a_journey_releases_when_destination_context_precedes_route_settlement()
     # before it emits `action_settled`. The relay must treat that latest,
     # already-sanitized snapshot as sufficient rather than wait forever for a
     # second app_context frame.
-    assert _goal_continuation_is_already_ready(
-        {"screen": "one_location"}, "one_location"
-    )
-    assert not _goal_continuation_is_already_ready(
-        {"screen": "one_location"}, "connect"
-    )
+    assert _goal_continuation_is_already_ready({"screen": "one_location"}, "one_location")
+    assert not _goal_continuation_is_already_ready({"screen": "one_location"}, "connect")
     assert not _goal_continuation_is_already_ready({}, "one_location")
 
 
@@ -561,17 +561,24 @@ def test_a_settled_action_step_is_never_mistaken_for_another_cue_to_act():
     # to hear -- re-arming here would send it back to run the step it just ran.
     ran = _navigation_run("goal.location.select_share_recipient", "one_location", step_cursor=1)
 
-    assert _navigation_continuation_screen(
-        "goal.location.select_share_recipient", ran, "succeeded"
-    ) is None
+    assert (
+        _navigation_continuation_screen("goal.location.select_share_recipient", ran, "succeeded")
+        is None
+    )
 
 
 def test_a_navigation_that_did_not_arrive_continues_nothing():
     run = _navigation_run("goal.location.select_share_recipient", "one_location")
 
     # Nothing to stand on, so there is nothing to run there.
-    assert _navigation_continuation_screen("goal.location.select_share_recipient", run, "blocked") is None
-    assert _navigation_continuation_screen("goal.location.select_share_recipient", run, "failed") is None
+    assert (
+        _navigation_continuation_screen("goal.location.select_share_recipient", run, "blocked")
+        is None
+    )
+    assert (
+        _navigation_continuation_screen("goal.location.select_share_recipient", run, "failed")
+        is None
+    )
     # A directive with no goal behind it is an ordinary action, not a journey.
     assert _navigation_continuation_screen(None, run, "succeeded") is None
     # The settled-choice journey shape has its own continuation path.
@@ -654,10 +661,7 @@ def test_an_action_that_already_succeeded_is_not_run_again():
     assert read_completed_action(session, "location.share_selected") is None
 
     record_completed_action(session, "location.share_selected", '{"duration_hours": "0.25"}')
-    assert (
-        read_completed_action(session, "location.share_selected")
-        == '{"duration_hours": "0.25"}'
-    )
+    assert read_completed_action(session, "location.share_selected") == '{"duration_hours": "0.25"}'
     # Scoped to the action. Finishing a share says nothing about a pause.
     assert read_completed_action(session, "location.pause_updates") is None
     # And to the session, so one person's completed work never suppresses

--- a/consent-protocol/tests/test_source_library_scope_retirement_migration.py
+++ b/consent-protocol/tests/test_source_library_scope_retirement_migration.py
@@ -10,7 +10,7 @@ MIGRATION = "142_source_library_scope_retirement.sql"
 def test_source_library_retirement_migration_is_registered_in_every_owning_lane() -> None:
     manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
 
-    assert manifest["ordered_migrations"][-1] == MIGRATION
+    assert MIGRATION in manifest["ordered_migrations"]
     for group in ("iam", "pkm", "developer"):
         assert MIGRATION in manifest["groups"][group]
 

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -729,12 +729,13 @@
       "exact_tables": [
         "enterprise_crm_registry",
         "crm_operation_endpoints",
-        "crm_zk_recipient_keys"
+        "crm_zk_recipient_keys",
+        "crm_zk_uat_recipient_keys"
       ],
       "id": "enterprise_crm_registry",
       "lifecycle_status": "customer0",
       "owner": "iam-consent-governance",
-      "primary_access_path": "DB-backed Connected Systems resolution: gateway URL, per-operation MCP tool catalog, and CRM-ZK recipient public-key registry for enterprise CRM integrations (replaces hardcoded ConnectedSystemDefinition)"
+      "primary_access_path": "DB-backed Connected Systems resolution: gateway URL, per-operation MCP tool catalog, and profile-specific CRM encrypted recipient public-key registries for enterprise CRM integrations (replaces hardcoded ConnectedSystemDefinition)"
     },
     {
       "data_class": "audit_regulated",
@@ -4642,9 +4643,9 @@
     "action_gateway": "74790933153ec3fbe350c77a182088913f917fd451589d71937963b8c1544ca7",
     "agent_registry": "d314300c0b773ea2f4bda36584f3ae515a1272e19043f320b89e604910df3142",
     "cache_manifest": "10c2f6644a392c85a57b65c04457bfaab5c605b6448651a7eb1db39697aa55f5",
-    "data_plane": "38beb4b9f6a35936e2ad2a860e058cd92fbb6488f92a6fd1641caec090b1b202",
+    "data_plane": "db4c0c9d3eb915828fd7670a842aaf7b5d4c2ba79072526c5f9e3ad59ec094e0",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "36c045c32bf380e72429c1402ed29298c1c5561fbb0ad1ab56c25b8649e59f49",
+    "one_specialist_tools": "f5d8f6cb50f8ed7701d2d763bf8c89c72221aa1c954888a54ef9a175a7f2443f",
     "route_index": "e8945cb8b2eebc57c32c2220973140dcb688d5f31b7e05427c49ae17114874d8",
     "route_layout": "074616efd1e8efddd5cc09df8576bb3d5293070355cd04d42d023930fa47bf62",
     "surface_map": "ecd7d8b6f43c23986f4220ef73349f3e0a4eb20a8bd970846e6a964381c93a1e",

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -425,6 +425,15 @@ Macy's compatibility aliases only and are routed through the same schema
 validation. Create, update, and delete are auditable, idempotently approved
 intents. Only intent approval issues the registered direct MCP mutation.
 
+Two mutually exclusive encrypted profiles are default-off per connector.
+`crm-zk.v1` is the stronger production-candidate contract with authenticated
+metadata and signatures. `crm-zk-uat.v1` is a MuleSoft compatibility profile
+for sandbox conformance only: X25519, direct SHA-256 of the shared secret, and
+AES-256-GCM without AAD. It encrypts `searchFields`, read `returnFields`, and
+update `additionalFields`; it relies on Hussh owner authentication/approval and
+the authenticated gateway transport. It must not be described as independent
+cryptographic authorization, replay-proof, or production-ready.
+
 A successful exact-bound-id read with a valid registered response contract and
 an empty record collection returns `bindingStatus=remote_record_missing`.
 Malformed responses and transport, authorization, timeout, or MCP tool failures
@@ -448,6 +457,10 @@ active binding exists.
 | POST | `/api/connected-systems/{system_id}/records/delete` | Compatibility path that creates a reviewable delete intent; it never deletes immediately |
 | POST | `/api/connected-systems/{system_id}/intents/{intent_id}/approve` | Idempotently approve and execute a pending mutation through its registered MCP tool |
 | POST | `/api/connected-systems/{system_id}/intents/{intent_id}/reject` | Reject a pending intent without calling MCP |
+| GET | `/api/connected-systems/{system_id}/crm-zk-uat/config` | Return the registry-pinned sandbox recipient key for `crm-zk-uat.v1`; never accepts a request-supplied key or connector configuration |
+| POST | `/api/connected-systems/{system_id}/records/search-zk-uat` | Relay encrypted verified-profile `searchFields` only for an already owner-bound sandbox record; Hussh supplies the bound record ID and MuleSoft must reject any lookup result for another record |
+| POST | `/api/connected-systems/{system_id}/records/update-intents-zk-uat` | Create a ciphertext-only pending update intent from `{ objectType, fieldNames, encryptedFields }`; no record ID or field value is browser-controlled plaintext |
+| POST | `/api/connected-systems/{system_id}/intents/{intent_id}/approve-zk-uat` | Execute the already-reviewed opaque update once through Hussh's authenticated, idempotent approval lifecycle; accepts no approval proof body and returns a metadata-only acknowledgement |
 
 Registry activation is not an API. Operators use the local, ignored
 `crm-registry.v1` descriptor with

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -688,9 +688,10 @@
       "exact_tables": [
         "enterprise_crm_registry",
         "crm_operation_endpoints",
-        "crm_zk_recipient_keys"
+        "crm_zk_recipient_keys",
+        "crm_zk_uat_recipient_keys"
       ],
-      "primary_access_path": "DB-backed Connected Systems resolution: gateway URL, per-operation MCP tool catalog, and CRM-ZK recipient public-key registry for enterprise CRM integrations (replaces hardcoded ConnectedSystemDefinition)",
+      "primary_access_path": "DB-backed Connected Systems resolution: gateway URL, per-operation MCP tool catalog, and profile-specific CRM encrypted recipient public-key registries for enterprise CRM integrations (replaces hardcoded ConnectedSystemDefinition)",
       "retention_policy": "Retain active enterprise CRM integration config, per-operation tool catalog, and recipient public-key records while the integration is provisioned; retire or revoke keys and deactivate the registry rather than delete active history.",
       "deletion_behavior": "Operator-managed reference config; not user-delete scoped. crm_operation_endpoints cascade-delete with their parent crm_id.",
       "trust_boundary": "Client credentials stored only as AES-256-GCM envelopes (matches vault/encrypt.py EncryptedPayload), decrypted at request time with VAULT_DATA_KEY; CRM-ZK recipient and response-signing public keys plus fingerprints are non-secret verification material. Gateway/base/token URLs are non-secret config in plaintext. No raw long-lived secrets at rest.",

--- a/hushh-webapp/__tests__/services/crm-zk-uat-v1.test.ts
+++ b/hushh-webapp/__tests__/services/crm-zk-uat-v1.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CRM_ZK_UAT_V1_PROFILE,
+  createCrmZkUatEnvelope,
+  discardCrmZkUatEphemeralKey,
+} from "@/lib/connected-systems/crm-zk-uat-v1";
+import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function joined(ciphertext: string, tag: string): ArrayBuffer {
+  const left = base64ToBytes(ciphertext);
+  const right = base64ToBytes(tag);
+  const value = new Uint8Array(left.length + right.length);
+  value.set(left);
+  value.set(right, left.length);
+  return arrayBuffer(value);
+}
+
+describe("crm-zk-uat.v1 browser envelope", () => {
+  it("uses X25519 then direct SHA-256 and AES-GCM without AAD", async () => {
+    const x25519 = { name: "X25519" } as unknown as AlgorithmIdentifier;
+    const partner = await crypto.subtle.generateKey(x25519, true, ["deriveBits"]) as CryptoKeyPair;
+    const publicKey = bytesToBase64(
+      new Uint8Array(await crypto.subtle.exportKey("raw", partner.publicKey)),
+    );
+    const envelope = await createCrmZkUatEnvelope({
+      configuration: {
+        profile: CRM_ZK_UAT_V1_PROFILE,
+        configurationRevision: 1,
+        recipientKey: { keyId: "mulesoft-uat-1", publicKey },
+        keyDerivation: "SHA-256(X25519 shared secret)",
+        aad: false,
+      },
+      direction: "update_request",
+      payload: { additionalFields: { Title: "VP Sales" } },
+    });
+    const clientPublic = await crypto.subtle.importKey(
+      "raw", arrayBuffer(base64ToBytes(envelope.clientPublicKey)), x25519, false, [],
+    );
+    const shared = await crypto.subtle.deriveBits(
+      { name: "X25519", public: clientPublic } as unknown as AlgorithmIdentifier,
+      partner.privateKey,
+      256,
+    );
+    const digest = await crypto.subtle.digest("SHA-256", shared);
+    const wrapKey = await crypto.subtle.importKey(
+      "raw", digest, { name: "AES-GCM", length: 256 }, false, ["decrypt"],
+    );
+    const payloadKeyBytes = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: arrayBuffer(base64ToBytes(envelope.wrappedKeyIv)) },
+      wrapKey,
+      joined(envelope.wrappedPayloadKey, envelope.wrappedKeyTag),
+    );
+    const payloadKey = await crypto.subtle.importKey(
+      "raw", payloadKeyBytes, { name: "AES-GCM", length: 256 }, false, ["decrypt"],
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: arrayBuffer(base64ToBytes(envelope.payloadIv)) },
+      payloadKey,
+      joined(envelope.ciphertext, envelope.payloadTag),
+    );
+
+    expect(JSON.parse(new TextDecoder().decode(plaintext))).toEqual({
+      additionalFields: { Title: "VP Sales" },
+    });
+    expect(envelope).not.toHaveProperty("aadSha256");
+    expect(envelope).not.toHaveProperty("ownerSignature");
+    expect(envelope).not.toHaveProperty("recipientKeyFingerprint");
+    expect(discardCrmZkUatEphemeralKey(envelope.clientOperationId)).toBe(false);
+  });
+
+  it("creates fresh keys, operation ids, and IVs for every operation", async () => {
+    const x25519 = { name: "X25519" } as unknown as AlgorithmIdentifier;
+    const partner = await crypto.subtle.generateKey(x25519, true, ["deriveBits"]) as CryptoKeyPair;
+    const configuration = {
+      profile: CRM_ZK_UAT_V1_PROFILE,
+      configurationRevision: 1,
+      recipientKey: {
+        keyId: "mulesoft-uat-1",
+        publicKey: bytesToBase64(new Uint8Array(await crypto.subtle.exportKey("raw", partner.publicKey))),
+      },
+      keyDerivation: "SHA-256(X25519 shared secret)" as const,
+      aad: false as const,
+    };
+    const first = await createCrmZkUatEnvelope({
+      configuration, direction: "read_request", payload: { searchFields: { Email: "a@example.test" } },
+    });
+    const second = await createCrmZkUatEnvelope({
+      configuration, direction: "read_request", payload: { searchFields: { Email: "a@example.test" } },
+    });
+
+    expect(second.clientOperationId).not.toBe(first.clientOperationId);
+    expect(second.clientPublicKey).not.toBe(first.clientPublicKey);
+    expect(second.wrappedKeyIv).not.toBe(first.wrappedKeyIv);
+    expect(second.payloadIv).not.toBe(first.payloadIv);
+    expect(discardCrmZkUatEphemeralKey(first.clientOperationId)).toBe(true);
+    expect(discardCrmZkUatEphemeralKey(second.clientOperationId)).toBe(true);
+  });
+});

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -44,12 +44,20 @@ import { cn } from "@/lib/utils";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { ConnectedSystemsResourceService } from "@/lib/services/connected-systems-resource-service";
 import {
+  clearCrmZkEphemeralKeys,
   createCrmZkEnvelope,
   decryptCrmZkPartnerResponse,
+  discardCrmZkEphemeralKey,
   ensureCrmZkOwnerSigningKey,
   signCrmZkApproval,
   type CrmZkPartnerResponseEnvelope,
 } from "@/lib/connected-systems/crm-zk-v1";
+import {
+  clearCrmZkUatEphemeralKeys,
+  createCrmZkUatEnvelope,
+  decryptCrmZkUatReadResponse,
+  discardCrmZkUatEphemeralKey,
+} from "@/lib/connected-systems/crm-zk-uat-v1";
 import {
   ConnectedSystemsService,
   ConnectedSystemsRequestError,
@@ -562,9 +570,21 @@ export function ConnectedSystemsPanel({
   const selectedSystem =
     systems.find((system) => system.systemId === systemId) ||
     (!systemId ? systems[0] || null : null);
-  const crmZkEnabled = selectedSystem?.crmZk?.enabled === true;
+  const crmZkProfile = selectedSystem?.crmZk?.profile;
+  const crmZkUatEnabled = crmZkProfile === "crm-zk-uat.v1";
+  const crmZkFullEnabled = crmZkProfile === "crm-zk.v1";
   const crmZkReadReady = selectedSystem?.crmZk?.readReady === true;
   const crmZkUpdateReady = selectedSystem?.crmZk?.updateReady === true;
+  useEffect(() => {
+    if (!vaultOwnerToken) {
+      clearCrmZkEphemeralKeys();
+      clearCrmZkUatEphemeralKeys();
+    }
+    return () => {
+      clearCrmZkEphemeralKeys();
+      clearCrmZkUatEphemeralKeys();
+    };
+  }, [vaultOwnerToken]);
   useEffect(() => {
     if (selectedSystem) onSystemResolved?.(selectedSystem);
   }, [onSystemResolved, selectedSystem]);
@@ -1125,16 +1145,21 @@ export function ConnectedSystemsPanel({
       ownerSigningKey,
       payload: {},
     });
-    const response = await ConnectedSystemsService.readCrmZkRecord({
-      vaultOwnerToken,
-      systemId: selectedSystem.systemId,
-      encryptedFields: envelope,
-    });
-    const decrypted = await decryptCrmZkPartnerResponse({
-      context,
-      configuration,
-      response: response.encryptedFields as CrmZkPartnerResponseEnvelope,
-    });
+    let decrypted: Awaited<ReturnType<typeof decryptCrmZkPartnerResponse>>;
+    try {
+      const response = await ConnectedSystemsService.readCrmZkRecord({
+        vaultOwnerToken,
+        systemId: selectedSystem.systemId,
+        encryptedFields: envelope,
+      });
+      decrypted = await decryptCrmZkPartnerResponse({
+        context,
+        configuration,
+        response: response.encryptedFields as CrmZkPartnerResponseEnvelope,
+      });
+    } finally {
+      discardCrmZkEphemeralKey(context.contextId);
+    }
     const rawFields =
       decrypted.fields && typeof decrypted.fields === "object" && !Array.isArray(decrypted.fields)
         ? (decrypted.fields as Record<string, unknown>)
@@ -1158,6 +1183,67 @@ export function ConnectedSystemsPanel({
       records: [{ recordId: currentRecordId || null, fields }],
       bindingStatus: "active",
       binding: binding || undefined,
+    } satisfies ConnectedSystemMcpResponse;
+  };
+
+  const readCrmZkUatRecord = async (returnFields: string[]) => {
+    if (!selectedSystem || !vaultOwnerToken) {
+      throw new Error("Unlock your vault to read this CRM record privately.");
+    }
+    if (!crmZkReadReady) {
+      throw new Error("This CRM is not ready for its encrypted UAT read.");
+    }
+    const emailField = cleanFieldValue(schema?.profileFieldMappings?.email);
+    const phoneField = cleanFieldValue(schema?.profileFieldMappings?.phone);
+    const email = cleanFieldValue(profile?.email);
+    const phone = cleanFieldValue(profile?.phone);
+    if (!emailField || !phoneField || !email || !phone) {
+      throw new Error("Verified email and phone are required for the encrypted CRM lookup.");
+    }
+    const configuration = await ConnectedSystemsService.getCrmZkUatConfiguration({
+      vaultOwnerToken,
+      systemId: selectedSystem.systemId,
+    });
+    const envelope = await createCrmZkUatEnvelope({
+      configuration,
+      direction: "read_request",
+      payload: { searchFields: { [emailField]: email, [phoneField]: phone } },
+    });
+    let response: Awaited<ReturnType<typeof ConnectedSystemsService.searchCrmZkUatRecord>>;
+    let decrypted: Awaited<ReturnType<typeof decryptCrmZkUatReadResponse>>;
+    try {
+      response = await ConnectedSystemsService.searchCrmZkUatRecord({
+        vaultOwnerToken,
+        systemId: selectedSystem.systemId,
+        objectType: selectedSystem.objectTypeDefault,
+        returnFields,
+        encryptedFields: envelope,
+      });
+      decrypted = await decryptCrmZkUatReadResponse({
+        configuration,
+        response: response.encryptedFields,
+      });
+    } finally {
+      discardCrmZkUatEphemeralKey(envelope.clientOperationId);
+    }
+    const allowed = new Set(returnFields);
+    const fields = Object.fromEntries(
+      Object.entries(decrypted.returnFields).filter(([name, value]) =>
+        allowed.has(name) &&
+        (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null)
+      ),
+    ) as Record<string, string | number | boolean | null>;
+    return {
+      systemId: response.systemId,
+      target: selectedSystem.target,
+      objectType: response.objectType,
+      recordId: response.recordId || null,
+      resultClass: response.status === "failed" ? "failed" : "succeeded",
+      records: response.totalSize === 1
+        ? [{ recordId: response.recordId || null, fields }]
+        : [],
+      bindingStatus: response.bindingStatus,
+      binding: response.binding || undefined,
     } satisfies ConnectedSystemMcpResponse;
   };
 
@@ -1187,12 +1273,14 @@ export function ConnectedSystemsPanel({
           objectType: selectedSystem?.objectTypeDefault,
           returnFields,
         };
-        const nextResult = options.bindSearch
-          ? await ConnectedSystemsService.searchRecord(
+        const nextResult = crmZkUatEnabled
+          ? await readCrmZkUatRecord(returnFields)
+          : options.bindSearch
+            ? await ConnectedSystemsService.searchRecord(
               vaultOwnerToken || "",
               payload,
             )
-          : crmZkEnabled
+          : crmZkFullEnabled
             ? await readBoundCrmZkRecord(returnFields)
             : await ConnectedSystemsService.readRecord(
                 vaultOwnerToken || "",
@@ -1422,7 +1510,36 @@ export function ConnectedSystemsPanel({
         error: `${customerName} record could not be updated.`,
       },
       async () => {
-        if (crmZkEnabled) {
+        if (crmZkUatEnabled) {
+          if (!selectedSystem || !vaultOwnerToken) {
+            throw new Error("Unlock your vault to approve this encrypted CRM update.");
+          }
+          if (!crmZkUpdateReady) {
+            throw new Error("This CRM is not ready for its encrypted UAT update.");
+          }
+          const configuration = await ConnectedSystemsService.getCrmZkUatConfiguration({
+            vaultOwnerToken,
+            systemId: selectedSystem.systemId,
+          });
+          const envelope = await createCrmZkUatEnvelope({
+            configuration,
+            direction: "update_request",
+            payload: { additionalFields: review.recordFields },
+          });
+          preparedIntent = await ConnectedSystemsService.createCrmZkUatUpdateIntent({
+            vaultOwnerToken,
+            systemId: selectedSystem.systemId,
+            objectType: selectedSystem.objectTypeDefault,
+            fieldNames: Object.keys(review.recordFields),
+            encryptedFields: envelope,
+          });
+          return ConnectedSystemsService.approveCrmZkUatIntent({
+            vaultOwnerToken,
+            systemId: selectedSystem.systemId,
+            intentId: preparedIntent.intentId,
+          });
+        }
+        if (crmZkFullEnabled) {
           if (!selectedSystem || !cacheUserId || !vaultKey || !vaultOwnerToken) {
             throw new Error("Unlock your vault to approve this private CRM update.");
           }
@@ -1454,40 +1571,42 @@ export function ConnectedSystemsPanel({
             ownerSigningKey,
             payload: review.recordFields,
           });
-          preparedIntent = await ConnectedSystemsService.createCrmZkUpdateIntent({
-            vaultOwnerToken,
-            systemId: selectedSystem.systemId,
-            encryptedFields: envelope,
-          });
-          const challenge = await ConnectedSystemsService.createCrmZkApprovalChallenge({
-            vaultOwnerToken,
-            systemId: selectedSystem.systemId,
-            intentId: preparedIntent.intentId,
-          });
-          const approvalProof = await signCrmZkApproval({
-            ownerSigningKey,
-            intentId: challenge.intentId,
-            envelopeDigest: challenge.envelopeDigest,
-            challengeId: challenge.challengeId,
-            nonce: challenge.nonce,
-            expiresAtMs: challenge.expiresAtMs,
-          });
-          const approved = await ConnectedSystemsService.approveCrmZkIntent({
-            vaultOwnerToken,
-            systemId: selectedSystem.systemId,
-            intentId: preparedIntent.intentId,
-            approvalProof,
-          });
-          if (approved.encryptedResponse) {
-            // Verify/decrypt the partner readback in runtime memory only. A
-            // fresh bound read remains the recovery path if this session dies.
-            await decryptCrmZkPartnerResponse({
-              context,
-              configuration,
-              response: approved.encryptedResponse as CrmZkPartnerResponseEnvelope,
+          try {
+            preparedIntent = await ConnectedSystemsService.createCrmZkUpdateIntent({
+              vaultOwnerToken,
+              systemId: selectedSystem.systemId,
+              encryptedFields: envelope,
             });
+            const challenge = await ConnectedSystemsService.createCrmZkApprovalChallenge({
+              vaultOwnerToken,
+              systemId: selectedSystem.systemId,
+              intentId: preparedIntent.intentId,
+            });
+            const approvalProof = await signCrmZkApproval({
+              ownerSigningKey,
+              intentId: challenge.intentId,
+              envelopeDigest: challenge.envelopeDigest,
+              challengeId: challenge.challengeId,
+              nonce: challenge.nonce,
+              expiresAtMs: challenge.expiresAtMs,
+            });
+            const approved = await ConnectedSystemsService.approveCrmZkIntent({
+              vaultOwnerToken,
+              systemId: selectedSystem.systemId,
+              intentId: preparedIntent.intentId,
+              approvalProof,
+            });
+            if (approved.encryptedResponse) {
+              await decryptCrmZkPartnerResponse({
+                context,
+                configuration,
+                response: approved.encryptedResponse as CrmZkPartnerResponseEnvelope,
+              });
+            }
+            return approved;
+          } finally {
+            discardCrmZkEphemeralKey(context.contextId);
           }
-          return approved;
         }
         preparedIntent = await ConnectedSystemsService.updateRecordIntent(
           vaultOwnerToken || "",
@@ -1516,10 +1635,12 @@ export function ConnectedSystemsPanel({
       return;
     }
     setPendingUpdateReview(null);
-    setCrmBaselineValues((current) => ({
-      ...current,
-      ...review.recordFields,
-    }));
+    if (!crmZkUatEnabled) {
+      setCrmBaselineValues((current) => ({
+        ...current,
+        ...review.recordFields,
+      }));
+    }
     void readRecord({ silent: true });
   };
 

--- a/hushh-webapp/lib/connected-systems/crm-zk-uat-v1.ts
+++ b/hushh-webapp/lib/connected-systems/crm-zk-uat-v1.ts
@@ -1,0 +1,206 @@
+/** Browser crypto for the isolated, UAT-only `crm-zk-uat.v1` profile. */
+
+import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
+
+export const CRM_ZK_UAT_V1_PROFILE = "crm-zk-uat.v1" as const;
+
+export type CrmZkUatConfiguration = {
+  profile: typeof CRM_ZK_UAT_V1_PROFILE;
+  configurationRevision: number;
+  recipientKey: { keyId: string; publicKey: string };
+  keyDerivation: "SHA-256(X25519 shared secret)";
+  aad: false;
+};
+
+export type CrmZkUatEncryptedFields = {
+  profile: typeof CRM_ZK_UAT_V1_PROFILE;
+  direction: "read_request" | "read_response" | "update_request";
+  recipientKeyId: string;
+  clientOperationId: string;
+  expiresAtMs: number;
+  clientPublicKey: string;
+  wrappedPayloadKey: string;
+  wrappedKeyIv: string;
+  wrappedKeyTag: string;
+  payloadIv: string;
+  payloadTag: string;
+  ciphertext: string;
+};
+
+type EphemeralKey = { privateKey: CryptoKey; publicKey: string; expiresAtMs: number };
+const ephemeralKeys = new Map<string, EphemeralKey>();
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+function splitGcm(value: ArrayBuffer): { ciphertext: Uint8Array; tag: Uint8Array } {
+  const bytes = new Uint8Array(value);
+  if (bytes.length < 17) throw new Error("Encrypted CRM output was invalid.");
+  return { ciphertext: bytes.slice(0, -16), tag: bytes.slice(-16) };
+}
+
+function joinGcm(ciphertext: string, tag: string): ArrayBuffer {
+  const left = base64ToBytes(ciphertext);
+  const right = base64ToBytes(tag);
+  const joined = new Uint8Array(left.length + right.length);
+  joined.set(left);
+  joined.set(right, left.length);
+  return arrayBuffer(joined);
+}
+
+async function wrappingKey(sharedSecret: ArrayBuffer): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest("SHA-256", sharedSecret);
+  return crypto.subtle.importKey(
+    "raw",
+    digest,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function createCrmZkUatEnvelope(params: {
+  configuration: CrmZkUatConfiguration;
+  direction: "read_request" | "update_request";
+  payload: { searchFields: Record<string, string> } | { additionalFields: Record<string, string> };
+}): Promise<CrmZkUatEncryptedFields> {
+  if (params.configuration.profile !== CRM_ZK_UAT_V1_PROFILE) {
+    throw new Error("CRM encrypted UAT profile mismatch.");
+  }
+  const x25519 = { name: "X25519" } as unknown as AlgorithmIdentifier;
+  let pair: CryptoKeyPair;
+  try {
+    pair = await crypto.subtle.generateKey(x25519, true, ["deriveBits"]) as CryptoKeyPair;
+  } catch {
+    throw new Error("This device does not support the required CRM encryption.");
+  }
+  const partnerPublicKey = await crypto.subtle.importKey(
+    "raw",
+    arrayBuffer(base64ToBytes(params.configuration.recipientKey.publicKey)),
+    x25519,
+    false,
+    [],
+  );
+  const sharedSecret = await crypto.subtle.deriveBits(
+    { name: "X25519", public: partnerPublicKey } as unknown as AlgorithmIdentifier,
+    pair.privateKey,
+    256,
+  );
+  const wrapKey = await wrappingKey(sharedSecret);
+  const payloadKeyBytes = randomBytes(32);
+  const payloadKey = await crypto.subtle.importKey(
+    "raw", arrayBuffer(payloadKeyBytes), { name: "AES-GCM", length: 256 }, false, ["encrypt"],
+  );
+  const wrappedKeyIv = randomBytes(12);
+  const payloadIv = randomBytes(12);
+  const wrapped = splitGcm(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: arrayBuffer(wrappedKeyIv) }, wrapKey, arrayBuffer(payloadKeyBytes),
+  ));
+  const encrypted = splitGcm(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: arrayBuffer(payloadIv) },
+    payloadKey,
+    new TextEncoder().encode(JSON.stringify(params.payload)),
+  ));
+  const publicKey = bytesToBase64(
+    new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+  );
+  const clientOperationId = `czku_${crypto.randomUUID().replace(/-/g, "")}`;
+  const expiresAtMs = Date.now() + 5 * 60 * 1000;
+  for (const [operationId, key] of ephemeralKeys) {
+    if (key.expiresAtMs <= Date.now()) ephemeralKeys.delete(operationId);
+  }
+  if (params.direction === "read_request") {
+    ephemeralKeys.set(clientOperationId, {
+      privateKey: pair.privateKey,
+      publicKey,
+      expiresAtMs,
+    });
+  }
+  return {
+    profile: CRM_ZK_UAT_V1_PROFILE,
+    direction: params.direction,
+    recipientKeyId: params.configuration.recipientKey.keyId,
+    clientOperationId,
+    expiresAtMs,
+    clientPublicKey: publicKey,
+    wrappedPayloadKey: bytesToBase64(wrapped.ciphertext),
+    wrappedKeyIv: bytesToBase64(wrappedKeyIv),
+    wrappedKeyTag: bytesToBase64(wrapped.tag),
+    payloadIv: bytesToBase64(payloadIv),
+    payloadTag: bytesToBase64(encrypted.tag),
+    ciphertext: bytesToBase64(encrypted.ciphertext),
+  };
+}
+
+export async function decryptCrmZkUatReadResponse(params: {
+  configuration: CrmZkUatConfiguration;
+  response: CrmZkUatEncryptedFields;
+}): Promise<{ returnFields: Record<string, unknown> }> {
+  const ephemeral = ephemeralKeys.get(params.response.clientOperationId);
+  if (!ephemeral || ephemeral.expiresAtMs <= Date.now()) {
+    ephemeralKeys.delete(params.response.clientOperationId);
+    throw new Error("This CRM response expired. Start a fresh encrypted read.");
+  }
+  try {
+    if (
+      params.response.profile !== CRM_ZK_UAT_V1_PROFILE ||
+      params.response.direction !== "read_response" ||
+      params.response.recipientKeyId !== params.configuration.recipientKey.keyId ||
+      params.response.clientPublicKey !== ephemeral.publicKey ||
+      params.response.expiresAtMs <= Date.now()
+    ) throw new Error("Encrypted CRM response metadata did not match the request.");
+    const x25519 = { name: "X25519" } as unknown as AlgorithmIdentifier;
+    const partnerPublicKey = await crypto.subtle.importKey(
+      "raw",
+      arrayBuffer(base64ToBytes(params.configuration.recipientKey.publicKey)),
+      x25519,
+      false,
+      [],
+    );
+    const sharedSecret = await crypto.subtle.deriveBits(
+      { name: "X25519", public: partnerPublicKey } as unknown as AlgorithmIdentifier,
+      ephemeral.privateKey,
+      256,
+    );
+    const wrapKey = await wrappingKey(sharedSecret);
+    const payloadKeyBytes = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: arrayBuffer(base64ToBytes(params.response.wrappedKeyIv)) },
+      wrapKey,
+      joinGcm(params.response.wrappedPayloadKey, params.response.wrappedKeyTag),
+    );
+    const payloadKey = await crypto.subtle.importKey(
+      "raw", payloadKeyBytes, { name: "AES-GCM", length: 256 }, false, ["decrypt"],
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: arrayBuffer(base64ToBytes(params.response.payloadIv)) },
+      payloadKey,
+      joinGcm(params.response.ciphertext, params.response.payloadTag),
+    );
+    const decoded: unknown = JSON.parse(new TextDecoder().decode(plaintext));
+    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+      throw new Error("Encrypted CRM response payload was invalid.");
+    }
+    const returnFields = (decoded as { returnFields?: unknown }).returnFields;
+    if (!returnFields || typeof returnFields !== "object" || Array.isArray(returnFields)) {
+      throw new Error("Encrypted CRM response contained no returnFields.");
+    }
+    return { returnFields: returnFields as Record<string, unknown> };
+  } finally {
+    ephemeralKeys.delete(params.response.clientOperationId);
+  }
+}
+
+export function clearCrmZkUatEphemeralKeys(): void {
+  ephemeralKeys.clear();
+}
+
+export function discardCrmZkUatEphemeralKey(clientOperationId: string): boolean {
+  return ephemeralKeys.delete(clientOperationId);
+}

--- a/hushh-webapp/lib/connected-systems/crm-zk-v1.ts
+++ b/hushh-webapp/lib/connected-systems/crm-zk-v1.ts
@@ -95,6 +95,14 @@ export type CrmZkPartnerResponseEnvelope = {
 type EphemeralKey = { privateKey: CryptoKey; publicKey: string; expiresAtMs: number };
 const ephemeralKeys = new Map<string, EphemeralKey>();
 
+export function discardCrmZkEphemeralKey(contextId: string): boolean {
+  return ephemeralKeys.delete(contextId);
+}
+
+export function clearCrmZkEphemeralKeys(): void {
+  ephemeralKeys.clear();
+}
+
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }

--- a/hushh-webapp/lib/services/connected-systems-service.ts
+++ b/hushh-webapp/lib/services/connected-systems-service.ts
@@ -1,4 +1,8 @@
 import { ApiService } from "@/lib/services/api-service";
+import type {
+  CrmZkUatConfiguration,
+  CrmZkUatEncryptedFields,
+} from "@/lib/connected-systems/crm-zk-uat-v1";
 
 export type ConnectedSystemStatus = "connected" | "needs_configuration" | string;
 
@@ -159,7 +163,7 @@ export type ConnectedSystemIntent = {
   errorMessage?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
-  deliveryMode?: "legacy" | "crm-zk.v1" | string;
+  deliveryMode?: "legacy" | "crm-zk.v1" | "crm-zk-uat.v1" | string;
   envelopeDigest?: string | null;
   encryptedResponse?: Record<string, unknown>;
 };
@@ -309,6 +313,83 @@ export class ConnectedSystemsService {
       { method: "GET", headers: authHeaders(input.vaultOwnerToken) }
     );
     return readJsonOrThrow<CrmZkConfiguration>(response);
+  }
+
+  static async getCrmZkUatConfiguration(input: {
+    vaultOwnerToken: string;
+    systemId?: string;
+  }): Promise<CrmZkUatConfiguration> {
+    const response = await ApiService.apiFetch(
+      `/api/connected-systems/${systemPath(input.systemId)}/crm-zk-uat/config`,
+      { method: "GET", headers: authHeaders(input.vaultOwnerToken) }
+    );
+    return readJsonOrThrow<CrmZkUatConfiguration>(response);
+  }
+
+  static async searchCrmZkUatRecord(input: {
+    vaultOwnerToken: string;
+    systemId?: string;
+    objectType?: string;
+    returnFields: string[];
+    encryptedFields: CrmZkUatEncryptedFields;
+  }): Promise<{
+    profile: "crm-zk-uat.v1";
+    systemId: string;
+    objectType: string;
+    status: string;
+    totalSize: number;
+    recordId?: string | null;
+    bindingStatus: string;
+    binding?: ConnectedSystemRecordBinding | null;
+    encryptedFields: CrmZkUatEncryptedFields;
+  }> {
+    const response = await ApiService.apiFetch(
+      `/api/connected-systems/${systemPath(input.systemId)}/records/search-zk-uat`,
+      {
+        method: "POST",
+        headers: authHeaders(input.vaultOwnerToken),
+        body: JSON.stringify({
+          objectType: input.objectType,
+          returnFields: input.returnFields,
+          encryptedFields: input.encryptedFields,
+        }),
+      }
+    );
+    return readJsonOrThrow(response);
+  }
+
+  static async createCrmZkUatUpdateIntent(input: {
+    vaultOwnerToken: string;
+    systemId?: string;
+    objectType?: string;
+    fieldNames: string[];
+    encryptedFields: CrmZkUatEncryptedFields;
+  }): Promise<ConnectedSystemIntent> {
+    const response = await ApiService.apiFetch(
+      `/api/connected-systems/${systemPath(input.systemId)}/records/update-intents-zk-uat`,
+      {
+        method: "POST",
+        headers: authHeaders(input.vaultOwnerToken),
+        body: JSON.stringify({
+          objectType: input.objectType,
+          fieldNames: input.fieldNames,
+          encryptedFields: input.encryptedFields,
+        }),
+      }
+    );
+    return readJsonOrThrow<ConnectedSystemIntent>(response);
+  }
+
+  static async approveCrmZkUatIntent(input: {
+    vaultOwnerToken: string;
+    systemId?: string;
+    intentId: string;
+  }): Promise<ConnectedSystemIntent> {
+    const response = await ApiService.apiFetch(
+      `/api/connected-systems/${systemPath(input.systemId)}/intents/${encodeURIComponent(input.intentId)}/approve-zk-uat`,
+      { method: "POST", headers: authHeaders(input.vaultOwnerToken) }
+    );
+    return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
 
   static async registerCrmZkOwnerSigningKey(input: {


### PR DESCRIPTION
## Summary
- add isolated, default-off `crm-zk-uat.v1` for MuleSoft sandbox READ/UPDATE field confidentiality
- use browser X25519 -> direct SHA-256 -> AES-256-GCM without HKDF or AAD, with runtime-memory-only ephemeral keys
- preserve plaintext CREATE/DELETE and the stronger `crm-zk.v1` contract unchanged
- add dedicated UAT routes/tools, static recipient-key pinning, bound-record enforcement, ciphertext-only intents, idempotent approval retry, migration 143, schema contracts, docs, and tests

## Security boundary
This is a UAT-only transport-trusting compatibility profile, not production ZK. It is mutually exclusive with `crm-zk.v1`, requires `ENVIRONMENT=uat`, has no plaintext fallback, and remains disabled until MuleSoft provides the fixed sandbox route, pinned key, dedicated tool mappings, field-allowlist enforcement, idempotency, and conformance evidence.

## Verification
- 99 focused Connected Systems/CRM tests passed before final hardening; final focused bundle: 96 passed
- 112 affected ADK tests passed after repo-required Ruff normalization
- frontend typecheck passed; 4 CRM crypto tests passed; targeted ESLint passed
- `./bin/hushh lint` passed
- docs verification passed
- DB release contract aligned at migration 143
- frontend service-boundary verification passed
- staged and committed gitleaks scans passed; GitHub secret alerts: 0

The full monorepo local runner currently reports unrelated baseline/order-environment failures outside this diff. Required PR checks remain the merge authority.
