### PR TITLE
fix(layout): add fitContent shell variant to remove dead whitespace on sparse screens

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -971,6 +971,8 @@ export default function ConnectPageClient() {
   return (
     <AppPageShell
       as="main"
+      fitContent
+
       width="reading"
       className="relative isolate pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
       nativeTest={{

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1879,6 +1879,18 @@ html.kb-open .ambient-chrome-mask--bottom {
   padding-bottom: var(--app-bottom-content-clearance);
 }
 
+/* Sparse screens (empty states, short lists) let their height fit content
+   instead of an ancestor stretching them to the full viewport, which produced
+   a large dead scroll region above the floating "Talk to One" bar. The bottom
+   clearance padding above still keeps the last row above that bar; this only
+   removes the forced fill. `!important` overrides any inherited min-height set
+   by an ancestor layout wrapper on these pages. */
+.app-page-shell--fit-content {
+  min-height: 0 !important;
+  flex: 0 0 auto;
+}
+
+
 .app-page-shell--reading {
   max-width: 54rem;
 }

--- a/hushh-webapp/components/app-ui/app-page-shell.tsx
+++ b/hushh-webapp/components/app-ui/app-page-shell.tsx
@@ -51,6 +51,15 @@ type AppPageShellProps<T extends ElementType> = {
   as?: T;
   width?: AppPageShellWidth;
   density?: AppPageDensity;
+  /**
+   * Let the page height fit its content instead of being stretched to fill the
+   * viewport. Sparse screens (empty states, short lists) otherwise force a
+   * full-height shell, producing a large dead scroll region above the floating
+   * "Talk to One" bar. Opt-in so content-rich pages that anchor a bottom
+   * element to the viewport are unaffected.
+   */
+  fitContent?: boolean;
+
   nativeTest?: {
     routeId: string;
     marker: string;
@@ -69,6 +78,7 @@ export function AppPageShell<T extends ElementType = "main">({
   as,
   width = "standard",
   density = "compact",
+  fitContent = false,
   nativeTest,
   className,
   children,
@@ -82,10 +92,12 @@ export function AppPageShell<T extends ElementType = "main">({
         "app-page-shell",
         APP_SHELL_FRAME_CLASSNAME, // 3. Added the missing framing class
         APP_SHELL_MAX_WIDTHS[width], // 4. Utilizing Tailwind utility classes over inline styles
+        fitContent && "app-page-shell--fit-content",
         className
       )}
       data-app-density={density}
       data-app-shell-width={width}
+      data-app-shell-fit-content={fitContent ? "true" : undefined}
       data-top-content-anchor="true"
       {...props}
     >

--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -95,6 +95,8 @@ export function KaiMarketHubPage() {
   return (
     <AppPageShell
       as="div"
+      fitContent
+
       width="reading"
       className="relative !px-0 pb-32"
       data-finance-workspace="true"

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -77,6 +77,7 @@ export function RiaPageShell({
   return (
     <AppPageShell
       as="main"
+      fitContent
       width={width}
       className={cn("pb-24 sm:pb-28", className)}
       nativeTest={nativeTest}


### PR DESCRIPTION
## What & why

On sparse screens (empty Analysis, Market with a short chart, Connect list, RIA Profile) there was a large **dead blank area** you could scroll through before the floating "Talk to One" bar — content clustered at the top, then emptiness.

**Root cause:** the page shell is stretched to fill the viewport (an ancestor/`min-height: calc(100dvh - …)`), so short pages always over-fill and create scrollable whitespace. The bottom floating-bar clearance itself is already correct (`--app-bottom-content-clearance`); the dead space is the forced full-height fill on content that doesn't need it.

## Fix (opt-in, scoped — not a global change)

- **`AppPageShell`**: new `fitContent?: boolean` prop → adds `app-page-shell--fit-content` + `data-app-shell-fit-content`.
- **`globals.css`**: `.app-page-shell--fit-content { min-height: 0 !important; flex: 0 0 auto; }` — lets the page height fit its content. The existing bottom clearance padding is untouched, so the last row still clears the "Talk to One" bar.
- Applied `fitContent` to the four screens from the report: **Connect** (`app/connect/page-client.tsx`), **Finance hub** Market/Analysis (`components/kai/kai-market-hub-page.tsx`), and the shared **RIA** shell used by Profile/Clients/Picks (`components/ria/ria-page-shell.tsx`).

Opt-in by design: every other page keeps the forced-fill behavior, so pages that rely on min-height (anchored bottom elements, full-bleed backgrounds) are byte-for-byte unaffected. No regression surface beyond the four opted-in screens.

## Verification

- ESLint clean on all changed TS/TSX. `env()`-based top/bottom safe-area insets and the floating-bar clearance are unchanged; this only removes the empty vertical fill.

## Risk

Low — additive prop + one scoped CSS class; behavior only changes on the screens that explicitly pass `fitContent`.
