### PR TITLE
fix(one-location): dismiss check-in back to the screen that opened it

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -177,11 +177,13 @@ vi.mock(
   () => ({
     NearbyCheckInSheet: ({
       open,
+      onOpenChange,
       onStateChange,
       onSearchAreaChange,
       onPlaceFocusChange,
     }: {
       open: boolean;
+      onOpenChange: (open: boolean) => void;
       onStateChange: (state: unknown) => void;
       onSearchAreaChange: (point: unknown) => void;
       onPlaceFocusChange: (focus: unknown) => void;
@@ -191,6 +193,13 @@ vi.mock(
         data-one-location-nearby-check-in-sheet=""
         data-open={open ? "true" : "false"}
       >
+        <button
+          type="button"
+          data-testid="dismiss-nearby-check-in"
+          onClick={() => onOpenChange(false)}
+        >
+          Dismiss check-in
+        </button>
         <button
           type="button"
           data-testid="publish-nearby-state"
@@ -560,7 +569,7 @@ describe("LocationImmersiveMap demo experience", () => {
     );
     fireEvent.click(screen.getByTestId("one-location-map-nearby-check-in"));
     expect(navigationHarness.push).toHaveBeenCalledWith(
-      "/one/location/map?action=check-in",
+      "/one/location/check-in?source=map",
       { scroll: false },
     );
 
@@ -617,7 +626,7 @@ describe("LocationImmersiveMap demo experience", () => {
       }),
     );
     expect(navigationHarness.push).toHaveBeenCalledWith(
-      "/one/location/map?action=check-in",
+      "/one/location/check-in?source=map",
       { scroll: false },
     );
   });
@@ -1029,6 +1038,66 @@ describe("LocationImmersiveMap demo experience", () => {
     render(<LocationImmersiveMap surface="check-in" />);
     await openMap();
     expect(screen.queryByTestId("one-location-map-people-tray")).toBeNull();
+  });
+
+  it("returns to Your Map when check-in was opened from Your Map", async () => {
+    // The reported bug: check in from Your Map, close the sheet, and you were
+    // thrown past the map onto the Location hub's Now tab -- two screens back,
+    // right after making yourself discoverable. Dismiss now follows the opener
+    // recorded when Your Map pushed the route.
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "source=map";
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to Your Map" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
+    // `replace`, not `push`: a dismissed flow must not be what the next Back
+    // press re-opens.
+    expect(navigationHarness.replace).toHaveBeenCalledWith(
+      "/one/location/map",
+      { scroll: false },
+    );
+    expect(navigationHarness.push).not.toHaveBeenCalledWith(
+      "/one/location",
+      expect.anything(),
+    );
+    expect(navigationHarness.push).not.toHaveBeenCalledWith("/one/location");
+  });
+
+  it("returns to the Location hub when nothing recorded an opener", async () => {
+    // The hub's own "Check in" card, notification deep links and old shared
+    // URLs record nothing. The hub is where those came from and where they go.
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "";
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to Your Map" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
+    expect(navigationHarness.replace).toHaveBeenCalledWith("/one/location", {
+      scroll: false,
+    });
   });
 
   it("does not build a synthetic history boundary on the check-in route", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -35,6 +35,11 @@ import {
   encryptLocationForRecipient,
 } from "@/lib/one-location/encryption";
 import {
+  buildCheckInHrefFromYourMap,
+  CHECK_IN_SOURCE_PARAM,
+  resolveCheckInDismissHref,
+} from "@/lib/one-location/check-in-navigation";
+import {
   readLocationWorkspaceMemory,
   writeLocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
@@ -460,25 +465,41 @@ export function LocationImmersiveMap({
       !nearbyCheckInAvailable ||
       !rendererReady ||
       demoMode ||
+      // Nothing to open: on the check-in route the flow already is the screen.
+      isCheckInSurface ||
       searchParams.get("action") === "check-in"
     ) {
       return;
     }
     setTrayExpanded(false);
-    nearbyHistoryPreparedRef.current = true;
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("action", "check-in");
-    router.push(`${ROUTES.ONE_LOCATION_MAP}?${params.toString()}`, {
+    // Recording Your Map as the opener is what lets dismiss come back here
+    // instead of dropping the person on the Location hub.
+    router.push(buildCheckInHrefFromYourMap(searchParams), {
       scroll: false,
     });
-  }, [demoMode, nearbyCheckInAvailable, rendererReady, router, searchParams]);
+  }, [
+    demoMode,
+    isCheckInSurface,
+    nearbyCheckInAvailable,
+    rendererReady,
+    router,
+    searchParams,
+  ]);
 
   const closeNearbyCheckIn = useCallback(() => {
     // Dismissing on the dedicated route must leave it. Clearing the flag alone
     // would strand the person on a bare map that is not Your Map and has none
     // of its content -- the emptiest possible screen.
     if (isCheckInSurface) {
-      router.push(ROUTES.ONE_LOCATION);
+      // `replace`, not `push`: check-in is done with, and leaving it on the
+      // stack made the very next Back press re-open the flow just dismissed.
+      // History is not consulted for the destination either -- this app's back
+      // is authored, because the browser stack carries external origins and on
+      // iOS walking it can eject the person out of the app entirely.
+      router.replace(
+        resolveCheckInDismissHref(searchParams.get(CHECK_IN_SOURCE_PARAM)),
+        { scroll: false },
+      );
       return;
     }
     setNearbyCheckInOpen(false);
@@ -488,7 +509,7 @@ export function LocationImmersiveMap({
     ) {
       window.history.back();
     }
-  }, [isCheckInSurface, router]);
+  }, [isCheckInSurface, router, searchParams]);
 
   useEffect(() => {
     const map = mapRef.current;

--- a/hushh-webapp/lib/one-location/__tests__/check-in-navigation.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/check-in-navigation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCheckInHrefFromYourMap,
+  resolveCheckInDismissHref,
+} from "@/lib/one-location/check-in-navigation";
+
+/**
+ * Nearby check-in has two openers -- Your Map and the Location hub -- and one
+ * dismiss control.
+ *
+ * When check-in moved from a drawer over Your Map to its own route, dismiss was
+ * pointed at the Location hub for everyone. That is right for the hub's own
+ * "Check in" card and wrong for Your Map: checking in from the map and closing
+ * the sheet threw the person two screens back, past the map they were standing
+ * on, at the moment they had just made themselves discoverable. These cases
+ * exist so a third opener cannot repeat that quietly.
+ */
+describe("resolveCheckInDismissHref", () => {
+  it("returns to Your Map when Your Map opened it", () => {
+    expect(resolveCheckInDismissHref("map")).toBe("/one/location/map");
+  });
+
+  it("falls back to the Location hub when no opener is recorded", () => {
+    // The hub's own check-in card records nothing, and neither does a deep
+    // link or a refreshed legacy URL. The hub is where those belong.
+    expect(resolveCheckInDismissHref(null)).toBe("/one/location");
+    expect(resolveCheckInDismissHref(undefined)).toBe("/one/location");
+    expect(resolveCheckInDismissHref("")).toBe("/one/location");
+  });
+
+  it("does not treat a near-miss source as Your Map", () => {
+    // Compared exactly, so a stale or hand-edited param cannot pick the
+    // destination.
+    expect(resolveCheckInDismissHref("Map")).toBe("/one/location");
+    expect(resolveCheckInDismissHref(" map")).toBe("/one/location");
+    expect(resolveCheckInDismissHref("map-view")).toBe("/one/location");
+    expect(resolveCheckInDismissHref("nearby")).toBe("/one/location");
+  });
+});
+
+describe("buildCheckInHrefFromYourMap", () => {
+  it("names the check-in route and records Your Map as the opener", () => {
+    expect(buildCheckInHrefFromYourMap(new URLSearchParams())).toBe(
+      "/one/location/check-in?source=map",
+    );
+  });
+
+  it("keeps the map's own query so entering check-in does not reset it", () => {
+    const href = buildCheckInHrefFromYourMap(
+      new URLSearchParams("demo=people"),
+    );
+
+    expect(href).toBe("/one/location/check-in?demo=people&source=map");
+  });
+
+  it("drops a legacy action param instead of carrying it onto the route", () => {
+    // `?action=check-in` is the old drawer entry. Riding along would leave the
+    // new route wearing the query that the redirect exists to retire.
+    const href = buildCheckInHrefFromYourMap(
+      new URLSearchParams("action=check-in"),
+    );
+
+    expect(href).toBe("/one/location/check-in?source=map");
+  });
+
+  it("overwrites a stale source rather than inheriting it", () => {
+    const href = buildCheckInHrefFromYourMap(new URLSearchParams("source=sos"));
+
+    expect(href).toBe("/one/location/check-in?source=map");
+  });
+});

--- a/hushh-webapp/lib/one-location/check-in-navigation.ts
+++ b/hushh-webapp/lib/one-location/check-in-navigation.ts
@@ -1,0 +1,54 @@
+import { ROUTES } from "@/lib/navigation/routes";
+
+/**
+ * Where nearby check-in came from, and therefore where dismissing it goes.
+ *
+ * Check-in has two openers -- Your Map and the Location hub -- and one dismiss,
+ * so the destination cannot be a constant. The opener is recorded in the URL
+ * rather than in state: a refresh, a resumed flow and a live navigation then all
+ * dismiss to the same place, which is not true of anything held in memory. This
+ * is the same `source` convention the hub's own flows already use to remember
+ * who opened them.
+ */
+export const CHECK_IN_SOURCE_PARAM = "source";
+export const YOUR_MAP_CHECK_IN_SOURCE = "map";
+
+/**
+ * Where dismissing nearby check-in lands.
+ *
+ * Check-in became its own route so it would stop reading as Your Map with a
+ * sheet on top. Dismissing had to leave that route, and it was pointed at the
+ * Location hub for everyone -- correct for the hub's own "Check in" card, but it
+ * threw anyone who opened check-in from Your Map two screens back, past the map
+ * they were standing on, at the moment they had just checked in.
+ *
+ * The hub stays the default: an absent, unknown or spoofed source means the
+ * person did not come from Your Map, and the hub is where every other entry
+ * point lives. The value is compared exactly for that last reason -- a stale or
+ * hand-edited param must not be able to choose the destination.
+ */
+export function resolveCheckInDismissHref(
+  source: string | null | undefined,
+): string {
+  return source === YOUR_MAP_CHECK_IN_SOURCE
+    ? ROUTES.ONE_LOCATION_MAP
+    : ROUTES.ONE_LOCATION;
+}
+
+/**
+ * The href Your Map opens check-in with, preserving the map's own query.
+ *
+ * Takes anything that stringifies to a query so the caller can hand over
+ * Next's read-only `useSearchParams()` value directly.
+ */
+export function buildCheckInHrefFromYourMap(currentQuery: {
+  toString(): string;
+}): string {
+  const params = new URLSearchParams(currentQuery.toString());
+  // The legacy `?action=check-in` redirect exists for callers we do not own --
+  // old links, notifications, breadcrumbs. Your Map is one we do own, so it
+  // names the destination directly instead of routing through the redirect.
+  params.delete("action");
+  params.set(CHECK_IN_SOURCE_PARAM, YOUR_MAP_CHECK_IN_SOURCE);
+  return `${ROUTES.ONE_LOCATION_CHECK_IN}?${params.toString()}`;
+}


### PR DESCRIPTION
## The bug

Check in from Your Map, close the check-in sheet, and you land on the Location hub's **Now** tab — two screens back, past the map you were standing on, at the moment you have just made yourself discoverable to people nearby. The first thing you want after that action is to see where you now appear, and instead the app moves you somewhere you did not ask to go.

Reported after testing the check-in flow on device. It reproduces from Your Map every time, on both the sheet's close control and the Android hardware back button.

## Root cause

Check-in used to be a drawer over Your Map, so dismissing it needed no destination — the map was already underneath. [`1cf4904d3`](https://github.com/hushh-labs/hushh-research/commit/1cf4904d3) gave check-in its own route, which was the right call, and dismissing then had to name a destination. It named one, for everyone:

```ts
// location-immersive-map.tsx
if (isCheckInSurface) {
  router.push(ROUTES.ONE_LOCATION);
  return;
}
```

That is correct for the Location hub's own "Check in" card — where the destination came from — and wrong for Your Map, the other opener. One dismiss control cannot serve two openers with a constant.

`push` was a second, quieter defect: it left the just-dismissed check-in one Back press away, so leaving the flow and pressing Back re-opened the screen you had closed.

## The fix

Same shape as [`faab1f779`](https://github.com/hushh-labs/hushh-research/commit/faab1f779) (`resolveSmsContactsBackFlow`) — the same defect, one screen along, where a second entry point appeared after a fixed target had already been written.

- The opener is recorded in a `source` query param, so a refresh, a resumed flow and a live navigation all dismiss to the same place. Nothing is kept in memory.
- `resolveCheckInDismissHref` is a named pure function with its own tests rather than an inline ternary, because the original defect was an assumption nobody revisited when a second caller appeared.
- The hub stays the default. An absent, unknown or spoofed source means the person did not come from Your Map, and the hub is where every other entry point lives. The value is compared exactly, so a hand-edited param cannot pick the destination.
- Dismiss is now `replace`, not `push`. The destination is still authored rather than read from browser history, which is this repo's standing rule (`top-shell-back.ts`): the history stack carries external origins, and on iOS walking it can eject the person out of the app.
- Your Map now names the check-in route directly instead of hopping through the legacy `?action=check-in` redirect. That redirect exists for callers we do not own — old links, notifications, breadcrumbs — and keeps its own test. A caller we do own should not mount Your Map's renderer just to be sent onward.

## Behaviour

| Opened from | Before | After |
| --- | --- | --- |
| Your Map | Location hub → Now tab | Your Map |
| Location hub "Check in" | Location hub | Location hub (unchanged) |
| Deep link / old shared URL | Location hub | Location hub (unchanged) |
| Back press after dismissing | re-opened check-in | leaves cleanly |

## Tests

- `lib/one-location/__tests__/check-in-navigation.test.ts` — new. Destination resolution: the Your Map opener, the absent/empty/unknown defaults, near-miss sources (`"Map"`, `" map"`, `"map-view"`), and href construction including dropping a legacy `action` param and overwriting a stale `source`.
- `__tests__/components/location-immersive-map.test.tsx` — two regression cases covering the reported flow: dismissing check-in opened from Your Map returns to Your Map via `replace` and never pushes the hub; dismissing with no recorded opener still returns to the hub. Two existing assertions updated for Your Map's direct route push.

Verified: `tsc --noEmit` clean, `eslint --max-warnings=0` clean on changed files, 289 navigation/one-location tests + 36 check-in component tests + the full `location-immersive-map` suite passing, `verify:service-boundary` and `generate-surface-map --check` passing.

## Not in this PR

`nearby-check-in-sheet.tsx` still sends the consent-center round trip back through `from: /one/location/map?action=check-in`. It works — the redirect lands on the check-in route — but the opener is not preserved across that hop, so dismissing after responding to a consent request falls back to the hub. Separate, unreported, and it needs `useSearchParams` in the sheet; left for a follow-up rather than widened into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
