### PR TITLE
fix(location): use inset ring for selected contact card so outline is never clipped

### DIFF
--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -71,7 +71,12 @@ export function TrustedPersonCard({
       className={cn(
         SUBCARD_SURFACE,
         "flex items-center gap-3 p-3.5",
-        selected && "border-[color:var(--app-accent)]/50 ring-1 ring-[color:var(--app-accent-ring)]",
+        // `ring-inset` draws the selection outline INSIDE the card bounds so a
+        // parent scroll/`overflow-hidden` container can never clip its edges or
+        // corners (the reported "incomplete blue outline"). `ring-2` gives a
+        // clean, complete 360° stroke; the border tints the same edge.
+        selected &&
+          "border-[color:var(--app-accent)] ring-2 ring-inset ring-[color:var(--app-accent)]",
       )}
     >
       <Avatar initials={initialsFrom(name)} />


### PR DESCRIPTION
## What & why

The blue selection outline on a selected contact row card (`TrustedPersonCard` — e.g. "Abdul Rashid", "Parth Mawai") appeared **incomplete/clipped** at the edges and corners instead of wrapping the whole rounded card.

**Root cause:** the selected state used an *outer* `ring-1` (drawn on the outside of the box). When the card sits inside a rounded/scroll container with `overflow-hidden`, that outer stroke gets cropped at the container edges — the CSS equivalent of the ticket's "border applied outside a clipped view / outer stroke overflows and is clipped."

## Fix (`components/one-location/redesign/cards.tsx`)

Draw the selection outline **inside** the card bounds and make it a clean 2px stroke:
```
border-[color:var(--app-accent)] ring-2 ring-inset ring-[color:var(--app-accent)]
```
`ring-inset` is the Tailwind equivalent of SwiftUI's `.strokeBorder` (inset by the line width), so the entire 360° outline renders within the element's own box and an ancestor `overflow-hidden`/scroll container can no longer clip any edge or corner. Unselected cards are unchanged (no ring).

## Verification

- ESLint clean. Selected state only; presentation-only card component (no logic/callbacks touched).

## Risk

Very low — one conditional className on one card's selected state; unselected styling and all behavior are unchanged.
