### PR TITLE
fix(location): render Ask duration as dropdown to match Share screen

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2486,10 +2486,13 @@ function AskFlow({
       </SectionCard>
 
       <SectionCard title="Duration requested">
+        {/* Dropdown picker (not chips) to match the Share location screen's
+            duration field — same shared DurationSelector `select` presentation. */}
         <DurationSelector
           value={vm.durationHours}
           onChange={vm.setDurationHours}
           label=""
+          presentation="select"
         />
       </SectionCard>
 


### PR DESCRIPTION
## What & why

On the "Ask someone" / Location Request screen, the **"Duration requested"** section rendered as horizontal chip buttons (15 min / 30 min / 1 hour / 4 hours / 24 hours), while the **"Share location"** screen already uses a compact dropdown picker. This makes the two screens consistent.

## Fix (`components/one-location/redesign/location-redesign-hub.tsx`)

The shared `DurationSelector` already supports a `presentation="select"` mode (a single field showing the current value + chevron, opening a menu with a checkmark on the selected item, using the app's `Select` — the CSS/Radix equivalent of a SwiftUI `Menu`/`Picker`). The Share screen passes it; the Ask screen didn't. This PR adds `presentation="select"` to the Ask screen's "Duration requested" instance so it renders the same dropdown.

No new component, no new options, no logic change — same values, same `onChange`, same state.

## Verification

- ESLint clean. Reuses the existing, already-shipped select presentation (identical to the Share screen), so styling/behavior are guaranteed to match.

## Risk

Very low — one prop added to one instance; the dropdown code path is already in production on the Share screen.
