### PR TITLE
fix(connect): standardize compact sizing on connection/people action buttons

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1034,6 +1034,7 @@ export default function ConnectPageClient() {
                           variant="none"
                           effect="fade"
                           size="sm"
+                          className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
                           disabled={busyId === connection.connectionId}
                           onClick={() => void viewInformationScopes(connection)}
                         >
@@ -1046,6 +1047,7 @@ export default function ConnectPageClient() {
                               variant="destructive"
                               effect="fill"
                               size="sm"
+                              className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
                               disabled={busyId === connection.connectionId}
                               onClick={() => void handleRemove(connection)}
                             >
@@ -1058,6 +1060,7 @@ export default function ConnectPageClient() {
                               variant="none"
                               effect="fade"
                               size="sm"
+                              className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
                               disabled={busyId === connection.connectionId}
                               onClick={() => setPendingRemoveId(null)}
                             >
@@ -1074,7 +1077,7 @@ export default function ConnectPageClient() {
                               setPendingRemoveId(connection.connectionId)
                             }
                             aria-label={`Remove connection with ${connection.displayName || connection.userId}`}
-                            className="text-muted-foreground hover:text-destructive"
+                            className="h-8 rounded-[10px] px-3 text-[13px] font-medium text-muted-foreground hover:text-destructive"
                           >
                             Remove
                           </Button>
@@ -1237,6 +1240,7 @@ export default function ConnectPageClient() {
                               variant="none"
                               effect="fill"
                               size="sm"
+                              className="h-8 rounded-[10px] px-4 text-[13px] font-semibold"
                               disabled={busyId === person.userId}
                               onClick={() => void cancelConnectionRequest(person)}
                             >
@@ -1250,6 +1254,7 @@ export default function ConnectPageClient() {
                               variant="none"
                               effect="fill"
                               size="sm"
+                              className="h-8 rounded-[10px] px-4 text-[13px] font-semibold"
                               disabled={cta.disabled || busyId === person.userId}
                               onClick={() => void handleConnect(person)}
                             >


### PR DESCRIPTION
## What & why

In the Connect view, the action buttons on "My connections" (Scopes / Remove / Confirm / Cancel) and the "People" list (Connect / Cancel request) looked disproportionately large/bold relative to the contact name and email, and varied in size row to row.

## Fix (`app/connect/page-client.tsx`)

Standardized every row action button to one compact, consistent spec (the CSS equivalent of the ticket's `.system(size: 13, weight: .medium)` + compact 32–34pt height + `cornerRadius 10`):

- **My connections** — Scopes / Confirm / Cancel / Remove: `h-8 rounded-[10px] px-3 text-[13px] font-medium` (Remove keeps its muted→destructive tone).
- **People list** — Connect / Cancel request: `h-8 rounded-[10px] px-4 text-[13px] font-semibold` (primary emphasis for the main CTA, still compact and vertically centered in the row).

All buttons are the shared `Button` in `SettingsRow`'s trailing slot, so they stay vertically centered within each row's `HStack`. Horizontal card insets are already consistent via `SettingsGroup`/`SettingsRow`.

## Verification

- ESLint clean. Class-only changes to existing buttons; no handler, data, or layout-structure changes.

## Risk

Very low — Tailwind sizing classes added to existing row action buttons on one screen; no behavior change.
