### PR TITLE
fix(one-location): deliver Circle invitation notifications

### DIFF
--- a/consent-protocol/api/utils/fcm_messages.py
+++ b/consent-protocol/api/utils/fcm_messages.py
@@ -12,6 +12,35 @@ ONE_LOCATION_SMS_EMERGENCY_ANDROID_CHANNEL = "one_location_sms_emergency_v1"
 ONE_LOCATION_SMS_EMERGENCY_IOS_SOUND = "one_location_sms_alarm.wav"
 
 
+def _webpush_link(request_url: str) -> str | None:
+    """Absolute HTTPS target for WebpushFCMOptions, or None when impossible.
+
+    FCM rejects a non-HTTPS ``WebpushFCMOptions.link`` outright, and that
+    rejection fails the whole ``messaging.send`` -- so a relative deep link
+    (every caller passes one) silently killed the entire notification rather
+    than just its click target. Callers keep passing app-relative paths, so
+    resolve them against the configured frontend origin here, and drop
+    fcm_options when the result still is not HTTPS (local http dev). The
+    click target survives either way: WebpushNotification.data carries the
+    same URL for the service worker to handle.
+    """
+
+    url = str(request_url or "").strip()
+    if url.lower().startswith("https://"):
+        return url
+    if not url.startswith("/"):
+        return None
+    try:
+        from hushh_mcp.services.consent_request_links import frontend_origin
+
+        origin = str(frontend_origin() or "").strip().rstrip("/")
+    except Exception:  # noqa: BLE001 - never let link resolution break a push
+        return None
+    if not origin.lower().startswith("https://"):
+        return None
+    return f"{origin}{url}"
+
+
 def _is_one_location_sms_emergency(data: dict[str, str]) -> bool:
     profile = str(data.get("notification_profile") or "").strip().lower()
     if profile == ONE_LOCATION_SMS_EMERGENCY_PROFILE:
@@ -40,6 +69,7 @@ def build_push_message(
     notification = messaging.Notification(title=title, body=body) if show_alert else None
 
     webpush = None
+    webpush_link = _webpush_link(request_url)
     if show_alert and normalized_platform == "web":
         webpush = messaging.WebpushConfig(
             headers={"Urgency": "high"},
@@ -53,7 +83,7 @@ def build_push_message(
                 silent=False,
                 vibrate=[240, 120, 240, 120, 520] if is_sms_emergency else None,
             ),
-            fcm_options=messaging.WebpushFCMOptions(link=request_url),
+            fcm_options=(messaging.WebpushFCMOptions(link=webpush_link) if webpush_link else None),
         )
 
     android = None

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -1960,6 +1960,7 @@ class OneLocationCircleService:
                     for invitee_user_id in cleaned_invitee_user_ids
                 ]
             if created_invite_ids:
+                from hushh_mcp.services.feed_service import FeedService
                 from hushh_mcp.services.push_notifications import (
                     send_circle_member_invite_push,
                 )
@@ -1974,6 +1975,25 @@ class OneLocationCircleService:
                         circle_id=cleaned_circle_id,
                         invite_id=str(payload.get("id") or ""),
                     )
+                    # Feed is a best-effort, post-commit projection: the
+                    # invitation itself is already durable in
+                    # one_location_circle_member_invites, so a feed-write
+                    # failure must never fail the invite that produced it.
+                    try:
+                        FeedService().record_event(
+                            user_id=str(payload.get("inviteeUserId") or ""),
+                            source_domain="location",
+                            event_type="circle_member_invited",
+                            actor_label=str(payload.get("inviterDisplayName") or "") or None,
+                            metadata={
+                                "invite_id": str(payload.get("id") or ""),
+                                "circle_id": cleaned_circle_id,
+                                "circle_name": str(payload.get("circleName") or ""),
+                                "inviter_user_id": actor_user_id,
+                            },
+                        )
+                    except Exception:  # noqa: BLE001 - projection cannot roll back the invite
+                        logger.exception("one_location.circle_member_invite_feed_projection_failed")
             logger.info(
                 "one_location.circle_members_invited actor=%s requested=%s created=%s",
                 redact_log_field("user_id", actor_user_id),

--- a/consent-protocol/tests/test_fcm_messages.py
+++ b/consent-protocol/tests/test_fcm_messages.py
@@ -284,6 +284,63 @@ def test_sms_emergency_uses_distinct_cross_platform_alert_profile() -> None:
     assert web.webpush.notification.vibrate == [240, 120, 240, 120, 520]
 
 
+def test_relative_web_link_resolves_against_https_frontend_origin(monkeypatch):
+    """A relative deep link must become an absolute HTTPS fcm_options link.
+
+    FCM rejects a non-HTTPS WebpushFCMOptions.link and fails the whole send,
+    so every caller that passes an app-relative path (circle invites,
+    connection requests) lost its notification entirely.
+    """
+
+    import hushh_mcp.services.consent_request_links as links
+
+    delivery_target = "web-device-id"
+    monkeypatch.setattr(links, "frontend_origin", lambda: "https://uat.one.hushh.ai")
+    message = build_push_message(
+        _MessagingStub,
+        token=delivery_target,
+        platform="web",
+        data={"type": "location_circle_member_invite"},
+        title="Circle invitation",
+        body="You have a new Circle invitation.",
+        request_url="/one/location?tab=people&circleInviteId=invite-1",
+        notification_tag="location-circle-member-invite:invite-1",
+        show_alert=True,
+    )
+
+    assert message.webpush.fcm_options.link == (
+        "https://uat.one.hushh.ai/one/location?tab=people&circleInviteId=invite-1"
+    )
+    # The service worker's click target is carried independently of fcm_options.
+    assert message.webpush.notification.data == {
+        "url": "/one/location?tab=people&circleInviteId=invite-1"
+    }
+
+
+def test_relative_web_link_drops_fcm_options_when_origin_is_not_https(monkeypatch):
+    """Local http dev must still deliver the push, just without a click link."""
+
+    import hushh_mcp.services.consent_request_links as links
+
+    delivery_target = "web-device-id"
+    monkeypatch.setattr(links, "frontend_origin", lambda: "http://localhost:3000")
+    message = build_push_message(
+        _MessagingStub,
+        token=delivery_target,
+        platform="web",
+        data={"type": "location_circle_member_invite"},
+        title="Circle invitation",
+        body="You have a new Circle invitation.",
+        request_url="/one/location?tab=people&circleInviteId=invite-1",
+        notification_tag="location-circle-member-invite:invite-1",
+        show_alert=True,
+    )
+
+    assert message.webpush is not None
+    assert message.webpush.fcm_options is None
+    assert message.webpush.notification.body == "You have a new Circle invitation."
+
+
 def test_build_push_message_without_alert_is_data_only():
     delivery_target = "web-device-id"
     message = build_push_message(

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2259,7 +2259,7 @@ function ShareFlow({
           onClick={vm.onOpenShareReview}
           disabled={!vm.canShare || shareNoteLimitExceeded}
           isLoading={vm.busy === "share"}
-          className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:opacity-50"
+          className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
         >
           Review share
         </Button>
@@ -2387,7 +2387,7 @@ function ShareFlow({
       <Button
         onClick={() => setStep("details")}
         disabled={!selectedReady.length}
-        className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:opacity-50"
+        className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
       >
         Continue
       </Button>
@@ -2534,7 +2534,7 @@ function AskFlow({
             disabled={!isFormValid || sending}
             aria-disabled={!isFormValid || sending}
             isLoading={sending}
-            className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:opacity-50"
+            className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
           >
             Send request
           </Button>

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
+import { buildOneLocationWorkflowHref } from "@/lib/one-location/notifications";
 import { buildKaiMarketRoute } from "@/lib/navigation/routes";
 import { ROUTES } from "@/lib/navigation/routes";
 import type { FeedItem, FeedSourceDomain } from "@/lib/services/feed-service";
@@ -155,6 +156,24 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         description: `${who} denied your location request.`,
         href: ROUTES.ONE_LOCATION,
       };
+    case "circle_member_invited": {
+      const circleName = metadataString(item.metadata, "circle_name");
+      const inviteId = metadataString(item.metadata, "invite_id");
+      return {
+        icon,
+        domainLabel,
+        label: "Circle invitation",
+        description: circleName
+          ? `You were invited to join ${circleName}.`
+          : "You were invited to join a Circle.",
+        href: inviteId
+          ? buildOneLocationWorkflowHref({
+              circleInviteId: inviteId,
+              section: "people",
+            })
+          : ROUTES.ONE_LOCATION,
+      };
+    }
     case "kai_analysis_completed": {
       const ticker = metadataString(item.metadata, "ticker");
       return {

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -3,7 +3,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
-import { MapPin, ShieldCheck, Siren, TrendingUp, UserRound } from "lucide-react";
+import {
+  MapPin,
+  ShieldCheck,
+  Siren,
+  TrendingUp,
+  UserRound,
+  Users,
+} from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
 import { useVault } from "@/lib/vault/vault-context";
@@ -49,6 +56,7 @@ import {
 } from "@/lib/one-location/encryption";
 import type {
   OneLocationAccessRequest,
+  OneLocationCircleMemberInvite,
   OneLocationGrant,
 } from "@/lib/one-location/types";
 import { buildOneLocationNotificationHref } from "@/lib/one-location/notifications";
@@ -309,6 +317,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
   const locationRequests = locationResource.data?.requests;
   const receivedGrants = locationResource.data?.receivedGrants;
   const myRecipientKey = locationResource.data?.myRecipientKey;
+  const circleMemberInvites = locationResource.data?.circleMemberInvites;
   const locationRefresh = locationResource.refresh;
   const connectionRequests = connectionsResource.data;
   const connectionsRefresh = connectionsResource.refresh;
@@ -531,6 +540,59 @@ export function useFeedActionables(): UseFeedActionablesResult {
       });
     }
 
+    // Circle invitations — inline Accept / Decline. The state read already
+    // scopes these to incoming + pending, but re-filter so a widened server
+    // response can never surface someone else's invite as actionable here.
+    const pendingCircleInvites = (circleMemberInvites ?? []).filter(
+      (invite: OneLocationCircleMemberInvite) =>
+        invite.inviteeUserId === userId && invite.status === "pending",
+    );
+    for (const invite of pendingCircleInvites) {
+      const label = invite.inviterDisplayName?.trim() || "Someone";
+      const circleName = invite.circleName?.trim() || "a Circle";
+      items.push({
+        id: `circle-invite:${invite.id}`,
+        icon: Users,
+        iconTone: "blue",
+        title: label,
+        description: `Invited you to join ${circleName}.`,
+        actions: [
+          {
+            key: "decline",
+            label: "Decline",
+            tone: "ghost",
+            disabled: !vaultOwnerToken,
+            confirm: true,
+            run: async () => {
+              if (!vaultOwnerToken) return;
+              await OneLocationService.declineNamedCircleMemberInvite({
+                vaultOwnerToken,
+                inviteId: invite.id,
+              });
+              if (userId) OneLocationStateResource.invalidate(userId);
+              await locationRefresh({ force: true });
+            },
+          },
+          {
+            key: "accept",
+            label: "Accept",
+            tone: "primary",
+            disabled: !vaultOwnerToken,
+            run: async () => {
+              if (!vaultOwnerToken) return;
+              await OneLocationService.acceptNamedCircleMemberInvite({
+                vaultOwnerToken,
+                inviteId: invite.id,
+              });
+              if (userId) OneLocationStateResource.invalidate(userId);
+              await locationRefresh({ force: true });
+            },
+          },
+        ],
+        sortAt: toTimestamp(invite.createdAt) || Date.now(),
+      });
+    }
+
     // Scoped connection requests require the Consent Center review surface.
     // A feed shortcut must never turn an omitted scope decision into a silent
     // decline (or, worse, an implied approval).
@@ -716,6 +778,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
     locationRequests,
     receivedGrants,
     smsEmergencyAddresses,
+    circleMemberInvites,
     locationRefresh,
     openAnalysis,
     pendingConsentCount,


### PR DESCRIPTION
Circle invitations were reaching **no notification surface** — not the push popup, not the consent manager, not the Feed. Root-caused to three independent problems.

## 1. The web push never sent (affects more than Circles)

`build_push_message` passed the caller's deep link straight into `WebpushFCMOptions(link=...)`. FCM rejects a non-HTTPS link, and that rejection **fails the whole `messaging.send`** — so an app-relative path didn't just lose its click target, it killed the notification outright. It surfaced only as a warning, because push is best-effort:

```
push.send_failed type=location_circle_member_invite error=WebpushFCMOptions.link must be a HTTPS URL.
```

**This was never Circle-specific.** `send_connection_request_push` passes `/one/consent?tab=connections` and was equally dead on web — any web user was silently losing connection-request notifications too.

Relative links now resolve against the configured frontend origin. When the result can't be HTTPS (local http dev), `fcm_options` is dropped so the push still delivers — the service worker's click target lives in `WebpushNotification.data` and is unaffected either way.

## 2. Feed "Needs you" never read circle invites

`useFeedActionables` aggregates live domain state but only looked at location *access requests*, so a pending invitation was invisible. It now surfaces with inline **Accept** / **Decline** against the existing service methods, following the location-request block exactly (vault-gated, cache-invalidate, force-refresh).

## 3. Feed "Earlier" had no write path

`create_member_invites` now records a `feed_events` row beside the existing push, as a best-effort post-commit projection that cannot roll back the invite that produced it. `source_domain "location"` was already permitted by the table's CHECK — **no migration required**.

## Also: disabled-state styling on the Location CTAs

The share/request buttons were already inert via their `disabled` prop, but styled only with `disabled:opacity-50` — a half-opacity accent fill still reads as tappable. They now drop to a grey fill, matching the treatment already used in `sms-contacts-flow.tsx`.

## Verification

Reproduced against a real pending invite in UAT, created through the actual service methods (not hand-written SQL):

| Surface | Before | After |
|---|---|---|
| Push send | throws, 0 delivered | ✅ `devices sent to: 1` |
| State returns invite | ✅ already worked | ✅ |
| Consent-center entry | ✅ already worked | ✅ `CIRCLE_MEMBER_INVITED` |
| Feed `feed_events` row | ❌ never written | ✅ written with correct metadata |

- `tsc --noEmit` clean on this branch
- 74 webapp tests pass (notification, consent-center, circle-flow, feed suites)
- 66 backend tests pass; 2 new regression tests cover both link-resolution branches
- `ruff check` + `ruff format --check` clean

## Note for reviewers

Hops 1 and 2 of the client chain (state → contributor → reconciliation → provider) already handled circle invites correctly. The break was entirely at the delivery layer. I'd suggest sanity-checking connection-request pushes on web after this lands, since they were broken by the same cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)