### PR TITLE
fix(onboarding): top-align capability intro screens to remove dead space

### DIFF
--- a/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
@@ -165,7 +165,15 @@ export function CapabilityCinematicIntroGate({
   const promise = copy.introPromise ?? copy.setupBlurb;
   const introLayoutClass = embedded
     ? "motion-step-enter relative mx-auto flex w-full max-w-[36rem] flex-col pt-8 text-center"
-    : "motion-step-enter relative mx-auto flex min-h-[calc(100dvh-16rem-env(safe-area-inset-top))] w-full max-w-[36rem] flex-col items-center justify-center pt-[max(2rem,env(safe-area-inset-top))] text-center";
+    : // Top-aligned with balanced padding rather than centered inside a
+      // near-full-height box. Centering within `min-h:100dvh-16rem` stacked on
+      // top of the shell's own header clearance pushed the hero into the lower
+      // half and left a large dead band under the nav bar (worse on the short
+      // Location intro than the taller AI-access one, so the screens looked
+      // inconsistent). Anchoring to the top with a clean, safe-area-aware top
+      // padding removes the gap and makes every intro screen sit the same
+      // distance below the header across device sizes.
+      "motion-step-enter relative mx-auto flex w-full max-w-[36rem] flex-col items-center pb-10 pt-[max(1.5rem,calc(env(safe-area-inset-top)+1rem))] text-center";
 
   const content = (
     <section


### PR DESCRIPTION
## What & why

The agent onboarding intro screens (Setup › AI access, Setup › Location — both rendered by the shared `CapabilityCinematicIntroGate`) showed a large dead band of white space under the nav header, with the hero icon/title/subtitle pushed into the lower half of the screen. It was worse on the shorter Location intro than the taller AI-access one, so the two screens looked inconsistent.

Root cause: the non-embedded intro was vertically centered inside `min-h:[calc(100dvh-16rem-…)]` while the route shell *also* contributes its own fixed-header clearance. Centering within that tall box dropped the content low and left the gap at the top.

## Fix (`components/onboarding/setup/capability-cinematic-intro.tsx`)

Replaced the center-in-tall-box layout with a **top-aligned** block:
- Dropped `min-h-…/justify-center`; the hero now anchors to the top with a clean, safe-area-aware top padding (`pt-[max(1.5rem, calc(env(safe-area-inset-top)+1rem))]`) plus `pb-10`.
- `env(safe-area-inset-top)` is 0 on web/desktop (no-op there) and clears the notch/native header on iOS, so every intro sits the same distance below the header across device sizes.
- The existing hero `VStack`-style spacing (eyebrow → title `mt-4` → subtitle `mt-5` → Continue `mt-10`) and the Continue button are unchanged, so alignment/CTA placement stay consistent; only the outer vertical anchoring changed.

This is the shared component behind the AI-access and Location intro screens, so both are fixed in one place.

## Verification

- ESLint clean. Presentation-only (Tailwind class change); no logic/state/behavior change.

## Base

Targets **uat** for TestFlight testing.
