### PR TITLE
fix(setup): stop setup-hub title and Finish setup action overlapping

### DIFF
--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -389,7 +389,13 @@ export function OneSetupHub() {
       }}
     >
       <AppPageHeaderRegion>
-        <div className="relative">
+        {/* Header title + mobile master action share one flex row. The action
+            was absolutely positioned over the header before, so the large
+            display title ran underneath it and the two overlapped. A flex row
+            with a min-w-0 title column and a shrink-0 button keeps real
+            horizontal separation; the title shrinks within its column. */}
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
           <PageHeader
             title={
               showVaultInvitation
@@ -406,6 +412,7 @@ export function OneSetupHub() {
             accent="neutral"
             className={styles.setupHeader}
           />
+          </div>
           {/* Mobile surfaces the master Skip/Finish action top-right in the
               header so it is always reachable and never hides behind the fixed
               "Talk to One" agent bar. Desktop keeps the in-flow footer below. */}
@@ -420,7 +427,7 @@ export function OneSetupHub() {
                   : undefined
               }
               data-testid="one-setup-master-ack-mobile"
-              className="absolute right-0 top-1 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-semibold text-[var(--app-accent)] transition hover:bg-[var(--app-accent-tint)] disabled:pointer-events-none disabled:opacity-40 sm:hidden"
+              className="mt-1 shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-semibold text-[var(--app-accent)] transition hover:bg-[var(--app-accent-tint)] disabled:pointer-events-none disabled:opacity-40 sm:hidden"
             >
               {masterActionLabel}
             </button>


### PR DESCRIPTION
## What & why

On the Setup hub (`/one/setup`, `OneSetupHub`), the large display title "Finish setting up One" and the mobile top-right "Finish setup" action rendered on top of each other — the title text ran straight under the button.

Root cause: the header wrapper was `position: relative` and the action button was `position: absolute right-0 top-1`, so it was lifted out of flow and overlaid the full-width `PageHeader` title (which has no right-edge bound to stop before the button).

## Fix (`components/onboarding/setup/one-setup-hub.tsx`)

Restructured the header into a proper horizontal flex row:
- Wrapper is now `flex items-start gap-3`.
- Title `PageHeader` sits in a `min-w-0 flex-1` column so it shrinks/wraps within its own space instead of running under the button.
- The "Finish setup" button is a normal `shrink-0` flex child (dropped `absolute right-0 top-1`, kept `mt-1` for baseline alignment), so it always sits to the right with real horizontal separation.

Behavior is unchanged: still mobile-only (`sm:hidden`), same `handleMasterAck`, same disabled/gating logic; the sub-label ("N of 6 ready…") and the segmented progress bar below are untouched.

## Verification

- ESLint clean; JSX balance verified. Presentation-only (layout classes + wrapper divs).

## Base

Targets **uat** for TestFlight testing.
