### PR TITLE
fix(setup): contain setup-hub render errors behind route error boundary

### DIFF
--- a/hushh-webapp/app/one/setup/page.tsx
+++ b/hushh-webapp/app/one/setup/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
+import { RouteErrorBoundary } from "@/components/app-ui/route-error-boundary";
 import { OneSetupHub } from "@/components/onboarding/setup/one-setup-hub";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
@@ -39,7 +40,13 @@ export default function OneSetupPage() {
         authState="authenticated"
         dataState="loaded"
       />
-      <OneSetupHub />
+      {/* A render error in the setup hub used to take down the whole native
+          shell (the TestFlight "Hussh One … Crashed" alert). Wrapping the hub
+          in the shared route error boundary contains any such failure to a
+          recoverable in-app screen (Retry / Go home) instead of crashing. */}
+      <RouteErrorBoundary fallbackRoute={ROUTES.ONE_HOME}>
+        <OneSetupHub />
+      </RouteErrorBoundary>
     </>
   );
 }


### PR DESCRIPTION
## What & why

The TestFlight build shows "Hussh One | Personal Agent Crashed" when the Setup Overview screen (`/one/setup`, `OneSetupHub`) is presented. In this codebase that screen is **web/React inside the Capacitor shell** (not SwiftUI), so a JavaScript render error there was not contained by any boundary — it propagated to the WebView and took the whole app down (the native "…Crashed" alert).

The `/one/setup` route rendered `<OneSetupHub />` directly with **no error boundary**, unlike KAI/RIA routes which use the shared `RouteErrorBoundary`. Any throw during the hub's render (e.g. partial/empty capability state, a missing lookup, a bad enrichment response) therefore became a fatal crash instead of a recoverable screen.

## Fix (`app/one/setup/page.tsx`)

Wrapped `<OneSetupHub />` in the existing `RouteErrorBoundary` (fallback route `ONE_HOME`), matching how KAI/RIA layouts already guard their routes:
- A render error now shows the shared recovery UI (Retry / Go home) and is logged via `componentDidCatch`, instead of crashing the native shell.
- Auth redirect and the `HushhLoader` gate are unchanged; the boundary only wraps the hub subtree.

This is the smallest change that satisfies the crash-containment intent using an existing, proven boundary. (The hub's own data path already degrades safely — `getOneSetupCapability` returns `undefined` rather than throwing, capability status falls back to an `unknown` default, and `summary` handles the empty/loading case — so no force-unwrap-style hazard was found to convert; the missing piece was the route-level boundary.)

## Verification

- ESLint clean. Behavior unchanged on the happy path; only failure handling improves.

## Base

Targets **uat** for TestFlight testing.
