### PR TITLE
fix(location): render Ask reason as a dropdown to match duration select

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2514,7 +2514,14 @@ function AskFlow({
       </SectionCard>
 
       <SectionCard title="Reason">
-        <ReasonChips value={reason} onChange={setReason} label="" />
+        {/* Dropdown (not chips) to match the Duration field's select
+            presentation on this same screen. */}
+        <ReasonChips
+          value={reason}
+          onChange={setReason}
+          label=""
+          presentation="select"
+        />
       </SectionCard>
 
       <SectionCard title="Message">

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -200,11 +200,50 @@ export function ReasonChips({
   value,
   onChange,
   label = "Reason",
+  presentation = "buttons",
+  placeholder = "Select a reason for request…",
 }: {
   value: ReasonValue | null;
   onChange: (next: ReasonValue) => void;
   label?: string;
+  presentation?: "buttons" | "select";
+  placeholder?: string;
 }) {
+  const labelId = useId();
+
+  // Dropdown presentation to match DurationSelector's select variant, for a
+  // denser Ask form. Buttons variant is retained for any other caller.
+  if (presentation === "select") {
+    return (
+      <div className="space-y-2">
+        {label ? (
+          <p id={labelId} className="text-sm font-semibold text-foreground">
+            {label}
+          </p>
+        ) : null}
+        <Select
+          value={value ?? undefined}
+          onValueChange={(next) => onChange(next as ReasonValue)}
+        >
+          <SelectTrigger
+            aria-label={label || "Reason"}
+            aria-labelledby={label ? labelId : undefined}
+            className="h-11 w-full rounded-[14px] border-border/70 bg-background text-sm shadow-none"
+          >
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent align="start" position="popper" className="rounded-[14px]">
+            {REASON_CHIPS.map((reason) => (
+              <SelectItem key={reason} value={reason}>
+                {reason}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-2">
       {label ? (


### PR DESCRIPTION
## What & why

On the Ask-someone location request flow (Location → "Ask someone to share" → Ask), **Duration requested** already renders as a clean dropdown (shipped in #5144), but **Reason** was still a wrapped group of pill/chip buttons. Per the ticket, convert Reason to a matching dropdown for consistent, denser UI.

## Fix

**`components/one-location/redesign/selectors.tsx`** — `ReasonChips` gains a `presentation` prop (`"buttons" | "select"`, default `"buttons"`, so no other caller changes):
- `presentation="select"` renders the shared `Select` (same `SelectTrigger/Content/Item` primitives + styling as `DurationSelector`'s select variant: `h-11 w-full rounded-[14px] border-border/70 bg-background`, right-aligned chevron, full-width touch target).
- Placeholder: **"Select a reason for request…"** (shown until a reason is chosen).
- Options come from the existing `REASON_CHIPS` (Safety check-in, Meeting nearby, Pick-up, Other) — unchanged, so the stored `ReasonValue` contract is identical.

**`components/one-location/redesign/location-redesign-hub.tsx`** — the Ask flow's Reason section now passes `presentation="select"`, sitting directly under the Duration dropdown.

Value state and `onChange` are unchanged (still the page-owned `reason`), so behavior/analytics are untouched — this is presentation only.

## Note on the reference options
The ticket suggested relabeling to Emergency / Meeting up / Travel update / Check-in / Other and defaulting Duration to "1 hour". I kept the **existing** reason set and the existing duration options/default to avoid changing the data contract and the voice/action copy in the same PR; happy to follow up with a copy change if you want those exact labels.

## Verification

- ESLint clean on both files. Duration dropdown unchanged; Reason now matches it.

## Base

Targets **uat**.
