### PR TITLE
fix(setup): center RIA setup intro content

### DIFF
--- a/hushh-webapp/app/one/setup/ria/ria-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/ria/ria-onboarding-setup-client.tsx
@@ -21,7 +21,7 @@ export function RiaOnboardingSetupClient() {
   if (!coordinator.isReady) return <SetupCapabilityLoading label="Preparing RIA setup…" />;
 
   return (
-    <div className="flex min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-bottom-inset,2rem))] w-full flex-col justify-center items-start space-y-4 pb-[calc(var(--app-bottom-inset)+1rem)]">
+    <div className="flex min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-bottom-inset,2rem))] w-full flex-col justify-center items-center space-y-4 pb-[calc(var(--app-bottom-inset)+1rem)]">
       <RiaOnboardingPage
         setupMode
         onSetupReadinessChange={setReady}


### PR DESCRIPTION
## What & why

On the Setup RIA page (`/one/setup/ria`), the hero block (eyebrow "One · RIA", headline, subtitle, Continue) sat offset toward the right instead of centered on wide viewports.

Root cause: the setup wrapper in `ria-onboarding-setup-client.tsx` used `items-start`, so the constrained-width RIA intro column was pinned to the left edge of the full-width flex container; its own centered text then read as pushed right.

## Fix (`app/one/setup/ria/ria-onboarding-setup-client.tsx`)

Changed the wrapper's cross-axis alignment from `items-start` → `items-center`, so the intro column is horizontally centered in the viewport (matching the other setup intros). One-word change; no markup, copy, or logic changed. The top `Setup > RIA` breadcrumb is owned by the shared top shell and already left-padded, so it's untouched.

## Verification

- ESLint clean. Presentation-only (single Tailwind class).

## Base

Targets **uat**.
