### PR TITLE
fix(location): relax Ask Send gating back to recipient-only (undo #5108)

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2532,15 +2532,13 @@ function AskFlow({
         description="They approve, decline, or ignore."
       />
 
-      {/* Single source of truth for whether the request can be sent: at least
-          one recipient AND a duration AND a reason must be chosen. Previously
-          the button only checked the recipient count, so it could look/act
-          submittable before every required selection existed. */}
+      {/* Send is enabled once at least one recipient is chosen. Duration and
+          reason default to sensible values, so gating Send on them too (added
+          in #5108) blocked submitting even when the request was already valid;
+          that extra gating is intentionally removed here. The "Request Sent"
+          success latch below is preserved. */}
       {(() => {
-        const isFormValid =
-          vm.selectedRequestOwnerIds.length > 0 &&
-          Boolean(vm.durationHours) &&
-          Boolean(reason);
+        const isFormValid = vm.selectedRequestOwnerIds.length > 0;
         const sending = vm.busy === "request";
         return (
           <Button


### PR DESCRIPTION
## What & why

You asked to undo PR #5108 (*"gate Send request on explicit isFormValid (recipient+duration+reason)"*) because its extra gating was causing issues. #5108 is **merged**, so it can't be "closed"; the effective undo is a forward change.

A literal `git revert` of #5108 conflicted and — worse — would have also thrown away the **"Request Sent" inline-confirmation UX (#5160)** and the **Reason dropdown (#5170)**, which both edited the same AskFlow Send button afterward. So instead of a blind revert, this is a **surgical undo**: it removes exactly what #5108 added (the duration + reason requirements) while preserving #5160 and #5170.

## Fix (`components/one-location/redesign/location-redesign-hub.tsx`)

In `AskFlow`, changed the Send gate:
- Before (from #5108): `isFormValid = recipient > 0 && Boolean(durationHours) && Boolean(reason)`
- After: `isFormValid = vm.selectedRequestOwnerIds.length > 0` (recipient-only, matching the pre-#5108 behavior)

Everything else is untouched: the `justSent` "Request Sent" success latch, the disabled/loading states, duplicate-submit guard, and the "Done" button all remain. Duration and reason still default to sensible values and are still sent — they're just no longer a hard gate on the button.

## Verification

- ESLint clean. Behavior: Send enables as soon as a recipient is selected; the Request-Sent confirmation still works.

## Base

Targets **uat** (that's where #5108 currently lives for your testing). Note: #5108's commit is also on `main`; if you want it undone there too, say so and I'll open a matching PR.
