### PR TITLE
fix(setup): prevent overscroll bounce on fullscreen setup intro screens

### DIFF
--- a/hushh-webapp/components/app-ui/fullscreen-flow-shell.tsx
+++ b/hushh-webapp/components/app-ui/fullscreen-flow-shell.tsx
@@ -40,7 +40,11 @@ export function FullscreenFlowShell<T extends ElementType = "main">({
   return (
     <Component
       className={cn(
-        "fullscreen-flow-shell mx-auto flex w-full flex-col",
+        // `overscroll-none` stops pull-to-refresh / rubber-band bounce so the
+        // fullscreen flow (e.g. the setup capability intros) does not visually
+        // "move" on touchpads and mobile. Layout/anchoring is unchanged — the
+        // hero stays top-aligned (see #5165); this only kills overscroll chaining.
+        "fullscreen-flow-shell mx-auto flex w-full flex-col overscroll-none",
         className
       )}
       style={{ maxWidth: WIDTH_CLASS_MAP[width], ...style }}


### PR DESCRIPTION
## What & why

On the Setup KYC / email intro screen (the "One · KYC" cinematic intro at `/one/setup/email`, rendered by the shared `CapabilityCinematicIntroGate` → `FullscreenFlowShell`), the page could "move" — pull-to-refresh / rubber-band overscroll bounce on touchpads and mobile.

## Fix (`components/app-ui/fullscreen-flow-shell.tsx`)

Added `overscroll-none` to the shared `FullscreenFlowShell` base class. This disables overscroll chaining / bounce so the fullscreen setup flows don't visually shift.

Deliberately **not** re-centering or forcing `100dvh`: the capability intros were intentionally **top-aligned** in #5165 (already on main), and centering here would reverse that for AI-access, Location, and KYC alike. This change is layout-neutral — the hero stays top-anchored; it only removes the bounce/movement.

Scope note: `FullscreenFlowShell` backs the setup capability intros (AI access, Location, KYC/email). They all gain the same no-bounce behavior, which is desirable and consistent.

## Verification

- ESLint clean. Single Tailwind utility added; no layout/markup/logic change.

## Base

Targets **main** (per request).
