### PR TITLE
fix(connections): stop cancel_request crashing on non-UUID request ids

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import uuid
 from contextlib import contextmanager
 from typing import Any, Callable
 
@@ -1598,23 +1599,38 @@ class ConnectionsService:
         request_id = (request_id or "").strip()
         with self._transaction():
             req = None
+            # `request_id` is normally a connection_requests.id (UUID). Some
+            # callers fall back to passing the counterpart's user id (not a
+            # UUID) when the real request id hasn't loaded client-side yet;
+            # querying the UUID column with that value would raise a raw DB
+            # type error rather than ConnectionsError, so route straight to
+            # the counterpart-lookup fallback instead of hitting the DB with
+            # a value that can't be a valid id.
             try:
-                req = self._load_request(request_id, for_update=True)
-            except ConnectionsError as err:
-                if err.code == "CONNECTION_REQUEST_NOT_FOUND":
-                    # Fallback lookup: find pending request sent by user_id to counterpart request_id
-                    req = self._execute_one(
-                        """
-                        SELECT id, requester_user_id, addressee_user_id, status
-                        FROM connection_requests
-                        WHERE status = 'pending'
-                          AND requester_user_id = :requester
-                          AND addressee_user_id = :addressee
-                        LIMIT 1
-                        FOR UPDATE
-                        """,
-                        {"requester": user_id, "addressee": request_id},
-                    )
+                uuid.UUID(request_id)
+                is_request_id = True
+            except ValueError:
+                is_request_id = False
+            if is_request_id:
+                try:
+                    req = self._load_request(request_id, for_update=True)
+                except ConnectionsError as err:
+                    if err.code != "CONNECTION_REQUEST_NOT_FOUND":
+                        raise
+            if not req:
+                # Fallback lookup: find pending request sent by user_id to counterpart request_id
+                req = self._execute_one(
+                    """
+                    SELECT id, requester_user_id, addressee_user_id, status
+                    FROM connection_requests
+                    WHERE status = 'pending'
+                      AND requester_user_id = :requester
+                      AND addressee_user_id = :addressee
+                    LIMIT 1
+                    FOR UPDATE
+                    """,
+                    {"requester": user_id, "addressee": request_id},
+                )
             if not req:
                 raise ConnectionsError(
                     "CONNECTION_REQUEST_NOT_FOUND", "Request not found.", status_code=404

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -470,6 +470,45 @@ def test_cancel_rejected_when_not_requester():
     assert exc.value.status_code == 403
 
 
+def test_cancel_falls_back_to_counterpart_lookup_for_non_uuid_request_id():
+    """Callers sometimes pass the counterpart's user id instead of the
+    request id (e.g. before the outgoing-request cache has loaded). Since
+    connection_requests.id is a UUID column, looking that value up directly
+    would raise a raw DB type error instead of the handled
+    CONNECTION_REQUEST_NOT_FOUND case, so a non-UUID id must go straight to
+    the counterpart-lookup fallback without touching the primary query.
+    """
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "counterpart-firebase-uid",
+                    "status": "pending",
+                }
+            ],
+            [{"id": "11111111-1111-1111-1111-111111111111"}],
+            [],
+        ]
+    )
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.cancel_request("user-a", "counterpart-firebase-uid")
+
+    assert out == {
+        "status": "cancelled",
+        "requestId": "11111111-1111-1111-1111-111111111111",
+    }
+    assert not any("SELECT" in sql and "WHERE id = :id" in sql for sql, _ in db.calls)
+    first_sql, first_params = db.calls[0]
+    assert "addressee_user_id = :addressee" in first_sql
+    assert first_params == {
+        "requester": "user-a",
+        "addressee": "counterpart-firebase-uid",
+    }
+
+
 def test_cancel_marks_request_and_pending_scope_proposals_declined():
     svc = _svc()
     db = _RecordingDB(


### PR DESCRIPTION
## What

`cancel_request` has a fallback path for when the frontend calls it with the counterpart's user id instead of the actual `connection_requests.id` (this happens when the outgoing-request-id cache hasn't loaded yet). That fallback only ran after catching `ConnectionsError` from the primary id lookup.

`connection_requests.id` is a UUID column. Looking it up with a non-UUID value (a Firebase user id) doesn't raise `ConnectionsError` — it raises a raw DB type error, which propagates uncaught through the route and surfaces as a generic 500. So the exact case the fallback exists for never actually reaches it, and cancelling fails every time it's needed, leaving the request stuck `pending`.

## Fix

Validate whether `request_id` is a UUID before choosing a lookup path. A non-UUID id skips the primary lookup entirely and goes straight to the counterpart fallback, instead of relying on catching an exception type that the type-mismatch failure never produces.

## Testing

- Added a regression test (`test_cancel_falls_back_to_counterpart_lookup_for_non_uuid_request_id`) asserting a non-UUID id never issues the primary `WHERE id = :id` lookup and goes straight to the counterpart-based fallback query.
- `pytest tests/services/test_connections_service.py tests/routes/test_connections_route.py tests/services/test_connection_graph_service.py` — 53 passed.
- `ruff check` / `ruff format --check` clean on both touched files.
