### PR TITLE
fix(feed): name the person in connection accepted/removed/rejected events

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -152,6 +152,29 @@ class ConnectionsService:
         result = get_db().execute_raw(sql, params or {})
         return result.data or []
 
+    def _display_name_for(self, user_id: str) -> str | None:
+        """Best-effort full display name for a user, for feed copy only.
+
+        Reads the same `actor_identity_cache.display_name` the connection and
+        directory queries already surface, so this never widens what the app
+        exposes about a mutual connection. Returns None when unresolved, letting
+        the feed fall back to its safe generic line.
+        """
+        uid = (user_id or "").strip()
+        if not uid:
+            return None
+        try:
+            row = self._execute_one(
+                "SELECT display_name FROM actor_identity_cache WHERE user_id = :uid",
+                {"uid": uid},
+            )
+        except Exception:  # noqa: BLE001 - name is cosmetic; never break the action
+            logger.exception("connections.feed_display_name_lookup_failed")
+            return None
+        name = str((row or {}).get("display_name") or "").strip()
+        return name or None
+
+
     @staticmethod
     def _row_mapping(row: Any) -> dict[str, Any]:
         """Normalize SQLAlchemy and lightweight-test rows at one boundary."""
@@ -1493,11 +1516,15 @@ class ConnectionsService:
         # caller to retry an already-authorized connection transition.
         for owner, counterpart in ((user_id, requester), (requester, user_id)):
             try:
+                counterpart_metadata: dict[str, Any] = {"counterpart_user_id": counterpart}
+                counterpart_name = self._display_name_for(counterpart)
+                if counterpart_name:
+                    counterpart_metadata["counterpart_label"] = counterpart_name
                 FeedService().record_event(
                     user_id=owner,
                     source_domain="connections",
                     event_type="connection_accepted",
-                    metadata={"counterpart_user_id": counterpart},
+                    metadata=counterpart_metadata,
                 )
             except Exception:  # noqa: BLE001 - feed projection cannot roll back consent
                 logger.exception("connections.accepted_feed_projection_failed")
@@ -1583,11 +1610,15 @@ class ConnectionsService:
             )
             requester = str(req.get("requester_user_id"))
         try:
+            rejected_metadata: dict[str, Any] = {"counterpart_user_id": user_id}
+            rejected_name = self._display_name_for(user_id)
+            if rejected_name:
+                rejected_metadata["counterpart_label"] = rejected_name
             FeedService().record_event(
                 user_id=requester,
                 source_domain="connections",
                 event_type="connection_rejected",
-                metadata={"counterpart_user_id": user_id},
+                metadata=rejected_metadata,
             )
         except Exception:  # noqa: BLE001 - projection cannot roll back rejection
             logger.exception("connections.rejected_feed_projection_failed")
@@ -1853,16 +1884,26 @@ class ConnectionsService:
                 {"id": (connection_id or "").strip()},
             )
         if conn:
+            user_a_id = str(user_a or "")
+            user_b_id = str(user_b or "")
+            user_a_name = self._display_name_for(user_a_id)
+            user_b_name = self._display_name_for(user_b_id)
+            a_metadata: dict[str, Any] = {"counterpart_user_id": user_b_id}
+            if user_b_name:
+                a_metadata["counterpart_label"] = user_b_name
+            b_metadata: dict[str, Any] = {"counterpart_user_id": user_a_id}
+            if user_a_name:
+                b_metadata["counterpart_label"] = user_a_name
             FeedService().record_event(
-                user_id=user_a,
+                user_id=user_a_id,
                 source_domain="connections",
                 event_type="connection_revoked",
-                metadata={"counterpart_user_id": user_b},
+                metadata=a_metadata,
             )
             FeedService().record_event(
-                user_id=user_b,
+                user_id=user_b_id,
                 source_domain="connections",
                 event_type="connection_revoked",
-                metadata={"counterpart_user_id": user_a},
+                metadata=b_metadata,
             )
         return {"removed": 1 if conn else 0}

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -75,7 +75,6 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
   const icon = DOMAIN_ICON[item.source_domain] || Newspaper;
   const domainLabel = DOMAIN_LABEL[item.source_domain] || "Activity";
   const scope = metadataString(item.metadata, "scope_description") || metadataString(item.metadata, "scope");
-  const counterparty = metadataString(item.metadata, "counterpart_label");
   // Best-available name for the other party (label → display → first → phone →
   // "Someone" last). Used to turn vague, subjectless lines like "A live
   // location share was revoked" into explicit subject-action-object sentences.
@@ -221,34 +220,45 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         description: "A connected-system action failed.",
         href: ROUTES.CONNECTED_SYSTEMS,
       };
-    case "connection_accepted":
+    case "connection_accepted": {
+      // Prefer any resolvable name (label → display → first → phone) so a row
+      // with partial metadata still names the person instead of the generic
+      // fallback. `hasWho` guards the "Someone" sentinel from resolveCounterpartName.
+      const hasWho = who !== "Someone";
       return {
         icon: UserRound,
         domainLabel,
         label: "Connection accepted",
-        description: counterparty ? `You and ${counterparty} are connected.` : "A connection was accepted.",
+        description: hasWho
+          ? `You and ${who} are connected.`
+          : "A connection was accepted.",
         href: ROUTES.CONNECT,
       };
-    case "connection_rejected":
+    }
+    case "connection_rejected": {
+      const hasWho = who !== "Someone";
       return {
         icon: UserRound,
         domainLabel,
         label: "Connection rejected",
-        description: counterparty
-          ? `${counterparty} declined your connection request.`
+        description: hasWho
+          ? `${who} declined your connection request.`
           : "A connection request was rejected.",
         href: ROUTES.CONNECT,
       };
-    case "connection_revoked":
+    }
+    case "connection_revoked": {
+      const hasWho = who !== "Someone";
       return {
         icon: UserRound,
         domainLabel,
         label: "Connection removed",
-        description: counterparty
-          ? `Your connection with ${counterparty} was removed.`
+        description: hasWho
+          ? `Your connection with ${who} was removed.`
           : "A connection was removed.",
         href: ROUTES.CONNECT,
       };
+    }
     default:
       return {
         icon,


### PR DESCRIPTION
Feed connection events showed generic lines ('A connection was accepted.', 'A connection was removed.') with no person, because the backend emitted only counterpart_user_id and the frontend renderer needs counterpart_label to name someone.\n\nBackend (consent-protocol/hushh_mcp/services/connections_service.py):\n- Added _display_name_for(user_id) reading actor_identity_cache.display_name (same source the connection/directory queries already use; no new exposure).\n- accept/reject/remove feed emits now attach counterpart_label (full display name) alongside counterpart_user_id; unresolved names fall back cleanly. Revoke user ids coerced to str.\n\nFrontend (hushh-webapp/lib/feed/feed-item-renderers.tsx):\n- connection_accepted/rejected/revoked now use the shared resolveCounterpartName fallback (label - - - so any resolvable name renders; generic line only when nothing is available.\n\nResult: 'You and Gautam Ahuja are connected.', 'Gautam Ahuja declined your connection request.', 'Your connection with Gautam Ahuja was removed.'\n\nNote: applies to NEW events; existing rows lack the name and keep the generic text. ESLint clean; Pylance clean. Base: main.