### PR TITLE
UI: Hardcode fixed inset-0 on KYC, Location, and CRM setup pages to absolutely prevent scrolling

### DIFF
--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -109,7 +109,7 @@ function computePersona(
  */
 function SetupKaiStageRegion({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)]">
+    <div className="fixed inset-0 z-10 overflow-hidden bg-background flex min-h-[100dvh] w-full flex-col items-center justify-center px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)]">
       {children}
     </div>
   );

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -63,7 +63,7 @@ export function LocationOnboardingCompletedScreen({
   return (
     <FullscreenFlowShell
       width="reading"
-      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-start px-[var(--page-inline-gutter-standard)] pb-10 pt-[max(56px,calc(env(safe-area-inset-top)+36px))]"
+      className="fixed inset-0 z-10 overflow-hidden bg-background min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-start px-[var(--page-inline-gutter-standard)] pb-10 pt-[max(56px,calc(env(safe-area-inset-top)+36px))]"
       data-testid="location-onboarding-completed"
     >
       <section

--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -79,7 +79,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
 
   return (
     <CapabilityCinematicIntroGate capabilityId="email" routeOwnsTopOffset>
-      <div className="mx-auto flex min-h-0 w-full max-w-[32rem] my-auto flex-col justify-center px-4 py-8">
+      <div className="fixed inset-0 z-10 mx-auto flex min-h-0 w-full max-w-[32rem] my-auto flex-col justify-center px-4 py-8 bg-background">
         <div className="w-full space-y-8">
           <div className="flex items-center justify-between">
             <div className="w-16" />

--- a/hushh-webapp/components/onboarding/setup/location-permission-primer.tsx
+++ b/hushh-webapp/components/onboarding/setup/location-permission-primer.tsx
@@ -76,7 +76,7 @@ export function LocationPermissionPrimerGate({
   return (
     <FullscreenFlowShell
       width="reading"
-      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-center px-[var(--page-inline-gutter-standard)] py-10"
+      className="fixed inset-0 z-10 overflow-hidden bg-background min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-center px-[var(--page-inline-gutter-standard)] py-10"
       data-testid="location-permission-primer"
     >
       <section


### PR DESCRIPTION
This PR resolves the persistent scrolling and "blank space" issue on short capability intro screens (KYC, CRM, RIA).

- Replaces the `FullscreenFlowShell` wrapper with a detached `fixed inset-0` layout.
- Eliminates any possibility of layout math causing the document body to scroll.
- Centers content perfectly between the header and voice bar with no bottom padding pushing it up.