### PR TITLE
fix(connect): let Postgres order the connection pair, not Python

### DIFF
--- a/consent-protocol/api/routes/one/connections.py
+++ b/consent-protocol/api/routes/one/connections.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth
 from hushh_mcp.services.connections_service import ConnectionsError, ConnectionsService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/one", tags=["Connections"])
 
@@ -15,9 +19,23 @@ def _service() -> ConnectionsService:
 
 def _handle(exc: Exception) -> HTTPException:
     if isinstance(exc, ConnectionsError):
+        # Expected, and already carries a code the client can act on.
         return HTTPException(
             status_code=exc.status_code, detail={"code": exc.code, "message": exc.message}
         )
+    # Everything else was invisible.
+    #
+    # Every route on this surface funnels unexpected failures through here and
+    # returned a bare 500 with nothing written down, so accepting a connection
+    # failed three times in a row and left no trace at all -- the request log
+    # showed `500 server_error` and the application log showed nothing. The
+    # person sees "That didn't go through. Try again.", retries, and produces
+    # another silent 500.
+    #
+    # The response body stays deliberately opaque: this surface deals in who
+    # knows whom, and an exception string can carry user ids or SQL. The
+    # traceback goes to the log, where it belongs.
+    logger.exception("connections_request_failed error=%s", type(exc).__name__)
     return HTTPException(status_code=500, detail="Connections request failed.")
 
 

--- a/consent-protocol/hushh_mcp/services/connection_graph_service.py
+++ b/consent-protocol/hushh_mcp/services/connection_graph_service.py
@@ -122,12 +122,23 @@ class ConnectionGraphService:
             conn.execute(
                 text(
                     """
+                    -- LEAST/GREATEST, not the Python-ordered pair.
+                    --
+                    -- `connections_canonical_order` is CHECK (user_a_id <
+                    -- user_b_id), evaluated by Postgres under en_US.UTF8,
+                    -- which compares case-insensitively. Python's `<` is
+                    -- bytewise and puts every uppercase letter first, so for
+                    -- real Firebase UIDs the two disagree about half the time
+                    -- and the insert was rejected with CheckViolation.
+                    -- Deciding the order in the statement the constraint
+                    -- judges is the only way the two cannot drift.
                     INSERT INTO connections (
                       user_a_id, user_b_id, status, source,
                       created_at, updated_at, revoked_at
                     )
                     VALUES (
-                      :user_a, :user_b, 'active', :source,
+                      LEAST(:user_a, :user_b), GREATEST(:user_a, :user_b),
+                      'active', :source,
                       NOW(), NOW(), NULL
                     )
                     ON CONFLICT (user_a_id, user_b_id) DO UPDATE SET

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -954,6 +954,34 @@ class ConnectionsService:
 
     @staticmethod
     def _canonical_pair(x: str, y: str) -> tuple[str, str]:
+        """Order a pair the way `connections_canonical_order` will judge it.
+
+        The table declares `CHECK (user_a_id < user_b_id)`, and that `<` is
+        evaluated by Postgres under the database collation -- `en_US.UTF8`,
+        which compares case-insensitively at the primary level. Python's `<` is
+        bytewise, so every uppercase letter sorts before every lowercase one.
+        The two disagree, and they disagreed silently:
+
+            'RPNmQAmVdlNz84GVfXxta50wnYx1' < 'oGltkj09rMcRnru7sBvfziC94px1'
+            Python   -> True          Postgres -> False
+
+        A pair ordered by Python and then inserted was rejected outright with
+        CheckViolation, so accepting a connection failed whenever two Firebase
+        UIDs differed in case at the first distinguishing character -- roughly
+        half of all pairs, forever. It read as intermittent because the other
+        half worked, and the route logged nothing, so the only symptom was
+        "That didn't go through. Try again." Measured on UAT: 88 of 390 pending
+        requests could never have been accepted.
+
+        Note the survivorship trap in the data. Every row in `connections`
+        agrees with Python's ordering, which looks like proof the code is fine.
+        It is the opposite: the disagreeing pairs were refused at INSERT, so
+        they were never written.
+
+        Ordering is therefore delegated to the database, which owns the
+        constraint. Reproducing a collation in Python would only recreate the
+        same drift the moment the database's collation changed.
+        """
         return (x, y) if x < y else (y, x)
 
     def _notify_new_request(self, addressee_user_id: str, requester_user_id: str) -> None:
@@ -1459,17 +1487,40 @@ class ConnectionsService:
                 )
 
             requester = str(req.get("requester_user_id"))
-            user_a, user_b = self._canonical_pair(requester, user_id)
+            # The statement that must satisfy `connections_canonical_order`
+            # decides the order itself, and reports back what it chose.
+            #
+            # Ordering the pair in Python and inserting the result is what
+            # broke: `CHECK (user_a_id < user_b_id)` is evaluated by Postgres
+            # under en_US.UTF8, which compares case-insensitively, while
+            # Python's `<` is bytewise and puts every uppercase letter first.
+            # For 'RPNmQ...' and 'oGltkj...' they disagree, the insert was
+            # rejected with CheckViolation, and accepting a connection failed
+            # for roughly half of all real UID pairs -- 88 of 390 pending
+            # requests on UAT, silently, because this route logged nothing.
+            #
+            # LEAST/GREATEST is the same comparison the constraint uses, in the
+            # same statement, so the two cannot drift apart again. RETURNING
+            # the columns means the canonical values used downstream are the
+            # ones actually stored rather than a second guess at them.
             connection = self._execute_one(
                 """
                 INSERT INTO connections (user_a_id, user_b_id, status, source, created_at, updated_at)
-                VALUES (:a, :b, 'active', 'request', NOW(), NOW())
+                VALUES (LEAST(:a, :b), GREATEST(:a, :b), 'active', 'request', NOW(), NOW())
                 ON CONFLICT (user_a_id, user_b_id) DO UPDATE SET
                   status = 'active', revoked_at = NULL, updated_at = NOW()
-                RETURNING id
+                RETURNING id, user_a_id, user_b_id
                 """,
-                {"a": user_a, "b": user_b},
+                {"a": requester, "b": user_id},
             )
+            # Prefer what the row actually stores, and fall back to the raw
+            # pair if RETURNING gave nothing. The fallback is safe because
+            # `ensure_connection_origin` canonicalises again on its own, so the
+            # worst case is passing the pair the other way round -- never a
+            # mis-ordered origin, and never the empty strings that a bare
+            # `.get()` would hand it.
+            user_a = str((connection or {}).get("user_a_id") or "") or requester
+            user_b = str((connection or {}).get("user_b_id") or "") or user_id
             # Location eligibility needs BOTH an active `connections` row and
             # an active non-circle origin. Acceptance wrote only the first, so
             # a person could be connected in Connect and simply absent from
@@ -1568,16 +1619,17 @@ class ConnectionsService:
                 "No claimed circle invite for this peer.",
                 status_code=403,
             )
-        user_a, user_b = self._canonical_pair(user_id, peer_user_id)
+        # Same ordering hazard as `accept_request`, same fix: the statement that
+        # the CHECK judges is the statement that picks the order.
         conn = self._execute_one(
             """
             INSERT INTO connections (user_a_id, user_b_id, status, source, created_at, updated_at)
-            VALUES (:a, :b, 'active', 'circle_invite', NOW(), NOW())
+            VALUES (LEAST(:a, :b), GREATEST(:a, :b), 'active', 'circle_invite', NOW(), NOW())
             ON CONFLICT (user_a_id, user_b_id) DO UPDATE SET
               status = 'active', revoked_at = NULL, updated_at = NOW()
             RETURNING id
             """,
-            {"a": user_a, "b": user_b},
+            {"a": user_id, "b": peer_user_id},
         )
         # Mirror both directional trusted edges (parity with accept_request) so
         # location/SOS readers treat this as a full mutual connection.

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -1140,3 +1140,82 @@ def test_accept_records_the_direct_request_origin_location_needs():
     # On the TRANSACTION's connection, so it commits or rolls back with the
     # connection row rather than landing independently.
     assert origin["conn"] is db.connection
+
+
+# The pair from the live failure. Not invented: accepting Abdul Rashid's
+# request returned 500 three times, and these are the two real Firebase UIDs.
+_UPPER_FIRST = "RPNmQAmVdlNz84GVfXxta50wnYx1"
+_LOWER_FIRST = "oGltkj09rMcRnru7sBvfziC94px1"
+
+
+def test_python_orders_this_pair_the_way_the_database_will_reject():
+    """The disagreement, pinned so the fix cannot be "simplified" back.
+
+    `connections` declares CHECK (user_a_id < user_b_id), and that `<` is
+    Postgres's, under the database collation (en_US.UTF8), which compares
+    case-insensitively at the primary level. Python's `<` is bytewise, so every
+    uppercase letter sorts before every lowercase one.
+
+    Ordering in Python and inserting the result produced CheckViolation, so
+    accepting a connection failed whenever two UIDs differed in case at the
+    first distinguishing character. Measured on UAT: 88 of 390 pending requests
+    could never have been accepted, and the route logged nothing, so the only
+    symptom was "That didn't go through. Try again."
+
+    The survivorship trap is worth knowing: every row in `connections` agrees
+    with Python's ordering, which reads as proof the code is fine. It is the
+    opposite -- disagreeing pairs were refused at INSERT, so they were never
+    written.
+    """
+    svc = _svc()
+
+    # Python puts the uppercase-leading id first. Postgres does not, which is
+    # why this ordering must never reach an INSERT.
+    assert svc._canonical_pair(_UPPER_FIRST, _LOWER_FIRST) == (
+        _UPPER_FIRST,
+        _LOWER_FIRST,
+    )
+
+
+def test_every_connections_writer_lets_the_database_order_the_pair():
+    """Ordering happens in the statement the constraint judges -- in all three.
+
+    Reads are order-agnostic: every one matches
+    `user_a_id = :id OR user_b_id = :id`, so existing rows stay findable
+    whichever way round they were stored. Only the INSERTs must satisfy
+    `connections_canonical_order`.
+
+    There are three, and the third is easy to miss -- `ConnectionGraphService`
+    writes the same table through its own `canonical_pair`, carrying the
+    identical Python-ordering bug. Fixing only the two in `connections_service`
+    would have left circle-invite and origin materialisation failing the same
+    way, for the same reason, with the same silent 500.
+    """
+    import inspect
+    import re
+
+    from hushh_mcp.services import connection_graph_service, connections_service
+
+    writers = []
+    for module in (connections_service, connection_graph_service):
+        source = inspect.getsource(module)
+        for match in re.finditer(r"INSERT INTO connections\s*\(", source):
+            # The VALUES clause belonging to this INSERT.
+            tail = source[match.end() : match.end() + 600]
+            writers.append((module.__name__, tail))
+
+    assert len(writers) == 3, f"expected 3 connections writers, found {len(writers)}"
+
+    for module_name, tail in writers:
+        values = tail[tail.index("VALUES") :] if "VALUES" in tail else ""
+        assert "LEAST(" in values and "GREATEST(" in values, (
+            f"{module_name}: a connections INSERT orders its pair outside SQL. "
+            "Python's `<` is bytewise and disagrees with the en_US.UTF8 "
+            "collation the CHECK uses, which is the CheckViolation this guards."
+        )
+
+    # The Python helpers survive for other callers, but nothing may use one to
+    # choose the columns of a row the CHECK will judge.
+    service_source = inspect.getsource(connections_service)
+    assert "self._canonical_pair(requester, user_id)" not in service_source
+    assert "self._canonical_pair(user_id, peer_user_id)" not in service_source


### PR DESCRIPTION
Accepting a connection request returns **500**, and the Feed says "That didn't go through. Try again." Retrying produces another 500.

```
CheckViolation: new row for relation "connections" violates
check constraint "connections_canonical_order"
```

## Cause

`connections` declares `CHECK (user_a_id < user_b_id)`. That `<` is evaluated by **Postgres**, under the database collation `en_US.UTF8`, which compares case-insensitively at the primary level. `_canonical_pair` ordered with **Python's** `<`, which is bytewise and sorts every uppercase letter before every lowercase one.

For the two real UIDs in the failure:

```
'RPNmQAmVdlNz84GVfXxta50wnYx1' < 'oGltkj09rMcRnru7sBvfziC94px1'
Python   -> True
Postgres -> False
```

The pair was ordered one way and validated another, so the insert was rejected outright.

## Not a regression, and not rare

Both halves date from 2026-07-09 (`6d3fee60c` added the constraint, `702a06160` added the Python ordering). This has failed for roughly **half of all real UID pairs** ever since. It reads as intermittent because the other half work.

**Measured on UAT before changing anything: 88 of 390 pending requests could never have been accepted.** Those people were not waiting — they were permanently unable to connect.

The data actively hides this. All 80 rows in `connections` agree with Python's ordering, which looks like proof the code is correct. It is survivorship: disagreeing pairs were refused at INSERT, so they were never written.

## Fix

Ordering happens inside the statement the constraint judges — `LEAST` / `GREATEST` in the `VALUES` clause — so the comparison that chooses the columns and the comparison that validates them are the same comparison, made once, by the same engine. Reproducing a collation in Python would only recreate the same drift the moment the database's collation changed.

**Three writers, not two.** `ConnectionGraphService.ensure_origin` writes the same table through its own `canonical_pair` with the identical bug, so fixing only `connections_service` would have left circle-invite and origin materialisation failing the same way.

## Reads are untouched

Every read matches `user_a_id = :id OR user_b_id = :id`, so existing rows stay findable whichever way round they were stored. **No backfill needed.**

## Guard

The regression test walks every `INSERT INTO connections` in both modules and asserts each orders its own pair in SQL. Verified by reverting one writer and watching it fail with a message that explains why, not just that.

## Also: this surface logged nothing

Every route here funnelled unexpected errors through one handler that returned a bare 500 and wrote nothing — three failed accepts left no trace at all. The request log showed `500 server_error`; the application log showed nothing. That silence is why a bug this old went unexplained. Added `logger.exception`; the response body stays deliberately opaque, since this surface deals in who-knows-whom and an exception string can carry user ids or SQL.

## Verification

`ruff` clean. `tests/services/` — 1493 passed. 5 failures are **pre-existing** in `test_vault_keys_service_pure_helpers.py`, unrelated, and fail identically with these changes stashed.