### PR TITLE
fix(one-location): preserve requested share duration on access requests

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -124,6 +124,7 @@ class UpdateMapPreferencesRequest(_CamelModel):
 class CreateAccessRequest(_CamelModel):
     owner_user_id: str = Field(alias="ownerUserId", min_length=1, max_length=160)
     message: str | None = Field(default=None, max_length=500)
+    duration_hours: float | None = Field(default=None, alias="durationHours", gt=0, le=24)
 
 
 class ResolveAccessRequest(_CamelModel):
@@ -1293,6 +1294,7 @@ def request_location_access(
                 requester_user_id=_user_id(token_data),
                 owner_user_id=payload.owner_user_id,
                 message=payload.message,
+                requested_duration_hours=payload.duration_hours,
             )
         }
     except Exception as exc:

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1896,6 +1896,10 @@ class OneLocationAgentService:
     def _request_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
         if not row:
             return None
+        metadata = _loads_json(row.get("metadata")) or {}
+        requested_duration_hours = (
+            metadata.get("requestedDurationHours") if isinstance(metadata, dict) else None
+        )
         return {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
@@ -1908,6 +1912,11 @@ class OneLocationAgentService:
             "requestedAt": _iso(row.get("requested_at")),
             "resolvedAt": _iso(row.get("resolved_at")),
             "approvedGrantId": str(row.get("approved_grant_id") or "") or None,
+            "requestedDurationHours": (
+                float(requested_duration_hours)
+                if isinstance(requested_duration_hours, (int, float))
+                else None
+            ),
         }
 
     @staticmethod
@@ -5915,6 +5924,7 @@ class OneLocationAgentService:
         referred_by_user_id: str | None = None,
         notify_owner: bool = True,
         require_requester_key_material: bool = False,
+        requested_duration_hours: float | None = None,
     ) -> dict[str, Any]:
         if requester_user_id == owner_user_id:
             raise OneLocationAgentError(
@@ -5926,6 +5936,14 @@ class OneLocationAgentService:
                 require_phone_verified=False,
             )
         message_value = (message or "").strip()[:500] or None
+        # The requester's picker is advisory context for the owner, not a grant
+        # duration of its own -- approve_request() always takes its own
+        # duration_hours from the owner. Stash it in metadata (no schema
+        # migration needed) purely so the value the requester saw survives the
+        # round trip instead of being silently dropped.
+        metadata_value = (
+            {"requestedDurationHours": requested_duration_hours} if requested_duration_hours else {}
+        )
         row = self._execute_one(
             """
             SELECT *
@@ -5952,7 +5970,7 @@ class OneLocationAgentService:
                 )
                 VALUES (
                   :owner_user_id, :requester_user_id, :referred_by_user_id, 'pending',
-                  :message, NOW(), '{}'::jsonb
+                  :message, NOW(), CAST(:metadata_json AS JSONB)
                 )
                 RETURNING *
                 """,
@@ -5961,21 +5979,43 @@ class OneLocationAgentService:
                     "requester_user_id": requester_user_id,
                     "referred_by_user_id": referred_by_user_id,
                     "message": message_value,
+                    "metadata_json": _json_param(metadata_value),
                 },
             )
-        elif message_value and str(row.get("message") or "") != message_value:
-            refreshed = self._execute_one(
-                """
-                UPDATE one_location_access_requests
-                SET message = :message,
-                    requested_at = NOW()
-                WHERE id = CAST(:request_id AS UUID)
-                  AND status = 'pending'
-                RETURNING *
-                """,
-                {"request_id": str(row.get("id") or ""), "message": message_value},
+        else:
+            existing_metadata = _loads_json(row.get("metadata")) or {}
+            existing_duration = (
+                existing_metadata.get("requestedDurationHours")
+                if isinstance(existing_metadata, dict)
+                else None
             )
-            row = refreshed or row
+            message_changed = bool(message_value and str(row.get("message") or "") != message_value)
+            duration_changed = bool(
+                requested_duration_hours and requested_duration_hours != existing_duration
+            )
+            if message_changed or duration_changed:
+                merged_metadata = (
+                    dict(existing_metadata) if isinstance(existing_metadata, dict) else {}
+                )
+                if duration_changed:
+                    merged_metadata["requestedDurationHours"] = requested_duration_hours
+                refreshed = self._execute_one(
+                    """
+                    UPDATE one_location_access_requests
+                    SET message = COALESCE(:message, message),
+                        metadata = CAST(:metadata_json AS JSONB),
+                        requested_at = NOW()
+                    WHERE id = CAST(:request_id AS UUID)
+                      AND status = 'pending'
+                    RETURNING *
+                    """,
+                    {
+                        "request_id": str(row.get("id") or ""),
+                        "message": message_value if message_changed else None,
+                        "metadata_json": _json_param(merged_metadata),
+                    },
+                )
+                row = refreshed or row
         request = self._request_payload(row)
         if not request:
             raise OneLocationAgentError(

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1770,13 +1770,17 @@ class FourUserMemoryService(OneLocationAgentService):
                 "requested_at": datetime.now(timezone.utc),
                 "resolved_at": None,
                 "approved_grant_id": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
             }
             self.requests[request_id] = row
             return row
-        if "UPDATE one_location_access_requests" in sql and "SET message = :message" in sql:
+        if "UPDATE one_location_access_requests" in sql and "SET message = " in sql:
             request = self.requests.get(params["request_id"])
             if request and request["status"] == "pending":
-                request["message"] = params["message"]
+                if params.get("message") is not None:
+                    request["message"] = params["message"]
+                if "metadata_json" in params:
+                    request["metadata"] = json.loads(params["metadata_json"])
                 request["requested_at"] = datetime.now(timezone.utc)
                 return request
             return None
@@ -2589,14 +2593,18 @@ def test_four_user_location_workflow_contract() -> None:
         requester_user_id=user_c,
         owner_user_id=user_a,
         message="Can you share where you are?",
+        requested_duration_hours=4,
     )
+    assert direct_request_c["requestedDurationHours"] == 4
     duplicate_request_c = service.request_access(
         requester_user_id=user_c,
         owner_user_id=user_a,
         message="Can you share where you are now?",
+        requested_duration_hours=24,
     )
     assert duplicate_request_c["id"] == direct_request_c["id"]
     assert duplicate_request_c["message"] == "Can you share where you are now?"
+    assert duplicate_request_c["requestedDurationHours"] == 24
 
     approved_c = service.approve_request(
         owner_user_id=user_a,

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -199,6 +199,7 @@ describe("OneLocationService", () => {
       vaultOwnerToken: "vault-token",
       ownerUserId: "user_b",
       message: "Can you share?",
+      durationHours: 24,
     });
 
     expect(mockApiJson).toHaveBeenCalledWith("/api/one/location/requests", {
@@ -210,6 +211,7 @@ describe("OneLocationService", () => {
       body: JSON.stringify({
         ownerUserId: "user_b",
         message: "Can you share?",
+        durationHours: 24,
       }),
     });
   });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4839,6 +4839,7 @@ export function OneLocationAgentPageContent({
           vaultOwnerToken: activeVaultOwnerToken,
           ownerUserId: owner.userId,
           message: buildOneLocationRequestMessage(reason, requestMessage),
+          durationHours: Number(durationHours) || undefined,
         });
         successCount += 1;
       }
@@ -4880,6 +4881,7 @@ export function OneLocationAgentPageContent({
   }, [
     auth.user,
     auth.userId,
+    durationHours,
     refresh,
     requestMessage,
     resetRequestComposer,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1438,7 +1438,13 @@ function LocationDetailFlow({
               <RequestCard
                 key={request.id}
                 name={vm.requesterLabel(request)}
-                promptLine="Asks to see your location"
+                promptLine={
+                  request.requestedDurationHours
+                    ? `Asks to see your location for ${durationLabel(
+                        String(request.requestedDurationHours),
+                      )}`
+                    : "Asks to see your location"
+                }
                 reason={request.message ?? undefined}
                 onApprove={() => vm.onApprove(request)}
                 onDecline={() => vm.onDeny(request.id)}
@@ -1907,7 +1913,13 @@ function PeopleHub({
               icon={Send}
               iconTone="blue"
               title={vm.requestOwnerLabel(request)}
-              description={vm.formatDateTime(request.requestedAt)}
+              description={
+                request.requestedDurationHours
+                  ? `${vm.formatDateTime(request.requestedAt)} · Requested for ${durationLabel(
+                      String(request.requestedDurationHours),
+                    )}`
+                  : vm.formatDateTime(request.requestedAt)
+              }
               trailing={
                 /active|approved|shared|granted/i.test(request.status)
                   ? "Active"

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1067,6 +1067,8 @@ export class OneLocationService {
     vaultOwnerToken: string;
     ownerUserId: string;
     message?: string;
+    /** Advisory only -- the owner still picks their own duration on approve. */
+    durationHours?: number;
   }): Promise<OneLocationAccessRequest> {
     const response = await apiJsonWithRetry<{
       request: OneLocationAccessRequest;
@@ -1078,6 +1080,7 @@ export class OneLocationService {
         body: JSON.stringify({
           ownerUserId: params.ownerUserId,
           message: params.message,
+          durationHours: params.durationHours,
         }),
       },
       1,

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -178,6 +178,8 @@ export type OneLocationAccessRequest = {
   requestedAt?: string | null;
   resolvedAt?: string | null;
   approvedGrantId?: string | null;
+  /** Advisory only -- the owner still picks their own duration on approve. */
+  requestedDurationHours?: number | null;
 };
 
 export type OneLocationReferral = {


### PR DESCRIPTION
## Bug
On the Location Agent's "Request location access" composer, the **duration picker** (15 min / 30 min / 1 hour / 4 hours / 24 hours) had no effect. The requester's choice was never sent to the API, never persisted, and never surfaced anywhere \u2014 not on the requester's own "Requests sent" card, not on the owner's incoming request card.

## Root cause
- Frontend never included `durationHours` in the create-request payload.
- API's `CreateAccessRequest` model had no field for it.
- Service layer's `request_access` didn't accept or persist it, and `_request_payload` didn't return it.

## Fix
- API/service: accept `durationHours` and store it in the access request's `metadata` JSONB column (advisory only \u2014 the owner still picks their own duration on approve). Handles both the create path and the existing-pending-request merge path.
- Response payload: surface it back as `requestedDurationHours`.
- Frontend: send `durationHours` when creating a request, and render it on both the owner's incoming request card and the requester's sent-requests list.

## Verification
- **UAT repro (before fix):** sent a 24-hour request on uat.one.hushh.ai \u2014 "Requests sent" showed only "Pending", no duration.
- **Local repro (after fix):** same flow locally with the fix applied \u2014 "Requests sent" now shows "Requested for 4 hours".
- Backend: `pytest tests/services/test_one_location_agent_service.py` \u2014 66/66 passed.
- Frontend: `vitest run __tests__/services/location-agent-service.test.ts` \u2014 10/10 passed.

## Scope
Only the files needed for this fix. No unrelated changes.