### PR TITLE
fix(location): preserve requested share duration on access requests

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -124,6 +124,7 @@ class UpdateMapPreferencesRequest(_CamelModel):
 class CreateAccessRequest(_CamelModel):
     owner_user_id: str = Field(alias="ownerUserId", min_length=1, max_length=160)
     message: str | None = Field(default=None, max_length=500)
+    duration_hours: float | None = Field(default=None, alias="durationHours", gt=0, le=24)
 
 
 class ResolveAccessRequest(_CamelModel):
@@ -1293,6 +1294,7 @@ def request_location_access(
                 requester_user_id=_user_id(token_data),
                 owner_user_id=payload.owner_user_id,
                 message=payload.message,
+                requested_duration_hours=payload.duration_hours,
             )
         }
     except Exception as exc:

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1896,6 +1896,10 @@ class OneLocationAgentService:
     def _request_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
         if not row:
             return None
+        metadata = _loads_json(row.get("metadata")) or {}
+        requested_duration_hours = (
+            metadata.get("requestedDurationHours") if isinstance(metadata, dict) else None
+        )
         return {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
@@ -1908,6 +1912,11 @@ class OneLocationAgentService:
             "requestedAt": _iso(row.get("requested_at")),
             "resolvedAt": _iso(row.get("resolved_at")),
             "approvedGrantId": str(row.get("approved_grant_id") or "") or None,
+            "requestedDurationHours": (
+                float(requested_duration_hours)
+                if isinstance(requested_duration_hours, (int, float))
+                else None
+            ),
         }
 
     @staticmethod
@@ -5915,6 +5924,7 @@ class OneLocationAgentService:
         referred_by_user_id: str | None = None,
         notify_owner: bool = True,
         require_requester_key_material: bool = False,
+        requested_duration_hours: float | None = None,
     ) -> dict[str, Any]:
         if requester_user_id == owner_user_id:
             raise OneLocationAgentError(
@@ -5926,6 +5936,14 @@ class OneLocationAgentService:
                 require_phone_verified=False,
             )
         message_value = (message or "").strip()[:500] or None
+        # The requester's picker is advisory context for the owner, not a grant
+        # duration of its own -- approve_request() always takes its own
+        # duration_hours from the owner. Stash it in metadata (no schema
+        # migration needed) purely so the value the requester saw survives the
+        # round trip instead of being silently dropped.
+        metadata_value = (
+            {"requestedDurationHours": requested_duration_hours} if requested_duration_hours else {}
+        )
         row = self._execute_one(
             """
             SELECT *
@@ -5952,7 +5970,7 @@ class OneLocationAgentService:
                 )
                 VALUES (
                   :owner_user_id, :requester_user_id, :referred_by_user_id, 'pending',
-                  :message, NOW(), '{}'::jsonb
+                  :message, NOW(), CAST(:metadata_json AS JSONB)
                 )
                 RETURNING *
                 """,
@@ -5961,21 +5979,43 @@ class OneLocationAgentService:
                     "requester_user_id": requester_user_id,
                     "referred_by_user_id": referred_by_user_id,
                     "message": message_value,
+                    "metadata_json": _json_param(metadata_value),
                 },
             )
-        elif message_value and str(row.get("message") or "") != message_value:
-            refreshed = self._execute_one(
-                """
-                UPDATE one_location_access_requests
-                SET message = :message,
-                    requested_at = NOW()
-                WHERE id = CAST(:request_id AS UUID)
-                  AND status = 'pending'
-                RETURNING *
-                """,
-                {"request_id": str(row.get("id") or ""), "message": message_value},
+        else:
+            existing_metadata = _loads_json(row.get("metadata")) or {}
+            existing_duration = (
+                existing_metadata.get("requestedDurationHours")
+                if isinstance(existing_metadata, dict)
+                else None
             )
-            row = refreshed or row
+            message_changed = bool(message_value and str(row.get("message") or "") != message_value)
+            duration_changed = bool(
+                requested_duration_hours and requested_duration_hours != existing_duration
+            )
+            if message_changed or duration_changed:
+                merged_metadata = (
+                    dict(existing_metadata) if isinstance(existing_metadata, dict) else {}
+                )
+                if duration_changed:
+                    merged_metadata["requestedDurationHours"] = requested_duration_hours
+                refreshed = self._execute_one(
+                    """
+                    UPDATE one_location_access_requests
+                    SET message = COALESCE(:message, message),
+                        metadata = CAST(:metadata_json AS JSONB),
+                        requested_at = NOW()
+                    WHERE id = CAST(:request_id AS UUID)
+                      AND status = 'pending'
+                    RETURNING *
+                    """,
+                    {
+                        "request_id": str(row.get("id") or ""),
+                        "message": message_value if message_changed else None,
+                        "metadata_json": _json_param(merged_metadata),
+                    },
+                )
+                row = refreshed or row
         request = self._request_payload(row)
         if not request:
             raise OneLocationAgentError(

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1770,13 +1770,17 @@ class FourUserMemoryService(OneLocationAgentService):
                 "requested_at": datetime.now(timezone.utc),
                 "resolved_at": None,
                 "approved_grant_id": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
             }
             self.requests[request_id] = row
             return row
-        if "UPDATE one_location_access_requests" in sql and "SET message = :message" in sql:
+        if "UPDATE one_location_access_requests" in sql and "SET message = " in sql:
             request = self.requests.get(params["request_id"])
             if request and request["status"] == "pending":
-                request["message"] = params["message"]
+                if params.get("message") is not None:
+                    request["message"] = params["message"]
+                if "metadata_json" in params:
+                    request["metadata"] = json.loads(params["metadata_json"])
                 request["requested_at"] = datetime.now(timezone.utc)
                 return request
             return None
@@ -2589,14 +2593,18 @@ def test_four_user_location_workflow_contract() -> None:
         requester_user_id=user_c,
         owner_user_id=user_a,
         message="Can you share where you are?",
+        requested_duration_hours=4,
     )
+    assert direct_request_c["requestedDurationHours"] == 4
     duplicate_request_c = service.request_access(
         requester_user_id=user_c,
         owner_user_id=user_a,
         message="Can you share where you are now?",
+        requested_duration_hours=24,
     )
     assert duplicate_request_c["id"] == direct_request_c["id"]
     assert duplicate_request_c["message"] == "Can you share where you are now?"
+    assert duplicate_request_c["requestedDurationHours"] == 24
 
     approved_c = service.approve_request(
         owner_user_id=user_a,

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -199,6 +199,7 @@ describe("OneLocationService", () => {
       vaultOwnerToken: "vault-token",
       ownerUserId: "user_b",
       message: "Can you share?",
+      durationHours: 24,
     });
 
     expect(mockApiJson).toHaveBeenCalledWith("/api/one/location/requests", {
@@ -210,6 +211,7 @@ describe("OneLocationService", () => {
       body: JSON.stringify({
         ownerUserId: "user_b",
         message: "Can you share?",
+        durationHours: 24,
       }),
     });
   });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4839,6 +4839,7 @@ export function OneLocationAgentPageContent({
           vaultOwnerToken: activeVaultOwnerToken,
           ownerUserId: owner.userId,
           message: buildOneLocationRequestMessage(reason, requestMessage),
+          durationHours: Number(durationHours) || undefined,
         });
         successCount += 1;
       }
@@ -4880,6 +4881,7 @@ export function OneLocationAgentPageContent({
   }, [
     auth.user,
     auth.userId,
+    durationHours,
     refresh,
     requestMessage,
     resetRequestComposer,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1438,7 +1438,13 @@ function LocationDetailFlow({
               <RequestCard
                 key={request.id}
                 name={vm.requesterLabel(request)}
-                promptLine="Asks to see your location"
+                promptLine={
+                  request.requestedDurationHours
+                    ? `Asks to see your location for ${durationLabel(
+                        String(request.requestedDurationHours),
+                      )}`
+                    : "Asks to see your location"
+                }
                 reason={request.message ?? undefined}
                 onApprove={() => vm.onApprove(request)}
                 onDecline={() => vm.onDeny(request.id)}
@@ -1907,7 +1913,13 @@ function PeopleHub({
               icon={Send}
               iconTone="blue"
               title={vm.requestOwnerLabel(request)}
-              description={vm.formatDateTime(request.requestedAt)}
+              description={
+                request.requestedDurationHours
+                  ? `${vm.formatDateTime(request.requestedAt)} · Requested for ${durationLabel(
+                      String(request.requestedDurationHours),
+                    )}`
+                  : vm.formatDateTime(request.requestedAt)
+              }
               trailing={
                 /active|approved|shared|granted/i.test(request.status)
                   ? "Active"

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1067,6 +1067,8 @@ export class OneLocationService {
     vaultOwnerToken: string;
     ownerUserId: string;
     message?: string;
+    /** Advisory only -- the owner still picks their own duration on approve. */
+    durationHours?: number;
   }): Promise<OneLocationAccessRequest> {
     const response = await apiJsonWithRetry<{
       request: OneLocationAccessRequest;
@@ -1078,6 +1080,7 @@ export class OneLocationService {
         body: JSON.stringify({
           ownerUserId: params.ownerUserId,
           message: params.message,
+          durationHours: params.durationHours,
         }),
       },
       1,

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -178,6 +178,8 @@ export type OneLocationAccessRequest = {
   requestedAt?: string | null;
   resolvedAt?: string | null;
   approvedGrantId?: string | null;
+  /** Advisory only -- the owner still picks their own duration on approve. */
+  requestedDurationHours?: number | null;
 };
 
 export type OneLocationReferral = {


### PR DESCRIPTION
## Problem
On the One Location "Ask to see location" flow, the requester's duration picker (15 min / 30 min / 1 hour / 4 hours / 24 hours) was silently dropped. It was never sent to the API, never persisted, and never shown anywhere — the owner's incoming request card and the requester's own "sent requests" list both only ever showed generic text ("Asks to see your location") with no indication of how long access was being requested for.

## Root cause
- `POST /api/one/location/requests` accepted no duration field, so the value picked in the composer never left the browser.
- `OneLocationAgentService.request_access()` had no parameter or storage path for a requested duration.
- The response payload (`_request_payload`) had no field to surface it back out, so neither the owner's request card nor the requester's sent-list could render it even if it had been sent.

## Fix
- **API**: `CreateAccessRequest` now accepts an optional `durationHours` (0 < h ≤ 24), passed through to the service.
- **Service**: `request_access()` stores the requested duration in the access request's `metadata` JSONB column (no schema migration needed) and merges/updates it on duplicate-request calls. `_request_payload()` surfaces it back as `requestedDurationHours`.
- **Frontend**: `OneLocationService.requestAccess()` sends `durationHours`; the request composer (`app/one/location/page.tsx`) passes the selected value; both the owner's incoming request card and the requester's sent-requests list (`location-redesign-hub.tsx`) render it, e.g. "Asks to see your location for 24 hours" / "Requested for 4 hours".
- Explicitly advisory only — the owner still sets their own grant duration on approve; this only carries the requester's original ask through to display.

## Verification

**UAT reproduction (before fix) — SUCCESS**
On live UAT (`https://uat.one.hushh.ai/one/location`), opened "Ask someone to share," selected "24 hours" as the duration, and sent the request. The "Requests sent" list afterward showed only:
> Smirthi · Aug 13, 12:44 AM · **Pending**

No trace of the selected duration anywhere, confirming the bug.

**Local browser verification (after fix) — SUCCESS**
Ran this branch locally (frontend on :3000, backend on :8000, both pointed at the same shared UAT database via Cloud SQL proxy) and repeated the identical flow: selected "4 hours," sent the request. The "Requests sent" list immediately showed:
> Smirthi · Aug 13, 1:49 AM · **Requested for 4 hours** · Pending

Confirmed via page text and screenshot.

**Tests — PASSED**
- Backend: 66/66 pytest (`consent-protocol/tests/services/test_one_location_agent_service.py`), including an updated `test_four_user_location_workflow_contract` asserting `requestedDurationHours` round-trips correctly on create and on duplicate-request update.
- Frontend: 10/10 vitest (`hushh-webapp/__tests__/services/location-agent-service.test.ts`)
- `tsc --noEmit`: clean
- `git diff --check`: clean

## Scope
Focused to this one bug only — no unrelated files touched. (A pre-existing `ruff format` drift on 3 unrelated files — `adk_live.py`, `test_one_adk_agent_tree.py`, `test_one_adk_live_protocol.py` — was verified present on a clean `upstream/uat` checkout with none of this branch's changes applied, so it was left untouched rather than folded into this PR.)
