### PR TITLE
chore(skills): drop the unsupported paths: key and add the gcp-access skill

### DIFF
--- a/.claude/skills/codex-bridge/SKILL.md
+++ b/.claude/skills/codex-bridge/SKILL.md
@@ -3,11 +3,6 @@ name: codex-bridge
 description: Answers questions about and routes tasks for the hushh-research codebase. Use whenever the user asks about or wants to change anything this repo owns, including consent-protocol, Operons, HCT, Kai, MCP, IAM, PKM, vault, backend, frontend, mobile, security, docs, comms, ops, skill authoring, and any new specialist added under .codex/ later. Reads .codex/skills/, .codex/workflows/, and .codex/agents/ at invocation time, composes a briefing the way codex route-task does (workflow plus owner_skill plus default_spoke unioned), surfaces .codex/agents/* as advisory delegation lanes, and auto-discovers anything added to the tree without a bridge edit.
 argument-hint: "[skill-or-workflow-name | --list | --check | --coverage | free-text]"
 allowed-tools: Read Grep Glob Bash(python3 *)
-paths:
-  - .codex/**
-  - consent-protocol/**
-  - hushh-webapp/**
-  - docs/**
 ---
 
 # Codex Bridge

--- a/.claude/skills/gcp-access/SKILL.md
+++ b/.claude/skills/gcp-access/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: gcp-access
+description: The complete GCP identity, permission, and deploy-authority map for the
+  hush1one.com org — who holds what, which credential this machine uses, why the UAT
+  deny policy blocks Owners, and the impersonation path around it. Use when a gcloud
+  command is denied, when asked to log in again, when deciding which identity to
+  deploy with, when auditing who can reach a project or secret, or before changing
+  any IAM binding, deny policy, or service account key. Verified 2026-08-07.
+---
+
+# GCP access — hush1one.com
+
+**Never run `gcloud auth login` on this machine.** It is already authenticated with a
+credential that does not expire. Logging in as a human reintroduces the exact problem
+this setup solved.
+
+---
+
+## The identity this machine uses
+
+```
+claude-code-gcp-operator@hussh-developer-platform.iam.gserviceaccount.com
+```
+
+A member of `gcp-admins@hushh.ai`, which holds org-level `roles/owner`,
+`resourcemanager.organizationAdmin`, `iam.denyAdmin`, and `billing.admin`.
+
+| | |
+|---|---|
+| Key file | `~/.config/gcloud/hushh-keys/claude-code-gcp-operator.json` (mode 600, outside every git tree) |
+| Wired in | `~/.zshenv` — **not** `.zshrc` |
+| Default project | `CLOUDSDK_CORE_PROJECT=hushh-pda-uat`, switch with `gp <project>` |
+| Named configs | `uat` `prod` `dev` `tech-prod` `tech-uat` `one` |
+
+`.zshenv` is deliberate: `.zshrc` is skipped by non-interactive shells, which is what
+scripts and agent sessions run in. Putting credentials in `.zshrc` means they work in
+your terminal and silently fail everywhere else.
+
+Re-activate on a new machine (note `$HOME` — zsh does **not** expand `~` after `=`):
+
+```bash
+gcloud auth activate-service-account --key-file="$HOME/.config/gcloud/hushh-keys/claude-code-gcp-operator.json"
+```
+
+### Why a key instead of a longer session
+
+The reauth loop was never a `gcloud` setting. Workspace session control was already
+set to never expire and the prompts continued. The real cause is Google's cap on
+refresh tokens **per OAuth client per user** — gcloud uses one client ID for everyone,
+so each `gcloud auth login` silently revokes an older token of yours. Service accounts
+have no OAuth session, so the cap does not apply.
+
+---
+
+## Who holds what (org `hush1one.com`, 369781862791)
+
+`ankit@hushh.ai` has **no direct org IAM bindings**. All access arrives through groups.
+Checking a person's roles with `get-iam-policy --filter` will show nothing and read as
+"no access" — resolve group membership instead.
+
+**`gcp-admins@hushh.ai`** → org `owner`, `organizationAdmin`, `denyAdmin`, `billing.admin`, `folderAdmin`
+
+```
+kushal@hushh.ai (group owner)   ankit@hushh.ai   manish@hush1one.com
+claude-code-gcp-operator@hussh-developer-platform (service account)
+```
+
+**`developers@hushh.ai`** → org `run.admin`, `secretmanager.admin`, `artifactregistry.admin`,
+`cloudbuild.builds.editor`, `storage.objectAdmin`, `cloudsql.client`, `projectCreator`
+
+```
+kushal@hushh.ai   ankit@hushh.ai   manish@hush1one.com   i-akshat@hush1one.com
+i-neelesh@hushh.ai   jhumma@hushh.ai   ahujagautam024@gmail.com
+abdul.zalil@gmail.com   anoushkagehani1@gmail.com   michael.jacobs@salesforce.com
+```
+
+Ten identities, four of them personal Gmail accounts and one external corporate
+address, each able to read every secret in the org. Group owners (`ankit`, `kushal`,
+`manish`) can add members without touching IAM, so this list changes without an IAM
+audit trail.
+
+**Standing exposure worth knowing:** `abdul.zalil@gmail.com` holds `roles/owner` on
+`hussh-developer-platform`, the project hosting the operator service account. A project
+Owner can mint a key for any service account in that project. That account is also org
+Owner directly.
+
+The operator SA carries **seven keys** from at least four setup episodes (Jun 18 ×2,
+Jul 10, Jul 11 ×2, Jul 30, Aug 7). Four never expire. Each is a working copy of org
+Owner on some disk. Disable rather than delete when pruning — disabling is reversible
+and an in-use key fails silently.
+
+---
+
+## Deploy authority
+
+Only **`hushh-pda-uat`** carries a deny policy. `hushh-pda` (prod) and `hushh-pda-dev`
+have none — manual deploys there work from ordinary admin credentials.
+
+**`uat-deploy-authority-lock`** (created 2026-05-03) denies
+`cloudbuild.builds.create` and `run.services.create/update/delete/setIamPolicy` to
+`principalSet://goog/public:all`. That means **everyone, including org Owners** — deny
+policies override every grant. Exceptions are service accounts only.
+
+| identity | direct | impersonating deployer |
+|---|---|---|
+| `ankit@hushh.ai` | DENY | **OK** |
+| `claude-code-gcp-operator` | DENY | **OK** |
+| `kushal@hushh.ai` | DENY | OK (had this since May) |
+
+### The escape hatch
+
+`github-actions-uat-deployer@hushh-pda-uat` is exempt from the deny policy and holds
+`editor`, `run.admin`, `cloudbuild.builds.editor`, `storage.admin`,
+`secretmanager.secretAccessor` on the project. It has **no key** — GitHub assumes it
+via OIDC, trusted through:
+
+```
+principalSet://…/workloadIdentityPools/github-actions-uat/attribute.repository/hushh-labs/hushh-research
+  → roles/iam.workloadIdentityUser
+```
+
+`ankit@hushh.ai` and the operator SA now hold `roles/iam.serviceAccountTokenCreator`
+on it (granted 2026-08-07, additively — Kushal's original binding untouched). So:
+
+```bash
+gcloud run deploy <svc> --project hushh-pda-uat --region us-central1 \
+  --impersonate-service-account=github-actions-uat-deployer@hushh-pda-uat.iam.gserviceaccount.com
+```
+
+This is preferable to weakening the deny policy: the guardrail stays intact for
+everyone else, and the action is still attributed to the governed deployer identity.
+
+The normal path remains the workflow:
+
+```bash
+gh workflow run deploy-uat.yml --repo hushh-labs/hushh-research --ref main -f scope=auto -f sha=<MERGE_SHA>
+```
+
+---
+
+## Traps
+
+**Deny policies are invisible with `--format='value(name)'`.** It prints nothing even
+when a policy exists, so a real lock reads as an absent one. This produced a wrong
+memory claiming prod and dev were locked. Use the default format:
+
+```bash
+gcloud iam policies list --attachment-point="cloudresourcemanager.googleapis.com/projects/<PROJ>" \
+  --kind=denypolicies | grep displayName
+```
+
+**Role listings lie when a deny policy exists.** `testIamPermissions` is the only
+authoritative answer — it returns just the permissions you actually hold:
+
+```bash
+TOKEN=$(gcloud auth print-access-token)
+curl -s -X POST "https://cloudresourcemanager.googleapis.com/v1/projects/<PROJ>:testIamPermissions" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"permissions":["run.services.update","cloudbuild.builds.create"]}'
+```
+
+Build the request in a script, not a shell one-liner — nested quotes in a `for` loop
+mangle the URL and return a 404 HTML page that looks like a permissions error.
+
+**Cross-project impersonation grants take up to ~60s to propagate.** A
+`PERMISSION_DENIED` on `iam.serviceAccounts.getAccessToken` immediately after
+`add-iam-policy-binding` is usually propagation, not a real denial. Retry before
+diagnosing.
+
+**Never index `status.traffic[0]`** when checking what a Cloud Run service serves.
+Tagged revisions occupy the first slots; select by `percent == 100`.
+
+**Only ever add access.** Use `add-iam-policy-binding`, never `set-iam-policy` — the
+latter replaces the whole policy and silently drops every other member.
+
+---
+
+## Fast checks
+
+```bash
+# am I authenticated, and as whom?
+gcloud config get-value account && gcloud auth print-access-token >/dev/null && echo "token OK"
+
+# does a fresh shell work? (the real test — not the current tab)
+zsh -l -c 'echo $CLOUDSDK_CORE_PROJECT; gcloud auth print-access-token >/dev/null && echo OK'
+
+# who is actually in the admin groups right now?
+gcloud identity groups memberships list --group-email=gcp-admins@hushh.ai \
+  --format='value(preferredMemberKey.id)'
+
+# does this project have a deny policy?
+gcloud iam policies list --attachment-point="cloudresourcemanager.googleapis.com/projects/<PROJ>" \
+  --kind=denypolicies | grep displayName
+```
+
+Related: `safe-changes` (R1 secret-binding order, R3 add-only IAM, R8 serving revision),
+`hushh-research-ship` (merge and deploy procedure).

--- a/.claude/skills/mobile-bug-log/SKILL.md
+++ b/.claude/skills/mobile-bug-log/SKILL.md
@@ -3,9 +3,6 @@ name: mobile-bug-log
 description: Running reference log of every iOS/mobile bug diagnosed + fixed on the `mobile` branch (symptom → root cause → fix → files/commit), plus the recurring build/runtime gotchas that keep biting. Use when the user asks "what bugs did we fix", "known issues", "list the resolved bugs", "why did X break", when a similar symptom reappears (check if it's a known regression before re-diagnosing), or before shipping a mobile build (re-verify the gotchas). ALWAYS append a new entry here whenever another mobile bug is resolved.
 argument-hint: "[optional: keyword to filter, e.g. 'keyboard' | 'backend' | 'navigation']"
 allowed-tools: Read Grep Glob Bash(git log*) Bash(git show*) Bash(grep*) Bash(xcrun simctl*)
-paths:
-  - .claude/skills/mobile-bug-log/**
-  - hushh-webapp/**
 ---
 
 # Mobile bug log (hushh One iOS)

--- a/.claude/skills/release-ios-appstore/SKILL.md
+++ b/.claude/skills/release-ios-appstore/SKILL.md
@@ -3,13 +3,6 @@ name: release-ios-appstore
 description: Compatibility entry point for the canonical Hushh iOS App Store release skill. Use only when explicitly asked to prepare or submit an App Store release.
 argument-hint: "[sha: <green-main-sha>] [dry_run: true|false] [whats_new: <text>] [submit: true|false] [notes: <text>]"
 allowed-tools: Read Grep Glob Bash(make ios-prod-release*) Bash(make ios-prod-release-dry*) Bash(node scripts/release/dispatch-ios-appstore.mjs*) Bash(gh *) Bash(git fetch*) Bash(git status*) Bash(git rev-parse*) Bash(git log*) Bash(git branch*)
-paths:
-  - .codex/skills/release-ios-appstore/**
-  - .codex/skills/repo-operations/references/admin-release-sop.md
-  - .github/workflows/release-ios-appstore.yml
-  - scripts/release/dispatch-ios-appstore.mjs
-  - config/ci-governance.json
-  - docs/guides/mobile/release-ios-appstore.md
 ---
 
 # Release iOS to App Store — compatibility bridge

--- a/.claude/skills/run-ios-sim/SKILL.md
+++ b/.claude/skills/run-ios-sim/SKILL.md
@@ -3,9 +3,6 @@ name: run-ios-sim
 description: Build the hushh One webapp, sync it into the native iOS shell, and launch it on an iPhone simulator against the UAT backend. Use when the user asks to run/launch/build the app on the simulator, take a screenshot on device, or verify a change in the real native app. Wraps the mobile build gotchas (UAT backend override, Node 22, 8 GB heap, /tmp DerivedData) into one command.
 argument-hint: "[optional: simulator UDID to override the default iPhone 16]"
 allowed-tools: Bash, Read
-paths:
-  - .claude/skills/run-ios-sim/**
-  - hushh-webapp/**
 ---
 
 # Run hushh One on the iOS simulator

--- a/.claude/skills/ship-discipline/SKILL.md
+++ b/.claude/skills/ship-discipline/SKILL.md
@@ -2,8 +2,6 @@
 name: ship-discipline
 description: The Hushh engineering operating standard for building, verifying, and reporting work. Release transitions are explicit user-authorized operations governed by the canonical Admin release SOP; ordinary code changes do not imply UAT or production deployment.
 allowed-tools: Read, Grep, Glob, Bash, Edit, Write
-paths:
-  - .claude/skills/ship-discipline/**
 ---
 
 # Ship Discipline — how we engineer at Hushh

--- a/.claude/skills/ship-ios-testflight/SKILL.md
+++ b/.claude/skills/ship-ios-testflight/SKILL.md
@@ -3,12 +3,6 @@ name: ship-ios-testflight
 description: Compatibility entry point for shipping an explicitly authorized green-main iOS build to TestFlight through the governed GitHub workflow.
 argument-hint: "[sha: <green-main-sha>] [dry_run: true|false] [notes: <what-to-test>]"
 allowed-tools: Read Grep Glob Bash(gh *) Bash(git fetch*) Bash(git status*) Bash(git rev-parse*) Bash(git log*) Bash(git branch*)
-paths:
-  - .codex/skills/repo-operations/references/admin-release-sop.md
-  - .codex/skills/release-ios-appstore/references/release-proof.md
-  - .github/workflows/ship-ios-testflight.yml
-  - config/ci-governance.json
-  - docs/guides/mobile/ship-ios-testflight.md
 ---
 
 # Ship iOS to TestFlight — governed compatibility bridge


### PR DESCRIPTION
# Description

Finishes the in-flight skills work that was sitting uncommitted in a working copy.

**Removes the `paths:` key from six skill frontmatter blocks.** It is not part of the skill frontmatter schema, so it was inert everywhere it appeared — it scoped nothing, while reading as though it did. Now the frontmatter states only what is actually honoured: `name`, `description`, `argument-hint`, `allowed-tools`.

**Adds the `gcp-access` skill**, which had never been committed. It maps the org's GCP identities, the deliberate deny policy that blocks Owners on `hushh-pda-uat`, and the impersonation path around it — the questions that otherwise get rediscovered from scratch every time a `gcloud` command is denied. It references the operator key by **file path only**; no credential value is in it, and gitleaks confirms that.

### Note on scope

I initially also rewrote `client-env-parity`, having checked for it in a stale working copy that was 680 commits behind `main`. It already exists on `main`, and the existing version is better than what I wrote: it detects a lane by the real mechanism (`build-arg X=`, `put X `) rather than the bare variable name, so a lane that merely mentions a variable in a comment cannot pass. I reverted my version entirely. This PR contains no change to that skill.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — `run-ios-sim`, `ship-ios-testflight` and `release-ios-appstore` lose only an inert frontmatter key; their bodies and `allowed-tools` are unchanged.

- Docs updated (exact files):
  - [x] Listed below:
  - `.claude/skills/gcp-access/SKILL.md` (new)
  - `.claude/skills/{codex-bridge,mobile-bug-log,release-ios-appstore,run-ios-sim,ship-discipline,ship-ios-testflight}/SKILL.md`

- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
  - Agent skills under `.claude/skills/`, consumed by the Claude Code skill loader. No generated artifact changes.

- Trust boundary touched:
  - [x] None — `gcp-access` documents which identity holds which role and names a key **path**. It contains no key, token, or secret value.

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below:
  - Documentation-only. Revert the commit to restore the previous frontmatter; nothing at runtime reads these files.

- UI browser or Playwright proof:
  - [x] Not applicable — no UI surface.

- Verification commands executed:
  - [x] Every skill's frontmatter parses as YAML (checked across all of `.claude/skills/*/SKILL.md`, not only the six edited)
  - [x] `gitleaks detect --source .claude/skills/` — no leaks across 3.84 MB
  - [x] `bash scripts/ci/local-release-gate.sh --stage governance` — **passed (15s)** on the CI interpreter (Python 3.13)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation checked; this PR does not duplicate `client-env-parity`, which already exists on `main` and is deliberately left untouched.
- [x] This PR changes a current reachable devex surface: skills loaded by Claude Code in this repository.
- [x] Reachable attach point: `.claude/skills/`, read at skill-invocation time.
- [x] Production surface proved: frontmatter validity is asserted mechanically, not by eye — the first attempt at this edit left orphaned YAML list items behind, and that check is what caught it.
- [ ] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: not applicable — no application code.
- [x] **iOS**: not applicable — no native code.
- [x] **Android**: not applicable — no native code.

## 🧪 Testing

- [x] Frontmatter parse check across every skill
- [x] Secret scan across `.claude/skills/`
- [x] Governance stage on the CI interpreter

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No.**
- [x] Sensitive surface touched: **none**. `gcp-access` describes IAM structure and names a local key path; it holds no credential value.
- [x] Error path / rollback proved: documentation-only; revert restores prior state.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies added
