### PR TITLE
fix(crm): prove encrypted external tool mappings

### DIFF
--- a/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
+++ b/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
@@ -63,9 +63,16 @@ before update. The browser never supplies a CRM ID.
 
 MuleSoft receives a registered tool call with no CRM URL, OAuth credentials,
 client secret, token URL, arbitrary target, browser-selected record ID, or
-request-supplied public key.
+request-supplied recipient public key. The browser's one-time ephemeral public
+key is part of `encryptedFields` by design.
 
-Read tool `read-crm-record-encrypted`:
+The registry maps the encrypted profile to deployed MuleSoft tools. For the
+current external CRM endpoint, use the existing `read-crm-record` and
+`update-crm-record` names; no second tool catalogue is required. The connector
+must recognise this profile and reject a plaintext fallback when
+`encryptedFields` is present.
+
+Read tool `read-crm-record`:
 
 ```json
 {
@@ -77,22 +84,24 @@ Read tool `read-crm-record-encrypted`:
   "encryptedFields": {
     "profile": "crm-encrypted-fields.v1",
     "direction": "read_request",
-    "recipientKeyId": "mulesoft-sandbox-key-1",
-    "clientOperationId": "cef_<random>",
-    "expiresAtMs": 0,
-    "clientPublicKey": "<base64-x25519-public-key>",
-    "wrappedPayloadKey": "<base64>",
-    "wrappedKeyIv": "<base64-12-byte-iv>",
-    "wrappedKeyTag": "<base64-16-byte-tag>",
-    "payloadIv": "<base64-12-byte-iv>",
-    "payloadTag": "<base64-16-byte-tag>",
+    "recipient_key_id": "mulesoft-sandbox-key-1",
+    "client_operation_id": "cef_<random>",
+    "expires_at_ms": 0,
+    "client_public_key": "<base64-x25519-public-key>",
+    "wrapped_payload_key": "<base64>",
+    "wrapped_key_iv": "<base64-12-byte-iv>",
+    "wrapped_key_tag": "<base64-16-byte-tag>",
+    "payload_iv": "<base64-12-byte-iv>",
+    "payload_tag": "<base64-16-byte-tag>",
     "ciphertext": "<base64>"
   }
 }
 ```
 
-Update tool `update-crm-record-encrypted` adds `intentId`, `approvalId`,
-`clientOperationId`, and allowed `fieldNames`; it carries the same
+The browser-facing Hussh API uses camelCase. The registered MuleSoft tool
+payload uses the snake_case envelope shown above, matching the existing MCP
+field convention. Update tool `update-crm-record` adds `intentId`,
+`approvalId`, `clientOperationId`, and allowed `fieldNames`; it carries the same
 `encryptedFields` shape with `direction: "update_request"`. MuleSoft returns
 only `{ "status": "accepted", "accepted": true, "operationId": "<opaque-id>" }`.
 

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -19,6 +19,7 @@ from hushh_mcp.services.crm_encrypted_fields_v1 import (
     CRM_ENCRYPTED_FIELDS_V1_PROFILE,
     CrmEncryptedFields,
     validate_crm_encrypted_fields_envelope,
+    validate_crm_encrypted_fields_recipient_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -1051,6 +1052,10 @@ class ConnectedSystemDefinition:
 
     def crm_encrypted_fields_ready(self, operation: str) -> bool:
         key = self.crm_encrypted_fields_recipient_key or {}
+        try:
+            validate_crm_encrypted_fields_recipient_key(key)
+        except Exception:
+            return False
         return bool(
             self.crm_encrypted_fields_v1_enabled
             and _crm_encrypted_fields_runtime_enabled()

--- a/consent-protocol/hushh_mcp/services/crm_encrypted_fields_v1.py
+++ b/consent-protocol/hushh_mcp/services/crm_encrypted_fields_v1.py
@@ -36,6 +36,19 @@ def _decode(value: str, *, name: str, expected_bytes: int | None = None) -> byte
     return decoded
 
 
+def validate_crm_encrypted_fields_recipient_key(value: dict[str, Any]) -> None:
+    """Prove a configured recipient key and fingerprint describe the same key."""
+    key_id = str(value.get("keyId") or "").strip()
+    public_key = value.get("publicKey")
+    fingerprint = str(value.get("publicKeyFingerprint") or "").strip().lower()
+    if not key_id or len(key_id) > 160 or not isinstance(public_key, str):
+        raise CrmEncryptedFieldsValidationError("crm_encrypted_fields_invalid_recipient_key")
+    decoded_public_key = _decode(public_key, name="recipient_public_key", expected_bytes=32)
+    expected_fingerprint = f"sha256:{hashlib.sha256(decoded_public_key).hexdigest()}"
+    if fingerprint != expected_fingerprint:
+        raise CrmEncryptedFieldsValidationError("crm_encrypted_fields_recipient_key_mismatch")
+
+
 class CrmEncryptedFields(BaseModel):
     """Opaque value envelope shared by browser, Hussh, and MuleSoft."""
 

--- a/consent-protocol/hushh_mcp/services/crm_registry_descriptor.py
+++ b/consent-protocol/hushh_mcp/services/crm_registry_descriptor.py
@@ -13,6 +13,10 @@ from urllib.parse import urlparse
 from hushh_mcp.services.connected_systems_service import (
     _valid_operation_response_contract,
 )
+from hushh_mcp.services.crm_encrypted_fields_v1 import (
+    CrmEncryptedFieldsValidationError,
+    validate_crm_encrypted_fields_recipient_key,
+)
 
 OPERATIONS = ("schema", "read", "create", "update", "delete")
 
@@ -62,6 +66,19 @@ class ValidatedCrmRegistryDescriptor:
     def encrypted_fields(self) -> dict[str, Any] | None:
         value = self.raw.get("encryptedFields")
         return dict(value) if isinstance(value, dict) else None
+
+    @property
+    def required_mcp_tool_names(self) -> tuple[str, ...]:
+        """All tool names an activation probe must find before it can enable a CRM.
+
+        An encrypted-fields tool may intentionally be the same registered
+        ``read`` or ``update`` tool. It is still listed here so a descriptor
+        cannot point the encrypted path at an undeployed MuleSoft capability.
+        """
+        names = {_text(config.get("toolName")) for config in self.operations.values()}
+        encrypted_tools = (self.encrypted_fields or {}).get("tools") or {}
+        names.update(_text(encrypted_tools.get(operation)) for operation in ("read", "update"))
+        return tuple(sorted(name for name in names if name))
 
 
 def load_and_validate_descriptor(
@@ -160,12 +177,23 @@ def load_and_validate_descriptor(
             raise CrmRegistryDescriptorError(
                 "encryptedFields.recipientKey requires keyId, publicKey, and publicKeyFingerprint."
             )
+        try:
+            validate_crm_encrypted_fields_recipient_key(recipient_key)
+        except CrmEncryptedFieldsValidationError as error:
+            raise CrmRegistryDescriptorError(
+                "encryptedFields.recipientKey must contain a 32-byte X25519 public key "
+                "and its matching SHA-256 fingerprint."
+            ) from error
         tools = encrypted_fields.get("tools")
         if not isinstance(tools, dict) or not all(
             _text(tools.get(key)) for key in ("read", "update")
         ):
             raise CrmRegistryDescriptorError(
                 "encryptedFields.tools requires read and update tool names."
+            )
+        if set(tools) != {"read", "update"}:
+            raise CrmRegistryDescriptorError(
+                "encryptedFields.tools may contain only read and update tool names."
             )
 
     if capability_set.intersection({"create", "update", "delete"}):

--- a/consent-protocol/scripts/ops/configure_crm_registry.py
+++ b/consent-protocol/scripts/ops/configure_crm_registry.py
@@ -156,7 +156,11 @@ async def _probe(descriptor: ValidatedCrmRegistryDescriptor) -> dict[str, Any]:
             await session.initialize()
             listed = await session.list_tools()
     listed_names = {str(tool.name) for tool in listed.tools}
-    required_names = {str(config["toolName"]) for config in descriptor.operations.values()}
+    # The encrypted profile may reuse the standard read/update tool names, but
+    # it may never point at a tool absent from the MuleSoft catalog. Include
+    # both mappings here so ``apply --activate`` proves the entire declared
+    # capability surface before changing the registry.
+    required_names = set(descriptor.required_mcp_tool_names)
     missing_names = sorted(required_names - listed_names)
     if missing_names:
         raise CrmRegistryDescriptorError(

--- a/consent-protocol/tests/test_crm_encrypted_fields_v1.py
+++ b/consent-protocol/tests/test_crm_encrypted_fields_v1.py
@@ -23,6 +23,7 @@ from hushh_mcp.services.crm_encrypted_fields_v1 import (
     CrmEncryptedFields,
     CrmEncryptedFieldsValidationError,
     validate_crm_encrypted_fields_envelope,
+    validate_crm_encrypted_fields_recipient_key,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -77,6 +78,18 @@ def test_encrypted_fields_envelope_accepts_only_exact_binary_shape_key_and_direc
             expected_key_id="mulesoft-uat-1",
             now_ms=wrong_key["expiresAtMs"] - 1,
         )
+
+
+def test_encrypted_fields_recipient_key_requires_a_matching_fingerprint() -> None:
+    key = {
+        "keyId": "mulesoft-uat-1",
+        "publicKey": _b64(32),
+        "publicKeyFingerprint": _fingerprint(),
+    }
+    validate_crm_encrypted_fields_recipient_key(key)
+
+    with pytest.raises(CrmEncryptedFieldsValidationError, match="recipient_key_mismatch"):
+        validate_crm_encrypted_fields_recipient_key({**key, "publicKeyFingerprint": "sha256:wrong"})
 
 
 @pytest.mark.parametrize(
@@ -278,12 +291,12 @@ async def test_encrypted_fields_update_is_ciphertext_only_and_approval_is_idempo
             {
                 "operation": "read",
                 "name": "read-crm-record",
-                "crmEncryptedFieldsToolName": "read-crm-record-encrypted",
+                "crmEncryptedFieldsToolName": "read-crm-record",
             },
             {
                 "operation": "update",
                 "name": "update-crm-record",
-                "crmEncryptedFieldsToolName": "update-crm-record-encrypted",
+                "crmEncryptedFieldsToolName": "update-crm-record",
             },
         ),
         crm_encrypted_fields_v1_enabled=True,
@@ -377,6 +390,8 @@ async def test_encrypted_fields_update_is_ciphertext_only_and_approval_is_idempo
     )
     assert partner_calls[1]["payload"]["id"] == "backend-bound-record"
     assert partner_calls[1]["payload"]["fieldNames"] == ["Title"]
+    assert partner_calls[1]["payload"]["encryptedFields"]["client_public_key"] == _b64(32, 2)
+    assert "clientPublicKey" not in partner_calls[1]["payload"]["encryptedFields"]
 
 
 @pytest.mark.parametrize(

--- a/consent-protocol/tests/test_crm_registry_descriptor.py
+++ b/consent-protocol/tests/test_crm_registry_descriptor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 
 import pytest
@@ -87,6 +89,15 @@ def _descriptor(*, crm_id: str = "crm_alpha", read_only: bool = True) -> dict:
     }
 
 
+def _recipient_key() -> dict[str, str]:
+    public_key = base64.b64encode(bytes([7]) * 32).decode("ascii")
+    return {
+        "keyId": "mulesoft-sandbox-key-1",
+        "publicKey": public_key,
+        "publicKeyFingerprint": f"sha256:{hashlib.sha256(bytes([7]) * 32).hexdigest()}",
+    }
+
+
 @pytest.mark.parametrize("read_only", [True, False])
 def test_descriptor_validates_structurally_different_capability_sets(
     tmp_path, monkeypatch, read_only
@@ -133,3 +144,65 @@ def test_descriptor_requires_explicit_cross_object_probe_mode(tmp_path, monkeypa
     raw["probe"] = {"mode": "cross-object-bound-lifecycle.v1"}
     path.write_text(json.dumps(raw))
     assert load_and_validate_descriptor(path).crm_id == "crm_alpha"
+
+
+def test_encrypted_fields_can_reuse_standard_read_and_update_tool_names(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_ID", "id")
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_SECRET", "secret")
+    raw = _descriptor(read_only=False)
+    raw["encryptedFields"] = {
+        "enabled": True,
+        "recipientKey": _recipient_key(),
+        "tools": {
+            "read": "find-person",
+            "update": "update-person",
+        },
+    }
+    path = tmp_path / "crm.json"
+    path.write_text(json.dumps(raw))
+
+    descriptor = load_and_validate_descriptor(path)
+
+    assert descriptor.required_mcp_tool_names == (
+        "create-person",
+        "delete-person",
+        "describe-person",
+        "find-person",
+        "update-person",
+    )
+
+
+def test_encrypted_fields_rejects_undeclared_operation_aliases(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_ID", "id")
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_SECRET", "secret")
+    raw = _descriptor(read_only=False)
+    raw["encryptedFields"] = {
+        "enabled": True,
+        "recipientKey": _recipient_key(),
+        "tools": {
+            "read": "find-person",
+            "update": "update-person",
+            "delete": "delete-person",
+        },
+    }
+    path = tmp_path / "crm.json"
+    path.write_text(json.dumps(raw))
+
+    with pytest.raises(CrmRegistryDescriptorError, match="only read and update"):
+        load_and_validate_descriptor(path)
+
+
+def test_encrypted_fields_rejects_a_key_and_fingerprint_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_ID", "id")
+    monkeypatch.setenv("CRM_ALPHA_CLIENT_SECRET", "secret")
+    raw = _descriptor(read_only=False)
+    raw["encryptedFields"] = {
+        "enabled": True,
+        "recipientKey": {**_recipient_key(), "publicKeyFingerprint": "sha256:wrong"},
+        "tools": {"read": "find-person", "update": "update-person"},
+    }
+    path = tmp_path / "crm.json"
+    path.write_text(json.dumps(raw))
+
+    with pytest.raises(CrmRegistryDescriptorError, match="matching SHA-256 fingerprint"):
+        load_and_validate_descriptor(path)

--- a/docs/reference/operations/crm-registry-operations.md
+++ b/docs/reference/operations/crm-registry-operations.md
@@ -24,13 +24,21 @@ base and Streamable HTTP MCP endpoints, capability list, exact per-operation
 tool names, request styles, fixed response paths, and synthetic probe arguments
 when CRUD is declared.
 
+For `crm-encrypted-fields.v1`, the descriptor also pins MuleSoft's recipient
+key ID, public key, and fingerprint, plus the encrypted read/update tool
+mappings. Those mappings may reuse the standard `read-crm-record` and
+`update-crm-record` tools when MuleSoft supports the exact `encryptedFields`
+wire contract. The operator verifies that the fingerprint is the SHA-256 digest
+of that exact 32-byte X25519 public key. The mapping may not introduce a
+plaintext fallback.
+
 ## Commands
 
 - `check` validates the descriptor, credential presence, URLs, exact operation
   set, and response-contract versions without network or database mutation.
 - `probe` performs MCP `initialize`, `tools/list`, schema normalization, and the
-  declared operation checks. CRUD runs create, ID read, update/readback, delete,
-  and absent-ID verification with cleanup.
+  declared operation and encrypted-fields tool checks. CRUD runs create, ID
+  read, update/readback, delete, and absent-ID verification with cleanup.
 - `apply --activate` repeats the probe, encrypts runtime credentials,
   transactionally replaces the parent and exact operation rows, increments the
   configuration revision, invalidates old caches, writes a redacted audit


### PR DESCRIPTION
## Summary
- use the existing MuleSoft `read-crm-record` and `update-crm-record` names for the encrypted-fields profile when they accept its exact envelope
- fail registry activation unless every declared standard and encrypted tool appears in `tools/list`
- validate the registered X25519 recipient public key against its SHA-256 fingerprint before the profile is ready
- document the exact MuleSoft snake_case envelope and Account-create → verified Contact-binding boundary

## Verification
- `./bin/hushh protocol test-ci` (846 passed)
- `cd hushh-webapp && npm run typecheck`
- `./bin/hushh docs verify`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `./bin/hushh codex pre-pr`

## UAT activation gate
This PR does not activate a connector. Activation still requires MuleSoft recipient key metadata, exact encrypted tool conformance, and the governed UAT registry descriptor apply.