### PR TITLE
fix(crm): keep Person Account and Contact bindings separate

### DIFF
--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -1117,6 +1117,14 @@ class ConnectedSystemDefinition:
             operation: self.supports(operation) and (operation != "delete" or delete_enabled)
             for operation in ("schema", "read", "create", "update", "delete")
         }
+        # The registry, never a browser-supplied object name, owns the record
+        # type used by each operation. This makes a Person Account create /
+        # Contact read-update lifecycle explicit without exposing record IDs.
+        operation_object_types = {
+            operation: self.object_type_for_operation(operation)
+            for operation, enabled in supported_actions.items()
+            if enabled
+        }
         return {
             "systemId": self.system_id,
             "configurationRevision": self.configuration_revision,
@@ -1127,6 +1135,7 @@ class ConnectedSystemDefinition:
             "status": "connected" if endpoint_configured else "needs_configuration",
             "target": self.target,
             "objectTypeDefault": self.object_type_default,
+            "operationObjectTypes": operation_object_types,
             "transport": self.transport,
             "transportLabel": "External CRM MCP",
             "endpointConfigured": endpoint_configured,
@@ -1290,7 +1299,8 @@ class ExternalCrmStreamableMcpAdapter:
         if resolved_endpoint.startswith("registry://"):
             return self._call_registry_tool(name, arguments)
 
-        # CRM ZK calls are allowed to use only a trusted connector reference.
+        # Encrypted-fields calls are allowed to use only a trusted connector
+        # reference.
         # Do not merge the legacy registry credentials/URLs into their MCP
         # arguments: MuleSoft resolves those from its own secret store.
         tool_arguments = (
@@ -3363,7 +3373,7 @@ class ConnectedSystemsService:
         if system.crm_encrypted_fields_v1_enabled:
             raise ConnectedSystemBlockedError(
                 "This CRM requires its configured encrypted update protocol.",
-                code="CONNECTED_SYSTEM_CRM_ZK_UPDATE_REQUIRED",
+                code="CONNECTED_SYSTEM_ENCRYPTED_FIELDS_UPDATE_REQUIRED",
             )
         self._require_operation(system, "update")
         object_type_value = system.object_type_for_operation("update")
@@ -3623,7 +3633,7 @@ class ConnectedSystemsService:
         if system.crm_encrypted_fields_v1_enabled:
             raise ConnectedSystemBlockedError(
                 "This CRM requires its configured encrypted read protocol.",
-                code="CONNECTED_SYSTEM_CRM_ZK_READ_REQUIRED",
+                code="CONNECTED_SYSTEM_ENCRYPTED_FIELDS_READ_REQUIRED",
             )
         object_type_value = system.object_type_for_operation("read")
         record_id = self._require_bound_record_id(
@@ -3870,7 +3880,8 @@ class ConnectedSystemsService:
             )
         if system.crm_encrypted_fields_v1_enabled:
             # Verified-identity discovery remains a deliberately narrow
-            # server-side exception. A ZK connector never receives plaintext
+            # server-side exception. An encrypted-fields connector never
+            # receives plaintext
             # CRM fields on this route; the browser must issue a fresh bound
             # encrypted-fields read after it receives binding metadata.
             return {

--- a/consent-protocol/tests/test_crm_encrypted_fields_v1.py
+++ b/consent-protocol/tests/test_crm_encrypted_fields_v1.py
@@ -271,6 +271,39 @@ def test_registry_owned_operation_objects_keep_person_account_and_contact_bindin
         )
 
 
+def test_registry_summary_exposes_safe_per_operation_object_types() -> None:
+    system = ConnectedSystemDefinition(
+        system_id="crm-person-account",
+        display_name="Hushh",
+        customer_display_name="Hushh",
+        system_type="Salesforce",
+        system_name="Salesforce",
+        target="Hushh",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="registry://crm-person-account",
+        registry_source="test",
+        tool_catalog=(
+            {"operation": "schema", "name": "object-schema", "objectType": "Contact"},
+            {"operation": "create", "name": "create-crm-record", "objectType": "Account"},
+            {"operation": "read", "name": "read-crm-record", "objectType": "Contact"},
+            {"operation": "update", "name": "update-crm-record", "objectType": "Contact"},
+            {"operation": "delete", "name": "delete-crm-record", "objectType": "Contact"},
+        ),
+    )
+
+    summary = system.to_summary(endpoint_configured=True, delete_enabled=True)
+
+    assert summary["operationObjectTypes"] == {
+        "schema": "Contact",
+        "read": "Contact",
+        "create": "Account",
+        "update": "Contact",
+        "delete": "Contact",
+    }
+    assert "record_id" not in json.dumps(summary)
+
+
 @pytest.mark.asyncio
 async def test_encrypted_fields_update_is_ciphertext_only_and_approval_is_idempotent(
     monkeypatch: pytest.MonkeyPatch,

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4853,7 +4853,7 @@
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "94a557650fa3944ba26c24260c079b457b6b64699aeee4ee6a793aba9616b423",
     "agent_registry": "5c9718afc8f323f91c1906e5fe58539514769337f38db7959bf3ce6feb7614ad",
-    "cache_manifest": "aaac578ca3599f1cf1639620657a5610ed0247202c849d5dc200575bffc8ab92",
+    "cache_manifest": "44fe96be2ef540812f726e064570c67b28e41f134a24839b66b10c72a7a63737",
     "data_plane": "314c1b4e33e47c02b2438aade82b0b92d09f21404e7dbff62b45463b2f51d70c",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "4067d2cabf3bf0c1c8bb2f53d2080a03dc68fd2a04819594cfc1593478538ac8",

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -465,11 +465,11 @@ active binding exists.
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| GET | `/api/connected-systems` | List active registry systems with `registryRevision` and per-system `configurationRevision`; signed-in metadata only |
+| GET | `/api/connected-systems` | List active registry systems with `registryRevision`, per-system `configurationRevision`, and registry-owned `operationObjectTypes`; signed-in metadata only |
 | GET | `/api/connected-systems/{system_id}/schema?objectType={primary_object}&forceRefresh=false` | Return the normalized schema catalogue, fingerprint, freshness, refresh guidance, and exact `effectiveActions` |
 | GET | `/api/connected-systems/record-bindings` | Return owner-scoped binding statuses for every active CRM in one request; no CRM record IDs or values |
-| GET | `/api/connected-systems/{system_id}/record-binding?objectType=Contact` | Return the current One user binding for this external CRM record, or `unbound` |
-| DELETE | `/api/connected-systems/{system_id}/record-binding?objectType=Contact` | Idempotently disconnect the authenticated owner's current local binding; the request accepts no record ID and does not delete the remote CRM record |
+| GET | `/api/connected-systems/{system_id}/record-binding?objectType={registry_object}` | Return the current One user binding for the requested registry-owned CRM object, or `unbound` |
+| DELETE | `/api/connected-systems/{system_id}/record-binding?objectType={registry_object}` | Idempotently disconnect the authenticated owner's current local binding; the request accepts no record ID and does not delete the remote CRM record |
 | POST | `/api/connected-systems/{system_id}/records/read` | Read the exact owner-bound record using `{ objectType, returnFields }`; returns a sanitized normalized projection or explicit `remote_record_missing` recovery state |
 | POST | `/api/connected-systems/{system_id}/records/search` | Search and bind the One user when the registered record id mapping resolves a record |
 | POST | `/api/connected-systems/{system_id}/records/create-intents` | Create a pending schema-validated `{ objectType, recordFields }` intent |

--- a/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
@@ -12,7 +12,10 @@ import {
   ConnectedSystemLogo,
   ConnectedSystemsPanel,
 } from "@/components/profile/connected-systems-panel";
-import { ConnectedSystemsService } from "@/lib/services/connected-systems-service";
+import {
+  ConnectedSystemsRequestError,
+  ConnectedSystemsService,
+} from "@/lib/services/connected-systems-service";
 import {
   CACHE_KEYS,
   CACHE_TTL,
@@ -45,6 +48,16 @@ vi.mock("@/lib/services/device-resource-cache-service", () => ({
 }));
 
 vi.mock("@/lib/services/connected-systems-service", () => ({
+  ConnectedSystemsRequestError: class ConnectedSystemsRequestError extends Error {
+    constructor(
+      message: string,
+      readonly code: string | null,
+      readonly status: number,
+    ) {
+      super(message);
+      this.name = "ConnectedSystemsRequestError";
+    }
+  },
   ConnectedSystemsService: {
     getRegistry: vi.fn(),
     getSchema: vi.fn(),
@@ -264,10 +277,7 @@ describe("ConnectedSystemsPanel", () => {
 
     const logo = screen.getByRole("img", { name: "Chase logo" });
     expect(logo).toHaveClass("filter-none");
-    expect(logo.parentElement).toHaveClass(
-      "!bg-white",
-      "dark:!bg-white",
-    );
+    expect(logo.parentElement).toHaveClass("!bg-white", "dark:!bg-white");
   });
 
   it("uses the same fixed row frame for branded and fallback CRM marks", () => {
@@ -570,6 +580,588 @@ describe("ConnectedSystemsPanel", () => {
       ),
     );
     expect(await screen.findByText("Review create request")).toBeTruthy();
+  });
+
+  it("waits for a separately verified Contact binding after Person Account creation", async () => {
+    const personAccountSystem = {
+      ...system,
+      objectTypeDefault: "Contact",
+      operationObjectTypes: {
+        schema: "Contact",
+        read: "Contact",
+        create: "Account",
+        update: "Contact",
+        delete: "Contact",
+      },
+    };
+    const contactSchema = {
+      ...readySchema,
+      objectType: "Contact",
+    };
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [personAccountSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce(
+      contactSchema,
+    );
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ objectType }) => ({
+        systemId: personAccountSystem.systemId,
+        target: personAccountSystem.target,
+        objectType: objectType || "Contact",
+        status: "unbound",
+        binding: null,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.createRecordIntent).mockResolvedValueOnce(
+      {
+        intentId: "intent-account-create",
+        systemId: personAccountSystem.systemId,
+        action: "create",
+        objectType: "Account",
+        status: "pending",
+        fieldNames: ["FirstName", "LastName", "PersonEmail"],
+      },
+    );
+    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
+      intentId: "intent-account-create",
+      systemId: personAccountSystem.systemId,
+      action: "create",
+      objectType: "Account",
+      status: "succeeded",
+      recordId: "001-person-account",
+      fieldNames: ["FirstName", "LastName", "PersonEmail"],
+      binding: {
+        systemId: personAccountSystem.systemId,
+        objectType: "Account",
+        recordId: "001-person-account",
+        status: "active",
+      },
+    });
+
+    render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={personAccountSystem.systemId}
+        profile={{
+          displayName: "Jordan Lee",
+          email: "jordan@example.test",
+          phone: "4155550100",
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Find my record" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create profile" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Confirm create" }),
+    );
+
+    expect(await screen.findByText("Your profile was created")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Check for Contact" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Create profile" })).toBeNull();
+    expect(screen.queryByText("001-person-account")).toBeNull();
+    expect(ConnectedSystemsService.readRecord).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(ConnectedSystemsService.searchRecord).toHaveBeenCalledTimes(2);
+      expect(ConnectedSystemsService.searchRecord).toHaveBeenLastCalledWith(
+        "HCT:test",
+        expect.objectContaining({ objectType: "Contact" }),
+      );
+    });
+  });
+
+  it("restores the Contact-binding wait after reload without reusing an Account ID", async () => {
+    const personAccountSystem = {
+      ...system,
+      objectTypeDefault: "Contact",
+      operationObjectTypes: {
+        schema: "Contact",
+        read: "Contact",
+        create: "Account",
+        update: "Contact",
+        delete: "Contact",
+      },
+    };
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [personAccountSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce({
+      ...readySchema,
+      objectType: "Contact",
+    });
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ objectType }) => {
+        if (objectType === "Account") {
+          return {
+            systemId: personAccountSystem.systemId,
+            target: personAccountSystem.target,
+            objectType: "Account",
+            status: "active",
+            binding: {
+              systemId: personAccountSystem.systemId,
+              objectType: "Account",
+              recordId: "001-person-account",
+              status: "active",
+            },
+          };
+        }
+        return {
+          systemId: personAccountSystem.systemId,
+          target: personAccountSystem.target,
+          objectType: "Contact",
+          status: "unbound",
+          binding: null,
+        };
+      },
+    );
+
+    render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={personAccountSystem.systemId}
+      />,
+    );
+
+    expect(await screen.findByText("Your profile was created")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Check for Contact" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Create profile" })).toBeNull();
+    expect(screen.queryByText("001-person-account")).toBeNull();
+    expect(ConnectedSystemsService.readRecord).not.toHaveBeenCalled();
+    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
+  });
+
+  it("ignores a late cross-object binding response after switching CRM systems", async () => {
+    const personAccountSystem = {
+      ...system,
+      systemId: "person-account-crm",
+      displayName: "Person Account CRM",
+      customerDisplayName: "Person Account CRM",
+      target: "Person Account CRM",
+      objectTypeDefault: "Contact",
+      operationObjectTypes: {
+        schema: "Contact",
+        read: "Contact",
+        create: "Account",
+        update: "Contact",
+        delete: "Contact",
+      },
+    };
+    const contactSystem = {
+      ...system,
+      systemId: "contact-crm",
+      displayName: "Contact CRM",
+      customerDisplayName: "Contact CRM",
+      target: "Contact CRM",
+      objectTypeDefault: "Contact",
+    };
+    let resolveAccountBinding!: (value: {
+      systemId: string;
+      target: string;
+      objectType: string;
+      status: string;
+      binding: {
+        systemId: string;
+        objectType: string;
+        recordId: string;
+        status: string;
+      };
+    }) => void;
+    const accountBinding = new Promise<{
+      systemId: string;
+      target: string;
+      objectType: string;
+      status: string;
+      binding: {
+        systemId: string;
+        objectType: string;
+        recordId: string;
+        status: string;
+      };
+    }>((resolve) => {
+      resolveAccountBinding = resolve;
+    });
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [personAccountSystem, contactSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockImplementation(
+      async ({ systemId }) => ({
+        ...readySchema,
+        systemId: systemId || personAccountSystem.systemId,
+        target:
+          systemId === contactSystem.systemId
+            ? contactSystem.target
+            : personAccountSystem.target,
+        objectType: "Contact",
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ systemId, objectType }) => {
+        if (
+          systemId === personAccountSystem.systemId &&
+          objectType === "Account"
+        ) {
+          return accountBinding;
+        }
+        return {
+          systemId: systemId || personAccountSystem.systemId,
+          target:
+            systemId === contactSystem.systemId
+              ? contactSystem.target
+              : personAccountSystem.target,
+          objectType: objectType || "Contact",
+          status: "unbound",
+          binding: null,
+        };
+      },
+    );
+
+    const { rerender } = render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={personAccountSystem.systemId}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ConnectedSystemsService.getRecordBinding).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemId: personAccountSystem.systemId,
+          objectType: "Account",
+        }),
+      );
+    });
+
+    rerender(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={contactSystem.systemId}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Find my record" }),
+    ).toBeTruthy();
+    await act(async () => {
+      resolveAccountBinding({
+        systemId: personAccountSystem.systemId,
+        target: personAccountSystem.target,
+        objectType: "Account",
+        status: "active",
+        binding: {
+          systemId: personAccountSystem.systemId,
+          objectType: "Account",
+          recordId: "001-person-account",
+          status: "active",
+        },
+      });
+    });
+
+    expect(screen.getByRole("button", { name: "Find my record" })).toBeTruthy();
+    expect(screen.queryByText("Your profile was created")).toBeNull();
+    expect(screen.queryByText("001-person-account")).toBeNull();
+  });
+
+  it("does not redirect for a late mutation failure after switching CRM systems", async () => {
+    const firstSystem = {
+      ...system,
+      systemId: "late-mutation-first-crm",
+      displayName: "First CRM",
+      customerDisplayName: "First CRM",
+      target: "First CRM",
+    };
+    const secondSystem = {
+      ...system,
+      systemId: "late-mutation-second-crm",
+      displayName: "Second CRM",
+      customerDisplayName: "Second CRM",
+      target: "Second CRM",
+    };
+    let rejectCreate!: (reason: Error) => void;
+    const createIntent = new Promise<never>((_resolve, reject) => {
+      rejectCreate = reject;
+    });
+
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [firstSystem, secondSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockImplementation(
+      async ({ systemId }) => ({
+        ...readySchema,
+        systemId: systemId || firstSystem.systemId,
+        target:
+          systemId === secondSystem.systemId
+            ? secondSystem.target
+            : firstSystem.target,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ systemId }) => ({
+        systemId: systemId || firstSystem.systemId,
+        target:
+          systemId === secondSystem.systemId
+            ? secondSystem.target
+            : firstSystem.target,
+        objectType: system.objectTypeDefault,
+        status: "unbound",
+        binding: null,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.createRecordIntent).mockImplementation(
+      async () => createIntent,
+    );
+
+    const { rerender } = render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={firstSystem.systemId}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Find my record" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create profile" }),
+    );
+    await waitFor(() => {
+      expect(ConnectedSystemsService.createRecordIntent).toHaveBeenCalledWith(
+        "HCT:test",
+        expect.objectContaining({ systemId: firstSystem.systemId }),
+      );
+    });
+
+    rerender(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={secondSystem.systemId}
+      />,
+    );
+    expect(
+      await screen.findByRole("button", { name: "Find my record" }),
+    ).toBeTruthy();
+
+    await act(async () => {
+      rejectCreate(
+        new ConnectedSystemsRequestError(
+          "Phone verification is required.",
+          "CONNECTED_SYSTEM_PHONE_VERIFICATION_REQUIRED",
+          403,
+        ),
+      );
+    });
+
+    expect(routerPushMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Find my record" })).toBeTruthy();
+  });
+
+  it("closes a pending CRM confirmation when the selected system changes", async () => {
+    const firstSystem = {
+      ...system,
+      systemId: "pending-confirmation-first-crm",
+      displayName: "First CRM",
+      customerDisplayName: "First CRM",
+      target: "First CRM",
+    };
+    const secondSystem = {
+      ...system,
+      systemId: "pending-confirmation-second-crm",
+      displayName: "Second CRM",
+      customerDisplayName: "Second CRM",
+      target: "Second CRM",
+    };
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [firstSystem, secondSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockImplementation(
+      async ({ systemId }) => ({
+        ...readySchema,
+        systemId: systemId || firstSystem.systemId,
+        target:
+          systemId === secondSystem.systemId
+            ? secondSystem.target
+            : firstSystem.target,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ systemId }) => ({
+        systemId: systemId || firstSystem.systemId,
+        target:
+          systemId === secondSystem.systemId
+            ? secondSystem.target
+            : firstSystem.target,
+        objectType: system.objectTypeDefault,
+        status: "unbound",
+        binding: null,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.createRecordIntent).mockResolvedValueOnce(
+      {
+        intentId: "intent-first-create",
+        systemId: firstSystem.systemId,
+        action: "create",
+        status: "pending",
+        fieldNames: ["Email"],
+      },
+    );
+
+    const { rerender } = render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={firstSystem.systemId}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Find my record" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create profile" }),
+    );
+    expect(await screen.findByText("Review create request")).toBeTruthy();
+
+    rerender(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={secondSystem.systemId}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Review create request")).toBeNull();
+    });
+    expect(ConnectedSystemsService.approveIntent).not.toHaveBeenCalled();
+    expect(
+      await screen.findByRole("button", { name: "Find my record" }),
+    ).toBeTruthy();
+  });
+
+  it("closes a staged update review when the selected system changes", async () => {
+    const firstSystem = {
+      ...system,
+      systemId: "staged-review-first-crm",
+      displayName: "First CRM",
+      customerDisplayName: "First CRM",
+      target: "First CRM",
+    };
+    const secondSystem = {
+      ...system,
+      systemId: "staged-review-second-crm",
+      displayName: "Second CRM",
+      customerDisplayName: "Second CRM",
+      target: "Second CRM",
+    };
+    vi.mocked(ConnectedSystemsService.getRegistry).mockResolvedValue({
+      registryRevision: 1,
+      systems: [firstSystem, secondSystem],
+    });
+    vi.mocked(ConnectedSystemsService.getSchema).mockImplementation(
+      async ({ systemId }) => ({
+        ...readySchema,
+        systemId: systemId || firstSystem.systemId,
+        target:
+          systemId === secondSystem.systemId
+            ? secondSystem.target
+            : firstSystem.target,
+      }),
+    );
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockImplementation(
+      async ({ systemId }) => {
+        const isFirstSystem = systemId !== secondSystem.systemId;
+        return {
+          systemId: systemId || firstSystem.systemId,
+          target: isFirstSystem ? firstSystem.target : secondSystem.target,
+          objectType: system.objectTypeDefault,
+          status: isFirstSystem ? "active" : "unbound",
+          binding: isFirstSystem
+            ? {
+                systemId: firstSystem.systemId,
+                objectType: system.objectTypeDefault,
+                recordId: "person-42",
+                status: "active",
+              }
+            : null,
+        };
+      },
+    );
+    // Schema and binding hydration can issue a second equivalent read. Both
+    // resolve the same bound record; this test is about discarding its staged
+    // update when the CRM changes, not incidental hook scheduling.
+    vi.mocked(ConnectedSystemsService.readRecord).mockResolvedValue({
+      systemId: firstSystem.systemId,
+      target: firstSystem.target,
+      objectType: system.objectTypeDefault,
+      resultClass: "succeeded",
+      recordId: "person-42",
+      records: [
+        {
+          recordId: "person-42",
+          fields: {
+            Email: "person@example.test",
+            PreferredLanguage: "English",
+          },
+        },
+      ],
+    });
+
+    const { rerender } = render(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={firstSystem.systemId}
+        profile={{ email: "person@example.test" }}
+      />,
+    );
+
+    // Let the current CRM detail finish its passive record lifecycle before
+    // opening the editor; the assertion below is about the later CRM switch.
+    expect(
+      await screen.findByRole("region", { name: "CRM record fields" }),
+    ).toBeTruthy();
+    expect(await screen.findByText("person@example.test")).toBeTruthy();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit Preferred language" }),
+    );
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "French" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stage change" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update record" }));
+    expect(await screen.findByText("Review changes")).toBeTruthy();
+
+    rerender(
+      <ConnectedSystemsPanel
+        cacheUserId="user-1"
+        vaultOwnerToken="HCT:test"
+        systemId={secondSystem.systemId}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Review changes")).toBeNull();
+    });
+    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
   });
 
   it("links a verified-identity match and renders its returned record", async () => {

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -11,7 +11,7 @@
   },
   "summary": {
     "total_screens": 126,
-    "physical_page_count": 0,
+    "physical_page_count": 126,
     "route_contract_count": 126,
     "surface_map_count": 126,
     "class_counts": {
@@ -5634,5 +5634,5 @@
       ]
     }
   ],
-  "content_sha256": "30a611c9cff7e41647f69eb47a1486a051cc6f7a6fbd4ed7310a380b9c6651cd"
+  "content_sha256": "a3240ed083f42c84d1a564552ee29d854e52e72a2c881da9600d504cc20405e9"
 }

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -137,8 +137,17 @@ type PendingUpdateReviewField = {
 };
 
 type PendingUpdateReview = {
+  systemKey: string;
   recordFields: CrmFieldValues;
   fields: PendingUpdateReviewField[];
+};
+
+type CrossObjectBindingState = "idle" | "account_created_waiting_for_contact";
+
+type PanelRequestContext = {
+  systemKey: string;
+  vaultOwnerToken: string;
+  mode: ConnectedSystemsPanelProps["mode"];
 };
 
 function statusBadge(status: string | undefined | null): string {
@@ -447,6 +456,13 @@ function normalizedCrmFieldToken(value?: string | null): string {
     .toLocaleLowerCase();
 }
 
+function sameCrmObjectType(
+  left?: string | null,
+  right?: string | null,
+): boolean {
+  return normalizedCrmFieldToken(left) === normalizedCrmFieldToken(right);
+}
+
 function isCrmFieldLocked(field: CrmProfileField): boolean {
   return (
     field.identityField === true ||
@@ -523,6 +539,10 @@ export function ConnectedSystemsPanel({
   const [unboundLookupState, setUnboundLookupState] = useState<
     "idle" | "checking" | "no_match" | "remote_missing" | "failed"
   >("idle");
+  const [crossObjectBindingState, setCrossObjectBindingState] =
+    useState<CrossObjectBindingState>("idle");
+  const [crossObjectBindingResolvedKey, setCrossObjectBindingResolvedKey] =
+    useState<string | null>(null);
   const consumedAgentInstructionRef = useRef<string | null>(null);
   // Tracks which systems (by systemId) have an active record binding, across
   // ALL available systems, not just the one currently open in detail view.
@@ -558,9 +578,25 @@ export function ConnectedSystemsPanel({
   const selectedSystem =
     systems.find((system) => system.systemId === systemId) ||
     (!systemId ? systems[0] || null : null);
-  const encryptedFieldsEnabled = selectedSystem?.crmEncryptedFields?.profile === "crm-encrypted-fields.v1";
-  const encryptedFieldsReadReady = selectedSystem?.crmEncryptedFields?.readReady === true;
-  const encryptedFieldsUpdateReady = selectedSystem?.crmEncryptedFields?.updateReady === true;
+  const selectedSystemId = selectedSystem?.systemId || "";
+  const defaultObjectType = selectedSystem?.objectTypeDefault || "Contact";
+  const readObjectType =
+    selectedSystem?.operationObjectTypes?.read || defaultObjectType;
+  const createObjectType =
+    selectedSystem?.operationObjectTypes?.create || defaultObjectType;
+  const updateObjectType =
+    selectedSystem?.operationObjectTypes?.update || defaultObjectType;
+  const deleteObjectType =
+    selectedSystem?.operationObjectTypes?.delete || defaultObjectType;
+  const hasCrossObjectCreateFlow = Boolean(
+    selectedSystem && !sameCrmObjectType(createObjectType, readObjectType),
+  );
+  const encryptedFieldsEnabled =
+    selectedSystem?.crmEncryptedFields?.profile === "crm-encrypted-fields.v1";
+  const encryptedFieldsReadReady =
+    selectedSystem?.crmEncryptedFields?.readReady === true;
+  const encryptedFieldsUpdateReady =
+    selectedSystem?.crmEncryptedFields?.updateReady === true;
   useEffect(() => {
     if (!vaultOwnerToken) {
       clearCrmEncryptedFieldsEphemeralKeys();
@@ -573,14 +609,48 @@ export function ConnectedSystemsPanel({
     if (selectedSystem) onSystemResolved?.(selectedSystem);
   }, [onSystemResolved, selectedSystem]);
   const selectedSystemKey = selectedSystem
-    ? `${selectedSystem.systemId}:${selectedSystem.objectTypeDefault || "Contact"}`
+    ? `${selectedSystem.systemId}:${readObjectType}`
     : "";
+  const previousSelectedSystemKeyRef = useRef<string | null>(null);
+  // Binding reads can have a second Account lookup for Person Account CRM
+  // configurations. Keep late results from an old system, vault token, or
+  // presentation mode from overwriting the detail currently on screen.
+  const bindingRequestSequenceRef = useRef(0);
+  const currentBindingContextRef = useRef({
+    systemKey: selectedSystemKey,
+    vaultOwnerToken: vaultOwnerToken || "",
+    mode,
+  });
+  currentBindingContextRef.current = {
+    systemKey: selectedSystemKey,
+    vaultOwnerToken: vaultOwnerToken || "",
+    mode,
+  };
+  const capturePanelRequestContext = (): PanelRequestContext => ({
+    ...currentBindingContextRef.current,
+  });
+  const isCurrentPanelRequest = (context: PanelRequestContext): boolean => {
+    const current = currentBindingContextRef.current;
+    return (
+      current.systemKey === context.systemKey &&
+      current.vaultOwnerToken === context.vaultOwnerToken &&
+      current.mode === context.mode
+    );
+  };
+  const activePendingIntent =
+    pendingIntent && pendingIntent.systemId === selectedSystem?.systemId
+      ? pendingIntent
+      : null;
+  const activePendingUpdateReview =
+    pendingUpdateReview?.systemKey === selectedSystemKey
+      ? pendingUpdateReview
+      : null;
   const selectedConfigurationRevision =
     selectedSystem?.configurationRevision || 1;
   const schemaCacheKey = ConnectedSystemsResourceService.schemaCacheKey({
     userId: cacheScope,
     systemId: selectedSystem?.systemId || "none",
-    objectType: selectedSystem?.objectTypeDefault || "Contact",
+    objectType: readObjectType,
     configurationRevision: selectedConfigurationRevision,
   });
   const loadSelectedSchema = useCallback(
@@ -592,13 +662,14 @@ export function ConnectedSystemsPanel({
         userId: cacheScope,
         vaultOwnerToken,
         systemId: selectedSystem.systemId,
-        objectType: selectedSystem.objectTypeDefault || "Contact",
+        objectType: readObjectType,
         configurationRevision: selectedConfigurationRevision,
         forceRefresh: options?.force,
       });
     },
     [
       cacheScope,
+      readObjectType,
       selectedConfigurationRevision,
       selectedSystem,
       vaultOwnerToken,
@@ -619,10 +690,10 @@ export function ConnectedSystemsPanel({
   const schemaReady = schema?.schemaStatus === "ready";
   const schemaMatchesSelectedConfiguration = Boolean(
     schema &&
-      selectedSystem &&
-      schema.systemId === selectedSystem.systemId &&
-      schema.objectType === (selectedSystem.objectTypeDefault || "Contact") &&
-      schema.configurationRevision === selectedConfigurationRevision,
+    selectedSystem &&
+    schema.systemId === selectedSystem.systemId &&
+    schema.objectType === readObjectType &&
+    schema.configurationRevision === selectedConfigurationRevision,
   );
   const supportsAction = (
     action: "schema" | "read" | "create" | "update" | "delete",
@@ -725,17 +796,21 @@ export function ConnectedSystemsPanel({
   const crmRecordReadKey = useMemo(
     () =>
       selectedSystem && currentRecordId
-        ? [
-            selectedSystem.systemId,
-            selectedSystem.objectTypeDefault || "Contact",
-            currentRecordId,
-          ].join(":")
+        ? [selectedSystem.systemId, readObjectType, currentRecordId].join(":")
         : "",
-    [currentRecordId, selectedSystem],
+    [currentRecordId, readObjectType, selectedSystem],
   );
   const bindingResolved = Boolean(
     selectedSystemKey && bindingResolvedKey === selectedSystemKey,
   );
+  const crossObjectBindingResolved =
+    !hasCrossObjectCreateFlow ||
+    Boolean(
+      selectedSystemKey && crossObjectBindingResolvedKey === selectedSystemKey,
+    );
+  const awaitingContactBinding =
+    hasCrossObjectCreateFlow &&
+    crossObjectBindingState === "account_created_waiting_for_contact";
   const boundRecordReadResolved =
     !hasBoundRecord ||
     readResultHasCurrentRecord ||
@@ -762,10 +837,12 @@ export function ConnectedSystemsPanel({
     !effectiveError &&
     (!selectedSystem ||
       !bindingResolved ||
+      !crossObjectBindingResolved ||
       isSchemaPreparationPending ||
       isBoundRecordHydrating);
   const canShowUnboundRecordActions =
     !hasBoundRecord &&
+    !awaitingContactBinding &&
     !isRecordStateLoading &&
     schemaReady &&
     visibleProfileFields.length > 0 &&
@@ -797,18 +874,49 @@ export function ConnectedSystemsPanel({
 
   useEffect(() => {
     if (mode !== "detail") return;
+    const previousSelectedSystemKey = previousSelectedSystemKeyRef.current;
+    // Registry hydration begins before a concrete CRM is selected. That first
+    // selection is not navigation and must not clear an edit/confirmation the
+    // user opens as the detail settles. Once a CRM has been selected, any
+    // different non-empty key is a true cross-CRM transition.
+    const selectionChanged = Boolean(
+      previousSelectedSystemKey &&
+      selectedSystemKey &&
+      previousSelectedSystemKey !== selectedSystemKey,
+    );
+    if (selectedSystemKey) {
+      previousSelectedSystemKeyRef.current = selectedSystemKey;
+    }
+    if (selectionChanged) {
+      // A confirmation belongs to one CRM only. Never keep a pending Account
+      // create, update review, record values, or local IDs when navigation
+      // moves to another CRM.
+      setBinding(null);
+      setCrmFieldValues({});
+      setCrmBaselineValues({});
+      setUpdateId("");
+      setDeleteId("");
+      setDeleteResult(null);
+      setEditingField(null);
+      setEditingValue("");
+      setPendingIntent(null);
+      setPendingUpdateReview(null);
+    }
     const cachedRecordSnapshot =
-      cacheUserId && selectedSystem
+      cacheUserId && selectedSystemId
         ? ConnectedSystemsResourceService.getLiveRecordSnapshot(
             cacheUserId,
-            selectedSystem.systemId,
+            selectedSystemId,
           )
         : null;
     setReadResolvedKey(null);
     setReadResult(cachedRecordSnapshot?.record ?? null);
     setCachedRecordRefreshPending(Boolean(cachedRecordSnapshot));
     setUnboundLookupState("idle");
-  }, [cacheUserId, mode, selectedSystem, selectedSystemKey]);
+    setCrossObjectBindingState("idle");
+    setCrossObjectBindingResolvedKey(null);
+    setBusy(null);
+  }, [cacheUserId, mode, selectedSystemId, selectedSystemKey]);
 
   useEffect(() => {
     if (vaultOwnerToken) return;
@@ -823,6 +931,9 @@ export function ConnectedSystemsPanel({
     setUpdateId("");
     setDeleteId("");
     setBoundSystemIds(new Set());
+    setCrossObjectBindingState("idle");
+    setCrossObjectBindingResolvedKey(null);
+    setBusy(null);
   }, [vaultOwnerToken]);
 
   const refreshSystems = useCallback(async () => {
@@ -875,26 +986,57 @@ export function ConnectedSystemsPanel({
   const refreshBinding = useCallback(async () => {
     if (!vaultOwnerToken || !selectedSystem || mode !== "detail") return null;
     const nextBindingKey = selectedSystemKey;
+    const requestSequence = ++bindingRequestSequenceRef.current;
+    const isCurrentRequest = () => {
+      const current = currentBindingContextRef.current;
+      return (
+        bindingRequestSequenceRef.current === requestSequence &&
+        current.systemKey === nextBindingKey &&
+        current.vaultOwnerToken === vaultOwnerToken &&
+        current.mode === mode
+      );
+    };
     setBusy("binding");
     setError(null);
     try {
       const response = await ConnectedSystemsService.getRecordBinding({
         vaultOwnerToken,
         systemId: selectedSystem.systemId,
-        objectType: selectedSystem.objectTypeDefault || "Contact",
+        objectType: readObjectType,
       });
+      if (!isCurrentRequest()) return null;
       const nextBinding =
         response.binding?.status === "active" ? response.binding : null;
       setBinding(nextBinding || null);
       if (nextBinding?.recordId) {
         setUpdateId(nextBinding.recordId);
         setDeleteId(nextBinding.recordId);
+        setCrossObjectBindingState("idle");
+      } else if (hasCrossObjectCreateFlow) {
+        // Person Account creation and Contact operations intentionally use
+        // different CRM bindings. Only retain the existence of the Account
+        // binding in UI state; never promote its ID to a Contact binding.
+        const createBinding = await ConnectedSystemsService.getRecordBinding({
+          vaultOwnerToken,
+          systemId: selectedSystem.systemId,
+          objectType: createObjectType,
+        });
+        if (!isCurrentRequest()) return null;
+        setCrossObjectBindingState(
+          createBinding.binding?.status === "active"
+            ? "account_created_waiting_for_contact"
+            : "idle",
+        );
+        setUpdateId("");
+        setDeleteId("");
       } else {
         setUpdateId("");
         setDeleteId("");
+        setCrossObjectBindingState("idle");
       }
       return nextBinding || null;
     } catch (err) {
+      if (!isCurrentRequest()) return null;
       if (err instanceof ConnectedSystemsRequestError) {
         if (err.code === "CONNECTED_SYSTEM_PHONE_VERIFICATION_REQUIRED") {
           router.push(ROUTES.PROFILE_ACCOUNT_PHONE);
@@ -911,15 +1053,28 @@ export function ConnectedSystemsPanel({
         setBinding(null);
         setUpdateId("");
         setDeleteId("");
+        setCrossObjectBindingState("idle");
         return null;
       }
       setError(message);
       return null;
     } finally {
-      setBindingResolvedKey(nextBindingKey);
-      setBusy(null);
+      if (isCurrentRequest()) {
+        setBindingResolvedKey(nextBindingKey);
+        setCrossObjectBindingResolvedKey(nextBindingKey);
+        setBusy(null);
+      }
     }
-  }, [mode, router, selectedSystem, selectedSystemKey, vaultOwnerToken]);
+  }, [
+    createObjectType,
+    hasCrossObjectCreateFlow,
+    mode,
+    readObjectType,
+    router,
+    selectedSystem,
+    selectedSystemKey,
+    vaultOwnerToken,
+  ]);
 
   useEffect(() => {
     if (!vaultOwnerToken || !selectedSystem || mode !== "detail") return;
@@ -936,6 +1091,7 @@ export function ConnectedSystemsPanel({
     action: () => Promise<T>,
     options: { showErrorToast?: boolean; background?: boolean } = {},
   ): Promise<T | null> {
+    const requestContext = capturePanelRequestContext();
     if (!vaultOwnerToken) {
       onRequestUnlock?.();
       return null;
@@ -945,8 +1101,10 @@ export function ConnectedSystemsPanel({
       setError(null);
     }
     try {
-      return await action();
+      const result = await action();
+      return isCurrentPanelRequest(requestContext) ? result : null;
     } catch (err) {
+      if (!isCurrentPanelRequest(requestContext)) return null;
       if (err instanceof ConnectedSystemsRequestError) {
         if (err.code === "CONNECTED_SYSTEM_PHONE_VERIFICATION_REQUIRED") {
           router.push(ROUTES.PROFILE_ACCOUNT_PHONE);
@@ -963,7 +1121,9 @@ export function ConnectedSystemsPanel({
       }
       return null;
     } finally {
-      if (!options.background) setBusy(null);
+      if (!options.background && isCurrentPanelRequest(requestContext)) {
+        setBusy(null);
+      }
     }
   }
 
@@ -976,6 +1136,7 @@ export function ConnectedSystemsPanel({
     },
     action: () => Promise<T>,
   ): Promise<T | null> {
+    const requestContext = capturePanelRequestContext();
     if (!vaultOwnerToken) {
       onRequestUnlock?.();
       return null;
@@ -991,7 +1152,10 @@ export function ConnectedSystemsPanel({
         return value;
       })
       .catch((err) => {
-        if (err instanceof ConnectedSystemsRequestError) {
+        if (
+          isCurrentPanelRequest(requestContext) &&
+          err instanceof ConnectedSystemsRequestError
+        ) {
           if (err.code === "CONNECTED_SYSTEM_PHONE_VERIFICATION_REQUIRED") {
             router.push(ROUTES.PROFILE_ACCOUNT_PHONE);
           } else if (
@@ -1002,18 +1166,55 @@ export function ConnectedSystemsPanel({
         }
         throw new Error(connectedSystemsUserMessage(err));
       });
-    toast.promise(promise, {
+    const mutationToast = toast.promise(promise, {
       ...messages,
-      error: (err) => (err instanceof Error ? err.message : messages.error),
+      success: (value) =>
+        isCurrentPanelRequest(requestContext)
+          ? typeof messages.success === "function"
+            ? messages.success(value)
+            : messages.success
+          : null,
+      error: (err) =>
+        isCurrentPanelRequest(requestContext)
+          ? err instanceof Error
+            ? err.message
+            : messages.error
+          : null,
     });
+    // Promise toasts outlive the route that started them. Dismiss a late
+    // completion instead of showing CRM A feedback while CRM B is on screen.
+    void promise.then(
+      () => {
+        if (!isCurrentPanelRequest(requestContext)) {
+          const toastId =
+            typeof mutationToast === "string" ||
+            typeof mutationToast === "number"
+              ? mutationToast
+              : null;
+          if (toastId !== null) toast.dismiss(toastId);
+        }
+      },
+      () => {
+        if (!isCurrentPanelRequest(requestContext)) {
+          const toastId =
+            typeof mutationToast === "string" ||
+            typeof mutationToast === "number"
+              ? mutationToast
+              : null;
+          if (toastId !== null) toast.dismiss(toastId);
+        }
+      },
+    );
     try {
-      return await promise;
+      const result = await promise;
+      return isCurrentPanelRequest(requestContext) ? result : null;
     } catch (err) {
+      if (!isCurrentPanelRequest(requestContext)) return null;
       const message = err instanceof Error ? err.message : messages.error;
       setError(message);
       return null;
     } finally {
-      setBusy(null);
+      if (isCurrentPanelRequest(requestContext)) setBusy(null);
     }
   }
 
@@ -1061,6 +1262,7 @@ export function ConnectedSystemsPanel({
     }
     if (nextBinding) {
       setBinding(nextBinding);
+      setCrossObjectBindingState("idle");
       if (nextBinding.recordId) {
         setUpdateId(nextBinding.recordId);
         setDeleteId(nextBinding.recordId);
@@ -1082,11 +1284,7 @@ export function ConnectedSystemsPanel({
       );
       if (selectedSystem && resolvedRecordId) {
         setReadResolvedKey(
-          [
-            selectedSystem.systemId,
-            selectedSystem.objectTypeDefault || "Contact",
-            resolvedRecordId,
-          ].join(":"),
+          [selectedSystem.systemId, readObjectType, resolvedRecordId].join(":"),
         );
       }
     }
@@ -1104,22 +1302,27 @@ export function ConnectedSystemsPanel({
     if (!encryptedFieldsReadReady) {
       throw new Error("This CRM is not ready for encrypted field reads.");
     }
-    const configuration = await ConnectedSystemsService.getCrmEncryptedFieldsConfiguration({
-      vaultOwnerToken,
-      systemId: selectedSystem.systemId,
-    });
+    const configuration =
+      await ConnectedSystemsService.getCrmEncryptedFieldsConfiguration({
+        vaultOwnerToken,
+        systemId: selectedSystem.systemId,
+      });
     const envelope = await createCrmEncryptedFieldsEnvelope({
       configuration,
       direction: "read_request",
       payload: { searchFields: {} },
     });
-    let response: Awaited<ReturnType<typeof ConnectedSystemsService.readCrmEncryptedFieldsRecord>>;
-    let decrypted: Awaited<ReturnType<typeof decryptCrmEncryptedFieldsReadResponse>>;
+    let response: Awaited<
+      ReturnType<typeof ConnectedSystemsService.readCrmEncryptedFieldsRecord>
+    >;
+    let decrypted: Awaited<
+      ReturnType<typeof decryptCrmEncryptedFieldsReadResponse>
+    >;
     try {
       response = await ConnectedSystemsService.readCrmEncryptedFieldsRecord({
         vaultOwnerToken,
         systemId: selectedSystem.systemId,
-        objectType: selectedSystem.objectTypeDefault,
+        objectType: readObjectType,
         returnFields,
         encryptedFields: envelope,
       });
@@ -1132,9 +1335,13 @@ export function ConnectedSystemsPanel({
     }
     const allowed = new Set(returnFields);
     const fields = Object.fromEntries(
-      Object.entries(decrypted.returnFields).filter(([name, value]) =>
-        allowed.has(name) &&
-        (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null)
+      Object.entries(decrypted.returnFields).filter(
+        ([name, value]) =>
+          allowed.has(name) &&
+          (typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value === "boolean" ||
+            value === null),
       ),
     ) as Record<string, string | number | boolean | null>;
     return {
@@ -1143,9 +1350,10 @@ export function ConnectedSystemsPanel({
       objectType: response.objectType,
       recordId: response.recordId || null,
       resultClass: response.status === "failed" ? "failed" : "succeeded",
-      records: response.totalSize === 1
-        ? [{ recordId: response.recordId || null, fields }]
-        : [],
+      records:
+        response.totalSize === 1
+          ? [{ recordId: response.recordId || null, fields }]
+          : [],
       bindingStatus: response.bindingStatus,
       binding: response.binding || undefined,
     } satisfies ConnectedSystemMcpResponse;
@@ -1158,6 +1366,7 @@ export function ConnectedSystemsPanel({
       background?: boolean;
     } = {},
   ) => {
+    const requestContext = capturePanelRequestContext();
     const result = await runAction(
       options.bindSearch ? "lookup" : "read",
       async () => {
@@ -1166,15 +1375,13 @@ export function ConnectedSystemsPanel({
           .map((field) => field.rawName || field.key);
         const completedReadKey =
           !options.bindSearch && selectedSystem && currentRecordId
-            ? [
-                selectedSystem.systemId,
-                selectedSystem.objectTypeDefault || "Contact",
-                currentRecordId,
-              ].join(":")
+            ? [selectedSystem.systemId, readObjectType, currentRecordId].join(
+                ":",
+              )
             : "";
         const payload = {
           systemId: selectedSystem?.systemId,
-          objectType: selectedSystem?.objectTypeDefault,
+          objectType: readObjectType,
           returnFields,
         };
         const nextResult = options.bindSearch
@@ -1188,7 +1395,9 @@ export function ConnectedSystemsPanel({
                 vaultOwnerToken || "",
                 payload,
               );
-        if (completedReadKey) setReadResolvedKey(completedReadKey);
+        if (completedReadKey && isCurrentPanelRequest(requestContext)) {
+          setReadResolvedKey(completedReadKey);
+        }
         return nextResult;
       },
       { showErrorToast: !options.silent, background: options.background },
@@ -1217,7 +1426,9 @@ export function ConnectedSystemsPanel({
         }
       }
     }
-    if (options.background) setCachedRecordRefreshPending(false);
+    if (options.background && isCurrentPanelRequest(requestContext)) {
+      setCachedRecordRefreshPending(false);
+    }
     return result || null;
   };
 
@@ -1303,6 +1514,7 @@ export function ConnectedSystemsPanel({
   };
 
   const createRecordFromSchema = async () => {
+    const requestContext = capturePanelRequestContext();
     const result = await runMutation(
       "create",
       {
@@ -1313,25 +1525,26 @@ export function ConnectedSystemsPanel({
       () =>
         ConnectedSystemsService.createRecordIntent(vaultOwnerToken || "", {
           systemId: selectedSystem?.systemId,
-          objectType: selectedSystem?.objectTypeDefault,
+          objectType: createObjectType,
         }),
     );
-    if (result) {
+    if (result && isCurrentPanelRequest(requestContext)) {
       setPendingIntent(result);
     }
-    return result;
+    return isCurrentPanelRequest(requestContext) ? result : null;
   };
 
   const recoverMissingRecord = async () => {
     if (!selectedSystem || unboundLookupState !== "remote_missing") return;
+    const requestContext = capturePanelRequestContext();
     const disconnected = await runAction("binding", () =>
       ConnectedSystemsService.disconnectRecordBinding({
         vaultOwnerToken: vaultOwnerToken || "",
         systemId: selectedSystem.systemId,
-        objectType: selectedSystem.objectTypeDefault,
+        objectType: readObjectType,
       }),
     );
-    if (!disconnected) return;
+    if (!disconnected || !isCurrentPanelRequest(requestContext)) return;
     setBinding(null);
     setReadResult(null);
     setUpdateId("");
@@ -1349,35 +1562,52 @@ export function ConnectedSystemsPanel({
       );
       ConnectedSystemsResourceService.rememberBindingStatus(cacheUserId, {
         systemId: selectedSystem.systemId,
-        objectType: selectedSystem.objectTypeDefault || "Contact",
+        objectType: readObjectType,
         status: "unbound",
       });
     }
     await createRecordFromSchema();
   };
 
-  const findExistingProfile = async () => {
-    if (!supportsAction("read")) return;
+  const findExistingProfile = async (
+    options: { afterAccountCreate?: boolean; announce?: boolean } = {},
+  ): Promise<boolean> => {
+    if (!supportsAction("read")) return false;
+    const requestContext = capturePanelRequestContext();
     setUnboundLookupState("checking");
     const found = await readRecord({ silent: true, bindSearch: true });
+    if (!isCurrentPanelRequest(requestContext)) return false;
     if (found?.binding?.status === "active") {
       setUnboundLookupState("idle");
+      setCrossObjectBindingState("idle");
       setBoundSystemIds((current) => new Set(current).add(found.systemId));
-      toast.success(
-        `Found your existing ${customerName} profile and linked it.`,
-      );
+      if (options.announce !== false) {
+        toast.success(
+          `Found your existing ${customerName} profile and linked it.`,
+        );
+      }
       if (isSetupPresentation && setupRouteBase) router.push(setupRouteBase);
-      return;
+      return true;
     }
     if (!found) {
       setUnboundLookupState("failed");
-      return;
+      if (options.afterAccountCreate) {
+        setCrossObjectBindingState("account_created_waiting_for_contact");
+      }
+      return false;
     }
     setUnboundLookupState("no_match");
-    toast.info(`No matching ${customerName} profile was found.`);
+    if (options.afterAccountCreate) {
+      setCrossObjectBindingState("account_created_waiting_for_contact");
+    }
+    if (options.announce !== false) {
+      toast.info(`No matching ${customerName} profile was found.`);
+    }
+    return false;
   };
 
   const updateRecordFromSchema = () => {
+    if (!selectedSystem) return;
     const recordFields = changedProfileFields;
     if (Object.keys(recordFields).length === 0) {
       toast.error("Change at least one CRM field before updating the record.");
@@ -1389,6 +1619,7 @@ export function ConnectedSystemsPanel({
       visibleProfileFields.map((field) => [field.key, field]),
     );
     setPendingUpdateReview({
+      systemKey: selectedSystemKey,
       recordFields,
       fields: Object.entries(recordFields).map(([key, nextValue]) => ({
         key,
@@ -1401,6 +1632,14 @@ export function ConnectedSystemsPanel({
 
   const approveUpdateReview = async () => {
     if (!pendingUpdateReview) return;
+    if (
+      !selectedSystem ||
+      pendingUpdateReview.systemKey !== selectedSystemKey
+    ) {
+      setPendingUpdateReview(null);
+      return;
+    }
+    const requestContext = capturePanelRequestContext();
     const review = pendingUpdateReview;
     updateReviewSubmittingRef.current = true;
     let preparedIntent: ConnectedSystemIntent | null = null;
@@ -1414,27 +1653,33 @@ export function ConnectedSystemsPanel({
       async () => {
         if (encryptedFieldsEnabled) {
           if (!selectedSystem || !vaultOwnerToken) {
-            throw new Error("Unlock your vault to approve this encrypted CRM update.");
+            throw new Error(
+              "Unlock your vault to approve this encrypted CRM update.",
+            );
           }
           if (!encryptedFieldsUpdateReady) {
-            throw new Error("This CRM is not ready for encrypted field updates.");
+            throw new Error(
+              "This CRM is not ready for encrypted field updates.",
+            );
           }
-          const configuration = await ConnectedSystemsService.getCrmEncryptedFieldsConfiguration({
-            vaultOwnerToken,
-            systemId: selectedSystem.systemId,
-          });
+          const configuration =
+            await ConnectedSystemsService.getCrmEncryptedFieldsConfiguration({
+              vaultOwnerToken,
+              systemId: selectedSystem.systemId,
+            });
           const envelope = await createCrmEncryptedFieldsEnvelope({
             configuration,
             direction: "update_request",
             payload: { additionalFields: review.recordFields },
           });
-          preparedIntent = await ConnectedSystemsService.createCrmEncryptedFieldsUpdateIntent({
-            vaultOwnerToken,
-            systemId: selectedSystem.systemId,
-            objectType: selectedSystem.objectTypeDefault,
-            fieldNames: Object.keys(review.recordFields),
-            encryptedFields: envelope,
-          });
+          preparedIntent =
+            await ConnectedSystemsService.createCrmEncryptedFieldsUpdateIntent({
+              vaultOwnerToken,
+              systemId: selectedSystem.systemId,
+              objectType: updateObjectType,
+              fieldNames: Object.keys(review.recordFields),
+              encryptedFields: envelope,
+            });
           return ConnectedSystemsService.approveCrmEncryptedFieldsIntent({
             vaultOwnerToken,
             systemId: selectedSystem.systemId,
@@ -1445,7 +1690,7 @@ export function ConnectedSystemsPanel({
           vaultOwnerToken || "",
           {
             systemId: selectedSystem?.systemId,
-            objectType: selectedSystem?.objectTypeDefault,
+            objectType: updateObjectType,
             additionalFields: {},
             recordFields: review.recordFields,
           },
@@ -1458,6 +1703,7 @@ export function ConnectedSystemsPanel({
       },
     );
     updateReviewSubmittingRef.current = false;
+    if (!isCurrentPanelRequest(requestContext)) return;
     if (!result) {
       // A prepared intent remains safely pending server-side. Reuse it rather
       // than submitting a second update if approval has to be retried.
@@ -1478,6 +1724,7 @@ export function ConnectedSystemsPanel({
   };
 
   const deleteRecord = async () => {
+    const requestContext = capturePanelRequestContext();
     const result = await runMutation(
       "delete",
       {
@@ -1488,17 +1735,22 @@ export function ConnectedSystemsPanel({
       () =>
         ConnectedSystemsService.createDeleteIntent(vaultOwnerToken || "", {
           systemId: selectedSystem?.systemId,
-          objectType: selectedSystem?.objectTypeDefault || "Contact",
+          objectType: deleteObjectType,
         }),
     );
-    if (result) {
+    if (result && isCurrentPanelRequest(requestContext)) {
       setPendingIntent(result);
     }
   };
 
   const approvePendingIntent = async () => {
     if (!pendingIntent) return;
+    if (!selectedSystem || pendingIntent.systemId !== selectedSystem.systemId) {
+      setPendingIntent(null);
+      return;
+    }
     const intent = pendingIntent;
+    const requestContext = capturePanelRequestContext();
     const result = await runMutation(
       intent.action === "delete"
         ? "delete"
@@ -1517,7 +1769,7 @@ export function ConnectedSystemsPanel({
           intentId: intent.intentId,
         }),
     );
-    if (!result) return;
+    if (!result || !isCurrentPanelRequest(requestContext)) return;
     setPendingIntent(null);
     if (result.action === "delete") {
       setDeleteResult(result);
@@ -1525,6 +1777,26 @@ export function ConnectedSystemsPanel({
       setReadResult(null);
       setUpdateId("");
       setDeleteId("");
+      return;
+    }
+    const completedObjectType =
+      result.objectType || intent.objectType || createObjectType;
+    if (
+      result.action === "create" &&
+      (hasCrossObjectCreateFlow ||
+        !sameCrmObjectType(completedObjectType, readObjectType))
+    ) {
+      // A Person Account creation result is not a Contact binding. Do not
+      // retain, display, or reuse its ID for Contact reads or updates. The
+      // only safe next step is the existing server-derived verified lookup.
+      setBinding(null);
+      setReadResult(null);
+      setReadResolvedKey(null);
+      setUpdateId("");
+      setDeleteId("");
+      setCrossObjectBindingState("account_created_waiting_for_contact");
+      setCrmBaselineValues((current) => ({ ...current, ...crmFieldValues }));
+      void findExistingProfile({ afterAccountCreate: true, announce: false });
       return;
     }
     const recordId = cleanFieldValue(
@@ -1563,14 +1835,21 @@ export function ConnectedSystemsPanel({
 
   const rejectPendingIntent = async () => {
     if (!pendingIntent) return;
-    await runAction("update", async () => {
-      await ConnectedSystemsService.rejectIntent({
+    if (!selectedSystem || pendingIntent.systemId !== selectedSystem.systemId) {
+      setPendingIntent(null);
+      return;
+    }
+    const requestContext = capturePanelRequestContext();
+    const rejected = await runAction("update", () =>
+      ConnectedSystemsService.rejectIntent({
         vaultOwnerToken: vaultOwnerToken || "",
         systemId: pendingIntent.systemId,
         intentId: pendingIntent.intentId,
-      });
+      }),
+    );
+    if (rejected && isCurrentPanelRequest(requestContext)) {
       setPendingIntent(null);
-    });
+    }
   };
 
   const crmFieldRows: CrmFieldTableRow[] = displayedProfileFields.map(
@@ -1882,7 +2161,9 @@ export function ConnectedSystemsPanel({
           aria-label={
             isSchemaPreparationPending
               ? "Preparing your CRM profile"
-              : "Checking saved CRM record"
+              : !crossObjectBindingResolved
+                ? "Checking your CRM profile link"
+                : "Checking saved CRM record"
           }
           className="flex justify-center py-2 text-muted-foreground"
         >
@@ -1914,6 +2195,34 @@ export function ConnectedSystemsPanel({
                     "This CRM is shown as a field catalogue until its verified onboarding mapping is available.",
             )}
           </div>
+        </SettingsGroup>
+      ) : null}
+
+      {awaitingContactBinding && !isRecordStateLoading ? (
+        <SettingsGroup title="Linking your CRM profile">
+          <SettingsRow
+            icon={Database}
+            title="Your profile was created"
+            description={`We are locating the separately verified ${readObjectType} record required before private CRM fields can be read or updated. The profile creation ID is never reused for this step.`}
+            trailing={
+              <Button
+                type="button"
+                variant="none"
+                effect="fade"
+                size="sm"
+                disabled={busy !== null || !supportsAction("read")}
+                onClick={() =>
+                  void findExistingProfile({ afterAccountCreate: true })
+                }
+              >
+                <Icon icon={RefreshCw} size="sm" className="mr-2" />
+                {busy === "lookup"
+                  ? `Checking ${readObjectType}…`
+                  : `Check for ${readObjectType}`}
+              </Button>
+            }
+            stackTrailingOnMobile
+          />
         </SettingsGroup>
       ) : null}
 
@@ -2192,7 +2501,7 @@ export function ConnectedSystemsPanel({
         </SettingsDetailPanel>
       ) : null}
       <AlertDialog
-        open={Boolean(pendingUpdateReview)}
+        open={Boolean(activePendingUpdateReview)}
         onOpenChange={(open) => {
           if (!open && !updateReviewSubmittingRef.current && busy === null) {
             setPendingUpdateReview(null);
@@ -2216,7 +2525,7 @@ export function ConnectedSystemsPanel({
               <span>Updated value</span>
             </div>
             <dl className="divide-y divide-[color:var(--app-card-border-standard)]">
-              {pendingUpdateReview?.fields.map((field) => (
+              {activePendingUpdateReview?.fields.map((field) => (
                 <div
                   key={field.key}
                   className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-x-3 gap-y-1 px-5 py-3 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,1fr)] sm:gap-x-4 sm:px-6"
@@ -2248,7 +2557,7 @@ export function ConnectedSystemsPanel({
         </AlertDialogContent>
       </AlertDialog>
       <AlertDialog
-        open={Boolean(pendingIntent)}
+        open={Boolean(activePendingIntent)}
         onOpenChange={(open) => {
           if (!open && busy === null) setPendingIntent(null);
         }}
@@ -2256,22 +2565,22 @@ export function ConnectedSystemsPanel({
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Review {pendingIntent?.action || "CRM"} request
+              Review {activePendingIntent?.action || "CRM"} request
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {pendingIntent
-                ? `${customerName} · ${pendingIntent.objectType || primaryObjectLabel}`
+              {activePendingIntent
+                ? `${customerName} · ${activePendingIntent.objectType || primaryObjectLabel}`
                 : ""}
             </AlertDialogDescription>
           </AlertDialogHeader>
-          {pendingIntent?.action === "delete" ? (
+          {activePendingIntent?.action === "delete" ? (
             <p className="text-sm text-muted-foreground">
               This permanently removes the selected record from {customerName}{" "}
               and clears its One binding after confirmation.
             </p>
           ) : (
             <div className="flex flex-wrap gap-2">
-              {pendingIntent?.fieldNames.map((field) => (
+              {activePendingIntent?.fieldNames.map((field) => (
                 <Badge key={field} variant="secondary">
                   {field}
                 </Badge>
@@ -2287,12 +2596,14 @@ export function ConnectedSystemsPanel({
             </AlertDialogCancel>
             <AlertDialogAction
               variant={
-                pendingIntent?.action === "delete" ? "destructive" : "default"
+                activePendingIntent?.action === "delete"
+                  ? "destructive"
+                  : "default"
               }
               disabled={busy !== null}
               onClick={() => void approvePendingIntent()}
             >
-              Confirm {pendingIntent?.action || "request"}
+              Confirm {activePendingIntent?.action || "request"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/hushh-webapp/lib/services/connected-systems-service.ts
+++ b/hushh-webapp/lib/services/connected-systems-service.ts
@@ -4,7 +4,8 @@ import type {
   CrmEncryptedFields,
 } from "@/lib/connected-systems/crm-encrypted-fields-v1";
 
-export type ConnectedSystemStatus = "connected" | "needs_configuration" | string;
+export type ConnectedSystemStatus =
+  "connected" | "needs_configuration" | string;
 
 export type ConnectedSystemSummary = {
   systemId: string;
@@ -15,6 +16,14 @@ export type ConnectedSystemSummary = {
   status: ConnectedSystemStatus;
   target: string;
   objectTypeDefault: string;
+  /** Registry-owned object type selected for each operation; never a record ID. */
+  operationObjectTypes?: Partial<{
+    schema: string;
+    read: string;
+    create: string;
+    update: string;
+    delete: string;
+  }>;
   transport: string;
   transportLabel?: string;
   endpointConfigured?: boolean;
@@ -150,7 +159,14 @@ export type ConnectedSystemIntent = {
   target?: string;
   objectType?: string;
   action: "create" | "update" | "delete" | string;
-  status: "pending" | "approved" | "rejected" | "succeeded" | "partial" | "failed" | string;
+  status:
+    | "pending"
+    | "approved"
+    | "rejected"
+    | "succeeded"
+    | "partial"
+    | "failed"
+    | string;
   recordId?: string | null;
   approvalId?: string | null;
   fieldNames: string[];
@@ -200,7 +216,7 @@ export class ConnectedSystemsRequestError extends Error {
   constructor(
     message: string,
     readonly code: string | null,
-    readonly status: number
+    readonly status: number,
   ) {
     super(message);
     this.name = "ConnectedSystemsRequestError";
@@ -212,10 +228,14 @@ async function readJsonOrThrow<T>(response: Response): Promise<T> {
   if (response.ok) {
     return payload as T;
   }
-  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-  const detail = record.detail && typeof record.detail === "object"
-    ? (record.detail as Record<string, unknown>)
-    : record;
+  const record =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+  const detail =
+    record.detail && typeof record.detail === "object"
+      ? (record.detail as Record<string, unknown>)
+      : record;
   const message =
     typeof detail.message === "string"
       ? detail.message
@@ -225,7 +245,7 @@ async function readJsonOrThrow<T>(response: Response): Promise<T> {
   throw new ConnectedSystemsRequestError(
     message,
     typeof detail.code === "string" ? detail.code : null,
-    response.status
+    response.status,
   );
 }
 
@@ -244,16 +264,23 @@ export class ConnectedSystemsService {
    * Signed-in is enough: pass a vault owner token when one is available (agent
    * lanes), otherwise the caller's Firebase ID token. The backend accepts both.
    */
-  static async listSystems(authToken: string): Promise<ConnectedSystemSummary[]> {
+  static async listSystems(
+    authToken: string,
+  ): Promise<ConnectedSystemSummary[]> {
     return (await this.getRegistry(authToken)).systems;
   }
 
-  static async getRegistry(authToken: string): Promise<ConnectedSystemsRegistryResponse> {
+  static async getRegistry(
+    authToken: string,
+  ): Promise<ConnectedSystemsRegistryResponse> {
     const response = await ApiService.apiFetch("/api/connected-systems", {
       method: "GET",
       headers: authHeaders(authToken),
     });
-    const payload = await readJsonOrThrow<Partial<ConnectedSystemsRegistryResponse>>(response);
+    const payload =
+      await readJsonOrThrow<Partial<ConnectedSystemsRegistryResponse>>(
+        response,
+      );
     return {
       registryRevision: Number(payload.registryRevision || 0),
       systems: Array.isArray(payload.systems) ? payload.systems : [],
@@ -275,7 +302,7 @@ export class ConnectedSystemsService {
       {
         method: "GET",
         headers: authHeaders(input.vaultOwnerToken),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemSchemaResponse>(response);
   }
@@ -286,7 +313,7 @@ export class ConnectedSystemsService {
   }): Promise<CrmEncryptedFieldsConfiguration> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/encrypted-fields/config`,
-      { method: "GET", headers: authHeaders(input.vaultOwnerToken) }
+      { method: "GET", headers: authHeaders(input.vaultOwnerToken) },
     );
     return readJsonOrThrow<CrmEncryptedFieldsConfiguration>(response);
   }
@@ -318,7 +345,7 @@ export class ConnectedSystemsService {
           returnFields: input.returnFields,
           encryptedFields: input.encryptedFields,
         }),
-      }
+      },
     );
     return readJsonOrThrow(response);
   }
@@ -340,7 +367,7 @@ export class ConnectedSystemsService {
           fieldNames: input.fieldNames,
           encryptedFields: input.encryptedFields,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
@@ -352,14 +379,14 @@ export class ConnectedSystemsService {
   }): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/intents/${encodeURIComponent(input.intentId)}/approve-encrypted`,
-      { method: "POST", headers: authHeaders(input.vaultOwnerToken) }
+      { method: "POST", headers: authHeaders(input.vaultOwnerToken) },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
 
   static async readRecord(
     vaultOwnerToken: string,
-    input: ConnectedSystemReadInput
+    input: ConnectedSystemReadInput,
   ): Promise<ConnectedSystemMcpResponse> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/records/read`,
@@ -370,7 +397,7 @@ export class ConnectedSystemsService {
           objectType: input.objectType,
           returnFields: input.returnFields,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemMcpResponse>(response);
   }
@@ -388,7 +415,7 @@ export class ConnectedSystemsService {
       {
         method: "GET",
         headers: authHeaders(input.vaultOwnerToken),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemBindingResponse>(response);
   }
@@ -406,27 +433,36 @@ export class ConnectedSystemsService {
       {
         method: "DELETE",
         headers: authHeaders(input.vaultOwnerToken),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemBindingResponse>(response);
   }
 
-  static async listRecordBindingStatuses(
-    vaultOwnerToken: string
-  ): Promise<{ bindings: Array<{ systemId: string; objectType: string; status: string }> }> {
-    const response = await ApiService.apiFetch("/api/connected-systems/record-bindings", {
-      method: "GET",
-      headers: authHeaders(vaultOwnerToken),
-    });
+  static async listRecordBindingStatuses(vaultOwnerToken: string): Promise<{
+    bindings: Array<{ systemId: string; objectType: string; status: string }>;
+  }> {
+    const response = await ApiService.apiFetch(
+      "/api/connected-systems/record-bindings",
+      {
+        method: "GET",
+        headers: authHeaders(vaultOwnerToken),
+      },
+    );
     const payload = await readJsonOrThrow<{
-      bindings?: Array<{ systemId: string; objectType: string; status: string }>;
+      bindings?: Array<{
+        systemId: string;
+        objectType: string;
+        status: string;
+      }>;
     }>(response);
-    return { bindings: Array.isArray(payload.bindings) ? payload.bindings : [] };
+    return {
+      bindings: Array.isArray(payload.bindings) ? payload.bindings : [],
+    };
   }
 
   static async searchRecord(
     vaultOwnerToken: string,
-    input: ConnectedSystemReadInput
+    input: ConnectedSystemReadInput,
   ): Promise<ConnectedSystemMcpResponse> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/records/search`,
@@ -437,14 +473,14 @@ export class ConnectedSystemsService {
           objectType: input.objectType,
           returnFields: input.returnFields,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemMcpResponse>(response);
   }
 
   static async createRecordIntent(
     vaultOwnerToken: string,
-    input: ConnectedSystemCreateIntentInput
+    input: ConnectedSystemCreateIntentInput,
   ): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/records/create-intents`,
@@ -454,14 +490,14 @@ export class ConnectedSystemsService {
         body: JSON.stringify({
           objectType: input.objectType,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
 
   static async updateRecordIntent(
     vaultOwnerToken: string,
-    input: ConnectedSystemUpdateIntentInput
+    input: ConnectedSystemUpdateIntentInput,
   ): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/records/update-intents`,
@@ -473,7 +509,7 @@ export class ConnectedSystemsService {
           additionalFields: input.additionalFields,
           recordFields: input.recordFields,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
@@ -485,12 +521,12 @@ export class ConnectedSystemsService {
   }): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/intents/${encodeURIComponent(
-        input.intentId
+        input.intentId,
       )}/approve`,
       {
         method: "POST",
         headers: authHeaders(input.vaultOwnerToken),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
@@ -502,12 +538,12 @@ export class ConnectedSystemsService {
   }): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/intents/${encodeURIComponent(
-        input.intentId
+        input.intentId,
       )}/reject`,
       {
         method: "POST",
         headers: authHeaders(input.vaultOwnerToken),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }
@@ -515,7 +551,7 @@ export class ConnectedSystemsService {
   /** Create a reviewable delete intent. Approval is a separate explicit call. */
   static async createDeleteIntent(
     vaultOwnerToken: string,
-    input: ConnectedSystemDeleteInput
+    input: ConnectedSystemDeleteInput,
   ): Promise<ConnectedSystemIntent> {
     const response = await ApiService.apiFetch(
       `/api/connected-systems/${systemPath(input.systemId)}/records/delete-intents`,
@@ -525,7 +561,7 @@ export class ConnectedSystemsService {
         body: JSON.stringify({
           objectType: input.objectType,
         }),
-      }
+      },
     );
     return readJsonOrThrow<ConnectedSystemIntent>(response);
   }


### PR DESCRIPTION
## Summary
- Keep Person Account creation separate from the Contact binding used by encrypted reads and updates.
- Publish registry-owned per-operation object types so the client cannot infer or reuse a cross-object record ID.
- Guard CRM transitions, reviews, and late async completions against cross-system state leakage.

## Verification
- Focused backend CRM contract suite: 100 passed.
- Focused Connected Systems frontend suite: 33 passed; panel suite repeated green.
- Protocol CI: 846 passed.
- Typecheck, lint, build, cache/service-boundary/docs/generated-contract checks passed.
- DCO, secret scan, and DB release-contract checks passed.