### PR TITLE
fix(deploy): honor UAT candidate evaluation plan

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -376,6 +376,11 @@ jobs:
           # Durable Kai analyze-run store ON in UAT: exercises the migration-125
           # persist/replay path against real Cloud SQL before prod flips it on.
           SUBSTITUTIONS="${SUBSTITUTIONS}##_KAI_ANALYZE_DURABLE_RUN_STORE=true"
+          verify_managed_vertex_runtime=false
+          if [ "${{ steps.verification-plan.outputs.pkm_evaluator_runs }}" != "0" ]; then
+            verify_managed_vertex_runtime=true
+          fi
+          SUBSTITUTIONS="${SUBSTITUTIONS}##_VERIFY_MANAGED_VERTEX_RUNTIME=${verify_managed_vertex_runtime}"
           # RIA claim-by-phone: identity resolver + the UAT demo passcode
           # allowlist (fixed code, no SMS to real firm lines). UAT-only.
           SUBSTITUTIONS="${SUBSTITUTIONS}##_RIA_IDENTITY_BASE_URL_SECRET=RIA_IDENTITY_BASE_URL##_RIA_IDENTITY_API_KEY_SECRET=RIA_IDENTITY_API_KEY##_RIA_CLAIM_TEST_NUMBERS_SECRET=RIA_CLAIM_TEST_NUMBERS##_RIA_CLAIM_TEST_CODE_SECRET=RIA_CLAIM_TEST_CODE##_RIA_CLAIM_TEST_EMAILS_SECRET=RIA_CLAIM_TEST_EMAILS##_INTELLIGENCE_API_BASE_URL_SECRET=INTELLIGENCE_API_BASE_URL##_INTELLIGENCE_API_KEY_SECRET=INTELLIGENCE_API_KEY##_SUPPORT_EMAIL_TEST_TO_SECRET=SUPPORT_EMAIL_TEST_TO##_SUPPORT_EMAIL_MODE_SECRET=SUPPORT_EMAIL_MODE##_SUPPORT_EMAIL_DELEGATED_USER_SECRET=SUPPORT_EMAIL_DELEGATED_USER##_SUPPORT_EMAIL_FROM_SECRET=SUPPORT_EMAIL_FROM##_GOOGLE_SERVICE_ACCOUNT_EMAIL_SECRET=GOOGLE_SERVICE_ACCOUNT_EMAIL##_GOOGLE_PRIVATE_KEY_SECRET=GOOGLE_PRIVATE_KEY"

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -33,6 +33,7 @@ def test_uat_deploy_builds_candidates_without_serving_traffic() -> None:
 
 def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
+    uat_workflow = _read(".github/workflows/deploy-uat.yml")
 
     # Gemini 3.1 Flash-Lite is part of the approved text matrix and only shares
     # global/us/eu endpoints with Gemini 3.5 Flash. The deployed service and its
@@ -43,6 +44,22 @@ def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> N
     assert "|HUSHH_VERTEX_LOCATIONS=global,us,eu|" in backend_build
     assert "HUSHH_VERTEX_LOCATIONS=global\\,us\\,eu" not in backend_build
     assert "GOOGLE_CLOUD_LOCATION=asia-southeast1" not in backend_build
+    # The managed-Vertex candidate job stays conservative for direct builds,
+    # while UAT must honor the same changed-SHA selector that governs the
+    # candidate evaluator lane. An unrelated release must not fail because an
+    # unselected advisory probe happened to be unavailable.
+    assert '_VERIFY_MANAGED_VERTEX_RUNTIME: "true"' in backend_build
+    assert 'case "${_VERIFY_MANAGED_VERTEX_RUNTIME}" in' in backend_build
+    assert "true) ;;" in backend_build
+    assert "false)" in backend_build
+    assert 'echo "_VERIFY_MANAGED_VERTEX_RUNTIME must be true or false." >&2' in backend_build
+    assert (
+        "Skipping managed Vertex candidate probe: not selected by the verification plan."
+        in backend_build
+    )
+    assert "verify_managed_vertex_runtime=false" in uat_workflow
+    assert "steps.verification-plan.outputs.pkm_evaluator_runs" in uat_workflow
+    assert "##_VERIFY_MANAGED_VERTEX_RUNTIME=${verify_managed_vertex_runtime}" in uat_workflow
 
 
 def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None:

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -329,13 +329,26 @@ steps:
     id: "deploy-backend"
 
   # Candidate-image GenAI probe under the exact runtime identity. This runs
-  # before the calling workflow can promote a no-traffic revision.
+  # before the calling workflow can promote a no-traffic revision when the
+  # change-aware verification plan selects it. Direct backend builds retain the
+  # conservative default of running this probe.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
     args:
       - "-c"
       - |
         set -euo pipefail
+        case "${_VERIFY_MANAGED_VERTEX_RUNTIME}" in
+          true) ;;
+          false)
+            echo "Skipping managed Vertex candidate probe: not selected by the verification plan."
+            exit 0
+            ;;
+          *)
+            echo "_VERIFY_MANAGED_VERTEX_RUNTIME must be true or false." >&2
+            exit 1
+            ;;
+        esac
         genai_project_id="${_GENAI_PROJECT_ID}"
         if [[ -z "${genai_project_id}" ]]; then
           genai_project_id="$PROJECT_ID"
@@ -458,6 +471,9 @@ substitutions:
   _CLOUD_RUN_MIN_INSTANCES: "1"
   _CLOUD_RUN_MAX_INSTANCES: "5"
   _RUNTIME_ENVIRONMENT: ""
+  # Direct backend builds remain conservative. The UAT workflow explicitly
+  # overrides this from its authoritative changed-SHA verification plan.
+  _VERIFY_MANAGED_VERTEX_RUNTIME: "true"
   _IMAGE_TAG: v2.1.0
   _DEPLOY_ENV: manual
   _DEPLOY_SOURCE: manual


### PR DESCRIPTION
## Summary
- honor the exact UAT changed-SHA verification plan before running the managed Vertex candidate job
- preserve the conservative default for direct, dev, and production backend builds
- reject invalid probe controls and cover selector-to-build wiring

## Evidence
- `46 passed`: Cloud Build argument, UAT no-traffic, PKM verification-plan, and selector wiring contracts
- DCO and secret scan passed
- failed UAT run `31657269264` rolled back before traffic promotion; root cause was an unselected Cloud Build Vertex probe

No credentials, CRM records, or customer data are included.