### PR TITLE
fix(profile): prevent fixed navigation from covering account actions

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1409,7 +1409,13 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
   display: flex;
   flex-direction: column;
   min-height: calc(100dvh - var(--top-shell-reserved-height, 0px));
-  padding-bottom: calc(env(safe-area-inset-bottom) + 7.5rem);
+  /* Was a hardcoded `env(safe-area-inset-bottom) + 7.5rem`, sized only for the
+   * bottom nav bar. That left the last "Your settings" rows (Account access →
+   * Sign out) tucked under the separate fixed "Talk to One" Agent Bar that
+   * floats above the nav. Use the shared, runtime-measured clearance token
+   * (see --bottom-chrome-stack-height in app/providers.tsx) so this page
+   * reserves space for both fixed bars, the same as every other route. */
+  padding-bottom: var(--app-bottom-content-clearance);
 }
 
 .profile-home-screen .app-page-header-region {
@@ -1633,10 +1639,6 @@ body:has(.profile-home-screen) .foundation-public-ambient {
 }
 
 @media (min-width: 768px) {
-  .profile-home-screen {
-    padding-bottom: calc(env(safe-area-inset-bottom) + 5rem);
-  }
-
   .profile-home-hero {
     padding-top: clamp(36px, 7vh, 64px);
   }


### PR DESCRIPTION
## Bug

On Profile routes, the fixed **Talk to One** bar and bottom navigation could cover important account actions such as Account access, Sign out, and Delete account.

## Root cause

The Profile settings screen (`.profile-home-screen`) hardcoded its own bottom padding (`env(safe-area-inset-bottom) + 7.5rem`, `5rem` on >=768px), sized only for the bottom nav bar. It did not account for the separate fixed "Talk to One" Agent Bar stacked above the nav, so the last "Your settings" rows (Account access -> Sign out) sat behind both fixed bars.

Every other route (including the `/profile/account` Delete/Reset-account sub-page) already uses the shared, runtime-measured `--app-bottom-content-clearance` token, which reserves space for both fixed bars together.

## Fix

Switch `.profile-home-screen` to the shared `--app-bottom-content-clearance` token and drop the now-redundant 768px override.

## Verification

- Reproduced the overlap on uat.one.hushh.ai/one/profile.
- Ran the app locally against the UAT backend; confirmed Account access, Sign out, and Delete account are fully visible and tappable above the fixed navigation, matching the clearance already used on unaffected routes.
- `tsc --noEmit`, `eslint` on touched files, and `verify-design-system` all pass.

Single-file change, scoped to this bug only.