### PR TITLE
fix(profile): prevent fixed navigation from covering account actions

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1413,7 +1413,14 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
   display: flex;
   flex-direction: column;
   min-height: calc(100dvh - var(--top-shell-reserved-height, 0px));
-  padding-bottom: calc(env(safe-area-inset-bottom) + 2rem);
+  /* Was a hardcoded `env(safe-area-inset-bottom) + 2rem` on main (uat had its
+   * own stale `7.5rem`), sized only for the bottom nav bar. That left the
+   * last "Your settings" rows (Account access → Sign out) tucked under the
+   * separate fixed "Talk to One" Agent Bar that floats above the nav. Use the
+   * shared, runtime-measured clearance token (see --bottom-chrome-stack-height
+   * in app/providers.tsx) so this page reserves space for both fixed bars,
+   * the same as every other route. */
+  padding-bottom: var(--app-bottom-content-clearance);
 }
 
 .profile-home-screen .app-page-header-region {
@@ -1641,10 +1648,6 @@ body:has(.profile-home-screen) .foundation-public-ambient {
 }
 
 @media (min-width: 768px) {
-  .profile-home-screen {
-    padding-bottom: calc(env(safe-area-inset-bottom) + 2.5rem);
-  }
-
   .profile-home-hero {
     padding-top: 24px;
   }


### PR DESCRIPTION
## Bug

On Profile routes, the fixed **Talk to One** bar and bottom navigation could cover important account actions such as Account access, Sign out, and Delete account.

## Root cause

The Profile settings screen (`.profile-home-screen`) hardcoded its own bottom padding (on `main`: `env(safe-area-inset-bottom) + 2rem`, `2.5rem` on >=768px), sized only for the bottom nav bar. It did not account for the separate fixed "Talk to One" Agent Bar stacked above the nav, so the last "Your settings" rows (Account access -> Sign out) sat behind both fixed bars.

Every other route (including the `/profile/account` Delete/Reset-account sub-page) already uses the shared, runtime-measured `--app-bottom-content-clearance` token, which reserves space for both fixed bars together.

## Fix

Switch `.profile-home-screen` to the shared `--app-bottom-content-clearance` token and drop the now-redundant 768px override.

This is the same fix as #5206 (already merged to `uat`), cherry-picked onto `main` and re-resolved against `main`'s own independently-drifted hardcoded values for this property.

## Verification

- Verified against `uat` (merged, #5206): Account access, Sign out, and Delete account fully visible and tappable above the fixed navigation.
- `tsc --noEmit`, `eslint` on touched files, and `verify-design-system` all pass on this branch.

Single-file change, scoped to this bug only.