### PR TITLE
fix(one-location): move the Location toggle on tap instead of after the device fix

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -669,6 +669,33 @@ async function skipLocationEntryFlow(options: { expectMain?: boolean } = {}) {
   mockCaptureCurrentPosition.mockClear();
 }
 
+/**
+ * Hold the next device fix open and hand back its release. Lets a test assert
+ * what the UI does DURING the capture — the window the Location switch used to
+ * spend frozen. Call it after `skipLocationEntryFlow`, which needs a real fix
+ * of its own to get through the entry picker.
+ */
+function holdNextCapture(): () => void {
+  let release: (() => void) | null = null;
+  mockCaptureCurrentPosition.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        release = () =>
+          resolve({
+            latitude: 28.6139,
+            longitude: 77.209,
+            accuracyM: 12,
+            capturedAt: "2026-07-31T00:00:00.000Z",
+            sourcePlatform: "web",
+          });
+      }),
+  );
+  return () => {
+    if (!release) throw new Error("No capture was in flight to release.");
+    release();
+  };
+}
+
 async function expectEmergencyAction(
   number: string,
   countryName: string,
@@ -789,6 +816,13 @@ describe("OneLocationAgentPage", () => {
     const { forgetOneLocationControlPreference } =
       await import("@/lib/one-location/location-control-state");
     forgetOneLocationControlPreference("user_a");
+    // The workspace's decrypted points and last self fix live in a module-level
+    // store too, and it was the one the reset above missed: a coarse point left
+    // by an earlier test carried into the next one's first render and showed as
+    // that test's own state.
+    const { clearAllLocationWorkspaceMemory } =
+      await import("@/lib/one-location/location-workspace-memory");
+    clearAllLocationWorkspaceMemory();
     mockSearchParams.toString = () => "";
     mockSearchParamsGet.mockReturnValue(null);
     mockUseSearchParams.mockReturnValue(mockSearchParams);
@@ -1259,6 +1293,118 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("switch", { name: "Turn location off" }),
     ).toHaveAttribute("aria-checked", "true");
+  });
+
+  // The Location on/off control is a preference over LOCAL state. Every one of
+  // these tests holds the slow half — the device fix, the nearby write — open
+  // and asserts the switch has already moved. Turning any of them back into
+  // "await the network, then render" is the regression they exist to catch.
+  it("moves the switch on tap instead of waiting for the device fix", async () => {
+    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    // Held open only from here: entry onboarding needs a real capture first.
+    const releaseFix = holdNextCapture();
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Turn location on" }),
+    );
+
+    // The fix is still outstanding here. The switch is on regardless, and the
+    // status — not a disabled control — carries the fact that we are waiting.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+    expect(screen.getByText("Finding you…")).toBeTruthy();
+    expect(
+      screen.getByRole("switch", { name: "Turn location off" }),
+    ).not.toBeDisabled();
+
+    await act(async () => {
+      releaseFix();
+    });
+    await waitFor(() => expect(screen.getByText("Location on")).toBeTruthy());
+  });
+
+  it("does not let a late fix undo a pause made while it was in flight", async () => {
+    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    const releaseFix = holdNextCapture();
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Turn location on" }),
+    );
+    const onSwitch = await screen.findByRole("switch", {
+      name: "Turn location off",
+    });
+    fireEvent.click(onSwitch);
+    await waitFor(() =>
+      expect(screen.getByText("Location paused")).toBeTruthy(),
+    );
+
+    // The fix belongs to an intent the person has already replaced. Applying it
+    // would silently turn location back on after they turned it off.
+    await act(async () => {
+      releaseFix();
+    });
+    expect(
+      screen.getByRole("switch", { name: "Turn location on" }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByText("Location paused")).toBeTruthy();
+  });
+
+  it("pauses the device without waiting on, or first probing, nearby presence", async () => {
+    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+    mockGetNearbyPresence.mockResolvedValue({
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: true,
+        consentVersion: "one-location-nearby-presence-v3",
+        checkedInAt: "2026-07-31T00:00:00.000Z",
+        expiresAt: "2026-07-31T01:00:00.000Z",
+        placeLabel: "Event venue",
+      },
+      attendees: [],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    const onSwitch = await screen.findByRole("switch", {
+      name: "Turn location off",
+    });
+    await waitFor(() => expect(mockGetNearbyPresence).toHaveBeenCalled());
+
+    // Any further presence read hangs. The pause used to read presence and only
+    // then check out — two serialized round trips in front of the switch — so a
+    // hanging read would strand it. It must not depend on one.
+    mockGetNearbyPresence.mockImplementation(() => new Promise(() => {}));
+    let releaseCheckout: (() => void) | null = null;
+    mockCheckoutNearby.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseCheckout = () => resolve({ presence: null, attendees: [] });
+        }),
+    );
+
+    fireEvent.click(onSwitch);
+
+    await waitFor(() =>
+      expect(screen.getByText("Location paused")).toBeTruthy(),
+    );
+    await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalledTimes(1));
+    // Still in flight while the device already reads as paused.
+    expect(releaseCheckout).not.toBeNull();
+
+    await act(async () => {
+      (releaseCheckout as unknown as () => void)();
+    });
   });
 
   it("renders a focused, validated share flow with a 15-minute default", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2136,6 +2136,27 @@ export function OneLocationAgentPageContent({
     automaticPrivatePublishingAllowedRef.current =
       !locationControl.paused && locationControl.autoShareEnabled;
   }, [locationControl.autoShareEnabled, locationControl.paused]);
+  // Monotonic claim on the Location on/off control. Every tap takes the next
+  // number; work started by an earlier tap must not write its result once a
+  // newer one exists. Without it, "on" (device fix still in flight) followed by
+  // "off" lands back ON when that fix arrives — the control silently undoing
+  // what the person just did, which on this particular switch is a privacy
+  // failure rather than a glitch.
+  const locationIntentSeqRef = useRef(0);
+  // True once a nearby checkout has been confirmed and nothing has checked us
+  // back in since. Nearby writes are capped at 6/minute, and a 429 here would
+  // be reported as "you may still be visible to people around you" — a false
+  // alarm about the one thing this surface must never be wrong about.
+  const nearbyPresenceClearedRef = useRef(false);
+  useEffect(() => {
+    if (locationControl.nearbyPresenceActive) {
+      nearbyPresenceClearedRef.current = false;
+    }
+  }, [locationControl.nearbyPresenceActive]);
+  useEffect(() => {
+    // A different account carries different presence; never inherit the flag.
+    nearbyPresenceClearedRef.current = false;
+  }, [auth.userId]);
   const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
   useEffect(() => {
     setLocationWorkspace(readLocationWorkspaceMemory(auth.userId));
@@ -2893,6 +2914,14 @@ export function OneLocationAgentPageContent({
       capturePoint?: boolean;
       autoOpenSettings?: boolean;
       requestNativePrompt?: boolean;
+      /**
+       * Lets a caller whose request has been superseded discard the fix instead
+       * of applying it. A capture can outlive the intent that started it, and
+       * `activateMyLocation` un-pauses — so a stale fix from an abandoned "turn
+       * on" would otherwise reverse the pause that replaced it. Only the
+       * on/off control passes this; every other caller keeps today's behaviour.
+       */
+      isStale?: () => boolean;
     }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
       const shouldCapturePoint = Boolean(options?.capturePoint);
       const shouldOpenSettings = options?.autoOpenSettings !== false;
@@ -2930,17 +2959,24 @@ export function OneLocationAgentPageContent({
         // is what keeps Safari honest, where the value is simply unreadable.
         observedLocationDenialRef.current = false;
         setLocationDenialObserved(false);
-        const nextPermission =
-          await OneLocationService.getPermissionState().catch(() => null);
-        setPermission(
-          nextPermission ?? {
-            state: "granted",
-            precise: null,
-            background: "foreground-only",
-            locationServicesEnabled: true,
-          },
-        );
-        if (shouldCapturePoint) {
+        // Re-reading permission here is bookkeeping — it refreshes `precise`
+        // for the accuracy badge — not a precondition for holding the fix we
+        // just got. Awaiting it put a second platform round trip in front of
+        // every caller, including the on/off control, for a value nothing on
+        // this path goes on to read. Fire it and let it land on its own.
+        void OneLocationService.getPermissionState()
+          .catch(() => null)
+          .then((nextPermission) =>
+            setPermission(
+              nextPermission ?? {
+                state: "granted",
+                precise: null,
+                background: "foreground-only",
+                locationServicesEnabled: true,
+              },
+            ),
+          );
+        if (shouldCapturePoint && !options?.isStale?.()) {
           activateMyLocation(point);
         }
         return shouldCapturePoint ? { ready: true, point } : { ready: true };
@@ -6938,16 +6974,65 @@ export function OneLocationAgentPageContent({
 
   // Returns its outcome so the voice handler below can report what actually
   // happened rather than assuming success. Tap call sites discard it.
+  //
+  // Turning Location on is a PREFERENCE, and the preference is local — nothing
+  // about storing it needs the network. What takes time is the device: a cold
+  // GPS fix is a second or two on a phone and can run the whole sampling budget
+  // on a laptop with no GPS at all. Holding the switch until that fix arrives
+  // is what made this control feel broken, identically, on every platform.
+  //
+  // So the switch moves first and the fix follows it. The one thing that could
+  // make that flip wrong is the platform refusing outright, and that is
+  // readable synchronously from state we already hold — so the common case
+  // never shows an "on" it has to take back.
   const handleShowMyLiveLocation =
     useCallback(async (): Promise<LocalOnboardingActionResult> => {
-      setBusy("selfLocation");
+      const intent = ++locationIntentSeqRef.current;
+      const isStale = () => locationIntentSeqRef.current !== intent;
+      const superseded: LocalOnboardingActionResult = {
+        status: "succeeded",
+        summary: "A newer location change replaced this one.",
+      };
       setMyLocationError(null);
+
+      // Already-known refusal: do not claim an "on" the device cannot deliver.
+      // Everything below still runs, so the person is routed to settings.
+      const platformRefuses = Boolean(locationBlockReason(permission));
+      const previous = locationControl;
+      const applyOptimisticOn = () => {
+        if (platformRefuses) return;
+        automaticPrivatePublishingAllowedRef.current = previous.autoShareEnabled;
+        updateOneLocationControlState(auth.userId, (current) => ({
+          ...current,
+          paused: false,
+          selfPreviewEnabled: true,
+        }));
+      };
+      const rollbackOptimisticOn = () => {
+        if (platformRefuses) return;
+        automaticPrivatePublishingAllowedRef.current =
+          !previous.paused && previous.autoShareEnabled;
+        updateOneLocationControlState(auth.userId, (current) => ({
+          ...current,
+          paused: previous.paused,
+          selfPreviewEnabled: previous.selfPreviewEnabled,
+        }));
+      };
+
+      applyOptimisticOn();
+      setBusy("selfLocation");
       try {
         const result = await ensureForegroundLocationReady({
           capturePoint: true,
           autoOpenSettings: true,
+          isStale,
         });
+        // A newer tap owns the control now. Reporting this one's outcome would
+        // describe a state the person has already moved on from, and rolling
+        // back would fight the newer intent.
+        if (isStale()) return superseded;
         if (!result.ready || !result.point) {
+          rollbackOptimisticOn();
           const message =
             "Live location preview needs device Location permission.";
           setMyLocationError(message);
@@ -6960,70 +7045,89 @@ export function OneLocationAgentPageContent({
           summary: "Location updates are on again for this device.",
         };
       } catch (error) {
+        if (isStale()) return superseded;
+        rollbackOptimisticOn();
         const message = locationServicesErrorMessage(error);
         setMyLocationError(message);
         toast.error(message);
         return { status: "failed", summary: message };
       } finally {
-        setBusy(null);
+        // A newer intent owns `busy` and will clear it itself; clearing it here
+        // would wipe the pending state of work that is still running.
+        if (!isStale()) setBusy(null);
       }
-    }, [ensureForegroundLocationReady]);
+    }, [
+      auth.userId,
+      ensureForegroundLocationReady,
+      locationControl,
+      permission,
+    ]);
 
   // One coordinated pause owns every Location entry point. Private grants keep
   // their consent/expiry contract, but all new foreground/background updates
   // stop. Nearby presence is a separate authority and must explicitly check
-  // out before the UI may claim that Location is paused.
+  // out before the UI may claim that Nearby is clear.
+  //
+  // The ORDER here is the whole safety argument. Every part of a pause that
+  // this device controls happens synchronously, before any await: someone who
+  // says "stop showing me" should not stay visible locally for as long as a
+  // round trip takes, and none of that state lives on a server anyway. What
+  // genuinely is remote — nearby checkout — follows, and is still reported
+  // exactly as honestly as before.
+  //
+  // The pause used to sit BEHIND two serialized nearby calls, which is what
+  // made the switch take seconds to move.
   const handleHideMyLiveLocation =
     useCallback(async (): Promise<LocalOnboardingActionResult> => {
     if (!auth.userId) {
       return { status: "blocked", summary: "Sign in to pause your location." };
     }
+
+    const intent = ++locationIntentSeqRef.current;
+    const isStale = () => locationIntentSeqRef.current !== intent;
+    // A capture still in flight from an earlier "on" no longer owns the pending
+    // state, and its own `finally` will decline to clear it. Clear it here so
+    // the control cannot be stranded looking busy.
+    setBusy((current) => (current === "selfLocation" ? null : current));
+
+    automaticPrivatePublishingAllowedRef.current = false;
+    updateOneLocationControlState(auth.userId, (current) => ({
+      ...current,
+      paused: true,
+      selfPreviewEnabled: false,
+      nearbyPresenceActive: false,
+      nearbyCheckedInAt: null,
+    }));
+    clearMyLocationPreview();
+    setBackgroundShareEnabled(false);
+    setMyLocationError(null);
+
+    // Nearby presence lives on the server under the vault's authority. A locked
+    // vault means we cannot check out — but that is no longer a reason to
+    // refuse the pause, which has already taken effect on this device. Refusing
+    // outright left the person MORE exposed than telling them both halves does.
     if (nearbyCheckInAvailable && !vaultOwnerToken) {
-      const message = "Unlock One before pausing nearby location.";
+      const message =
+        "Location updates are paused on this device, but I could not check you out of nearby presence -- unlock One and pause again to finish that.";
       toast.error(message);
-      return { status: "blocked", summary: message };
+      return { status: "succeeded", summary: message };
     }
 
-    setBusy("selfLocation");
-    automaticPrivatePublishingAllowedRef.current = false;
-    // Nearby checkout is attempted first and is allowed to fail on its own.
-    //
-    // It used to sit inside the main try, so a throw from either nearby call
-    // abandoned the WHOLE pause -- including the local pause, which would
-    // have worked. Observed live: every spoken "pause my location" settled
-    // `failed` with "you may still be visible nearby", while resume always
-    // succeeded. Resume touches nearby not at all, which is the entire
-    // asymmetry: the failure was never about pausing.
-    //
-    // Hiding locally is the part the person asked for and the part that can
-    // still be delivered, so it is no longer held hostage to the other. What
-    // is NOT done is call it a clean pause when the nearby half failed --
-    // that would be the one lie this action must never tell.
-    let nearbyCheckoutFailed = false;
-    if (nearbyCheckInAvailable && vaultOwnerToken) {
+    // Checkout is idempotent server-side: it clears an ACTIVE row and reports
+    // success either way. So the presence GET that used to precede it bought
+    // nothing but a second serialized round trip inside the pause — and asking
+    // first is strictly worse than just telling, because the answer can go
+    // stale between the two calls. `nearbyPresenceClearedRef` keeps repeated
+    // pauses off the 6/minute nearby-write limit.
+    const shouldCheckOut =
+      nearbyCheckInAvailable &&
+      Boolean(vaultOwnerToken) &&
+      !nearbyPresenceClearedRef.current;
+    if (shouldCheckOut && vaultOwnerToken) {
       try {
-        const nearby = await OneLocationService.getNearbyPresence({
-          vaultOwnerToken,
-        });
-        if (nearby.presence) {
-          await OneLocationService.checkoutNearby({ vaultOwnerToken });
-        }
+        await OneLocationService.checkoutNearby({ vaultOwnerToken });
+        nearbyPresenceClearedRef.current = true;
       } catch {
-        nearbyCheckoutFailed = true;
-      }
-    }
-    try {
-      updateOneLocationControlState(auth.userId, (current) => ({
-        ...current,
-        paused: true,
-        selfPreviewEnabled: false,
-        nearbyPresenceActive: false,
-        nearbyCheckedInAt: null,
-      }));
-      clearMyLocationPreview();
-      setBackgroundShareEnabled(false);
-      setMyLocationError(null);
-      if (nearbyCheckoutFailed) {
         // Both halves of the truth, in the order that matters: what is now
         // private, then what is not. Told as `succeeded` because the thing
         // asked for did happen -- reporting failure would send someone to
@@ -7034,27 +7138,25 @@ export function OneLocationAgentPageContent({
         toast.error(message);
         return { status: "succeeded", summary: message };
       }
-      toast.success("Location updates are paused on this device.");
+    }
+
+    // The checkout still had to happen, but announcing a pause after the person
+    // has already turned Location back on would describe a state that is no
+    // longer true.
+    if (isStale()) {
       return {
         status: "succeeded",
-        summary: "Location updates are paused on this device.",
+        summary: "A newer location change replaced this one.",
       };
-    } catch {
-      automaticPrivatePublishingAllowedRef.current =
-        locationControl.autoShareEnabled;
-      const message =
-        "Pause did not complete. You may still be visible nearby; please try again.";
-      toast.error(message);
-      // Reported as failed, not blocked: the person may still be visible, and
-      // saying "paused" here would be the one lie this action must never tell.
-      return { status: "failed", summary: message };
-    } finally {
-      setBusy(null);
     }
+    toast.success("Location updates are paused on this device.");
+    return {
+      status: "succeeded",
+      summary: "Location updates are paused on this device.",
+    };
   }, [
     auth.userId,
     clearMyLocationPreview,
-    locationControl.autoShareEnabled,
     nearbyCheckInAvailable,
     vaultOwnerToken,
   ]);
@@ -8669,6 +8771,12 @@ export function OneLocationAgentPageContent({
     autoShareEnabled: locationControl.autoShareEnabled,
     locationPaused: locationControl.paused,
     locationAccuracyLimited,
+    // The switch is already on and the device has not found us yet. This is the
+    // honest replacement for the old disabled-and-pulsing switch: the control
+    // stays live and the STATUS carries the waiting, instead of the person
+    // being locked out of a control that looks stuck.
+    locationAcquiring:
+      locationEnabled && !myLocationPoint && busy === "selfLocation",
     myLocationPoint,
     myLocationError,
     recipients: shareRecipientPool,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -191,6 +191,12 @@ export type LocationHubViewModel = {
   autoShareEnabled: boolean;
   locationPaused: boolean;
   locationAccuracyLimited: boolean;
+  /**
+   * Location is on and the device has not produced a fix yet. Drives the status
+   * text only — never a disabled control, because this is exactly the window in
+   * which someone is most likely to want to change their mind.
+   */
+  locationAcquiring: boolean;
   myLocationPoint: PlainLocationPoint | null;
   myLocationError: string | null;
 
@@ -510,18 +516,21 @@ export function resolveLocationDeepLinkFocus(input: {
   return { detailAction: null, nextTab: null };
 }
 
-const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
-
 function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
   const locationOn = vm.locationEnabled;
-  const toggling = BUSY(vm, "selfLocation");
-  const refreshing = BUSY(vm, "load");
-  const statusLabel = locationStatusLabel({
-    readiness: vm.locationBlocked ? "blocked" : locationOn ? "ready" : "askable",
-    previewOn: locationOn,
-    paused: vm.locationPaused,
-    accuracyLimited: vm.locationAccuracyLimited,
-  });
+  const acquiring = vm.locationAcquiring;
+  const statusLabel = acquiring
+    ? "Finding you…"
+    : locationStatusLabel({
+        readiness: vm.locationBlocked
+          ? "blocked"
+          : locationOn
+            ? "ready"
+            : "askable",
+        previewOn: locationOn,
+        paused: vm.locationPaused,
+        accuracyLimited: vm.locationAccuracyLimited,
+      });
 
   const handleLocationChange = (checked: boolean) => {
     if (checked === locationOn) return;
@@ -550,7 +559,11 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
           size="ios"
           checked={locationOn}
           onCheckedChange={handleLocationChange}
-          disabled={toggling || refreshing}
+          // Deliberately never disabled. What it controls is local state that
+          // flips on tap, so a disabled window could only ever swallow the
+          // person's NEXT tap — during the very seconds the device spends
+          // finding them, which is when they are most likely to change their
+          // mind. The status text carries the waiting instead.
           aria-label={locationOn ? "Turn location off" : "Turn location on"}
           // The same pair of contract actions the Settings toggle carries.
           // Both are the same control in two places, so voice can offer
@@ -558,7 +571,7 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
           data-voice-control-id="one-location-updates-toggle"
           // No colour override: the shared Switch already carries the iOS
           // system green, so this toggle reads the same as every other one.
-          className={cn(toggling && "animate-pulse")}
+          className={cn(acquiring && "animate-pulse")}
         />
       </div>
     </div>
@@ -1532,7 +1545,6 @@ function LocationSettingsFlow({
               checked={vm.autoShareEnabled}
               onChange={vm.onAutoShareChange}
               label="Auto-share my location"
-              disabled={BUSY(vm, "selfLocation")}
             />
           }
           density="compact"
@@ -1551,7 +1563,6 @@ function LocationSettingsFlow({
                 vm.onResumeMyLocation();
               }}
               label="Pause my location"
-              disabled={BUSY(vm, "selfLocation")}
               voiceControlId="one-location-updates-toggle"
             />
           }

--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -133,6 +133,13 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         }
     }
 
+    /// How old a cached fix may be before we insist on a fresh one. Matches the
+    /// Android plugin's `getLastKnownLocation` window and the web plugin's
+    /// last-resort reader exactly, and stays well under the 60s the backend
+    /// allows between capture and confirmation — so a fix accepted here still
+    /// passes the server's freshness check and still says where the user is.
+    private static let cachedFixMaxAgeSeconds: TimeInterval = 30
+
     private func requestOneShotLocation(_ call: CAPPluginCall) {
         if
             let existing = pendingLocationCall,
@@ -142,6 +149,24 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
                 "A newer location request replaced this request."
             )
         }
+
+        // iOS was the only platform that always waited for a NEW fix. Android
+        // and web both resolve from a recent cached one first, and CoreLocation
+        // is already holding a good position whenever a watch is running or the
+        // app was recently foregrounded -- so `requestLocation()` spent one to
+        // three seconds rediscovering a coordinate we had the whole time.
+        if
+            let cached = manager.location,
+            cached.horizontalAccuracy >= 0,
+            abs(cached.timestamp.timeIntervalSinceNow) <= Self.cachedFixMaxAgeSeconds
+        {
+            pendingLocationTimeout?.cancel()
+            pendingLocationTimeout = nil
+            pendingLocationCall = nil
+            call.resolve(locationPayload(cached))
+            return
+        }
+
         pendingLocationTimeout?.cancel()
         pendingLocationCall = call
         let timeoutMs = max(3_000, min(call.getInt("timeoutMs") ?? 15_000, 30_000))
@@ -162,6 +187,19 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
             execute: timeout
         )
         manager.requestLocation()
+    }
+
+    /// The single shape a CLLocation is handed to JS in. Shared by the cached
+    /// fast path, the one-shot delegate callback, and every active watch, so
+    /// they can never drift apart.
+    private func locationPayload(_ location: CLLocation) -> [String: Any] {
+        [
+            "latitude": location.coordinate.latitude,
+            "longitude": location.coordinate.longitude,
+            "accuracyM": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : NSNull(),
+            "capturedAt": ISO8601DateFormatter().string(from: location.timestamp),
+            "sourcePlatform": "ios"
+        ]
     }
 
     private func clearPendingLocationCall() -> CAPPluginCall? {
@@ -380,13 +418,7 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
             return
         }
 
-        let payload: [String: Any] = [
-            "latitude": location.coordinate.latitude,
-            "longitude": location.coordinate.longitude,
-            "accuracyM": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : NSNull(),
-            "capturedAt": ISO8601DateFormatter().string(from: location.timestamp),
-            "sourcePlatform": "ios"
-        ]
+        let payload = locationPayload(location)
 
         // One-shot getCurrentPosition resolves and clears its single call.
         if let call = clearPendingLocationCall() {

--- a/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-position.test.ts
+++ b/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-position.test.ts
@@ -123,3 +123,89 @@ describe("HushhLocationWeb.getCurrentPosition", () => {
     await settled;
   });
 });
+
+const SAMPLING_BUDGET_MS = 9_000;
+
+/**
+ * Install a geolocation whose watch delivers a scripted sequence of fixes. Each
+ * assertion below advances the clock by only as much as the behaviour under
+ * test should need, so a regression that reinstates the full-budget wait shows
+ * up as an unresolved promise rather than a slower pass.
+ */
+function stubWatchSequence(
+  fixes: Array<{ latitude: number; accuracy: number; afterMs: number }>,
+) {
+  const clearWatch = vi.fn();
+  const watchPosition = vi.fn((onSuccess: (value: unknown) => void) => {
+    for (const fix of fixes) {
+      setTimeout(() => {
+        onSuccess({
+          coords: {
+            latitude: fix.latitude,
+            longitude: 12.34,
+            accuracy: fix.accuracy,
+          },
+          timestamp: Date.parse("2026-08-08T00:00:00.000Z"),
+        });
+      }, fix.afterMs);
+    }
+    return 7;
+  });
+
+  vi.stubGlobal("navigator", {
+    geolocation: {
+      getCurrentPosition: vi.fn(),
+      watchPosition,
+      clearWatch,
+    },
+  });
+
+  return { clearWatch };
+}
+
+describe("HushhLocationWeb.getCurrentPosition sampling window", () => {
+  it("returns a coarse fix shortly after it lands instead of waiting out the budget", async () => {
+    // A laptop with no GPS: one coarse fix arrives and no better one is ever
+    // coming. Holding the caller for the remaining ~9s bought nothing, and it
+    // was the single largest source of "turning location on takes forever".
+    stubWatchSequence([{ latitude: 47.61, accuracy: 400, afterMs: 100 }]);
+
+    const web = new HushhLocationWeb();
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: SAMPLING_BUDGET_MS }),
+    ).resolves.toMatchObject({ latitude: 47.61, accuracyM: 400 });
+    await vi.advanceTimersByTimeAsync(1_500);
+    await settled;
+  });
+
+  it("still prefers a better fix that arrives inside the refinement window", async () => {
+    // The reason sampling exists at all: one jumpy first reading must not be
+    // shown as the person's location. Returning early must not cost that.
+    stubWatchSequence([
+      { latitude: 47.61, accuracy: 400, afterMs: 100 },
+      { latitude: 47.68, accuracy: 60, afterMs: 400 },
+    ]);
+
+    const web = new HushhLocationWeb();
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: SAMPLING_BUDGET_MS }),
+    ).resolves.toMatchObject({ latitude: 47.68, accuracyM: 60 });
+    await vi.advanceTimersByTimeAsync(1_500);
+    await settled;
+  });
+
+  it("resolves a confident fix immediately and stops watching", async () => {
+    const { clearWatch } = stubWatchSequence([
+      { latitude: 47.68, accuracy: 10, afterMs: 50 },
+    ]);
+
+    const web = new HushhLocationWeb();
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: SAMPLING_BUDGET_MS }),
+    ).resolves.toMatchObject({ latitude: 47.68, accuracyM: 10 });
+    // Well inside the refinement window: an accurate fix never waits for it.
+    await vi.advanceTimersByTimeAsync(60);
+    await settled;
+    expect(clearWatch).toHaveBeenCalledWith(7);
+  });
+});

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -114,6 +114,15 @@ export class HushhLocationWeb implements HushhLocationPlugin {
     // Accuracy (meters) at which we stop sampling early — a confident fix.
     const TARGET_ACCURACY_M = 35;
 
+    // How long to keep refining AFTER the first usable fix lands. The sampling
+    // budget below is the ceiling for finding ANY fix at all; once one is in
+    // hand, holding the caller for the rest of it buys accuracy nobody is
+    // waiting for. It cost the most on the devices that could least afford it:
+    // a laptop with no GPS produces one coarse fix and no better one is ever
+    // coming, so every capture sat out the entire budget before returning a
+    // result it already had within a few hundred milliseconds.
+    const REFINE_AFTER_FIRST_FIX_MS = 1_200;
+
     const toFix = (position: GeolocationPosition): WebFix => ({
       latitude: position.coords.latitude,
       longitude: position.coords.longitude,
@@ -162,11 +171,16 @@ export class HushhLocationWeb implements HushhLocationPlugin {
         let settled = false;
         let watchId: number | null = null;
         let timer: ReturnType<typeof setTimeout> | null = null;
+        let refineTimer: ReturnType<typeof setTimeout> | null = null;
 
         const cleanup = () => {
           if (timer !== null) {
             clearTimeout(timer);
             timer = null;
+          }
+          if (refineTimer !== null) {
+            clearTimeout(refineTimer);
+            refineTimer = null;
           }
           if (watchId !== null) {
             navigator.geolocation.clearWatch(watchId);
@@ -191,6 +205,17 @@ export class HushhLocationWeb implements HushhLocationPlugin {
                 best.accuracyM <= TARGET_ACCURACY_M
               ) {
                 finish(best);
+                return;
+              }
+              // First fix in hand but not yet confident. Give later fixes a
+              // short window to beat it — enough to reject one jumpy reading,
+              // which is the whole point of sampling — then return the best of
+              // them rather than waiting out the full budget.
+              if (refineTimer === null) {
+                refineTimer = setTimeout(
+                  () => finish(best),
+                  REFINE_AFTER_FIRST_FIX_MS,
+                );
               }
             },
             (error) => {


### PR DESCRIPTION
# Description

The Location on/off control on the One Location screen took roughly two seconds to
register a tap. The reported cause was "the backend is slow so the switch syncs with
it". That is not what was happening in either direction.

**Turning ON made no network call at all.** `handleShowMyLiveLocation` awaited a
permission read, then a GPS fix, then a *second* permission read, and only then
flipped state. The fix is the cost: the web sampler held out for a `<=35m` reading or
its full 9s budget, so a laptop with no GPS paid the whole budget every time. iOS was
the only platform that never accepted a recent cached fix — Android
(`getLastKnownLocation`, 30s) and web (last-resort reader, 30s) both already do.

**Turning OFF awaited `getNearbyPresence` and then `checkoutNearby`** — two serialized
round trips — before touching the pause. The pause is local state (a module-level map
plus `localStorage`); nothing about storing it needs a server.

So the switch moves first and the slow half follows it:

- **ON flips optimistically** and rolls back only if the platform actually refuses
  (read synchronously from `locationBlockReason`, so the common case never shows an
  "on" it has to retract). The post-capture permission re-read no longer blocks; it
  only refreshes `precise` for the accuracy badge.
- **OFF enforces the pause synchronously, before any await.** Pausing only ever
  *removes* visibility, so this device stops publishing immediately and the server is
  told afterwards. The existing partial-failure honesty contract is unchanged: a failed
  nearby checkout still reports "paused on this device, but you may still be visible to
  people around you".
- **The nearby presence probe is gone.** `checkout` is idempotent server-side
  (`UPDATE … WHERE status = 'active'`, reporting success either way), so reading
  presence first bought nothing but a second round trip and a chance for the answer to
  go stale between the two calls. A cleared-flag keeps repeated pauses off the
  `ONE_LOCATION_NEARBY_WRITE` 6/minute limit, whose 429 would have surfaced as a false
  "you may still be visible".
- **A monotonic intent counter guards the control.** Tapping on and then off used to
  land back **ON** when the abandoned fix arrived, because `activateMyLocation`
  un-pauses. That was a correctness bug rather than a latency one; it now has a test.
- **The switch is never disabled.** A disabled window could only ever swallow the next
  tap during the seconds the device spends finding you — exactly when someone is most
  likely to change their mind. The status text carries the wait instead
  ("Finding you…").
- **The web sampler returns its best fix ~1.2s after the first one lands** rather than
  waiting out the budget, still long enough to reject a single jumpy reading.
- **iOS resolves from a `<=30s` cached CoreLocation fix**, matching Android and web.

Also fixes a test-isolation leak found while writing the tests: the page suite's
`beforeEach` cleared the cache and the control preference but not the workspace memory,
so one test's coarse point bled into the next test's first render.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/location` — header Location switch and the Settings tab's "Pause my
      location" / "Auto-share my location" toggles. No route added, removed, or renamed.

- API / schema / type changes:
  - [x] Listed below:
    - `LocationHubViewModel` gains `locationAcquiring: boolean` (internal view-model
      type, not a wire contract).
    - `ensureForegroundLocationReady` gains an optional `isStale?: () => boolean`
      option. Every existing caller is unchanged and keeps today's behaviour.
    - No backend, HTTP, or DB schema change. No new endpoint. No endpoint removed —
      `GET /api/one/location/nearby-presence` is simply no longer called from the pause
      path (it is still used by the mount reconciliation effect).

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - iOS `HushhLocationPlugin.getCurrentPosition` now resolves from a `<=30s` cached
      `CLLocationManager.location` before falling back to `requestLocation()`. This
      brings iOS to the behaviour Android and web already had; it does not introduce a
      new policy. The 30s window is deliberately under the backend's 60s
      capture-to-confirmation freshness check, so an accepted fix still passes it.
    - Android: no change needed — already had this fast path.

- Docs updated (exact files):
  - [x] None — behaviour is documented in-code at each decision point.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below:
    - **Consent / visibility.** This changes the *order* of a privacy control, so the
      direction of every reorder was chosen to fail safe. Pausing now takes effect
      locally *before* the network call rather than after, so a person who taps pause
      stops publishing from this device immediately instead of a round trip later. The
      optimistic ON flip cannot leak a position, because there is no position to publish
      until the fix lands, and the flip is rolled back if it never does. No consent
      token, grant, expiry, or envelope path is touched, and no grant is created or
      revoked.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof:
    - Removing the presence probe relies on `checkout` being idempotent. Proof:
      `PostgresNearbyPresenceStore.checkout` runs
      `UPDATE one_location_nearby_presences SET status='checked_out' … WHERE
      owner_user_id = :user_id AND status = 'active'` and discards the returned row;
      `NearbyPresenceService.checkout` then returns
      `{"presence": None, "attendees": [], "checkedOut": True}` unconditionally
      (`consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py`).
      Calling it when no presence exists is a successful no-op.

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - ON failure rolls the optimistic flip back to the exact prior `paused` /
      `selfPreviewEnabled` snapshot and surfaces the existing blocked/failed message.
    - OFF keeps the local pause even when nearby checkout fails, and says so — it never
      reports a clean pause it did not achieve.
    - A superseded toggle discards its own result instead of writing it, so a late fix
      cannot reverse a newer intent.
    - The three pieces are independently revertible: the Swift fast path, the web
      sampler window, and the page/hub changes do not depend on one another.

- UI browser or Playwright proof:
  - [ ] Not applicable
  - [x] Route/spec/command listed below:
    - `hushh-webapp/__tests__/components/one-location-agent-page.test.tsx` renders the
      real `/one/location` page component and drives the actual switch. No Playwright
      run and no manual browser session — see "Not verified" below.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [x] `cd hushh-webapp && npm test` (location suites, scoped — see below)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py …`

### What was verified, exactly

- `npx tsc --noEmit` — clean.
- `npx vitest run components/one-location app/one/location lib/one-location lib/capacitor
  __tests__/components/one-location-agent-page.test.tsx
  __tests__/components/one-location-onboarding-flow.test.tsx` → **511 passing, 4 failing**.
- Those 4 were confirmed **pre-existing**: the working tree was stashed and the same 4
  failed identically on the unmodified branch (3 jsdom layout assertions in
  `one-location-onboarding-flow`, `shared-with-me-card`, `sos-panel`; 1 approval-flow
  test in the page suite).
- ESLint on all changed files: the same 5 errors before and after at shifted line
  numbers (`react-hooks/refs`, `react-hooks/preserve-manual-memoization`,
  `Cannot access variable before it is declared`). **Zero new.**
- **Each of the 6 new tests was confirmed to fail against the previous implementation**
  before being kept — the two sampler tests hang on the old 9s budget, and all three
  toggle tests fail. They are regression guards, not decoration.

### Not verified

- **The Swift change is not build-checked** — no Xcode on the authoring machine — and no
  simulator or device run was performed. It is ~20 lines mirroring the existing Android
  policy and can be dropped independently of the rest.
- `npm run build` was not run.
- Local verification ran against a base 18 commits behind `main`. None of those 18
  commits touch any file in this PR, and none touch the one-location or capacitor trees,
  so CI on `main` is the check that matters here.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
      no open PR touches the toggle handlers, the hub switch, or the geolocation sampler.
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: the Location switch in `LocationHeaderActions`
      (`/one/location`, Now tab) and the "Pause my location" row in the Settings tab,
      both already shipped and both already carrying the
      `one-location-updates-toggle` voice control id.
- [x] New tests import and exercise production code — they render `OneLocationAgentPage`
      and the real `HushhLocationWeb` plugin, not test-local fakes.
- [x] New helpers/components/services are wired: `locationAcquiring` is produced by the
      page view-model and consumed by the shipped hub header; `isStale` is passed by the
      shipped toggle handler.
- [x] Production surface proved: see the three page-level tests, which drive the real
      switch through `fireEvent.click` and assert on `aria-checked`.
- [x] Required checks are current on this head, commits are signed off, and the branch is
      based directly on current `main`.
- [x] Maintainer edits are enabled.
- [ ] If this is one PR in a stack, the predecessor PR is linked here: not a stack.
- [ ] If this responds to requested changes: not applicable, first submission.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `lib/capacitor/plugins/location-web.ts` — bounded refinement window after
      the first fix.
- [x] **iOS**: `ios/App/App/Plugins/HushhLocationPlugin.swift` — cached-fix fast path,
      plus a shared payload builder so the fast path, the one-shot delegate, and every
      watch cannot drift apart.
- [x] **Android**: `android/app/.../HushhLocation/HushhLocationPlugin.kt` — **no change
      required**, it already resolves from a `<=30s` `getLastKnownLocation`. This PR
      brings the other two platforms to Android's behaviour.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) — automated component tests only, no manual session
- [ ] Tested on iOS Simulator/Device — **not run**
- [ ] Tested on Android Emulator/Device — **not run**
- [x] Commits are signed off
- [x] If generated files changed, they were regenerated by the canonical repo command —
      no generated files changed

## 📸 Screenshots / Video

No screenshot or video. The change is a timing and ordering change rather than a visual
one: the same switch, in the same place, reaching the same end state — it simply arrives
there on tap instead of ~2s later. The one new piece of visible copy is the transient
"Finding you…" status, asserted in
`__tests__/components/one-location-agent-page.test.tsx` →
*"moves the switch on tap instead of waiting for the device fix"*.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? Yes — device location, the same data the
      surface already handled. No new collection, no new recipient, no new retention.
- [x] If yes, have you implemented `checkConsentToken()`? Unchanged — the vault owner
      token requirement on every nearby call is untouched, and no new authenticated call
      was added (one was removed).
- [x] Sensitive surface touched: **consent** (location visibility ordering). See the
      trust-boundary note above for why each reorder fails safe.
- [x] Error path, rollback, or safe-failure behavior proved: covered by
      *"keeps Pause enabled when resuming cannot capture a fresh point"* and
      *"does not claim Location is paused when Nearby checkout fails"* (both existing,
      both still passing) plus the new
      *"does not let a late fix undo a pause made while it was in flight"*.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed — no dependencies added or changed
