### PR TITLE
fix(one-location): dismissing check-in closes the sheet, nothing else

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -576,7 +576,7 @@ describe("LocationImmersiveMap demo experience", () => {
     );
     fireEvent.click(screen.getByTestId("one-location-map-nearby-check-in"));
     expect(navigationHarness.push).toHaveBeenCalledWith(
-      "/one/location/check-in?source=map",
+      "/one/location/check-in",
       { scroll: false },
     );
 
@@ -633,7 +633,7 @@ describe("LocationImmersiveMap demo experience", () => {
       }),
     );
     expect(navigationHarness.push).toHaveBeenCalledWith(
-      "/one/location/check-in?source=map",
+      "/one/location/check-in",
       { scroll: false },
     );
   });
@@ -1047,11 +1047,85 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(screen.queryByTestId("one-location-map-people-tray")).toBeNull();
   });
 
-  it("returns to Your Map when check-in was opened from Your Map", async () => {
-    // The reported bug: check in from Your Map, close the sheet, and you were
-    // thrown past the map onto the Location hub's Now tab -- two screens back,
-    // right after making yourself discoverable. Dismiss now follows the opener
-    // recorded when Your Map pushed the route.
+  // The reported bug, in both of its lives: dismissing the sheet on check-in's
+  // own route navigated away -- first to the Location hub for everyone, then to
+  // whichever screen a `?source=` param claimed had opened the flow. Someone who
+  // has just checked in and closed the sheet is asking for the sheet to be gone,
+  // not for the screen behind it to be replaced. Every entry point is covered
+  // here because dismiss no longer consults where the person came from; if it
+  // ever starts again, the `query: ""` case is the one that regresses first.
+  const CHECK_IN_ENTRIES = [
+    { name: "Your Map", query: "source=map" },
+    { name: "the Location hub", query: "" },
+    { name: "a legacy deep link", query: "demo=people" },
+  ] as const;
+
+  for (const entry of CHECK_IN_ENTRIES) {
+    it(`closes the sheet without navigating when opened from ${entry.name}`, async () => {
+      experienceHarness.demoMode = false;
+      experienceHarness.nearbyAvailable = true;
+      experienceHarness.query = entry.query;
+
+      render(<LocationImmersiveMap surface="check-in" />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "Continue to Your Map" }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("nearby-check-in-sheet-mock"),
+        ).toHaveAttribute("data-open", "true");
+      });
+      navigationHarness.push.mockClear();
+      navigationHarness.replace.mockClear();
+
+      fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("nearby-check-in-sheet-mock"),
+        ).toHaveAttribute("data-open", "false");
+      });
+      // The map itself is what stays behind, so nothing routes anywhere.
+      expect(navigationHarness.push).not.toHaveBeenCalled();
+      expect(navigationHarness.replace).not.toHaveBeenCalled();
+    });
+  }
+
+  it("keeps the sheet dismissed while the route re-renders", async () => {
+    // The dismissal is a ref rather than URL state, and the effect that syncs
+    // the sheet to the route re-runs on every fresh `searchParams` object. If
+    // that effect stops respecting the ref, the sheet springs back open a paint
+    // after the person closes it.
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "source=map";
+
+    const view = render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to Your Map" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+    view.rerender(<LocationImmersiveMap surface="check-in" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
+  });
+
+  it("re-opens check-in from the map's own pill after a dismiss", async () => {
+    // Dismissing leaves the check-in map standing, so there has to be a way
+    // back in from it. The pill is that way, and on this route it must toggle
+    // the sheet rather than push the route it is already on.
     experienceHarness.demoMode = false;
     experienceHarness.nearbyAvailable = true;
     experienceHarness.query = "source=map";
@@ -1066,45 +1140,24 @@ describe("LocationImmersiveMap demo experience", () => {
         "true",
       );
     });
-
     fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
+    navigationHarness.push.mockClear();
 
-    // `replace`, not `push`: a dismissed flow must not be what the next Back
-    // press re-opens.
-    expect(navigationHarness.replace).toHaveBeenCalledWith(
-      "/one/location/map",
-      { scroll: false },
-    );
-    expect(navigationHarness.push).not.toHaveBeenCalledWith(
-      "/one/location",
-      expect.anything(),
-    );
-    expect(navigationHarness.push).not.toHaveBeenCalledWith("/one/location");
-  });
+    fireEvent.click(screen.getByTestId("one-location-map-nearby-check-in"));
 
-  it("returns to the Location hub when nothing recorded an opener", async () => {
-    // The hub's own "Check in" card, notification deep links and old shared
-    // URLs record nothing. The hub is where those came from and where they go.
-    experienceHarness.demoMode = false;
-    experienceHarness.nearbyAvailable = true;
-    experienceHarness.query = "";
-
-    render(<LocationImmersiveMap surface="check-in" />);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
-    );
     await waitFor(() => {
       expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
         "data-open",
         "true",
       );
     });
-
-    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
-
-    expect(navigationHarness.replace).toHaveBeenCalledWith("/one/location", {
-      scroll: false,
-    });
+    expect(navigationHarness.push).not.toHaveBeenCalled();
   });
 
   it("does not build a synthetic history boundary on the check-in route", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -34,11 +34,7 @@ import {
   decryptLocationEnvelope,
   encryptLocationForRecipient,
 } from "@/lib/one-location/encryption";
-import {
-  buildCheckInHrefFromYourMap,
-  CHECK_IN_SOURCE_PARAM,
-  resolveCheckInDismissHref,
-} from "@/lib/one-location/check-in-navigation";
+import { buildCheckInHrefFromYourMap } from "@/lib/one-location/check-in-navigation";
 import {
   readLocationWorkspaceMemory,
   writeLocationWorkspaceMemory,
@@ -301,6 +297,11 @@ export function LocationImmersiveMap({
   const initialDemoModeRef = useRef(initialDemoMode);
   const closeRequestedRef = useRef(false);
   const nearbyHistoryPreparedRef = useRef(false);
+  // Whether the person has dismissed the sheet on check-in's own route. Held in
+  // a ref, not the URL: the route-sync effect below re-runs whenever Next hands
+  // back a fresh `searchParams` object, and without this the dismiss would be
+  // undone on the next render.
+  const checkInSheetDismissedRef = useRef(false);
   const entryLocationRequestedRef = useRef(false);
   const locationCaptureRef = useRef<Promise<PlainLocationPoint> | null>(null);
   const nearbyConnectInFlightRef = useRef(false);
@@ -408,9 +409,15 @@ export function LocationImmersiveMap({
       );
       return;
     }
-    // On its own route the sheet is the screen, not an overlay the URL
-    // toggles -- there is no Your Map underneath to fall back to.
-    const requested = isCheckInSurface;
+    // On its own route the sheet opens with the screen, but it is not welded to
+    // it: once dismissed it stays dismissed until the person re-opens it, and
+    // the check-in map is left standing underneath.
+    if (!isCheckInSurface) {
+      // Leaving the route retires the dismissal, so arriving at check-in always
+      // arrives with the flow open.
+      checkInSheetDismissedRef.current = false;
+    }
+    const requested = isCheckInSurface && !checkInSheetDismissedRef.current;
     setNearbyCheckInOpen(requested);
     if (
       !requested ||
@@ -461,14 +468,19 @@ export function LocationImmersiveMap({
   }, [isCheckInSurface, nearbyCheckInAvailable, router, searchParams]);
 
   const openNearbyCheckIn = useCallback(() => {
-    if (
-      !nearbyCheckInAvailable ||
-      !rendererReady ||
-      demoMode ||
-      // Nothing to open: on the check-in route the flow already is the screen.
-      isCheckInSurface ||
-      searchParams.get("action") === "check-in"
-    ) {
+    if (!nearbyCheckInAvailable || !rendererReady || demoMode) {
+      return;
+    }
+    // Already on the flow's own route: re-opening is a state change, not a
+    // navigation. This is the way back in after a dismiss -- the "Check in"
+    // pill in the top controls renders here too -- and pushing the route onto
+    // itself would only stack a duplicate history entry.
+    if (isCheckInSurface) {
+      checkInSheetDismissedRef.current = false;
+      setNearbyCheckInOpen(true);
+      return;
+    }
+    if (searchParams.get("action") === "check-in") {
       return;
     }
     setTrayExpanded(false);
@@ -487,19 +499,23 @@ export function LocationImmersiveMap({
   ]);
 
   const closeNearbyCheckIn = useCallback(() => {
-    // Dismissing on the dedicated route must leave it. Clearing the flag alone
-    // would strand the person on a bare map that is not Your Map and has none
-    // of its content -- the emptiest possible screen.
+    // Closing a drawer is not a request to leave the screen behind it.
+    //
+    // On its own route dismiss used to navigate -- first to the Location hub
+    // for everyone, then to whichever screen a `?source=` param said had opened
+    // the flow. Both were answering the wrong question. Someone who has just
+    // checked in and swiped the sheet away wants the sheet away; the map they
+    // were standing on, with where they are and the place they picked, is
+    // already the right screen. Sending them anywhere -- especially back to the
+    // Location hub, two screens from the flow they just completed -- reads as
+    // the app throwing them out.
+    //
+    // What is left behind is a real screen, not a bare map: the top controls
+    // still carry the "Check in" pill that re-opens the sheet, the locate
+    // button, and an explicit "Back to Location" X for people who do want out.
     if (isCheckInSurface) {
-      // `replace`, not `push`: check-in is done with, and leaving it on the
-      // stack made the very next Back press re-open the flow just dismissed.
-      // History is not consulted for the destination either -- this app's back
-      // is authored, because the browser stack carries external origins and on
-      // iOS walking it can eject the person out of the app entirely.
-      router.replace(
-        resolveCheckInDismissHref(searchParams.get(CHECK_IN_SOURCE_PARAM)),
-        { scroll: false },
-      );
+      checkInSheetDismissedRef.current = true;
+      setNearbyCheckInOpen(false);
       return;
     }
     setNearbyCheckInOpen(false);
@@ -509,7 +525,7 @@ export function LocationImmersiveMap({
     ) {
       window.history.back();
     }
-  }, [isCheckInSurface, router, searchParams]);
+  }, [isCheckInSurface]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -1553,8 +1569,14 @@ export function LocationImmersiveMap({
     // native, where the map layer/transition could leave the close affordance
     // inert), force a hard navigation to the Location dashboard so the user is
     // never trapped in the full-screen map.
+    //
+    // The escape hatch is armed against the route we are leaving, whichever it
+    // is. Hard-coding Your Map's path silently disarmed it on check-in's own
+    // route -- the one screen where the X is now the primary way out, because
+    // dismissing the sheet deliberately leaves you standing here.
+    const exitingFrom = window.location.pathname;
     window.setTimeout(() => {
-      if (window.location.pathname !== ROUTES.ONE_LOCATION_MAP) return;
+      if (window.location.pathname !== exitingFrom) return;
       window.location.assign(ROUTES.ONE_LOCATION);
     }, 1_200);
   }, [router]);

--- a/hushh-webapp/lib/one-location/__tests__/check-in-navigation.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/check-in-navigation.test.ts
@@ -1,48 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  buildCheckInHrefFromYourMap,
-  resolveCheckInDismissHref,
-} from "@/lib/one-location/check-in-navigation";
-
-/**
- * Nearby check-in has two openers -- Your Map and the Location hub -- and one
- * dismiss control.
- *
- * When check-in moved from a drawer over Your Map to its own route, dismiss was
- * pointed at the Location hub for everyone. That is right for the hub's own
- * "Check in" card and wrong for Your Map: checking in from the map and closing
- * the sheet threw the person two screens back, past the map they were standing
- * on, at the moment they had just made themselves discoverable. These cases
- * exist so a third opener cannot repeat that quietly.
- */
-describe("resolveCheckInDismissHref", () => {
-  it("returns to Your Map when Your Map opened it", () => {
-    expect(resolveCheckInDismissHref("map")).toBe("/one/location/map");
-  });
-
-  it("falls back to the Location hub when no opener is recorded", () => {
-    // The hub's own check-in card records nothing, and neither does a deep
-    // link or a refreshed legacy URL. The hub is where those belong.
-    expect(resolveCheckInDismissHref(null)).toBe("/one/location");
-    expect(resolveCheckInDismissHref(undefined)).toBe("/one/location");
-    expect(resolveCheckInDismissHref("")).toBe("/one/location");
-  });
-
-  it("does not treat a near-miss source as Your Map", () => {
-    // Compared exactly, so a stale or hand-edited param cannot pick the
-    // destination.
-    expect(resolveCheckInDismissHref("Map")).toBe("/one/location");
-    expect(resolveCheckInDismissHref(" map")).toBe("/one/location");
-    expect(resolveCheckInDismissHref("map-view")).toBe("/one/location");
-    expect(resolveCheckInDismissHref("nearby")).toBe("/one/location");
-  });
-});
+import { buildCheckInHrefFromYourMap } from "@/lib/one-location/check-in-navigation";
 
 describe("buildCheckInHrefFromYourMap", () => {
-  it("names the check-in route and records Your Map as the opener", () => {
+  it("names the check-in route directly", () => {
     expect(buildCheckInHrefFromYourMap(new URLSearchParams())).toBe(
-      "/one/location/check-in?source=map",
+      "/one/location/check-in",
     );
   });
 
@@ -51,7 +14,7 @@ describe("buildCheckInHrefFromYourMap", () => {
       new URLSearchParams("demo=people"),
     );
 
-    expect(href).toBe("/one/location/check-in?demo=people&source=map");
+    expect(href).toBe("/one/location/check-in?demo=people");
   });
 
   it("drops a legacy action param instead of carrying it onto the route", () => {
@@ -61,12 +24,12 @@ describe("buildCheckInHrefFromYourMap", () => {
       new URLSearchParams("action=check-in"),
     );
 
-    expect(href).toBe("/one/location/check-in?source=map");
+    expect(href).toBe("/one/location/check-in");
   });
 
-  it("overwrites a stale source rather than inheriting it", () => {
-    const href = buildCheckInHrefFromYourMap(new URLSearchParams("source=sos"));
-
-    expect(href).toBe("/one/location/check-in?source=map");
+  it("leaves no trailing '?' when dropping the only param", () => {
+    expect(
+      buildCheckInHrefFromYourMap(new URLSearchParams("action=check-in")),
+    ).not.toContain("?");
   });
 });

--- a/hushh-webapp/lib/one-location/check-in-navigation.ts
+++ b/hushh-webapp/lib/one-location/check-in-navigation.ts
@@ -1,54 +1,27 @@
 import { ROUTES } from "@/lib/navigation/routes";
 
 /**
- * Where nearby check-in came from, and therefore where dismissing it goes.
+ * The href Your Map opens nearby check-in with, preserving the map's own query.
  *
- * Check-in has two openers -- Your Map and the Location hub -- and one dismiss,
- * so the destination cannot be a constant. The opener is recorded in the URL
- * rather than in state: a refresh, a resumed flow and a live navigation then all
- * dismiss to the same place, which is not true of anything held in memory. This
- * is the same `source` convention the hub's own flows already use to remember
- * who opened them.
- */
-export const CHECK_IN_SOURCE_PARAM = "source";
-export const YOUR_MAP_CHECK_IN_SOURCE = "map";
-
-/**
- * Where dismissing nearby check-in lands.
+ * Your Map could reach check-in through the legacy `?action=check-in` redirect
+ * like everyone else, but that costs two navigations for a screen we own -- a
+ * push onto the map route followed by a replace off it, which on native shows
+ * as a flash and leaves a history entry nobody asked for. Naming the
+ * destination directly is one navigation.
  *
- * Check-in became its own route so it would stop reading as Your Map with a
- * sheet on top. Dismissing had to leave that route, and it was pointed at the
- * Location hub for everyone -- correct for the hub's own "Check in" card, but it
- * threw anyone who opened check-in from Your Map two screens back, past the map
- * they were standing on, at the moment they had just checked in.
- *
- * The hub stays the default: an absent, unknown or spoofed source means the
- * person did not come from Your Map, and the hub is where every other entry
- * point lives. The value is compared exactly for that last reason -- a stale or
- * hand-edited param must not be able to choose the destination.
- */
-export function resolveCheckInDismissHref(
-  source: string | null | undefined,
-): string {
-  return source === YOUR_MAP_CHECK_IN_SOURCE
-    ? ROUTES.ONE_LOCATION_MAP
-    : ROUTES.ONE_LOCATION;
-}
-
-/**
- * The href Your Map opens check-in with, preserving the map's own query.
- *
- * Takes anything that stringifies to a query so the caller can hand over
- * Next's read-only `useSearchParams()` value directly.
+ * Takes anything that stringifies to a query so the caller can hand over Next's
+ * read-only `useSearchParams()` value directly.
  */
 export function buildCheckInHrefFromYourMap(currentQuery: {
   toString(): string;
 }): string {
   const params = new URLSearchParams(currentQuery.toString());
-  // The legacy `?action=check-in` redirect exists for callers we do not own --
-  // old links, notifications, breadcrumbs. Your Map is one we do own, so it
-  // names the destination directly instead of routing through the redirect.
+  // The redirect exists for callers we do not own -- old links, notifications,
+  // breadcrumbs. Carrying its param onto the route it redirects to would leave
+  // the new screen wearing the query the redirect exists to retire.
   params.delete("action");
-  params.set(CHECK_IN_SOURCE_PARAM, YOUR_MAP_CHECK_IN_SOURCE);
-  return `${ROUTES.ONE_LOCATION_CHECK_IN}?${params.toString()}`;
+  const query = params.toString();
+  return query
+    ? `${ROUTES.ONE_LOCATION_CHECK_IN}?${query}`
+    : ROUTES.ONE_LOCATION_CHECK_IN;
 }


### PR DESCRIPTION
# Description

Dismissing the nearby check-in sheet now closes the sheet and nothing else. Closing a drawer is not a request to leave the screen behind it.

**Follow-up to #5116, which did not fix the reported bug.** That PR replaced a constant dismiss destination (the Location hub, for everyone) with one chosen from a `?source=` param — but only Your Map's own check-in pill ever writes that param. Every other entry point reaches check-in through the legacy `?action=check-in` redirect in `location-immersive-map.tsx`, which strips the query and sets no `source`, so dismiss still fell through to the default and still threw the person onto the Location hub:

| Entry point | Writes `source`? | Dismiss landed on |
| --- | --- | --- |
| Location hub "Check in" card | no | `/one/location` |
| Hub `?action=check-in` handler | no | `/one/location` |
| Hub nearby return href | no | `/one/location` |
| Top-shell breadcrumb | no | `/one/location` |
| Sheet's private-share return | no | `/one/location` |
| Your Map's check-in pill | yes | `/one/location/map` |

Reproduced on UAT and production, both of which carry #5116.

Dismiss no longer asks where you came from, so all six rows are fixed by one change rather than each caller needing to be taught to stamp a param. What is left behind is a real screen: your location, the place you picked, the "Check in" pill to re-open, and the explicit "Back to Location" X for anyone who does want out.

Three supporting pieces make that hold:

- **The dismissal is a ref, not URL state.** The route-sync effect re-runs on every fresh `searchParams` object and set the sheet open unconditionally — without the ref a dismiss would last one paint.
- **`openNearbyCheckIn` now works on the check-in route**, toggling state instead of early-returning. Otherwise dismiss would be a one-way door with no way back into the flow.
- **`resolveCheckInDismissHref` and the `source=map` stamp are retired.** They existed only to choose a dismiss destination that no longer exists. `buildCheckInHrefFromYourMap` stays — it still saves Your Map a double navigation through the legacy redirect.

Also arms `closeMap`'s guaranteed-exit fallback against whichever route is being left. It was gated on `pathname !== ROUTES.ONE_LOCATION_MAP`, so it was silently dead on `/one/location/check-in` — the one screen where the X is now the primary way out, precisely because dismissing the sheet leaves you standing there.

Android hardware back keeps drawer semantics: first press closes the sheet, second leaves the map.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
  - `/one/location/check-in` — dismissing the sheet no longer navigates; the map stays. Re-open via the existing "Check in" pill.
  - `/one/location/map` — entry href drops the now-meaningless `?source=map` stamp.

- API / schema / type changes:
  - [x] Listed below:
  - `lib/one-location/check-in-navigation.ts`: removed exports `resolveCheckInDismissHref`, `CHECK_IN_SOURCE_PARAM`, `YOUR_MAP_CHECK_IN_SOURCE`. Internal module added two days ago in #5116; `location-immersive-map.tsx` was its only consumer.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
  - Shared web surface, so iOS and Android inherit the fix from the next native build (Capacitor serves bundled `webDir` assets). No Swift or Kotlin change: the Android hardware-back handler already routes through `closeNearbyCheckIn`/`closeMap` and picks up the new drawer semantics unchanged.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None
  - Navigation-only. No auth, consent, vault, or location data path is touched; the check-in grant flow itself is unchanged.

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below:
  - Client-side navigation only, no migration or persisted state; reverting the commit fully restores prior behaviour. The dismissal ref is per-mount and resets on leaving the route, so a stuck-dismissed sheet cannot survive a navigation. `closeMap`'s hard-navigation escape hatch is now armed on this route rather than disarmed, so the failure mode is strictly better than before.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
  - `cd hushh-webapp && npx vitest run __tests__/components/location-immersive-map.test.tsx` — covers `/one/location/check-in` dismiss for all three entry-query shapes, the re-render case, and re-open from the pill.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` (scoped: 265 tests / 31 files across one-location, breadcrumbs, nearby-check-in, check-in-flow)
  - [x] `cd hushh-webapp && npm run build` — proved by CI, not locally. This authoring checkout is a git worktree whose `node_modules` is a symlink outside the worktree root, which Turbopack rejects before compiling anything (`Symlink [project]/hushh-webapp/node_modules is invalid`). The **Web Core (Next.js)** lane builds from a clean checkout and passed on this head.
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (intentional fixture reset only)
  - [ ] `python scripts/ops/kai-system-audit.py ...`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: it supersedes the dismiss-destination logic added in #5116 (merged), which did not fix the reported bug.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Reachable production attach point: `/one/location/check-in`, live on production since the 2026-08-11 release.
- [x] New tests import and exercise production code — `LocationImmersiveMap` and `buildCheckInHrefFromYourMap` are imported directly.
- [x] New helpers/components/services are wired to an existing route: no new helpers; one existing helper simplified and one export set removed.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [ ] If this is one PR in a stack, the predecessor PR is linked here: not a stack; branched from `main`.
- [ ] If this responds to requested changes: n/a.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — `components/one-location/location-immersive-map.tsx`, `lib/one-location/check-in-navigation.ts`
- [x] **iOS**: not applicable — no plugin surface involved; the fix ships in the shared web bundle.
- [x] **Android**: not applicable — no plugin surface involved; the existing `CapacitorApp` back-button handler needs no change.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) — via component tests; see proof note above.
- [ ] Tested on iOS Simulator/Device — pending the next native build.
- [ ] Tested on Android Emulator/Device — pending the next native build.
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command: no generated files changed.

## 📸 Screenshots / Video

Behaviour is a navigation change with no new visual surface: after dismiss the existing check-in map remains, unchanged, with its existing top controls. Proof is the test suite — `closes the sheet without navigating when opened from …` asserts the sheet reaches `data-open="false"` while `router.push` and `router.replace` are never called.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [ ] If yes, have you implemented `checkConsentToken()`? n/a
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: see Rollback above.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependency changes.
