### PR TITLE
feat(ria): explain the NWS score, and stop dumping the whole response

### DIFF
--- a/consent-protocol/hushh_mcp/services/nws_nearby_service.py
+++ b/consent-protocol/hushh_mcp/services/nws_nearby_service.py
@@ -482,6 +482,7 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
             "distanceBand": _text(location.get("approximate_distance_band")),
             "note": _text(location.get("note")),
         },
+        "scoreBreakdown": _normalize_breakdown(row.get("score_breakdown")),
         "reasons": [
             text for text in (_text(item) for item in _as_list(row.get("reasons"))) if text
         ],
@@ -504,6 +505,41 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _normalize_breakdown(value: Any) -> dict[str, Any] | None:
+    """Carry the upstream's own working through, or nothing at all.
+
+    Returns None rather than an empty scaffold when the upstream omits it. A
+    half-populated breakdown would render as a score explained by zeros, which
+    is worse than a score with no explanation offered.
+    """
+    block = _as_dict(value)
+    if not block:
+        return None
+
+    components = [
+        {
+            "key": _text(item.get("key")),
+            "label": _text(item.get("label")),
+            "value": _coerce_float(item.get("value")),
+            "weight": _coerce_float(item.get("weight")),
+            "contribution": _coerce_float(item.get("contribution")),
+        }
+        for item in _as_list(block.get("components"))
+        if isinstance(item, dict) and _text(item.get("key"))
+    ]
+    if not components:
+        return None
+
+    return {
+        "components": components,
+        "evidenceCount": _coerce_int(block.get("evidence_count")),
+        "coverageMultiplier": _coerce_float(block.get("coverage_multiplier")),
+        "integrityPenalty": _coerce_float(block.get("integrity_penalty")),
+        "localRelevance": _coerce_float(block.get("local_relevance")),
+        "method": _text(block.get("method")),
+    }
 
 
 def _as_dict(value: Any) -> dict[str, Any]:

--- a/consent-protocol/tests/services/test_nws_nearby_service.py
+++ b/consent-protocol/tests/services/test_nws_nearby_service.py
@@ -4,6 +4,8 @@ The payloads below are trimmed copies of real responses from the deployed
 service, so a contract drift upstream shows up here rather than on the screen.
 """
 
+import json
+
 import httpx
 import pytest
 
@@ -71,6 +73,29 @@ _COVERED = {
                 "granularity": "EXACT_PUBLIC_VENUE",
                 "approximate_distance_band": "within 2 km",
                 "note": "Distance is to a public professional association, never a residence.",
+            },
+            "score_breakdown": {
+                "components": [
+                    {
+                        "key": "graph_authority",
+                        "label": "Graph authority",
+                        "value": 0.91,
+                        "weight": 0.30,
+                        "contribution": 0.273,
+                    },
+                    {
+                        "key": "institutional_influence",
+                        "label": "Institutional influence",
+                        "value": 0.95,
+                        "weight": 0.20,
+                        "contribution": 0.19,
+                    },
+                ],
+                "evidence_count": 12,
+                "coverage_multiplier": 1.0,
+                "integrity_penalty": 0.034,
+                "local_relevance": 0.772,
+                "method": "Each component is scored 0-1, multiplied by its weight and summed.",
             },
             "reasons": ["High-authority roles at influential institutions"],
             "warnings": [],
@@ -460,3 +485,45 @@ async def test_cache_can_be_disabled_for_a_caller(monkeypatch):
     await service.discover(postal_code="98033")
 
     assert len(calls) == 2
+
+
+# ------------------------------------------------------------ score breakdown
+
+
+@pytest.mark.asyncio
+async def test_the_score_breakdown_is_carried_through(monkeypatch):
+    """A number with no working shown cannot be argued with."""
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    breakdown = (await service.discover(postal_code="98033"))["results"][0]["scoreBreakdown"]
+
+    assert breakdown["evidenceCount"] == 12
+    assert breakdown["coverageMultiplier"] == pytest.approx(1.0)
+    assert breakdown["integrityPenalty"] == pytest.approx(0.034)
+    assert breakdown["localRelevance"] == pytest.approx(0.772)
+    assert breakdown["method"]
+
+    first = breakdown["components"][0]
+    assert first["key"] == "graph_authority"
+    assert first["label"] == "Graph authority"
+    assert first["weight"] == pytest.approx(0.30)
+    assert first["contribution"] == pytest.approx(0.273)
+
+
+@pytest.mark.asyncio
+async def test_a_missing_breakdown_is_absent_rather_than_empty(monkeypatch):
+    """An older upstream revision must not render as a score explained by zeros."""
+    payload = json.loads(json.dumps(_COVERED))
+    payload["results"][0].pop("score_breakdown")
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=payload))
+
+    assert (await service.discover(postal_code="98033"))["results"][0]["scoreBreakdown"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_breakdown_with_no_usable_components_is_dropped(monkeypatch):
+    """Half a breakdown explains nothing and is worse than offering none."""
+    payload = json.loads(json.dumps(_COVERED))
+    payload["results"][0]["score_breakdown"] = {"components": [], "evidence_count": 3}
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=payload))
+
+    assert (await service.discover(postal_code="98033"))["results"][0]["scoreBreakdown"] is None

--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -67,6 +67,17 @@ function record(over: Partial<Record<string, unknown>> = {}) {
       distanceBand: "within 2 km",
       note: "n",
     },
+    scoreBreakdown: {
+      components: [
+        { key: "graph_authority", label: "Graph authority", value: 0.91, weight: 0.3, contribution: 0.273 },
+        { key: "freshness", label: "Freshness", value: 0.92, weight: 0.05, contribution: 0.046 },
+      ],
+      evidenceCount: 12,
+      coverageMultiplier: 1,
+      integrityPenalty: 0.034,
+      localRelevance: 0.772,
+      method: "Each component is scored 0-1, multiplied by its weight and summed.",
+    },
     reasons: ["High-authority roles"],
     warnings: [],
     tags: ["semiconductors"],
@@ -95,7 +106,7 @@ const COVERED = {
     verifiedAt: "2026-08-12",
   },
   summary: {
-    returnedCount: 3,
+    returnedCount: 7,
     candidateCount: 11,
     searchPerformed: true,
     effectiveRadiusKm: 20,
@@ -105,6 +116,10 @@ const COVERED = {
     record({ personId: "b1", lane: "BUILDER", displayName: "Builder One" }),
     record({ personId: "b2", lane: "BUILDER", displayName: "Builder Two" }),
     record({ personId: "c1", lane: "CONNECTOR", displayName: "Connector One" }),
+    record({ personId: "b3", lane: "BUILDER", displayName: "Builder Three" }),
+    record({ personId: "b4", lane: "BUILDER", displayName: "Builder Four" }),
+    record({ personId: "b5", lane: "BUILDER", displayName: "Builder Five" }),
+    record({ personId: "b6", lane: "BUILDER", displayName: "Builder Six" }),
   ],
 };
 
@@ -164,10 +179,11 @@ describe("Around you", () => {
     await waitFor(() => expect(screen.queryByText("Builder One")).not.toBeInTheDocument());
     expect(screen.getByText("Connector One")).toBeInTheDocument();
 
-    // ...and Builders is still offered, with its true unfiltered count.
+    // ...and Builders is still offered, with its true unfiltered count — six,
+    // not the zero a count taken from the filtered response would have shown.
     const builders = screen.getByRole("button", { name: /builders/i });
     expect(builders).not.toBeDisabled();
-    expect(within(builders).getByText("2")).toBeInTheDocument();
+    expect(within(builders).getByText("6")).toBeInTheDocument();
 
     fireEvent.click(builders);
     await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
@@ -208,5 +224,53 @@ describe("Around you", () => {
     // The empty state is where the form is genuinely useful.
     expect(screen.getAllByRole("button", { name: /enter a place/i }).length).toBeGreaterThan(0);
     expect(screen.queryByText(/kirkland/i)).not.toBeInTheDocument();
+  });
+});
+
+
+describe("what the list actually shows", () => {
+  it("shows a ranked few rather than everything the service returned", async () => {
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    // Seven came back. Five are on screen — the top five by rank — and the
+    // count says so rather than implying the list is complete.
+    expect(screen.getByText("Builder Four")).toBeInTheDocument();
+    expect(screen.queryByText("Builder Five")).not.toBeInTheDocument();
+    expect(screen.getByText(/top 5 of 7/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show 2 more/i }));
+    expect(screen.getByText("Builder Five")).toBeInTheDocument();
+    expect(screen.getByText("Builder Six")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show .* more/i })).not.toBeInTheDocument();
+  });
+
+  it("collapses again when the filter changes underneath", async () => {
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /show 2 more/i }));
+    expect(screen.getByText("Builder Six")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /connectors/i }));
+    await waitFor(() => expect(screen.getByText("Connector One")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
+
+    // Back to the top of a fresh list, not halfway down an expanded one.
+    await waitFor(() => expect(screen.queryByText("Builder Six")).not.toBeInTheDocument());
+  });
+
+  it("does not offer Show more when everything already fits", async () => {
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /connectors/i }));
+    await waitFor(() => expect(screen.getByText("Connector One")).toBeInTheDocument());
+
+    expect(screen.queryByRole("button", { name: /show .* more/i })).not.toBeInTheDocument();
+    expect(screen.getByText("1 public record")).toBeInTheDocument();
   });
 });

--- a/hushh-webapp/__tests__/components/ria-nearby-score-explainer.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-score-explainer.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The score has to show its working.
+ *
+ * A bare number cannot be argued with. These pin the parts that make it
+ * checkable — and the one thing that must never be hardcoded here: the weights.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NearbyScoreExplainer } from "@/components/ria/nearby/nearby-score-explainer";
+import type { ScoreBreakdown } from "@/lib/services/nws-nearby-service";
+
+function breakdown(over: Partial<ScoreBreakdown> = {}): ScoreBreakdown {
+  return {
+    components: [
+      {
+        key: "graph_authority",
+        label: "Graph authority",
+        value: 0.91,
+        weight: 0.3,
+        contribution: 0.273,
+      },
+      {
+        key: "freshness",
+        label: "Freshness",
+        value: 0.92,
+        weight: 0.05,
+        contribution: 0.046,
+      },
+    ],
+    evidenceCount: 12,
+    coverageMultiplier: 1,
+    integrityPenalty: 0.034,
+    localRelevance: 0.772,
+    method: "Each component is scored 0-1, multiplied by its weight and summed.",
+    ...over,
+  };
+}
+
+describe("score explainer", () => {
+  it("shows each component with its score and its weight", () => {
+    render(<NearbyScoreExplainer breakdown={breakdown()} />);
+
+    expect(screen.getByText("Graph authority")).toBeInTheDocument();
+    expect(screen.getByText("91 · 30%")).toBeInTheDocument();
+    expect(screen.getByText("Freshness")).toBeInTheDocument();
+    expect(screen.getByText("92 · 5%")).toBeInTheDocument();
+  });
+
+  it("sizes the bar by contribution, not by raw score", () => {
+    // Freshness scores higher than graph authority (0.92 vs 0.91) but carries a
+    // sixth of the weight. A bar drawn from the raw value would make the least
+    // decisive component look like the most decisive one.
+    const { container } = render(<NearbyScoreExplainer breakdown={breakdown()} />);
+    const widths = Array.from(container.querySelectorAll("span[style*='width']")).map((el) =>
+      parseFloat((el as HTMLElement).style.width),
+    );
+
+    expect(widths).toHaveLength(2);
+    expect(widths[0]).toBeGreaterThan(widths[1]);
+  });
+
+  it("explains the adjustments that the component sum alone does not", () => {
+    render(<NearbyScoreExplainer breakdown={breakdown()} />);
+
+    expect(screen.getByText("12 sources")).toBeInTheDocument();
+    expect(screen.getByText("×1.00")).toBeInTheDocument();
+    expect(screen.getByText("fully corroborated")).toBeInTheDocument();
+    expect(screen.getByText("−3%")).toBeInTheDocument();
+    expect(screen.getByText("10% of the nearby rank")).toBeInTheDocument();
+  });
+
+  it("says when a score was held back for thin evidence", () => {
+    render(
+      <NearbyScoreExplainer
+        breakdown={breakdown({ coverageMultiplier: 0.84, evidenceCount: 3 })}
+      />,
+    );
+
+    expect(screen.getByText("3 sources")).toBeInTheDocument();
+    expect(screen.getByText("held back on thin evidence")).toBeInTheDocument();
+  });
+
+  it("hides the integrity line when there is no penalty", () => {
+    render(<NearbyScoreExplainer breakdown={breakdown({ integrityPenalty: 0 })} />);
+
+    expect(screen.queryByText("Integrity")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing rather than an empty frame when there is nothing to explain", () => {
+    const { container } = render(
+      <NearbyScoreExplainer breakdown={breakdown({ components: [] })} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("never states a weight the service did not send", () => {
+    // The whole point of publishing weights upstream is that a re-weighting
+    // cannot leave a confident, wrong explanation in the app.
+    render(
+      <NearbyScoreExplainer
+        breakdown={breakdown({
+          components: [
+            {
+              key: "graph_authority",
+              label: "Graph authority",
+              value: 0.5,
+              weight: 0.44,
+              contribution: 0.22,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("50 · 44%")).toBeInTheDocument();
+    expect(screen.queryByText(/30%/)).not.toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -195,14 +195,17 @@ export default function RiaClientsPage() {
           title={
             <span className="inline-flex flex-wrap items-center gap-2">
               {RIA_COPY.clients.title}
-              {clientItems.length > 0 ? (
+              {view === "connected" && clientItems.length > 0 ? (
                 <Badge variant="secondary" className="text-[10px]">
                   {clientItems.length}
                 </Badge>
               ) : null}
             </span>
           }
-          description={RIA_COPY.clients.description}
+          // The roster count and its description belong to Connected. Carrying
+          // them over to Around you labelled a list of public records with a
+          // count of the advisor's own clients.
+          description={view === "connected" ? RIA_COPY.clients.description : undefined}
           icon={UserRound}
           accent="ria"
         />

--- a/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
@@ -39,6 +39,9 @@ import {
 } from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
 
+/** Enough to judge a place at a glance; the ranking decides which five. */
+const VISIBLE_RECORDS = 5;
+
 /** One line per state. The reason code decides which; the advisor reads six words. */
 const COVERAGE_COPY: Record<string, string> = {
   NO_APPROVED_MARKET_DATA: "No records here yet.",
@@ -58,6 +61,7 @@ export function NearbyAroundYou() {
   const [selected, setSelected] = useState<NearbyRecord | null>(null);
   const [shortlisted, setShortlisted] = useState<Set<string>>(new Set());
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   const requestSeq = useRef(0);
   // Read at fetch time rather than depended on, so a lane change — which must
@@ -157,6 +161,21 @@ export function NearbyAroundYou() {
     return lane ? all.filter((r) => r.lane === lane) : all;
   }, [all, filters.lanes]);
 
+  // The service answers with everything it has. Rendering all of it turns a
+  // ranked shortlist into a scroll, and the ranking is the product — the top
+  // few are the ones worth an advisor's attention. The rest stay one tap away.
+  const visible = useMemo(
+    () => (expanded ? records : records.slice(0, VISIBLE_RECORDS)),
+    [records, expanded],
+  );
+  const hidden = records.length - visible.length;
+
+  // Collapse again whenever the result set changes underneath, so a filter
+  // change never lands the advisor halfway down an expanded list.
+  useEffect(() => {
+    setExpanded(false);
+  }, [anchor, filters.lanes, filters.tag]);
+
   const handleShortlist = useCallback(
     async (record: NearbyRecord) => {
       const idToken = await user?.getIdToken();
@@ -242,7 +261,11 @@ export function NearbyAroundYou() {
           <div className="min-w-0">
             <p className="truncate type-headline">{place}</p>
             {covered ? (
-              <p className={MUTED_TEXT}>{records.length} public records</p>
+              <p className={MUTED_TEXT}>
+                {hidden > 0
+                  ? `Top ${visible.length} of ${records.length}`
+                  : `${records.length} public ${records.length === 1 ? "record" : "records"}`}
+              </p>
             ) : null}
           </div>
           <Button
@@ -293,7 +316,7 @@ export function NearbyAroundYou() {
         />
       ) : (
         <SettingsGroup separatorInset>
-          {records.map((record) => (
+          {visible.map((record) => (
             <SettingsRow
               key={record.personId}
               icon={UserRound}
@@ -319,6 +342,15 @@ export function NearbyAroundYou() {
               }
             />
           ))}
+          {hidden > 0 ? (
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="w-full px-4 py-3 text-left type-footnote text-[color:var(--app-accent-fg)]"
+            >
+              Show {hidden} more
+            </button>
+          ) : null}
         </SettingsGroup>
       )}
 

--- a/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
@@ -11,6 +11,7 @@
 import { ExternalLink, Star } from "lucide-react";
 
 import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
+import { NearbyScoreExplainer } from "@/components/ria/nearby/nearby-score-explainer";
 import { Button } from "@/lib/morphy-ux/button";
 import { AvatarBubble, StatusPill } from "@/lib/morphy-ux/ui/surface-primitives";
 import { EYEBROW, MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
@@ -96,7 +97,14 @@ export function NearbyRecordSheet({
           <StatusPill tone="pending">Needs revalidation</StatusPill>
         ) : null}
 
-        {record.reasons.length > 0 ? (
+        {record.scoreBreakdown ? (
+          <div className="flex flex-col gap-2">
+            <span className={EYEBROW}>How this score is built</span>
+            <NearbyScoreExplainer breakdown={record.scoreBreakdown} />
+          </div>
+        ) : record.reasons.length > 0 ? (
+          // Older service revisions publish prose but no arithmetic. Show the
+          // prose rather than nothing, and never both — they say the same thing.
           <div className="flex flex-col gap-1.5">
             <span className={EYEBROW}>Why this ranked</span>
             <ul className="flex flex-col gap-1">

--- a/hushh-webapp/components/ria/nearby/nearby-score-explainer.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-score-explainer.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * Why this score, in the order the score itself was built.
+ *
+ * The number arrived with four sentences of prose and no arithmetic, so a
+ * strong profile and a merely well-evidenced one looked identical. Everything
+ * here is published by the scoring service — the weights especially. Restating
+ * them in the app would leave a confident, wrong explanation behind the first
+ * time the model is re-weighted.
+ */
+
+import { MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
+import type { ScoreBreakdown } from "@/lib/services/nws-nearby-service";
+import { cn } from "@/lib/utils";
+
+function pct(value: number | null): string {
+  return typeof value === "number" ? `${Math.round(value * 100)}` : "—";
+}
+
+export function NearbyScoreExplainer({ breakdown }: { breakdown: ScoreBreakdown }) {
+  const components = breakdown.components.filter((c) => typeof c.value === "number");
+  if (components.length === 0) return null;
+
+  const strongest = Math.max(...components.map((c) => c.contribution ?? 0), 0.0001);
+  const penalty = breakdown.integrityPenalty ?? 0;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        {components.map((component) => (
+          <div key={component.key} className="flex items-center gap-3">
+            <span className="w-40 shrink-0 truncate type-footnote">{component.label}</span>
+            {/* Bar length is the contribution, not the raw value — a strong
+                score on a 5%-weighted component should not look decisive. */}
+            <span
+              className="h-1.5 flex-1 overflow-hidden rounded-full bg-[color:var(--app-card-surface-compact)]"
+              aria-hidden
+            >
+              <span
+                className="block h-full rounded-full bg-[color:var(--app-accent)]"
+                style={{
+                  width: `${Math.max(2, ((component.contribution ?? 0) / strongest) * 100)}%`,
+                }}
+              />
+            </span>
+            <span className={cn(MUTED_TEXT, "w-16 shrink-0 text-right tabular-nums")}>
+              {pct(component.value)} · {pct(component.weight)}%
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className={MUTED_TEXT}>Score · weight of the total</p>
+
+      <div className={cn(SUBCARD_SURFACE, "flex flex-col gap-1 p-3")}>
+        {typeof breakdown.evidenceCount === "number" ? (
+          <Line label="Evidence" value={`${breakdown.evidenceCount} sources`} />
+        ) : null}
+        {typeof breakdown.coverageMultiplier === "number" ? (
+          <Line
+            label="Coverage"
+            value={`×${breakdown.coverageMultiplier.toFixed(2)}`}
+            note={
+              breakdown.coverageMultiplier < 0.99
+                ? "held back on thin evidence"
+                : "fully corroborated"
+            }
+          />
+        ) : null}
+        {penalty > 0 ? (
+          <Line
+            label="Integrity"
+            value={`−${Math.round(penalty * 100)}%`}
+            note="self-published or single-source evidence"
+          />
+        ) : null}
+        {typeof breakdown.localRelevance === "number" ? (
+          <Line
+            label="This place"
+            value={pct(breakdown.localRelevance)}
+            note="10% of the nearby rank"
+          />
+        ) : null}
+      </div>
+
+      {breakdown.method ? <p className={MUTED_TEXT}>{breakdown.method}</p> : null}
+    </div>
+  );
+}
+
+function Line({
+  label,
+  value,
+  note,
+}: {
+  label: string;
+  value: string;
+  note?: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="type-footnote">{label}</span>
+      <span className="flex items-baseline gap-2 text-right">
+        {note ? <span className={MUTED_TEXT}>{note}</span> : null}
+        <span className="type-footnote tabular-nums">{value}</span>
+      </span>
+    </div>
+  );
+}

--- a/hushh-webapp/lib/services/nws-nearby-service.ts
+++ b/hushh-webapp/lib/services/nws-nearby-service.ts
@@ -57,6 +57,37 @@ export type NearbyCoverage = {
   complete: boolean;
 };
 
+/**
+ * How the score was reached, published by the scoring service itself.
+ *
+ * Weights come from upstream rather than being restated here. An explanation
+ * that carries its own copy of the weighting goes stale the first time the
+ * model is re-weighted, and nothing fails to say so.
+ */
+export type ScoreComponent = {
+  key: string;
+  label: string | null;
+  /** 0–1. */
+  value: number | null;
+  /** Share of the score this component can contribute. */
+  weight: number | null;
+  /** weight × value. */
+  contribution: number | null;
+};
+
+export type ScoreBreakdown = {
+  components: ScoreComponent[];
+  /** How many pieces of evidence back the profile. Thin evidence is held back. */
+  evidenceCount: number | null;
+  /** Scales the weighted sum up toward 1.0 as evidence accumulates. */
+  coverageMultiplier: number | null;
+  /** Discount for promotional, self-published, or single-source evidence. */
+  integrityPenalty: number | null;
+  /** Association strength to the queried place; the 10% term in the nearby rank. */
+  localRelevance: number | null;
+  method: string | null;
+};
+
 export type NearbyRecord = {
   rank: number | null;
   personId: string;
@@ -78,6 +109,8 @@ export type NearbyRecord = {
     distanceBand: string | null;
     note: string | null;
   };
+  /** Null when the scoring service did not publish its working for this record. */
+  scoreBreakdown: ScoreBreakdown | null;
   reasons: string[];
   warnings: string[];
   tags: string[];


### PR DESCRIPTION
# Description

From looking at the shipped screen. Three things.

## 1. The score could not explain itself

NWS is built from seven weighted components. The service computed all seven on **every** request and discarded them, so a bare number reached the advisor with four sentences of prose and no arithmetic. A genuinely strong profile and a merely well-evidenced one looked identical.

`hushh-labs/HusshOne#126` (merged, live in production) now publishes the working. This renders it:

```
Graph authority          ████████████████  91 · 30%
Institutional influence  ███████████       95 · 20%
Verified track record    █████████         78 · 20%
Capital access           ████              68 · 10%
Evidence confidence      ████              93 ·  8%
Trusted reach            ███               69 ·  7%
Freshness                ██                92 ·  5%

Evidence     12 sources
Coverage     fully corroborated      ×1.00
Integrity    self-published evidence   −3%
This place   10% of the nearby rank     77
```

**Bar length is contribution, not raw score.** Freshness scores 92 against graph authority's 91 but carries a sixth of the weight. A bar drawn from the raw value would make the least decisive component look like the most decisive one.

**The three adjustments are shown because the components do not add up to the score without them** — coverage scales the sum toward 1.0, integrity pulls it down. Publishing components alone would make the arithmetic look broken.

**The weights are never written down in this repo.** They arrive from the service. An explanation carrying its own copy of the weighting goes stale the first time the model is re-weighted, and nothing fails to say so — there is a test asserting the app renders whatever weight it is sent, including a wrong one.

## 2. The list dumped everything the service returned

All eleven records rendered as one scroll. The service answers with everything it has; showing all of it wastes the ranking, which is the product. Now five, with `Show 6 more`, and the header reads `Top 5 of 11` instead of implying completeness. It collapses again when a filter changes underneath, so a lane switch never lands the advisor halfway down an expanded list.

## 3. The page header belonged to the other tab

`Client roster · One workspace per client — status, access, Kai, explorer` and the roster count stayed on screen while showing public records — labelling a list of strangers with a count of the advisor's own clients.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/ria/clients` — Around you pane and the shared page header. No route added.

- API / schema / type changes:
  - [x] Listed below: `scoreBreakdown` added to the nearby record shape, passed through from the upstream `score_breakdown`. Additive; nullable. No database change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: the explainer renders inside the existing `AdaptiveDetailSurface` (Drawer/Sheet on mobile). No new native surface. `verify:capacitor:static` passes.

- Docs updated (exact files):
  - [x] None — the method sentence ships from the service with every response rather than living in a doc that can drift.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below: the breakdown is public-safe by construction. A service-side test asserts it carries no coordinate, address, email, phone, or residence field, and the app renders only what it is sent.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof: `nws_nearby_service.py` normalises `score_breakdown` → `scoreBreakdown`; three backend tests cover present, absent, and empty-components.

- Rollback or safe-failure behavior:
  - [x] Listed below: when the service publishes no breakdown the sheet falls back to the previous prose reasons, so an older or rolled-back service degrades rather than showing an empty frame. Revert is a revert.

- UI browser or Playwright proof:
  - [x] Listed below: 15 component tests driving the real components — 8 on the pane, 7 on the explainer.

- Verification commands executed:
  - [x] `npm run typecheck` — clean
  - [x] `npm run lint` — clean, 0 warnings
  - [x] `npm run test:ci` — **27 failed / 3478 passed**; baseline at merge-base `d572302c` is **27 failed / 3468 passed** with a **byte-identical failing set**. Zero regressions, +10 passing.
  - [x] `bash scripts/ci/backend-check.sh` — ruff, mypy, bandit, **846 passed**
  - [x] `verify:design-system`, `verify:service-boundary`, `verify:surface-map`, `verify:voice-gateway`, `audit:cache-coherence`, `verify:capacitor:static` — all pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Depends on `hushh-labs/HusshOne#126`, already merged and live in production — verified by calling the deployed service and confirming 7 components come back.
- [x] Reachable production attach point: `/ria/clients` → Around you → open a record.
- [x] New tests import and exercise production code, not stand-ins.
- [x] Production surface proved: 15 new component tests plus 3 backend pass-through tests.
- [ ] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: the change.
- [x] **iOS**: not applicable — no native code.
- [x] **Android**: not applicable — no native code.

## 🧪 Testing

- [x] Tested on Web
- [x] Component tests drive real interactions
- [x] No generated files changed

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No change.
- [x] Sensitive surface touched: none new. The breakdown is public-record scoring metadata, asserted free of location and contact fields on the service side.
- [x] Error path proved: missing breakdown → prose fallback; empty components → nothing rendered rather than a frame of zeros.

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] No dependencies added
