### PR TITLE
feat(ria): consume the reviewed 98033 release — evidence quality, and no dead filters

### DIFF
--- a/consent-protocol/hushh_mcp/services/nws_nearby_service.py
+++ b/consent-protocol/hushh_mcp/services/nws_nearby_service.py
@@ -491,11 +491,21 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
         ],
         "tags": [text for text in (_text(item) for item in _as_list(row.get("tags"))) if text],
         "revalidationRequired": bool(row.get("revalidation_required")),
+        "evidence": _normalize_evidence(row.get("evidence")),
         "sources": [
             {
                 "publisher": _text(item.get("publisher")),
                 "title": _text(item.get("title")),
                 "url": _text(item.get("url")),
+                # What this citation actually establishes — identity, current
+                # role, organization identity, public association. An advisor
+                # doing diligence needs to know which claim a link supports.
+                "factTypes": [
+                    text
+                    for text in (_text(fact) for fact in _as_list(item.get("fact_types")))
+                    if text
+                ],
+                "retrievedAt": _text(item.get("retrieved_at")),
             }
             for item in sources
         ],
@@ -505,6 +515,29 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _normalize_evidence(value: Any) -> dict[str, Any] | None:
+    """How well-sourced a record is, as the reviewed release reports it.
+
+    This is the diligence signal. Two links from the same organization are not
+    two independent confirmations, and the release says so per record rather
+    than leaving a reader to count publishers by eye.
+    """
+    block = _as_dict(value)
+    if not block:
+        return None
+
+    return {
+        "citationCount": _coerce_int(block.get("citation_count")),
+        # Distinct publishing organizations behind the citations.
+        "sourceFamilyCount": _coerce_int(block.get("source_family_count")),
+        "factCount": _coerce_int(block.get("evidence_fact_count")),
+        "independentSourceFamilies": bool(block.get("independent_source_families")),
+        "reviewFlags": [
+            text for text in (_text(flag) for flag in _as_list(block.get("review_flags"))) if text
+        ],
+    }
 
 
 def _normalize_breakdown(value: Any) -> dict[str, Any] | None:

--- a/consent-protocol/tests/services/test_nws_nearby_service.py
+++ b/consent-protocol/tests/services/test_nws_nearby_service.py
@@ -101,11 +101,20 @@ _COVERED = {
             "warnings": [],
             "tags": ["semiconductors", "founder", "board"],
             "revalidation_required": False,
+            "evidence": {
+                "citation_count": 2,
+                "source_family_count": 1,
+                "evidence_fact_count": 4,
+                "independent_source_families": False,
+                "review_flags": ["SINGLE_SOURCE_FAMILY"],
+            },
             "sources": [
                 {
                     "publisher": "Monolithic Power Systems",
                     "title": "Management",
                     "url": "https://www.monolithicpower.com/management",
+                    "fact_types": ["identity", "current_role"],
+                    "retrieved_at": "2026-08-13",
                 }
             ],
             "model_version": "nws-v2.2.0-bootstrap.2026-08-12",
@@ -527,3 +536,47 @@ async def test_a_breakdown_with_no_usable_components_is_dropped(monkeypatch):
     service = _service(monkeypatch, lambda request: httpx.Response(200, json=payload))
 
     assert (await service.discover(postal_code="98033"))["results"][0]["scoreBreakdown"] is None
+
+
+# ------------------------------------------------------- reviewed release v2
+
+
+@pytest.mark.asyncio
+async def test_evidence_quality_is_carried_through(monkeypatch):
+    """Two links from one organisation are not two confirmations.
+
+    The reviewed release reports that per record, and it is the difference
+    between a claim an advisor can act on and one they should check first.
+    """
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    evidence = (await service.discover(postal_code="98033"))["results"][0]["evidence"]
+
+    assert evidence["citationCount"] == 2
+    assert evidence["sourceFamilyCount"] == 1
+    assert evidence["factCount"] == 4
+    assert evidence["independentSourceFamilies"] is False
+    assert evidence["reviewFlags"] == ["SINGLE_SOURCE_FAMILY"]
+
+
+@pytest.mark.asyncio
+async def test_each_citation_says_what_it_proves(monkeypatch):
+    """An advisor doing diligence needs to know which claim a link supports."""
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    source = (await service.discover(postal_code="98033"))["results"][0]["sources"][0]
+
+    assert source["factTypes"] == ["identity", "current_role"]
+    assert source["retrievedAt"] == "2026-08-13"
+
+
+@pytest.mark.asyncio
+async def test_a_service_without_the_reviewed_release_still_works(monkeypatch):
+    """An older revision publishes no evidence block; the app degrades, not breaks."""
+    payload = json.loads(json.dumps(_COVERED))
+    payload["results"][0].pop("evidence")
+    payload["results"][0]["sources"][0].pop("fact_types")
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=payload))
+
+    record = (await service.discover(postal_code="98033"))["results"][0]
+    assert record["evidence"] is None
+    assert record["sources"][0]["factTypes"] == []
+    assert record["sources"][0]["url"]

--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -59,7 +59,7 @@ function record(over: Partial<Record<string, unknown>> = {}) {
     globalNws: 83.4,
     nearbyRankScore: 83.4,
     scoreStatus: "PROVISIONAL",
-    confidence: { score: 0.93, grade: "A" },
+    confidence: { score: 0.78, grade: "B" },
     publicLocation: {
       label: "MPS public Kirkland office",
       associationKind: "CURRENT_ORGANIZATION_OFFICE",
@@ -78,11 +78,26 @@ function record(over: Partial<Record<string, unknown>> = {}) {
       localRelevance: 0.772,
       method: "Each component is scored 0-1, multiplied by its weight and summed.",
     },
+    evidence: {
+      citationCount: 2,
+      sourceFamilyCount: 1,
+      factCount: 4,
+      independentSourceFamilies: false,
+      reviewFlags: ["SINGLE_SOURCE_FAMILY"],
+    },
     reasons: ["High-authority roles"],
     warnings: [],
     tags: ["semiconductors"],
     revalidationRequired: false,
-    sources: [{ publisher: "MPS", title: "Management", url: "https://x.test" }],
+    sources: [
+      {
+        publisher: "MPS",
+        title: "Management",
+        url: "https://x.test",
+        factTypes: ["identity", "current_role"],
+        retrievedAt: "2026-08-13",
+      },
+    ],
     modelVersion: "m",
     ...over,
   };
@@ -272,5 +287,29 @@ describe("what the list actually shows", () => {
 
     expect(screen.queryByRole("button", { name: /show .* more/i })).not.toBeInTheDocument();
     expect(screen.getByText("1 public record")).toBeInTheDocument();
+  });
+});
+
+
+describe("filters only offer what exists", () => {
+  it("hides a confidence grade with no records behind it", async () => {
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    // One "All" before opening: the lane chip.
+    expect(screen.getAllByRole("button", { name: /^All$/ })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /more filters/i }));
+
+    // The reviewed release grades every record B. Offering A would return an
+    // empty screen — the same dead-option trap the empty lane chips had.
+    expect(screen.getByRole("button", { name: /^B$/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^A$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^C$/ })).not.toBeInTheDocument();
+
+    // Two now: the lane chip plus the confidence "All", which always stands
+    // because it can never come back empty.
+    expect(screen.getAllByRole("button", { name: /^All$/ })).toHaveLength(2);
   });
 });

--- a/hushh-webapp/__tests__/components/ria-nearby-evidence-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-evidence-panel.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * The reviewed release attaches a note to every record it publishes: limited
+ * coverage on all sixty, single source family on fifty-five. These pin the
+ * reframing — that is a property of a careful first release, not a fault, and
+ * an alarm on every profile teaches an advisor to ignore all of them.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NearbyEvidencePanel } from "@/components/ria/nearby/nearby-evidence-panel";
+import type { NearbyEvidence } from "@/lib/services/nws-nearby-service";
+
+function evidence(over: Partial<NearbyEvidence> = {}): NearbyEvidence {
+  return {
+    citationCount: 2,
+    sourceFamilyCount: 1,
+    factCount: 4,
+    independentSourceFamilies: false,
+    reviewFlags: ["SINGLE_SOURCE_FAMILY"],
+    ...over,
+  };
+}
+
+const RELEASE_WARNINGS = [
+  "Limited evidence coverage; score is conservative.",
+  "Most evidence comes from one source family.",
+];
+
+describe("evidence panel", () => {
+  it("states how much evidence stands behind the record", () => {
+    render(<NearbyEvidencePanel evidence={evidence()} warnings={[]} />);
+
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("reviewed facts")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("citations")).toBeInTheDocument();
+    expect(screen.getByText("organisation")).toBeInTheDocument();
+  });
+
+  it("says plainly when nothing independent has confirmed the record", () => {
+    // Two links from one organisation are not two confirmations. This is the
+    // difference between a claim to act on and one to check first.
+    render(<NearbyEvidencePanel evidence={evidence()} warnings={[]} />);
+
+    expect(
+      screen.getByText("Not yet confirmed by a second organisation"),
+    ).toBeInTheDocument();
+  });
+
+  it("credits a record that independent organisations do confirm", () => {
+    render(
+      <NearbyEvidencePanel
+        evidence={evidence({
+          independentSourceFamilies: true,
+          sourceFamilyCount: 2,
+          reviewFlags: [],
+        })}
+        warnings={[]}
+      />,
+    );
+
+    expect(screen.getByText("Confirmed by independent organisations")).toBeInTheDocument();
+    expect(screen.getByText("organisations")).toBeInTheDocument();
+  });
+
+  it("does not render release notes as errors", () => {
+    const { container } = render(
+      <NearbyEvidencePanel evidence={evidence()} warnings={RELEASE_WARNINGS} />,
+    );
+
+    // Sixty of sixty records carry these. Red on all of them is alarm fatigue.
+    expect(container.querySelector(".text-destructive")).toBeNull();
+  });
+
+  it("shows a flag instead of the warning that repeats it", () => {
+    render(<NearbyEvidencePanel evidence={evidence()} warnings={RELEASE_WARNINGS} />);
+
+    expect(screen.getByText("All citations come from one organisation")).toBeInTheDocument();
+    // The flag already said it; saying it twice is noise.
+    expect(
+      screen.queryByText("Most evidence comes from one source family."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the warning text when the release raised no flag", () => {
+    render(<NearbyEvidencePanel evidence={evidence({ reviewFlags: [] })} warnings={RELEASE_WARNINGS} />);
+
+    expect(
+      screen.getByText("Limited evidence coverage; score is conservative."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an unmapped flag readably rather than as a constant", () => {
+    render(
+      <NearbyEvidencePanel
+        evidence={evidence({ reviewFlags: ["SOME_FUTURE_FLAG"] })}
+        warnings={[]}
+      />,
+    );
+
+    expect(screen.getByText("some future flag")).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
@@ -29,6 +29,7 @@ import { MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
 import {
   DEFAULT_NEARBY_FILTERS,
   NwsNearbyService,
+  availableGrades,
   availableTags,
   formatScore,
   laneCounts as computeLaneCounts,
@@ -156,6 +157,7 @@ export function NearbyAroundYou() {
   const all = useMemo(() => result?.results ?? [], [result?.results]);
   const laneCounts = useMemo(() => computeLaneCounts(all), [all]);
   const tags = useMemo(() => availableTags(all), [all]);
+  const grades = useMemo(() => availableGrades(all), [all]);
   const records = useMemo(() => {
     const lane = filters.lanes[0];
     return lane ? all.filter((r) => r.lane === lane) : all;
@@ -286,6 +288,7 @@ export function NearbyAroundYou() {
               onChange={setFilters}
               laneCounts={laneCounts}
               tags={tags}
+              grades={grades}
               disabled={loading}
             />
           </div>

--- a/hushh-webapp/components/ria/nearby/nearby-evidence-panel.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-evidence-panel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * How well-sourced this record is — the diligence signal, stated once.
+ *
+ * The reviewed release attaches a "warning" to every record it publishes:
+ * limited coverage on all sixty, single source family on fifty-five. Rendering
+ * those as red errors would put an alarm on every profile and teach an advisor
+ * to ignore all of them, including the one that matters. They are a property of
+ * a careful first release, not a fault, so they read as evidence quality.
+ *
+ * The one distinction worth keeping loud is independence: two links from the
+ * same organisation are not two confirmations, and that is the difference
+ * between a claim to act on and one to check first.
+ */
+
+import { CheckCircle2, Info } from "lucide-react";
+
+import { StatusPill } from "@/lib/morphy-ux/ui/surface-primitives";
+import { EYEBROW, MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
+import type { NearbyEvidence } from "@/lib/services/nws-nearby-service";
+import { cn } from "@/lib/utils";
+
+/** Flags the release raises. Anything unmapped falls back to its own wording. */
+const FLAG_COPY: Record<string, string> = {
+  SINGLE_SOURCE_FAMILY: "All citations come from one organisation",
+  ROLE_REFRESH_REQUIRED: "Role claim is due a refresh",
+};
+
+function flagLabel(flag: string): string {
+  return FLAG_COPY[flag] ?? flag.replace(/_/g, " ").toLowerCase();
+}
+
+export function NearbyEvidencePanel({
+  evidence,
+  warnings,
+}: {
+  evidence: NearbyEvidence;
+  warnings: string[];
+}) {
+  const { citationCount, sourceFamilyCount, factCount, independentSourceFamilies } = evidence;
+  const independent = independentSourceFamilies;
+
+  // The flags already say what the warnings say, in fewer words. Show the
+  // warnings only when the release raised no flag to explain itself.
+  const notes = evidence.reviewFlags.length > 0 ? [] : warnings;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className={EYEBROW}>Evidence</span>
+
+      <div className={cn(SUBCARD_SURFACE, "flex flex-col gap-2 p-3")}>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {typeof factCount === "number" ? (
+            <Stat value={factCount} label="reviewed facts" />
+          ) : null}
+          {typeof citationCount === "number" ? (
+            <Stat value={citationCount} label={citationCount === 1 ? "citation" : "citations"} />
+          ) : null}
+          {typeof sourceFamilyCount === "number" ? (
+            <Stat
+              value={sourceFamilyCount}
+              label={sourceFamilyCount === 1 ? "organisation" : "organisations"}
+            />
+          ) : null}
+        </div>
+
+        <div className="flex items-start gap-1.5">
+          {independent ? (
+            <CheckCircle2
+              className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[color:var(--app-accent-fg)]"
+              aria-hidden
+            />
+          ) : (
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          )}
+          <span className="type-footnote">
+            {independent
+              ? "Confirmed by independent organisations"
+              : "Not yet confirmed by a second organisation"}
+          </span>
+        </div>
+      </div>
+
+      {evidence.reviewFlags.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {evidence.reviewFlags.map((flag) => (
+            <StatusPill key={flag} tone="pending">
+              {flagLabel(flag)}
+            </StatusPill>
+          ))}
+        </div>
+      ) : null}
+
+      {notes.map((note) => (
+        <p key={note} className={MUTED_TEXT}>
+          {note}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function Stat({ value, label }: { value: number; label: string }) {
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="type-headline tabular-nums">{value}</span>
+      <span className={MUTED_TEXT}>{label}</span>
+    </span>
+  );
+}

--- a/hushh-webapp/components/ria/nearby/nearby-filters.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-filters.tsx
@@ -30,12 +30,15 @@ export function NearbyFilterBar({
   onChange,
   laneCounts,
   tags,
+  grades,
   disabled = false,
 }: {
   filters: NearbyFilters;
   onChange: (next: NearbyFilters) => void;
   laneCounts: Record<NearbyLane, number>;
   tags: string[];
+  /** Grades present in the current results. See the confidence control below. */
+  grades: Set<ConfidenceGrade>;
   disabled?: boolean;
 }) {
   const [more, setMore] = useState(false);
@@ -112,6 +115,10 @@ export function NearbyFilterBar({
                 label: `${km} km`,
               }))}
             />
+            {/* Only grades with records behind them. The reviewed release
+                grades every record B, so offering A would return an empty
+                screen — the same dead-option trap the empty lane chips had.
+                "All" always stands, because it can never come back empty. */}
             <SegmentedTabs
               value={filters.minimumConfidenceGrade}
               disabled={disabled}
@@ -119,9 +126,9 @@ export function NearbyFilterBar({
                 onChange({ ...filters, minimumConfidenceGrade: v as ConfidenceGrade })
               }
               options={[
-                { value: "A", label: "A" },
-                { value: "B", label: "B" },
-                { value: "C", label: "C" },
+                ...(["A", "B", "C"] as const)
+                  .filter((grade) => grades.has(grade))
+                  .map((grade) => ({ value: grade, label: grade })),
                 { value: "D", label: "All" },
               ]}
             />

--- a/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
@@ -11,11 +11,12 @@
 import { ExternalLink, Star } from "lucide-react";
 
 import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
+import { NearbyEvidencePanel } from "@/components/ria/nearby/nearby-evidence-panel";
 import { NearbyScoreExplainer } from "@/components/ria/nearby/nearby-score-explainer";
 import { Button } from "@/lib/morphy-ux/button";
 import { AvatarBubble, StatusPill } from "@/lib/morphy-ux/ui/surface-primitives";
 import { EYEBROW, MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
-import { formatScore, type NearbyRecord } from "@/lib/services/nws-nearby-service";
+import { factTypeLabel, formatScore, type NearbyRecord } from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
 
 function initialsOf(name: string | null): string {
@@ -93,10 +94,6 @@ export function NearbyRecordSheet({
           </p>
         ) : null}
 
-        {record.revalidationRequired ? (
-          <StatusPill tone="pending">Needs revalidation</StatusPill>
-        ) : null}
-
         {record.scoreBreakdown ? (
           <div className="flex flex-col gap-2">
             <span className={EYEBROW}>How this score is built</span>
@@ -117,10 +114,12 @@ export function NearbyRecordSheet({
           </div>
         ) : null}
 
-        {record.warnings.length > 0 ? (
+        {record.evidence ? (
+          <NearbyEvidencePanel evidence={record.evidence} warnings={record.warnings} />
+        ) : record.warnings.length > 0 ? (
           <ul className="flex flex-col gap-1">
             {record.warnings.map((warning) => (
-              <li key={warning} className="type-footnote text-destructive">
+              <li key={warning} className={MUTED_TEXT}>
                 {warning}
               </li>
             ))}
@@ -141,16 +140,23 @@ export function NearbyRecordSheet({
           <div className="flex flex-col gap-1.5">
             <span className={EYEBROW}>Sources</span>
             {record.sources.map((source) => (
-              <a
-                key={`${source.url}-${source.title}`}
-                href={source.url ?? "#"}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="type-footnote inline-flex items-center gap-1.5 text-[color:var(--app-accent-fg)] underline-offset-4 hover:underline"
-              >
-                <span>{source.title || source.publisher}</span>
-                <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
-              </a>
+              <div key={`${source.url}-${source.title}`} className="flex flex-col gap-0.5">
+                <a
+                  href={source.url ?? "#"}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="type-footnote inline-flex items-center gap-1.5 text-[color:var(--app-accent-fg)] underline-offset-4 hover:underline"
+                >
+                  <span>{source.title || source.publisher}</span>
+                  <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
+                </a>
+                {source.factTypes.length > 0 ? (
+                  <span className={MUTED_TEXT}>
+                    {source.publisher ? `${source.publisher} · ` : ""}
+                    Proves {source.factTypes.map(factTypeLabel).join(", ").toLowerCase()}
+                  </span>
+                ) : null}
+              </div>
             ))}
           </div>
         ) : null}

--- a/hushh-webapp/lib/services/nws-nearby-service.ts
+++ b/hushh-webapp/lib/services/nws-nearby-service.ts
@@ -88,6 +88,31 @@ export type ScoreBreakdown = {
   method: string | null;
 };
 
+/**
+ * How well-sourced a record is, from the reviewed release.
+ *
+ * Two links from the same organisation are not two independent confirmations.
+ * The release reports that per record, which is the difference between a claim
+ * an advisor can act on and one they should check first.
+ */
+export type NearbyEvidence = {
+  citationCount: number | null;
+  /** Distinct publishing organisations behind those citations. */
+  sourceFamilyCount: number | null;
+  factCount: number | null;
+  independentSourceFamilies: boolean;
+  reviewFlags: string[];
+};
+
+export type NearbySource = {
+  publisher: string | null;
+  title: string | null;
+  url: string | null;
+  /** What this citation establishes: identity, current role, association. */
+  factTypes: string[];
+  retrievedAt: string | null;
+};
+
 export type NearbyRecord = {
   rank: number | null;
   personId: string;
@@ -115,7 +140,9 @@ export type NearbyRecord = {
   warnings: string[];
   tags: string[];
   revalidationRequired: boolean;
-  sources: { publisher: string | null; title: string | null; url: string | null }[];
+  /** Null on a service revision that predates the reviewed release. */
+  evidence: NearbyEvidence | null;
+  sources: NearbySource[];
   modelVersion: string | null;
 };
 
@@ -328,6 +355,30 @@ export function availableTags(records: NearbyRecord[]): string[] {
     for (const tag of record.tags) seen.add(tag);
   }
   return [...seen].sort();
+}
+
+/** Plain names for what a citation proves. */
+export const FACT_TYPE_LABELS: Record<string, string> = {
+  identity: "Identity",
+  current_role: "Current role",
+  organization_identity: "Organisation",
+  public_association: "Association",
+};
+
+export function factTypeLabel(key: string): string {
+  return FACT_TYPE_LABELS[key] ?? key.replace(/_/g, " ");
+}
+
+/** Confidence grades that actually have records behind them.
+ *
+ * The reviewed release grades every record B, so offering A returns an empty
+ * screen — the same dead-option trap the empty lane chips had. */
+export function availableGrades(records: NearbyRecord[]): Set<ConfidenceGrade> {
+  const grades = new Set<ConfidenceGrade>();
+  for (const record of records) {
+    if (record.confidence.grade) grades.add(record.confidence.grade);
+  }
+  return grades;
 }
 
 /** Score to one decimal. The approved range spans ~16 points, so a bar would be noise. */


### PR DESCRIPTION
# Description

The service moved from 11 hard-coded seeds to a versioned 60-record reviewed release ([HusshOne #127](https://github.com/hushh-labs/HusshOne/pull/127), live: `v2.4.0`, `REVIEWED_PUBLIC_ASSOCIATION_RELEASE`). I probed the deployed API before touching anything. Three things in the app were calibrated on the old shape and are now wrong.

## 1. Every record now carries a "warning", and they were red

The reviewed release attaches a note to **every** record it publishes:

| Note | Records |
| --- | ---: |
| Limited evidence coverage; score is conservative | 60 / 60 |
| Most evidence comes from one source family | 55 / 60 |
| A role claim requires an earlier revalidation | 1 / 60 |

Rendering those as red errors puts an alarm on every profile, which teaches an advisor to ignore all of them — including the one that matters. They are a property of a careful first release, not a fault.

They now read as **evidence quality**: reviewed facts, citations, distinct organisations, and one line stating whether anything independent has confirmed the record.

**That last line is the point.** Two links from the same organisation are not two confirmations, and 55 of 60 records are in exactly that position (`independent_source_families: false`). It is the difference between a claim an advisor can act on and one they should check first, so it is stated plainly rather than left to be inferred by counting publishers.

## 2. "Needs revalidation" went from 1 record to 55

As a standalone alarm pill at 55/60 it was noise. It folds into the evidence panel, where the release's own `review_flags` explain *why* (`SINGLE_SOURCE_FAMILY`, `ROLE_REFRESH_REQUIRED`) in fewer words than the warning did. The warning is suppressed when a flag already says the same thing.

## 3. The confidence filter offered a grade with nothing behind it

Every record in the reviewed release grades **B**. Selecting **A** returned an empty screen — the same dead-option trap the empty lane chips had, and fixed the same way: only grades with records behind them are offered. **All** always stands, because it can never come back empty.

## Also

Each citation now says **what it proves** — identity, current role, organisation, association — and when it was read. That is what an advisor needs when a link is the evidence for a claim.

## Verified against the live service, not the changelog

- 60 records, `data_mode: REVIEWED_PUBLIC_ASSOCIATION_RELEASE`, `model_version: nws-v2.3.0-kirkland.2026-08-13`
- `score_breakdown` from #126 survived the release — checked, still present on every record
- Lanes: BUILDER 20, KNOWLEDGE 21, CIVIC 9, CONNECTOR 10. CAPITAL and GENERAL remain empty, so those chips stay hidden — the existing rule already handles it.
- Score range moved 67–83 → 47–61, consistent with the more conservative coverage multiplier. No app change needed; the bars are relative.
- Server-side diversification is working: the top 5 are 5 different organisations, despite 13 organisations across 60 records. No client-side de-duplication needed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/ria/clients` → Around you. No route added.

- API / schema / type changes:
  - [x] Listed below: `evidence` added to the nearby record; `factTypes` and `retrievedAt` added to each source. Both additive and nullable. No database change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: renders inside the existing `AdaptiveDetailSurface`. No new native surface. `verify:capacitor:static` passes.

- Docs updated (exact files):
  - [x] None — the release's own handoff document covers the data change.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below: this makes evidence provenance **more** visible, not less. Still no residence, contact detail, or exact position — the API does not return them and the app renders only what it is sent.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof: `nws_nearby_service.py` normalises `evidence` and per-source `fact_types`; 3 new backend tests cover present, absent, and an older service revision.

- Rollback or safe-failure behavior:
  - [x] Listed below: a service revision without the evidence block falls back to the previous prose, and sources without fact types render as before. Revert is a revert.

- UI browser or Playwright proof:
  - [x] Listed below: 16 component tests driving the real components.

- Verification commands executed:
  - [x] `npm run typecheck` — clean
  - [x] `npm run lint` — clean, 0 warnings
  - [x] `npm run test:ci` — **27 failed / 3486 passed**; baseline at merge-base `c8f6b4cb` is **27 failed / 3478 passed**, **byte-identical failing set**. Zero regressions, +8 passing.
  - [x] `bash scripts/ci/backend-check.sh` — ruff, mypy, bandit, **846 passed**
  - [x] `verify:design-system`, `verify:service-boundary`, `verify:surface-map`, `verify:voice-gateway`, `audit:cache-coherence`, `verify:capacitor:static` — all pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Consumes `hushh-labs/HusshOne#127`, already merged and live — confirmed by calling the deployed service.
- [x] Reachable production attach point: `/ria/clients` → Around you → open a record.
- [x] New tests import and exercise production code, not stand-ins.
- [x] Production surface proved: 7 evidence-panel tests, 1 dead-filter test, 3 backend pass-through tests, plus the existing 15 still passing.
- [ ] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: the change.
- [x] **iOS** / **Android**: not applicable — no native code.

## 🧪 Testing

- [x] Tested on Web
- [x] Component tests drive real interactions
- [x] No generated files changed

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No change.
- [x] Sensitive surface touched: none new. Evidence provenance is public-record metadata and this makes it more legible.
- [x] Error path proved: missing evidence block → prose fallback; missing fact types → source renders as before; unmapped review flag → readable text rather than a raw constant.

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] No dependencies added
