### PR TITLE
fix(one-location): give the iOS location payload the contextual type it needs

### DIFF
--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -158,7 +158,7 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         if
             let cached = manager.location,
             cached.horizontalAccuracy >= 0,
-            abs(cached.timestamp.timeIntervalSinceNow) <= Self.cachedFixMaxAgeSeconds
+            abs(cached.timestamp.timeIntervalSinceNow) <= HushhLocationPlugin.cachedFixMaxAgeSeconds
         {
             pendingLocationTimeout?.cancel()
             pendingLocationTimeout = nil
@@ -193,13 +193,18 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
     /// fast path, the one-shot delegate callback, and every active watch, so
     /// they can never drift apart.
     private func locationPayload(_ location: CLLocation) -> [String: Any] {
-        [
+        // The explicit annotation is load-bearing rather than stylistic: the
+        // `accuracyM` ternary yields Double on one branch and NSNull on the
+        // other, and those only unify once something supplies `Any` as the
+        // contextual type. This is the exact form that already compiles below.
+        let payload: [String: Any] = [
             "latitude": location.coordinate.latitude,
             "longitude": location.coordinate.longitude,
             "accuracyM": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : NSNull(),
             "capturedAt": ISO8601DateFormatter().string(from: location.timestamp),
             "sourcePlatform": "ios"
         ]
+        return payload
     }
 
     private func clearPendingLocationCall() -> CAPPluginCall? {


### PR DESCRIPTION
# Description

Follow-up to #5209, raised before the queued iOS build rather than after it.

#5209 extracted the `CLLocation` → JS payload into `locationPayload(_:)` so the new
cached fast path, the one-shot delegate callback, and every active watch would share a
single shape. The extraction used a single-expression body with an implicit return,
which dropped the explicit `[String: Any]` annotation the dictionary literal previously
carried.

That annotation is load-bearing. One of the values is a ternary:

```swift
"accuracyM": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : NSNull()
```

Its branches are `Double` and `NSNull`, which share no common type. They unify only when
something supplies `Any` as the contextual type — which `let payload: [String: Any] = […]`
did directly, and which an implicit return is not guaranteed to propagate. The failure
mode is a build-time `Result values in '? :' expression have mismatching types
'CLLocationAccuracy' (aka 'Double') and 'NSNull'`, not anything observable at runtime.

This restores the exact form that already compiles elsewhere in the same file: an
explicitly typed local, then `return payload`. It also addresses the static constant by
its type name instead of `Self.`, which removes a (small) Swift-version assumption for
free.

**No behaviour change.** Same payload, same three callers, same values.

## Why this is a separate PR rather than a note on the original

The repo has no iOS lane on pull requests, and `ship-ios-testflight` refuses any SHA that
is not already on `main` and past `Main Post-Merge Smoke Gate`
(`scripts/ci/require-deploy-sha-on-main.sh`). So the first time this code is compiled is
the release archive itself. With an iOS build and an App Store submission queued behind
it, that is the wrong place to discover a type-checker error — it would fail the archive
step and block the cut.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None — native plugin internals only.
- API / schema / type changes:
  - [x] None — `locationPayload(_:)` keeps its signature; the emitted dictionary is
    byte-for-byte the same keys and values.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: iOS only. Web and Android are untouched.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — no consent, grant, envelope, or permission path is involved. The payload
    still leaves the plugin only to the local web layer, which encrypts before
    persistence.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below: single file, seven lines, revertible on its own. Reverting returns
    to the #5209 form.
- UI browser or Playwright proof:
  - [x] Not applicable — Swift compile-shape change with no rendered surface.
- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run typecheck` — not re-run; no TypeScript changed
  - [ ] `cd hushh-webapp && npm test` — not re-run; no TypeScript changed
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py …`

### Verification, stated plainly

**This is still not build-verified** — there is no Xcode on the authoring machine, and no
CI lane compiles Swift on a PR. I am not claiming this compiles because I ran it.

The argument is narrower and checkable by reading: the new form is character-identical to
the `let payload: [String: Any] = […]` / `return` construction that has been compiling in
`locationManager(_:didUpdateLocations:)` in this same file for as long as the plugin has
existed. The #5209 form was not identical to anything already proven here.

The real check is the archive step of `ship-ios-testflight`. **Recommended: run it once
with `dry_run: true` after this merges** — that archives and signs without uploading to
testers, so it proves the compile without spending a TestFlight build or touching
anything user-visible.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this does not duplicate
      anything. It amends code merged in #5209.
- [x] This PR changes a current reachable app surface — the iOS `HushhLocation` plugin,
      invoked by `OneLocationService.captureCurrentPosition` on every location capture.
- [x] Reachable production attach point: `HushhLocationPlugin.getCurrentPosition`, the
      registered Capacitor bridge method.
- [x] New tests import and exercise production code — **no new tests.** This is a
      compile-shape change with no observable behaviour to assert; a test would only
      restate that the dictionary has five keys, which the existing web-side contract
      already covers.
- [x] New helpers/components/services are wired: none added.
- [x] Production surface proved: the payload builder is the sole path by which any iOS
      fix reaches JS — the cached fast path, the one-shot resolve, and every watch call
      through it.
- [x] Required checks are current on this head and commits are signed off.
- [x] Maintainer edits are enabled.
- [x] Predecessor PR: #5209.
- [ ] Not a response to requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: not applicable — unchanged.
- [x] **iOS**: `ios/App/App/Plugins/HushhLocationPlugin.swift`.
- [x] **Android**: not applicable — unchanged.

## 🧪 Testing

- [ ] Tested on Web — not applicable
- [ ] Tested on iOS Simulator/Device — **not run; this is the gap the PR exists to close**
- [ ] Tested on Android — not applicable
- [x] Commits are signed off
- [x] No generated files changed

## 📸 Screenshots / Video

Not applicable — no rendered surface. The diff is seven lines of Swift with identical
runtime output.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No change to what is accessed. The same
      coordinate, the same single consumer.
- [x] `checkConsentToken()` — unchanged, not on this path.
- [x] Sensitive surface touched: none.
- [x] Error path / rollback proved: single-file revert.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed
