### PR TITLE
fix(one-location): bound the nearby checkout dedupe so it cannot outlive its truth

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1880,6 +1880,19 @@ function savedLocationPromptKey(prefix: string, userId: string): string {
   return `${prefix}:${userId}`;
 }
 
+/**
+ * How long a confirmed nearby checkout suppresses the next one.
+ *
+ * Deliberately short. Nearby presence is account-wide rather than per-device,
+ * so this device's belief that it already checked out can be made wrong by a
+ * check-in somewhere else. Any window long enough to cover that is far too
+ * long: it would let a pause silently skip the checkout and leave someone
+ * visible while being told they are not. Ten seconds absorbs a person flicking
+ * the switch — the only thing that can actually reach the 6/minute nearby-write
+ * limit — and no real cross-device sequence fits inside it.
+ */
+const NEARBY_CHECKOUT_DEDUPE_MS = 10_000;
+
 export function OneLocationAgentPageContent({
   mode = "workspace",
   surface = "hub",
@@ -2143,19 +2156,20 @@ export function OneLocationAgentPageContent({
   // what the person just did, which on this particular switch is a privacy
   // failure rather than a glitch.
   const locationIntentSeqRef = useRef(0);
-  // True once a nearby checkout has been confirmed and nothing has checked us
-  // back in since. Nearby writes are capped at 6/minute, and a 429 here would
-  // be reported as "you may still be visible to people around you" — a false
-  // alarm about the one thing this surface must never be wrong about.
-  const nearbyPresenceClearedRef = useRef(false);
+  // When the last nearby checkout was confirmed, guarding the next one for
+  // NEARBY_CHECKOUT_DEDUPE_MS. Nearby writes are capped at 6/minute, and a 429
+  // here would be reported as "you may still be visible to people around you" —
+  // a false alarm about the one thing this surface must never be wrong about.
+  const nearbyCheckoutConfirmedAtRef = useRef(0);
   useEffect(() => {
+    // Checked back in: whatever we last confirmed no longer describes presence.
     if (locationControl.nearbyPresenceActive) {
-      nearbyPresenceClearedRef.current = false;
+      nearbyCheckoutConfirmedAtRef.current = 0;
     }
   }, [locationControl.nearbyPresenceActive]);
   useEffect(() => {
-    // A different account carries different presence; never inherit the flag.
-    nearbyPresenceClearedRef.current = false;
+    // A different account carries different presence; never inherit the window.
+    nearbyCheckoutConfirmedAtRef.current = 0;
   }, [auth.userId]);
   const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
   useEffect(() => {
@@ -7117,16 +7131,19 @@ export function OneLocationAgentPageContent({
     // success either way. So the presence GET that used to precede it bought
     // nothing but a second serialized round trip inside the pause — and asking
     // first is strictly worse than just telling, because the answer can go
-    // stale between the two calls. `nearbyPresenceClearedRef` keeps repeated
-    // pauses off the 6/minute nearby-write limit.
+    // stale between the two calls. The dedupe window below keeps a flurry of
+    // taps off the 6/minute nearby-write limit without letting this device act
+    // on a stale belief about account-wide presence.
+    const checkedOutRecently =
+      nearbyCheckoutConfirmedAtRef.current > 0 &&
+      Date.now() - nearbyCheckoutConfirmedAtRef.current <
+        NEARBY_CHECKOUT_DEDUPE_MS;
     const shouldCheckOut =
-      nearbyCheckInAvailable &&
-      Boolean(vaultOwnerToken) &&
-      !nearbyPresenceClearedRef.current;
+      nearbyCheckInAvailable && Boolean(vaultOwnerToken) && !checkedOutRecently;
     if (shouldCheckOut && vaultOwnerToken) {
       try {
         await OneLocationService.checkoutNearby({ vaultOwnerToken });
-        nearbyPresenceClearedRef.current = true;
+        nearbyCheckoutConfirmedAtRef.current = Date.now();
       } catch {
         // Both halves of the truth, in the order that matters: what is now
         // private, then what is not. Told as `succeeded` because the thing


### PR DESCRIPTION
# Description

Follow-up to #5209, found by re-auditing the merged change rather than by a failure.

#5209 replaced the pause path's presence GET with a direct, idempotent `checkoutNearby`
and added a flag so repeated pauses would not spend the 6/minute `ONE_LOCATION_NEARBY_WRITE`
budget — a 429 there surfaces as "you may still be visible to people around you", a false
alarm about the one thing this surface must never get wrong.

**The flag had no expiry.** It cleared when this device observed presence go active, or when
the account changed, and otherwise stayed set for the whole session. But nearby presence is
**account-wide, not per-device**:

1. Pause on phone A → checkout confirmed, flag set.
2. Check in on phone B → phone A never observes it.
3. Pause again on phone A → **checkout skipped.**

The person is told they are paused while still visible nearby. That is exactly the lie the
surrounding code is written to refuse, and it is a regression — before #5209 the pause read
presence fresh every time and would have caught it.

This bounds the suppression to ten seconds instead of the session. The only thing that can
realistically reach the rate limit is someone flicking the switch — easier now that the toggle
responds instantly — and that happens in seconds. No genuine cross-device sequence fits inside
the window, so the stale-belief case disappears while the protection stays. Worst case cost of
the shorter window is one extra idempotent DELETE.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` — pause path only. No route added, removed, or renamed.
- API / schema / type changes:
  - [x] None — same endpoint, same payload. Only how often it is called.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None — `checkout` is idempotent (`UPDATE … WHERE status='active'`); an extra call is a no-op.
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared web layer, identical on all platforms.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Listed below: **consent / visibility.** This is the point of the PR — it removes a case
    where the UI could claim a pause that had not reached the server.
- Caller / proxy / backend pairing:
  - [x] Listed below: relies on `checkout` idempotency, same contract proof as #5209
    (`one_location_nearby_presence_service.py`). This PR only makes us call it more often.
- Rollback or safe-failure behavior:
  - [x] Listed below: one file, revertible alone. Failure direction is one redundant DELETE,
    never a skipped one.
- UI browser or Playwright proof:
  - [x] Not applicable — no rendered change.
- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `npm run typecheck` — **via CI `Web Core` on this PR** (see below)
  - [ ] `npm test` — see below
  - [ ] `npm run build` — covered by CI `Web Core`

### Verification, stated plainly

The local working tree is mid-flight with unrelated work from another author, so this change was
authored against `origin/main` directly and **not** typechecked locally. CI `Web Core` runs
`typecheck`, `lint` and a Next build on this PR and is the gate for that — unlike Swift, TypeScript
genuinely is compiled on PRs here.

**No new test.** The failing sequence needs two devices and account-wide presence state; the
existing suite mocks presence per-render and cannot express it. A test asserting "a second pause
eleven seconds later calls checkout again" would only restate the constant. Flagging that honestly
rather than adding a test that proves nothing.

Note for reviewers: the web unit suite does **not** run on PRs in this repo (`web-full` is
`merge_group`-only, and the merge queue is not currently in the merge path), so `npm test` green
is not something this PR can demonstrate through CI.

## ✅ Review-Ready Contract

- [x] Title, body, and diff describe the same contract.
- [x] Does not duplicate other work; amends #5209.
- [x] Changes a reachable production surface: the pause path behind the Location toggle.
- [x] Reachable attach point: `handleHideMyLiveLocation` in `app/one/location/page.tsx`.
- [x] No new helpers/components/services.
- [x] Commits are signed off; branch is based on current `main`.
- [x] Maintainer edits enabled.
- [x] Predecessor PR: #5209.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `app/one/location/page.tsx`.
- [x] **iOS**: not applicable — no native change.
- [x] **Android**: not applicable — no native change.

## 🧪 Testing

- [ ] Tested on Web — CI typecheck/lint/build only
- [ ] Tested on iOS — not applicable
- [ ] Tested on Android — not applicable
- [x] Commits are signed off
- [x] No generated files changed

## 📸 Screenshots / Video

Not applicable — no visual change. The switch behaves identically; only the frequency of an
idempotent background DELETE changes.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No new access. It makes an existing checkout more
      reliable.
- [x] `checkConsentToken()` — unchanged; the vault owner token requirement is untouched.
- [x] Sensitive surface touched: **consent / visibility**.
- [x] Error path proved: unchanged — a failed checkout still reports both halves of the truth
      and never claims a clean pause.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed
