### PR TITLE
fix(webapp): always open RIA setup at the welcome step

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -480,6 +480,9 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("clears stale regulator fields before applying a fresh verification result", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams("step=license_number"),
+    );
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "license_number",
       onboardingType: "individual",
@@ -558,6 +561,9 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("repairs stale verified draft location from the license API on load", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams("step=license_details"),
+    );
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "license_details",
       onboardingType: "individual",
@@ -625,6 +631,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("repairs conflicting verified draft location from the license API on load", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=services"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",
       onboardingType: "individual",
@@ -807,10 +814,10 @@ describe("RiaOnboardingPage", () => {
     });
   });
 
-  it("loads existing draft and restores saved step", async () => {
+  it("loads an existing draft but still opens at the welcome step", async () => {
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",
-      onboardingType: "individual",
+      onboardingType: "firm",
       licenseNumber: "111222",
       licenseVerificationStatus: "found",
       advisorName: "Saved Advisor",
@@ -824,9 +831,19 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(mocks.draftService.load).toHaveBeenCalledWith("user-ria-1");
     });
+
+    // Entering RIA setup never resumes mid-wizard — the saved step pointer is
+    // ignored so step 1 (and its cinematic intro) is never skipped...
+    await waitFor(() => {
+      expect(screen.getByTestId("step-welcome")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("step-services")).toBeNull();
+    // ...while every other saved field still prefills the flow.
+    expect(screen.getByTestId("welcome-type").textContent).toBe("firm");
   });
 
   it("drafts a bio from verified onboarding fields", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=services"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",
       onboardingType: "individual",
@@ -869,6 +886,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("opens Kai command from the review update action", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=review"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "review",
       onboardingType: "individual",
@@ -903,6 +921,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("does not force a second live verification after license verification", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=review"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "review",
       onboardingType: "individual",
@@ -954,6 +973,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("does not submit onboarding twice while the first request is pending", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=review"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "review",
       onboardingType: "individual",
@@ -1001,6 +1021,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("turns provider unavailable submit errors into actionable verification copy", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=review"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "review",
       onboardingType: "individual",
@@ -1128,6 +1149,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("keeps the user on the services step when Continue is pressed with empty required fields", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=services"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",
       onboardingType: "individual",
@@ -1162,6 +1184,7 @@ describe("RiaOnboardingPage", () => {
   });
 
   it("completes onboarding and routes to the RIA profile when verification is pending", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("step=review"));
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "review",
       onboardingType: "individual",

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -396,10 +396,12 @@ export default function RiaOnboardingPage({
           });
         }
 
-        // An explicit ?edit=license / ?step= / ?reinitiate deep-link wins over the
-        // persisted draft step so the profile CTAs land on the right step.
-        const preferredStepId =
-          requestedStepIdRef.current ?? localDraft?.currentStepId ?? null;
+        // Opening RIA setup always lands on step 1. The saved draft still
+        // prefills every field, but its step pointer is deliberately ignored so
+        // entering the flow never drops the user mid-wizard (and never skips the
+        // welcome step's cinematic intro). Only an explicit
+        // ?edit=license / ?step= / ?reinitiate deep-link may land elsewhere.
+        const preferredStepId = requestedStepIdRef.current;
         const currentStepId = preferredStepId
           ? resolveRiaOnboardingStepId(resolvedDraft, preferredStepId, {
               licenseVerificationSatisfied:


### PR DESCRIPTION
## Problem

Clicking the **RIA** agent tile opens [`/ria/onboarding`](https://github.com/hushh-labs/hushh-research/blob/main/hushh-webapp/lib/onboarding/one-capabilities.ts). On load, the page read the saved step pointer out of the locally persisted draft and jumped straight there:

```ts
const preferredStepId =
  requestedStepIdRef.current ?? localDraft?.currentStepId ?? null;
```

So once a user had gotten as far as the licence step, **every later entry dropped them at 2/5** instead of step 1. It also skipped the welcome step's cinematic intro, which only renders when the current step is `welcome` (`showIntro={currentStep.id === "welcome"}`).

Reported by a user: *"when I click the RIA agent, I always want it to open to the first page and not skip it."*

## Fix

One line in `app/ria/onboarding/page.tsx` — stop consulting `localDraft.currentStepId`. Entry now always resolves to `welcome`.

Deliberately unchanged:

- **The saved draft still loads and prefills every field.** Only the step pointer is ignored, so nothing the user typed is lost.
- **Deep-links still land where they point:** `?edit=license` (the profile's re-verify CTA), `?reinitiate=1`, and explicit `?step=`.
- **Established advisors still redirect to `/ria/profile`** rather than entering the wizard. That's a separate entry gate and is untouched.

## Trade-off

This is a deliberate reversal of resume-mid-wizard. An advisor who abandons at step 4 and returns now re-walks steps 1–3 — but with every field already filled, so it's Continue×3, not re-entry. The prior behaviour also meant the first-run intro could never be seen twice, which is what made the flow feel like it was skipping.

## Verification

- `__tests__/app/ria/onboarding-page.test.tsx` — **23/23 pass**, re-confirmed against latest `main`.
- Full RIA + onboarding suites — 182/184. The 2 failures are in `picks-page.test.tsx` and are **pre-existing**; confirmed failing identically with this change stashed on a clean tree.
- `tsc --noEmit` and `eslint` clean on both changed files.

Ten tests had relied on the persisted draft to land mid-flow. They now deep-link via `?step=`, which is the path that still honours a requested step — so they still test what they were written to test. The test formerly named *"loads existing draft and restores saved step"* now asserts the opposite (a draft saved at `services` opens at `welcome` with its other fields intact), so the old behaviour can't creep back in silently.
