### PR TITLE
fix(connect): explain why a person can't be selected, instead of a mute disabled checkbox

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -498,6 +498,44 @@ describe("Connect — People", () => {
       expect(screen.queryByText("Connect to Selected (1/20)")).toBeNull(),
     );
   });
+
+  it("says why an ineligible person's checkbox can't be checked, instead of a mute disabled box", async () => {
+    // The reported bug: a few rows in selection mode showed a disabled
+    // checkbox and nothing else, so clicking looked like it "did nothing"
+    // with no way to tell an already-connected person from a bug. A row
+    // that isn't a real choice now carries no checkbox at all -- just its
+    // reason, in place of one.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [
+        { ...person("u1", "Connected Carl"), relationship: "connected" as const },
+        {
+          ...person("u2", "Requested Rita"),
+          relationship: "pending_outgoing" as const,
+        },
+        person("u3", "Selectable Sam"),
+      ],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    expect(await screen.findByText("Connected Carl")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
+
+    // Eligible: a real, enabled checkbox.
+    expect(
+      (screen.getByLabelText("Select Selectable Sam") as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+
+    // Already connected: no checkbox to click -- its reason stands in for one.
+    expect(screen.getByText("Connected")).toBeTruthy();
+    expect(screen.queryByLabelText("Select Connected Carl")).toBeNull();
+
+    // Request already out: same treatment, its own reason.
+    expect(screen.getByText("Requested")).toBeTruthy();
+    expect(screen.queryByLabelText("Select Requested Rita")).toBeNull();
+  });
 });
 
 describe("Connect — removing a connection", () => {

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1371,29 +1371,56 @@ export default function ConnectPageClient() {
                         density="compact"
                         trailing={
                           isSelectionMode ? (
-                            <Checkbox
-                              checked={isSelected}
-                              disabled={
-                                person.relationship !== "none" ||
-                                (!isSelected && selectionLimitReached)
-                              }
-                              aria-describedby="connect-selection-limit"
-                              onCheckedChange={(checked) => {
-                                setSelectedUserIds((current) => {
-                                  const next = new Set(current);
-                                  if (checked) {
-                                    if (next.size >= MAX_BULK_CONNECTION_REQUESTS) {
-                                      return current;
+                            // A disabled checkbox alone said nothing about WHY.
+                            // Someone already connected, already asked, or
+                            // already asking you looked identical to someone
+                            // selection had simply run out of room for -- both
+                            // rendered as the same greyed box with a
+                            // not-allowed cursor and no visible text. A row
+                            // ineligible because of its relationship isn't a
+                            // choice at all, so it gets no checkbox -- just the
+                            // reason, standing in its place. The limit case
+                            // stays a real (disabled) checkbox, since it flips
+                            // back to selectable the moment the reader frees a
+                            // slot, and it already has a persistent explanation
+                            // in the section description above the list.
+                            person.relationship !== "none" ? (
+                              <span
+                                className="text-xs font-medium text-emerald-700 dark:text-emerald-300"
+                                aria-label={`${title}: ${cta.label}, not selectable`}
+                              >
+                                {cta.label}
+                              </span>
+                            ) : (
+                              <Checkbox
+                                checked={isSelected}
+                                disabled={!isSelected && selectionLimitReached}
+                                // The default unchecked border (border-input)
+                                // reads as near-invisible on this row's light
+                                // background -- readers couldn't tell an
+                                // eligible, clickable checkbox from empty
+                                // space. A darker, thicker border only changes
+                                // that idle state; data-[state=checked] still
+                                // wins once picked.
+                                className="border-2 border-foreground/50"
+                                aria-describedby="connect-selection-limit"
+                                onCheckedChange={(checked) => {
+                                  setSelectedUserIds((current) => {
+                                    const next = new Set(current);
+                                    if (checked) {
+                                      if (next.size >= MAX_BULK_CONNECTION_REQUESTS) {
+                                        return current;
+                                      }
+                                      next.add(person.userId);
+                                    } else {
+                                      next.delete(person.userId);
                                     }
-                                    next.add(person.userId);
-                                  } else {
-                                    next.delete(person.userId);
-                                  }
-                                  return next;
-                                });
-                              }}
-                              aria-label={`Select ${title}`}
-                            />
+                                    return next;
+                                  });
+                                }}
+                                aria-label={`Select ${title}`}
+                              />
+                            )
                           ) : person.relationship === "pending_outgoing" ? (
                             <Button
                               type="button"


### PR DESCRIPTION
## Bug
Connect → People, selection mode: some rows had their checkbox replaced by a disabled state with a not-allowed cursor and zero explanation. Clicking the row/control did nothing visible, and there was no way to tell an already-connected person from an actual bug.

## Root cause
The checkbox was disabled whenever `person.relationship !== "none"` (already connected / pending outgoing / pending incoming) — that logic was correct — but nothing in the UI said why. `aria-describedby` only pointed at the unrelated 20-person selection cap text.

## Reproduction (UAT)
Confirmed 2/2 on live UAT: 6 rows disabled (5 existing connections + 1 pending outgoing request), all legitimately ineligible, none explained.

## Fix
- Rows ineligible because of relationship state now render their reason (`Connected` / `Requested` / `Respond`, from the existing `relationshipCta` map) in green text, in place of the checkbox — nothing pretends to be clickable when it isn't a real choice.
- Eligible rows keep a real, enabled checkbox, now with a more visible unchecked border (`border-input` read as near-invisible against the row background).
- The 20-person selection cap is untouched (it already has a persistent explanation above the list, and it's a different, reversible reason for being disabled).

## Testing
- Added a regression test covering connected / pending_outgoing / eligible rows in one render.
- `__tests__/app/connect/page-client.test.tsx`: 20/20 pass.
- `tsc --noEmit`: clean.
- `eslint`: clean on both changed files.
- Manually verified locally against real UAT-backed account data (local backend + Cloud SQL proxy).

## Scope
1 bug, 1 fix: `hushh-webapp/app/connect/page-client.tsx` + its test file only.