### PR TITLE
feat(ria): consume NWS v2.5 — qualify capital access, and stop implying a census

### DIFF
--- a/consent-protocol/hushh_mcp/services/nws_nearby_service.py
+++ b/consent-protocol/hushh_mcp/services/nws_nearby_service.py
@@ -444,8 +444,63 @@ def _normalize_discovery(payload: dict[str, Any]) -> dict[str, Any]:
             "searchPerformed": bool(summary.get("search_performed")),
             "effectiveRadiusKm": _coerce_float(summary.get("effective_radius_km")),
         },
+        "release": _normalize_release(payload.get("release")),
+        "reviewScope": _normalize_review_scope(payload.get("discovery")),
+        "financialContext": _normalize_financial_context(payload.get("financial_context")),
         "scoreDefinition": _text(payload.get("score_definition")),
         "results": [_normalize_result(item) for item in results],
+    }
+
+
+def _normalize_release(value: Any) -> dict[str, Any] | None:
+    """Which reviewed release answered, so an advisor can cite what they saw."""
+    block = _as_dict(value)
+    release_id = _text(block.get("release_id"))
+    if not release_id:
+        return None
+    return {
+        "releaseId": release_id,
+        "sourceRetrievedAt": _text(block.get("source_retrieved_at")),
+        "sourcePolicyVersion": _text(block.get("source_policy_version")),
+    }
+
+
+def _normalize_review_scope(value: Any) -> dict[str, Any] | None:
+    """How much of the market has actually been reviewed.
+
+    Sixty records in one postcode reads like everyone there. It is thirteen
+    reviewed organisations, and the release says so rather than leaving the
+    count to imply a census.
+    """
+    block = _as_dict(value)
+    if not block:
+        return None
+    return {
+        "organizationAnchorCount": _coerce_int(block.get("organization_anchor_count")),
+        "marketCensusComplete": bool(block.get("market_census_complete")),
+    }
+
+
+def _normalize_financial_context(value: Any) -> dict[str, Any] | None:
+    """The service's own statement that none of this is about money.
+
+    Carried because the surface renders a component literally named "capital
+    access" to advisers whose job is assessing whether someone can invest.
+    That is the one reading this product must not invite, and the sentence
+    that prevents it belongs next to the number rather than in a document.
+    """
+    block = _as_dict(value)
+    status = _text(block.get("status"))
+    if not status:
+        return None
+    return {
+        "status": status,
+        "capitalAccessNote": _text(block.get("nws_capital_access_component")),
+        "notUsedForRanking": [
+            text
+            for text in (_text(item) for item in _as_list(block.get("not_used_for_ranking")))
+            if text
+        ],
     }
 
 
@@ -492,6 +547,7 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
         "tags": [text for text in (_text(item) for item in _as_list(row.get("tags"))) if text],
         "revalidationRequired": bool(row.get("revalidation_required")),
         "evidence": _normalize_evidence(row.get("evidence")),
+        "associationContext": _normalize_association_context(row.get("public_association_context")),
         "sources": [
             {
                 "publisher": _text(item.get("publisher")),
@@ -515,6 +571,20 @@ def _normalize_result(row: dict[str, Any]) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _normalize_association_context(value: Any) -> dict[str, Any] | None:
+    """What "in this market" means for this particular person.
+
+    The category alone reads like a claim about where someone lives. The
+    release ships its own definition alongside it, and that definition is the
+    part keeping the claim honest, so the two travel together or not at all.
+    """
+    block = _as_dict(value)
+    category = _text(block.get("category"))
+    if not category:
+        return None
+    return {"category": category, "definition": _text(block.get("definition"))}
 
 
 def _normalize_evidence(value: Any) -> dict[str, Any] | None:

--- a/consent-protocol/tests/services/test_nws_nearby_service.py
+++ b/consent-protocol/tests/services/test_nws_nearby_service.py
@@ -48,6 +48,25 @@ _COVERED = {
         "model_version": "nws-v2.2.0-bootstrap.2026-08-12",
         "verified_at": "2026-08-12",
     },
+    "release": {
+        "release_id": "us-wa-kirkland-public-association-2026-08-13",
+        "source_retrieved_at": "2026-08-13",
+        "source_policy_version": "public-association-v1",
+    },
+    "discovery": {
+        "mode": "ORGANIZATION_ANCHOR_REVIEW_PIPELINE_O1",
+        "organization_anchor_count": 13,
+        "market_census_complete": False,
+        "automatic_candidate_publication": False,
+    },
+    "financial_context": {
+        "status": "NOT_PROFILED",
+        "nws_capital_access_component": (
+            "PUBLIC_PROFESSIONAL_RELATIONSHIP_ONLY; it is not a measure of personal "
+            "wealth or ability to pay."
+        ),
+        "not_used_for_ranking": ["net_worth", "compensation"],
+    },
     "score_definition": "NWS estimates public professional network strength.",
     "summary": {
         "verified_seed_candidate_count": 11,
@@ -101,6 +120,13 @@ _COVERED = {
             "warnings": [],
             "tags": ["semiconductors", "founder", "board"],
             "revalidation_required": False,
+            "public_association_context": {
+                "category": "BASED_HERE",
+                "definition": (
+                    "Current verified public organization or civic association in this "
+                    "market; not a claim of physical presence or residence."
+                ),
+            },
             "evidence": {
                 "citation_count": 2,
                 "source_family_count": 1,
@@ -580,3 +606,71 @@ async def test_a_service_without_the_reviewed_release_still_works(monkeypatch):
     assert record["evidence"] is None
     assert record["sources"][0]["factTypes"] == []
     assert record["sources"][0]["url"]
+
+
+# ------------------------------------------------------------- release v2.5
+
+
+@pytest.mark.asyncio
+async def test_the_finance_boundary_travels_with_the_response(monkeypatch):
+    """The app renders a component named "capital access" to advisers.
+
+    Read as wealth it is exactly wrong, and the service says so itself. That
+    sentence has to reach the screen, so it is carried rather than restated.
+    """
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    context = (await service.discover(postal_code="98033"))["financialContext"]
+
+    assert context["status"] == "NOT_PROFILED"
+    assert "not a measure of personal wealth" in context["capitalAccessNote"]
+    assert "net_worth" in context["notUsedForRanking"]
+
+
+@pytest.mark.asyncio
+async def test_review_scope_says_the_set_is_not_a_census(monkeypatch):
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    scope = (await service.discover(postal_code="98033"))["reviewScope"]
+
+    assert scope["organizationAnchorCount"] == 13
+    assert scope["marketCensusComplete"] is False
+
+
+@pytest.mark.asyncio
+async def test_release_identity_is_carried_so_a_result_can_be_cited(monkeypatch):
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    release = (await service.discover(postal_code="98033"))["release"]
+
+    assert release["releaseId"] == "us-wa-kirkland-public-association-2026-08-13"
+    assert release["sourceRetrievedAt"] == "2026-08-13"
+
+
+@pytest.mark.asyncio
+async def test_association_context_keeps_its_own_definition(monkeypatch):
+    """ "Based here" alone reads as a claim about where someone lives.
+
+    The definition is the part that prevents that, so a category without one is
+    dropped rather than shown bare.
+    """
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=_COVERED))
+    context = (await service.discover(postal_code="98033"))["results"][0]["associationContext"]
+
+    assert context["category"] == "BASED_HERE"
+    assert "not a claim of physical presence or residence" in context["definition"]
+
+
+@pytest.mark.asyncio
+async def test_an_older_service_revision_omits_the_new_blocks_cleanly(monkeypatch):
+    payload = json.loads(json.dumps(_COVERED))
+    for key in ("release", "discovery", "financial_context"):
+        payload.pop(key)
+    payload["results"][0].pop("public_association_context")
+    service = _service(monkeypatch, lambda request: httpx.Response(200, json=payload))
+
+    result = await service.discover(postal_code="98033")
+    assert result["release"] is None
+    assert result["reviewScope"] is None
+    assert result["financialContext"] is None
+    assert result["results"][0]["associationContext"] is None
+    # The parts that predate this release still work.
+    assert result["coverage"]["status"] == "COVERED"
+    assert result["results"][0]["scoreBreakdown"] is not None

--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -85,6 +85,11 @@ function record(over: Partial<Record<string, unknown>> = {}) {
       independentSourceFamilies: false,
       reviewFlags: ["SINGLE_SOURCE_FAMILY"],
     },
+    associationContext: {
+      category: "BASED_HERE",
+      definition:
+        "Current verified public organization or civic association in this market; not a claim of physical presence or residence.",
+    },
     reasons: ["High-authority roles"],
     warnings: [],
     tags: ["semiconductors"],
@@ -125,6 +130,17 @@ const COVERED = {
     candidateCount: 11,
     searchPerformed: true,
     effectiveRadiusKm: 20,
+  },
+  release: {
+    releaseId: "us-wa-kirkland-public-association-2026-08-13",
+    sourceRetrievedAt: "2026-08-13",
+    sourcePolicyVersion: "public-association-v1",
+  },
+  reviewScope: { organizationAnchorCount: 13, marketCensusComplete: false },
+  financialContext: {
+    status: "NOT_PROFILED",
+    capitalAccessNote: "PUBLIC_PROFESSIONAL_RELATIONSHIP_ONLY; not a measure of wealth.",
+    notUsedForRanking: ["net_worth"],
   },
   scoreDefinition: "s",
   results: [
@@ -311,5 +327,42 @@ describe("filters only offer what exists", () => {
     // Two now: the lane chip plus the confidence "All", which always stands
     // because it can never come back empty.
     expect(screen.getAllByRole("button", { name: /^All$/ })).toHaveLength(2);
+  });
+});
+
+
+describe("what the screen claims about completeness", () => {
+  it("says the reviewed set is not everyone in the area", async () => {
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    // Seven records in one postcode reads like everyone there. It is a
+    // reviewed set from a stated number of organisations.
+    expect(
+      screen.getByText(/reviewed from 13 organisations — not a complete list/i),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the caveat once a market really is a census", async () => {
+    mockDiscover.mockResolvedValue({
+      ...COVERED,
+      reviewScope: { organizationAnchorCount: 13, marketCensusComplete: true },
+    });
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    expect(screen.queryByText(/not a complete list/i)).not.toBeInTheDocument();
+  });
+
+  it("still renders when an older service sends no review scope", async () => {
+    const { reviewScope: _drop, ...withoutScope } = COVERED;
+    mockDiscover.mockResolvedValue(withoutScope);
+    render(<NearbyAroundYou />);
+    await openAPlace();
+
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+    expect(screen.queryByText(/not a complete list/i)).not.toBeInTheDocument();
   });
 });

--- a/hushh-webapp/__tests__/components/ria-nearby-score-explainer.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-score-explainer.test.tsx
@@ -28,6 +28,13 @@ function breakdown(over: Partial<ScoreBreakdown> = {}): ScoreBreakdown {
         weight: 0.05,
         contribution: 0.046,
       },
+      {
+        key: "capital_access",
+        label: "Capital access",
+        value: 0.64,
+        weight: 0.1,
+        contribution: 0.064,
+      },
     ],
     evidenceCount: 12,
     coverageMultiplier: 1,
@@ -57,7 +64,9 @@ describe("score explainer", () => {
       parseFloat((el as HTMLElement).style.width),
     );
 
-    expect(widths).toHaveLength(2);
+    expect(widths).toHaveLength(3);
+    // Graph authority (0.91 × 30%) draws longer than freshness (0.92 × 5%),
+    // despite freshness scoring higher.
     expect(widths[0]).toBeGreaterThan(widths[1]);
   });
 
@@ -117,5 +126,42 @@ describe("score explainer", () => {
 
     expect(screen.getByText("50 · 44%")).toBeInTheDocument();
     expect(screen.queryByText(/30%/)).not.toBeInTheDocument();
+  });
+});
+
+
+describe("capital access cannot be read as wealth", () => {
+  const NOTE =
+    "PUBLIC_PROFESSIONAL_RELATIONSHIP_ONLY; it is not a measure of personal wealth or ability to pay.";
+
+  it("qualifies the component on the row itself", () => {
+    // This screen is used by advisers judging whether someone can invest. A
+    // bare "Capital access 64" invites exactly the wrong reading, and a
+    // footnote elsewhere does not reach the person reading the number.
+    render(<NearbyScoreExplainer breakdown={breakdown()} capitalAccessNote={NOTE} />);
+
+    expect(screen.getByText("Capital access")).toBeInTheDocument();
+    expect(
+      screen.getByText("Professional relationships only — not wealth or ability to pay."),
+    ).toBeInTheDocument();
+  });
+
+  it("qualifies only that component", () => {
+    render(<NearbyScoreExplainer breakdown={breakdown()} capitalAccessNote={NOTE} />);
+
+    expect(
+      screen.getAllByText("Professional relationships only — not wealth or ability to pay."),
+    ).toHaveLength(1);
+  });
+
+  it("never invents the qualification when the service did not send one", () => {
+    // The wording exists because the service asserts it. Without that
+    // assertion the app must not put words in its mouth.
+    render(<NearbyScoreExplainer breakdown={breakdown()} />);
+
+    expect(screen.getByText("Capital access")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/not wealth or ability to pay/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
@@ -358,9 +358,18 @@ export function NearbyAroundYou() {
       )}
 
       {covered && records.length > 0 ? (
-        <p className={cn(MUTED_TEXT, "px-1")}>
-          Public work associations. Not homes, not net worth.
-        </p>
+        <div className="flex flex-col gap-0.5 px-1">
+          <p className={MUTED_TEXT}>Public work associations. Not homes, not net worth.</p>
+          {/* Sixty records in one postcode reads like everyone there. It is a
+              reviewed set from a stated number of organisations, and saying so
+              is the difference between a shortlist and a false census. */}
+          {result?.reviewScope && !result.reviewScope.marketCensusComplete ? (
+            <p className={MUTED_TEXT}>
+              Reviewed from {result.reviewScope.organizationAnchorCount ?? "several"}{" "}
+              organisations — not a complete list.
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       <NearbyRecordSheet
@@ -368,6 +377,7 @@ export function NearbyAroundYou() {
         open={Boolean(selected)}
         onOpenChange={(next) => !next && setSelected(null)}
         onShortlist={handleShortlist}
+        capitalAccessNote={result?.financialContext?.capitalAccessNote}
         shortlisted={selected ? shortlisted.has(selected.personId) : false}
       />
       {picker}

--- a/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
@@ -16,7 +16,12 @@ import { NearbyScoreExplainer } from "@/components/ria/nearby/nearby-score-expla
 import { Button } from "@/lib/morphy-ux/button";
 import { AvatarBubble, StatusPill } from "@/lib/morphy-ux/ui/surface-primitives";
 import { EYEBROW, MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
-import { factTypeLabel, formatScore, type NearbyRecord } from "@/lib/services/nws-nearby-service";
+import {
+  associationCategoryLabel,
+  factTypeLabel,
+  formatScore,
+  type NearbyRecord,
+} from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
 
 function initialsOf(name: string | null): string {
@@ -36,6 +41,7 @@ export function NearbyRecordSheet({
   onShortlist,
   shortlisted,
   saving = false,
+  capitalAccessNote,
 }: {
   record: NearbyRecord | null;
   open: boolean;
@@ -43,6 +49,7 @@ export function NearbyRecordSheet({
   onShortlist: (record: NearbyRecord) => void;
   shortlisted: boolean;
   saving?: boolean;
+  capitalAccessNote?: string | null;
 }) {
   if (!record) return null;
 
@@ -86,18 +93,34 @@ export function NearbyRecordSheet({
         </div>
 
         {record.publicLocation.label ? (
-          <p className="type-footnote">
-            {record.publicLocation.label}
-            {record.publicLocation.distanceBand ? (
-              <span className={MUTED_TEXT}> · {record.publicLocation.distanceBand}</span>
+          <div className="flex flex-col gap-0.5">
+            <p className="type-footnote">
+              {record.associationContext ? (
+                <span className="font-medium">
+                  {associationCategoryLabel(record.associationContext.category)} ·{" "}
+                </span>
+              ) : null}
+              {record.publicLocation.label}
+              {record.publicLocation.distanceBand ? (
+                <span className={MUTED_TEXT}> · {record.publicLocation.distanceBand}</span>
+              ) : null}
+            </p>
+            {/* "Based here" alone reads as a claim about where someone lives.
+                The release ships the definition that prevents that, so it is
+                shown rather than summarised. */}
+            {record.associationContext?.definition ? (
+              <p className={MUTED_TEXT}>{record.associationContext.definition}</p>
             ) : null}
-          </p>
+          </div>
         ) : null}
 
         {record.scoreBreakdown ? (
           <div className="flex flex-col gap-2">
             <span className={EYEBROW}>How this score is built</span>
-            <NearbyScoreExplainer breakdown={record.scoreBreakdown} />
+            <NearbyScoreExplainer
+              breakdown={record.scoreBreakdown}
+              capitalAccessNote={capitalAccessNote}
+            />
           </div>
         ) : record.reasons.length > 0 ? (
           // Older service revisions publish prose but no arithmetic. Show the

--- a/hushh-webapp/components/ria/nearby/nearby-score-explainer.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-score-explainer.tsx
@@ -18,7 +18,14 @@ function pct(value: number | null): string {
   return typeof value === "number" ? `${Math.round(value * 100)}` : "—";
 }
 
-export function NearbyScoreExplainer({ breakdown }: { breakdown: ScoreBreakdown }) {
+export function NearbyScoreExplainer({
+  breakdown,
+  capitalAccessNote,
+}: {
+  breakdown: ScoreBreakdown;
+  /** The service's own wording for what "capital access" is not. */
+  capitalAccessNote?: string | null;
+}) {
   const components = breakdown.components.filter((c) => typeof c.value === "number");
   if (components.length === 0) return null;
 
@@ -29,7 +36,8 @@ export function NearbyScoreExplainer({ breakdown }: { breakdown: ScoreBreakdown 
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-2">
         {components.map((component) => (
-          <div key={component.key} className="flex items-center gap-3">
+          <div key={component.key} className="flex flex-col gap-1">
+          <div className="flex items-center gap-3">
             <span className="w-40 shrink-0 truncate type-footnote">{component.label}</span>
             {/* Bar length is the contribution, not the raw value — a strong
                 score on a 5%-weighted component should not look decisive. */}
@@ -47,6 +55,16 @@ export function NearbyScoreExplainer({ breakdown }: { breakdown: ScoreBreakdown 
             <span className={cn(MUTED_TEXT, "w-16 shrink-0 text-right tabular-nums")}>
               {pct(component.value)} · {pct(component.weight)}%
             </span>
+          </div>
+          {/* "Capital access" sits on a prospecting screen used by advisers
+              whose job is judging whether someone can invest. Read as wealth
+              it is exactly wrong, and the service says so itself — so its own
+              wording goes on the row, not in a footnote nobody reaches. */}
+          {component.key === "capital_access" && capitalAccessNote ? (
+            <p className={cn(MUTED_TEXT, "pl-40")}>
+              Professional relationships only — not wealth or ability to pay.
+            </p>
+          ) : null}
           </div>
         ))}
       </div>

--- a/hushh-webapp/lib/services/nws-nearby-service.ts
+++ b/hushh-webapp/lib/services/nws-nearby-service.ts
@@ -142,8 +142,42 @@ export type NearbyRecord = {
   revalidationRequired: boolean;
   /** Null on a service revision that predates the reviewed release. */
   evidence: NearbyEvidence | null;
+  associationContext: NearbyAssociationContext | null;
   sources: NearbySource[];
   modelVersion: string | null;
+};
+
+/** Which reviewed release answered, so an advisor can cite what they saw. */
+export type NearbyRelease = {
+  releaseId: string;
+  sourceRetrievedAt: string | null;
+  sourcePolicyVersion: string | null;
+};
+
+/** How much of the market has been reviewed. 60 records is not a census. */
+export type NearbyReviewScope = {
+  organizationAnchorCount: number | null;
+  marketCensusComplete: boolean;
+};
+
+/**
+ * The service's own statement that none of this is about money.
+ *
+ * This surface renders a component literally named "capital access" to
+ * advisers whose job is judging whether someone can invest. That is the one
+ * reading the product must not invite, so the sentence that prevents it is
+ * carried and shown next to the number.
+ */
+export type NearbyFinancialContext = {
+  status: string;
+  capitalAccessNote: string | null;
+  notUsedForRanking: string[];
+};
+
+/** What "in this market" means for one person — never where they live. */
+export type NearbyAssociationContext = {
+  category: string;
+  definition: string | null;
 };
 
 export type NearbyDiscoverResult = {
@@ -161,6 +195,9 @@ export type NearbyDiscoverResult = {
     searchPerformed: boolean;
     effectiveRadiusKm: number | null;
   };
+  release: NearbyRelease | null;
+  reviewScope: NearbyReviewScope | null;
+  financialContext: NearbyFinancialContext | null;
   scoreDefinition: string | null;
   results: NearbyRecord[];
 };
@@ -355,6 +392,20 @@ export function availableTags(records: NearbyRecord[]): string[] {
     for (const tag of record.tags) seen.add(tag);
   }
   return [...seen].sort();
+}
+
+/** Plain wording for how a person is associated with the queried market. */
+export const ASSOCIATION_CATEGORY_LABELS: Record<string, string> = {
+  BASED_HERE: "Based here",
+  WORKS_HERE: "Works here",
+  SERVES_HERE: "Serves here",
+};
+
+export function associationCategoryLabel(key: string): string {
+  return (
+    ASSOCIATION_CATEGORY_LABELS[key] ??
+    key.charAt(0) + key.slice(1).toLowerCase().replace(/_/g, " ")
+  );
 }
 
 /** Plain names for what a citation proves. */


### PR DESCRIPTION
# Description

Consumes the v2.5.0 release. I probed the deployed service rather than working from the handoff document — everything the app already consumed survived (`score_breakdown`, `evidence`, `market_label`, and `verified_seed_candidate_count` is retained alongside its new name). Three new blocks matter.

## 1. "Capital access" could be read as wealth — the one reading this product must not invite

The score explainer renders a component **literally named "Capital access"**, showing **64** on the top record, to advisers whose entire job is judging whether someone can invest.

The service now states plainly what that component is:

> `PUBLIC_PROFESSIONAL_RELATIONSHIP_ONLY; it is not a measure of personal wealth or ability to pay.`

That sentence now sits **on the row**, not in a footnote nobody reaches:

```
Capital access                    ████        64 · 10%
  Professional relationships only — not wealth or ability to pay.
```

It appears **only when the service actually asserts it**. There is a test proving the app renders nothing when the note is absent — the wording exists because the service says so, and the app does not put words in its mouth.

## 2. Sixty records in one postcode reads like everyone there

`discovery.market_census_complete` is `false`, across 13 reviewed organisations. The list now says so:

> Public work associations. Not homes, not net worth.
> Reviewed from 13 organisations — not a complete list.

The second line disappears if a market ever genuinely is a census.

## 3. "Based here" reads as "lives here" without its definition

`public_association_context` gives each record a category plus the release's own definition. The definition is the part that keeps the claim honest, so the two travel together — a category arriving without one is dropped rather than shown bare.

```
Based here · Monolithic Power Systems public Kirkland office association · within 2 km
Current verified public organization or civic association in this market;
not a claim of physical presence or residence.
```

Release identity (`release_id`, retrieval date, source policy version) is also carried so a result can be cited later.

## A bug the tests caught

The new discovery normaliser was named `_normalize_discovery` — which **already existed** as the whole-response normaliser. Defined later, it shadowed the original, and `coverage` vanished from every result. Twelve tests failed immediately. Renamed to `_normalize_review_scope`.

## Verified against the live service

| Checked | Result |
| --- | --- |
| `score_breakdown` survived v2.5 | present, 7 components |
| `evidence` survived | present |
| `coverage.market_label` survived | `Kirkland public-association market` |
| `summary.verified_seed_candidate_count` | retained alongside the new name — no break |
| Records / lanes | 60; BUILDER 20, KNOWLEDGE 21, CIVIC 9, CONNECTOR 10 |
| Grades | all B — the existing dead-option rule already hides A and C |

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/ria/clients` → Around you. No route added.

- API / schema / type changes:
  - [x] Listed below: `release`, `reviewScope`, `financialContext` on the response; `associationContext` on each record. All additive and nullable. No database change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: renders inside the existing `AdaptiveDetailSurface`. No new native surface. `verify:capacitor:static` passes.

- Docs updated (exact files):
  - [x] None — the service ships its own wording with every response, which is the point; a copy in a doc would go stale.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below: this strengthens it. The finance boundary and the association definition are now shown to the reader rather than living in a handoff document.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof: `nws_nearby_service.py` normalises all four; 5 new backend tests including one that drops every new block.

- Rollback or safe-failure behavior:
  - [x] Listed below: an older service revision omitting any block renders exactly as before — proved by `test_an_older_service_revision_omits_the_new_blocks_cleanly`. Revert is a revert.

- UI browser or Playwright proof:
  - [x] Listed below: 22 component tests driving the real components.

- Verification commands executed:
  - [x] `npm run typecheck` — clean
  - [x] `npm run lint` — clean, 0 warnings
  - [x] `npm run test:ci` — **27 failed / 3498 passed**; baseline at merge-base `60198c5c` is **27 failed / 3492 passed**, **byte-identical failing set**. Zero regressions, +6 passing.
  - [x] `bash scripts/ci/backend-check.sh` — ruff, mypy, bandit, **846 passed**
  - [x] `verify:design-system`, `verify:service-boundary`, `verify:surface-map`, `verify:voice-gateway`, `audit:cache-coherence`, `verify:capacitor:static` — all pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Consumes NWS `v2.5.0`, already live — confirmed by calling the deployed service.
- [x] Reachable production attach point: `/ria/clients` → Around you → open a record.
- [x] New tests import and exercise production code, not stand-ins.
- [x] Production surface proved: 3 capital-access tests, 3 review-scope tests, 5 backend pass-through tests, plus the existing 31 still passing.
- [ ] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: the change.
- [x] **iOS** / **Android**: not applicable — no native code.

## 🧪 Testing

- [x] Tested on Web
- [x] Component tests drive real interactions
- [x] No generated files changed

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No change.
- [x] Sensitive surface touched: this **reduces** misread risk on the highest-risk element on the screen — a component named "capital access" shown to advisers assessing investability.
- [x] Error path proved: each block absent → renders as before; a category without its definition → dropped rather than shown bare.

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] No dependencies added
