### PR TITLE
feat(agent): queue chat prompts and bound composer

### DIFF
--- a/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
@@ -39,4 +39,24 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).toContain("setWelcomePromptSetIndex((current)");
     expect(workspace).toContain("prompts={welcomePrompts}");
   });
+
+  it("keeps prompt and calendar work serialized while preserving an editable pending queue", () => {
+    const workspace = read("components/agent/agent-chat-workspace.tsx");
+
+    expect(workspace).toContain("drainOperationQueue");
+    expect(workspace).toContain("agent-chat-prompt-queue");
+    expect(workspace).toContain("enqueueCalendarDirective");
+    expect(workspace).toContain('text: "Scheduling…"');
+    expect(workspace).not.toContain("streamAbortControllerRef.current?.abort();\n    streamAbortControllerRef.current = streamAbortController");
+  });
+
+  it("bounds the responsive composer and only reveals the larger editor control for long input", () => {
+    const workspace = read("components/agent/agent-chat-workspace.tsx");
+
+    expect(workspace).toContain("agent-chat-composer-expand");
+    expect(workspace).toContain("overflow-y-auto");
+    expect(workspace).toContain("max-h-[min(40dvh,18rem)]");
+    expect(workspace).toContain("max-h-28 sm:max-h-36");
+    expect(workspace).toContain("composerLong ?");
+  });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -3706,8 +3706,8 @@ export function AgentChatWorkspace({
     const prompt = queuedHandoffPrompt?.trim();
     if (!prompt) return;
     setQueuedHandoffPrompt(null);
-    enqueuePrompt(prompt);
-  }, [enqueuePrompt, queuedHandoffPrompt]);
+    void handoffPromptSubmitRef.current?.(prompt);
+  }, [queuedHandoffPrompt, setQueuedHandoffPrompt]);
 
   useEffect(() => {
     if (!isPopover || !isSurfaceClosing) return;

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -1660,7 +1660,7 @@ export function AgentChatWorkspace({
     skipInitialHistoryLoadRef.current = false;
     latestVisibleTurnIdRef.current = null;
     inlineConsentRequestIdsRef.current.clear();
-  }, [abortAgentTurnWork, user?.uid, isVaultUnlocked]);
+  }, [abortAgentTurnWork, isVaultUnlocked, updateConversationId, user?.uid]);
 
   const handleCreateNewChat = useCallback(() => {
     abortAgentTurnWork();
@@ -1682,7 +1682,7 @@ export function AgentChatWorkspace({
     setEditingQueuedPromptId(null);
     setEditingQueuedPromptText("");
     setWelcomePromptSetIndex((current) => getWelcomePromptSetIndex(current));
-  }, [abortAgentTurnWork]);
+  }, [abortAgentTurnWork, updateConversationId]);
 
   const updateMessage = (
     messageId: string,
@@ -1949,7 +1949,7 @@ export function AgentChatWorkspace({
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [hasChatAccess, user?.uid, vaultOwnerToken]);
+  }, [hasChatAccess, updateConversationId, user?.uid, vaultOwnerToken]);
 
   const restoreConversationMessages = useCallback(
     async (nextConversationId: string, token: string) => {
@@ -1970,7 +1970,7 @@ export function AgentChatWorkspace({
       setPendingSpecialistDirective(null);
       setSpecialistBusy(false);
     },
-    [user?.uid]
+    [updateConversationId, user?.uid]
   );
 
   const loadConversationList = useCallback(async (force = false) => {
@@ -3707,7 +3707,7 @@ export function AgentChatWorkspace({
     if (!prompt) return;
     setQueuedHandoffPrompt(null);
     enqueuePrompt(prompt);
-  }, [queuedHandoffPrompt]);
+  }, [enqueuePrompt, queuedHandoffPrompt]);
 
   useEffect(() => {
     if (!isPopover || !isSurfaceClosing) return;

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -21,12 +21,16 @@ import {
   KeyRound,
   LogIn,
   Menu,
+  Maximize2,
   Mic,
+  Minimize2,
   Minus,
+  Pencil,
   RotateCcw,
   Send,
   ThumbsDown,
   ThumbsUp,
+  Trash2,
   UserRound,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -149,9 +153,13 @@ import {
 } from "@/lib/agent/one-conversation-session";
 import {
   dedupeAdjacentAgentMessages,
-  releaseAgentTurnSubmitLock,
-  tryAcquireAgentTurnSubmitLock,
 } from "@/lib/agent/agent-chat-turn-safety";
+import {
+  editQueuedAgentPrompt,
+  removeQueuedAgentPrompt,
+  SerialAgentOperationQueue,
+  type QueuedAgentPrompt,
+} from "@/lib/agent/agent-chat-prompt-queue";
 import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import { getVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
@@ -177,6 +185,12 @@ type AgentDebugEvent = {
   timestamp: string;
   event: string;
   payload: unknown;
+};
+
+type QueuedWorkspaceOperation = {
+  id: string;
+  prompt?: QueuedAgentPrompt;
+  run: () => Promise<void>;
 };
 
 function upsertVisibleStreamEvent(
@@ -1154,6 +1168,11 @@ export function AgentChatWorkspace({
   // (background-task tracking and its local voice state) below.
   const sharedRuntime = useAgentRuntimeStateOptional();
   const [input, setInput] = useState("");
+  const [composerExpanded, setComposerExpanded] = useState(false);
+  const [composerLong, setComposerLong] = useState(false);
+  const [queuedPrompts, setQueuedPrompts] = useState<QueuedAgentPrompt[]>([]);
+  const [editingQueuedPromptId, setEditingQueuedPromptId] = useState<string | null>(null);
+  const [editingQueuedPromptText, setEditingQueuedPromptText] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [conversations, setConversations] = useState<AgentChatConversation[]>([]);
   const [messages, setMessages] = useState<AgentMessage[]>(() => [createGreetingMessage()]);
@@ -1210,12 +1229,18 @@ export function AgentChatWorkspace({
   const historyRestoreEpochRef = useRef(0);
   const skipInitialHistoryLoadRef = useRef(false);
   const streamAbortControllerRef = useRef<AbortController | null>(null);
-  const agentTurnSubmitLockRef = useRef(false);
+  const conversationIdRef = useRef<string | null>(null);
+  const operationQueueRef = useRef(new SerialAgentOperationQueue<QueuedWorkspaceOperation>());
+  const calendarActionIdsRef = useRef<Set<string>>(new Set());
   const savingPkmReviewIdsRef = useRef<Set<string>>(new Set());
   const handoffPromptSubmitRef = useRef<((prompt: string) => Promise<void>) | null>(null);
   const pkmAbortControllersRef = useRef<Set<AbortController>>(new Set());
   const latestVisibleTurnIdRef = useRef<string | null>(null);
   const inlineConsentRequestIdsRef = useRef<Set<string>>(new Set());
+  const updateConversationId = useCallback((nextConversationId: string | null) => {
+    conversationIdRef.current = nextConversationId;
+    setConversationId(nextConversationId);
+  }, []);
   const oneLocationConsentActions = useOneLocationConsentActions({
     userId: user?.uid,
     onActionComplete: () => {
@@ -1447,10 +1472,8 @@ export function AgentChatWorkspace({
   // full agent, otherwise it runs the pre-vault informational tier. Voice and
   // vault-backed tools stay gated separately by hasChatAccess.
   const canSend =
-    !isChatLoading &&
     !isLoadingHistory &&
     !isVoiceConnecting &&
-    !isStreaming &&
     !voiceActive &&
     input.trim().length > 0;
   const canToggleVoice =
@@ -1461,7 +1484,9 @@ export function AgentChatWorkspace({
     isToolWorking ||
     isVoiceConnecting ||
     isStreaming ||
-    voiceActive;
+    voiceActive ||
+    specialistBusy ||
+    queuedPrompts.length > 0;
   const statusText = useMemo(
     () => {
       if (authLoading) return "Checking access";
@@ -1480,6 +1505,7 @@ export function AgentChatWorkspace({
       if (isVoiceConnecting) return "Voice connecting";
       if (isToolWorking) return "Working";
       if (isPkmMemoryWorking) return "Saving memory";
+      if (queuedPrompts.length > 0) return `${queuedPrompts.length} queued`;
       if (isChatLoading) return "Thinking";
       if (isStreaming) return "Streaming";
       return "Ready";
@@ -1495,6 +1521,7 @@ export function AgentChatWorkspace({
       isStreaming,
       isVoiceConnecting,
       isVaultUnlocked,
+      queuedPrompts.length,
       tokenIsFresh,
       user?.uid,
       vaultOwnerToken,
@@ -1511,7 +1538,13 @@ export function AgentChatWorkspace({
     const textarea = composerTextareaRef.current;
     if (!textarea || voiceActive) return;
     textarea.style.height = "0px";
-    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+    const nextHeight = textarea.scrollHeight;
+    textarea.style.height = `${nextHeight}px`;
+    // `scrollHeight` includes soft-wrapped text, which is the visual behavior
+    // people notice. Reveal the larger editor after roughly four rendered rows.
+    const long = input.trim().length > 0 && nextHeight > 96;
+    setComposerLong(long);
+    if (!long) setComposerExpanded(false);
   }, [input, voiceActive]);
 
   useEffect(() => {
@@ -1608,7 +1641,7 @@ export function AgentChatWorkspace({
     setActivePkmToolCount(0);
     setPkmReviews([]);
     setPkmActivity([]);
-    setConversationId(null);
+    updateConversationId(null);
     setConversations([]);
     setHistoryActionPendingId(null);
     setMessages([createGreetingMessage()]);
@@ -1617,7 +1650,11 @@ export function AgentChatWorkspace({
     setPendingSpecialistDirective(null);
     setSpecialistBusy(false);
     setSpecialistBusyItemId(null);
-    releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
+    operationQueueRef.current.replace([]);
+    calendarActionIdsRef.current.clear();
+    setQueuedPrompts([]);
+    setEditingQueuedPromptId(null);
+    setEditingQueuedPromptText("");
     historyLoadKeyRef.current = null;
     historyRestoreEpochRef.current += 1;
     skipInitialHistoryLoadRef.current = false;
@@ -1629,7 +1666,7 @@ export function AgentChatWorkspace({
     abortAgentTurnWork();
     historyRestoreEpochRef.current += 1;
     latestVisibleTurnIdRef.current = null;
-    setConversationId(null);
+    updateConversationId(null);
     setMessages([createGreetingMessage()]);
     setInput("");
     setIsLoadingHistory(false);
@@ -1639,6 +1676,11 @@ export function AgentChatWorkspace({
     setAppActionBusy(false);
     setPendingSpecialistDirective(null);
     setSpecialistBusy(false);
+    operationQueueRef.current.replace([]);
+    calendarActionIdsRef.current.clear();
+    setQueuedPrompts([]);
+    setEditingQueuedPromptId(null);
+    setEditingQueuedPromptText("");
     setWelcomePromptSetIndex((current) => getWelcomePromptSetIndex(current));
   }, [abortAgentTurnWork]);
 
@@ -1863,14 +1905,14 @@ export function AgentChatWorkspace({
       if (cancelled || restoreEpoch !== historyRestoreEpochRef.current) return;
       setConversations(snapshot.conversations);
       if (!snapshot.latestConversationId) {
-        setConversationId(null);
+        updateConversationId(null);
         setMessages([createGreetingMessage()]);
         return;
       }
       const restored = snapshot.latestMessages
         .map(storedMessageToAgentMessage)
         .filter((message): message is AgentMessage => Boolean(message));
-      setConversationId(snapshot.latestConversationId);
+      updateConversationId(snapshot.latestConversationId);
       setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
     };
 
@@ -1921,7 +1963,7 @@ export function AgentChatWorkspace({
         .map(storedMessageToAgentMessage)
         .filter((message): message is AgentMessage => Boolean(message));
       latestVisibleTurnIdRef.current = null;
-      setConversationId(nextConversationId);
+      updateConversationId(nextConversationId);
       setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
       setPkmActivity([]);
       setPkmReviews([]);
@@ -2808,9 +2850,6 @@ export function AgentChatWorkspace({
       }
       return [...current, ...(appendUserMessage ? [userMessage] : []), assistantMessage];
     });
-    if (options.source === "typed" && appendUserMessage) {
-      setInput("");
-    }
     latestVisibleTurnIdRef.current = debugTurnId;
     setPkmActivity([]);
     setIsChatLoading(true);
@@ -2834,7 +2873,6 @@ export function AgentChatWorkspace({
     }
 
     const streamAbortController = new AbortController();
-    streamAbortControllerRef.current?.abort();
     streamAbortControllerRef.current = streamAbortController;
     let specialistDirectiveReceived = false;
     const pkmContextStartedAt = performance.now();
@@ -2936,7 +2974,7 @@ export function AgentChatWorkspace({
       const streamResult = await streamAgentChat({
         userId,
         message: text,
-        conversationId,
+        conversationId: conversationIdRef.current,
         vaultOwnerToken: token,
         pkmContext: agentPkmContext.text || undefined,
         screenContext: buildOneVoiceStructuredScreenContext({
@@ -2954,7 +2992,7 @@ export function AgentChatWorkspace({
           onStart: ({ conversationId: nextConversationId }) => {
             if (streamAbortController.signal.aborted) return;
             if (nextConversationId) {
-              setConversationId(nextConversationId);
+              updateConversationId(nextConversationId);
             }
           },
           onToolStart: (toolEvent) => {
@@ -3026,7 +3064,7 @@ export function AgentChatWorkspace({
             if (streamAbortController.signal.aborted) return;
             flushAssistantDelta();
             if (nextConversationId) {
-              setConversationId(nextConversationId);
+              updateConversationId(nextConversationId);
             }
             updateMessage(assistantMessageId, (message) => ({
               ...message,
@@ -3056,7 +3094,7 @@ export function AgentChatWorkspace({
       }
       flushAssistantDelta();
       if (streamResult.conversationId) {
-        setConversationId(streamResult.conversationId);
+        updateConversationId(streamResult.conversationId);
       }
       updateMessage(assistantMessageId, (message) => {
         if (message.status === "error") return message;
@@ -3167,7 +3205,6 @@ export function AgentChatWorkspace({
     setIsStreaming(true);
 
     const streamAbortController = new AbortController();
-    streamAbortControllerRef.current?.abort();
     streamAbortControllerRef.current = streamAbortController;
 
     try {
@@ -3179,7 +3216,7 @@ export function AgentChatWorkspace({
       const streamResult = await streamAgentChat({
         userId,
         message: "",
-        conversationId,
+        conversationId: conversationIdRef.current,
         vaultOwnerToken: token,
         delegateResult: result,
         screenContext: buildOneVoiceStructuredScreenContext({
@@ -3202,7 +3239,7 @@ export function AgentChatWorkspace({
         handlers: {
           onStart: ({ conversationId: nextConversationId }) => {
             if (streamAbortController.signal.aborted) return;
-            if (nextConversationId) setConversationId(nextConversationId);
+            if (nextConversationId) updateConversationId(nextConversationId);
           },
           onToken: (delta) => {
             if (streamAbortController.signal.aborted) return;
@@ -3249,7 +3286,7 @@ export function AgentChatWorkspace({
           onComplete: ({ conversationId: nextConversationId }) => {
             if (streamAbortController.signal.aborted) return;
             flushAssistantDelta();
-            if (nextConversationId) setConversationId(nextConversationId);
+            if (nextConversationId) updateConversationId(nextConversationId);
             updateMessage(assistantMessageId, (message) => ({
               ...message,
               status: "done",
@@ -3283,7 +3320,7 @@ export function AgentChatWorkspace({
       }
       flushAssistantDelta();
       if (streamResult.conversationId) {
-        setConversationId(streamResult.conversationId);
+        updateConversationId(streamResult.conversationId);
       }
       updateMessage(assistantMessageId, (message) => {
         if (message.status === "error") return message;
@@ -3337,7 +3374,7 @@ export function AgentChatWorkspace({
    */
   const runIntroTurn = async (textInput: string) => {
     const text = textInput.trim();
-    if (!text || isChatLoading || isStreaming) return;
+    if (!text) return;
 
     const turnId = Date.now();
     const assistantMessageId = `msg-${turnId}-assistant`;
@@ -3387,12 +3424,10 @@ export function AgentChatWorkspace({
       status: "streaming",
     };
     setMessages((current) => [...current, userMessage, assistantMessage]);
-    setInput("");
     setIsChatLoading(true);
     setIsStreaming(true);
 
     const streamAbortController = new AbortController();
-    streamAbortControllerRef.current?.abort();
     streamAbortControllerRef.current = streamAbortController;
 
     const stageIntroNavigation = (toolEvent: AgentChatToolEvent) => {
@@ -3521,49 +3556,158 @@ export function AgentChatWorkspace({
     }
   };
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const text = input.trim();
-    if (!text || isChatLoading || isStreaming) return;
-    if (!tryAcquireAgentTurnSubmitLock(agentTurnSubmitLockRef)) return;
-    if (hasChatAccess) {
-      try {
-        await runAgentTurn(text, { source: "typed" });
-      } finally {
-        releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
-      }
-      return;
-    }
-    // Pre-vault / anonymous: single bar degrades to the informational tier.
-    try {
-      await runIntroTurn(text);
-    } finally {
-      releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
+  const syncQueuedPrompts = () => {
+    setQueuedPrompts(
+      operationQueueRef.current
+        .snapshot()
+        .flatMap((operation) => (operation.prompt ? [operation.prompt] : [])),
+    );
+  };
+
+  const drainOperationQueue = async () => {
+    await operationQueueRef.current.drain(async (operation) => {
+      syncQueuedPrompts();
+      await operation.run();
+    });
+  };
+
+  const enqueueWorkspaceOperation = (operation: QueuedWorkspaceOperation) => {
+    operationQueueRef.current.enqueue(operation);
+    syncQueuedPrompts();
+    void drainOperationQueue();
+  };
+
+  const enqueuePrompt = (textInput: string) => {
+    const text = textInput.trim();
+    if (!text) return;
+    const prompt: QueuedAgentPrompt = {
+      id: crypto.randomUUID(),
+      text,
+      createdAtMs: Date.now(),
+    };
+    const operation: QueuedWorkspaceOperation = {
+      id: prompt.id,
+      prompt,
+      run: async () => {
+        if (hasChatAccess) {
+          await runAgentTurn(operation.prompt?.text ?? "", { source: "typed" });
+          return;
+        }
+        await runIntroTurn(operation.prompt?.text ?? "");
+      },
+    };
+    enqueueWorkspaceOperation(operation);
+  };
+
+  const editQueuedPrompt = (id: string, textInput: string) => {
+    const text = textInput.trim();
+    if (!text) return;
+    operationQueueRef.current.replace(operationQueueRef.current.snapshot().map((operation) =>
+      operation.prompt?.id === id
+        ? { ...operation, prompt: { ...operation.prompt, text } }
+        : operation,
+    ));
+    setQueuedPrompts((current) => editQueuedAgentPrompt(current, id, text));
+    setEditingQueuedPromptId(null);
+    setEditingQueuedPromptText("");
+  };
+
+  const removeQueuedPrompt = (id: string) => {
+    operationQueueRef.current.replace(operationQueueRef.current.snapshot().filter(
+      (operation) => operation.prompt?.id !== id,
+    ));
+    setQueuedPrompts((current) => removeQueuedAgentPrompt(current, id));
+    if (editingQueuedPromptId === id) {
+      setEditingQueuedPromptId(null);
+      setEditingQueuedPromptText("");
     }
   };
 
+  const enqueueCalendarDirective = (
+    directive: SpecialistDirectiveEvent,
+    token: string,
+    userId: string,
+  ) => {
+    const payload = directive.directive.payload as Record<string, unknown>;
+    const actionKey = String(payload.proposalId ?? payload.id ?? directive.message);
+    if (calendarActionIdsRef.current.has(actionKey)) return;
+    calendarActionIdsRef.current.add(actionKey);
+    const label = String(payload.confirmLabel ?? "Confirm");
+    const resultMessageId = `msg-${crypto.randomUUID()}-calendar-result`;
+
+    appendMessage({
+      id: `msg-${crypto.randomUUID()}-calendar-confirm`,
+      role: "user",
+      text: label,
+      timestamp: formatNow(),
+      status: "done",
+      kind: "selection",
+    });
+    appendMessage({
+      id: resultMessageId,
+      role: "assistant",
+      text: "Scheduling…",
+      timestamp: formatNow(),
+      status: "streaming",
+    });
+    setPendingSpecialistDirective(null);
+    setSpecialistBusy(true);
+
+    enqueueWorkspaceOperation({
+      id: `calendar-${actionKey}`,
+      run: async () => {
+        try {
+          const result = await runCalendarDirective(directive.directive, token, userId);
+          updateMessage(resultMessageId, (message) => ({
+            ...message,
+            text: result.detail || "Calendar updated.",
+            status: "done",
+          }));
+        } catch (error) {
+          updateMessage(resultMessageId, (message) => ({
+            ...message,
+            text:
+              error instanceof Error
+                ? error.message
+                : "The Calendar change could not be completed.",
+            status: "error",
+          }));
+        } finally {
+          calendarActionIdsRef.current.delete(actionKey);
+          setSpecialistBusy(false);
+        }
+      },
+    });
+  };
+
+  const enqueueDelegateResult = (result: DelegateResult) => {
+    enqueueWorkspaceOperation({
+      id: `delegate-${crypto.randomUUID()}`,
+      run: async () => {
+        await sendDelegateResult(result);
+      },
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const text = input.trim();
+    if (!text || isLoadingHistory || isVoiceConnecting || voiceActive) return;
+    setInput("");
+    setComposerExpanded(false);
+    enqueuePrompt(text);
+  };
+
   handoffPromptSubmitRef.current = async (prompt: string) => {
-    if (hasChatAccess) {
-      await runAgentTurn(prompt, { source: "typed" });
-      return;
-    }
-    await runIntroTurn(prompt);
+    enqueuePrompt(prompt);
   };
 
   useEffect(() => {
     const prompt = queuedHandoffPrompt?.trim();
-    if (!prompt || isChatLoading || isStreaming) return;
-    if (!tryAcquireAgentTurnSubmitLock(agentTurnSubmitLockRef)) return;
+    if (!prompt) return;
     setQueuedHandoffPrompt(null);
-
-    void (async () => {
-      try {
-        await handoffPromptSubmitRef.current?.(prompt);
-      } finally {
-        releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
-      }
-    })();
-  }, [isChatLoading, isStreaming, queuedHandoffPrompt]);
+    enqueuePrompt(prompt);
+  }, [queuedHandoffPrompt]);
 
   useEffect(() => {
     if (!isPopover || !isSurfaceClosing) return;
@@ -3643,7 +3787,6 @@ export function AgentChatWorkspace({
           message.text.trim().length > 0
       )?.id ?? null;
   const handleRetryAssistantResponse = (messageId: string) => {
-    if (isChatLoading || isStreaming) return;
     const assistantIndex = messages.findIndex((message) => message.id === messageId);
     if (assistantIndex < 0) return;
     const previousUserMessage = [...messages.slice(0, assistantIndex)]
@@ -3654,24 +3797,24 @@ export function AgentChatWorkspace({
       toast.error("No previous message found to retry.");
       return;
     }
-    if (!tryAcquireAgentTurnSubmitLock(agentTurnSubmitLockRef)) return;
     setPkmReviews([]);
     setPkmActivity([]);
     // Pre-vault / anonymous turns go through the informational intro tier, which
     // runAgentTurn early-returns on (no vault access). Route the retry to the
     // same tier the original turn used so the button is not a no-op there.
-    if (!hasChatAccess) {
-      void runIntroTurn(retryText).finally(() => {
-        releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
-      });
-      return;
-    }
-    void runAgentTurn(retryText, {
-      source: "typed",
-      appendUserMessage: false,
-      replaceAssistantMessageId: messageId,
-    }).finally(() => {
-      releaseAgentTurnSubmitLock(agentTurnSubmitLockRef);
+    enqueueWorkspaceOperation({
+      id: `retry-${crypto.randomUUID()}`,
+      run: async () => {
+        if (!hasChatAccess) {
+          await runIntroTurn(retryText);
+          return;
+        }
+        await runAgentTurn(retryText, {
+          source: "typed",
+          appendUserMessage: false,
+          replaceAssistantMessageId: messageId,
+        });
+      },
     });
   };
   const handleWelcomePromptSelect = useCallback((prompt: string) => {
@@ -4123,7 +4266,7 @@ export function AgentChatWorkspace({
                           status: "done",
                           kind: "selection",
                         });
-                        await sendDelegateResult({
+                        enqueueDelegateResult({
                           delegate_agent_id: "agent_connected_systems",
                           kind: "selection",
                           id: String(prompt.id ?? ""),
@@ -4154,7 +4297,7 @@ export function AgentChatWorkspace({
                         status: "done",
                         kind: "selection",
                       });
-                      await sendDelegateResult({
+                      enqueueDelegateResult({
                         delegate_agent_id: "agent_connected_systems",
                         kind: "selection",
                         id: String(prompt.id ?? ""),
@@ -4189,7 +4332,7 @@ export function AgentChatWorkspace({
                           status: "done",
                           kind: "selection",
                         });
-                        await sendDelegateResult({
+                        enqueueDelegateResult({
                           delegate_agent_id: evt.delegateAgentId as DelegateResult["delegate_agent_id"],
                           kind: "selection",
                           id: prompt.id,
@@ -4217,7 +4360,7 @@ export function AgentChatWorkspace({
                           status: "done",
                           kind: "selection",
                         });
-                        await sendDelegateResult({
+                        enqueueDelegateResult({
                           delegate_agent_id: evt.delegateAgentId as DelegateResult["delegate_agent_id"],
                           kind: "selection",
                           id: prompt.id,
@@ -4243,7 +4386,7 @@ export function AgentChatWorkspace({
                         status: "done",
                         kind: "selection",
                       });
-                      await sendDelegateResult({
+                      enqueueDelegateResult({
                         delegate_agent_id: evt.delegateAgentId as DelegateResult["delegate_agent_id"],
                         kind: "selection",
                         id: prompt.id,
@@ -4306,40 +4449,7 @@ export function AgentChatWorkspace({
                         addErrorMessage("Vault access expired. Unlock again to continue.");
                         return;
                       }
-                      setSpecialistBusy(true);
-                      try {
-                        const label = String(payload.confirmLabel ?? "Confirm");
-                        appendMessage({
-                          id: `msg-${Date.now()}-calendar-confirm`,
-                          role: "user",
-                          text: label,
-                          timestamp: formatNow(),
-                          status: "done",
-                          kind: "selection",
-                        });
-                        const result = await runCalendarDirective(
-                          directive.directive,
-                          token,
-                          user.uid,
-                        );
-                        setPendingSpecialistDirective(null);
-                        appendMessage({
-                          id: `msg-${Date.now()}-calendar-result`,
-                          role: "assistant",
-                          text: result.detail || "Calendar updated.",
-                          timestamp: formatNow(),
-                          status: "done",
-                        });
-                      } catch (error) {
-                        setPendingSpecialistDirective(null);
-                        addErrorMessage(
-                          error instanceof Error
-                            ? error.message
-                            : "The Calendar change could not be completed.",
-                        );
-                      } finally {
-                        setSpecialistBusy(false);
-                      }
+                      enqueueCalendarDirective(directive, token, user.uid);
                     }}
                     onCancel={() => {
                       setPendingSpecialistDirective(null);
@@ -4387,7 +4497,7 @@ export function AgentChatWorkspace({
                           },
                         );
                         setPendingSpecialistDirective(null);
-                        await sendDelegateResult(result);
+                        enqueueDelegateResult(result);
                       } finally {
                         setSpecialistBusy(false);
                       }
@@ -4403,7 +4513,7 @@ export function AgentChatWorkspace({
                         status: "done",
                         kind: "selection",
                       });
-                      await sendDelegateResult({
+                      enqueueDelegateResult({
                         delegate_agent_id: "agent_connected_systems",
                         kind: "action",
                         id: String(
@@ -4476,7 +4586,7 @@ export function AgentChatWorkspace({
                           );
                         }
                         // Follow-up turn: report the result back so One confirms in words.
-                        await sendDelegateResult(result);
+                        enqueueDelegateResult(result);
                       } finally {
                         setSpecialistBusy(false);
                       }
@@ -4492,7 +4602,7 @@ export function AgentChatWorkspace({
                         status: "done",
                         kind: "selection",
                       });
-                      await sendDelegateResult({
+                      enqueueDelegateResult({
                         delegate_agent_id: directive.delegateAgentId as DelegateResult["delegate_agent_id"],
                         kind: "action",
                         id: String(
@@ -4533,6 +4643,84 @@ export function AgentChatWorkspace({
             )}
           >
             <div className="mx-auto w-full max-w-4xl">
+              {queuedPrompts.length > 0 ? (
+                <div
+                  className="mb-2 rounded-2xl border border-border/70 bg-muted/45 px-3 py-2"
+                  data-testid="agent-chat-prompt-queue"
+                  aria-live="polite"
+                >
+                  <div className="flex items-center justify-between gap-3 text-xs font-medium text-muted-foreground">
+                    <span>{queuedPrompts.length} {queuedPrompts.length === 1 ? "message" : "messages"} queued</span>
+                    <span>One will send these in order.</span>
+                  </div>
+                  <div className="mt-1.5 space-y-1.5">
+                    {queuedPrompts.map((prompt, index) => (
+                      <div
+                        key={prompt.id}
+                        className="flex min-w-0 items-center gap-2 rounded-xl bg-background/75 px-2 py-1.5 text-sm"
+                      >
+                        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{index + 1}</span>
+                        {editingQueuedPromptId === prompt.id ? (
+                          <input
+                            autoFocus
+                            aria-label="Edit queued message"
+                            className="min-w-0 flex-1 bg-transparent outline-none"
+                            value={editingQueuedPromptText}
+                            onChange={(event) => setEditingQueuedPromptText(event.target.value)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") {
+                                event.preventDefault();
+                                editQueuedPrompt(prompt.id, editingQueuedPromptText);
+                              }
+                              if (event.key === "Escape") {
+                                setEditingQueuedPromptId(null);
+                                setEditingQueuedPromptText("");
+                              }
+                            }}
+                          />
+                        ) : (
+                          <span className="min-w-0 flex-1 truncate">{prompt.text}</span>
+                        )}
+                        {editingQueuedPromptId === prompt.id ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 px-2 text-xs"
+                            onClick={() => editQueuedPrompt(prompt.id, editingQueuedPromptText)}
+                          >
+                            Save
+                          </Button>
+                        ) : (
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            className="h-7 w-7"
+                            aria-label={`Edit queued message ${index + 1}`}
+                            onClick={() => {
+                              setEditingQueuedPromptId(prompt.id);
+                              setEditingQueuedPromptText(prompt.text);
+                            }}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                          aria-label={`Remove queued message ${index + 1}`}
+                          onClick={() => removeQueuedPrompt(prompt.id)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
               {voiceActive ? (
                 <div className="rounded-[var(--app-card-radius-compact)] border border-border/70 bg-foreground/[0.04] p-2 shadow-[var(--app-card-shadow-standard)]">
                   <AgentVoiceWaveInput
@@ -4545,26 +4733,51 @@ export function AgentChatWorkspace({
                   />
                 </div>
               ) : (
-                <div className="flex min-h-14 items-end gap-2 rounded-[var(--app-radius-pill)] border border-border/70 bg-foreground/[0.04] px-3 py-2 shadow-[var(--app-card-shadow-standard)] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 max-sm:focus-within:border-[color:var(--app-accent)] max-sm:focus-within:ring-[color:var(--app-accent-ring)]">
-                  <textarea
-                    ref={composerTextareaRef}
-                    aria-label="Message One"
-                    value={input}
-                    onChange={(event) => setInput(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
-                        return;
-                      }
-                      event.preventDefault();
-                      if (canSend) {
-                        event.currentTarget.form?.requestSubmit();
-                      }
-                    }}
-                    disabled={isLoadingHistory || isVoiceConnecting}
-                    placeholder="Message One..."
-                    rows={1}
-                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-[16px] leading-6 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:text-sm"
-                  />
+                <div
+                  data-testid="agent-chat-composer"
+                  className="flex min-h-14 items-end gap-2 rounded-[var(--app-radius-pill)] border border-border/70 bg-foreground/[0.04] px-3 py-2 shadow-[var(--app-card-shadow-standard)] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 max-sm:focus-within:border-[color:var(--app-accent)] max-sm:focus-within:ring-[color:var(--app-accent-ring)]"
+                >
+                  <div className="relative min-w-0 flex-1 self-stretch">
+                    <textarea
+                      ref={composerTextareaRef}
+                      data-testid="agent-chat-composer-textarea"
+                      aria-label="Message One"
+                      value={input}
+                      onChange={(event) => setInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
+                          return;
+                        }
+                        event.preventDefault();
+                        if (canSend) {
+                          event.currentTarget.form?.requestSubmit();
+                        }
+                      }}
+                      disabled={isLoadingHistory || isVoiceConnecting}
+                      placeholder="Message One..."
+                      rows={1}
+                      className={cn(
+                        "min-h-8 w-full resize-none overscroll-contain overflow-y-auto bg-transparent px-1 py-2 pr-9 text-[16px] leading-6 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:text-sm",
+                        composerExpanded
+                          ? "max-h-[min(40dvh,18rem)] sm:max-h-[min(48dvh,28rem)]"
+                          : "max-h-28 sm:max-h-36",
+                      )}
+                    />
+                    {composerLong ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        data-testid="agent-chat-composer-expand"
+                        className="absolute right-0.5 top-0.5 h-8 w-8 rounded-lg text-muted-foreground"
+                        aria-label={composerExpanded ? "Collapse message editor" : "Expand message editor"}
+                        title={composerExpanded ? "Collapse" : "Expand"}
+                        onClick={() => setComposerExpanded((expanded) => !expanded)}
+                      >
+                        {composerExpanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+                      </Button>
+                    ) : null}
+                  </div>
                   {agentVoiceEnabled ? (
                     <Button
                       type="button"

--- a/hushh-webapp/lib/agent/__tests__/agent-chat-prompt-queue.test.ts
+++ b/hushh-webapp/lib/agent/__tests__/agent-chat-prompt-queue.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  editQueuedAgentPrompt,
+  enqueueAgentPrompt,
+  removeQueuedAgentPrompt,
+  SerialAgentOperationQueue,
+} from "@/lib/agent/agent-chat-prompt-queue";
+
+describe("agent chat prompt queue", () => {
+  const first = { id: "first", text: "First", createdAtMs: 1 };
+  const second = { id: "second", text: "Second", createdAtMs: 2 };
+  const third = { id: "third", text: "Third", createdAtMs: 3 };
+
+  it("preserves FIFO insertion order", () => {
+    const queue = [first, second].reduce(enqueueAgentPrompt, [] as Array<typeof first>);
+    expect(enqueueAgentPrompt(queue, third).map((prompt) => prompt.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("edits in place without moving a pending prompt", () => {
+    const queue = editQueuedAgentPrompt([first, second, third], "second", "Updated");
+    expect(queue.map((prompt) => prompt.id)).toEqual(["first", "second", "third"]);
+    expect(queue[1].text).toBe("Updated");
+  });
+
+  it("removes a pending prompt without affecting the remaining order", () => {
+    expect(removeQueuedAgentPrompt([first, second, third], "second").map((prompt) => prompt.id)).toEqual([
+      "first",
+      "third",
+    ]);
+  });
+
+  it("serializes rapid operations and begins the next only after the active work settles", async () => {
+    const queue = new SerialAgentOperationQueue<string>();
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    queue.enqueue("calendar");
+    queue.enqueue("second prompt");
+    queue.enqueue("third prompt");
+    const drain = queue.drain(async (operation) => {
+      events.push(`start:${operation}`);
+      if (operation === "calendar") await first;
+      events.push(`end:${operation}`);
+    });
+
+    expect(events).toEqual(["start:calendar"]);
+    releaseFirst?.();
+    await drain;
+    expect(events).toEqual([
+      "start:calendar",
+      "end:calendar",
+      "start:second prompt",
+      "end:second prompt",
+      "start:third prompt",
+      "end:third prompt",
+    ]);
+  });
+});

--- a/hushh-webapp/lib/agent/agent-chat-prompt-queue.ts
+++ b/hushh-webapp/lib/agent/agent-chat-prompt-queue.ts
@@ -1,0 +1,62 @@
+export type QueuedAgentPrompt = {
+  id: string;
+  text: string;
+  createdAtMs: number;
+};
+
+export function enqueueAgentPrompt(
+  queue: readonly QueuedAgentPrompt[],
+  prompt: QueuedAgentPrompt,
+): QueuedAgentPrompt[] {
+  return [...queue, prompt];
+}
+
+export function editQueuedAgentPrompt(
+  queue: readonly QueuedAgentPrompt[],
+  id: string,
+  text: string,
+): QueuedAgentPrompt[] {
+  return queue.map((prompt) => (prompt.id === id ? { ...prompt, text } : prompt));
+}
+
+export function removeQueuedAgentPrompt(
+  queue: readonly QueuedAgentPrompt[],
+  id: string,
+): QueuedAgentPrompt[] {
+  return queue.filter((prompt) => prompt.id !== id);
+}
+
+/** A tiny in-memory serial runner. The workspace owns lifecycle cancellation;
+ * this primitive only guarantees that rapid enqueue calls start in FIFO order. */
+export class SerialAgentOperationQueue<T> {
+  private items: T[] = [];
+  private draining = false;
+
+  enqueue(item: T) {
+    this.items.push(item);
+  }
+
+  replace(items: T[]) {
+    this.items = items;
+  }
+
+  snapshot(): readonly T[] {
+    return this.items;
+  }
+
+  async drain(run: (item: T) => Promise<void> | void): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      while (this.items.length > 0) {
+        const next = this.items.shift();
+        if (next !== undefined) await run(next);
+      }
+    } finally {
+      this.draining = false;
+      if (this.items.length > 0) {
+        void this.drain(run);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- bound the Agent composer and add an expand control for long input\n- serialize prompts, Calendar confirmations, and delegate follow-ups\n- make queued prompts visible and editable/removable before execution\n\n## Validation\n- npm run typecheck\n- npm run lint\n- focused Vitest queue/chat shell tests\n- npm run verify:service-boundary\n- npm run cap:build && npm run cap:sync:ios