### PR TITLE
fix(webapp): RIA profile delete — stop the freeze, add a typed DELETE confirmation

### DIFF
--- a/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
@@ -26,6 +26,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <span />,
   ArrowRight: () => <span />,
   CheckCircle2: () => <span />,
   ClipboardCheck: () => <span />,
@@ -298,6 +299,16 @@ describe("RiaProfileSection manage actions", () => {
       expect(screen.getByTestId("delete-dialog")).toBeTruthy(),
     );
 
+    // The destructive action is gated behind a typed confirmation: tapping it
+    // before the word is entered must do nothing at all.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-confirm"));
+    });
+    expect(mocks.riaService.deleteProfile).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+      target: { value: "DELETE" },
+    });
     await act(async () => {
       fireEvent.click(screen.getByTestId("delete-confirm"));
     });

--- a/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
@@ -27,6 +27,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <span />,
   ArrowRight: () => <span />,
   CheckCircle2: () => <span />,
   ClipboardCheck: () => <span />,

--- a/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -115,8 +115,22 @@ vi.mock("@/components/ui/alert-dialog", () => ({
   AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
-  AlertDialogAction: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  // Pass props through (notably onClick/disabled) — the delete confirmation is
+  // only reachable in a test if the action button actually wires its handler.
+  AlertDialogCancel: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  ),
+  AlertDialogAction: ({
+    children,
+    variant: _variant,
+    ...props
+  }: {
+    children: React.ReactNode;
+    variant?: string;
+  } & Record<string, unknown>) => <button {...props}>{children}</button>,
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -228,5 +242,63 @@ describe("RiaProfileSection redirect loop breaker", () => {
   it("never redirects when the profile exists", () => {
     renderSection({ exists: true, verification_status: "submitted" });
     expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Regression: deleting the RIA profile froze the page on "Loading profile..."
+   * and never returned to One home (reported on web, 2026-08-13).
+   *
+   * `deleting` is the single guard suppressing BOTH the "no profile →
+   * onboarding" redirect effect and the `pendingOnboardingRedirect` skeleton.
+   * Clearing it in a `finally` fired before the async router.replace("/one")
+   * had landed, so the still-mounted component saw the post-delete state
+   * (capability "setup", exists:false), re-fired the redirect over the trip to
+   * One home, and rendered the spinner — permanently, because the effect's
+   * one-attempt ref makes it return before arming the redirectSettled timer.
+   */
+  it("goes to One home after delete without redirecting to onboarding or freezing", async () => {
+    mocks.riaService.deleteProfile.mockResolvedValue(undefined);
+    mocks.switchPersona.mockResolvedValue(undefined);
+
+    const { rerender } = renderSection({
+      exists: true,
+      verification_status: "verified",
+      advisory_status: "active",
+    });
+
+    fireEvent.click(screen.getByTestId("ria-profile-delete"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("Delete profile"));
+    });
+
+    await waitFor(() =>
+      expect(mocks.riaService.deleteProfile).toHaveBeenCalledTimes(1),
+    );
+
+    // The delete has landed server-side: persona drops to the investor and the
+    // profile row is gone. The component is still mounted because the App
+    // Router navigation has not completed yet — exactly the window the bug
+    // lived in.
+    mocks.usePersonaState.mockReturnValue({
+      riaCapability: "setup",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+    rerender(
+      <RiaProfileSection
+        status={{ exists: false } as never}
+        loading={false}
+        onRefresh={vi.fn()}
+      />,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mocks.routerReplace).toHaveBeenCalledWith("/one");
+    expect(mocks.routerReplace).not.toHaveBeenCalledWith("/ria/onboarding");
+    expect(screen.queryByText("Loading profile...")).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
@@ -41,6 +41,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <span />,
   ArrowRight: () => <span />,
   CheckCircle2: () => <span />,
   ClipboardCheck: () => <span />,
@@ -244,6 +245,86 @@ describe("RiaProfileSection redirect loop breaker", () => {
     expect(mocks.routerReplace).not.toHaveBeenCalled();
   });
 
+  describe("typed delete confirmation", () => {
+    const LIVE_PROFILE = {
+      exists: true,
+      verification_status: "verified",
+      advisory_status: "active",
+    };
+
+    function openDeleteDialog() {
+      const view = renderSection(LIVE_PROFILE);
+      fireEvent.click(screen.getByTestId("ria-profile-delete"));
+      return view;
+    }
+
+    it("keeps the delete button disabled until DELETE is typed", () => {
+      openDeleteDialog();
+      const action = screen.getByTestId(
+        "ria-delete-confirm-action",
+      ) as HTMLButtonElement;
+
+      expect(action.disabled).toBe(true);
+
+      fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+        target: { value: "DELETE" },
+      });
+      expect(
+        (screen.getByTestId("ria-delete-confirm-action") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+
+    it("rejects near-miss text and never calls the API", async () => {
+      openDeleteDialog();
+
+      for (const value of ["", "delete my profile", "DELET", "remove"]) {
+        fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+          target: { value },
+        });
+        expect(
+          (screen.getByTestId("ria-delete-confirm-action") as HTMLButtonElement)
+            .disabled,
+        ).toBe(true);
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("ria-delete-confirm-action"));
+        });
+      }
+
+      expect(mocks.riaService.deleteProfile).not.toHaveBeenCalled();
+    });
+
+    it("accepts lowercase and surrounding whitespace", () => {
+      openDeleteDialog();
+      fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+        target: { value: "  delete " },
+      });
+      expect(
+        (screen.getByTestId("ria-delete-confirm-action") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+
+    it("re-arms the gate when the dialog is cancelled and reopened", () => {
+      openDeleteDialog();
+      fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+        target: { value: "DELETE" },
+      });
+      fireEvent.click(screen.getByText("Cancel"));
+
+      // Reopening must start inert again, not inherit the satisfied text.
+      fireEvent.click(screen.getByTestId("ria-profile-delete"));
+      expect(
+        (screen.getByTestId("ria-delete-confirm-input") as HTMLInputElement)
+          .value,
+      ).toBe("");
+      expect(
+        (screen.getByTestId("ria-delete-confirm-action") as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    });
+  });
+
   /**
    * Regression: deleting the RIA profile froze the page on "Loading profile..."
    * and never returned to One home (reported on web, 2026-08-13).
@@ -267,8 +348,11 @@ describe("RiaProfileSection redirect loop breaker", () => {
     });
 
     fireEvent.click(screen.getByTestId("ria-profile-delete"));
+    fireEvent.change(screen.getByTestId("ria-delete-confirm-input"), {
+      target: { value: "DELETE" },
+    });
     await act(async () => {
-      fireEvent.click(screen.getByText("Delete profile"));
+      fireEvent.click(screen.getByTestId("ria-delete-confirm-action"));
     });
 
     await waitFor(() =>

--- a/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
@@ -25,6 +25,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <span />,
   ArrowRight: () => <span />,
   CheckCircle2: () => <span />,
   ClipboardCheck: () => <span />,

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -962,7 +962,15 @@ export function RiaProfileSection({
         description:
           error instanceof Error ? error.message : "Please try again.",
       });
-    } finally {
+      // Reset ONLY on failure, where the user stays on this screen and must be
+      // able to retry. On success `deleting` deliberately stays true until the
+      // navigation above unmounts this component: it is the single guard that
+      // suppresses both the "no profile → onboarding" redirect effect and the
+      // `pendingOnboardingRedirect` skeleton. Clearing it in a `finally` fired
+      // before the async router.replace landed, which let the redirect effect
+      // hijack the trip to One home and stranded the screen on a permanent
+      // "Loading profile..." (redirectSettled can never flip on that second
+      // pass, because the effect returns early on its one-attempt ref).
       setDeleting(false);
     }
   }, [deleting, refresh, router, switchPersona, user]);

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
+  AlertTriangle,
   ArrowRight,
   CheckCircle2,
   ClipboardCheck,
@@ -704,6 +705,10 @@ export function RiaProfileSection({
   const [draft, setDraft] = useState<RiaOnboardingDraft | null>(null);
   const [saving, setSaving] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // Typed confirmation for the destructive delete. Deleting the profile revokes
+  // every client's consent, so the action stays inert until the word is typed
+  // exactly — a mis-tap on the dialog cannot destroy the practice.
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
   const [deleting, setDeleting] = useState(false);
 
   // License-refresh ("Update license data") — folded in from the old /one/profile
@@ -932,8 +937,15 @@ export function RiaProfileSection({
     status?.display_name ||
     "Official regulator record";
 
+  // Exact, case-insensitive match on the trimmed value: "delete" and " DELETE "
+  // both count, "delete my profile" does not.
+  const deleteConfirmSatisfied =
+    deleteConfirmText.trim().toUpperCase() === "DELETE";
+
   const handleDeleteProfile = useCallback(async () => {
-    if (!user || deleting) return;
+    // The typed confirmation is re-checked here, not just on the button, so no
+    // caller can reach the destructive call without it.
+    if (!user || deleting || !deleteConfirmSatisfied) return;
     setDeleting(true);
     try {
       const idToken = await user.getIdToken();
@@ -973,7 +985,14 @@ export function RiaProfileSection({
       // pass, because the effect returns early on its one-attempt ref).
       setDeleting(false);
     }
-  }, [deleting, refresh, router, switchPersona, user]);
+  }, [
+    deleteConfirmSatisfied,
+    deleting,
+    refresh,
+    router,
+    switchPersona,
+    user,
+  ]);
 
   const isBooting = (personaLoading || personaRefreshing || loading) && !status;
 
@@ -1109,7 +1128,10 @@ export function RiaProfileSection({
           tone="destructive"
           title="Delete RIA profile"
           description="Remove your RIA profile and disconnect any clients. Your One account stays."
-          onClick={() => setShowDeleteConfirm(true)}
+          onClick={() => {
+            setDeleteConfirmText("");
+            setShowDeleteConfirm(true);
+          }}
           disabled={deleting}
           testId="ria-profile-delete"
         />
@@ -1233,27 +1255,69 @@ export function RiaProfileSection({
       <AlertDialog
         open={showDeleteConfirm}
         onOpenChange={(open) => {
-          if (!deleting) setShowDeleteConfirm(open);
+          if (deleting) return;
+          setShowDeleteConfirm(open);
+          // Never carry a satisfied confirmation across opens: reopening the
+          // dialog must start inert again.
+          if (!open) setDeleteConfirmText("");
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="w-[calc(100%-1rem)] sm:max-w-lg">
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete your RIA profile?</AlertDialogTitle>
+            <AlertDialogTitle className="app-critical-title flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5" />
+              Delete your RIA profile?
+            </AlertDialogTitle>
             <AlertDialogDescription>
               This removes your RIA advisor profile and automatically disconnects
               any active clients (their consent is revoked). Your One account and
               investor information is not affected. This can&apos;t be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="ria-delete-confirm"
+              className="block text-sm text-muted-foreground"
+            >
+              Type <span className="font-semibold text-foreground">DELETE</span>{" "}
+              to confirm.
+            </label>
+            <Input
+              id="ria-delete-confirm"
+              value={deleteConfirmText}
+              onChange={(event) => setDeleteConfirmText(event.target.value)}
+              disabled={deleting}
+              placeholder="DELETE"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              aria-describedby="ria-delete-confirm-hint"
+              data-testid="ria-delete-confirm-input"
+            />
+            <p
+              id="ria-delete-confirm-hint"
+              className="text-xs text-muted-foreground"
+            >
+              {deleteConfirmSatisfied
+                ? "Confirmed — the delete button is now enabled."
+                : "The delete button stays disabled until this matches."}
+            </p>
+          </div>
+
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
-              disabled={deleting}
+              disabled={deleting || !deleteConfirmSatisfied}
               onClick={(event) => {
                 event.preventDefault();
-                if (!deleting) void handleDeleteProfile();
+                if (!deleting && deleteConfirmSatisfied) {
+                  void handleDeleteProfile();
+                }
               }}
+              data-testid="ria-delete-confirm-action"
             >
               {deleting ? "Deleting..." : "Delete profile"}
             </AlertDialogAction>


### PR DESCRIPTION
Two commits on the RIA profile delete flow: a **bug fix** for a hard freeze, and a **safety gate** on the destructive action.

---

## 1. `fix`: delete froze the page on "Loading profile..."

Deleting the RIA profile left the page stuck on a permanent spinner and never returned to One home.

> *"when I delete my account on RIA, the page starts blurring and freezing … and it doesn't go back on the old account."*

### Root cause

`deleting` is the single flag suppressing **two** things: the "no profile → onboarding" redirect effect (`:729`) and the `pendingOnboardingRedirect` skeleton (`:977`). It was cleared in a `finally`:

```js
router.replace(ROUTES.ONE_HOME);   // async — component stays mounted
} finally {
  setDeleting(false);              // fires immediately, before nav lands
}
```

App Router navigation doesn't unmount synchronously, so `deleting` flipped back to `false` while still on the page — by which point the delete had made `riaCapability === "setup"` and `status.exists === false`. Both suppressed behaviours fired:

1. The redirect effect issued `router.replace("/ria/onboarding")`, **overriding the in-flight navigation to `/one`** → "doesn't go back on the old account".
2. `pendingOnboardingRedirect` (which begins `!deleting`) flipped true → the spinner → the freeze.

**Why it never recovered:** `redirectSettled` is armed only by a timer created *inside* that effect, and on the second pass the effect returns early on its one-attempt ref. Nothing ever ended the spinner. The comment at `:725` documents this exact dead end; it just didn't cover the post-delete path, and `:720` states the intent outright — *"Skipped while a delete is in flight."* The `finally` defeated it.

### Fix

Reset `deleting` only in the `catch`, where the user stays on the page and must retry. On success it stays `true` until the navigation unmounts the component — what the surrounding code already assumed.

---

## 2. `feat`: typed DELETE confirmation

Deleting the profile revokes every connected client's consent and can't be undone, but sat behind a single tap.

The action now stays disabled until `DELETE` is typed. Case-insensitive and whitespace-trimmed (`delete`, `  DELETE  ` pass) but exact — `delete my profile` does not. Re-checked inside `handleDeleteProfile` as well as on the button, so no caller reaches the destructive call without it, and the text resets on every open/dismiss so a satisfied gate is never inherited.

Note: the **One account dialog has no typed step** — its friction is an upstream vault unlock. So this matches One's *visual* grammar (warning icon, critical title, explicit action label) rather than copying a typed flow that doesn't exist there.

---

## Verification

- **Freeze regression test** confirmed to fail without the fix: `expected "vi.fn()" to not be called with [ '/ria/onboarding' ]`.
- **4 new gate tests**: disabled until typed; near-miss text (`""`, `delete my profile`, `DELET`, `remove`) never calls the API; lowercase/whitespace accepted; cancel-and-reopen re-arms.
- The existing `profile-page` delete test now taps the action *before* typing and asserts the API is untouched, so the gate is proven from a second suite.
- RIA suites **198/200**. The 2 failures are `picks-page.test.tsx` and are **pre-existing** — confirmed failing identically on clean `main`.
- `tsc --noEmit` and `eslint` clean across all five touched files.

Also fixes the redirect-loop suite's `AlertDialogAction` mock, which dropped `onClick` and made the delete confirmation unreachable from any test — part of why the freeze shipped unnoticed. Adding `AlertTriangle` to the component's lucide import broke every sibling suite that mocks lucide with a fixed icon set; those three mocks gain the icon.

## Not included

No post-delete "account deleted" *screen* — still `toast.success("RIA profile deleted")` on the way to `/one`. Separate, additive work.
