### PR TITLE
fix(location): give each person in the request list a real status

### DIFF
--- a/hushh-webapp/__tests__/components/request-recipient-status.test.ts
+++ b/hushh-webapp/__tests__/components/request-recipient-status.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  requestRecipientStatus,
+  shortAgo,
+  shortRemaining,
+} from "@/lib/one-location/request-recipient-status";
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+} from "@/lib/one-location/types";
+
+/**
+ * What a person's row says in "ask someone to share".
+ *
+ * Every row used to read "Ready for private sharing" with Select as the only
+ * affordance -- so "what is active status?" had no answer, and somebody who
+ * had just asked Roopmann for an hour came back to a row offering to ask
+ * again, exactly as if they never had.
+ */
+
+const NOW = Date.parse("2026-08-14T12:00:00.000Z");
+const ROOPMANN = "user_roopmann";
+
+function request(
+  overrides: Partial<OneLocationAccessRequest>,
+): OneLocationAccessRequest {
+  return {
+    id: "req_1",
+    ownerUserId: ROOPMANN,
+    requesterUserId: "user_me",
+    status: "pending",
+    requestedAt: new Date(NOW - 6 * 60_000).toISOString(),
+    ...overrides,
+  } as OneLocationAccessRequest;
+}
+
+function grant(overrides: Partial<OneLocationGrant>): OneLocationGrant {
+  return {
+    id: "grant_1",
+    ownerUserId: ROOPMANN,
+    status: "active",
+    expiresAt: new Date(NOW + 55 * 60_000).toISOString(),
+    ...overrides,
+  } as OneLocationGrant;
+}
+
+function statusFor(input: {
+  requestedByMe?: OneLocationAccessRequest[];
+  receivedGrants?: OneLocationGrant[];
+}) {
+  return requestRecipientStatus({
+    recipientUserId: ROOPMANN,
+    requestedByMe: input.requestedByMe ?? [],
+    receivedGrants: input.receivedGrants ?? [],
+    nowMs: NOW,
+  });
+}
+
+describe("someone with nothing between you yet", () => {
+  it("is the only row that offers to ask", () => {
+    const status = statusFor({});
+    expect(status.subtitle).toBe("Ready for private sharing");
+    expect(status.selectable).toBe(true);
+  });
+});
+
+describe("someone you already asked", () => {
+  it("says when, and stops offering to ask again", () => {
+    // The reported bug: going back to the same screen re-offered a person who
+    // already had an unanswered request.
+    const status = statusFor({ requestedByMe: [request({})] });
+    expect(status.subtitle).toBe("Asked 6m ago, waiting on them");
+    expect(status.statusLabel).toBe("Asked");
+    expect(status.selectable).toBe(false);
+  });
+
+  it("reports the most recent ask when there are several", () => {
+    const status = statusFor({
+      requestedByMe: [
+        request({ id: "old", requestedAt: new Date(NOW - 5 * 3_600_000).toISOString() }),
+        request({ id: "new", requestedAt: new Date(NOW - 60_000).toISOString() }),
+      ],
+    });
+    expect(status.subtitle).toBe("Asked 1m ago, waiting on them");
+  });
+});
+
+describe("someone already sharing with you", () => {
+  it("says so, with how long is left, and is not askable", () => {
+    // Asking somebody to share while they already are is the clearest possible
+    // sign the list is not looking at anything.
+    const status = statusFor({ receivedGrants: [grant({})] });
+    expect(status.subtitle).toBe("Sharing with you, 55 more min");
+    expect(status.statusLabel).toBe("Live");
+    expect(status.selectable).toBe(false);
+  });
+
+  it("outranks a pending request to the same person", () => {
+    const status = statusFor({
+      requestedByMe: [request({})],
+      receivedGrants: [grant({})],
+    });
+    expect(status.statusLabel).toBe("Live");
+  });
+
+  it("ignores a grant that is no longer active", () => {
+    const status = statusFor({ receivedGrants: [grant({ status: "revoked" })] });
+    expect(status.subtitle).toBe("Ready for private sharing");
+    expect(status.selectable).toBe(true);
+  });
+});
+
+describe("someone who said no", () => {
+  it("says so plainly and stays askable", () => {
+    // A refusal is not permanent. Hiding it is how somebody nags without
+    // meaning to; blocking on it would be worse.
+    const status = statusFor({
+      requestedByMe: [
+        request({
+          status: "denied",
+          resolvedAt: new Date(NOW - 2 * 3_600_000).toISOString(),
+        }),
+      ],
+    });
+    expect(status.subtitle).toBe("Declined 2h ago");
+    expect(status.selectable).toBe(true);
+  });
+});
+
+describe("relative labels", () => {
+  it("stays coarse enough not to tick", () => {
+    expect(shortAgo(NOW - 30_000, NOW)).toBe("just now");
+    expect(shortAgo(NOW - 6 * 60_000, NOW)).toBe("6m ago");
+    expect(shortAgo(NOW - 3 * 3_600_000, NOW)).toBe("3h ago");
+    expect(shortAgo(NOW - 50 * 3_600_000, NOW)).toBe("2d ago");
+  });
+
+  it("never reports remaining time on access that already ended", () => {
+    expect(shortRemaining(NOW - 1, NOW)).toBeNull();
+    expect(shortRemaining(NOW + 55 * 60_000, NOW)).toBe("55 more min");
+    expect(shortRemaining(NOW + 60 * 60_000, NOW)).toBe("1 more hour");
+    expect(shortRemaining(NOW + 3 * 3_600_000, NOW)).toBe("3 more hours");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -43,6 +43,7 @@ import {
   UsersRound,
 } from "lucide-react";
 
+import { requestRecipientStatus } from "@/lib/one-location/request-recipient-status";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -2470,6 +2471,17 @@ function AskFlow({
   // the specific request they just made, rather than popping straight back to
   // the hub. `justSent` latches the success state and blocks duplicate submits.
   const [justSent, setJustSent] = useState(false);
+  // "Asked 6m ago" is only true at the moment it renders. Without a clock the
+  // list freezes at whatever it said when the screen opened, which is how a
+  // request sent half an hour ago still reads as just now.
+  //
+  // Coarse on purpose: these labels move in minutes, so a 30s tick keeps them
+  // honest without re-rendering a list of people every second.
+  const [statusNowMs, setStatusNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setStatusNowMs(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
+  }, []);
   return (
     <div className="space-y-5">
       <TaskFlowHeader
@@ -2500,18 +2512,40 @@ function AskFlow({
           <div className={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}>
             {filtered.map((r) => {
               const selected = vm.selectedRequestOwnerIds.includes(r.userId);
+              // Every row used to read "Ready for private sharing" with Select
+              // as the only affordance, whoever the person was and whatever had
+              // already happened with them -- so there was no active status to
+              // read, and somebody who had just asked came back to a row
+              // offering to ask again.
+              const status = requestRecipientStatus({
+                recipientUserId: r.userId,
+                requestedByMe: vm.requestedByMe,
+                receivedGrants: vm.receivedGrants,
+                nowMs: statusNowMs,
+              });
               return (
                 <TrustedPersonCard
                   key={r.userId}
                   name={vm.recipientLabel(r)}
-                  subtitle="Ready for private sharing"
-                  tone="ready"
-                  actionLabel={selected ? "Selected" : "Select"}
+                  subtitle={status.subtitle}
+                  tone={status.tone}
+                  statusLabel={status.statusLabel}
+                  actionLabel={
+                    status.selectable
+                      ? selected
+                        ? "Selected"
+                        : "Select"
+                      : undefined
+                  }
                   actionAriaLabel={`${
                     selected ? "Deselect" : "Select"
                   } ${vm.recipientLabel(r)} for location request`}
-                  onAction={() => vm.toggleRequestOwner(r.userId, "ask_flow")}
-                  selected={selected}
+                  onAction={
+                    status.selectable
+                      ? () => vm.toggleRequestOwner(r.userId, "ask_flow")
+                      : undefined
+                  }
+                  selected={selected && status.selectable}
                 />
               );
             })}

--- a/hushh-webapp/lib/one-location/request-recipient-status.ts
+++ b/hushh-webapp/lib/one-location/request-recipient-status.ts
@@ -1,0 +1,151 @@
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+} from "@/lib/one-location/types";
+
+/**
+ * What one person's row in the "ask someone to share" list should say.
+ *
+ * The list used to say "Ready for private sharing" under every name, with
+ * Select as the only affordance, whoever they were and whatever had already
+ * happened with them. So "what is active status?" had no answer -- nothing
+ * computed one -- and somebody who had just asked Roopmann for an hour came
+ * back to a row that offered to ask again, exactly as if they never had.
+ *
+ * Every input here is already in the Location view model. This decides what to
+ * say about it, and nothing else: no fetching, no time formatting, no copy that
+ * depends on a locale.
+ */
+export type RequestRecipientStatus = {
+  /** The line under the name. */
+  subtitle: string;
+  tone: "ready" | "pending" | "neutral";
+  /** Short pill, when the row is in a state worth naming at a glance. */
+  statusLabel?: string;
+  /**
+   * False when asking again would do nothing. A person already sharing with
+   * you, or already holding your unanswered request, is not a person to ask.
+   */
+  selectable: boolean;
+};
+
+/** Milliseconds, or null when the timestamp is missing or unparseable. */
+function timestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * "just now", "6m", "3h", "2d" -- said the way a person would.
+ *
+ * Deliberately coarse. A request sent four minutes ago and one sent five are
+ * the same fact to the person reading it, and a ticking seconds counter in a
+ * list of people is noise pretending to be precision.
+ */
+export function shortAgo(fromMs: number, nowMs: number): string {
+  const elapsed = Math.max(0, nowMs - fromMs);
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/** "for 55 more minutes", "for 3 more hours" -- how much access is left. */
+export function shortRemaining(untilMs: number, nowMs: number): string | null {
+  const remaining = untilMs - nowMs;
+  if (remaining <= 0) return null;
+  const minutes = Math.ceil(remaining / 60_000);
+  if (minutes < 60) return `${minutes} more min`;
+  const hours = Math.round(minutes / 60);
+  return hours === 1 ? "1 more hour" : `${hours} more hours`;
+}
+
+export function requestRecipientStatus(input: {
+  recipientUserId: string;
+  /** Requests THIS person sent, i.e. outgoing. */
+  requestedByMe: readonly OneLocationAccessRequest[];
+  /** Grants shared WITH this person, i.e. incoming. */
+  receivedGrants: readonly OneLocationGrant[];
+  nowMs: number;
+}): RequestRecipientStatus {
+  const { recipientUserId, requestedByMe, receivedGrants, nowMs } = input;
+
+  // Already sharing beats everything else. Asking somebody to share when they
+  // already are is the clearest possible sign the list is not looking.
+  const activeGrant = receivedGrants.find(
+    (grant) =>
+      grant.ownerUserId === recipientUserId && grant.status === "active",
+  );
+  if (activeGrant) {
+    const expiresAt = timestamp(activeGrant.expiresAt);
+    const remaining = expiresAt === null ? null : shortRemaining(expiresAt, nowMs);
+    return {
+      subtitle: remaining
+        ? `Sharing with you, ${remaining}`
+        : "Sharing with you now",
+      tone: "ready",
+      statusLabel: "Live",
+      selectable: false,
+    };
+  }
+
+  // The unanswered ask. This is the row the report was about: it has to say
+  // that it happened and when, and it must not offer to do it again.
+  const pending = requestedByMe
+    .filter(
+      (request) =>
+        request.ownerUserId === recipientUserId && request.status === "pending",
+    )
+    .sort(
+      (left, right) =>
+        (timestamp(right.requestedAt) ?? 0) - (timestamp(left.requestedAt) ?? 0),
+    )[0];
+  if (pending) {
+    const askedAt = timestamp(pending.requestedAt);
+    return {
+      subtitle: askedAt
+        ? `Asked ${shortAgo(askedAt, nowMs)}, waiting on them`
+        : "Asked already, waiting on them",
+      tone: "pending",
+      statusLabel: "Asked",
+      // Nothing here can move this along -- it is the other person's to answer.
+      selectable: false,
+    };
+  }
+
+  // A refusal is not a permanent state, so this row stays askable. It is said
+  // plainly rather than hidden: asking again without knowing they declined is
+  // how somebody ends up nagging without meaning to.
+  const declined = requestedByMe
+    .filter(
+      (request) =>
+        request.ownerUserId === recipientUserId &&
+        (request.status === "denied" || request.status === "cancelled"),
+    )
+    .sort(
+      (left, right) =>
+        (timestamp(right.resolvedAt) ?? 0) - (timestamp(left.resolvedAt) ?? 0),
+    )[0];
+  if (declined) {
+    const resolvedAt = timestamp(declined.resolvedAt);
+    const wasDenied = declined.status === "denied";
+    return {
+      subtitle: resolvedAt
+        ? `${wasDenied ? "Declined" : "Cancelled"} ${shortAgo(resolvedAt, nowMs)}`
+        : wasDenied
+          ? "Declined earlier"
+          : "Cancelled earlier",
+      tone: "neutral",
+      selectable: true,
+    };
+  }
+
+  return {
+    subtitle: "Ready for private sharing",
+    tone: "ready",
+    selectable: true,
+  };
+}


### PR DESCRIPTION
Reported as two things, which turned out to be one defect:

> **"what is active status / why it is only showing select"**
> **"person list is not realtime, it should show real time status. if req sent earlier to Roopmann for an hour, it should showcase time span and all — and shouldn't come when going to the same path in 2nd go"**

## The cause

The list rendered the same three literals for everybody:

```tsx
subtitle="Ready for private sharing"
tone="ready"
actionLabel={selected ? "Selected" : "Select"}
```

There was no per-person state at all. "What is active status" had no answer because nothing computed one, and Select was the only affordance showing because it was the only affordance there. Re-entering the screen re-offered someone who already had an unanswered request, exactly as if it had never been sent.

## The fix

Each row now reads its own state, from data **already in the view model** — `requestedByMe` was present and used in another section, `receivedGrants` likewise. Nothing new is fetched.

In priority order:

| State | Row reads | Askable |
|---|---|---|
| Already sharing with you | "Sharing with you, 55 more min" · **Live** | no |
| Asked, unanswered | "Asked 6m ago, waiting on them" · **Asked** | no |
| Declined / cancelled | "Declined 2h ago" | yes |
| Nothing yet | "Ready for private sharing" *(unchanged)* | yes |

Already-sharing outranks a pending request deliberately: asking someone to share while they already are is the clearest possible sign the list isn't looking at anything.

A declined request stays askable. A refusal isn't permanent — but it's said plainly, because hiding it is how somebody nags without meaning to.

## Keeping it real-time

Relative labels are only true at the moment they render, so the list holds a **30-second clock** rather than freezing at first render — which is how a request sent half an hour ago still read as recent. Coarse on purpose: these move in minutes, and a ticking counter in a list of people is noise pretending to be precision.

## Verification

- `tsc --noEmit` clean, `eslint --max-warnings=0` clean
- New `request-recipient-status.test.ts` — **9 passed**, written as the situations in the report
- `one-location-agent-page.test.tsx` — 59/60; the one failure ("approval-first location request") **fails identically on clean main**, verified by stashing

The derivation is a pure function, so these situations are tested directly rather than through the screen.