### PR TITLE
fix(location): stop the shared address skeleton spinning forever

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1311,7 +1311,6 @@ function LocationDetailFlow({
   const reverseGeocodePoint = vm.reverseGeocodePoint;
   useEffect(() => {
     if (kind !== "shared-with-me" || !reverseGeocodePoint) return;
-    let cancelled = false;
     for (const grant of vm.receivedGrants) {
       const point = vm.decryptedPoints[grant.id];
       if (!point) continue;
@@ -1322,18 +1321,44 @@ function LocationDetailFlow({
         ...current,
         [grant.id]: { key, status: "loading", text: null },
       }));
-      void reverseGeocodePoint(point).then((text) => {
-        if (cancelled) return;
+      // The skeleton has exactly one way to stop: this settling the entry. It
+      // used to have three ways not to, and all three left it spinning
+      // forever under a pin that never resolved.
+      const settle = (text: string | null) => {
         setAddressByGrant((current) => {
           const entry = current[grant.id];
+          // Still keyed to these coordinates? A newer position owns the row
+          // now, and its own lookup will settle it.
           if (!entry || entry.key !== key) return current;
           return { ...current, [grant.id]: { key, status: "done", text } };
         });
-      });
+      };
+      void reverseGeocodePoint(point)
+        .then(settle)
+        .catch(() => {
+          // 1. A rejected lookup never settled anything, so one network
+          //    hiccup meant a permanent skeleton. Falling through to `done`
+          //    with no text lets the card show the coordinates it already
+          //    has, which is worse than a street name and far better than
+          //    a grey bar.
+          //
+          // 2. The retry guard was claimed BEFORE the call, so a failure was
+          //    permanent for those coordinates -- the loop skipped them on
+          //    every later pass and never tried again. Releasing it here
+          //    means the next refresh at this position gets another go.
+          if (resolvedAddressKeyRef.current[grant.id] === key) {
+            delete resolvedAddressKeyRef.current[grant.id];
+          }
+          settle(null);
+        });
     }
-    return () => {
-      cancelled = true;
-    };
+    // 3. No `cancelled` flag. `vm.decryptedPoints` changes on the five-second
+    //    live refresh, so this effect re-runs constantly; cancelling on
+    //    cleanup abandoned every in-flight lookup, while the guard above
+    //    stopped it being retried. That combination -- not a failing geocoder
+    //    -- is what left the address loading indefinitely in normal use.
+    //    `settle` is keyed by coordinates, so a late resolution either lands
+    //    on the row it belongs to or is ignored.
   }, [kind, reverseGeocodePoint, vm.receivedGrants, vm.decryptedPoints]);
   const copy = {
     "active-shares": {


### PR DESCRIPTION
Reported as **"address is loading still"** — the grey bar under the pin in "Shared with me" never resolves.

The address effect had **three separate ways** to leave an entry `loading`, and no way to recover from any of them.

## 1. A rejected lookup settled nothing

`void reverseGeocodePoint(point).then(...)` with no `.catch`. One network hiccup meant a permanent skeleton.

Now falls through to `done` with no text, and the card shows the coordinates it already had. Worse than a street name, far better than a grey bar — and `coordinatesFallback` was already there, it just never got to render.

## 2. The retry guard was claimed *before* the call

```ts
resolvedAddressKeyRef.current[grant.id] = key;   // claimed first
void reverseGeocodePoint(point)                   // then attempted
```

So a failure was permanent *for those coordinates* — the loop skipped them on every later pass and never tried again. The guard is now released on failure, so the next refresh at that position gets another go.

## 3. The cancellation — this is the one that caused it in normal use

`vm.decryptedPoints` is a dependency and **changes on the five-second live refresh**, so the effect re-runs constantly. The cleanup set `cancelled = true`, abandoning every in-flight lookup — while fault 2 stopped it being retried.

**A geocode only had to be slower than one refresh cycle to be stranded forever.** No failing geocoder required; this is why it reproduces so easily.

The flag is gone. Settling is keyed by coordinates, so a late resolution either lands on the row it belongs to or is ignored — which is what the `cancelled` flag was really protecting against, done in a way that can't strand the row.

## Verification

- `tsc --noEmit` clean, `eslint --max-warnings=0` clean
- `one-location-agent-page.test.tsx` — 59/60; the one failure ("approval-first location request") **fails identically on clean main**, verified by stashing

Same behaviour on web and the Capacitor build — this is transport-agnostic React state, with no platform branch.