### PR TITLE
feat(location): let people appear on the maps of those they share with

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -445,6 +445,20 @@ def get_location_map_state(token_data: dict = Depends(require_vault_owner_token)
         raise _handle_error(exc) from exc
 
 
+@router.get("/location/map-preferences")
+def get_location_map_preferences(token_data: dict = Depends(require_vault_owner_token)):
+    """Read the viewer's own map presence preference.
+
+    Separate from `/location/map-state`, which also returns every marker and
+    costs a decrypt-and-render pass. Location settings needs one boolean, and
+    should not pay for the map to ask a question about a switch.
+    """
+    try:
+        return {"preferences": _service().get_map_preferences(user_id=_user_id(token_data))}
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
 @router.patch("/location/map-preferences")
 def update_location_map_preferences(
     payload: UpdateMapPreferencesRequest,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4806,6 +4806,19 @@ class OneLocationAgentService:
         coordinates. The browser/native renderer decrypts returned ciphertext
         only in its foreground memory.
         """
+        # Retention, not freshness. The 90-second cut used to remove people from
+        # the response entirely, so a sharer who locked their phone vanished
+        # from the map with nothing said -- indistinguishable from having
+        # stopped sharing. They are returned now with `capturedAt`, and the
+        # renderer ages them: past the freshness window the pin goes grey and
+        # carries a disconnected badge, which is a fact about their signal
+        # rather than a claim about their intent.
+        retention_seconds = _bounded_int_env(
+            "ONE_LOCATION_MAP_RETENTION_SECONDS", 3600, 300, 86_400
+        )
+        # Still published to the client, and still means the same thing: how
+        # recent a position has to be to count as live. It just no longer
+        # decides who exists.
         freshness_seconds = _bounded_int_env("ONE_LOCATION_MAP_FRESHNESS_SECONDS", 90, 30, 300)
         rows = self._execute_many(
             """
@@ -4826,6 +4839,16 @@ class OneLocationAgentService:
               envelope.created_at AS map_envelope_created_at,
               envelope.metadata AS map_envelope_metadata
             FROM one_location_share_grants g
+            -- Opt-in, and it stays opt-in.
+            --
+            -- `presence_mode` defaults to 'ghost', so appearing on somebody
+            -- else's map is something the sharer has to choose. Widening this
+            -- to "anyone who has not explicitly opted out" was considered and
+            -- rejected: it would have made every existing sharer visible
+            -- without asking them, which is not a default anyone gets to
+            -- change on their behalf. The answer was to make the choice
+            -- findable instead -- it now lives in Location settings rather
+            -- than only behind a Ghost toggle on the map screen.
             JOIN one_location_map_preferences preference
               ON preference.user_id = g.owner_user_id
              AND preference.presence_mode = 'foreground_private'
@@ -4836,7 +4859,7 @@ class OneLocationAgentService:
               WHERE candidate.grant_id = g.id
                 AND candidate.recipient_user_id = :user_id
                 AND candidate.publication_context = 'foreground_map_visible'
-                AND candidate.captured_at >= NOW() - make_interval(secs => :freshness_seconds)
+                AND candidate.captured_at >= NOW() - make_interval(secs => :retention_seconds)
               ORDER BY candidate.captured_at DESC, candidate.created_at DESC
               LIMIT 1
             ) envelope ON TRUE
@@ -4846,7 +4869,7 @@ class OneLocationAgentService:
             ORDER BY envelope.captured_at DESC
             LIMIT 100
             """,
-            {"user_id": user_id, "freshness_seconds": freshness_seconds},
+            {"user_id": user_id, "retention_seconds": retention_seconds},
         )
         markers: list[dict[str, Any]] = []
         for row in rows:

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2423,6 +2423,58 @@ export function OneLocationAgentPageContent({
       ),
     [contactSignalRecipients, selectedRequestOwnerIds],
   );
+  // Whether this person appears as a pin on the maps of people they already
+  // share with.
+  //
+  // The preference itself is not new -- it is `presence_mode`, and it defaults
+  // to 'ghost'. What was new is being able to find it: it lived only behind a
+  // Ghost toggle on the immersive map screen, so somebody who shared their
+  // location and then wondered why they never appeared on the other person's
+  // map had no way to discover the switch that decided it. Null while loading,
+  // so the control can be shown disabled rather than lying about its state.
+  const [mapPresenceEnabled, setMapPresenceEnabled] = useState<boolean | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!vaultOwnerToken) return;
+    let cancelled = false;
+    void OneLocationService.getMapPreferences(vaultOwnerToken)
+      .then((preferences) => {
+        if (cancelled) return;
+        setMapPresenceEnabled(preferences.presenceMode === "foreground_private");
+      })
+      .catch(() => {
+        // Unknown is not the same as off, but the control has to say something
+        // -- and offering it as "off" is the honest failure: it cannot make a
+        // person more visible than they already are.
+        if (!cancelled) setMapPresenceEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultOwnerToken]);
+  const handleMapPresenceChange = useCallback(
+    (next: boolean) => {
+      if (!vaultOwnerToken) return;
+      // Optimistic, then corrected by the server's answer. A privacy switch
+      // that lags behind the finger reads as broken, and people toggle it
+      // again -- which is how somebody ends up visible when they meant not to.
+      setMapPresenceEnabled(next);
+      void OneLocationService.updateMapPreferences({
+        vaultOwnerToken,
+        presenceMode: next ? "foreground_private" : "ghost",
+      })
+        .then((preferences) => {
+          setMapPresenceEnabled(preferences.presenceMode === "foreground_private");
+        })
+        .catch(() => {
+          setMapPresenceEnabled(!next);
+          toast.error("Could not change map visibility.");
+        });
+    },
+    [vaultOwnerToken],
+  );
+
   const pendingOwnerRequests = useMemo(
     () =>
       (state?.requests ?? []).filter(
@@ -3259,6 +3311,21 @@ export function OneLocationAgentPageContent({
         recipientPublicKeyJwk: recipient.publicKeyJwk,
         recipientKeyId: recipient.keyId,
       });
+      // Eligible for the recipient's map.
+      //
+      // Until now `foreground_map_visible` was written in exactly one place --
+      // the locate button on the map screen -- so a pin only ever appeared
+      // while the SHARER happened to be standing on that screen. Sharing your
+      // location through the normal flow put you in their "Shared with me"
+      // card and nowhere else, which is why the map read "0 live locations"
+      // next to a card saying someone was live 23 seconds ago.
+      //
+      // The widening is bounded by what the envelope already is: it is
+      // encrypted to one recipient's key and exists only because the sharer
+      // created a grant for that person, for a duration they chose. Appearing
+      // as a pin on that person's map is the thing they agreed to. It does not
+      // make anyone visible to anyone else, and Ghost Mode still overrides it.
+      envelope.publicationContext = "foreground_map_visible";
       // Returned so Save My Soul can tell the sender which contacts the alert
       // actually reached. null for every other share kind, which does not
       // notify from this route.
@@ -8779,6 +8846,8 @@ export function OneLocationAgentPageContent({
         observedDenial: locationDenialObserved,
       }) === "blocked",
     autoShareEnabled: locationControl.autoShareEnabled,
+    mapPresenceEnabled,
+    onMapPresenceChange: handleMapPresenceChange,
     locationPaused: locationControl.paused,
     locationAccuracyLimited,
     // The switch is already on and the device has not found us yet. This is the

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -17,6 +17,7 @@ import {
   MapPin,
   Search,
   UsersRound,
+  WifiOff,
   X,
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -104,6 +105,22 @@ type RenderMarker = {
 
 /** Grey. A pin whose owner has gone quiet stops claiming to be live. */
 const STALE_TINT = { r: 142, g: 142, b: 147, a: 255 } as const;
+
+/** "last seen 7m ago" -- a fact about their signal, not their intent. */
+function lastSeenLabel(
+  capturedAt: string | null | undefined,
+  nowMs: number,
+): string | null {
+  if (!capturedAt) return null;
+  const captured = Date.parse(capturedAt);
+  if (!Number.isFinite(captured)) return null;
+  const minutes = Math.floor(Math.max(0, nowMs - captured) / 60_000);
+  if (minutes < 1) return "last seen just now";
+  if (minutes < 60) return `last seen ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `last seen ${hours}h ago`;
+  return `last seen ${Math.floor(hours / 24)}d ago`;
+}
 
 function isStaleAt(
   capturedAt: string | null | undefined,
@@ -2218,6 +2235,19 @@ export function LocationImmersiveMap({
                 >
                   {filteredPeople.map((person) => {
                     const selectedPerson = selected?.key === person.key;
+                    // The tray is where identity lives, because it is the only
+                    // part of this screen that is real DOM. Map pins come from
+                    // the Capacitor bridge, which offers a tint and nothing
+                    // else -- no avatar, no badge, and no hover at all on a
+                    // touch device.
+                    const personStale = isStaleAt(
+                      person.capturedAt,
+                      freshnessSeconds,
+                      staleClockMs,
+                    );
+                    const lastSeen = personStale
+                      ? lastSeenLabel(person.capturedAt, staleClockMs)
+                      : null;
                     return (
                       <button
                         key={person.key}
@@ -2227,22 +2257,59 @@ export function LocationImmersiveMap({
                             ? MAP_ACCENT_ACTIVE_CLASSNAME
                             : "border-border/60 bg-muted/70 text-foreground hover:bg-muted"
                         }`}
-                        aria-label={`Show ${person.label} on the map`}
+                        // The live case keeps its original name exactly. Only a
+                        // person who has gone quiet has anything extra worth
+                        // announcing, and saying "sharing live" on every other
+                        // row would be noise in a screen reader.
+                        aria-label={
+                          lastSeen
+                            ? `Show ${person.label} on the map. Last seen ${lastSeen}.`
+                            : `Show ${person.label} on the map`
+                        }
+                        title={
+                          lastSeen
+                            ? `${person.label} — last seen ${lastSeen}`
+                            : `${person.label} — live now`
+                        }
                         data-testid="one-location-map-person"
+                        data-stale={personStale ? "true" : "false"}
                         onClick={() => void focusMarker(person)}
                       >
-                        <span
-                          className="grid h-7 w-7 place-items-center rounded-full text-[11px] font-semibold text-white"
-                          style={{
-                            backgroundColor: person.tint
-                              ? `rgba(${person.tint.r}, ${person.tint.g}, ${person.tint.b}, ${person.tint.a / 255})`
-                              : "var(--app-accent)",
-                          }}
-                        >
-                          {personInitials(person.label)}
+                        <span className="relative shrink-0">
+                          <span
+                            className={`grid h-7 w-7 place-items-center rounded-full text-[11px] font-semibold text-white transition-[filter,opacity] ${
+                              personStale ? "opacity-70 grayscale" : ""
+                            }`}
+                            style={{
+                              backgroundColor: person.tint
+                                ? `rgba(${person.tint.r}, ${person.tint.g}, ${person.tint.b}, ${person.tint.a / 255})`
+                                : "var(--app-accent)",
+                            }}
+                          >
+                            {personInitials(person.label)}
+                          </span>
+                          {/* Bottom-right, over the avatar's own edge. Shape as
+                              well as colour, so it survives being read on a
+                              greyscale avatar by someone who cannot rely on
+                              the grey itself. */}
+                          {personStale ? (
+                            <span
+                              className="absolute -bottom-0.5 -right-0.5 grid h-3.5 w-3.5 place-items-center rounded-full bg-background ring-1 ring-border"
+                              aria-hidden="true"
+                            >
+                              <WifiOff className="h-2.5 w-2.5 text-muted-foreground" />
+                            </span>
+                          ) : null}
                         </span>
-                        <span className="max-w-28 truncate font-medium">
-                          {person.label}
+                        <span className="flex min-w-0 flex-col leading-tight">
+                          <span className="max-w-28 truncate font-medium">
+                            {person.label}
+                          </span>
+                          {lastSeen ? (
+                            <span className="max-w-28 truncate text-[11px] text-muted-foreground">
+                              {lastSeen}
+                            </span>
+                          ) : null}
                         </span>
                       </button>
                     );

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -93,7 +93,28 @@ type RenderMarker = {
   kind: "person" | "self" | "place";
   grantId?: string;
   tint?: { r: number; g: number; b: number; a: number };
+  /**
+   * When this position was taken, not when it was fetched. A person whose
+   * phone locked keeps their last known pin instead of disappearing, and this
+   * is what lets the map say so rather than quietly implying they are still
+   * moving.
+   */
+  capturedAt?: string | null;
 };
+
+/** Grey. A pin whose owner has gone quiet stops claiming to be live. */
+const STALE_TINT = { r: 142, g: 142, b: 147, a: 255 } as const;
+
+function isStaleAt(
+  capturedAt: string | null | undefined,
+  freshnessSeconds: number,
+  nowMs: number,
+): boolean {
+  if (!capturedAt) return false;
+  const captured = Date.parse(capturedAt);
+  if (!Number.isFinite(captured)) return false;
+  return nowMs - captured > freshnessSeconds * 1_000;
+}
 
 function displayLabel(marker: OneLocationMapMarker): string {
   return marker.grant.ownerDisplayName?.trim() || "A trusted person";
@@ -325,6 +346,18 @@ export function LocationImmersiveMap({
     presenceMode: "ghost",
   });
   const [markers, setMarkers] = useState<RenderMarker[]>([]);
+  // The server's own definition of live, rather than a second copy of 90 in
+  // the client that could drift away from it.
+  const [freshnessSeconds, setFreshnessSeconds] = useState(90);
+  // Staleness is a function of time passing, not of new data arriving -- a pin
+  // has to go grey while nothing at all is happening. The marker refresh alone
+  // would never notice, because a phone that stopped publishing sends nothing
+  // to notice.
+  const [staleClockMs, setStaleClockMs] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setStaleClockMs(Date.now()), 15_000);
+    return () => window.clearInterval(timer);
+  }, []);
   const [selfMarker, setSelfMarker] = useState<RenderMarker | null>(null);
   // Count of the account's own ACTIVE outgoing shares (people it is sharing
   // its location WITH). Sourced from the full getState (map-state only carries
@@ -680,6 +713,7 @@ export function LocationImmersiveMap({
               label: displayLabel(marker),
               kind: "person",
               grantId: marker.grant.id,
+              capturedAt: marker.envelope.capturedAt ?? null,
             } satisfies RenderMarker;
           } catch {
             // A device without the recipient private key must not show a stale or
@@ -693,6 +727,9 @@ export function LocationImmersiveMap({
         (item): item is RenderMarker => item !== null,
       );
       setPreferences(state.preferences);
+      if (Number.isFinite(state.freshnessSeconds) && state.freshnessSeconds > 0) {
+        setFreshnessSeconds(state.freshnessSeconds);
+      }
       const nextSignature = markerSignature(nextMarkers);
       if (nextSignature !== markerSignatureRef.current) {
         markerSignatureRef.current = nextSignature;
@@ -1287,7 +1324,13 @@ export function LocationImmersiveMap({
                       : "Sharing privately now",
               }
             : {}),
-          tintColor: marker.tint,
+          // Grey once the position is older than live. tintColor is the only
+          // per-pin styling this bridge exposes -- `title` cannot carry it,
+          // because the web renderer paints titles across the map as a glyph
+          // (see above) -- so the colour is where staleness has to be said.
+          tintColor: isStaleAt(marker.capturedAt, freshnessSeconds, staleClockMs)
+            ? STALE_TINT
+            : marker.tint,
           zIndex:
             marker.kind === "self" ? 10 : marker.kind === "place" ? 9 : 1,
         };
@@ -1325,7 +1368,18 @@ export function LocationImmersiveMap({
     return () => {
       cancelled = true;
     };
-  }, [entryLocationSettled, mapReady, visibleMarkers]);
+    // staleClockMs and freshnessSeconds are dependencies because a pin has to
+    // change colour while nothing else changes at all. Without them the tint
+    // is decided once, when the marker is drawn, and a person who went quiet
+    // keeps a live-coloured pin until some unrelated refresh happens to redraw
+    // it.
+  }, [
+    entryLocationSettled,
+    mapReady,
+    visibleMarkers,
+    freshnessSeconds,
+    staleClockMs,
+  ]);
 
   const acceptRenderer = useCallback(async () => {
     if (!vaultOwnerToken) return;

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2225,8 +2225,8 @@ export function LocationImmersiveMap({
                     </h3>
                     <p className="text-xs text-muted-foreground">
                       Nearby check-ins stay in the list and never become map
-                      pins. A pin appears only after that person explicitly
-                      shares their location with you.
+                      pins. A pin needs two things: they share their location
+                      with you, and they have turned on appearing on maps.
                     </p>
                   </div>
                   <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold">

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1438,8 +1438,12 @@ export function LocationImmersiveMap({
       setPreferences(next);
       toast.success(
         nextMode === "ghost"
-          ? "Ghost Mode is on."
-          : "Map visibility is ready. Tap Locate me to appear.",
+          ? "Ghost Mode is on. Nobody sees you on their map."
+          // "Tap Locate me to appear" was true while the locate button was the
+          // only thing that ever published a map-visible position. Sharing does
+          // it now, so telling somebody to go and tap something else would send
+          // them looking for a step that no longer exists.
+          : "You will appear on the map of anyone you share with.",
       );
     } catch {
       toast.error("Map visibility could not be updated.");

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -190,6 +190,14 @@ export type LocationHubViewModel = {
    */
   locationBlocked: boolean;
   autoShareEnabled: boolean;
+  /**
+   * Whether this person appears as a pin on the maps of people they already
+   * share with. Opt-in, and separate from sharing itself: sharing sends a
+   * position to one person, this decides whether it becomes a pin they can
+   * watch move. Null while the preference is still loading.
+   */
+  mapPresenceEnabled: boolean | null;
+  onMapPresenceChange: (next: boolean) => void;
   locationPaused: boolean;
   locationAccuracyLimited: boolean;
   /**
@@ -1568,6 +1576,19 @@ function LocationSettingsFlow({
               checked={vm.autoShareEnabled}
               onChange={vm.onAutoShareChange}
               label="Auto-share my location"
+            />
+          }
+          density="compact"
+        />
+        <SettingsRow
+          title="Show me on their map"
+          description="On — people you already share with can see you move on their map. Off — they still get your location, but only as a card. This never adds anyone new."
+          trailing={
+            <LocationToggle
+              checked={vm.mapPresenceEnabled === true}
+              onChange={vm.onMapPresenceChange}
+              disabled={vm.mapPresenceEnabled === null}
+              label="Show me on their map"
             />
           }
           density="compact"

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -537,6 +537,17 @@ export class OneLocationService {
     });
   }
 
+  /** The viewer's own map presence preference, without the marker payload. */
+  static async getMapPreferences(
+    vaultOwnerToken: string,
+  ): Promise<OneLocationMapPreferences> {
+    const response = await apiJson<{ preferences: OneLocationMapPreferences }>(
+      "/api/one/location/map-preferences",
+      { headers: authHeaders(vaultOwnerToken) },
+    );
+    return response.preferences;
+  }
+
   static async updateMapPreferences(params: {
     vaultOwnerToken: string;
     presenceMode?: OneLocationMapPreferences["presenceMode"];


### PR DESCRIPTION
Reported as **"can't see the pins of the people who shared their location"** — the map read *0 live locations* beside a "Shared with me" card saying somebody was live 23 seconds ago.

Both were telling the truth about different pipelines.

## Why no pin ever appeared

`foreground_map_visible` was written in **exactly one place** in the codebase — the locate button on the map screen. So a pin only existed while *the sharer* happened to be standing on that screen themselves, with Ghost off, in the last 90 seconds. Sharing through the normal flow put you in the other person's card and nowhere else.

In practice that meant the map only worked when two people were on it simultaneously, which is approximately never.

## What changed

**The share flow's own publisher now marks its envelopes map-eligible.** Bounded by what the envelope already is: encrypted to one recipient's key, existing only because the sharer created a grant for that person, for a duration they chose.

**Eligible is not visible.** `presence_mode` still gates it and still defaults to `'ghost'`. Appearing on someone's map stays opt-in.

> An earlier draft of this branch treated "never opened the map screen" as consent, via `COALESCE(presence_mode,'foreground_private') <> 'ghost'`. That was reverted. It would have made every existing sharer visible without asking them, and that is not a default anyone gets to change on their behalf.

**The choice is now findable.** It was only ever reachable through a Ghost toggle on the immersive map — so somebody who shared, then wondered why they never appeared, had no route to the switch that decided it. It is now a row in Location settings, with a dedicated `GET /location/map-preferences` rather than fetching the entire map state to read one boolean.

**90 seconds stops deleting people.** It removed them from the response outright, so a locked phone made someone vanish — indistinguishable from having stopped sharing. Positions are retained an hour and returned with `capturedAt`; `freshnessSeconds` still ships and now means how recent a position is, not whether its owner exists.

## Saying who has gone quiet

| Surface | Treatment |
|---|---|
| Map pin | Turns grey, keeps its place |
| Tray | Greyscale avatar, disconnected badge bottom-right, "last seen 7m ago" |

The split is forced by the platform: pins are Capacitor-bridged markers exposing `tintColor` and nothing else — no avatar, no badge, no hover, and no hover at all on iOS. `title` is already ruled out on web, where the renderer feeds it to the pin's *glyph* and paints the text across the map. The tray is the only real DOM here, so that is where identity goes.

The stale clock is a **dependency of the marker effect** on purpose: staleness is time passing, not data arriving, and a phone that stopped publishing sends nothing to notice.

## Verification

- `tsc --noEmit`, `eslint --max-warnings=0`, `ruff` — all clean
- `location-immersive-map.test.tsx` — 20/20

One of those tests caught a real regression: my first version appended "Sharing live." to every row's accessible name. The live row now keeps its original name exactly, and only somebody who has gone quiet gets extra announced.