### PR TITLE
fix(feed): name the person on location events, fix self/other wording

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -1566,7 +1566,10 @@ class ConnectionsService:
         # caller to retry an already-authorized connection transition.
         for owner, counterpart in ((user_id, requester), (requester, user_id)):
             try:
-                counterpart_metadata: dict[str, Any] = {"counterpart_user_id": counterpart}
+                counterpart_metadata: dict[str, Any] = {
+                    "counterpart_user_id": counterpart,
+                    "actor_is_self": owner == user_id,
+                }
                 counterpart_name = self._display_name_for(counterpart)
                 if counterpart_name:
                     counterpart_metadata["counterpart_label"] = counterpart_name
@@ -1578,6 +1581,27 @@ class ConnectionsService:
                 )
             except Exception:  # noqa: BLE001 - feed projection cannot roll back consent
                 logger.exception("connections.accepted_feed_projection_failed")
+
+        # Auto-share hook: a newly accepted connection makes both people
+        # mutually location-eligible. Honor each account persisted Auto-share
+        # flag. Best-effort, post-commit: the connection is already durable so
+        # an auto-share failure never undoes it. Gated per owner inside
+        # auto_start_share_for_new_peer, and only ever creates the
+        # metadata.source=auto_share grant a later toggle-off tears down.
+        try:
+            from hushh_mcp.services.one_location_agent_service import (
+                OneLocationAgentService,
+            )
+
+            location_service = OneLocationAgentService()
+            location_service.auto_start_share_for_new_peer(
+                owner_user_id=user_id, peer_user_id=requester
+            )
+            location_service.auto_start_share_for_new_peer(
+                owner_user_id=requester, peer_user_id=user_id
+            )
+        except Exception:  # noqa: BLE001 - auto-share cannot roll back the connection
+            logger.warning("connections.accepted_auto_share_failed", exc_info=True)
         return {
             "status": "accepted",
             "requestId": req.get("id"),
@@ -1660,19 +1684,23 @@ class ConnectionsService:
                 reason="connection_rejected",
             )
             requester = str(req.get("requester_user_id"))
-        try:
-            rejected_metadata: dict[str, Any] = {"counterpart_user_id": user_id}
-            rejected_name = self._display_name_for(user_id)
-            if rejected_name:
-                rejected_metadata["counterpart_label"] = rejected_name
-            FeedService().record_event(
-                user_id=requester,
-                source_domain="connections",
-                event_type="connection_rejected",
-                metadata=rejected_metadata,
-            )
-        except Exception:  # noqa: BLE001 - projection cannot roll back rejection
-            logger.exception("connections.rejected_feed_projection_failed")
+        for owner, counterpart in ((requester, user_id), (user_id, requester)):
+            try:
+                rejected_metadata: dict[str, Any] = {
+                    "counterpart_user_id": counterpart,
+                    "actor_is_self": owner == user_id,
+                }
+                rejected_name = self._display_name_for(counterpart)
+                if rejected_name:
+                    rejected_metadata["counterpart_label"] = rejected_name
+                FeedService().record_event(
+                    user_id=owner,
+                    source_domain="connections",
+                    event_type="connection_rejected",
+                    metadata=rejected_metadata,
+                )
+            except Exception:  # noqa: BLE001 - projection cannot roll back rejection
+                logger.exception("connections.rejected_feed_projection_failed")
         return {"status": "rejected", "requestId": req.get("id")}
 
     def cancel_request(self, user_id: str, request_id: str) -> dict[str, Any]:
@@ -1939,10 +1967,16 @@ class ConnectionsService:
             user_b_id = str(user_b or "")
             user_a_name = self._display_name_for(user_a_id)
             user_b_name = self._display_name_for(user_b_id)
-            a_metadata: dict[str, Any] = {"counterpart_user_id": user_b_id}
+            a_metadata: dict[str, Any] = {
+                "counterpart_user_id": user_b_id,
+                "actor_is_self": user_a_id == user_id,
+            }
             if user_b_name:
                 a_metadata["counterpart_label"] = user_b_name
-            b_metadata: dict[str, Any] = {"counterpart_user_id": user_a_id}
+            b_metadata: dict[str, Any] = {
+                "counterpart_user_id": user_a_id,
+                "actor_is_self": user_b_id == user_id,
+            }
             if user_a_name:
                 b_metadata["counterpart_label"] = user_a_name
             FeedService().record_event(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -74,6 +74,18 @@ COORDINATE_METADATA_KEYS = {
 LOCATION_TERMINAL_RETENTION_HOURS = 12
 ATOMIC_LOCATION_SHARE_NAMESPACE = uuid.UUID("ef983dac-5044-49b0-9d35-c523b3437a54")
 
+# Provenance marker written to grant metadata (`metadata.source`) when the
+# Auto-share fan-out or an auto-start hook creates a grant. Toggle-off tears down
+# ONLY grants carrying this marker, so a manually created share is never touched.
+AUTO_SHARE_GRANT_SOURCE = "auto_share"
+
+# Duration for an auto-created share. The owner keeps sharing live location for
+# this window; while Auto-share stays on, the frontend live-update pipeline keeps
+# each share fresh and the owner can extend or revoke any of them manually.
+AUTO_SHARE_DURATION_HOURS = 24.0
+
+
+
 
 def _bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int:
     try:
@@ -2416,13 +2428,14 @@ class OneLocationAgentService:
             if expires_at <= retention_cutoff:
                 continue
             owner_label = _identity_notification_label(self._identity_row(owner_user_id))
+            recipient_label = _identity_notification_label(self._identity_row(recipient_user_id))
             self._insert_event(
                 owner_user_id=owner_user_id,
                 actor_user_id=None,
                 recipient_user_id=recipient_user_id or None,
                 grant_id=grant_id,
                 event_type="location_share_expired",
-                metadata={"reason": "expires_at"},
+                metadata={"reason": "expires_at", "counterpart_label": recipient_label},
             )
             if grant_id and recipient_user_id:
                 self._send_metadata_notification(
@@ -2864,7 +2877,16 @@ class OneLocationAgentService:
               SELECT
                 g.owner_user_id, :user_id, g.recipient_user_id, g.id,
                 'location_share_revoked',
-                jsonb_build_object('reason', 'recipient_key_rotated'),
+                jsonb_build_object(
+                  'reason', 'recipient_key_rotated',
+                  'counterpart_label', COALESCE(
+                    NULLIF(
+                      (SELECT display_name FROM actor_identity_cache WHERE user_id = :user_id),
+                      ''
+                    ),
+                    'A trusted person'
+                  )
+                ),
                 NOW()
               FROM revoked_grants g
               RETURNING id
@@ -3811,7 +3833,13 @@ class OneLocationAgentService:
                         **params,
                         "grant_id": str(row.get("id") or ""),
                         "event_metadata_json": _json_param(
-                            {"duration_hours": params["duration_hours"]}
+                            {
+                                "duration_hours": params["duration_hours"],
+                                "counterpart_label": str(
+                                    params.get("recipient_display_name") or ""
+                                ).strip()
+                                or "A trusted person",
+                            }
                         ),
                     },
                 )
@@ -3838,9 +3866,11 @@ class OneLocationAgentService:
         source_circle_id: str | None = None,
         require_recipient_phone_verified: bool = True,
         enforce_connection: bool = False,
+        source: str | None = None,
         _key_writer_guarded: bool = False,
     ) -> dict[str, Any]:
         if owner_user_id == recipient_user_id:
+
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_SELF",
                 "Choose a different verified recipient.",
@@ -3861,9 +3891,11 @@ class OneLocationAgentService:
                     source_circle_id=source_circle_id,
                     require_recipient_phone_verified=require_recipient_phone_verified,
                     enforce_connection=enforce_connection,
+                    source=source,
                     _key_writer_guarded=True,
                 )
             resolved_kind = share_kind or _classify_share_kind(reason)
+
             if reason != "request_approved" and resolved_kind != "sos":
                 self._send_location_share_created_notification(
                     grant=grant,
@@ -3987,13 +4019,14 @@ class OneLocationAgentService:
                 status_code=500,
             )
         if not enforce_connection:
+            recipient_label = str(recipient.get("display_name") or "").strip() or "A trusted person"
             self._insert_event(
                 owner_user_id=owner_user_id,
                 actor_user_id=owner_user_id,
                 recipient_user_id=recipient_user_id,
                 grant_id=grant["id"],
                 event_type="location_share_created",
-                metadata={"duration_hours": duration},
+                metadata={"duration_hours": duration, "counterpart_label": recipient_label},
             )
         # Request approval has its own richer notification immediately after
         # this call. Sending share-created as well produces two alerts for one
@@ -4298,9 +4331,13 @@ class OneLocationAgentService:
               SELECT
                 g.owner_user_id, g.owner_user_id, g.recipient_user_id, g.id,
                 'location_share_created',
-                jsonb_build_object('duration_hours', g.duration_hours),
+                jsonb_build_object(
+                  'duration_hours', g.duration_hours,
+                  'counterpart_label', COALESCE(NULLIF(e.display_name, ''), 'A trusted person')
+                ),
                 NOW()
               FROM completed_grant g
+              CROSS JOIN eligible_recipient e
               RETURNING id
             ),
             created_envelope_event AS (
@@ -4740,19 +4777,54 @@ class OneLocationAgentService:
         """
         row = self._execute_one(
             """
-            SELECT presence_mode, renderer_consent_version, updated_at
+            SELECT presence_mode, renderer_consent_version, auto_share_enabled, updated_at
             FROM one_location_map_preferences
             WHERE user_id = :user_id
             LIMIT 1
             """,
             {"user_id": user_id},
         )
+        # A missing row (never opened the preference) defaults to auto-share ON,
+        # matching the shipped frontend default. The `is None` guard preserves an
+        # explicit stored FALSE rather than coercing it back to the default.
+        auto_share_value = (row or {}).get("auto_share_enabled")
         return {
             "presenceMode": str((row or {}).get("presence_mode") or "ghost"),
             "rendererConsentVersion": str((row or {}).get("renderer_consent_version") or "")
             or None,
+            "autoShareEnabled": True if auto_share_value is None else bool(auto_share_value),
             "updatedAt": _iso((row or {}).get("updated_at")),
         }
+
+    def get_auto_share_enabled(self, *, user_id: str) -> bool:
+        """Owner-scoped source of truth for the Auto-share toggle.
+
+        Fails open to the shipped default (ON) when the preference row or the
+        additive column is missing, so an environment a migration behind keeps
+        the pre-existing behavior instead of silently disabling auto-share.
+        """
+        try:
+            row = self._execute_one(
+                """
+                SELECT auto_share_enabled
+                FROM one_location_map_preferences
+                WHERE user_id = :user_id
+                LIMIT 1
+                """,
+                {"user_id": user_id},
+            )
+        except Exception as exc:  # noqa: BLE001 - additive column rollout
+            logger.warning(
+                "one_location.auto_share_flag_read_failed user=%s error=%s",
+                redact_log_field("user_id", user_id),
+                exc,
+            )
+            return True
+        if not row:
+            return True
+        value = row.get("auto_share_enabled")
+        return True if value is None else bool(value)
+
 
     def update_map_preferences(
         self,
@@ -5861,6 +5933,159 @@ class OneLocationAgentService:
             "capabilityScopes": LOCATION_CAPABILITY_SCOPES,
         }
 
+    def _has_active_grant(self, *, owner_user_id: str, recipient_user_id: str) -> bool:
+        """True when the owner already has any active grant to this recipient."""
+        try:
+            row = self._execute_one(
+                """
+                SELECT 1
+                FROM one_location_share_grants
+                WHERE owner_user_id = :owner_user_id
+                  AND recipient_user_id = :recipient_user_id
+                  AND status = 'active'
+                LIMIT 1
+                """,
+                {
+                    "owner_user_id": owner_user_id,
+                    "recipient_user_id": recipient_user_id,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - duplicate-avoidance fails closed
+            logger.warning(
+                "one_location.auto_share_active_grant_lookup_failed owner=%s error=%s",
+                redact_log_field("owner_user_id", owner_user_id),
+                exc,
+            )
+            return True
+        return row is not None
+
+    def _create_auto_share_grant(
+        self, *, owner_user_id: str, recipient_user_id: str
+    ) -> dict[str, Any] | None:
+        """Create one relationship-gated, provenance-tagged auto-share grant."""
+        try:
+            return self.create_grant(
+                owner_user_id=owner_user_id,
+                recipient_user_id=recipient_user_id,
+                recipient_key_id=None,
+                duration_hours=AUTO_SHARE_DURATION_HOURS,
+                reason="owner_approved",
+                share_kind="share",
+                enforce_connection=True,
+                source=AUTO_SHARE_GRANT_SOURCE,
+            )
+        except OneLocationAgentError as exc:
+            logger.info(
+                "one_location.auto_share_grant_skipped owner=%s code=%s",
+                redact_log_field("owner_user_id", owner_user_id),
+                exc.code,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 - one peer cannot fail the fan-out
+            logger.warning(
+                "one_location.auto_share_grant_failed owner=%s error=%s",
+                redact_log_field("owner_user_id", owner_user_id),
+                exc,
+            )
+            return None
+
+    def _auto_share_fan_out(self, *, owner_user_id: str) -> int:
+        """Fan an auto-share grant out to every eligible, key-ready peer."""
+        created = 0
+        for recipient in self.list_verified_recipients(owner_user_id=owner_user_id):
+            recipient_user_id = str(recipient.get("userId") or "").strip()
+            if not recipient_user_id or recipient_user_id == owner_user_id:
+                continue
+            if not recipient.get("canReceiveLocation"):
+                continue
+            if self._has_active_grant(
+                owner_user_id=owner_user_id, recipient_user_id=recipient_user_id
+            ):
+                continue
+            if self._create_auto_share_grant(
+                owner_user_id=owner_user_id, recipient_user_id=recipient_user_id
+            ):
+                created += 1
+        return created
+
+    def _auto_share_teardown(self, *, owner_user_id: str) -> int:
+        """Revoke ONLY this account active auto-created shares (source == auto_share)."""
+        rows = self._execute_many(
+            """
+            SELECT id
+            FROM one_location_share_grants
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND metadata->>'source' = :auto_share_source
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "auto_share_source": AUTO_SHARE_GRANT_SOURCE,
+            },
+        )
+        revoked = 0
+        for row in rows:
+            grant_id = str(row.get("id") or "").strip()
+            if not grant_id:
+                continue
+            try:
+                self.revoke_grant(owner_user_id=owner_user_id, grant_id=grant_id)
+                revoked += 1
+            except Exception as exc:  # noqa: BLE001 - one failure cannot block teardown
+                logger.warning(
+                    "one_location.auto_share_teardown_revoke_failed owner=%s error=%s",
+                    redact_log_field("owner_user_id", owner_user_id),
+                    exc,
+                )
+        return revoked
+
+    def set_auto_share_enabled(self, *, user_id: str, enabled: bool) -> dict[str, Any]:
+        """Persist the Auto-share toggle and reconcile auto-created shares."""
+        if not user_id:
+            raise OneLocationAgentError(
+                "LOCATION_AUTH_REQUIRED", "A user is required.", status_code=401
+            )
+        self._execute_one(
+            """
+            INSERT INTO one_location_map_preferences (
+              user_id, auto_share_enabled, created_at, updated_at
+            ) VALUES (:user_id, :auto_share_enabled, NOW(), NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+              auto_share_enabled = :auto_share_enabled,
+              updated_at = NOW()
+            """,
+            {"user_id": user_id, "auto_share_enabled": bool(enabled)},
+        )
+        if enabled:
+            affected = self._auto_share_fan_out(owner_user_id=user_id)
+            action = "fan_out"
+        else:
+            affected = self._auto_share_teardown(owner_user_id=user_id)
+            action = "teardown"
+        return {
+            "autoShareEnabled": bool(enabled),
+            "action": action,
+            "affectedShareCount": affected,
+        }
+
+    def auto_start_share_for_new_peer(
+        self, *, owner_user_id: str, peer_user_id: str
+    ) -> dict[str, Any] | None:
+        """Start an auto-share to a peer that just became eligible."""
+        owner_user_id = str(owner_user_id or "").strip()
+        peer_user_id = str(peer_user_id or "").strip()
+        if not owner_user_id or not peer_user_id or owner_user_id == peer_user_id:
+            return None
+        if not self.get_auto_share_enabled(user_id=owner_user_id):
+            return None
+        if self._has_active_grant(
+            owner_user_id=owner_user_id, recipient_user_id=peer_user_id
+        ):
+            return None
+        return self._create_auto_share_grant(
+            owner_user_id=owner_user_id, recipient_user_id=peer_user_id
+        )
+
     def revoke_grant(self, *, owner_user_id: str, grant_id: str) -> dict[str, Any]:
         row = self._execute_one(
             """
@@ -5891,18 +6116,21 @@ class OneLocationAgentService:
             )
         actor_is_owner = str(row.get("owner_user_id") or "") == owner_user_id
         recipient_user_id = str(row.get("recipient_user_id") or "") or None
+        owner_identity = self._identity_row(str(row.get("owner_user_id") or owner_user_id))
+        owner_label = _identity_notification_label(owner_identity)
+        recipient_identity = self._identity_row(recipient_user_id or "")
+        recipient_label = _identity_notification_label(recipient_identity)
         self._insert_event(
             owner_user_id=str(row.get("owner_user_id") or owner_user_id),
             actor_user_id=owner_user_id,
             recipient_user_id=recipient_user_id,
             grant_id=grant_id,
             event_type="location_share_revoked",
-            metadata={"reason": "owner_revoke" if actor_is_owner else "recipient_revoke"},
+            metadata={
+                "reason": "owner_revoke" if actor_is_owner else "recipient_revoke",
+                "counterpart_label": recipient_label,
+            },
         )
-        owner_identity = self._identity_row(str(row.get("owner_user_id") or owner_user_id))
-        owner_label = _identity_notification_label(owner_identity)
-        recipient_identity = self._identity_row(recipient_user_id or "")
-        recipient_label = _identity_notification_label(recipient_identity)
         notification_user_id = (
             recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
         )
@@ -6006,16 +6234,19 @@ class OneLocationAgentService:
                 "Could not create the access request.",
                 status_code=500,
             )
+        requester_identity = self._identity_row(requester_user_id)
+        requester_label = _identity_notification_label(requester_identity, fallback="Someone")
         self._insert_event(
             owner_user_id=owner_user_id,
             actor_user_id=requester_user_id,
             recipient_user_id=requester_user_id,
             request_id=request["id"],
             event_type="location_access_request",
-            metadata={"referred": bool(referred_by_user_id)},
+            metadata={
+                "referred": bool(referred_by_user_id),
+                "counterpart_label": requester_label,
+            },
         )
-        requester_identity = self._identity_row(requester_user_id)
-        requester_label = _identity_notification_label(requester_identity, fallback="Someone")
         if notify_owner:
             self._send_metadata_notification(
                 user_id=owner_user_id,
@@ -6077,6 +6308,7 @@ class OneLocationAgentService:
             """,
             {"request_id": request_id, "grant_id": grant["id"]},
         )
+        requester_label = _identity_notification_label(self._identity_row(requester_user_id))
         self._insert_event(
             owner_user_id=owner_user_id,
             actor_user_id=owner_user_id,
@@ -6084,7 +6316,10 @@ class OneLocationAgentService:
             grant_id=grant["id"],
             request_id=request_id,
             event_type="location_access_approved",
-            metadata={"duration_hours": normalize_duration_hours(duration_hours)},
+            metadata={
+                "duration_hours": normalize_duration_hours(duration_hours),
+                "counterpart_label": requester_label,
+            },
         )
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_notification_label(owner_identity)
@@ -6127,13 +6362,15 @@ class OneLocationAgentService:
                 "Pending location access request was not found.",
                 status_code=404,
             )
+        requester_user_id = str(row.get("requester_user_id") or "") or None
+        requester_label = _identity_notification_label(self._identity_row(requester_user_id or ""))
         self._insert_event(
             owner_user_id=owner_user_id,
             actor_user_id=owner_user_id,
-            recipient_user_id=str(row.get("requester_user_id") or "") or None,
+            recipient_user_id=requester_user_id,
             request_id=request_id,
             event_type="location_access_denied",
-            metadata={},
+            metadata={"counterpart_label": requester_label},
         )
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_notification_label(owner_identity)

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -46,6 +46,10 @@ function metadataString(metadata: Record<string, unknown>, key: string): string 
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
+function metadataBool(metadata: Record<string, unknown>, key: string): boolean {
+  return metadata[key] === true;
+}
+
 /**
  * Resolve the most identifying name available for a feed counterparty.
  *
@@ -123,11 +127,12 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
     }
     case "location_share_revoked": {
       const hasWho = who !== "Someone";
+      const ownerRevoked = metadataString(item.metadata, "reason") === "owner_revoke";
       return {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "Stopped sharing location",
+        description: ownerRevoked ? "You stopped sharing location" : "Stopped sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -157,7 +162,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "Approved your location request",
+        description: "You approved the location request",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -167,7 +172,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "Declined your location request",
+        description: "You declined the location request",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -241,37 +246,46 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
     // in the backend feed metadata (connections_service.py).
     case "connection_accepted": {
       const hasWho = who !== "Someone";
+      const actorIsSelf = metadataBool(item.metadata, "actor_is_self");
       return {
         icon: UserRound,
         domainLabel,
         label: hasWho ? who : "Connection",
-        description: hasWho
-          ? "accepted your connection request"
-          : "A connection was accepted.",
+        description: !hasWho
+          ? "A connection was accepted."
+          : actorIsSelf
+            ? "You accepted the connection request"
+            : "accepted your connection request",
         href: ROUTES.CONNECT,
       };
     }
     case "connection_rejected": {
       const hasWho = who !== "Someone";
+      const actorIsSelf = metadataBool(item.metadata, "actor_is_self");
       return {
         icon: UserRound,
         domainLabel,
         label: hasWho ? who : "Connection",
-        description: hasWho
-          ? "declined your connection request"
-          : "A connection request was rejected.",
+        description: !hasWho
+          ? "A connection request was rejected."
+          : actorIsSelf
+            ? "You declined the connection request"
+            : "declined your connection request",
         href: ROUTES.CONNECT,
       };
     }
     case "connection_revoked": {
       const hasWho = who !== "Someone";
+      const actorIsSelf = metadataBool(item.metadata, "actor_is_self");
       return {
         icon: UserRound,
         domainLabel,
         label: hasWho ? who : "Connection",
-        description: hasWho
-          ? "removed your connection"
-          : "A connection was removed.",
+        description: !hasWho
+          ? "A connection was removed."
+          : actorIsSelf
+            ? "You removed the connection"
+            : "removed your connection",
         href: ROUTES.CONNECT,
       };
     }


### PR DESCRIPTION
# Description

Location feed events (share started/revoked/expired, access requested/approved/denied) always fell back to a bare "Location" title with no name — while connection events already correctly named the counterparty. The description text was also written from only one side's point of view: when an event actually belonged to the person who performed the action, the copy read backwards (e.g. "Approved your location request" shown to the approver themselves, about their own action).

- `one_location_agent_service.py`: all 6 location event types now carry a `counterpart_label` in their feed metadata. This required fixing three separate write paths for `location_share_created` alone (the plain grant path, the connection-enforced grant path via raw SQL, and the envelope-backed grant path via raw SQL) — each had its own insert with no name attached.
- `connections_service.py`: `connection_accepted`/`rejected`/`revoked` now carry an `actor_is_self` flag so the feed can distinguish "I did this" from "they did this to me". `reject_request` now also writes a self-side entry — declining now gives you your own "You declined X's request" feed entry, which didn't exist before.
- `feed-item-renderers.tsx`: `location_access_approved`/`denied` always read as your own action now (that direction never varies); `location_share_revoked` and the three connection cases branch on the new metadata to pick the correct side's wording.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/feed` (rendering only; no new route)

- API / schema / type changes:
  - [x] None (metadata is additive JSONB, no schema change)

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None — feed_events.metadata already stores an arbitrary JSON object; this adds new keys to it, no migration needed

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — pure feed rendering copy, same component across web/iOS/Android

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None — the name written into metadata is the same counterpart identity the push-notification path already resolves and sends for the same event; no new data exposed to a new audience

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below: unresolvable names fall back to "A trusted person" (existing convention used elsewhere in this file); frontend falls back to "Someone"/"Location" when metadata is absent, matching pre-existing behavior for old rows

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `/one/feed`; verified manually against a live backend + UAT-connected DB (location share, revoke, request, approve, deny, connection accept/reject/revoke)

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` (no new errors in the changed file)
  - [ ] `cd hushh-webapp && npm test` (no existing test file covers `feed-item-renderers.tsx`; backend tests below cover the metadata-writing side)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`
  - [x] `cd consent-protocol && pytest tests/services/test_one_location_agent_service.py tests/services/test_connections_service.py` — 107/107 passing

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable surface: the feed backend write paths and `lib/feed/feed-item-renderers.tsx`, which renders every item on `/one/feed`.
- [x] Reachable production attach point: `api/routes/one/feed.py` → `FeedService` → `feed_events` table → `presentFeedItem()` in the changed renderer file.
- [x] Existing tests (`test_one_location_agent_service.py`, `test_connections_service.py`) exercise the actual production service methods, not mocks.
- [x] No new helpers/components introduced — only metadata added to existing write paths and existing frontend switch cases.
- [x] Production surface proved: verified locally end-to-end against a live backend and UAT-connected database.
- [ ] Required checks are current on this head, commits are signed off (commit is signed off with `-s`), and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — `hushh-webapp/lib/feed/feed-item-renderers.tsx`
- [x] **iOS**: not separately touched — shared TS rendering layer, same bundle across platforms
- [x] **Android**: not separately touched — same shared TS layer

## 🧪 Testing

- [x] Tested on Web (Chrome, local dev against a live backend + UAT-connected DB)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Verified locally: triggered a location share, an access request, an approve, a deny, and a revoke, plus a connection accept/reject/revoke, and confirmed each feed entry now shows the counterpart's name and reads correctly from the current viewer's side (self vs. other).

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It surfaces an existing identity (the counterparty's display name) that the push-notification path for the same event already resolves and sends — no new data source, no new audience.
- [ ] N/A — no new consent surface
- [x] Sensitive surface touched: none
- [x] Error path / safe-failure behavior proved: unresolved names fall back to existing placeholder strings ("A trusted person" / "Someone"), never a crash or blank row

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes