### PR TITLE
Polish post-login UI copy and spacing

### DIFF
--- a/docs/reference/quality/app-surface-design-system.md
+++ b/docs/reference/quality/app-surface-design-system.md
@@ -127,6 +127,23 @@ Rules:
 9. Email Helper draft previews must not expose raw information structure terms such as `changes`, `entities`, hashes, provenance, parser metadata, or internal ids. Use readable sections, facts, and tables from the approved render model.
 10. Dense email tables, especially portfolios and holdings, should remain complete and readable on mobile through horizontal scrolling. Do not force all table columns to fit the viewport when that creates overlap.
 
+## Concise Product Copy Contract
+
+Signed-in product UI should feel minimal, calm, and easy to understand in a few seconds.
+
+Rules:
+
+1. Headlines should usually be 2-6 words.
+2. Supporting text is optional. When present, keep it to one short sentence that helps the next action.
+3. Button labels should usually be 1-3 words.
+4. Do not repeat the same idea in the title, subtitle, row body, and button.
+5. Do not explain what a visible control already communicates.
+6. Prefer `View details`, `Request sent`, `Profile updated`, and similarly direct phrases over procedural copy.
+7. Empty states should name what happens next, not describe the full system.
+8. Use whitespace for hierarchy. Do not fill quiet space with helper text, badges, chips, or extra cards.
+9. Preserve required compliance, consent, security, and destructive-action warnings, but write them as short user-facing decisions.
+10. Every shared component should render concise copy by default so route screens do not solve clarity with local typography overrides.
+
 ## Shell Contract
 
 1. The top shell is the single authority for header clearance.

--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -31,8 +31,8 @@ describe("Connect canonical surface contract", () => {
       "utf8",
     );
 
-    expect(source).toContain("Review connection capabilities");
-    expect(source).toContain("No capabilities available yet");
+    expect(source).toContain("Connection access");
+    expect(source).toContain("No access yet");
     expect(source).toContain("requestedHandles: []");
     expect(source).not.toContain(
       "if (catalog.items.length === 0 && catalog.offerableItems.length === 0)",

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -110,7 +110,7 @@ describe("Connect — People", () => {
 
     expect(
       await screen.findByText(
-        "A few people on Hussh. Search by name to find someone specific.",
+        "Search by name.",
       ),
     ).toBeTruthy();
     expect(screen.getByText("Person 0")).toBeTruthy();
@@ -124,7 +124,7 @@ describe("Connect — People", () => {
 
     expect(
       await screen.findByText(
-        "A few people on Hussh. Search by name to find someone specific.",
+        "Search by name.",
       ),
     ).toBeTruthy();
     expect(screen.getByText("Page 1")).toBeTruthy();
@@ -176,7 +176,7 @@ describe("Connect — People", () => {
     await waitFor(() =>
       expect(
         screen.queryByText(
-          "A few people on Hussh. Search by name to find someone specific.",
+          "Search by name.",
         ),
       ).toBeNull(),
     );
@@ -451,7 +451,7 @@ describe("Connect — People", () => {
       fireEvent.click(screen.getByLabelText(`Select Bulk person ${index}`));
     }
 
-    expect(screen.getByText("Connect to Selected (20/20)")).toBeTruthy();
+    expect(screen.getByText("Connect selected (20/20)")).toBeTruthy();
     expect(
       (screen.getByLabelText("Select Bulk person 20") as HTMLButtonElement)
         .disabled,
@@ -464,7 +464,7 @@ describe("Connect — People", () => {
     ).toBe(false);
     fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
 
-    fireEvent.click(screen.getByRole("button", { name: "Connect to Selected (20/20)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Connect selected (20/20)" }));
 
     await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(20));
 
@@ -482,7 +482,7 @@ describe("Connect — People", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
     fireEvent.click(screen.getByLabelText("Select Person 0"));
-    expect(screen.getByText("Connect to Selected (1/20)")).toBeTruthy();
+    expect(screen.getByText("Connect selected (1/20)")).toBeTruthy();
 
     mocks.searchDirectory.mockResolvedValue({
       items: [person("u9", "Person 9")],
@@ -495,7 +495,7 @@ describe("Connect — People", () => {
 
     expect(await screen.findByText("Person 9")).toBeTruthy();
     await waitFor(() =>
-      expect(screen.queryByText("Connect to Selected (1/20)")).toBeNull(),
+      expect(screen.queryByText("Connect selected (1/20)")).toBeNull(),
     );
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -341,6 +341,14 @@ vi.mock("@/lib/services/pre-vault-sensitive-draft-service", () => ({
 }));
 
 vi.mock("@/lib/one-location/contact-signals", () => ({
+  OneLocationContactSyncError: class OneLocationContactSyncError extends Error {
+    failure: unknown;
+
+    constructor(failure: unknown) {
+      super("Contact sync failed");
+      this.failure = failure;
+    }
+  },
   syncOneLocationContactSignals: mockSyncOneLocationContactSignals,
 }));
 
@@ -772,16 +780,16 @@ async function openShareConfirmStep() {
 }
 
 async function openAskFlow() {
-  fireEvent.click(screen.getByRole("button", { name: /Request Location/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Request location/i }));
   expect(
-    await screen.findByRole("heading", { name: "Make it comfortable" }),
+    await screen.findByRole("heading", { name: "Ask clearly" }),
   ).toBeTruthy();
 }
 
 async function openTemporaryLinkFlow() {
   fireEvent.click(screen.getByRole("button", { name: "Links" }));
   fireEvent.click(
-    await screen.findByRole("button", { name: /Create a new link/i }),
+    await screen.findByRole("button", { name: /Create link/i }),
   );
   expect(
     await screen.findByRole("heading", { name: "Share outside your Circle" }),
@@ -2748,11 +2756,11 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.queryByRole("heading", { name: "Pending invites" }),
     ).toBeNull();
-    // Links tab: "Active links" list + a single "Create a new link" CTA. The
+    // Links tab: "Active links" list + a single "Create link" CTA. The
     // mock has no active links, so the empty state shows.
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
-      await screen.findByRole("button", { name: /Create a new link/i }),
+      await screen.findByRole("button", { name: /Create link/i }),
     ).toBeTruthy();
     expect(screen.getByText("Active links")).toBeTruthy();
     expect(screen.getByText("No active links")).toBeTruthy();
@@ -3320,9 +3328,7 @@ describe("OneLocationAgentPage", () => {
       }),
     );
     await waitFor(() =>
-      expect(
-        screen.getByRole("heading", { name: "Location Agent" }),
-      ).toBeTruthy(),
+      expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
     );
   });
 
@@ -3439,7 +3445,7 @@ describe("OneLocationAgentPage", () => {
     // The populated People tab exposes a compact "Sync contacts" circle action.
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(
-      await screen.findByRole("button", { name: /Add Connections/i }),
+      await screen.findByRole("button", { name: /Add people/i }),
     ).toBeTruthy();
     fireEvent.click(
       await screen.findByRole("button", { name: /Sync contacts/i }),
@@ -3596,10 +3602,10 @@ describe("OneLocationAgentPage", () => {
     // "Ask someone to share" is populated-state-only, and the redundant
     // approval explainer must not add another card below these actions.
     expect(
-      screen.getByRole("button", { name: /Add Connections/i }),
+      screen.getByRole("button", { name: /Add people/i }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /Invite trusted person/i }),
+      screen.getByRole("button", { name: /^Invite$/i }),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
     expect(
@@ -3611,12 +3617,12 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     mockRouterPush.mockClear();
-    fireEvent.click(screen.getByRole("button", { name: /Add Connections/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Add people/i }));
     expect(mockRouterPush).toHaveBeenCalledWith("/one/connect");
 
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
-      await screen.findByRole("button", { name: /Create a new link/i }),
+      await screen.findByRole("button", { name: /Create link/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -85,7 +85,9 @@ const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
 const CONNECT_ROW_ACTION_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px]";
 const CONNECT_PAGER_BUTTON_CLASSNAME =
-  "h-[30px] min-h-[30px] rounded-[15px] px-2.5 text-[14px] font-semibold leading-[18px]";
+  "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
+const CONNECT_INLINE_BUTTON_CLASSNAME =
+  "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
 
 /** Maximum number of connection requests the People bulk action can send. */
 const MAX_BULK_CONNECTION_REQUESTS = 20;
@@ -1159,7 +1161,7 @@ export default function ConnectPageClient() {
               {connections.length === 0 ? (
                 <SettingsRow
                   title="No connections yet"
-                  description="People you connect with will appear here."
+                  description="Connections appear here."
                   density="compact"
                   disabled
                 />
@@ -1172,13 +1174,13 @@ export default function ConnectPageClient() {
                     title={connection.displayName || connection.userId}
                     density="compact"
                     trailing={
-                      <span className="flex shrink-0 items-center gap-1 whitespace-nowrap">
+                      <span className="flex shrink-0 items-center justify-end gap-1.5 whitespace-nowrap">
                         <Button
                           type="button"
                           variant="none"
                           effect="fade"
                           size="sm"
-                          className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
+                          className={CONNECT_INLINE_BUTTON_CLASSNAME}
                           disabled={busyId === connection.connectionId}
                           onClick={() => void viewInformationScopes(connection)}
                         >
@@ -1191,7 +1193,7 @@ export default function ConnectPageClient() {
                               variant="destructive"
                               effect="fill"
                               size="sm"
-                              className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
+                              className={CONNECT_INLINE_BUTTON_CLASSNAME}
                               disabled={busyId === connection.connectionId}
                               onClick={() => void handleRemove(connection)}
                             >
@@ -1204,7 +1206,7 @@ export default function ConnectPageClient() {
                               variant="none"
                               effect="fade"
                               size="sm"
-                              className="h-8 rounded-[10px] px-3 text-[13px] font-medium"
+                              className={CONNECT_INLINE_BUTTON_CLASSNAME}
                               disabled={busyId === connection.connectionId}
                               onClick={() => setPendingRemoveId(null)}
                             >
@@ -1221,7 +1223,10 @@ export default function ConnectPageClient() {
                               setPendingRemoveId(connection.connectionId)
                             }
                             aria-label={`Remove connection with ${connection.displayName || connection.userId}`}
-                            className="h-8 rounded-[10px] px-3 text-[13px] font-medium text-muted-foreground hover:text-destructive"
+                            className={cn(
+                              CONNECT_INLINE_BUTTON_CLASSNAME,
+                              "text-muted-foreground hover:text-destructive",
+                            )}
                           >
                             Remove
                           </Button>
@@ -1308,12 +1313,12 @@ export default function ConnectPageClient() {
                   isSelectionMode
                     ? (
                         <span id="connect-selection-limit">
-                          Select up to {MAX_BULK_CONNECTION_REQUESTS} people to send connection requests.
+                          Select up to {MAX_BULK_CONNECTION_REQUESTS} people.
                         </span>
                       )
                     : hasQuery
-                    ? "Send a connection request to someone you know."
-                    : "A few people on Hussh. Search by name to find someone specific."
+                    ? "Send a request."
+                    : "Search by name."
                 }
                 separatorInset
               >
@@ -1334,14 +1339,14 @@ export default function ConnectPageClient() {
                   hasQuery ? (
                     <SettingsRow
                       title={`No one matches "${trimmedQuery}"`}
-                      description="Check the spelling, or try their full name."
+                      description="Try their full name."
                       density="compact"
                       disabled
                     />
                   ) : (
                     <SettingsRow
                       title="No people yet"
-                      description="Search by name to find someone on Hussh."
+                      description="Search by name."
                       density="compact"
                       disabled
                     />
@@ -1541,8 +1546,8 @@ export default function ConnectPageClient() {
                       onClick={() => void handleConnectMultiple()}
                     >
                       {isConnectingMultiple
-                        ? "Sending requests…"
-                        : `Connect to Selected (${selectedUserIds.size}/${MAX_BULK_CONNECTION_REQUESTS})`}
+                        ? "Sending…"
+                        : `Connect selected (${selectedUserIds.size}/${MAX_BULK_CONNECTION_REQUESTS})`}
                     </Button>
                   </div>
                 )}
@@ -1562,11 +1567,9 @@ export default function ConnectPageClient() {
       >
         <DialogContent showCloseButton={false} className="gap-5">
           <DialogHeader className="text-left">
-            <DialogTitle>Review connection capabilities</DialogTitle>
+            <DialogTitle>Connection access</DialogTitle>
             <DialogDescription>
-              A connection never shares information by itself. Choose only the
-              capabilities you want to request or offer; the other person can
-              approve a subset or decline them all.
+              Choose what to request or offer.
             </DialogDescription>
           </DialogHeader>
 
@@ -1632,13 +1635,13 @@ export default function ConnectPageClient() {
               {scopeDraft.catalog.items.length === 0 &&
               scopeDraft.catalog.offerableItems.length === 0 ? (
                 <SettingsGroup
-                  title="No capabilities available yet"
-                  description="You can still send a connection request. Capabilities appear here only when this relationship is eligible for them."
+                  title="No access yet"
+                  description="Send a connection request now."
                   separatorInset
                 >
                   <SettingsRow
                     title="Connection only"
-                    description="This request does not grant access to any information or Kai debate."
+                    description="No information access."
                     density="compact"
                     disabled
                   />
@@ -1687,23 +1690,21 @@ export default function ConnectPageClient() {
       >
         <DialogContent className="gap-5">
           <DialogHeader className="text-left">
-            <DialogTitle>Available information scopes</DialogTitle>
+            <DialogTitle>Available details</DialogTitle>
             <DialogDescription>
-              {informationScopeDraft?.connection.displayName || "This person"} controls which
-              scopes appear here. This is metadata only; requesting a scope still requires their
-              explicit consent before an encrypted export can be created.
+              They choose what appears here.
             </DialogDescription>
           </DialogHeader>
           <Input
             type="search"
             value={informationScopeQuery}
             onChange={(event) => setInformationScopeQuery(event.target.value)}
-            placeholder="Search available scopes"
-            aria-label="Search available scopes"
+            placeholder="Search details"
+            aria-label="Search details"
           />
           <div className="max-h-[45vh] overflow-y-auto">
             {visibleInformationScopes && visibleInformationScopes.length > 0 ? (
-              <SettingsGroup title="Discoverable scopes" separatorInset>
+              <SettingsGroup title="Available" separatorInset>
                 {visibleInformationScopes.map((item) => (
                   <SettingsRow
                     key={item.scope}
@@ -1715,10 +1716,10 @@ export default function ConnectPageClient() {
                 ))}
               </SettingsGroup>
             ) : (
-              <SettingsGroup title="No matching scopes" separatorInset>
+              <SettingsGroup title="No matches" separatorInset>
                 <SettingsRow
-                  title="Nothing is available for this search"
-                  description="Private, internal, and empty scopes are never listed."
+                  title="Nothing found"
+                  description="Private details stay hidden."
                   density="compact"
                   disabled
                 />

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -680,7 +680,7 @@ textarea {
   --ios-account-row-vertical-pad: 11px;
   --ios-account-separator-thickness: 0.5px;
   --ios-account-section-header-bottom-gap: 8px;
-  --ios-account-section-gap: 28px;
+  --ios-account-section-gap: 22px;
   --ios-account-icon-tile-size: 34px;
   --ios-account-icon-tile-radius: 8px;
   --ios-account-icon-glyph-size: 20px;
@@ -1402,7 +1402,7 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
 
 .profile-home-screen {
   --settings-group-stack-gap: 8px;
-  --settings-heading-stack-gap: 6px;
+  --settings-heading-stack-gap: 4px;
   --settings-row-px: 20px;
   --settings-row-py: 10px;
   --settings-row-gap: 12px;
@@ -1432,8 +1432,8 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
 }
 
 .profile-home-hero {
-  gap: 12px !important;
-  padding-top: 16px;
+  gap: 10px !important;
+  padding-top: 10px;
 }
 
 .profile-home-screen [data-profile-avatar-frame="true"] {
@@ -1522,8 +1522,8 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
 .profile-home-content {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-top: 20px;
+  gap: 16px;
+  margin-top: 14px;
   width: 100%;
 }
 
@@ -1646,7 +1646,7 @@ body:has(.profile-home-screen) .foundation-public-ambient {
 
 @media (min-width: 768px) {
   .profile-home-hero {
-    padding-top: 24px;
+    padding-top: 16px;
   }
 
   .profile-home-screen [data-profile-avatar-frame="true"] {
@@ -1659,7 +1659,7 @@ body:has(.profile-home-screen) .foundation-public-ambient {
   }
 
   .profile-home-content {
-    margin-top: 24px;
+    margin-top: 18px;
   }
 }
 

--- a/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
+++ b/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
@@ -116,7 +116,7 @@ export function ConnectedSystemDetailClient({
           open={showUnlock}
           onOpenChange={setShowUnlock}
           title="Unlock vault"
-          description="Unlock your vault to inspect CRM records and approve Connected Systems actions."
+          description="Unlock to review CRM."
           onSuccess={() => setShowUnlock(false)}
         />
       ) : null}

--- a/hushh-webapp/app/one/connected-systems/page.tsx
+++ b/hushh-webapp/app/one/connected-systems/page.tsx
@@ -76,7 +76,7 @@ export default function ConnectedSystemsPage() {
           open={showUnlock}
           onOpenChange={setShowUnlock}
           title="Set up your private vault"
-          description="Set up or open your private vault to inspect CRM records and approve Connected Systems actions."
+          description="Open your vault to review CRM."
           onSuccess={() => setShowUnlock(false)}
         />
       ) : null}

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -1838,7 +1838,7 @@ export function OneKycWorkspace({
         <PageHeader
           eyebrow="One"
           title="KYC"
-          description="Review requests for personal information, choose what to share, and approve each response."
+          description="Review and approve each request."
           icon={ShieldCheck}
           accent="neutral"
           actions={
@@ -1876,11 +1876,11 @@ export function OneKycWorkspace({
 
         <div className="w-full">
           {(!vaultKey || !vaultOwnerToken) ? (
-            <SettingsGroup title="Vault required" description="You must have a Vault set up to use KYC review.">
+            <SettingsGroup title="Vault required" description="Set up your vault to use KYC.">
               <SettingsRow
                 icon={AlertTriangle}
                 title="Vault missing"
-                description="We couldn't save settings to your vault because it isn't set up yet. Please complete the setup in Onboarding or Settings to use this feature."
+                description="Set up your vault first."
               />
             </SettingsGroup>
           ) : (
@@ -1890,7 +1890,7 @@ export function OneKycWorkspace({
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Unsupported Account"
-                    description="Your primary account uses an Apple Private Relay ID. Request review is not supported for proxy addresses."
+                    description="Private Relay addresses are not supported."
                   />
                 ) : showInitialLoading ? (
                 <SettingsRow
@@ -1906,7 +1906,7 @@ export function OneKycWorkspace({
                 <SettingsRow
                   icon={Inbox}
                   title="No matched requests"
-                  description="New requests appear here after One matches them to one of your verified addresses."
+                  description="Matched requests appear here."
                 />
               ) : (
                 workflows.map((workflow) => (
@@ -2051,7 +2051,7 @@ export function OneKycWorkspace({
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Sync required"
-                    description="Unlock completed. Sync this request so One can prepare access safely from your device."
+                    description="Sync to prepare access."
                   />
                 </SettingsGroup>
               ) : null}
@@ -2329,7 +2329,7 @@ export function OneKycWorkspace({
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Additional details needed"
-                    description="One needs additional approved details before it can prepare a complete reply."
+                    description="Approve more details to continue."
                   />
                 </SettingsGroup>
               ) : null}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -451,12 +451,12 @@ const LOCATION_VOICE_CONTROLS = [
   { id: "one-location-action-settings", label: "Settings", purpose: "Open privacy controls.", actionId: "location.open_settings", role: "button" },
   { id: "one-location-action-check-in", label: "Check-In", purpose: "Send a one-off check in.", actionId: "location.open_check_in", role: "button" },
   { id: "one-location-action-sos", label: "SMS", purpose: "Open emergency SOS.", actionId: "location.open_sos", role: "button" },
-  { id: "one-location-action-ask", label: "Ask someone to share", purpose: "Request another person's location.", actionId: "location.open_ask", role: "button" },
-  { id: "one-location-action-invite", label: "Invite trusted person", purpose: "Invite someone not on Hushh yet.", actionId: "location.open_invite", role: "button" },
+  { id: "one-location-action-ask", label: "Request location", purpose: "Ask for location access.", actionId: "location.open_ask", role: "button" },
+  { id: "one-location-action-invite", label: "Invite", purpose: "Invite someone to One.", actionId: "location.open_invite", role: "button" },
   { id: "one-location-action-create-circle", label: "Create", purpose: "Create a circle.", actionId: "location.open_create_circle", role: "button" },
   { id: "one-location-action-join-circle", label: "Join with code", purpose: "Join a circle by code.", actionId: "location.open_join_circle", role: "button" },
-  { id: "one-location-action-temp-link", label: "Create a new link", purpose: "Create a temporary link.", actionId: "location.open_temporary_link", role: "button" },
-  { id: "one-location-add-connections", label: "Add Connections", purpose: "Open Connect to find people.", actionId: "location.add_connections", role: "button" },
+  { id: "one-location-action-temp-link", label: "Create link", purpose: "Create a temporary link.", actionId: "location.open_temporary_link", role: "button" },
+  { id: "one-location-add-connections", label: "Add people", purpose: "Open Connect.", actionId: "location.add_connections", role: "button" },
   { id: "one-location-refresh", label: "Refresh", purpose: "Reload location state.", actionId: "location.refresh", role: "button" },
   // One control, two contract actions: the direction is whichever one the
   // switch is not already in. It is rendered in the header and again in
@@ -9365,7 +9365,7 @@ export function OneLocationAgentPageContent({
         <PageHeader
           eyebrow="Private location sharing"
           title="Your circle, safely connected."
-          description="Let the people you trust see where you are only when you choose, only for as long as you choose."
+          description="Share only when you choose."
           icon={MapPin}
           accent="success"
           actionsInlineMobile
@@ -10578,7 +10578,7 @@ export function OneLocationAgentPageContent({
                       <EmptyOneState
                         icon={ExternalLink}
                         title="No public responses"
-                        description="Responses from your public location link show up here after visitors open it."
+                        description="Responses appear here."
                       />
                     )}
                   </div>

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -1015,7 +1015,7 @@ function OneMarketplacePageImpl() {
     <PkmSettingsShell
       eyebrow="One / Marketplace"
       title="Information Marketplace"
-      description="Choose private sharing separately from owner-published public profile summaries. Nothing private is shared without your approval."
+      description="Private sharing always needs approval."
       actions={
         <div className="flex flex-wrap items-center gap-2">
           <SettingsSegmentedTabs

--- a/hushh-webapp/app/one/setup/connected-systems/connected-systems-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/connected-systems/connected-systems-onboarding-setup-client.tsx
@@ -64,7 +64,7 @@ export function ConnectedSystemsOnboardingSetupClient() {
         <AppPageHeaderRegion>
           <PageHeader
             title="CRM"
-            description="Find your existing CRM record or approve creating one from your verified identity."
+            description="Find or create your CRM record."
             accent="neutral"
           />
         </AppPageHeaderRegion>
@@ -94,7 +94,7 @@ export function ConnectedSystemsOnboardingSetupClient() {
             open={showUnlock}
             onOpenChange={setShowUnlock}
             title="Set up your private vault"
-            description="Set up or open your private vault to inspect CRM records and approve CRM actions."
+            description="Open your vault to review CRM."
             allowVaultCreation={false}
             onSuccess={() => setShowUnlock(false)}
           />

--- a/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
@@ -219,7 +219,7 @@ export function EmailOnboardingSetupClient() {
       <AppPageContentRegion>
         <SettingsGroup
           title="Response preparation"
-          description="This is off by default. When enabled, One recognizes requests sent from your verified email to one@hushh.ai. You still approve every response before it is sent."
+          description="One finds requests. You approve every reply."
           separatorInset
         >
           <SettingsRow

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -301,20 +301,17 @@ const SUPPORT_KIND_COPY: Record<
 > = {
   bug_report: {
     title: "Report a bug",
-    description:
-      "Tell us what broke, what you expected, and anything we should look at.",
+    description: "Tell us what broke.",
     subject: "Bug report",
   },
   support_request: {
     title: "Contact support",
-    description:
-      "Ask for help with your account, portfolio flows, or something unclear in the app.",
+    description: "Get help with One.",
     subject: "Support request",
   },
   developer_reachout: {
     title: "Reach the developer",
-    description:
-      "Share product feedback, implementation notes, or a direct engineering question.",
+    description: "Send product feedback.",
     subject: "Developer feedback",
   },
 };
@@ -1928,14 +1925,14 @@ function ProfilePageContent() {
     ? "Unlock to delete account"
     : "Delete account";
   const deleteRowDescription = vaultAccess.needsVaultCreation
-    ? "No vault exists yet. This deletes cloud-linked account records."
-    : "This permanently deletes your One account.";
+    ? "Deletes cloud-linked records."
+    : "Deletes your One account.";
   const deleteDialogTitle = DELETE_ACCOUNT_DIALOG_TITLE;
   const deleteDialogDescription = DELETE_ACCOUNT_DIALOG_DESCRIPTION;
 
   const resetRowDescription =
-    "Clear your saved details and start onboarding fresh. Keeps your account and sign-in.";
-  const resetDialogTitle = "Reset your One account?";
+    "Clears saved details. Keeps sign-in.";
+  const resetDialogTitle = "Reset account?";
   const resetDialogDescription =
     "This clears all your saved details: connected services, finance and Gmail, your knowledge base, consents, and saved preferences. It keeps your account, your sign-in, and your vault. You will start onboarding again.";
 
@@ -1956,16 +1953,16 @@ function ProfilePageContent() {
 
   const unlockDialogTitle =
     vaultUnlockReason === "delete_account"
-      ? "Unlock Vault to Delete Account"
+      ? "Unlock to delete"
       : vaultUnlockReason === "reset_account"
-        ? "Unlock Vault to Reset Account"
-        : "Unlock Vault";
+        ? "Unlock to reset"
+        : "Unlock vault";
   const unlockDialogDescription =
     vaultUnlockReason === "delete_account"
-      ? "Unlock your vault to confirm deletion. This is permanent and removes all encrypted records."
+      ? "This permanently removes encrypted records."
       : vaultUnlockReason === "reset_account"
-        ? "Unlock your vault to confirm reset. This clears your saved details but keeps your account and vault."
-        : "Unlock your vault to access profile settings.";
+        ? "Saved details reset. Account and vault stay."
+        : "Unlock to continue.";
 
   const displayedUnlockMethod = effectiveVaultMethod ?? vaultMethod;
   const recommendedQuickMethod =
@@ -2013,7 +2010,7 @@ function ProfilePageContent() {
   const contactDiscoverableStatusText = loadingContactDiscoverable
     ? "Checking discoverability…"
     : contactDiscoverable
-      ? "People who have your number can find you"
+      ? "People with your number can find you"
       : "Hidden from contact sync";
   const phoneSummaryText = phoneNumber
     ? maskPhoneNumber(phoneNumber)
@@ -2996,7 +2993,7 @@ function ProfilePageContent() {
         <SettingsRow
           icon={MapPin}
           title="Location sharing"
-          description="Share, request, and revoke encrypted live-location access."
+          description="Manage live location."
           trailing={<Badge variant="secondary">One</Badge>}
           chevron
           stackTrailingOnMobile
@@ -3005,7 +3002,7 @@ function ProfilePageContent() {
         <SettingsRow
           icon={ExternalLink}
           title="Consent center"
-          description="Open the full sharing workspace."
+          description="Review sharing."
           trailing={<Badge variant="secondary">Manage</Badge>}
           chevron
           stackTrailingOnMobile
@@ -3146,7 +3143,7 @@ function ProfilePageContent() {
         <SettingsRow
           icon={Palette}
           title="Accent"
-          description="The highlight color One uses across the app."
+          description="Choose the app accent."
           trailing={
             <Select
               value={appAccent}
@@ -3189,7 +3186,7 @@ function ProfilePageContent() {
         <SettingsRow
           leading={<GeminiLogo className="h-8 w-8" />}
           title="Gemini"
-          description="Choose Hussh managed Gemini or keep your own key in your encrypted vault."
+          description="Choose managed or BYOK."
           chevron
           onClick={() =>
             updateProfileView(
@@ -3270,7 +3267,7 @@ function ProfilePageContent() {
         <SettingsRow
           icon={RefreshCw}
           title="Actions"
-          description="Connect, sync, receipts, or disconnect."
+          description="Sync, receipts, or disconnect."
           chevron
           onClick={() =>
             updateProfileView(
@@ -3303,7 +3300,7 @@ function ProfilePageContent() {
           <SettingsRow
             icon={KeyRound}
             title="Create your vault"
-            description="Set up a passphrase to secure your saved details."
+            description="Secure saved details."
             chevron
             onClick={() => setShowVaultCreation(true)}
           />
@@ -3371,7 +3368,7 @@ function ProfilePageContent() {
               <SettingsRow
                 icon={KeyRound}
                 title="Unlock vault"
-                description="Unlock your vault to change methods or update your passphrase."
+                description="Change methods or passphrase."
                 chevron
                 onClick={() => requestVaultUnlock("profile_data")}
               />
@@ -3387,8 +3384,8 @@ function ProfilePageContent() {
                 }
                 description={
                   isPasskeyVaultMethod(recommendedQuickMethod)
-                    ? "Create a saved passkey for this device or browser."
-                    : "Enable this device's secure quick unlock."
+                    ? "Save a passkey."
+                    : "Enable quick unlock."
                 }
                 disabled={switchingVaultMethod}
                 chevron
@@ -3467,7 +3464,7 @@ function ProfilePageContent() {
               <SettingsRow
                 icon={RefreshCw}
                 title="Change passphrase"
-                description="Update the passphrase that protects your vault."
+                description="Update vault protection."
                 disabled={switchingVaultMethod}
                 chevron
                 onClick={() => setPassphraseDialogOpen(true)}
@@ -3729,7 +3726,7 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:account",
       title: "Account",
-      description: "Manage email, phone number, and sign-in identity.",
+      description: "Email, phone, and sign-in.",
       content: accountContent,
     });
     if (activeDetail === "phone") {
@@ -3737,8 +3734,8 @@ function ProfilePageContent() {
         key: "detail:phone",
         title: phoneNumber ? "Change phone number" : "Add phone number",
         description: phoneNumber
-          ? "Verify a new number to replace the current one."
-          : "Add a verified phone number to this account.",
+          ? "Verify a new number."
+          : "Add a verified number.",
         content: (
           <>
             <PhoneVerificationFlow
@@ -3756,8 +3753,8 @@ function ProfilePageContent() {
               className="gap-5"
               helperText={
                 phoneNumber
-                  ? "Choose your country code and enter the new phone number you want to use for this account."
-                  : "Choose your country code and enter your phone number. We’ll send you a verification code."
+                  ? "Enter the new phone number."
+                  : "Enter your phone number."
               }
             />
             <div id="recaptcha-container" className="min-h-0" />
@@ -3769,14 +3766,14 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:my-data",
       title: "Memory",
-      description: "Browse saved details and sharing controls.",
+      description: "Saved details and sharing.",
       content: myDataContent,
     });
     if (selectedDomain) {
       profileStackEntries.push({
         key: `detail:domain:${selectedDomain.key}`,
         title: selectedDomain.title,
-        description: "Review sections and sharing controls.",
+        description: "Sections and sharing.",
         content: (
           <PkmDomainDetailPanel
             domain={selectedDomain}
@@ -3842,14 +3839,14 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:access",
       title: "Access & sharing",
-      description: "Review who can read what and manage live grants.",
+      description: "Review live access.",
       content: accessContent,
     });
     if (selectedConnection) {
       profileStackEntries.push({
         key: `detail:connection:${selectedConnection.id}`,
         title: selectedConnection.requesterLabel,
-        description: "Inspect exact scopes and revoke access inline.",
+        description: "Scopes and access.",
         content: (
           <PkmAccessConnectionDetailPanel
             connection={selectedConnection}
@@ -3864,21 +3861,21 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:connected-systems",
       title: "Connected Systems",
-      description: "Salesforce CRM and future MuleSoft-backed systems.",
+      description: "Connected CRM systems.",
       content: connectedSystemsContent,
     });
   } else if (!routeBlockedByVault && activePanel === "preferences") {
     profileStackEntries.push({
       key: "panel:preferences",
       title: PROFILE_LABELS.preferences,
-      description: "Choose the app theme and accent color.",
+      description: "Theme and accent.",
       content: preferencesContent,
     });
     if (activeDetail === "kai-preferences") {
       profileStackEntries.push({
         key: "detail:kai-preferences",
         title: "Kai preferences",
-        description: "Secure personal investing preferences.",
+        description: "Investing preferences.",
         content: (
           <ProfileKaiPreferencesPanel
             userId={user.uid}
@@ -3893,7 +3890,7 @@ function ProfilePageContent() {
       profileStackEntries.push({
         key: "detail:gemini",
         title: "Gemini",
-        description: "Choose how your private agent reaches Gemini.",
+        description: "Gemini access.",
         content: (
           <GeminiRuntimeSettingsCard
             userId={user.uid}
@@ -3911,21 +3908,21 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:security",
       title: PROFILE_LABELS.security,
-      description: "Vault methods and account access controls.",
+      description: "Vault and sign-in.",
       content: securityContent,
     });
     if (activeDetail === "vault") {
       profileStackEntries.push({
         key: "detail:vault",
         title: "Vault methods",
-        description: "Review unlock method and secure defaults.",
+        description: "Unlock methods.",
         content: vaultMethodsContent,
       });
     } else if (activeDetail === "session") {
       profileStackEntries.push({
         key: "detail:session",
         title: PROFILE_LABELS.accountAccess,
-        description: "Manage sign-in on this device.",
+        description: "This device.",
         content: (
           <SettingsGroup title={PROFILE_LABELS.accountAccess}>
             <SettingsRow
@@ -3943,21 +3940,21 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:gmail",
       title: "Gmail receipts",
-      description: "Connection state, sync health, and receipt actions.",
+      description: "Receipts and sync.",
       content: gmailContent,
     });
     if (activeDetail === "gmail-connection") {
       profileStackEntries.push({
         key: "detail:gmail-connection",
         title: "Connection",
-        description: "Current inbox, status, and latest sync.",
+        description: "Inbox and sync.",
         content: gmailConnectionContent,
       });
     } else if (activeDetail === "gmail-actions") {
       profileStackEntries.push({
         key: "detail:gmail-actions",
         title: "Actions",
-        description: "Connect, sync, open receipts, or disconnect.",
+        description: "Sync, receipts, or disconnect.",
         content: gmailActionsContent,
       });
     }
@@ -3965,21 +3962,21 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:support",
       title: PROFILE_LABELS.support,
-      description: "Get help, report bugs, or send product feedback.",
+      description: "Help and feedback.",
       content: supportContent,
     });
     if (activeDetail === "support-routing") {
       profileStackEntries.push({
         key: "detail:support-routing",
         title: "Support routing",
-        description: "Where support messages are routed and replied.",
+        description: "Reply routing.",
         content: supportRoutingContent,
       });
     } else if (supportComposeKind && supportComposeContent) {
       profileStackEntries.push({
         key: `detail:support-compose:${supportComposeKind}`,
         title: SUPPORT_KIND_COPY[supportComposeKind].title,
-        description: "Write and send a concise support message.",
+        description: "Write your message.",
         content: supportComposeContent,
       });
     }

--- a/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
@@ -257,7 +257,7 @@ export function GeminiRuntimeConfigurationPage({
               ? "Set up your private vault"
               : "Open your private vault"
           }
-          description="Your Gemini access is encrypted in your private vault and is never stored by Hussh."
+          description="Gemini access stays in your vault."
           onSuccess={() => setUnlockOpen(false)}
         />
       ) : null}

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -484,7 +484,7 @@ function AgentGridItem({
         // consistent gaps keep every cell's icon/title/KPI on the same
         // baseline across columns. Colors are unchanged (the tone logic in
         // AgentMetric still drives them).
-        "group relative flex min-h-[9.5rem] min-w-0 w-full flex-col items-center justify-start gap-2.5 overflow-hidden rounded-[16px] px-2 py-3.5 text-center",
+        "group relative flex min-h-[7rem] min-w-0 w-full flex-col items-center justify-start gap-2 overflow-hidden rounded-[16px] px-2 py-3 text-center",
         "transition-[background-color,transform] duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
         "hover:bg-[color:var(--app-card-surface-compact)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 focus-visible:ring-inset active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
         className,
@@ -503,7 +503,7 @@ function AgentGridItem({
       />
       <span className="relative z-10 flex w-full min-w-0 flex-col items-center gap-1 text-center">
         <span
-          className="block w-full truncate text-center text-[16px] font-semibold leading-5 tracking-[-0.01em] text-[#1D1D1F] dark:text-[#F5F5F7]"
+          className="block w-full truncate text-center text-[15px] font-semibold leading-5 tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
           data-ui-role="body-strong"
         >
           {mode.title}
@@ -523,7 +523,7 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
       title={mode.description}
       data-testid={`one-agent-list-row-${mode.id}`}
       className={cn(
-        "group/agent-row relative grid min-h-[60px] w-full grid-cols-[40px_minmax(0,1fr)_minmax(92px,auto)_14px] items-center gap-x-3 overflow-hidden px-3.5 text-left outline-none",
+        "group/agent-row relative grid min-h-[58px] w-full grid-cols-[40px_minmax(0,1fr)_minmax(84px,auto)_14px] items-center gap-x-3 overflow-hidden px-3.5 text-left outline-none",
         "transition-colors duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
         "hover:bg-[rgba(120,120,128,.08)] active:bg-[rgba(120,120,128,.12)]",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
@@ -689,11 +689,11 @@ export function OneAgentRoster({
         {view === "grid" ? (
           <div
             data-testid="one-agents-grid"
-            className="rounded-[var(--app-card-radius-standard,24px)] bg-white p-2 shadow-[var(--app-card-shadow-standard)] dark:bg-[#1C1C1E]"
+            className="rounded-[20px] bg-white p-2 shadow-[var(--app-card-shadow-standard)] dark:bg-[#1C1C1E]"
           >
             <div
               data-agent-roster-layout="grouped-icon-grid"
-              className="grid w-full grid-cols-[repeat(3,minmax(96px,1fr))] justify-center gap-x-2 gap-y-2 min-[430px]:grid-cols-[repeat(3,minmax(108px,1fr))] sm:grid-cols-[repeat(4,minmax(112px,1fr))] sm:gap-x-2.5 sm:gap-y-3"
+              className="grid w-full grid-cols-[repeat(3,minmax(92px,1fr))] justify-center gap-x-1.5 gap-y-1.5 min-[430px]:grid-cols-[repeat(3,minmax(104px,1fr))] sm:grid-cols-[repeat(4,minmax(108px,1fr))] sm:gap-x-2 sm:gap-y-2"
             >
               {visibleModes.map((mode) => (
                 <AgentGridItem key={mode.id} mode={mode} />
@@ -703,7 +703,7 @@ export function OneAgentRoster({
         ) : (
           <div
             data-testid="one-agents-list"
-            className="group/agent-list overflow-hidden rounded-[var(--app-card-radius-standard,24px)] bg-white shadow-[var(--app-card-shadow-standard)] dark:bg-[#1C1C1E]"
+            className="group/agent-list overflow-hidden rounded-[20px] bg-white shadow-[var(--app-card-shadow-standard)] dark:bg-[#1C1C1E]"
           >
             {visibleModes.map((mode) => (
               <AgentListRow key={mode.id} mode={mode} />

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -317,9 +317,7 @@ describe("named Circle flows", () => {
     expect(
       screen.getByTestId("one-location-circle-invite-invite-1"),
     ).toHaveAttribute("data-focused", "true");
-    expect(
-      screen.getByText(/current and future Circle members/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/Join first\. Sharing stays private\./i)).toBeTruthy();
     const joinButton = screen.getByRole("button", { name: "Join" });
     fireEvent.click(joinButton);
     fireEvent.click(joinButton);

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -230,7 +230,7 @@ export function CirclesSection({
       {incomingInvites.length ? (
         <SettingsGroup
           title="Circle invitations"
-          description="Joining connects you with current and future Circle members. Location and SMS stay private until you choose to share."
+          description="Join first. Sharing stays private."
           testId="one-location-circle-member-invites"
         >
           {incomingInvites.map((invite) => {
@@ -418,7 +418,7 @@ export function CreateCircleFlow({
       <TaskFlowHeader
         eyebrow="People"
         title="Create a circle"
-        description="Give this group a name. People join only by accepting an invitation or entering its code."
+        description="Name the group."
       />
 
       <label className="block space-y-2">
@@ -457,7 +457,7 @@ export function CreateCircleFlow({
 
       <TrustNoteCard
         title="Connected, still private"
-        description="Circle members become connections with current and future members. Location and SMS stay private until each person chooses to share."
+        description="Members connect. Sharing stays explicit."
       />
 
       <Button
@@ -619,7 +619,7 @@ export function JoinCircleFlow({
 
       <TrustNoteCard
         title="No request wait"
-        description="A valid code is your consent to join and connect with the Circle. Location access remains explicit, time-limited and revocable."
+        description="Join the Circle. Location stays explicit."
       />
     </div>
   );
@@ -1485,7 +1485,7 @@ export function CircleDetailFlow({
 
           <SettingsGroup
             title="Members"
-            description="Members are connected through this Circle. Location and SMS sharing remain explicit."
+            description="Members connect through this Circle."
             testId="one-location-circle-members"
           >
             {members.map((member) => (
@@ -1507,7 +1507,7 @@ export function CircleDetailFlow({
 
           <TrustNoteCard
             title="Connected does not mean visible"
-            description="Circle membership is not live-view permission. Every location recipient still needs a separate encrypted, time-limited grant."
+            description="Live access still needs approval."
           />
 
           {isOwner ? (

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1253,7 +1253,7 @@ function NowHub({
         <SettingsRow
           icon={MessageCircleQuestionMark}
           iconTone="accent"
-          title="Request Location"
+          title="Request location"
           density="compact"
           chevron
           onClick={onRequestLocation}
@@ -1382,15 +1382,15 @@ function LocationDetailFlow({
   const copy = {
     "active-shares": {
       title: "Active shares",
-      description: "Only the people below can currently see your location.",
+      description: "People who can see you now.",
     },
     "shared-with-me": {
       title: "Shared with me",
-      description: "Live locations disappear when access ends or is revoked.",
+      description: "Live access from others.",
     },
     "needs-review": {
       title: "Needs my review",
-      description: "Review every request before location is shared.",
+      description: "Approve before sharing.",
     },
   }[kind];
 
@@ -1424,7 +1424,7 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="No active shares"
-            description="Start a consent-first share when you are ready."
+            description="Share when needed."
           />
         )
       ) : null}
@@ -1484,7 +1484,7 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="Nothing shared with you"
-            description="A person's live location appears here only while their grant is active."
+            description="Live grants appear here."
           />
         )
       ) : null}
@@ -1507,7 +1507,7 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="Nothing to review"
-            description="Incoming location requests will appear here."
+            description="Requests appear here."
           />
         )
       ) : null}
@@ -1577,13 +1577,13 @@ function LocationSettingsFlow({
       <TaskFlowHeader
         eyebrow="Location"
         title="Settings"
-        description="You control who sees your location and when. Change this anytime."
+        description="Control live sharing."
       />
 
       <SettingsGroup title="Location sharing" separatorInset>
         <SettingsRow
           title="Auto-share my location"
-          description="On — approved shares keep receiving live updates. Off — new shares send only the location you explicitly confirm."
+          description="Approved shares get live updates."
           trailing={
             <LocationToggle
               checked={vm.autoShareEnabled}
@@ -1595,7 +1595,7 @@ function LocationSettingsFlow({
         />
         <SettingsRow
           title="Show me on their map"
-          description="On — people you already share with can see you move on their map. Off — they still get your location, but only as a card. This never adds anyone new."
+          description="Controls live movement on shared maps."
           trailing={
             <LocationToggle
               checked={vm.mapPresenceEnabled === true}
@@ -1608,7 +1608,7 @@ function LocationSettingsFlow({
         />
         <SettingsRow
           title="Pause my location"
-          description="Stop new private-share updates and check out from Nearby. Existing shares keep their expiry and may retain your last encrypted point."
+          description="Stop new updates."
           trailing={
             <LocationToggle
               checked={vm.locationPaused}
@@ -1630,8 +1630,7 @@ function LocationSettingsFlow({
       <div className="flex items-start gap-2.5 px-1">
         <Shield className="mt-0.5 h-[15px] w-[15px] shrink-0 text-[color:var(--app-accent)]" />
         <p className={MUTED_TEXT}>
-          Private shares stay in your circle. Nearby Check-In is separate and
-          only starts after you explicitly agree.
+          Private shares stay in your circle.
         </p>
       </div>
 
@@ -1770,7 +1769,7 @@ function PeopleHub({
 
         <SectionCard
           title="Connections"
-          description="Connections and Circle members are eligible for explicit private sharing."
+          description="People ready for sharing."
         >
           {/* Symmetric action layout with generous breathing room: a 2-col
               primary row (Add / Invite) over a matching 2-col contact row
@@ -1784,7 +1783,7 @@ function PeopleHub({
                 className="h-12 w-full font-medium"
               >
                 <UsersRound className="mr-2 h-4 w-4" />
-                Add Connections
+                Add people
               </Button>
               <Button
                 variant="outline"
@@ -1793,7 +1792,7 @@ function PeopleHub({
                 className="h-12 w-full font-medium"
               >
                 <UserPlus className="mr-2 h-4 w-4" />
-                Invite trusted person
+                Invite
               </Button>
             </div>
             <div className="grid grid-cols-2 gap-3.5">
@@ -1857,7 +1856,7 @@ function PeopleHub({
             className="h-12 w-full font-medium"
           >
             <UsersRound className="mr-2 h-4 w-4" />
-            Add Connections
+            Add people
           </Button>
           <Button
             variant="outline"
@@ -1866,7 +1865,7 @@ function PeopleHub({
             className="h-12 w-full font-medium border-[color:var(--app-accent)] text-[color:var(--app-accent)]"
           >
             <UserPlus className="mr-2 h-4 w-4" />
-            Invite trusted person
+            Invite
           </Button>
         </div>
         <div className="grid grid-cols-2 gap-3.5">
@@ -2058,7 +2057,7 @@ function LinksHub({
       ) : (
         <EmptyState
           title="No active links"
-          description="Create one below to share with someone outside your Circle."
+          description="Create one when needed."
         />
       )}
 
@@ -2068,14 +2067,13 @@ function LinksHub({
         className="w-full"
       >
         <Plus className="mr-2 h-4 w-4" />
-        Create a new link
+        Create link
       </Button>
 
       <div className="flex items-start gap-2 px-1">
         <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         <p className={MUTED_TEXT}>
-          Links stop working automatically when they expire. You can revoke any
-          link anytime.
+          Links expire automatically.
         </p>
       </div>
     </div>
@@ -2376,7 +2374,7 @@ function ShareFlow({
       <TaskFlowHeader
         eyebrow="Step 1 of 2 · Choose people"
         title="Who can see you?"
-        description="Only trusted and location-ready people can receive private live location."
+        description="Only ready people appear."
       />
       {vm.circles.length ? (
         <SectionCard title="Share with a Circle">
@@ -2485,7 +2483,7 @@ function ShareFlow({
       ) : (
         <EmptyState
           title="No trusted people yet"
-          description="Invite someone to your Circle to start sharing."
+          description="Invite someone first."
         />
       )}
       {/* A plain step change. Advancing must not depend on device permission:
@@ -2564,8 +2562,8 @@ function AskFlow({
     <div className="space-y-5">
       <TaskFlowHeader
         eyebrow="Request with context"
-        title="Make it comfortable"
-        description="Requests should explain why. The other person chooses whether to share."
+        title="Ask clearly"
+        description="They choose whether to share."
       />
 
       {justSent ? (
@@ -2575,7 +2573,7 @@ function AskFlow({
         >
           <ShieldCheck className="mt-0.5 h-[18px] w-[18px] shrink-0 text-[color:var(--app-success)]" />
           <p className="text-sm font-medium text-foreground">
-            Request sent. We&apos;ll notify you here when they respond.
+            Request sent.
           </p>
         </div>
       ) : null}
@@ -2632,7 +2630,7 @@ function AskFlow({
           <div className="mt-3">
             <EmptyState
               title="No one to request from yet"
-              description="Invite someone to your Circle, then ask them to share."
+              description="Invite someone first."
             />
           </div>
         )}
@@ -2672,7 +2670,7 @@ function AskFlow({
 
       <TrustNoteCard
         title="No silent tracking"
-        description="They approve, decline, or ignore."
+        description="They choose."
       />
 
       {/* Send is enabled once at least one recipient is chosen. Duration and
@@ -2710,7 +2708,7 @@ function AskFlow({
             {justSent ? (
               <>
                 <ShieldCheck className="mr-1.5 h-[18px] w-[18px]" aria-hidden />
-                Request Sent
+                Sent
               </>
             ) : (
               "Send request"
@@ -2753,7 +2751,7 @@ function InviteFlow({
         <TaskFlowHeader
           eyebrow="Share invite link"
           title="Invite link created"
-          description="They must approve before location sharing starts."
+          description="They approve first."
         />
         <SectionCard>
           <div className="flex items-center gap-3">
@@ -2817,12 +2815,11 @@ function InviteFlow({
       <TaskFlowHeader
         eyebrow="Invite to One / Circle"
         title="Invite to Circle"
-        description="Use this when the person is not ready for private location sharing yet."
+        description="Invite before sharing."
       />
       <SectionCard title="What happens next?">
         <p className="text-sm text-muted-foreground">
-          They sign in, verify phone, and approve before private sharing starts.
-          This invite does not share your live location.
+          They sign in, verify phone, and approve.
         </p>
       </SectionCard>
       <SectionCard title="Invite expires after">
@@ -2838,8 +2835,8 @@ function InviteFlow({
         />
       </SectionCard>
       <TrustNoteCard
-        title="No location is shared by creating an invite"
-        description="Sharing starts only after they approve."
+        title="No location shared"
+        description="They approve first."
       />
       <Button
         onClick={vm.onCreateCircleInvite}
@@ -2876,8 +2873,8 @@ function TemporaryLinkFlow({
           title="Public location link active"
         />
         <WarningCard
-          title="Anyone with this link can view your location until it expires."
-          description="Public access ends automatically at expiry."
+          title="Anyone with the link can view you."
+          description="Access expires automatically."
         />
         {invite ? (
           <TemporaryLinkCard

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -341,7 +341,7 @@ export function SosPanel({
       data-ambient-chrome-ignore
       data-testid="sms-safety-screen"
     >
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(44px,env(safe-area-inset-top))]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(44px,env(safe-area-inset-top))] lg:max-w-[520px]">
         <button
           type="button"
           onClick={onClose}

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -1020,7 +1020,7 @@ export function RiaProfileSection({
     return (
       <RiaCompatibilityState
         title="RIA profile is waiting on the IAM rollout"
-        description="This environment needs the IAM schema before your advisor profile can load."
+        description="IAM setup is required here."
       />
     );
   }
@@ -1110,7 +1110,7 @@ export function RiaProfileSection({
           icon={ClipboardCheck}
           iconTone="blue"
           title="Update license data"
-          description="Refresh official regulator fields (CRD, regulator). Your bio, services, fees, and contact details stay unchanged."
+          description="Refresh regulator fields."
           onClick={openLicenseRefresh}
           chevron
           testId="ria-profile-update-license"
@@ -1118,7 +1118,7 @@ export function RiaProfileSection({
         <SettingsRow
           icon={RotateCcw}
           title="Re-initiate onboarding"
-          description="Run the 5-step setup wizard again. Your profile goes to pending until re-verified; clients stay connected."
+          description="Run setup again."
           onClick={handleReinitiate}
           chevron
           testId="ria-profile-reinitiate"
@@ -1127,7 +1127,7 @@ export function RiaProfileSection({
           icon={Trash2}
           tone="destructive"
           title="Delete RIA profile"
-          description="Remove your RIA profile and disconnect any clients. Your One account stays."
+          description="Remove profile. One stays."
           onClick={() => {
             setDeleteConfirmText("");
             setShowDeleteConfirm(true);

--- a/hushh-webapp/components/ria/ria-client-account-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-account-detail.tsx
@@ -124,7 +124,7 @@ export function RiaClientAccountDetail({
     return (
       <RiaCompatibilityState
         title="Account detail is unavailable in this environment"
-        description="The route is wired, but this environment still needs the full IAM schema before advisor-side account detail can load."
+        description="IAM setup is required here."
         nativeTest={{
           routeId: "/ria/clients/[userId]/accounts/[accountId]",
           marker: "native-route-ria-client-account-detail",
@@ -179,7 +179,7 @@ export function RiaClientAccountDetail({
         <SettingsGroup
           embedded
           title="Account not available"
-          description="The account branch is not part of the current client workspace or has not been approved for this advisor view."
+          description="This branch is not approved."
         >
           <SettingsRow
             title="Return to the client workspace"
@@ -215,7 +215,7 @@ export function RiaClientAccountDetail({
               <SectionHeader
                 eyebrow="Access"
                 title="Approval and branch status"
-                description="Per-account approval remains explicit. This route surfaces what the advisor can currently access for this branch."
+                description="Approved account access."
                 icon={Wallet}
                 accent="ria"
               />
@@ -248,14 +248,14 @@ export function RiaClientAccountDetail({
               <SectionHeader
                 eyebrow="Explorer"
                 title="Readable branch summary"
-                description="This view stays intentionally summary-first until richer account-level explorer payloads are available from the backend."
+                description="Summary-first view."
                 icon={Database}
                 accent="ria"
               />
               <SettingsGroup embedded>
                 <SettingsRow
                   title="Account coverage"
-                  description="This advisor route currently inherits domain-level financial summaries plus explicit branch approval metadata."
+                  description="Approved branch metadata."
                 />
                 <SettingsRow
                   title="Household risk"

--- a/hushh-webapp/components/ria/ria-client-request-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-request-detail.tsx
@@ -119,7 +119,7 @@ export function RiaClientRequestDetail({
     return (
       <RiaCompatibilityState
         title="Request detail is unavailable in this environment"
-        description="The route is wired, but this environment still needs the full IAM schema before advisor-side request detail can load."
+        description="IAM setup is required here."
         nativeTest={{
           routeId: "/ria/clients/[userId]/requests/[requestId]",
           marker: "native-route-ria-client-request-detail",
@@ -168,11 +168,11 @@ export function RiaClientRequestDetail({
         <SettingsGroup
           embedded
           title="Request not available"
-          description="This request is not part of the current client workspace history or the identifier is no longer valid."
+          description="This request is no longer available."
         >
           <SettingsRow
             title="Return to client access"
-            description="Use the client workspace to review active access and recent relationship activity."
+            description="Review active access."
             trailing={
               <Button asChild variant="link" size="sm" className="h-auto px-0">
                 <Link
@@ -204,7 +204,7 @@ export function RiaClientRequestDetail({
               <SectionHeader
                 eyebrow="Request"
                 title="Access request summary"
-                description="This route keeps request context readable without forcing the advisor back into the main workspace list."
+                description="Request context."
                 icon={ClipboardList}
                 accent="ria"
               />
@@ -237,7 +237,7 @@ export function RiaClientRequestDetail({
               <SectionHeader
                 eyebrow="Coverage"
                 title="Client access framing"
-                description="Account branches and Kai/explorer access are still governed from the client workspace. This detail route stays intentionally focused on request metadata."
+                description="Workspace access still applies."
                 icon={ClipboardList}
                 accent="ria"
               />

--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -531,7 +531,7 @@ export function RiaClientWorkspace({
       {iamUnavailable ? (
         <RiaCompatibilityState
           title="Client workspace is unavailable in this environment"
-          description="The route is wired correctly, but this environment still needs the full IAM schema before advisor workspaces can read investor information."
+          description="IAM setup is required here."
         />
       ) : null}
 


### PR DESCRIPTION
## Summary
- add the concise signed-in product copy contract to the app surface design system
- reduce noisy helper/subtitle copy across Connect, Profile/Account, Location, KYC, Marketplace, CRM setup, Gemini, and RIA surfaces
- tighten Profile spacing, Connect inline actions/pager buttons, Agent roster density, and Location action flow labels

## Verification
- npm run typecheck
- npm run verify:design-system
- npx vitest run __tests__/components/settings-ui.test.tsx __tests__/components/one-agent-roster-metrics.test.ts __tests__/components/one-location-agent-page.test.tsx __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts components/one-location/redesign/__tests__/sos-panel.test.tsx components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx __tests__/app/profile/profile-layout.contract.test.ts
- python .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- git diff --check