### PR TITLE
fix(location): make saving an address possible, and readable afterwards

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2131,7 +2131,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockReverseGeocode).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2221,7 +2221,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Second user's home" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2401,7 +2401,7 @@ describe("OneLocationAgentPage", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2599,7 +2599,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Tower 2, Floor 4" },
     });
     fireEvent.change(screen.getByLabelText(/Building colour/), {

--- a/hushh-webapp/__tests__/lib/one-location/saved-locations-persistence.integration.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-locations-persistence.integration.test.ts
@@ -155,8 +155,10 @@ describe("saved-place onboarding to Settings persistence", () => {
       expect.objectContaining({
         domain: "location",
         domainData: expect.objectContaining({
+          // v2 adds addressBase + addressDetails so an edit rebuilds the
+          // composed line from its parts. v1 entries stay readable.
           saved_places: expect.objectContaining({
-            schema_version: 1,
+            schema_version: 2,
           }),
         }),
       }),

--- a/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
@@ -448,7 +448,11 @@ describe("encrypted saved-locations PKM store", () => {
       code: "duplicate_saved_location",
       existingCategory: "home",
     });
-    expect(await loadSavedLocations(CONTEXT)).toEqual([concurrentlySavedHome]);
+    // Read normalizes the v2 fields onto a v1 entry, so it loads with the
+    // parts explicitly absent rather than undefined.
+    expect(await loadSavedLocations(CONTEXT)).toEqual([
+      { ...concurrentlySavedHome, addressBase: null, addressDetails: null },
+    ]);
   });
 
   it("uses the final retry when a concurrent duplicate is removed", async () => {

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -224,7 +224,7 @@ describe("SavedLocationsSection", () => {
     await screen.findByText("Kasturba Road, Bengaluru");
     expect(screen.getByRole("button", { name: /add place/i })).toBeDisabled();
     expect(
-      screen.getByText(/resume location before capturing another saved place/i),
+      screen.getByText(/resume location to save another place/i),
     ).toBeInTheDocument();
     expect(mocks.captureCurrentPosition).not.toHaveBeenCalled();
   });
@@ -318,7 +318,7 @@ describe("SavedLocationsSection", () => {
       await screen.findByRole("heading", { name: "Add your address details" }),
     ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B, Tower 2" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -339,6 +339,16 @@ describe("SavedLocationsSection", () => {
           // buildSavedLocationAddress folds the entrance details into the
           // pinned map address (postal code already present, so not repeated).
           address: `Flat 4B, Tower 2, ${PICKED_ENTRANCE_ADDRESS}`,
+          // Stored alongside so a later edit rebuilds this line from its
+          // parts. Composing on top of the composed result is what made an
+          // edited address grow its own entrance details a second time.
+          addressBase: PICKED_ENTRANCE_ADDRESS,
+          addressDetails: {
+            houseOrFlat: "Flat 4B, Tower 2",
+            buildingColor: "",
+            landmark: "",
+            postalCode: "110001",
+          },
         },
       }),
     );
@@ -358,7 +368,7 @@ describe("SavedLocationsSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
     await screen.findByRole("heading", { name: "Add your address details" });
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
@@ -390,7 +400,7 @@ describe("SavedLocationsSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
     await screen.findByRole("heading", { name: "Add your address details" });
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
@@ -410,7 +420,11 @@ describe("SavedLocationsSection", () => {
     render(<SavedLocationsSection />);
     await screen.findByText("Kasturba Road, Bengaluru");
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove Home" }));
+    // Edit and Remove now live inside the row, behind its disclosure arrow --
+    // they were crowding every row for the two moments a year anyone needs
+    // them, and the address had no room left to be read.
+    fireEvent.click(screen.getByRole("button", { name: /Home/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() =>
       expect(mocks.removeSavedLocation).toHaveBeenCalledWith({

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -225,11 +225,12 @@ describe("SaveLocationModal", () => {
     expect(
       screen.getByText(/held for this session/i),
     ).toBeInTheDocument();
-    // The detected address lands in the Address field, where it can be
-    // corrected, instead of only being shown back as a read-only card.
-    expect(screen.getByLabelText("Address")).toHaveValue(
-      "Kartavya Path, New Delhi, Delhi 110001, India",
-    );
+    // The detected address is shown, and the fields below were filled from
+    // it -- here only the PIN, since "Kartavya Path" is a street rather than
+    // a house number.
+    expect(
+      screen.getByText("Kartavya Path, New Delhi, Delhi 110001, India"),
+    ).toBeInTheDocument();
 
     const saveButton = screen.getByRole("button", { name: "Save location" });
     // Still off, but now for the one reason that remains, and it says so.
@@ -357,7 +358,7 @@ describe("SaveLocationModal", () => {
     expect(baseProps.onSave).not.toHaveBeenCalled();
   });
 
-  it("saves with just an address, so the button is never dead with nothing to fix", () => {
+  it("saves with just a pinned address, so the button is never dead with nothing to fix", () => {
     // The gate used to require House, flat AND a valid postal code. On the
     // edit flow House, flat came back blank every time, so "Update location"
     // could not be pressed and nothing said why -- which is what "saving
@@ -376,6 +377,8 @@ describe("SaveLocationModal", () => {
     expect(saveButton).toBeEnabled();
     fireEvent.click(saveButton);
 
+    // "Kartavya Path" is a street, not a house number, so nothing is inferred
+    // into House-flat -- and the save still goes through.
     expect(baseProps.onSave).toHaveBeenCalledWith(
       "home",
       "",
@@ -396,89 +399,141 @@ describe("SaveLocationModal", () => {
     expect(
       screen.getByText("Pick Home, Work or Other first."),
     ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Home" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: /use detected/i }));
-    fireEvent.change(screen.getByLabelText("Address"), {
-      target: { value: "   " },
-    });
-
-    expect(
-      screen.getByText("Add an address, or tick the box to use the one we found."),
-    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Save location" }),
     ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+      target: { value: "!" },
+    });
+
+    // Distinct from the field's own inline error, which says "Enter a valid
+    // PIN or postal code." right beside the input. Two places worth looking,
+    // not the same sentence twice.
+    expect(
+      screen.getByText("Check the PIN or postal code above."),
+    ).toBeInTheDocument();
   });
 
-  describe("the detected-address checkbox", () => {
-    it("fills the Address field from the pin while it is ticked", () => {
+  describe("filling the fields from the detected address", () => {
+    const HOUSE_NUMBER_ADDRESS =
+      "B-284/3, Rd Number 1, Chhatarpur Enclave Phase 2, New Delhi, Delhi 110074, India";
+
+    it("puts the house number and PIN into their own fields", () => {
+      // The address was on screen the whole time and only its postal code was
+      // ever mined, so a person looking at "B-284/3, ..." still had to retype
+      // B-284/3 into the box directly underneath it.
       render(
         <SaveLocationModal
           {...baseProps}
-          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          address={HOUSE_NUMBER_ADDRESS}
           collectAddressDetails
         />,
       );
 
-      const checkbox = screen.getByRole("checkbox", { name: /use detected/i });
-      expect(checkbox).toBeChecked();
-      expect(screen.getByLabelText("Address")).toHaveValue(
-        "Kartavya Path, New Delhi, Delhi 110001, India",
+      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+        "B-284/3",
       );
-      // Read-only while it follows the pin: an editable field that silently
-      // reverts on the next geocode is worse than one that says it is locked.
-      expect(screen.getByLabelText("Address")).toBeDisabled();
+      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110074");
+      // And the address itself is still shown, as it was before.
+      expect(screen.getByText(HOUSE_NUMBER_ADDRESS)).toBeInTheDocument();
     });
 
-    it("hands the field over once unticked, and stops the pin overwriting it", () => {
+    it("leaves House-flat empty when the address opens with a street", () => {
+      // A wrong prefill is worse than an empty one: people trust prefilled
+      // fields and stop reading them. "12 MG Road" is a street that happens
+      // to carry a number, not somebody's flat.
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address="12 MG Road, Bengaluru, Karnataka 560001, India"
+          collectAddressDetails
+        />,
+      );
+
+      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+        "",
+      );
+      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("560001");
+    });
+
+    it("never overwrites a field the person typed in", () => {
       const { rerender } = render(
         <SaveLocationModal
           {...baseProps}
-          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          address={HOUSE_NUMBER_ADDRESS}
           collectAddressDetails
         />,
       );
 
-      fireEvent.click(screen.getByRole("checkbox", { name: /use detected/i }));
-      fireEvent.change(screen.getByLabelText("Address"), {
-        target: { value: "Gate 3, Rear entrance, New Delhi" },
+      fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+        target: { value: "Flat 9, Rear block" },
       });
 
       // A later reverse-geocode arrives. It must not take the field back.
       rerender(
         <SaveLocationModal
           {...baseProps}
-          address="Somewhere Else Entirely, Delhi"
+          address="C-11/2, Somewhere Else, Delhi 110088, India"
           collectAddressDetails
         />,
       );
 
-      expect(screen.getByLabelText("Address")).toHaveValue(
-        "Gate 3, Rear entrance, New Delhi",
+      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+        "Flat 9, Rear block",
       );
+      // The untouched field still follows the pin.
+      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110088");
     });
 
-    it("restores the detected address when ticked again", () => {
+    it("clears the filled fields when unticked, and refills them when ticked again", () => {
       render(
         <SaveLocationModal
           {...baseProps}
-          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          address={HOUSE_NUMBER_ADDRESS}
           collectAddressDetails
         />,
       );
 
-      const checkbox = screen.getByRole("checkbox", { name: /use detected/i });
-      fireEvent.click(checkbox);
-      fireEvent.change(screen.getByLabelText("Address"), {
-        target: { value: "Typed over it" },
+      const checkbox = screen.getByRole("checkbox", {
+        name: /fill the fields below/i,
       });
-      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
 
-      // Ticked but still showing the edit it was meant to undo would make the
-      // box a lie, so the field is refilled on the tick itself.
-      expect(screen.getByLabelText("Address")).toHaveValue(
-        "Kartavya Path, New Delhi, Delhi 110001, India",
+      fireEvent.click(checkbox);
+      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+        "",
+      );
+      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("");
+
+      fireEvent.click(checkbox);
+      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+        "B-284/3",
+      );
+      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110074");
+    });
+
+    it("does not save the house number twice when it came from the address", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address={HOUSE_NUMBER_ADDRESS}
+          collectAddressDetails
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.click(screen.getByRole("button", { name: "Save location" }));
+
+      // The caller composes address + details. Both now carry B-284/3, so the
+      // composition has to recognise its own prefill rather than produce
+      // "B-284/3, B-284/3, Rd Number 1, ...".
+      expect(baseProps.onSave).toHaveBeenCalledWith(
+        "home",
+        "",
+        expect.objectContaining({ houseOrFlat: "B-284/3" }),
+        HOUSE_NUMBER_ADDRESS,
       );
     });
   });

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -221,15 +221,22 @@ describe("SaveLocationModal", () => {
     expect(
       screen.getByRole("heading", { name: "Add your address details" }),
     ).toHaveFocus();
-    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
     expect(
-      screen.getByText(/kept only for this setup session/i),
+      screen.getByText(/held for this session/i),
     ).toBeInTheDocument();
+    // The detected address lands in the Address field, where it can be
+    // corrected, instead of only being shown back as a read-only card.
+    expect(screen.getByLabelText("Address")).toHaveValue(
+      "Kartavya Path, New Delhi, Delhi 110001, India",
+    );
 
     const saveButton = screen.getByRole("button", { name: "Save location" });
+    // Still off, but now for the one reason that remains, and it says so.
     expect(saveButton).toBeDisabled();
+    expect(screen.getByText("Pick Home, Work or Other first.")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: " Flat 4B, Tower 2 " },
     });
     fireEvent.change(screen.getByLabelText(/Building colour/), {
@@ -246,12 +253,20 @@ describe("SaveLocationModal", () => {
     expect(saveButton).toBeEnabled();
     fireEvent.click(saveButton);
 
-    expect(baseProps.onSave).toHaveBeenCalledWith("other", "Parents' home", {
-      houseOrFlat: "Flat 4B, Tower 2",
-      buildingColor: "Blue gate",
-      landmark: "Opposite City Mall",
-      postalCode: "110001",
-    });
+    // The address line is passed alongside the details, not folded into them,
+    // so the caller composes from parts instead of layering this save on top
+    // of whatever the previous one produced.
+    expect(baseProps.onSave).toHaveBeenCalledWith(
+      "other",
+      "Parents' home",
+      {
+        houseOrFlat: "Flat 4B, Tower 2",
+        buildingColor: "Blue gate",
+        landmark: "Opposite City Mall",
+        postalCode: "110001",
+      },
+      "Kartavya Path, New Delhi, Delhi 110001, India",
+    );
   });
 
   it("updates the dialog context and focus after renderer disclosure", async () => {
@@ -299,14 +314,14 @@ describe("SaveLocationModal", () => {
       <SaveLocationModal {...props} rendererDisclosureAccepted={false} />,
     );
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
     rerender(<SaveLocationModal {...props} rendererDisclosureAccepted />);
 
-    expect(screen.getByLabelText("House, flat, floor or block")).toHaveValue(
+    expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
       "Flat 4B",
     );
     expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
@@ -324,15 +339,15 @@ describe("SaveLocationModal", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: "12A" },
     });
-    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
       target: { value: "!" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
-    expect(screen.getByLabelText("PIN / postal code")).toHaveAttribute(
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveAttribute(
       "aria-invalid",
       "true",
     );
@@ -340,6 +355,132 @@ describe("SaveLocationModal", () => {
       screen.getByRole("button", { name: "Save location" }),
     ).toBeDisabled();
     expect(baseProps.onSave).not.toHaveBeenCalled();
+  });
+
+  it("saves with just an address, so the button is never dead with nothing to fix", () => {
+    // The gate used to require House, flat AND a valid postal code. On the
+    // edit flow House, flat came back blank every time, so "Update location"
+    // could not be pressed and nothing said why -- which is what "saving
+    // address not working" looked like from the outside.
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+    const saveButton = screen.getByRole("button", { name: "Save location" });
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+
+    expect(baseProps.onSave).toHaveBeenCalledWith(
+      "home",
+      "",
+      expect.objectContaining({ houseOrFlat: "" }),
+      "Kartavya Path, New Delhi, Delhi 110001, India",
+    );
+  });
+
+  it("says which single thing is missing instead of sitting there dead", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+      />,
+    );
+
+    expect(
+      screen.getByText("Pick Home, Work or Other first."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /use detected/i }));
+    fireEvent.change(screen.getByLabelText("Address"), {
+      target: { value: "   " },
+    });
+
+    expect(
+      screen.getByText("Add an address, or tick the box to use the one we found."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeDisabled();
+  });
+
+  describe("the detected-address checkbox", () => {
+    it("fills the Address field from the pin while it is ticked", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          collectAddressDetails
+        />,
+      );
+
+      const checkbox = screen.getByRole("checkbox", { name: /use detected/i });
+      expect(checkbox).toBeChecked();
+      expect(screen.getByLabelText("Address")).toHaveValue(
+        "Kartavya Path, New Delhi, Delhi 110001, India",
+      );
+      // Read-only while it follows the pin: an editable field that silently
+      // reverts on the next geocode is worse than one that says it is locked.
+      expect(screen.getByLabelText("Address")).toBeDisabled();
+    });
+
+    it("hands the field over once unticked, and stops the pin overwriting it", () => {
+      const { rerender } = render(
+        <SaveLocationModal
+          {...baseProps}
+          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          collectAddressDetails
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("checkbox", { name: /use detected/i }));
+      fireEvent.change(screen.getByLabelText("Address"), {
+        target: { value: "Gate 3, Rear entrance, New Delhi" },
+      });
+
+      // A later reverse-geocode arrives. It must not take the field back.
+      rerender(
+        <SaveLocationModal
+          {...baseProps}
+          address="Somewhere Else Entirely, Delhi"
+          collectAddressDetails
+        />,
+      );
+
+      expect(screen.getByLabelText("Address")).toHaveValue(
+        "Gate 3, Rear entrance, New Delhi",
+      );
+    });
+
+    it("restores the detected address when ticked again", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          collectAddressDetails
+        />,
+      );
+
+      const checkbox = screen.getByRole("checkbox", { name: /use detected/i });
+      fireEvent.click(checkbox);
+      fireEvent.change(screen.getByLabelText("Address"), {
+        target: { value: "Typed over it" },
+      });
+      fireEvent.click(checkbox);
+
+      // Ticked but still showing the edit it was meant to undo would make the
+      // box a lie, so the field is refilled on the tick itself.
+      expect(screen.getByLabelText("Address")).toHaveValue(
+        "Kartavya Path, New Delhi, Delhi 110001, India",
+      );
+    });
   });
 
   it("refreshes an inferred postal code when the confirmed pin moves", () => {
@@ -355,7 +496,7 @@ describe("SaveLocationModal", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
 
     mapPickerMockState.picked = {
       latitude: 12.9716,
@@ -365,7 +506,7 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
-    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("560001");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("560001");
   });
 
   it("preserves a manually corrected postal code when the pin moves", () => {
@@ -381,7 +522,7 @@ describe("SaveLocationModal", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
       target: { value: "110002" },
     });
 
@@ -393,7 +534,7 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
-    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110002");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110002");
   });
 
   it("restores the inferred postal code when the same modal reopens", () => {
@@ -404,13 +545,13 @@ describe("SaveLocationModal", () => {
     };
     const { rerender } = render(<SaveLocationModal {...props} />);
 
-    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
       target: { value: "110002" },
     });
     rerender(<SaveLocationModal {...props} open={false} />);
     rerender(<SaveLocationModal {...props} open />);
 
-    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
   });
 
   it("maps Escape to the same safe skip action on the map step", () => {

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -23,7 +23,7 @@ import { cn } from "@/lib/utils";
 import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
 import {
   EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
-  inferPostalCode,
+  inferSavedLocationAddressDetails,
   isValidPostalCode,
   normalizeSavedLocationAddressDetails,
   type SavedLocationAddressDetails,
@@ -103,6 +103,27 @@ export type SaveLocationModalProps = {
 };
 
 type SaveLocationFlowStep = "summary" | "map" | "details";
+
+/**
+ * Fold what a detected address can tell us into the form, leaving anything the
+ * person typed alone.
+ *
+ * Defined outside the component and taking its "has been edited" flags as an
+ * argument so the rule reads as one thing rather than as three closures that
+ * each have to remember to check a ref.
+ */
+function detectedAddressDetails(
+  current: SavedLocationAddressDetails,
+  address: string | null,
+  edited: { houseOrFlat: boolean; postalCode: boolean },
+): SavedLocationAddressDetails {
+  const inferred = inferSavedLocationAddressDetails(address);
+  return {
+    ...current,
+    houseOrFlat: edited.houseOrFlat ? current.houseOrFlat : inferred.houseOrFlat,
+    postalCode: edited.postalCode ? current.postalCode : inferred.postalCode,
+  };
+}
 
 const CATEGORY_OPTIONS: {
   category: SavedLocationCategory;
@@ -194,16 +215,9 @@ export function SaveLocationModal({
   const [flowStep, setFlowStep] = useState<SaveLocationFlowStep>("summary");
   const [pickedAddress, setPickedAddress] = useState<string | null>(null);
   /**
-   * The Address field. Previously the reverse-geocoded address was shown in a
-   * read-only card and never reached an input, so nothing carried it and a
-   * wrong or partial result could not be corrected without moving the pin.
-   */
-  const [addressLine, setAddressLine] = useState("");
-  /**
-   * Ticked: the Address field mirrors whatever the pin resolves to, and keeps
-   * doing so as the pin moves. Unticked: the person owns the field and the pin
-   * stops overwriting it -- which is the only reason this is a checkbox rather
-   * than an always-on autofill.
+   * Ticked: the fields below are filled from whatever the pin resolves to, and
+   * keep following it as the pin moves. Unticked: they are cleared and left
+   * alone. Anything typed by hand wins either way -- see the edited refs.
    */
   const [useDetectedAddress, setUseDetectedAddress] = useState(true);
   const [addressDetails, setAddressDetails] =
@@ -223,7 +237,11 @@ export function SaveLocationModal({
   const postalCodeErrorId = useId();
   const mapTitleRef = useRef<HTMLHeadingElement | null>(null);
   const detailsTitleRef = useRef<HTMLHeadingElement | null>(null);
+  // A field the person has typed in is theirs. The pin may fill a blank field
+  // and refill it as it moves, but it must never overwrite an answer someone
+  // gave -- a prefill that fights the typing is worse than no prefill.
   const postalCodeEditedRef = useRef(false);
+  const houseOrFlatEditedRef = useRef(false);
 
   // Reset internal selection each time the modal (re)opens. When editing an
   // existing saved place, seed the category/label/detail fields from the
@@ -233,14 +251,15 @@ export function SaveLocationModal({
       // Treat provided initial details (edit mode) as already user-authored so
       // the inferred-postal effect does not clobber them.
       postalCodeEditedRef.current = Boolean(
-        initialDetails &&
-          (initialDetails.postalCode || initialDetails.houseOrFlat),
+        initialDetails && initialDetails.postalCode,
+      );
+      houseOrFlatEditedRef.current = Boolean(
+        initialDetails && initialDetails.houseOrFlat,
       );
       setCategory(initialCategory ?? null);
       setCustomLabel(initialCustomLabel ?? "");
       setEditingPlace(false);
       setPickedAddress(null);
-      setAddressLine((address && address.trim()) || "");
       setUseDetectedAddress(true);
       setAddressDetails(
         initialDetails
@@ -321,13 +340,16 @@ export function SaveLocationModal({
     if (!open) return;
     const next = (address && address.trim()) || null;
     if (next) setPickedAddress(next);
-    // Only while the box is ticked. Once someone has typed their own address,
-    // a later reverse-geocode must not silently replace it.
-    if (next && useDetectedAddress) setAddressLine(next);
+    if (!useDetectedAddress) return;
+    // Spread the detected address across the fields it can actually answer.
+    // It was previously only mined for a postal code, so a person looking at
+    // "B-284/3, Rd Number 1, ..." on screen still had to retype B-284/3 into
+    // the box directly underneath it.
     setAddressDetails((current) =>
-      postalCodeEditedRef.current
-        ? current
-        : { ...current, postalCode: inferPostalCode(next) },
+      detectedAddressDetails(current, next, {
+        houseOrFlat: houseOrFlatEditedRef.current,
+        postalCode: postalCodeEditedRef.current,
+      }),
     );
   }, [address, open, useDetectedAddress]);
 
@@ -344,7 +366,7 @@ export function SaveLocationModal({
 
   const normalizedAddressDetails =
     normalizeSavedLocationAddressDetails(addressDetails);
-  const trimmedAddressLine = addressLine.trim();
+  const detectedAddress = pickedAddress || resolvedAddress || "";
   const postalCodeInvalid =
     normalizedAddressDetails.postalCode.length > 0 &&
     !isValidPostalCode(normalizedAddressDetails.postalCode);
@@ -363,10 +385,14 @@ export function SaveLocationModal({
       ? null
       : category === null
         ? "Pick Home, Work or Other first."
-        : collectAddressDetails && trimmedAddressLine.length === 0
-          ? "Add an address, or tick the box to use the one we found."
+        : collectAddressDetails && detectedAddress.length === 0
+          ? "Pin a spot on the map first."
           : postalCodeInvalid
-            ? "Enter a valid PIN or postal code."
+            ? // Not the field's own wording. The invalid PIN already says
+              // "Enter a valid PIN or postal code." right next to itself, and
+              // the same sentence twice on one screen reads as a stutter
+              // rather than as two places worth looking.
+              "Check the PIN or postal code above."
             : null;
   const canSave =
     category !== null &&
@@ -396,13 +422,14 @@ export function SaveLocationModal({
   const handleConfirmMapPick = (picked: PickedLocation) => {
     onPickExactLocation?.(picked);
     setPickedAddress(picked.address);
-    if (useDetectedAddress && picked.address) setAddressLine(picked.address);
-    setAddressDetails((current) => ({
-      ...current,
-      postalCode: postalCodeEditedRef.current
-        ? current.postalCode
-        : inferPostalCode(picked.address),
-    }));
+    if (useDetectedAddress) {
+      setAddressDetails((current) =>
+        detectedAddressDetails(current, picked.address, {
+          houseOrFlat: houseOrFlatEditedRef.current,
+          postalCode: postalCodeEditedRef.current,
+        }),
+      );
+    }
     setFlowStep(collectAddressDetails ? "details" : "summary");
   };
 
@@ -420,7 +447,7 @@ export function SaveLocationModal({
         category,
         label ?? "",
         normalizedAddressDetails,
-        trimmedAddressLine || null,
+        detectedAddress || null,
       );
       return;
     }
@@ -432,6 +459,7 @@ export function SaveLocationModal({
     value: string,
   ) => {
     if (key === "postalCode") postalCodeEditedRef.current = true;
+    if (key === "houseOrFlat") houseOrFlatEditedRef.current = true;
     setAddressDetails((current) => ({ ...current, [key]: value }));
   };
 
@@ -540,16 +568,22 @@ export function SaveLocationModal({
               </p>
             </header>
 
-            {/* The pinned address is no longer repeated here -- it is in the
-                Address field below, where it can also be corrected. This row
-                is now only the way back to the map. */}
-            <div className="flex items-center gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
-              <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+            {/* The detected address, shown as the thing the fields below were
+                filled from. */}
+            <div className="flex items-start gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
+              <span className="mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
                 <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
               </span>
-              <p className="min-w-0 flex-1 text-[15px] leading-5 text-foreground">
-                Pinned on the map
-              </p>
+              <div className="min-w-0 flex-1">
+                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+                  Pinned location
+                </p>
+                <p className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-5 text-foreground">
+                  {loadingAddress
+                    ? "Finding your address…"
+                    : detectedAddress || "Your selected map point"}
+                </p>
+              </div>
               {canPickOnMap ? (
                 <button
                   type="button"
@@ -562,56 +596,36 @@ export function SaveLocationModal({
               ) : null}
             </div>
 
-            <div className="space-y-3.5">
-              <div>
-                <div className="mb-1.5 flex items-baseline justify-between gap-3">
-                  <label
-                    htmlFor="saved-location-address-line"
-                    className="block text-[13px] font-semibold leading-[18px] text-muted-foreground"
-                  >
-                    Address
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-1.5 text-[13px] leading-[18px] text-muted-foreground">
-                    <input
-                      type="checkbox"
-                      checked={useDetectedAddress}
-                      onChange={(event) => {
-                        const next = event.target.checked;
-                        setUseDetectedAddress(next);
-                        // Ticking it again means "go back to the pin", so the
-                        // field is refilled here rather than only on the next
-                        // pin move -- otherwise the box would read as on while
-                        // the field still showed the edit it was meant to undo.
-                        if (next) {
-                          setAddressLine(pickedAddress || resolvedAddress || "");
-                        }
-                      }}
-                      disabled={interactionBusy}
-                      className="h-[15px] w-[15px] shrink-0 accent-[color:var(--app-accent)] disabled:opacity-45"
-                    />
-                    Use detected
-                  </label>
-                </div>
-                <textarea
-                  id="saved-location-address-line"
-                  value={addressLine}
-                  onChange={(event) => setAddressLine(event.target.value)}
-                  disabled={interactionBusy || useDetectedAddress}
-                  rows={2}
-                  maxLength={300}
-                  autoComplete={deferredUntilVault ? "off" : "street-address"}
-                  placeholder={
-                    loadingAddress
-                      ? "Finding your address…"
-                      : "Street, area, city"
-                  }
-                  className={cn(
-                    controlInputClassName,
-                    "h-auto resize-none py-3 leading-5",
-                  )}
-                />
-              </div>
+            {/* Ticked, the fields below are filled from that address and keep
+                following the pin. Unticked, they are cleared and left alone.
+                Anything typed by hand survives either way. */}
+            <label className="flex cursor-pointer items-center gap-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={useDetectedAddress}
+                onChange={(event) => {
+                  const next = event.target.checked;
+                  setUseDetectedAddress(next);
+                  // Both directions act now rather than at the next pin move,
+                  // so the box never reads as on while the fields disagree
+                  // with it. Unticking forgets that anything was typed, which
+                  // is what makes re-ticking a clean redo.
+                  houseOrFlatEditedRef.current = false;
+                  postalCodeEditedRef.current = false;
+                  setAddressDetails((current) =>
+                    detectedAddressDetails(current, next ? detectedAddress : null, {
+                      houseOrFlat: false,
+                      postalCode: false,
+                    }),
+                  );
+                }}
+                disabled={interactionBusy}
+                className="h-[15px] w-[15px] shrink-0 accent-[color:var(--app-accent)] disabled:opacity-45"
+              />
+              Fill the fields below from this address
+            </label>
 
+            <div className="space-y-3.5">
               <div>
                 <label
                   htmlFor="saved-location-house-or-flat"

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -91,6 +91,13 @@ export type SaveLocationModalProps = {
     category: SavedLocationCategory,
     label: string,
     details?: SavedLocationAddressDetails,
+    /**
+     * The street address as it stands in the Address field -- detected from
+     * the pin, or typed over it. Passed separately from `details` so callers
+     * compose the saved line from its parts instead of layering this save on
+     * top of whatever the last one produced.
+     */
+    addressLine?: string | null,
   ) => void;
   onSkip: () => void;
 };
@@ -186,6 +193,19 @@ export function SaveLocationModal({
   const [editingPlace, setEditingPlace] = useState(false);
   const [flowStep, setFlowStep] = useState<SaveLocationFlowStep>("summary");
   const [pickedAddress, setPickedAddress] = useState<string | null>(null);
+  /**
+   * The Address field. Previously the reverse-geocoded address was shown in a
+   * read-only card and never reached an input, so nothing carried it and a
+   * wrong or partial result could not be corrected without moving the pin.
+   */
+  const [addressLine, setAddressLine] = useState("");
+  /**
+   * Ticked: the Address field mirrors whatever the pin resolves to, and keeps
+   * doing so as the pin moves. Unticked: the person owns the field and the pin
+   * stops overwriting it -- which is the only reason this is a checkbox rather
+   * than an always-on autofill.
+   */
+  const [useDetectedAddress, setUseDetectedAddress] = useState(true);
   const [addressDetails, setAddressDetails] =
     useState<SavedLocationAddressDetails>(EMPTY_SAVED_LOCATION_ADDRESS_DETAILS);
   const [placeQuery, setPlaceQuery] = useState("");
@@ -220,6 +240,8 @@ export function SaveLocationModal({
       setCustomLabel(initialCustomLabel ?? "");
       setEditingPlace(false);
       setPickedAddress(null);
+      setAddressLine((address && address.trim()) || "");
+      setUseDetectedAddress(true);
       setAddressDetails(
         initialDetails
           ? { ...EMPTY_SAVED_LOCATION_ADDRESS_DETAILS, ...initialDetails }
@@ -299,12 +321,15 @@ export function SaveLocationModal({
     if (!open) return;
     const next = (address && address.trim()) || null;
     if (next) setPickedAddress(next);
+    // Only while the box is ticked. Once someone has typed their own address,
+    // a later reverse-geocode must not silently replace it.
+    if (next && useDetectedAddress) setAddressLine(next);
     setAddressDetails((current) =>
       postalCodeEditedRef.current
         ? current
         : { ...current, postalCode: inferPostalCode(next) },
     );
-  }, [address, open]);
+  }, [address, open, useDetectedAddress]);
 
   useEffect(() => {
     if (!open) return;
@@ -319,16 +344,38 @@ export function SaveLocationModal({
 
   const normalizedAddressDetails =
     normalizeSavedLocationAddressDetails(addressDetails);
-  const detailsComplete =
-    normalizedAddressDetails.houseOrFlat.length > 0 &&
-    isValidPostalCode(normalizedAddressDetails.postalCode);
+  const trimmedAddressLine = addressLine.trim();
+  const postalCodeInvalid =
+    normalizedAddressDetails.postalCode.length > 0 &&
+    !isValidPostalCode(normalizedAddressDetails.postalCode);
+  /**
+   * Why the primary button is off, in the person's own terms, or null when it
+   * is on. This exists because the button used to just sit there dead: House,
+   * flat was required and blank, so "Update location" could not be pressed and
+   * nothing on screen said why -- which is what "saving address not working"
+   * looked like from the outside.
+   *
+   * The gate is now the one thing saving an address actually needs: an
+   * address. The entrance details are enrichment and no longer block a save.
+   */
+  const saveBlockedReason: string | null =
+    saving || changingPlace || loadingAddress || editingPlace || flowStep === "map"
+      ? null
+      : category === null
+        ? "Pick Home, Work or Other first."
+        : collectAddressDetails && trimmedAddressLine.length === 0
+          ? "Add an address, or tick the box to use the one we found."
+          : postalCodeInvalid
+            ? "Enter a valid PIN or postal code."
+            : null;
   const canSave =
     category !== null &&
     !saving &&
     !loadingAddress &&
     !editingPlace &&
     flowStep !== "map" &&
-    !changingPlace;
+    !changingPlace &&
+    saveBlockedReason === null;
 
   const handleSelectPlace = async (placeId: string) => {
     if (!onSelectPlace || changingPlace) return;
@@ -349,6 +396,7 @@ export function SaveLocationModal({
   const handleConfirmMapPick = (picked: PickedLocation) => {
     onPickExactLocation?.(picked);
     setPickedAddress(picked.address);
+    if (useDetectedAddress && picked.address) setAddressLine(picked.address);
     setAddressDetails((current) => ({
       ...current,
       postalCode: postalCodeEditedRef.current
@@ -364,13 +412,16 @@ export function SaveLocationModal({
   };
 
   const handleSave = () => {
-    if (!category || !canSave || (collectAddressDetails && !detailsComplete)) {
-      return;
-    }
+    if (!category || !canSave) return;
     const label =
       category === "other" ? customLabel.trim() || "Other" : undefined;
     if (collectAddressDetails) {
-      onSave(category, label ?? "", normalizedAddressDetails);
+      onSave(
+        category,
+        label ?? "",
+        normalizedAddressDetails,
+        trimmedAddressLine || null,
+      );
       return;
     }
     onSave(category, label ?? "");
@@ -485,25 +536,20 @@ export function SaveLocationModal({
                 id={descriptionId}
                 className="mt-2 text-[15px] leading-5 text-muted-foreground"
               >
-                The pin tells One where. These details make the entrance easy to
-                recognise.
+                Only the address is needed. The rest helps at the door.
               </p>
             </header>
 
-            <div className="flex items-start gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
-              <span className="mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+            {/* The pinned address is no longer repeated here -- it is in the
+                Address field below, where it can also be corrected. This row
+                is now only the way back to the map. */}
+            <div className="flex items-center gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
+              <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
                 <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
               </span>
-              <div className="min-w-0 flex-1">
-                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
-                  Pinned location
-                </p>
-                <p className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-5 text-foreground">
-                  {pickedAddress ||
-                    resolvedAddress ||
-                    "Your selected map point"}
-                </p>
-              </div>
+              <p className="min-w-0 flex-1 text-[15px] leading-5 text-foreground">
+                Pinned on the map
+              </p>
               {canPickOnMap ? (
                 <button
                   type="button"
@@ -518,11 +564,61 @@ export function SaveLocationModal({
 
             <div className="space-y-3.5">
               <div>
+                <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                  <label
+                    htmlFor="saved-location-address-line"
+                    className="block text-[13px] font-semibold leading-[18px] text-muted-foreground"
+                  >
+                    Address
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-1.5 text-[13px] leading-[18px] text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={useDetectedAddress}
+                      onChange={(event) => {
+                        const next = event.target.checked;
+                        setUseDetectedAddress(next);
+                        // Ticking it again means "go back to the pin", so the
+                        // field is refilled here rather than only on the next
+                        // pin move -- otherwise the box would read as on while
+                        // the field still showed the edit it was meant to undo.
+                        if (next) {
+                          setAddressLine(pickedAddress || resolvedAddress || "");
+                        }
+                      }}
+                      disabled={interactionBusy}
+                      className="h-[15px] w-[15px] shrink-0 accent-[color:var(--app-accent)] disabled:opacity-45"
+                    />
+                    Use detected
+                  </label>
+                </div>
+                <textarea
+                  id="saved-location-address-line"
+                  value={addressLine}
+                  onChange={(event) => setAddressLine(event.target.value)}
+                  disabled={interactionBusy || useDetectedAddress}
+                  rows={2}
+                  maxLength={300}
+                  autoComplete={deferredUntilVault ? "off" : "street-address"}
+                  placeholder={
+                    loadingAddress
+                      ? "Finding your address…"
+                      : "Street, area, city"
+                  }
+                  className={cn(
+                    controlInputClassName,
+                    "h-auto resize-none py-3 leading-5",
+                  )}
+                />
+              </div>
+
+              <div>
                 <label
                   htmlFor="saved-location-house-or-flat"
                   className={controlLabelClassName}
                 >
-                  House, flat, floor or block
+                  House, flat, floor or block{" "}
+                  <span className="font-normal">(optional)</span>
                 </label>
                 <input
                   id="saved-location-house-or-flat"
@@ -532,7 +628,6 @@ export function SaveLocationModal({
                     updateAddressDetail("houseOrFlat", event.target.value)
                   }
                   disabled={interactionBusy}
-                  required
                   maxLength={80}
                   autoComplete={deferredUntilVault ? "off" : "address-line1"}
                   placeholder="e.g. Flat 4B, Tower 2"
@@ -568,7 +663,8 @@ export function SaveLocationModal({
                     htmlFor="saved-location-postal-code"
                     className={controlLabelClassName}
                   >
-                    PIN / postal code
+                    PIN / postal code{" "}
+                    <span className="font-normal">(optional)</span>
                   </label>
                   <input
                     id="saved-location-postal-code"
@@ -578,7 +674,6 @@ export function SaveLocationModal({
                       updateAddressDetail("postalCode", event.target.value)
                     }
                     disabled={interactionBusy}
-                    required
                     maxLength={12}
                     inputMode="text"
                     autoComplete={deferredUntilVault ? "off" : "postal-code"}
@@ -664,15 +759,26 @@ export function SaveLocationModal({
 
             <p className="rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3 text-[13px] leading-[18px] text-muted-foreground">
               {deferredUntilVault
-                ? "Kept only for this setup session. One encrypts and saves it after your private vault is ready."
-                : "Saved in your private vault and shared only when you approve location access."}
+                ? "Held for this session. One encrypts it once your vault is ready."
+                : "Encrypted in your vault. Shared only when you approve access."}
             </p>
 
             <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-[18px] border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)]/95 px-3 pb-1 pt-3 backdrop-blur">
+              {/* A disabled primary button with no explanation is the whole of
+                  "saving is not working" from the outside. When it is off, say
+                  which single thing turns it on. */}
+              {saveBlockedReason ? (
+                <p
+                  role="status"
+                  className="text-center text-[13px] leading-[18px] text-muted-foreground"
+                >
+                  {saveBlockedReason}
+                </p>
+              ) : null}
               <button
                 type="button"
                 onClick={handleSave}
-                disabled={!canSave || !detailsComplete}
+                disabled={!canSave}
                 aria-busy={saving || undefined}
                 className={cn(
                   "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45",

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Briefcase,
+  ChevronDown,
   Home,
   Loader2,
   MapPin,
@@ -78,6 +79,9 @@ export function SavedLocationsSection() {
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<string | null>(null);
+  // One row open at a time: this is a short list a person scans, not a set of
+  // panels they compare, and several open rows push the rest off the screen.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [repairingId, setRepairingId] = useState<string | null>(null);
   const [capturing, setCapturing] = useState(false);
   const [saveLocationModalOpen, setSaveLocationModalOpen] = useState(false);
@@ -322,18 +326,25 @@ export function SavedLocationsSection() {
       category: SavedLocationCategory,
       label: string,
       details?: SavedLocationAddressDetails,
+      addressLine?: string | null,
     ) => {
       if (!userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
         toast.error("Unlock your vault and capture the location again.");
         return;
       }
 
-      // Fold the structured entrance details into the single encrypted address
-      // string (same contract onboarding uses), so Home/Work/Other saved from
-      // Settings carry the house/flat, landmark and postal code too.
+      // Compose from the Address field the person just confirmed, NOT from
+      // this component's `saveLocationAddress`. On an edit the latter holds
+      // the previously composed line, so folding the details in again
+      // prepended them to a string that already began with them -- "Flat 5C,
+      // Flat 4B, Blue gate building, ..." growing on every save until it hit
+      // the 300-character ceiling. The base is stored alongside so the next
+      // edit rebuilds from parts instead of from the result.
+      const baseAddress =
+        addressLine === undefined ? saveLocationAddress : addressLine;
       const composedAddress = details
-        ? buildSavedLocationAddress(saveLocationAddress, details)
-        : saveLocationAddress;
+        ? buildSavedLocationAddress(baseAddress, details)
+        : baseAddress;
 
       const editing = editingLocation;
       // Only guard against a *different* saved place occupying the same spot.
@@ -358,6 +369,8 @@ export function SavedLocationsSection() {
           latitude: saveLocationPoint.latitude,
           longitude: saveLocationPoint.longitude,
           address: composedAddress,
+          addressBase: baseAddress,
+          addressDetails: details ?? null,
         };
         const next = editing
           ? await updateSavedLocation({
@@ -418,7 +431,10 @@ export function SavedLocationsSection() {
         capturedAt: new Date().toISOString(),
         sourcePlatform: "web",
       });
-      setSaveLocationAddress(location.address ?? null);
+      // The street address on its own where it was recorded. Places saved
+      // before that was kept fall back to their composed line, which is the
+      // closest thing they have to a base and is at least editable.
+      setSaveLocationAddress(location.addressBase ?? location.address ?? null);
       setSaveLocationAddressLoading(false);
       setSaveLocationModalOpen(true);
     },
@@ -626,80 +642,113 @@ export function SavedLocationsSection() {
               </div>
             </div>
           ) : (
-            locations.map((location, index) => (
-              <div
-                key={location.id}
-                className={cn(
-                  "flex min-h-[60px] items-center gap-3.5 p-3.5",
-                  index > 0 &&
-                    "border-t border-[color:var(--app-separator)]",
-                )}
-              >
-                <CategoryIcon category={location.category} />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
-                    {location.label}
-                  </p>
-                  <p className="mt-0.5 truncate text-[15px] leading-5 text-muted-foreground">
-                    {location.address || "Address unavailable"}
-                  </p>
-                </div>
-                {!location.address ? (
+            locations.map((location, index) => {
+              const expanded = expandedId === location.id;
+              return (
+                <div
+                  key={location.id}
+                  className={cn(
+                    index > 0 && "border-t border-[color:var(--app-separator)]",
+                  )}
+                >
+                  {/* A saved address is longer than one line at this width, so
+                      the row used to end in an ellipsis with no way to read the
+                      rest. The arrow opens it -- and takes the edit and delete
+                      buttons with it, which were crowding every row for the two
+                      moments a year anyone needs them. */}
                   <button
                     type="button"
-                    aria-label={`Find address for ${location.label}`}
-                    title="Find address"
-                    onClick={() => void handleRepairAddress(location)}
-                    disabled={repairingId !== null}
-                    className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-foreground/[0.05] hover:text-[color:var(--app-accent)] disabled:opacity-45"
+                    onClick={() =>
+                      setExpandedId((current) =>
+                        current === location.id ? null : location.id,
+                      )
+                    }
+                    aria-expanded={expanded}
+                    className="press-scale flex min-h-[60px] w-full items-center gap-3.5 p-3.5 text-left"
                   >
-                    <RefreshCw
+                    <CategoryIcon category={location.category} />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
+                        {location.label}
+                      </p>
+                      <p
+                        className={cn(
+                          "mt-0.5 text-[15px] leading-5 text-muted-foreground",
+                          expanded ? "whitespace-pre-line" : "truncate",
+                        )}
+                      >
+                        {location.address || "Address unavailable"}
+                      </p>
+                    </div>
+                    <ChevronDown
                       className={cn(
-                        "h-[17px] w-[17px]",
-                        repairingId === location.id && "animate-spin",
+                        "h-[18px] w-[18px] shrink-0 text-[color:var(--app-tertiary-label)] transition-transform duration-200",
+                        expanded && "rotate-180",
                       )}
                       strokeWidth={2}
+                      aria-hidden
                     />
                   </button>
-                ) : null}
-                <button
-                  type="button"
-                  aria-label={`Edit ${location.label}`}
-                  title="Edit place"
-                  onClick={() => handleEditSavedLocation(location)}
-                  disabled={
-                    removingId !== null ||
-                    repairingId !== null ||
-                    capturing ||
-                    locationControl.paused
-                  }
-                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-foreground/[0.05] hover:text-[color:var(--app-accent)] disabled:opacity-45"
-                >
-                  <Pencil className="h-[17px] w-[17px]" strokeWidth={2} />
-                </button>
-                <button
-                  type="button"
-                  aria-label={`Remove ${location.label}`}
-                  onClick={() => void handleRemove(location.id)}
-                  disabled={removingId !== null}
-                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[color:var(--app-tertiary-label)] transition-colors hover:bg-[color:var(--app-destructive)]/10 hover:text-[color:var(--app-destructive)] disabled:opacity-45"
-                >
 
-                  {removingId === location.id ? (
-                    <Loader2 className="h-[18px] w-[18px] animate-spin" />
-                  ) : (
-                    <Trash2 className="h-[18px] w-[18px]" strokeWidth={2} />
-                  )}
-                </button>
-              </div>
-            ))
+                  {expanded ? (
+                    <div className="flex items-center gap-2 px-3.5 pb-3.5 pl-[64px]">
+                      {!location.address ? (
+                        <button
+                          type="button"
+                          onClick={() => void handleRepairAddress(location)}
+                          disabled={repairingId !== null}
+                          className="press-scale inline-flex h-9 items-center gap-1.5 rounded-full bg-[color:var(--app-accent)]/12 px-3 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
+                        >
+                          <RefreshCw
+                            className={cn(
+                              "h-[15px] w-[15px]",
+                              repairingId === location.id && "animate-spin",
+                            )}
+                            strokeWidth={2}
+                            aria-hidden
+                          />
+                          Find address
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => handleEditSavedLocation(location)}
+                        disabled={
+                          removingId !== null ||
+                          repairingId !== null ||
+                          capturing ||
+                          locationControl.paused
+                        }
+                        className="press-scale inline-flex h-9 items-center gap-1.5 rounded-full bg-foreground/[0.05] px-3 text-[13px] font-semibold text-foreground disabled:opacity-45"
+                      >
+                        <Pencil className="h-[15px] w-[15px]" strokeWidth={2} aria-hidden />
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleRemove(location.id)}
+                        disabled={removingId !== null}
+                        className="press-scale inline-flex h-9 items-center gap-1.5 rounded-full px-3 text-[13px] font-semibold text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/10 disabled:opacity-45"
+                      >
+                        {removingId === location.id ? (
+                          <Loader2 className="h-[15px] w-[15px] animate-spin" aria-hidden />
+                        ) : (
+                          <Trash2 className="h-[15px] w-[15px]" strokeWidth={2} aria-hidden />
+                        )}
+                        Remove
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })
           )}
         </div>
         {hasVaultAccess ? (
           <p className="mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
             {locationControl.paused
-              ? "Resume Location before capturing another saved place."
-              : "Saved places are encrypted in your vault and shared only when you explicitly approve location access."}
+              ? "Resume Location to save another place."
+              : "Encrypted in your vault. Shared only when you approve access."}
           </p>
         ) : null}
       </section>
@@ -729,19 +778,23 @@ export function SavedLocationsSection() {
         initialCustomLabel={
           editingLocation?.category === "other" ? editingLocation.label : null
         }
+        // What the person actually typed last time. This used to hand back an
+        // empty houseOrFlat on every edit, which the modal required before it
+        // would enable its own button -- so "Update location" was permanently
+        // dead on a screen that gave no reason.
         initialDetails={
           editingLocation
-            ? {
+            ? (editingLocation.addressDetails ?? {
                 houseOrFlat: "",
                 buildingColor: "",
                 landmark: "",
                 postalCode: inferPostalCode(editingLocation.address),
-              }
+              })
             : null
         }
         saveLabel={editingLocation ? "Update location" : "Save location"}
-        onSave={(category, label, details) =>
-          void handleSave(category, label, details)
+        onSave={(category, label, details, addressLine) =>
+          void handleSave(category, label, details, addressLine)
         }
         onSkip={() => {
           if (saveLocationSaving) return;

--- a/hushh-webapp/lib/one-location/__tests__/infer-address-details.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/infer-address-details.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inferHouseOrFlat,
+  inferSavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
+
+/**
+ * Splitting a detected address across the form's own fields.
+ *
+ * The bar for prefilling is higher than for leaving a field empty: people
+ * trust a filled field and stop reading it, so a wrong guess here ships a
+ * wrong address. Every test below that expects "" is the function declining
+ * to guess.
+ */
+
+describe("pulling a house number out of a detected address", () => {
+  it("takes a compact house or plot designator", () => {
+    expect(
+      inferHouseOrFlat("B-284/3, Rd Number 1, New Delhi, Delhi 110074, India"),
+    ).toBe("B-284/3");
+    expect(inferHouseOrFlat("42, Baker Street, London")).toBe("42");
+    expect(inferHouseOrFlat("A-12, Sector 5, Noida")).toBe("A-12");
+  });
+
+  it("takes a segment that names itself, spaces and all", () => {
+    expect(inferHouseOrFlat("Flat 4B, Tower 2, Bengaluru")).toBe("Flat 4B");
+    expect(inferHouseOrFlat("Plot 22, Industrial Area, Pune")).toBe("Plot 22");
+    expect(inferHouseOrFlat("No. 7, Church Street, Bengaluru")).toBe("No. 7");
+  });
+
+  it("declines a street that merely carries a number", () => {
+    // "12 MG Road" is where the building is, not which door is yours. Putting
+    // it in House-flat would be confidently wrong.
+    expect(inferHouseOrFlat("12 MG Road, Bengaluru, Karnataka 560001")).toBe("");
+    expect(inferHouseOrFlat("1600 Pennsylvania Avenue NW, Washington")).toBe("");
+  });
+
+  it("declines a first segment with no number in it at all", () => {
+    expect(inferHouseOrFlat("Kartavya Path, New Delhi, Delhi 110001")).toBe("");
+    expect(inferHouseOrFlat("Hushh Office, Bengaluru, Karnataka, India")).toBe(
+      "",
+    );
+  });
+
+  it("declines nothing, empties, and a segment too long to be a door", () => {
+    expect(inferHouseOrFlat(null)).toBe("");
+    expect(inferHouseOrFlat(undefined)).toBe("");
+    expect(inferHouseOrFlat("")).toBe("");
+    expect(inferHouseOrFlat(`${"x".repeat(90)}1`)).toBe("");
+  });
+});
+
+describe("what a detected address can fill on its own", () => {
+  it("answers house number and postal code together", () => {
+    expect(
+      inferSavedLocationAddressDetails(
+        "B-284/3, Rd Number 1, Chhatarpur, New Delhi, Delhi 110074, India",
+      ),
+    ).toEqual({ houseOrFlat: "B-284/3", postalCode: "110074" });
+  });
+
+  it("answers only what is there", () => {
+    // Building colour and landmark are never inferred: an address does not
+    // carry them, and only the person standing there knows.
+    expect(
+      inferSavedLocationAddressDetails("Kartavya Path, New Delhi, Delhi 110001"),
+    ).toEqual({ houseOrFlat: "", postalCode: "110001" });
+    expect(inferSavedLocationAddressDetails("Somewhere, Nowhere")).toEqual({
+      houseOrFlat: "",
+      postalCode: "",
+    });
+  });
+});

--- a/hushh-webapp/lib/one-location/__tests__/saved-location-address-round-trip.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/saved-location-address-round-trip.test.ts
@@ -81,6 +81,49 @@ describe("re-saving an edited place", () => {
     expect(corrected).not.toContain("Kartavya Path");
   });
 
+  it("does not repeat a house number that the address already opens with", () => {
+    // House-flat is now prefilled FROM the address, so on most saves it is the
+    // address's own first segment coming back round. Prepending it would read
+    // "B-284/3, B-284/3, Rd Number 1, ...".
+    const detected =
+      "B-284/3, Rd Number 1, Chhatarpur Enclave Phase 2, New Delhi, Delhi 110074, India";
+    const composed = buildSavedLocationAddress(detected, {
+      houseOrFlat: "B-284/3",
+      buildingColor: "",
+      landmark: "",
+      postalCode: "110074",
+    });
+
+    expect(composed).toBe(detected);
+    expect(composed?.match(/B-284\/3/g)).toHaveLength(1);
+  });
+
+  it("still prepends a house number the address does not already carry", () => {
+    // The other half of that rule: a flat the person typed themselves is not
+    // in the street address and must survive.
+    const composed = buildSavedLocationAddress(BASE, {
+      houseOrFlat: "Flat 9, Rear block",
+      buildingColor: "",
+      landmark: "",
+      postalCode: "",
+    });
+
+    expect(composed).toBe(`Flat 9, Rear block, ${BASE}`);
+  });
+
+  it("does not swallow a house number that merely shares its opening digits", () => {
+    // Compared segment-to-segment, not as a prefix of the whole line, so "12"
+    // is not eaten by a "1234 Main Street" that happens to start the same way.
+    const composed = buildSavedLocationAddress("1234 Main Street, Springfield", {
+      houseOrFlat: "12",
+      buildingColor: "",
+      landmark: "",
+      postalCode: "",
+    });
+
+    expect(composed).toBe("12, 1234 Main Street, Springfield");
+  });
+
   it("still saves something usable when only the address is given", () => {
     // House, flat and postal code no longer block a save, so composing with
     // empty details has to produce the address rather than nothing.

--- a/hushh-webapp/lib/one-location/__tests__/saved-location-address-round-trip.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/saved-location-address-round-trip.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSavedLocationAddress,
+  type SavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
+
+/**
+ * Editing a saved place and saving it again.
+ *
+ * The saved `address` is a single composed line, so the only question that
+ * matters on a re-save is which string the entrance details get folded into.
+ * Fold them into the previous *result* and they end up in front of themselves,
+ * a little further every time. Fold them into the *base* -- the street address
+ * on its own, which is why it is now stored -- and the second save produces
+ * exactly what the first one did.
+ */
+
+const BASE = "Kartavya Path, New Delhi, Delhi";
+
+const DETAILS: SavedLocationAddressDetails = {
+  houseOrFlat: "Flat 4B, Tower 2",
+  buildingColor: "Blue gate",
+  landmark: "Opposite City Mall",
+  postalCode: "110001",
+};
+
+describe("re-saving an edited place", () => {
+  it("produces the same line every time when composed from the base", () => {
+    const first = buildSavedLocationAddress(BASE, DETAILS);
+    const second = buildSavedLocationAddress(BASE, DETAILS);
+    const third = buildSavedLocationAddress(BASE, DETAILS);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    // No "building" or "Near" prefix here: the helpers only add those when
+    // the text does not already carry the word ("gate", "Opposite").
+    expect(first).toBe(
+      "Flat 4B, Tower 2, Blue gate, Opposite City Mall, Kartavya Path, New Delhi, Delhi, 110001",
+    );
+  });
+
+  it("grows without bound when composed from its own output", () => {
+    // The old behaviour, kept as a test so the regression is named rather than
+    // merely avoided. The edit flow passed the previously COMPOSED address as
+    // the base, so each save prepended the entrance details again.
+    const first = buildSavedLocationAddress(BASE, DETAILS) ?? "";
+    const second = buildSavedLocationAddress(first, {
+      ...DETAILS,
+      houseOrFlat: "Flat 5C",
+    });
+
+    expect(second).toContain("Flat 5C");
+    expect(second).toContain("Flat 4B, Tower 2");
+    expect((second ?? "").length).toBeGreaterThan(first.length);
+  });
+
+  it("changes only what the person changed", () => {
+    const before = buildSavedLocationAddress(BASE, DETAILS);
+    const after = buildSavedLocationAddress(BASE, {
+      ...DETAILS,
+      houseOrFlat: "Flat 5C",
+    });
+
+    expect(after).toBe(
+      "Flat 5C, Blue gate, Opposite City Mall, Kartavya Path, New Delhi, Delhi, 110001",
+    );
+    expect(after).not.toBe(before);
+    expect(after).not.toContain("Flat 4B");
+  });
+
+  it("carries a corrected address line straight through", () => {
+    // What the Address field is for: the pin resolved to the wrong side of the
+    // building, and the person typed the right one over it.
+    const corrected = buildSavedLocationAddress(
+      "Gate 3, Rear entrance, New Delhi",
+      DETAILS,
+    );
+
+    expect(corrected).toContain("Gate 3, Rear entrance, New Delhi");
+    expect(corrected).not.toContain("Kartavya Path");
+  });
+
+  it("still saves something usable when only the address is given", () => {
+    // House, flat and postal code no longer block a save, so composing with
+    // empty details has to produce the address rather than nothing.
+    expect(
+      buildSavedLocationAddress(BASE, {
+        houseOrFlat: "",
+        buildingColor: "",
+        landmark: "",
+        postalCode: "",
+      }),
+    ).toBe(BASE);
+  });
+});

--- a/hushh-webapp/lib/one-location/saved-location-address.ts
+++ b/hushh-webapp/lib/one-location/saved-location-address.ts
@@ -51,6 +51,49 @@ export function inferPostalCode(address: string | null | undefined): string {
   );
 }
 
+/** The part before the first comma, which is where a house number sits. */
+function firstAddressSegment(address: string | null | undefined): string {
+  return String(address || "").split(",")[0]?.trim() ?? "";
+}
+
+/**
+ * Pull a house/plot designator out of a formatted address, when there plainly
+ * is one -- "B-284/3, Rd Number 1, Chhatarpur, New Delhi 110074" opens with a
+ * house number, "Kartavya Path, New Delhi" does not.
+ *
+ * Deliberately narrow. It accepts a first segment with no spaces that contains
+ * a digit ("B-284/3", "42", "A-12"), or one that names itself ("Flat 4B",
+ * "Plot 22"). It will not take "12 MG Road", which is a street that happens to
+ * carry a number -- putting that in the House-flat box would be wrong, and a
+ * wrong prefill is worse than an empty one because people trust prefilled
+ * fields and stop reading them.
+ */
+export function inferHouseOrFlat(address: string | null | undefined): string {
+  const segment = firstAddressSegment(address);
+  if (!segment || segment.length > MAX_HOUSE_OR_FLAT_LENGTH) return "";
+  if (!/\d/.test(segment)) return "";
+  const namesItself =
+    /^(flat|plot|house|apartment|apt|no\.?|#|door|shop|unit|block)\b/i.test(
+      segment,
+    );
+  if (!namesItself && /\s/.test(segment)) return "";
+  return cleanText(segment, MAX_HOUSE_OR_FLAT_LENGTH);
+}
+
+/**
+ * The fields a detected address can fill on its own. Everything else on the
+ * form -- building colour, landmark -- is knowledge the address does not carry
+ * and only the person standing there has.
+ */
+export function inferSavedLocationAddressDetails(
+  address: string | null | undefined,
+): Pick<SavedLocationAddressDetails, "houseOrFlat" | "postalCode"> {
+  return {
+    houseOrFlat: inferHouseOrFlat(address),
+    postalCode: inferPostalCode(address),
+  };
+}
+
 /**
  * Accept the common global PIN/postal-code shapes without pretending that all
  * countries use India's six-digit format. The field remains human-editable.
@@ -90,8 +133,18 @@ export function buildSavedLocationAddress(
     String(mapAddress || ""),
     MAX_SAVED_ADDRESS_LENGTH,
   );
+  // The house number is now prefilled FROM the address, so on most saves it is
+  // the address's own opening segment coming back round. Prepending it would
+  // read "B-284/3, B-284/3, Rd Number 1, ...". Compared segment-to-segment, not
+  // as a prefix of the whole line, so a genuine "12" is not swallowed by a
+  // "1234 Main St" that merely starts with the same digits.
+  const houseOrFlatAlreadyLeads =
+    Boolean(normalized.houseOrFlat) &&
+    comparable(firstAddressSegment(baseAddress)) ===
+      comparable(normalized.houseOrFlat);
+
   const rawSegments = [
-    normalized.houseOrFlat,
+    houseOrFlatAlreadyLeads ? "" : normalized.houseOrFlat,
     buildingColorSegment(normalized.buildingColor),
     landmarkSegment(normalized.landmark),
     baseAddress,

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -4,11 +4,18 @@ import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
 import { buildPersonalKnowledgeModelStructureArtifacts } from "@/lib/personal-knowledge-model/manifest";
 import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
 import { haversineMeters } from "@/lib/one-location/marker-interpolation";
+import {
+  normalizeSavedLocationAddressDetails,
+  type SavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
 
 export const LOCATION_PKM_DOMAIN = "location";
 
 const SAVED_PLACES_KEY = "saved_places";
-const SAVED_PLACES_SCHEMA_VERSION = 1;
+// v2 adds addressBase + addressDetails. v1 entries stay valid and readable --
+// both fields are optional, and a place saved before this simply has no parts
+// recorded, which the edit flow handles by treating its address as the base.
+const SAVED_PLACES_SCHEMA_VERSION = 2;
 const MAX_LABEL_LENGTH = 40;
 const MAX_ADDRESS_LENGTH = 300;
 export const SAVED_LOCATION_DUPLICATE_RADIUS_METERS = 25;
@@ -27,7 +34,24 @@ export type SavedLocation = {
   label: string;
   latitude: number;
   longitude: number;
+  /** The composed, human-readable line. What every reader displays. */
   address?: string | null;
+  /**
+   * The street address on its own, before the entrance details were folded in.
+   *
+   * Kept so an edit can rebuild `address` from its parts instead of composing
+   * on top of the previous composition. Without it, saving an edit prepended
+   * the entrance details to a string that already began with them -- "Flat 5C,
+   * Flat 4B, Blue gate building, ..." -- growing until it hit the 300-character
+   * ceiling and was truncated.
+   */
+  addressBase?: string | null;
+  /**
+   * The entrance details as the owner entered them, so re-opening a saved
+   * place shows what they typed rather than empty fields it then refuses to
+   * save without.
+   */
+  addressDetails?: SavedLocationAddressDetails | null;
   savedAt: string;
 };
 
@@ -60,6 +84,32 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+/**
+ * Read back the entrance details, tolerating anything. A malformed or missing
+ * block means "no parts recorded", never a rejected saved place: losing a
+ * person's Home over an unexpected field would be far worse than showing its
+ * detail fields empty.
+ */
+function sanitizeAddressDetails(
+  value: unknown,
+): SavedLocationAddressDetails | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const details = normalizeSavedLocationAddressDetails({
+    houseOrFlat: typeof raw.houseOrFlat === "string" ? raw.houseOrFlat : "",
+    buildingColor:
+      typeof raw.buildingColor === "string" ? raw.buildingColor : "",
+    landmark: typeof raw.landmark === "string" ? raw.landmark : "",
+    postalCode: typeof raw.postalCode === "string" ? raw.postalCode : "",
+  });
+  const hasAnything =
+    details.houseOrFlat ||
+    details.buildingColor ||
+    details.landmark ||
+    details.postalCode;
+  return hasAnything ? details : null;
 }
 
 function isValidLocation(value: unknown): value is SavedLocation {
@@ -95,7 +145,12 @@ function locationsFromDomain(
   const savedPlaces = asRecord(domainData?.[SAVED_PLACES_KEY]);
   const locations = savedPlaces.locations;
   if (!Array.isArray(locations)) return [];
-  return locations.filter(isValidLocation);
+  return locations.filter(isValidLocation).map((location) => ({
+    ...location,
+    addressBase:
+      typeof location.addressBase === "string" ? location.addressBase : null,
+    addressDetails: sanitizeAddressDetails(location.addressDetails),
+  }));
 }
 
 function requireUnlockedVault(
@@ -277,6 +332,9 @@ export async function addSavedLocation(params: {
     latitude: number;
     longitude: number;
     address?: string | null;
+    /** The street address alone, so a later edit rebuilds rather than re-composes. */
+    addressBase?: string | null;
+    addressDetails?: SavedLocationAddressDetails | null;
   };
 }): Promise<SavedLocation[]> {
   const { input } = params;
@@ -301,6 +359,10 @@ export async function addSavedLocation(params: {
     latitude: input.latitude,
     longitude: input.longitude,
     address: cleanText(input.address, MAX_ADDRESS_LENGTH),
+    addressBase: cleanText(input.addressBase, MAX_ADDRESS_LENGTH),
+    addressDetails: input.addressDetails
+      ? sanitizeAddressDetails(input.addressDetails)
+      : null,
     savedAt: new Date().toISOString(),
   };
 
@@ -348,6 +410,9 @@ export async function updateSavedLocation(params: {
     latitude: number;
     longitude: number;
     address?: string | null;
+    /** The street address alone, so a later edit rebuilds rather than re-composes. */
+    addressBase?: string | null;
+    addressDetails?: SavedLocationAddressDetails | null;
   };
 }): Promise<SavedLocation[]> {
   const { id, input } = params;
@@ -381,6 +446,10 @@ export async function updateSavedLocation(params: {
     latitude: input.latitude,
     longitude: input.longitude,
     address: cleanText(input.address, MAX_ADDRESS_LENGTH),
+    addressBase: cleanText(input.addressBase, MAX_ADDRESS_LENGTH),
+    addressDetails: input.addressDetails
+      ? sanitizeAddressDetails(input.addressDetails)
+      : null,
     savedAt: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Bugs 3, 4 and 5 of 5 — the saved-places screen

One cause between them: **the address was something the screen showed you, never something it held.**

---

### Bug 3 — auto-fill the address into the fields, with a checkbox

The reverse-geocoded address sat in a read-only card and was mined for exactly one thing — a postal code. So somebody looking at `B-284/3, Rd Number 1, Chhatarpur…` on screen still had to **retype `B-284/3` into the House-flat box directly underneath it**.

The card is unchanged. What changed is that the address now fills the fields it can actually answer:

| Field | Filled from the address |
|---|---|
| House, flat, floor or block | ✅ `B-284/3` |
| PIN / postal code | ✅ `110074` |
| Building colour | ✗ never inferred |
| Nearby landmark | ✗ never inferred |

Colour and landmark are not in an address, and only the person standing there knows them.

A checkbox above the fields — *"Fill the fields below from this address"* — decides whether this happens. Unticking clears what it filled and forgets that anything was typed, which is what makes re-ticking a clean redo.

**`inferHouseOrFlat` is deliberately narrow.** It takes a compact designator (`B-284/3`, `42`, `A-12`) or one that names itself (`Flat 4B`, `Plot 22`), and **refuses `12 MG Road`** — a street that happens to carry a number, not anybody's door. The bar for prefilling is higher than for leaving a field blank, because a filled field is one people stop reading.

Anything typed by hand survives a later reverse-geocode, now per field rather than only for the postal code.

---

### Bug 4 — "saving address not working"

**Two separate faults.**

**The Save button was structurally impossible to press on edit.** Opening a saved place handed the modal `houseOrFlat: ""` every time, and the modal required House-flat *and* a valid postal code. So **"Update location" could never be pressed**, and nothing said why.

- The gate is now the one thing saving an address needs: **an address**. The rest is enrichment.
- When the button is off it names the single blocker — "Pick Home, Work or Other first.", "Pin a spot on the map first.", "Check the PIN or postal code above."
- What the person typed last time is stored and pre-filled, so an edit opens on their own details.

> ⚠️ **Product call worth a look:** House-flat and postal code were *required*. They are now optional — that is what makes the edit flow reachable at all. If they were meant to be mandatory, say so and I'll gate new saves only.

**Saving twice corrupted the address.** An edit composed the entrance details into the *previously composed* line:

```
save 1:  Flat 4B, Blue gate, Kartavya Path, New Delhi, 110001
save 2:  Flat 5C, Flat 4B, Blue gate, Kartavya Path, New Delhi, 110001
save 3:  Flat 6D, Flat 5C, Flat 4B, Blue gate, Kartavya Path, ...
```

…until the 300-character ceiling truncated it. The street address is now stored on its own as `addressBase` with the details beside it, and each save **rebuilds from parts**. `schema_version` 2; v1 entries stay readable.

Composition also had to learn to recognise its own prefill — with House-flat now coming *from* the address, the line would otherwise read `B-284/3, B-284/3, Rd Number 1, …`. Compared segment-to-segment, not as a prefix, so a genuine `12` is not swallowed by a `1234 Main Street`.

---

### Bug 5 — dropdown arrow on saved addresses

An address doesn't fit on one line at this width, so every row ended in an ellipsis with no way to read the rest. The arrow expands the row to the full address — and takes **Edit** and **Remove** with it, which were crowding every row for the two moments a year anyone needs them. One row open at a time.

---

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on every touched file
- **361 of 362 passing** across the location suites; the one failure was pre-existing on `main` and has since been fixed there
- New `infer-address-details.test.ts` (7) — every case expecting `""` is the parser declining to guess
- New `saved-location-address-round-trip.test.ts` (8) — a re-save is byte-identical when composed from the base; the old compounding behaviour is kept named as a test rather than merely avoided
- `save-location-modal` 23/23, `saved-locations-section` 9/9, `saved-locations` 18/18, persistence integration 2/2

## Not verified

**iOS.** Web-verified only. No Capacitor bridge surface is touched, but this is a keyboard-heavy modal and native keyboard avoidance has bitten this repo before — worth a device pass.