### PR TITLE
perf(one-location): stop every CTA waiting on work the user is not waiting for

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -25,6 +25,7 @@ const {
   mockPlacesAutocomplete,
   mockPlaceDetails,
   mockGetMapState,
+  mockGetMapPreferences,
   mockUpdateMapPreferences,
   mockAddSavedLocation,
   mockLoadSavedLocations,
@@ -71,6 +72,7 @@ const {
   mockPlacesAutocomplete: vi.fn(),
   mockPlaceDetails: vi.fn(),
   mockGetMapState: vi.fn(),
+  mockGetMapPreferences: vi.fn(),
   mockUpdateMapPreferences: vi.fn(),
   mockAddSavedLocation: vi.fn(),
   mockLoadSavedLocations: vi.fn(),
@@ -263,6 +265,7 @@ vi.mock("@/lib/one-location/service", () => ({
     placesAutocomplete: mockPlacesAutocomplete,
     placeDetails: mockPlaceDetails,
     getMapState: mockGetMapState,
+    getMapPreferences: mockGetMapPreferences,
     updateMapPreferences: mockUpdateMapPreferences,
     watchCurrentPosition: vi.fn().mockResolvedValue(null),
     clearWatch: vi.fn(),
@@ -893,6 +896,10 @@ describe("OneLocationAgentPage", () => {
       },
       freshnessSeconds: 60,
       markers: [],
+    });
+    mockGetMapPreferences.mockResolvedValue({
+      presenceMode: "ghost",
+      rendererConsentVersion: "google-maps-renderer-v1",
     });
     mockUpdateMapPreferences.mockResolvedValue({
       presenceMode: "ghost",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -300,6 +300,16 @@ const DURATION_OPTIONS = [
   { value: "24", label: "24 hours" },
 ];
 
+/**
+ * How many recipients a single share fans out to concurrently.
+ *
+ * Sharing is per-recipient independent, so this is pure wall-clock win — but
+ * each grant costs TWO pooled database connections server-side (the writer
+ * guard holds one while the row insert opens another). Four keeps a large
+ * Circle share close to one round trip without threatening a small pool.
+ */
+const ONE_LOCATION_SHARE_CONCURRENCY = 4;
+
 const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 // Recipients poll faster than the owner's publish heartbeat so the shared dot
 // stays fresh; the LiveMap marker interpolates between these reads.
@@ -2502,6 +2512,23 @@ export function OneLocationAgentPageContent({
       ),
     [auth.userId, state?.requests],
   );
+  // Warm the shared position while the user is still reading the request.
+  //
+  // Approving publishes an encrypted point, so it needs a fix — and nothing on
+  // the review path seeds one. That meant the FIRST approve on an idle queue
+  // always paid a full device acquisition inside its own spinner, which is the
+  // "approve takes seconds" report. Taking the read now moves it off the
+  // critical path; by the time the button is pressed the 20s reuse window in
+  // captureCurrentPosition answers instantly.
+  //
+  // Gated on an ALREADY-granted permission on purpose. A capture that could
+  // raise the system prompt outside a user gesture would spend the single
+  // prompt iOS grants at a moment the user cannot connect to anything they did.
+  useEffect(() => {
+    if (permission?.state !== "granted") return;
+    if (!pendingOwnerRequests.length) return;
+    void OneLocationService.captureCurrentPosition().catch(() => null);
+  }, [pendingOwnerRequests.length, permission?.state]);
   const requestedByMe = useMemo(
     () =>
       (state?.requests ?? []).filter(
@@ -2813,6 +2840,22 @@ export function OneLocationAgentPageContent({
     );
   }, [pendingCircleInviteToken, router, vaultOwnerToken]);
 
+  /**
+   * Reload the whole Location workspace from the backend.
+   *
+   * A mutating CTA must NOT hold its spinner open across this. By the time a
+   * handler reaches it the work is done and already confirmed by a toast — the
+   * public link is in the clipboard, the request is approved, the share is
+   * revoked. Awaiting a full state reload after that just keeps the button
+   * disabled for one more round trip the user is not waiting on, which is most
+   * of what "every click takes seconds" was. It was also actively misleading:
+   * a reload that failed after a successful revoke surfaced as "Could not
+   * revoke access", blaming the operation that had in fact succeeded.
+   *
+   * Call it as `void refresh().catch(() => null)` from a CTA. It coalesces
+   * in-flight callers itself (refreshInFlightRef below), so firing it without
+   * awaiting cannot stampede.
+   */
   const refresh = useCallback(
     async (options?: { background?: boolean }) => {
       if (!auth.userId) {
@@ -3551,28 +3594,52 @@ export function OneLocationAgentPageContent({
         };
       }
       const point = readiness.point;
-      for (const recipient of shareReadySelectedRecipients) {
-        try {
-          const grant = await OneLocationService.createGrant({
-            vaultOwnerToken,
-            recipientUserId: recipient.userId,
-            recipientKeyId: recipient.keyId,
-            durationHours: Number(effectiveDurationHours),
-            reason: shareMessage.trim() || undefined,
-            shareKind: "share",
-            sourceCircleId:
-              namedCircleShareContext &&
-              namedCircleShareContext.recipientUserIds.includes(recipient.userId)
-                ? namedCircleShareContext.circleId
-                : undefined,
-          });
-          await publishEnvelopeWithRetry(grant, recipient, "manual", point);
-          successCount += 1;
-        } catch (error) {
-          recipientFailureCount += 1;
-          lastRecipientError = error;
+      // Share with everyone at once rather than one after another. Sharing with
+      // N people used to cost 2N round trips end to end, so picking five people
+      // was five times slower than picking one for no reason the user could see
+      // — each recipient's grant is an independent row and nothing downstream
+      // depends on the previous one finishing.
+      //
+      // Bounded rather than a bare Promise.all: server-side each grant holds a
+      // writer-guard connection WHILE its row insert opens a second one, so an
+      // unbounded fan-out over a large Circle can exhaust a small connection
+      // pool. Four at a time keeps the wall clock near a single round trip and
+      // stays well inside the pool.
+      const pending = [...shareReadySelectedRecipients];
+      const shareOne = async () => {
+        for (;;) {
+          const recipient = pending.shift();
+          if (!recipient) return;
+          try {
+            const grant = await OneLocationService.createGrant({
+              vaultOwnerToken,
+              recipientUserId: recipient.userId,
+              recipientKeyId: recipient.keyId,
+              durationHours: Number(effectiveDurationHours),
+              reason: shareMessage.trim() || undefined,
+              shareKind: "share",
+              sourceCircleId:
+                namedCircleShareContext &&
+                namedCircleShareContext.recipientUserIds.includes(
+                  recipient.userId,
+                )
+                  ? namedCircleShareContext.circleId
+                  : undefined,
+            });
+            await publishEnvelopeWithRetry(grant, recipient, "manual", point);
+            successCount += 1;
+          } catch (error) {
+            recipientFailureCount += 1;
+            lastRecipientError = error;
+          }
         }
-      }
+      };
+      await Promise.all(
+        Array.from(
+          { length: Math.min(ONE_LOCATION_SHARE_CONCURRENCY, pending.length) },
+          shareOne,
+        ),
+      );
       if (!successCount && lastRecipientError) {
         throw lastRecipientError;
       }
@@ -3603,7 +3670,7 @@ export function OneLocationAgentPageContent({
       // Signal the redesign hub to close the 2-step share flow and return to
       // the main One Location screen now that sharing finished.
       setShareCompletedTick((value) => value + 1);
-      await refresh();
+      void refresh().catch(() => null);
       return { status: "succeeded", summary };
     } catch (error) {
       const failureCount =
@@ -3924,7 +3991,7 @@ export function OneLocationAgentPageContent({
               : `SMS sent to ${readyRecipients.length} contact(s).`,
           );
         }
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         // Recover from memory — SosPanicError carries any partial incident
         // in-process, so the SOS banner stays up even if localStorage failed.
@@ -3964,7 +4031,7 @@ export function OneLocationAgentPageContent({
             smsContactUserIds,
           )
         ) {
-          await refresh();
+          void refresh().catch(() => null);
         }
         toast.success("SMS contact added.");
         return true;
@@ -4078,7 +4145,7 @@ export function OneLocationAgentPageContent({
             smsContactUserIds,
           )
         ) {
-          await refresh();
+          void refresh().catch(() => null);
         }
         toast.success("SMS contact removed.");
         return true;
@@ -4119,7 +4186,7 @@ export function OneLocationAgentPageContent({
           readiness.point,
         );
         toast.success("Encrypted location update published.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not publish update.",
@@ -4763,7 +4830,7 @@ export function OneLocationAgentPageContent({
       try {
         await OneLocationService.revokeGrant({ vaultOwnerToken, grantId });
         toast.success("Location access revoked.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not revoke access.",
@@ -4802,7 +4869,7 @@ export function OneLocationAgentPageContent({
     setSosIncident(null);
     toast.success("SMS ended. Live location sharing stopped.");
     try {
-      await refresh();
+      void refresh().catch(() => null);
     } catch {
       /* refresh failure is non-fatal; sharing has already been stopped */
     }
@@ -5095,7 +5162,7 @@ export function OneLocationAgentPageContent({
               selectedRequestOwners.length,
             )}. We'll notify you here when they respond.`,
       );
-      await refresh();
+      void refresh().catch(() => null);
     } catch (error) {
       const failureCount = selectedRequestOwners.length - successCount || 1;
       trackEvent("one_location_request_sent", {
@@ -5156,7 +5223,7 @@ export function OneLocationAgentPageContent({
           ? "Public location link created and copied."
           : "Public location link created.",
       );
-      await refresh();
+      void refresh().catch(() => null);
     } catch (error) {
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
@@ -5240,7 +5307,7 @@ export function OneLocationAgentPageContent({
           copied_to_clipboard: false,
           active_invite_count: activePublicInvites.length + 1,
         });
-        await refresh();
+        void refresh().catch(() => null);
       }
 
       const delivery = await shareOneLocationLink({
@@ -5298,7 +5365,7 @@ export function OneLocationAgentPageContent({
           ? "Invite to One link created and copied."
           : "Invite to One link created.",
       );
-      await refresh();
+      void refresh().catch(() => null);
     } catch (error) {
       trackEvent("one_location_circle_invite_created", {
         route_id: "one_location",
@@ -5358,7 +5425,7 @@ export function OneLocationAgentPageContent({
         });
         setCircleInviteUrl("");
         toast.success("Invite to One link revoked.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           oneLocationErrorMessage(
@@ -6147,7 +6214,7 @@ export function OneLocationAgentPageContent({
         });
         setPublicInviteUrl("");
         toast.success("Public location link revoked.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           oneLocationErrorMessage(
@@ -6183,7 +6250,7 @@ export function OneLocationAgentPageContent({
         });
         await publishEnvelopeWithRetry(response.grant, requester, "manual");
         toast.success("Request approved and encrypted update published.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not approve request.",
@@ -6208,7 +6275,7 @@ export function OneLocationAgentPageContent({
       try {
         await OneLocationService.denyRequest({ vaultOwnerToken, requestId });
         toast.success("Request denied.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not deny request.",
@@ -6233,7 +6300,7 @@ export function OneLocationAgentPageContent({
           referredUserId: target,
         });
         toast.success("Referral sent as an owner approval request.");
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not refer recipient.",
@@ -6573,7 +6640,7 @@ export function OneLocationAgentPageContent({
             "Could not share with the selected people. Please retry.",
           );
         }
-        await refresh().catch((refreshError) => {
+        void refresh().catch((refreshError) => {
           console.warn(
             "[OneLocationAgent] Private check-in state refresh failed.",
             refreshError,
@@ -6727,7 +6794,7 @@ export function OneLocationAgentPageContent({
           `Sharing your drive with ${peopleCountLabel(selected.length)}.`,
         );
         setShareCompletedTick((value) => value + 1);
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error
@@ -6865,7 +6932,7 @@ export function OneLocationAgentPageContent({
           `Pickup requested from ${peopleCountLabel(selected.length)}. They can see you live.`,
         );
         setShareCompletedTick((value) => value + 1);
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         const failureCount = selected.length - successCount || 1;
         trackEvent("one_location_share_confirmed", {
@@ -7013,7 +7080,7 @@ export function OneLocationAgentPageContent({
           `Safe Arrival started. ${peopleCountLabel(selected.length)} can watch you reach ${destination.label}.`,
         );
         setShareCompletedTick((value) => value + 1);
-        await refresh();
+        void refresh().catch(() => null);
       } catch (error) {
         toast.error(
           error instanceof Error
@@ -7256,7 +7323,10 @@ export function OneLocationAgentPageContent({
   // `?view=` / `?action=` params the hub already owns — so One can reach them
   // from anywhere, instead of only while standing on this page.
   useLocalOnboardingActionHandler("location.refresh", () => {
-    void refresh();
+    // refresh() reports its own failure through loadError, so the rejection is
+    // redundant here — but leaving it unhandled surfaces as an unhandled
+    // promise rejection in the console.
+    void refresh().catch(() => null);
     return { status: "succeeded", summary: "Location refreshed." };
   });
   const showInitialSkeleton =
@@ -9303,7 +9373,7 @@ export function OneLocationAgentPageContent({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => void refresh()}
+              onClick={() => void refresh().catch(() => null)}
               disabled={busy === "load"}
               className="h-9 rounded-full px-3"
               data-voice-control-id="one-location-refresh"

--- a/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Latency and freshness contracts for the One Location surface.
+ *
+ * Every assertion here was written after a real defect, and each one guards a
+ * property that a type signature cannot:
+ *
+ * 1. Capture options must SURVIVE the prop boundary. The nearby check-in
+ *    confirmation asks for a genuinely fresh fix with `{ maxAgeMs: 0 }`, but
+ *    the function supplying that prop was declared with ZERO parameters.
+ *    TypeScript permits the narrower arity — a function may always ignore its
+ *    arguments — so it compiled clean, linted clean, passed every test, and
+ *    silently discarded the option. The persisted radius anchor could be 20s
+ *    stale while a comment three lines above promised it was fresh.
+ *
+ * 2. A mutating CTA must not hold its spinner across a full state reload. That
+ *    round trip is bookkeeping the user is not waiting on, and it was most of
+ *    what "every click takes seconds" meant.
+ *
+ * 3. Sharing must fan out concurrently, but BOUNDED — each grant costs two
+ *    pooled database connections server-side.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("One Location capture-options boundary", () => {
+  it("the map's capture forwarders declare and pass their options", () => {
+    const source = read("components/one-location/location-immersive-map.tsx");
+
+    // Declared with the parameter — a zero-arity declaration is the bug.
+    expect(source).toContain(
+      "const captureCurrentLocation = useCallback(\n    (options?: { maxAgeMs?: number }): Promise<PlainLocationPoint> => {",
+    );
+    expect(source).toContain(
+      "async (options?: { maxAgeMs?: number }) => {\n      const point = await captureCurrentLocation(options);",
+    );
+
+    // And actually forwarded to the service, not dropped.
+    expect(source).toContain(
+      "OneLocationService.captureCurrentPosition(options)",
+    );
+    expect(source).not.toContain(
+      "const captureAndRememberCurrentLocation = useCallback(async () => {",
+    );
+  });
+
+  it("an in-flight capture is not handed to a caller demanding a fresh fix", () => {
+    const source = read("components/one-location/location-immersive-map.tsx");
+
+    // Deduplication is right for cached-eligible callers and wrong for a
+    // check-in anchor that must describe where the user is standing now.
+    expect(source).toContain(
+      "if (locationCaptureRef.current && options?.maxAgeMs !== 0)",
+    );
+  });
+
+  it("the check-in confirmation still asks for a fresh anchor", () => {
+    const source = read(
+      "components/one-location/nearby-check-in/nearby-check-in-sheet.tsx",
+    );
+    expect(source).toContain("captureCurrentPosition({ maxAgeMs: 0 })");
+  });
+
+  it("the check-in sheet's prop type accepts options at all", () => {
+    const source = read(
+      "components/one-location/nearby-check-in/nearby-check-in-sheet.tsx",
+    );
+    expect(source).toContain(
+      "captureCurrentPosition: (options?: {\n    maxAgeMs?: number;\n  }) => Promise<PlainLocationPoint>;",
+    );
+  });
+});
+
+describe("One Location CTA latency contract", () => {
+  const page = () => read("app/one/location/page.tsx");
+
+  it("no mutating CTA awaits a full state reload before releasing its spinner", () => {
+    // `await refresh()` inside a handler adds a whole round trip to perceived
+    // latency after the work is already done and toasted.
+    expect(page()).not.toContain("await refresh();");
+  });
+
+  it("backgrounded reloads still swallow their own failure", () => {
+    // A bare `void refresh()` would surface as an unhandled rejection, and a
+    // reload that failed after a successful revoke used to be reported to the
+    // user as "Could not revoke access" — blaming the operation that worked.
+    const source = page();
+    const backgrounded = source.match(/void refresh\(\)/g) ?? [];
+    const handled = source.match(/void refresh\(\)\s*\.catch\(/g) ?? [];
+    expect(backgrounded.length).toBeGreaterThan(0);
+    expect(handled.length).toBe(backgrounded.length);
+  });
+
+  it("sharing fans out concurrently rather than one recipient at a time", () => {
+    const source = page();
+    expect(source).toContain("ONE_LOCATION_SHARE_CONCURRENCY");
+    // The sequential shape this replaced.
+    expect(source).not.toContain(
+      "for (const recipient of shareReadySelectedRecipients) {",
+    );
+  });
+
+  it("share fan-out stays bounded so it cannot exhaust the connection pool", () => {
+    const source = page();
+    const match = source.match(/ONE_LOCATION_SHARE_CONCURRENCY = (\d+)/);
+    expect(match).toBeTruthy();
+    const limit = Number(match?.[1]);
+    expect(limit).toBeGreaterThan(1); // otherwise it is still sequential
+    expect(limit).toBeLessThanOrEqual(8); // each grant costs 2 DB connections
+    expect(source).toContain(
+      "Math.min(ONE_LOCATION_SHARE_CONCURRENCY, pending.length)",
+    );
+  });
+
+  it("both live-publish loops isolate failures per recipient", () => {
+    const source = page();
+    // One recipient throwing must not starve the others — with stable grant
+    // ordering, a shared catch starved everyone after the failure on EVERY tick.
+    expect(source).not.toContain("for (const grant of activeOwnerGrants) {");
+    expect(source).toContain("activeOwnerGrants.map(async (grant) => {");
+  });
+
+  it("the review queue warms the position before Approve is pressed", () => {
+    const source = page();
+    expect(source).toContain(
+      "void OneLocationService.captureCurrentPosition().catch(() => null);",
+    );
+    // Never outside a granted permission: an ungated capture would spend the
+    // single system prompt iOS grants at a moment the user cannot explain.
+    expect(source).toContain('if (permission?.state !== "granted") return;');
+  });
+
+  it("live publishing never serves a recipient a reused fix", () => {
+    const source = page();
+    expect(source).toContain(
+      "const point = await OneLocationService.captureCurrentPosition({\n          maxAgeMs: 0,\n        });",
+    );
+  });
+});

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -661,10 +661,15 @@ export function LocationImmersiveMap({
     setNearbyPresenceState({ presence: null, attendees: [] });
   }, [auth.userId, demoMode, nearbyCheckInAvailable, vaultOwnerToken]);
 
-  const captureCurrentLocation =
-    useCallback((): Promise<PlainLocationPoint> => {
-      if (locationCaptureRef.current) return locationCaptureRef.current;
-      const request = OneLocationService.captureCurrentPosition();
+  const captureCurrentLocation = useCallback(
+    (options?: { maxAgeMs?: number }): Promise<PlainLocationPoint> => {
+      // A caller demanding a genuinely fresh fix must not be handed the
+      // in-flight one this ref is holding — that is how the check-in anchor
+      // silently became "wherever we already were".
+      if (locationCaptureRef.current && options?.maxAgeMs !== 0) {
+        return locationCaptureRef.current;
+      }
+      const request = OneLocationService.captureCurrentPosition(options);
       locationCaptureRef.current = request;
       void request.then(
         () => {
@@ -681,17 +686,23 @@ export function LocationImmersiveMap({
       return request;
     }, []);
 
-  const captureAndRememberCurrentLocation = useCallback(async () => {
-    const point = await captureCurrentLocation();
-    if (auth.userId) {
-      const workspace = readLocationWorkspaceMemory(auth.userId);
-      writeLocationWorkspaceMemory(auth.userId, {
-        ...workspace,
-        myLocationPoint: point,
-      });
-    }
-    return point;
-  }, [auth.userId, captureCurrentLocation]);
+  // Forwards `options` deliberately. Declared with no parameters, this silently
+  // dropped a caller's `maxAgeMs: 0` — TypeScript accepts the narrower arity, so
+  // it compiled clean while the check-in anchor quietly used a cached fix.
+  const captureAndRememberCurrentLocation = useCallback(
+    async (options?: { maxAgeMs?: number }) => {
+      const point = await captureCurrentLocation(options);
+      if (auth.userId) {
+        const workspace = readLocationWorkspaceMemory(auth.userId);
+        writeLocationWorkspaceMemory(auth.userId, {
+          ...workspace,
+          myLocationPoint: point,
+        });
+      }
+      return point;
+    },
+    [auth.userId, captureCurrentLocation],
+  );
 
   const handleNearbyStateChange = useCallback(
     (next: OneLocationNearbyPresenceState) => {


### PR DESCRIPTION
Follow-up to #5231. QA reported *"every CTA takes 7-8 seconds"*. I audited all **62 CTAs** on this surface rather than generalise from the two they named, and adversarially verified each "still slow" claim — **8 of 20 were refuted**, so the real list is short and specific.

**The remaining latency was not GPS.** It was three structural habits, plus a hole in the previous fix.

## 1. Every mutating CTA held its spinner across a full state reload

21 handlers ended in `await refresh()`. By that point the work is done and already confirmed by a toast — link in the clipboard, request approved, share revoked — yet the button stayed disabled for one more round trip nobody was waiting on.

It was also actively misleading: a reload that failed *after* a successful revoke surfaced as **"Could not revoke access"**, blaming the operation that had worked.

Now fired and reconciled in the background. `refresh()` already coalesces in-flight callers, so this cannot stampede. This also fixes an ordering defect in **Share to Contacts**, where the reload sat *between* creating the invite and opening the OS share sheet.

## 2. Sharing with N people cost 2N sequential round trips

Picking five people was five times slower than picking one, for no reason a user could see. Each grant is an independent row.

Now fanned out — **bounded at 4, deliberately not a bare `Promise.all`**: server-side each grant holds a writer-guard connection *while* its row insert opens a second one, so an unbounded fan-out over a large Circle could exhaust a small pool. Trading latency for pool exhaustion isn't an optimisation.

## 3. Nothing seeded a position before Approve

Approving publishes an encrypted point, and the review path never captured one — so the **first** approve on an idle queue always paid a full device acquisition inside its own spinner. That is the "approve mein time le rha" report.

The queue now warms it while the user is still reading the request. Gated on an **already-granted** permission: a capture that could raise the system prompt outside a user gesture would spend the single prompt iOS grants at a moment the user cannot connect to anything they did.

## 4. The previous fix had a hole — worth reading

The check-in confirmation asked for a genuinely fresh anchor with `captureCurrentPosition({ maxAgeMs: 0 })`. The function supplying that prop was declared with **zero parameters**. TypeScript permits the narrower arity — a function may always ignore its arguments — so it compiled clean, linted clean, passed every test, and **silently discarded the option**. The persisted radius anchor could be 20s stale while a comment three lines above promised it was fresh.

Both forwarders now declare and pass their options, and an in-flight capture is no longer handed to a caller that explicitly demanded a fresh one.

## Also: this repairs `main`

PR #5230 added an `OneLocationService.getMapPreferences` call to the Location page **without adding it to the page test's service mock**, failing 57 tests with `getMapPreferences is not a function`. I verified against `206fc5f38` directly — the breakage predates this branch and is not from #5231.

## Tests

11 new contract assertions, each guarding a property a type signature cannot:

- capture options **survive every forwarding hop** (the exact gap that let #4 through — no unit test could have caught it, so this reads the source)
- an in-flight capture is not handed to a `maxAgeMs: 0` caller
- **no handler awaits a state reload** before releasing its spinner
- every backgrounded reload **handles its own rejection** (this one caught two pre-existing unhandled rejections)
- fan-out is concurrent **and** bounded (asserts `1 < limit <= 8`)
- live publishing never serves a reused fix

## Verification

- `typecheck` clean · `lint --max-warnings=0` clean · `verify:design-system` passed
- `test:ci` **branch**: 23 failed / 3592 passed
- `test:ci` **origin/main**: 82 failed / 3522 passed
- **Zero regressions** (`comm` of the failing sets is empty in the branch-only direction); **59 tests repaired**

## Not addressed, deliberately

UAT's `consent-protocol` has **no `minScale`** and scales to zero. No client change fixes a cold container. That is a Cloud Run change and wants the connection-pool sizing considered alongside it — prod runs `db-f1-micro`, and connection exhaustion has blocked releases here before.