### PR TITLE
test(one-location): cover the map lifecycle and budget how fast it opens

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -283,10 +283,14 @@ import {
   updateOneLocationControlState,
 } from "@/lib/one-location/location-control-state";
 import { forgetCachedRendererConsent } from "@/lib/one-location/map-renderer-consent";
+import { __resetNativeMapLifecycleForTests } from "@/lib/one-location/native-map-lifecycle";
 
 const DEFAULT_PLACE_FOCUS = { ...experienceHarness.placeFocus };
 
 beforeEach(() => {
+  // Lanes are module state: without this a superseded claim or a queued
+  // teardown from an earlier case leaks into the next one.
+  __resetNativeMapLifecycleForTests();
   experienceHarness.placeFocus = { ...DEFAULT_PLACE_FOCUS };
   forgetOneLocationControlPreference("test-user");
   forgetCachedRendererConsent("test-user");
@@ -1409,5 +1413,158 @@ describe("LocationImmersiveMap native map lifecycle", () => {
       "destroyed:1",
       "create:2",
     ]);
+  });
+});
+
+/**
+ * Time-to-map is a latency budget, not a feeling. These cases pin the cost of
+ * opening Your Map in bridge round-trips and scheduler turns so a regression
+ * shows up here rather than in someone's hand on a device.
+ */
+describe("LocationImmersiveMap open latency", () => {
+  it("issues the native create without waiting on any timer", async () => {
+    render(<LocationImmersiveMap />);
+
+    // Drain microtasks only -- never advance a timer. Reaching the bridge here
+    // proves nothing on the open path is gated on a scheduled delay: not the
+    // layout wait, which short-circuits on an already-measured container, and
+    // not the lane, which is free. A regression that puts either behind a
+    // timer fails right here rather than showing up as a slow map on a device.
+    await act(async () => {
+      for (let tick = 0; tick < 12; tick += 1) await Promise.resolve();
+    });
+    expect(mapHarness.create).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    // One native create per open. A second would mean the map is built twice
+    // on the way in -- the cost the serialization exists to avoid, not add.
+    expect(mapHarness.create).toHaveBeenCalledTimes(1);
+    expect(mapHarness.map.destroy).not.toHaveBeenCalled();
+  });
+
+  it("costs the live map one teardown, not an unbounded wait, when a mount is superseded", async () => {
+    const first = render(<LocationImmersiveMap />);
+    await waitFor(() => expect(mapHarness.create).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    render(<LocationImmersiveMap />);
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    // Exactly two creates and one destroy: the outgoing map is torn down once
+    // and the incoming one is built once. Serializing must not turn a remount
+    // into a retry loop.
+    expect(mapHarness.create).toHaveBeenCalledTimes(2);
+    expect(mapHarness.map.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still opens after a create fails, instead of hanging behind it", async () => {
+    // A poisoned lane would leave every later open on a spinner that never
+    // resolves -- a worse outcome than the blank map this all started with.
+    mapHarness.create.mockRejectedValueOnce(new Error("bridge unavailable"));
+
+    const failed = render(<LocationImmersiveMap />);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("one-location-map"),
+      ).toHaveAttribute("data-map-ready", "false");
+    });
+    failed.unmount();
+
+    render(<LocationImmersiveMap />);
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+  });
+});
+
+/**
+ * The paths that actually put a second mount inside a create window. Each one
+ * is ordinary navigation, not an edge case, which is why the blank map was
+ * reproducible enough for QA to file it.
+ */
+describe("LocationImmersiveMap remount triggers", () => {
+  it("survives the owner-scoped remount both map routes perform", async () => {
+    // /one/location/map and /one/location/check-in both render this component
+    // under key={auth.userId ?? "anonymous"}. When the owner id arrives the key
+    // changes, React throws the mount away and builds a fresh one -- straight
+    // through an in-flight create.
+    const first = render(<LocationImmersiveMap key="anonymous" />);
+    await waitFor(() => expect(mapHarness.create).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    render(<LocationImmersiveMap key="test-user" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+    expect(mapHarness.map.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects the legacy check-in entry point off the map route", async () => {
+    // The Location hub still pushes /one/location/map?action=check-in, and the
+    // map route bounces it to the check-in route. That bounce is a second
+    // mount of this same component on the same native map id.
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "action=check-in";
+
+    render(<LocationImmersiveMap />);
+
+    await waitFor(() => {
+      expect(navigationHarness.replace).toHaveBeenCalledWith(
+        "/one/location/check-in",
+        { scroll: false },
+      );
+    });
+  });
+
+  it("leaves a usable map behind when check-in is opened and dismissed", async () => {
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "";
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    // Renderer consent gates the sheet and the marker refresh alike.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to Your Map" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
+    // Dismissing the sheet is not leaving the screen: the map underneath has
+    // to still be there, and still be the one this mount created.
+    await waitFor(() => {
+      expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
+    expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+      "data-map-ready",
+      "true",
+    );
+    expect(mapHarness.map.destroy).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location/native-map-lifecycle.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/native-map-lifecycle.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const platformHarness = vi.hoisted(() => ({ native: false }));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  getPlatform: () => (platformHarness.native ? "ios" : "web"),
+  isNative: () => platformHarness.native,
+}));
+
+import {
+  LAYOUT_WAIT_INTERVAL_MS,
+  LAYOUT_WAIT_TIMEOUT_MS,
+  __resetNativeMapLifecycleForTests,
+  claimNativeMap,
+  isNativeMapSuperseded,
+  waitForLaidOutBox,
+  withNativeMapLock,
+} from "@/lib/one-location/native-map-lifecycle";
+
+const MAP_ID = "one-location-private-map";
+const OTHER_ID = "one-location-onboarding-picker-map";
+
+/** A box that reports whatever dimensions the case wants, when it wants them. */
+function stubElement(rect: { width: number; height: number }): HTMLElement {
+  return {
+    getBoundingClientRect: () => ({ width: rect.width, height: rect.height }),
+  } as unknown as HTMLElement;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  __resetNativeMapLifecycleForTests();
+  platformHarness.native = false;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("withNativeMapLock", () => {
+  it("runs tasks in call order and never overlaps them", async () => {
+    const events: string[] = [];
+    const first = deferred<void>();
+    const second = deferred<void>();
+
+    const a = withNativeMapLock(MAP_ID, async () => {
+      events.push("a:start");
+      await first.promise;
+      events.push("a:end");
+    });
+    const b = withNativeMapLock(MAP_ID, async () => {
+      events.push("b:start");
+      await second.promise;
+      events.push("b:end");
+    });
+
+    // B must not have begun while A is still in flight -- overlapping create
+    // and destroy on one id is the whole defect.
+    await Promise.resolve();
+    expect(events).toEqual(["a:start"]);
+
+    first.resolve();
+    await a;
+    await Promise.resolve();
+    expect(events).toEqual(["a:start", "a:end", "b:start"]);
+
+    second.resolve();
+    await b;
+    expect(events).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("keeps a rejected task from stalling every later task on that id", async () => {
+    // Without isolation one failed create would hang the lane forever, and
+    // every later entry to Your Map would sit on a spinner that never ends.
+    const failed = withNativeMapLock(MAP_ID, async () => {
+      throw new Error("create failed");
+    });
+    await expect(failed).rejects.toThrow("create failed");
+
+    const after = await withNativeMapLock(MAP_ID, async () => "recovered");
+    expect(after).toBe("recovered");
+  });
+
+  it("still reports a failure to the caller that owns it", async () => {
+    const boom = withNativeMapLock(MAP_ID, async () => {
+      throw new Error("bridge unavailable");
+    });
+    await expect(boom).rejects.toThrow("bridge unavailable");
+  });
+
+  it("does not let one map id block another", async () => {
+    // Your Map and the onboarding picker are separate native maps. A slow or
+    // wedged create on one must never delay the other.
+    const held = deferred<void>();
+    const order: string[] = [];
+
+    void withNativeMapLock(MAP_ID, async () => {
+      order.push("map:start");
+      await held.promise;
+    });
+    const other = withNativeMapLock(OTHER_ID, async () => {
+      order.push("picker:ran");
+      return "picker";
+    });
+
+    expect(await other).toBe("picker");
+    expect(order).toEqual(["map:start", "picker:ran"]);
+    held.resolve();
+  });
+});
+
+describe("claimNativeMap / isNativeMapSuperseded", () => {
+  it("supersedes an earlier claim and leaves the current one live", () => {
+    const first = claimNativeMap(MAP_ID);
+    expect(isNativeMapSuperseded(MAP_ID, first)).toBe(false);
+
+    const second = claimNativeMap(MAP_ID);
+    expect(isNativeMapSuperseded(MAP_ID, first)).toBe(true);
+    expect(isNativeMapSuperseded(MAP_ID, second)).toBe(false);
+  });
+
+  it("tracks each map id independently", () => {
+    const map = claimNativeMap(MAP_ID);
+    claimNativeMap(OTHER_ID);
+    claimNativeMap(OTHER_ID);
+    expect(isNativeMapSuperseded(MAP_ID, map)).toBe(false);
+  });
+});
+
+describe("waitForLaidOutBox latency", () => {
+  it("adds no latency on web", async () => {
+    const timer = vi.spyOn(window, "setTimeout");
+    await waitForLaidOutBox(stubElement({ width: 0, height: 0 }));
+    // Web uses the JS SDK and has no native frame to get wrong, so this must
+    // not cost even one scheduler turn.
+    expect(timer).not.toHaveBeenCalled();
+  });
+
+  it("adds no latency when the container is already laid out", async () => {
+    platformHarness.native = true;
+    const timer = vi.spyOn(window, "setTimeout");
+    await waitForLaidOutBox(stubElement({ width: 390, height: 844 }));
+    // The common path: the box is real on the first measurement, so opening
+    // Your Map must not wait on a polling interval before create() is issued.
+    expect(timer).not.toHaveBeenCalled();
+  });
+
+  it("waits for a container that has width but no height yet", async () => {
+    platformHarness.native = true;
+    vi.useFakeTimers();
+    const box = { width: 390, height: 0 };
+    let settled = false;
+
+    const wait = waitForLaidOutBox({
+      getBoundingClientRect: () => ({ ...box }),
+    } as unknown as HTMLElement).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(LAYOUT_WAIT_INTERVAL_MS);
+    // The plugin only retries a zero *width*, so this is exactly the shape it
+    // would have accepted and baked into the native frame as a zero height.
+    expect(settled).toBe(false);
+
+    box.height = 844;
+    await vi.advanceTimersByTimeAsync(LAYOUT_WAIT_INTERVAL_MS);
+    await wait;
+    expect(settled).toBe(true);
+  });
+
+  it("gives up within its budget when the container never lays out", async () => {
+    platformHarness.native = true;
+    vi.useFakeTimers();
+    let settled = false;
+
+    const wait = waitForLaidOutBox(stubElement({ width: 0, height: 0 })).then(
+      () => {
+        settled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(LAYOUT_WAIT_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    // Bounded on purpose: a container that never measures must not hold the
+    // lane open, or one wedged map stalls every create queued behind it.
+    await vi.advanceTimersByTimeAsync(LAYOUT_WAIT_INTERVAL_MS * 2);
+    await wait;
+    expect(settled).toBe(true);
+  });
+});

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -70,6 +70,12 @@ import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition
 import { motionDurations, motionEasings } from "@/lib/morphy-ux/motion";
 import { useVault } from "@/lib/vault/vault-context";
 import {
+  claimNativeMap,
+  isNativeMapSuperseded,
+  waitForLaidOutBox,
+  withNativeMapLock,
+} from "@/lib/one-location/native-map-lifecycle";
+import {
   GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
   readCachedRendererConsentAccepted,
   writeCachedRendererConsentAccepted,
@@ -77,52 +83,12 @@ import {
 
 const MAP_ID = "one-location-private-map";
 
-// @capacitor/google-maps addresses every native map by its string id alone.
-// `destroy()` resolves to `maps.removeValue(forKey: id)` on both iOS and
-// Android with no check that the caller is the instance that registered it,
-// and `create()` cannot be called back: it waits ~200 ms (longer while the
-// element still measures zero) before the native view is registered, and
-// nothing cancels that.
-//
-// So an unmount landing inside a create window left the screen blank. The
-// cleanup found `mapRef.current` still null and destroyed nothing, the
-// abandoned create registered its map anyway, and its cancelled branch then
-// destroyed MAP_ID -- by which time MAP_ID belonged to the map the NEXT mount
-// had just created. The component believed it was ready (`mapReady` true,
-// loading overlay gone) over a native canvas that no longer existed: chrome
-// and people tray drawn over a blank surface, correct again on the next entry
-// because that one mounts only once.
-//
-// Serializing every create and destroy for this id fixes the ordering. A
-// superseded instance tears its own map down while still holding the lock, so
-// the next create always starts on a free id and no destroy outlives it.
-let nativeMapLifecycle: Promise<unknown> = Promise.resolve();
-let nativeMapGeneration = 0;
-
-function withNativeMapLock<T>(task: () => Promise<T>): Promise<T> {
-  const run = nativeMapLifecycle.then(task, task);
-  nativeMapLifecycle = run.catch(() => undefined);
-  return run;
-}
-
-/**
- * The plugin measures the container once and bakes width/height into the
- * native view's frame, but it only retries while the *width* is zero. A
- * container measured mid-layout at full width and zero height is accepted as
- * given, and the native map is placed with no height at all -- created, ready,
- * and invisible, with no later resize to correct it. Hand the element over
- * only once it has a real box.
- */
-async function waitForLaidOutBox(element: HTMLElement): Promise<void> {
-  // Native only: on web the plugin renders the JS SDK into this element and
-  // has no native frame to get wrong, and jsdom reports every box as zero.
-  if (!isNative()) return;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    const rect = element.getBoundingClientRect();
-    if (rect.width > 0 && rect.height > 0) return;
-    await new Promise((resolve) => window.setTimeout(resolve, 32));
-  }
-}
+// Create and destroy for this id are serialized in `native-map-lifecycle`.
+// The plugin addresses every native map by its string id alone and cannot
+// cancel an in-flight create, so an unmount inside a create window used to let
+// an abandoned instance destroy the map the NEXT mount had just created --
+// leaving Your Map blank while the screen reported itself ready. See that
+// module for the full contract and its latency budget.
 
 const NEARBY_CHECK_IN_RADIUS_METERS = 500;
 const MAP_ACCENT_CONTROL_CLASSNAME =
@@ -977,7 +943,7 @@ export function LocationImmersiveMap({
     let cancelled = false;
     // Claimed before any await, so a later mount always wins the id even if
     // React runs this effect before the previous instance's cleanup.
-    const generation = ++nativeMapGeneration;
+    const claim = claimNativeMap(MAP_ID);
     if (isNative()) {
       document.documentElement.classList.add("one-location-map-native");
       document.body.classList.add("one-location-map-native");
@@ -988,9 +954,10 @@ export function LocationImmersiveMap({
     const cachedPoint = rendererReady
       ? readLocationWorkspaceMemory(auth.userId).myLocationPoint
       : null;
-    const superseded = () => cancelled || generation !== nativeMapGeneration;
+    const superseded = () =>
+      cancelled || isNativeMapSuperseded(MAP_ID, claim);
 
-    void withNativeMapLock(async () => {
+    void withNativeMapLock(MAP_ID, async () => {
       // Never touch the bridge on behalf of a mount that is already gone: the
       // point of the lock is that a superseded instance cannot register a map
       // the live instance would then inherit and destroy out from under.
@@ -1067,7 +1034,9 @@ export function LocationImmersiveMap({
       markerIdsRef.current = [];
       markerByMapIdRef.current.clear();
       if (staleMap) {
-        void withNativeMapLock(() => staleMap.destroy()).catch(() => undefined);
+        void withNativeMapLock(MAP_ID, () => staleMap.destroy()).catch(
+          () => undefined,
+        );
       }
     };
     // rendererReady is read once, at creation time, only to decide the
@@ -1788,7 +1757,7 @@ export function LocationImmersiveMap({
     const closingMap = mapRef.current;
     mapRef.current = null;
     if (closingMap) {
-      void withNativeMapLock(async () => {
+      void withNativeMapLock(MAP_ID, async () => {
         await closingMap.disableTouch().catch(() => undefined);
         await closingMap.destroy().catch(() => undefined);
       });

--- a/hushh-webapp/lib/one-location/native-map-lifecycle.ts
+++ b/hushh-webapp/lib/one-location/native-map-lifecycle.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { isNative } from "@/lib/capacitor/platform";
+
+/**
+ * Lifecycle serialization for the @capacitor/google-maps native map.
+ *
+ * The plugin addresses every native map by its string id alone. `destroy()`
+ * resolves to `maps.removeValue(forKey: id)` on both iOS and Android with no
+ * check that the caller is the instance that registered it, and `create()`
+ * cannot be called back: it waits ~200 ms (longer while the element still
+ * measures zero) before the native view is registered, and nothing cancels it.
+ *
+ * So an unmount landing inside a create window used to leave Your Map blank.
+ * The cleanup found no map handle yet and destroyed nothing, the abandoned
+ * create registered its map anyway, and its cancelled branch then destroyed
+ * the id -- which by then belonged to the map the NEXT mount had created. The
+ * screen reported itself ready over a native canvas that no longer existed.
+ *
+ * Serializing create and destroy per id restores the ordering: a superseded
+ * instance tears its own map down while still holding the lock, so the next
+ * create always starts on a free id and no destroy outlives it.
+ *
+ * Extracted from the component so the ordering and its latency budget can be
+ * asserted directly instead of only through a rendered map.
+ */
+
+/** How long the box wait may run before giving up, in ms. */
+export const LAYOUT_WAIT_TIMEOUT_MS = 960;
+/** Gap between box measurements while waiting for layout, in ms. */
+export const LAYOUT_WAIT_INTERVAL_MS = 32;
+
+const MAX_LAYOUT_ATTEMPTS = Math.ceil(
+  LAYOUT_WAIT_TIMEOUT_MS / LAYOUT_WAIT_INTERVAL_MS,
+);
+
+type Lane = { queue: Promise<unknown>; generation: number };
+
+const lanes = new Map<string, Lane>();
+
+function laneFor(mapId: string): Lane {
+  let lane = lanes.get(mapId);
+  if (!lane) {
+    lane = { queue: Promise.resolve(), generation: 0 };
+    lanes.set(mapId, lane);
+  }
+  return lane;
+}
+
+/**
+ * Run `task` with exclusive access to `mapId`'s native slot. Tasks run in call
+ * order and never overlap.
+ *
+ * A rejected task must not poison the lane: the next caller has to run
+ * normally, or one failed create would hang every later map forever. The
+ * rejection still reaches this call's own caller.
+ */
+export function withNativeMapLock<T>(
+  mapId: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const lane = laneFor(mapId);
+  const run = lane.queue.then(task, task);
+  lane.queue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Claim `mapId` for a new owner. Returns a token that later reports whether
+ * this owner is still the current one. Claim before any await, so a later
+ * mount wins the id even if effects run before the previous cleanup.
+ */
+export function claimNativeMap(mapId: string): number {
+  const lane = laneFor(mapId);
+  lane.generation += 1;
+  return lane.generation;
+}
+
+/** True once some other owner has claimed `mapId`. */
+export function isNativeMapSuperseded(mapId: string, token: number): boolean {
+  return laneFor(mapId).generation !== token;
+}
+
+/**
+ * The plugin measures the container once and bakes width/height into the
+ * native view's frame, but it only retries while the *width* is zero. A
+ * container measured mid-layout at full width and zero height is accepted as
+ * given, and the native map is placed with no height at all -- created, ready,
+ * and invisible, with no later resize to correct it.
+ *
+ * Resolves as soon as the element has a real box, so a laid-out container adds
+ * no latency at all: the common path never yields to a timer.
+ */
+export async function waitForLaidOutBox(element: HTMLElement): Promise<void> {
+  // Native only: on web the plugin renders the JS SDK into this element and
+  // has no native frame to get wrong, and jsdom reports every box as zero.
+  if (!isNative()) return;
+  for (let attempt = 0; attempt < MAX_LAYOUT_ATTEMPTS; attempt += 1) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) return;
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, LAYOUT_WAIT_INTERVAL_MS),
+    );
+  }
+  // Bounded: a container that never lays out must not hold the lane open, or
+  // one stuck map would stall every later create behind it.
+}
+
+/** Test-only: clears every lane so each case starts from a known state. */
+export function __resetNativeMapLifecycleForTests(): void {
+  lanes.clear();
+}


### PR DESCRIPTION
Follow-up to #5235. That PR fixed the blank map and shipped two tests for the race itself, which left the parts an engineer would otherwise check by hand — **how fast Your Map opens, and whether it opens at all after something goes wrong** — with no coverage.

## Extraction

The serialization moves out of the 2,500-line component into `lib/one-location/native-map-lifecycle.ts`, so ordering and cost can be asserted directly instead of only through a rendered map. It is now keyed **per map id**, so Your Map and the onboarding picker cannot block each other.

## Latency is a budget now, not a feeling

| Guarantee | Test |
|---|---|
| Opening issues the native create **within microtasks**, never behind a timer | `issues the native create without waiting on any timer` |
| A laid-out container costs **zero** timers | `adds no latency when the container is already laid out` |
| Web costs **zero** timers | `adds no latency on web` |
| The layout wait is **bounded** — a container that never measures can't hold the lane open | `gives up within its budget when the container never lays out` |
| A superseded mount costs the live map **one** teardown + **one** create, not a retry loop | `costs the live map one teardown, not an unbounded wait` |

All deterministic — fake timers and microtask draining, no wall-clock assertions, so nothing here flakes in CI.

## Availability

A failed create must not poison the lane. Without that, one bad create leaves every later entry to Your Map on a spinner that never resolves — strictly worse than the blank map this started from. Covered at both the unit and component level.

## Trigger paths, now named rather than implied

- the owner-scoped `key={auth.userId ?? "anonymous"}` both map routes carry
- the hub's legacy `?action=check-in` redirect off the map route
- opening then dismissing check-in, leaving a usable map behind

## Verified by mutation, not by assertion

I checked these tests actually fail when the behaviour they guard is broken:

| Mutation | Result |
|---|---|
| Gate the open path behind one timer | **6 fail** — incl. both "adds no latency" guards |
| Drop the lane's reject handler | 38 pass — *no-op* |
| Drop the lane queue's catch | 38 pass — *no-op* |
| Drop **both** | **2 fail** — unit + component |

That third row is worth keeping: the two error defenses are independent, so neither alone fails a test. Not redundancy by accident — either one is sufficient, and a future reader removing "the dead one" would still be safe. Recorded so nobody has to rediscover it.

## Verification

- 38/38 across the two files; `tsc --noEmit` and `eslint` clean.
- Full suite **82 failed / 3538 passed** vs main's **82 failed / 3522 passed** — same 82 pre-existing failures, same 18 files, +16 new passing tests. No regressions.

## Still needs a human

None of this replaces a QA pass of Your Map on a real build — these are jsdom tests against a modelled bridge, not a device. They guarantee the ordering and the budget; they cannot prove the native view is painted. I can't drive the simulator through the auth + vault gate.