### PR TITLE
perf(one-location): trade forced-fresh GPS for a tight window, and cut repeated copy

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2931,7 +2931,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openTemporaryLinkFlow();
     fireEvent.click(
-      screen.getByRole("button", { name: /Review public location link/i }),
+      screen.getByRole("button", { name: /^Create link$/i }),
     );
 
     await waitFor(() =>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -8755,11 +8755,11 @@ export function OneLocationAgentPageContent({
     }
     const sessionEpoch = savedLocationSessionEpochRef.current;
     try {
-      // "Locate me" drops a pin, so it reads the device directly. Reusing an
-      // earlier fix here is what previously placed the pin at the last place
-      // the user was rather than this one.
+      // "Locate me" drops a pin, so it needs a current fix — but only current,
+      // not brand new. A reading from the last few seconds puts the pin in the
+      // same place and saves the user a full acquisition.
       const point = await OneLocationService.captureCurrentPosition({
-        maxAgeMs: 0,
+        fresh: true,
       });
       if (
         savedLocationSessionEpochRef.current !== sessionEpoch ||

--- a/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
@@ -37,10 +37,10 @@ describe("One Location capture-options boundary", () => {
 
     // Declared with the parameter — a zero-arity declaration is the bug.
     expect(source).toContain(
-      "const captureCurrentLocation = useCallback(\n    (options?: { maxAgeMs?: number }): Promise<PlainLocationPoint> => {",
+      "const captureCurrentLocation = useCallback(\n    (options?: {\n      maxAgeMs?: number;\n      fresh?: boolean;\n    }): Promise<PlainLocationPoint> => {",
     );
     expect(source).toContain(
-      "async (options?: { maxAgeMs?: number }) => {\n      const point = await captureCurrentLocation(options);",
+      "async (options?: { maxAgeMs?: number; fresh?: boolean }) => {\n      const point = await captureCurrentLocation(options);",
     );
 
     // And actually forwarded to the service, not dropped.
@@ -58,15 +58,15 @@ describe("One Location capture-options boundary", () => {
     // Deduplication is right for cached-eligible callers and wrong for a
     // check-in anchor that must describe where the user is standing now.
     expect(source).toContain(
-      "if (locationCaptureRef.current && options?.maxAgeMs !== 0)",
+      "options?.maxAgeMs !== 0 &&\n        !options?.fresh",
     );
   });
 
-  it("the check-in confirmation still asks for a fresh anchor", () => {
+  it("the check-in confirmation anchors on a current fix, not a stale one", () => {
     const source = read(
       "components/one-location/nearby-check-in/nearby-check-in-sheet.tsx",
     );
-    expect(source).toContain("captureCurrentPosition({ maxAgeMs: 0 })");
+    expect(source).toContain("captureCurrentPosition({ fresh: true })");
   });
 
   it("the check-in sheet's prop type accepts options at all", () => {
@@ -74,7 +74,7 @@ describe("One Location capture-options boundary", () => {
       "components/one-location/nearby-check-in/nearby-check-in-sheet.tsx",
     );
     expect(source).toContain(
-      "captureCurrentPosition: (options?: {\n    maxAgeMs?: number;\n  }) => Promise<PlainLocationPoint>;",
+      "captureCurrentPosition: (options?: {\n    maxAgeMs?: number;\n    fresh?: boolean;\n  }) => Promise<PlainLocationPoint>;",
     );
   });
 });

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -662,11 +662,18 @@ export function LocationImmersiveMap({
   }, [auth.userId, demoMode, nearbyCheckInAvailable, vaultOwnerToken]);
 
   const captureCurrentLocation = useCallback(
-    (options?: { maxAgeMs?: number }): Promise<PlainLocationPoint> => {
+    (options?: {
+      maxAgeMs?: number;
+      fresh?: boolean;
+    }): Promise<PlainLocationPoint> => {
       // A caller demanding a genuinely fresh fix must not be handed the
       // in-flight one this ref is holding — that is how the check-in anchor
       // silently became "wherever we already were".
-      if (locationCaptureRef.current && options?.maxAgeMs !== 0) {
+      if (
+        locationCaptureRef.current &&
+        options?.maxAgeMs !== 0 &&
+        !options?.fresh
+      ) {
         return locationCaptureRef.current;
       }
       const request = OneLocationService.captureCurrentPosition(options);
@@ -690,7 +697,7 @@ export function LocationImmersiveMap({
   // dropped a caller's `maxAgeMs: 0` — TypeScript accepts the narrower arity, so
   // it compiled clean while the check-in anchor quietly used a cached fix.
   const captureAndRememberCurrentLocation = useCallback(
-    async (options?: { maxAgeMs?: number }) => {
+    async (options?: { maxAgeMs?: number; fresh?: boolean }) => {
       const point = await captureCurrentLocation(options);
       if (auth.userId) {
         const workspace = readLocationWorkspaceMemory(auth.userId);

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -372,6 +372,7 @@ export function NearbyCheckInSheet({
   vaultOwnerToken: string | null;
   captureCurrentPosition: (options?: {
     maxAgeMs?: number;
+    fresh?: boolean;
   }) => Promise<PlainLocationPoint>;
   onOpenChange: (open: boolean) => void;
   onStateChange?: (state: OneLocationNearbyPresenceState) => void;
@@ -1175,9 +1176,10 @@ export function NearbyCheckInSheet({
     let confirmationPoint: PlainLocationPoint | null = null;
     try {
       // The persisted radius anchor must describe where the owner confirms the
-      // check-in, not the earlier point used to load place suggestions — so
-      // this one opts out of the shared capture cache entirely.
-      const freshPoint = await captureCurrentPosition({ maxAgeMs: 0 });
+      // check-in, not the earlier point used to load place suggestions — but a
+      // fix from a few seconds ago describes the same spot, so the tight window
+      // keeps the anchor honest without paying a full acquisition on the press.
+      const freshPoint = await captureCurrentPosition({ fresh: true });
       confirmationPoint = freshPoint;
       if (
         ownerEpochRef.current !== expectedOwnerEpoch ||

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2231,11 +2231,10 @@ function ShareFlow({
     const peopleNoun = selectedReady.length === 1 ? "person" : "people";
     return (
       <div className="space-y-5">
-        <TaskFlowHeader
-          eyebrow="Step 2 of 2 · Confirm"
-          title="Ready to share?"
-          description="Check who can see you and when access ends, then start."
-        />
+        {/* No description: the summary card directly below states who can see
+            you, for how long and when it ends. Repeating that in prose above it
+            is the design explaining itself. */}
+        <TaskFlowHeader eyebrow="Step 2 of 2 · Confirm" title="Ready to share?" />
 
         <SectionCard
           title="Can see you"
@@ -2904,14 +2903,14 @@ function TemporaryLinkFlow({
 
   return (
     <div className="space-y-5">
-      <TaskFlowHeader
-        eyebrow="Share with anyone outside Circle"
-        title="Share outside your Circle"
-        description="Use only when the person is not in your trusted Circle."
-      />
+      {/* The eyebrow, title and description all used to say "outside your
+          Circle", then the warning said "until it expires" and the trust note
+          said it a third time. The consent point is load-bearing here, so it is
+          stated ONCE, in the warning, where it carries the most weight. */}
+      <TaskFlowHeader title="Share outside your Circle" />
       <WarningCard
-        title="Important"
-        description="Anyone with this link can view your location until it expires."
+        title="Anyone with this link can see you"
+        description="Access ends when the link expires."
       />
       <SectionCard title="Duration">
         <DurationSelector
@@ -2927,17 +2926,15 @@ function TemporaryLinkFlow({
         />
       </SectionCard>
       {/* The temporary link shares the same precise point as everything else,
-          so it offers no precision card either. */}
-      <TrustNoteCard
-        title="Expires automatically"
-        description="Public location links are safer when they expire quickly."
-      />
+          so it offers no precision card either. The "expires automatically"
+          note that sat here was the third statement of the same fact — the
+          warning above and the duration control already carry it. */}
       <Button
         onClick={vm.onCreatePublicInvite}
         isLoading={vm.busy === "publicInvite"}
         className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
       >
-        Review public location link
+        Create link
       </Button>
     </div>
   );

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -236,10 +236,10 @@ export function SavedLocationsSection() {
     captureRequestIdRef.current = captureRequestId;
     const session = { userId, vaultKey, vaultOwnerToken };
     try {
-      // Saving a place records where the user is standing right now, so this
-      // reads the device rather than reusing an earlier fix.
+      // Saving a place records where the user is standing right now — a fix
+      // from the last few seconds says the same thing and costs nothing.
       const point = await OneLocationService.captureCurrentPosition({
-        maxAgeMs: 0,
+        fresh: true,
       });
       if (
         captureRequestIdRef.current !== captureRequestId ||
@@ -503,11 +503,11 @@ export function SavedLocationsSection() {
     setSaveLocationAddressLoading(false);
   }, []);
 
-  // "Locate me" inside the map picker — re-center on a fresh GPS fix.
+  // "Locate me" inside the map picker — re-centre on a current fix.
   const locateMeForSavedLocation = useCallback(async () => {
     try {
       const point = await OneLocationService.captureCurrentPosition({
-        maxAgeMs: 0,
+        fresh: true,
       });
       return { latitude: point.latitude, longitude: point.longitude };
     } catch {

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -94,6 +94,23 @@ async function apiJsonWithRetry<T>(
  */
 export const CAPTURE_DEFAULT_MAX_AGE_MS = 20_000;
 
+/**
+ * The window for a caller that needs a fix describing where the user is *now*
+ * — dropping a pin, saving a place, anchoring a check-in.
+ *
+ * Deliberately a few seconds rather than zero. `maxAgeMs: 0` forces a full
+ * device acquisition on every press, and on a laptop with no GPS that is well
+ * over a second of dead time before any UI appears. But a fix taken five
+ * seconds ago is not meaningfully different: at walking pace that is about
+ * seven metres, comfortably inside the 10-35m accuracy the device reports
+ * anyway. So the "fresh" reading and the reused one describe the same place,
+ * and one of them is free.
+ *
+ * Zero is still correct for the live-share publisher — nobody is waiting on it,
+ * and a recipient watching someone move must see the newest fix there is.
+ */
+export const CAPTURE_FRESH_MAX_AGE_MS = 5_000;
+
 /** The most recent fix, reused inside CAPTURE_DEFAULT_MAX_AGE_MS. */
 let lastCapturedPoint: PlainLocationPoint | null = null;
 
@@ -140,8 +157,21 @@ export class OneLocationService {
    */
   static async captureCurrentPosition(options?: {
     maxAgeMs?: number;
+    /**
+     * "I need a fix that describes where the user is right now" — dropping a
+     * pin, saving a place, anchoring a check-in.
+     *
+     * Prefer this over `maxAgeMs: 0` at a call site. It says what the caller
+     * needs rather than a number, and it keeps the freshness policy in one
+     * place. It is also deliberately not importable state: a caller that had to
+     * import a constant from this module would break the moment a test mocked
+     * the module without re-exporting it.
+     */
+    fresh?: boolean;
   }): Promise<PlainLocationPoint> {
-    const maxAgeMs = options?.maxAgeMs ?? CAPTURE_DEFAULT_MAX_AGE_MS;
+    const maxAgeMs =
+      options?.maxAgeMs ??
+      (options?.fresh ? CAPTURE_FRESH_MAX_AGE_MS : CAPTURE_DEFAULT_MAX_AGE_MS);
 
     if (lastCapturedPoint && maxAgeMs > 0) {
       const capturedMs = Date.parse(lastCapturedPoint.capturedAt);


### PR DESCRIPTION
Follow-up to #5238, answering two direct questions: *why is `maxAgeMs` zero at all*, and *why does the copy repeat itself*.

## 1. `maxAgeMs: 0` was over-strict on the click paths

Four CTAs forced a **full device acquisition on every press** — dropping a pin, saving a place, "locate me", and the check-in anchor. On a laptop with no GPS that is well over a second of dead time before any UI appears.

Zero was never the requirement. Those callers need a fix describing where the user is **now** — and a reading from five seconds ago already does. At walking pace that's about **seven metres**, comfortably inside the 10–35m accuracy the device reports anyway. The "fresh" reading and the reused one describe the same place; one of them is free.

They now pass `{ fresh: true }`, which the service maps to a 5s window. **`maxAgeMs: 0` stays exactly where it is still correct** — the live-share publisher, where nobody is waiting and a recipient watching someone move must see the newest fix there is.

### Why `{ fresh: true }` and not an exported constant

I tried the constant first. It broke four test suites immediately: a caller that imports a value from `@/lib/one-location/service` fails the moment a test mocks that module without re-exporting it — **precisely how 57 tests broke on main last week** via `getMapPreferences`.

So the API takes intent at the call site and keeps the policy in one place, with nothing to import. Same trap, permanently closed rather than worked around.

## 2. Copy that said the same thing four times

The public-link screen (the one in QA's screenshot) led with an eyebrow, a title **and** a description all saying *"outside your Circle"*, then warned *"until it expires"*, then repeated expiry a third time in a trust note. Six text blocks, one idea.

Now three. This is a consent screen, so the warning is **not** shortened away — it's stated once and given the prominence it deserves:

| | Before | After |
|---|---|---|
| Header | eyebrow + title + description, all saying "outside your Circle" | `Share outside your Circle` |
| Warning | "Important" / "Anyone with this link can view your location until it expires." | **"Anyone with this link can see you"** / "Access ends when the link expires." |
| Trust note | "Expires automatically" / "Public location links are safer when they expire quickly." | *removed — third statement of the same fact* |
| Button | "Review public location link" | **"Create link"** |

`Important` was a content-free label; the actual warning was underneath it. Promoting the warning to the title makes the consequence the first thing read, not the second.

The confirm step also lost its description — the summary card directly beneath already states who can see you, for how long, and when it ends. Repeating that in prose above it is the design explaining itself.

## Verification

- `typecheck` clean · `lint --max-warnings=0` clean · `verify:design-system` passed
- `test:ci` **branch**: 23 failed / 3592 passed
- `test:ci` **origin/main**: 23 failed / 3592 passed
- Failing sets **byte-identical**; zero regressions

## Note on infrastructure

I previously reported that UAT scales to zero. **That was wrong** — both UAT and prod already run `minInstanceCount: 1` at the service level. I had read the v1 revision-template annotation (`autoscaling.knative.dev/minScale`), which is empty by design; the service-level minimum lives in the Cloud Run v2 service resource. The `--min-instances=0` in `deploy/backend.cloudbuild.yaml` is the *revision*-level setting, deliberately 0 so retired revisions don't pin warm DB pools.

No infra change is needed, and the cold-start theory for the 7–8s reports does not hold.