### PR TITLE
fix(connect): match first name only, not surname, in People search

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -183,6 +183,28 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Page 1")).toBeTruthy();
   });
 
+  it("matches the first name, not the surname, when filtering search results", async () => {
+    // The directory API matches a substring anywhere in the name, so a
+    // search for "R" server-side returns both people below -- one whose
+    // surname happens to start with R, one whose first name does. The
+    // client-side filter must keep only the first-name match.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [person("u1", "Abdul Rashid"), person("u2", "Rashid Ahmed")],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "R" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+
+    expect(await screen.findByText("Rashid Ahmed")).toBeTruthy();
+    expect(screen.queryByText("Abdul Rashid")).toBeNull();
+  });
+
   it("runs a spoken name through the governed Connect search handler", async () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -666,15 +666,16 @@ export default function ConnectPageClient() {
         .toLowerCase();
     // Strict prefix filter. The directory API matches a substring anywhere
     // (`LIKE '%q%'`), so typing "z" returned "Abdul Zalil" and "shankz".
-    // Constrain the rendered list to entries whose NAME (full or any word) or
-    // EMAIL local-part starts with the query, which is what the user expects
-    // from a name search. Applied on top of the server result, so it never
-    // fetches more; it only hides the substring-only matches.
+    // Constrain the rendered list to entries whose FIRST NAME or EMAIL
+    // local-part starts with the query -- matching on the last/middle name
+    // too (as an earlier version of this did) meant searching "r" surfaced
+    // "Abdul Rashid" and "Divya Rajendran" on their surnames, which reads as
+    // random to someone searching by first name. Applied on top of the
+    // server result, so it never fetches more; it only hides non-matches.
     const prefixMatches = (person: DirectoryPerson): boolean => {
       if (!q) return true;
       const name = nameOf(person);
       if (name.startsWith(q)) return true;
-      if (name.split(/\s+/).some((word) => word.startsWith(q))) return true;
       const email = (person.email || "").trim().toLowerCase();
       return email.startsWith(q) || email.split("@")[0]?.startsWith(q) === true;
     };


### PR DESCRIPTION
# Description

Searching "R" in Connect's People search surfaced "Abdul Rashid" and "Divya Rajendran" — both matched on their surname, not their first name, which reads as random results to someone typing a first-name prefix.

The existing client-side prefix filter (already layered on top of the directory API's substring search, from an earlier fix) checked whether **any** word in the name — first or last — started with the query. This narrows it to the first name only. The email-prefix fallback is unchanged.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/connect` (People search filtering only, no new route)

- API / schema / type changes:
  - [x] None — purely client-side filtering on top of the existing directory search response

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — same shared component across web/iOS/Android

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below: this only narrows an existing client-side filter; on any unexpected input it degrades to "fewer matches shown," never a crash or wrong data exposed

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `/connect`; `hushh-webapp/__tests__/app/connect/page-client.test.tsx`

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` (no new errors)
  - [x] `cd hushh-webapp && npm test` — `page-client.test.tsx`: 21/21 passing
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable surface: `app/connect/page-client.tsx`, mounted at `/connect`.
- [x] Reachable production attach point: this is the live People-search filter rendered on the Connect page.
- [x] New test renders the real `ConnectPageClient` component and asserts on rendered DOM text, not a mock standing in for it.
- [x] No new helpers/components introduced — a narrowing of one existing function, plus one new test case.
- [x] Production surface proved: verified locally against a live backend before opening this PR.
- [ ] Required checks are current on this head, commits are signed off (commit is signed off with `-s`), and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — `app/connect/page-client.tsx`
- [x] **iOS**: not separately touched — shared TS component, same bundle
- [x] **Android**: not separately touched — same shared TS component

## 🧪 Testing

- [x] Tested on Web (Chrome, local dev against a live backend)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Verified locally: searching "R" now shows only people whose first name starts with R, not people whose surname does.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it only narrows which already-fetched, already-visible directory rows render for a given query.
- [ ] N/A — no new consent surface
- [x] Sensitive surface touched: none
- [x] Error path / safe-failure behavior proved: narrowing a filter can only ever show fewer results, never expose more

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes