### PR TITLE
perf(one-location): answer Approve and Decline on the press, not after the work

### DIFF
--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -10,7 +10,7 @@
  * No business logic lives here.
  */
 
-import { useId, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 import {
   ChevronDown,
   Clock3,
@@ -195,8 +195,6 @@ export function RequestCard({
   approveLabel = "Approve",
   onApprove,
   onDecline,
-  approveBusy,
-  declineBusy,
 }: {
   name: string;
   promptLine: string;
@@ -204,9 +202,20 @@ export function RequestCard({
   approveLabel?: string;
   onApprove: () => void;
   onDecline: () => void;
-  approveBusy?: boolean;
-  declineBusy?: boolean;
 }) {
+  // Latch the decision on THIS card, the moment it is pressed.
+  //
+  // Two problems this solves. First, `approveBusy` is derived from one global
+  // busy value, so approving a single request put a spinner on EVERY card in
+  // the list. Second, that spinner was held across three sequential server
+  // calls — approve, publish the encrypted point, reload state — none of which
+  // the person is waiting to see. They pressed Approve; the answer is "yes".
+  //
+  // So the card answers immediately and the work continues behind it. The same
+  // latch blocks a second press, which is what makes the optimism safe.
+  const [decision, setDecision] = useState<"approved" | "declined" | null>(null);
+  const decided = decision !== null;
+
   return (
     <div className={cn(SUBCARD_SURFACE, "p-4")}>
       <div className="flex items-center gap-3">
@@ -227,22 +236,42 @@ export function RequestCard({
           {reason}
         </p>
       ) : null}
-      <div className="mt-3.5 flex gap-2.5">
-        <Button
-          onClick={onApprove}
-          isLoading={approveBusy}
-          className="h-11 flex-1 rounded-full bg-[color:var(--app-accent)] text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+      {decided ? (
+        <p
+          role="status"
+          className="mt-3.5 flex h-11 items-center justify-center gap-1.5 rounded-full bg-[color:var(--app-success)]/12 text-sm font-semibold text-[color:var(--app-success)]"
         >
-          {approveLabel}
-        </Button>
-        <Button
-          onClick={onDecline}
-          isLoading={declineBusy}
-          className="h-11 flex-1 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-sm font-semibold text-foreground hover:bg-[color:var(--app-neutral-fill-strong)]/80 dark:bg-white/10"
-        >
-          Decline
-        </Button>
-      </div>
+          <ShieldCheck className="h-[17px] w-[17px]" aria-hidden />
+          {decision === "approved" ? "Approved" : "Declined"}
+        </p>
+      ) : (
+        <div className="mt-3.5 flex gap-2.5">
+          <Button
+            onClick={() => {
+              if (decided) return;
+              setDecision("approved");
+              onApprove();
+            }}
+            disabled={decided}
+            // Deliberately not `isLoading`: the card has already answered. A
+            // spinner here would reintroduce the wait it was pressed to remove.
+            className="h-11 flex-1 rounded-full bg-[color:var(--app-accent)] text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+          >
+            {approveLabel}
+          </Button>
+          <Button
+            onClick={() => {
+              if (decided) return;
+              setDecision("declined");
+              onDecline();
+            }}
+            disabled={decided}
+            className="h-11 flex-1 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-sm font-semibold text-foreground hover:bg-[color:var(--app-neutral-fill-strong)]/80 dark:bg-white/10"
+          >
+            Decline
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1499,8 +1499,6 @@ function LocationDetailFlow({
                 reason={request.message ?? undefined}
                 onApprove={() => vm.onApprove(request)}
                 onDecline={() => vm.onDeny(request.id)}
-                approveBusy={vm.busy === "approve"}
-                declineBusy={vm.busy === "deny"}
               />
             ))}
           </div>


### PR DESCRIPTION
QA: *"yahan approve mein time le rha"*. It did, and the wait was avoidable.

## Two problems, one card

**1. One spinner for the whole list.** `approveBusy` came from a single page-wide `busy` value, so approving ONE request put a spinner on **every** card in the review queue. Nothing was happening to those other requests.

**2. The spinner was held across three sequential server calls** — approve the request, publish the encrypted point, reload the whole workspace. None of which the person is waiting to see. They pressed Approve; the answer is "yes". Making them watch the consequences arrive isn't confirmation, it's delay.

## The fix

The card latches its own decision the moment it's pressed and shows **Approved** / **Declined** immediately, while the work continues behind it. The same latch disables both buttons, so the optimism can't produce a duplicate.

## Why this pattern, and not a faster server

This is exactly what the Ask flow already does — and it's why QA said *"request location sahi se ja rha"* about a control that makes **five** network calls, more than Approve's three. It never felt slow because it never made anyone wait to be told what they had already decided.

Same work. Different answer time.

## Verification

- `typecheck` clean · `lint --max-warnings=0` clean · `verify:design-system` passed
- `test:ci` **branch**: 26 failed / 3609 passed
- `test:ci` **origin/main**: 26 failed / 3609 passed
- Failing sets **byte-identical**; zero regressions

Note: the 2 `one-location-settings-placement.contract` failures are pre-existing on `main` — verified by running that file directly against `origin/main` before touching anything.