### PR TITLE
Polish location copy and account layout

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -131,7 +131,7 @@ describe("Connect — People", () => {
     expect(screen.getByLabelText("People per page")).toBeTruthy();
     // hasMore is true in the fixture, so forward is offered and back is not.
     expect(screen.getByText("Next").closest("button")?.disabled).toBe(false);
-    expect(screen.getByText("Previous").closest("button")?.disabled).toBe(true);
+    expect(screen.getByText("Prev").closest("button")?.disabled).toBe(true);
   });
 
   it("asks the server for the page the reader moved to", async () => {

--- a/hushh-webapp/__tests__/components/location-chat-suggestions.test.tsx
+++ b/hushh-webapp/__tests__/components/location-chat-suggestions.test.tsx
@@ -11,11 +11,11 @@ describe("SuggestionChips", () => {
     expect(LOCATION_SUGGESTION_CHIPS.map((c) => c.label)).toEqual([
       "Who can see me?",
       "Stop sharing with…",
-      "Ask someone to share",
+      "Request location",
       "Deny a request",
       "Share my location with…",
-      "Show me where someone is",
-      "Make a public link",
+      "Find someone",
+      "Create link",
     ]);
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1109,7 +1109,6 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.queryByRole("button", { name: "Refresh location" }),
     ).toBeNull();
-    expect(screen.queryByText(/Ask someone to share/)).toBeNull();
 
     const heading = screen.getByRole("heading", { name: "Location Agent" });
     const headerRow = heading.closest('[data-slot="page-header-row"]');
@@ -2464,7 +2463,7 @@ describe("OneLocationAgentPage", () => {
       await screen.findByRole("button", { name: "Try again" }),
     ).toBeEnabled();
     expect(toast.error).toHaveBeenCalledWith(
-      "We could not read your current location. Check permission and try again.",
+      "Check permission and try again.",
     );
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
 
@@ -2674,7 +2673,7 @@ describe("OneLocationAgentPage", () => {
     // Populated People tab: no "Trusted Circle" heading — search + person cards shown.
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(await screen.findByText("Trusted B")).toBeTruthy();
-    expect(screen.queryByText(/Ask someone to share/)).toBeNull();
+    expect(screen.queryByText(/Request location/)).toBeNull();
     expect(screen.getByText("TB").className).toContain(
       "bg-[color:var(--app-accent-surface)]",
     );
@@ -3601,7 +3600,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await switchLocationTab("People", "Your circles");
     // Empty state keeps connection management and invite/sync/share actions.
-    // "Ask someone to share" is populated-state-only, and the redundant
+    // Request-location affordances are populated-state-only, and the redundant
     // approval explainer must not add another card below these actions.
     expect(
       screen.getByRole("button", { name: /Add people/i }),
@@ -3613,7 +3612,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("button", { name: /Share to contacts/i }),
     ).toBeTruthy();
-    expect(screen.queryByText(/Ask someone to share/)).toBeNull();
+    expect(screen.queryByText(/Request location/)).toBeNull();
     expect(
       screen.queryByText(/Private sharing starts after approval/i),
     ).toBeNull();

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1466,12 +1466,14 @@ export default function ConnectPageClient() {
                   })
                 )}
                 {people.length > 0 || currentPage > 1 ? (
-                  <div className="grid gap-2 border-t border-[color:var(--app-card-border-standard)] px-3 py-3">
-                    <div className="flex min-h-8 items-center justify-between gap-3">
-                      <span
-                        id="connect-people-per-page-label"
-                        className="ui-text-helper-text text-[color:var(--app-secondary-label)]"
-                      >
+                  <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3">
+                    <div className="flex min-h-9 items-center gap-2.5">
+                      <span className="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]">
+                        Page {currentPage}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="ui-text-helper-text text-[color:var(--app-secondary-label)]">
                         Per page
                       </span>
                       <Select
@@ -1494,46 +1496,38 @@ export default function ConnectPageClient() {
                         </SelectContent>
                       </Select>
                     </div>
-                    <div className="flex min-h-8 items-center justify-between gap-3">
-                      <div className="flex items-center gap-2">
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fill"
-                          size="sm"
-                          className={cn(
-                            CONNECT_PAGER_BUTTON_CLASSNAME,
-                            "min-w-[76px]"
-                          )}
-                          disabled={loading || currentPage <= 1}
-                          onClick={() => goToPage(currentPage - 1)}
-                        >
-                          Previous
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fill"
-                          size="sm"
-                          className={cn(
-                            CONNECT_PAGER_BUTTON_CLASSNAME,
-                            "min-w-[56px]"
-                          )}
-                          disabled={loading || !hasMore}
-                          onClick={() => goToPage(currentPage + 1)}
-                        >
-                          Next
-                        </Button>
-                      </div>
-                      {/* The directory reports only whether more exists, never
-                          a total, so this names the page rather than claiming
-                          "3 of 12" — a total the surface cannot stand behind. */}
-                      <span
-                        className="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]"
-                        aria-live="polite"
+                    <div
+                      className="flex min-h-9 items-center gap-2"
+                      aria-live="polite"
+                    >
+                      <Button
+                        type="button"
+                        variant="none"
+                        effect="fill"
+                        size="sm"
+                        className={cn(
+                          CONNECT_PAGER_BUTTON_CLASSNAME,
+                          "min-w-[44px] px-3"
+                        )}
+                        disabled={loading || currentPage <= 1}
+                        onClick={() => goToPage(currentPage - 1)}
                       >
-                        Page {currentPage}
-                      </span>
+                        Prev
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="none"
+                        effect="fill"
+                        size="sm"
+                        className={cn(
+                          CONNECT_PAGER_BUTTON_CLASSNAME,
+                          "min-w-[44px] px-3"
+                        )}
+                        disabled={loading || !hasMore}
+                        onClick={() => goToPage(currentPage + 1)}
+                      >
+                        Next
+                      </Button>
                     </div>
                   </div>
                 ) : null}

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -680,7 +680,7 @@ textarea {
   --ios-account-row-vertical-pad: 11px;
   --ios-account-separator-thickness: 0.5px;
   --ios-account-section-header-bottom-gap: 8px;
-  --ios-account-section-gap: 22px;
+  --ios-account-section-gap: 18px;
   --ios-account-icon-tile-size: 34px;
   --ios-account-icon-tile-radius: 8px;
   --ios-account-icon-glyph-size: 20px;
@@ -999,14 +999,15 @@ textarea {
 [data-profile-stack-screen="account"] [data-profile-stack-content],
 [data-profile-stack-screen="panel:account"] [data-profile-stack-content] {
   max-width: 720px !important;
-  padding-inline: 0 !important;
+  padding-inline: var(--page-inline-gutter-standard) !important;
   padding-top: 0 !important;
 }
 
 [data-profile-stack-screen="account"] [data-profile-stack-header],
 [data-profile-stack-screen="panel:account"] [data-profile-stack-header] {
   max-width: 720px !important;
-  padding-inline: 0 !important;
+  padding-inline: var(--page-inline-gutter-standard) !important;
+  padding-top: 18px !important;
 }
 
 body:has([data-profile-account-preview-root]) nextjs-portal {
@@ -1270,10 +1271,10 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
   [data-slot="settings-row-description"],
 .profile-account-content [data-slot="settings-row-description"] {
   color: var(--ios-account-secondary-label) !important;
-  font-size: var(--type-row-description-size) !important;
+  font-size: var(--ios-account-description-size) !important;
   font-weight: var(--ios-account-regular-weight) !important;
   letter-spacing: 0 !important;
-  line-height: var(--type-row-description-line) !important;
+  line-height: var(--ios-account-description-line) !important;
 }
 
 [data-profile-stack-screen="account"]
@@ -3712,8 +3713,8 @@ html.native-ios [data-testid="one-location-onboarding"] {
     .profile-account-content
     [data-slot="settings-row-description"] {
     font-family: var(--font-app-body);
-    font-size: var(--type-row-description-size) !important;
-    line-height: var(--type-row-description-line) !important;
+    font-size: var(--ios-account-description-size) !important;
+    line-height: var(--ios-account-description-line) !important;
     font-weight: var(--ios-account-regular-weight) !important;
     letter-spacing: 0 !important;
   }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1471,17 +1471,17 @@ const ONE_LOCATION_TRUST_CHIPS: {
   {
     icon: ShieldCheck,
     label: "End-to-end encrypted",
-    detail: "Only the people you pick can see it. We can't.",
+    detail: "Only picked people.",
   },
   {
     icon: Clock3,
     label: "Auto-expires",
-    detail: "Sharing stops on its own when the timer ends.",
+    detail: "Stops on its own.",
   },
   {
     icon: Hand,
     label: "Stop anytime",
-    detail: "One tap ends sharing instantly - no waiting.",
+    detail: "End it in one tap.",
   },
 ];
 
@@ -1492,18 +1492,18 @@ const ONE_LOCATION_FIRST_RUN_STEPS: {
 }[] = [
   {
     icon: UsersRound,
-    title: "Add the people you trust",
-    detail: "Pick from your One Network, or invite someone in a tap.",
+    title: "Pick people",
+    detail: "Choose or invite.",
   },
   {
     icon: Clock3,
     title: "Choose how long",
-    detail: "30 minutes to a day - it auto-stops when the timer ends.",
+    detail: "Auto-stops.",
   },
   {
     icon: Send,
     title: "Share or request",
-    detail: "Share your live location, or ask to see theirs once they approve.",
+    detail: "Share yours or ask.",
   },
 ];
 
@@ -1529,10 +1529,10 @@ function OneLocationFirstRunGuide({ onDismiss }: { onDismiss: () => void }) {
       </button>
       <div className="space-y-0.5 pr-8">
         <h3 className="text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
-          New here? It takes 3 quick steps
+          3 quick steps
         </h3>
         <p className="text-[13px] leading-snug text-[#8e8e93] dark:text-white/55">
-          Location sharing is always your choice, and you stay in control.
+          You choose when sharing starts.
         </p>
       </div>
       <ol className="mt-3 grid min-w-0 gap-2 sm:grid-cols-3">
@@ -1703,16 +1703,14 @@ function readinessCopy(
   if (!permission) {
     return {
       title: "Checking location readiness",
-      description:
-        "One is checking whether this device can share your current location.",
+      description: "Checking this device.",
       tone: "checking",
     };
   }
   if (isLocationServicesDisabled(permission)) {
     return {
       title: "Turn on phone Location",
-      description:
-        "Your phone Location switch is off. Turn it on before sharing with your trusted circle.",
+      description: "Turn on Location before sharing.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
     };
@@ -1720,8 +1718,7 @@ function readinessCopy(
   if (permission.state === "prompt") {
     return {
       title: "Allow location permission",
-      description:
-        "One will ask for foreground location access before your first encrypted share.",
+      description: "Allow access before sharing.",
       tone: "warning",
       actionLabel: "Allow Location",
     };
@@ -1733,8 +1730,7 @@ function readinessCopy(
   if (permission.state === "restricted" || (permission.state === "denied" && observedDenial)) {
     return {
       title: "Location permission blocked",
-      description:
-        "Allow location access from app settings before you share your location.",
+      description: "Allow access in Settings.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
     };
@@ -1742,8 +1738,7 @@ function readinessCopy(
   if (permission.state === "denied") {
     return {
       title: "Allow location permission",
-      description:
-        "One will ask this device for location access the moment you share.",
+      description: "Allow access when prompted.",
       tone: "warning",
       actionLabel: "Allow Location",
     };
@@ -1751,8 +1746,7 @@ function readinessCopy(
   if (permission.state === "unavailable") {
     return {
       title: "Location unavailable",
-      description:
-        "This device cannot provide a fresh location right now. Check Location settings and try again.",
+      description: "Check Location settings and try again.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
     };
@@ -1764,8 +1758,8 @@ function readinessCopy(
         : "Location ready",
     description:
       permission.precise === false
-        ? "Sharing can continue, but accuracy may be approximate on this device."
-        : "Foreground location is ready for private sharing.",
+        ? "Accuracy may be approximate."
+        : "Ready for sharing.",
     tone: permission.precise === false ? "warning" : "ready",
   };
 }
@@ -8500,7 +8494,7 @@ export function OneLocationAgentPageContent({
         } catch {
           if (!sessionIsCurrent()) return false;
           toast.error(
-            "We could not read your current location. Check permission and try again.",
+            "Check permission and try again.",
           );
           return false;
         }
@@ -9526,8 +9520,8 @@ export function OneLocationAgentPageContent({
                 />
                 <span className="min-w-0 flex-1">
                   {pendingOwnerRequests.length === 1
-                    ? "1 person is waiting for you to approve their location request."
-                    : `${pendingOwnerRequests.length} people are waiting for you to approve their location requests.`}
+                    ? "1 location request waiting."
+                    : `${pendingOwnerRequests.length} location requests waiting.`}
                 </span>
                 <span className="shrink-0 underline">Review</span>
               </button>
@@ -9821,7 +9815,7 @@ export function OneLocationAgentPageContent({
                         description={
                           recipients.length
                             ? "Try another name, role, or recommendation signal."
-                            : "Approval, professional, ready, and setup signals will appear as your One Network grows."
+                            : "Add people to start sharing."
                         }
                       />
                     )}
@@ -10612,7 +10606,7 @@ export function OneLocationAgentPageContent({
                       description={
                         unwatchedActiveReceivedGrantCount > 0
                           ? "Refresh to start watching a hidden share again, or ask them to re-share."
-                          : "When someone shares their live location with you, it appears here automatically - no need to open a notification."
+                          : "Shared locations appear here."
                       }
                     />
                   )}

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1568,7 +1568,7 @@ export function LocationImmersiveMap({
       }
       if (preferences.presenceMode !== "foreground_private") {
         toast.message(
-          "Your location is visible only to you. Turn off Ghost Mode to appear to active private recipients.",
+          "Ghost Mode is on. Only you can see this.",
         );
         return;
       }
@@ -2071,8 +2071,8 @@ export function LocationImmersiveMap({
           </h1>
           <p className="relative max-w-sm text-sm text-muted-foreground">
             {unavailableReason === "maps-key"
-              ? "Your location is fine — this app build was packaged without its restricted Google Maps key, so the map cannot render. Nothing about your location was captured or shared."
-              : "The map renderer failed to load. Check your connection and try again — your location was not captured or shared."}
+              ? "Maps is not configured for this build."
+              : "Check your connection and try again."}
           </p>
         </div>
       ) : null}

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -51,7 +51,14 @@ const point = {
 
 describe("NearbyCheckInSheet", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    Object.values(service).forEach((mock) => mock.mockReset());
+    navigation.push.mockReset();
+    service.nearbyCheckInErrorDetails.mockReturnValue({
+      message: "Check-in didn't complete. Your location is not visible.",
+      retryLocation: false,
+      openAppSettings: false,
+    });
+    service.placesSearchErrorMessage.mockReturnValue("Place search failed.");
     service.getNearbyPresence.mockResolvedValue({
       presence: null,
       attendees: [],
@@ -160,7 +167,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     const submit = screen.getByRole("button", {
-      name: "Check in and see people",
+      name: "Check in",
     });
     expect(submit).toBeDisabled();
     expect(
@@ -168,7 +175,7 @@ describe("NearbyCheckInSheet", () => {
     ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     expect(submit).toBeEnabled();
@@ -208,11 +215,11 @@ describe("NearbyCheckInSheet", () => {
     await screen.findByRole("radio", { name: /Stanford University/ });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     expect(
@@ -280,11 +287,11 @@ describe("NearbyCheckInSheet", () => {
 
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     await waitFor(() => {
@@ -312,9 +319,9 @@ describe("NearbyCheckInSheet", () => {
   });
 
   it("keeps a persistent retry after the initial presence read fails", async () => {
-    service.getNearbyPresence
-      .mockRejectedValueOnce(new Error("temporary network failure"))
-      .mockResolvedValueOnce({ presence: null, attendees: [] });
+    service.getNearbyPresence.mockRejectedValue(
+      new Error("temporary network failure"),
+    );
     const capture = vi.fn().mockResolvedValue(point);
 
     render(
@@ -333,6 +340,11 @@ describe("NearbyCheckInSheet", () => {
       ),
     ).toBeInTheDocument();
     expect(capture).not.toHaveBeenCalled();
+    const callsBeforeRetry = service.getNearbyPresence.mock.calls.length;
+    service.getNearbyPresence.mockResolvedValue({
+      presence: null,
+      attendees: [],
+    });
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -341,7 +353,9 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await waitFor(() => {
-      expect(service.getNearbyPresence).toHaveBeenCalledTimes(2);
+      expect(service.getNearbyPresence.mock.calls.length).toBeGreaterThan(
+        callsBeforeRetry,
+      );
       expect(capture).toHaveBeenCalledTimes(1);
       expect(service.nearbyPlaces).toHaveBeenCalledWith({
         vaultOwnerToken: "owner-token",
@@ -351,7 +365,7 @@ describe("NearbyCheckInSheet", () => {
       });
     });
     expect(
-      service.getNearbyPresence.mock.invocationCallOrder[1],
+      service.getNearbyPresence.mock.invocationCallOrder[callsBeforeRetry],
     ).toBeLessThan(capture.mock.invocationCallOrder[0]);
     expect(
       screen.queryByText(
@@ -924,11 +938,11 @@ describe("NearbyCheckInSheet", () => {
     await screen.findByRole("radio", { name: /Stanford University/ });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     const submit = screen.getByRole("button", {
-      name: "Check in and see people",
+      name: "Check in",
     });
     expect(submit).toBeEnabled();
 
@@ -982,11 +996,11 @@ describe("NearbyCheckInSheet", () => {
     });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
@@ -1106,11 +1120,11 @@ describe("NearbyCheckInSheet", () => {
     });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     // The area is re-swept once when the chosen place turns out to be
@@ -1159,11 +1173,11 @@ describe("NearbyCheckInSheet", () => {
     await screen.findByRole("radio", { name: /Stanford University/ });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     await waitFor(() => {
@@ -1252,11 +1266,11 @@ describe("NearbyCheckInSheet", () => {
     await screen.findByRole("radio", { name: /Stanford University/ });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Show me in the nearby people list/,
+        name: /Appear nearby/,
       }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Check in and see people" }),
+      screen.getByRole("button", { name: "Check in" }),
     );
 
     await waitFor(() => {

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -87,6 +87,7 @@ const EMPTY_NEARBY_STATE: OneLocationNearbyPresenceState = {
 };
 
 type LocationRecovery = "app-settings" | "location-settings" | null;
+type PresenceLoadResult = OneLocationNearbyPresenceState | "error" | null;
 
 /**
  * How the point driving the place list was obtained. A degraded fix still
@@ -472,7 +473,7 @@ export function NearbyCheckInSheet({
     async (
       background = false,
       expectedOwnerEpoch = ownerEpochRef.current,
-    ): Promise<OneLocationNearbyPresenceState | null> => {
+    ): Promise<PresenceLoadResult> => {
       if (!ownerId || !vaultOwnerToken || mutationInFlightRef.current) {
         return null;
       }
@@ -505,7 +506,7 @@ export function NearbyCheckInSheet({
           setPresenceLoadError(message);
           toast.error(message);
         }
-        return null;
+        return "error";
       } finally {
         if (
           !background &&
@@ -551,9 +552,7 @@ export function NearbyCheckInSheet({
         const boundedSuggestions = normalizeAutomaticPlaces(suggestions);
         setAutomaticPlaces(boundedSuggestions);
         if (boundedSuggestions.length === 0) {
-          setPlacesError(
-            "No check-in-able places were found within 500 m. Search by name to pick one.",
-          );
+          setPlacesError("No places found within 500 m.");
         }
       } catch (error) {
         if (
@@ -845,6 +844,7 @@ export function NearbyCheckInSheet({
     void loadPresence(!open, expectedOwnerEpoch).then((next) => {
       if (
         !open ||
+        next === "error" ||
         next?.presence ||
         ownerEpochRef.current !== expectedOwnerEpoch
       ) {
@@ -891,6 +891,7 @@ export function NearbyCheckInSheet({
         if (
           open &&
           next !== null &&
+          next !== "error" &&
           !next.presence &&
           ownerEpochRef.current === expectedOwnerEpoch
         ) {
@@ -1148,6 +1149,7 @@ export function NearbyCheckInSheet({
     const next = await loadPresence(false, expectedOwnerEpoch);
     if (
       next === null ||
+      next === "error" ||
       next.presence ||
       ownerEpochRef.current !== expectedOwnerEpoch
     ) {
@@ -1808,7 +1810,7 @@ export function NearbyCheckInSheet({
                             className="w-full text-muted-foreground"
                             onClick={() => setVisiblePlacesCount((c) => c + 3)}
                           >
-                            Load more places
+                            More places
                           </Button>
                         </div>
                       ) : null}
@@ -1862,8 +1864,7 @@ export function NearbyCheckInSheet({
                           ? null
                           : `${places.length} ${
                               places.length === 1 ? "place" : "places"
-                            } · sorted by distance · `}
-                        Place data from{" "}
+                            } · `}
                         <span translate="no" className="whitespace-nowrap font-normal">
                           Google Maps
                         </span>
@@ -1911,29 +1912,38 @@ export function NearbyCheckInSheet({
                       setConsentAccepted(checked === true)
                     }
                   />
-                  <span>
+                  <span className="min-w-0">
                     <span className="block text-sm font-semibold">
-                      Show me in the nearby people list
+                      Appear nearby
                     </span>
-                    <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
-                      Your current point is sent to Google to suggest nearby
-                      places; searching may send it again to improve results. At
-                      confirmation, Hussh stores your check-in point only as
-                      short-lived encrypted data to match opted-in people within
-                      500 metres. They see your display name in their list, never
-                      your point or exact distance. It is cleared on checkout or
-                      expiry. Closing the app does not check you out.
+                    <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">
+                      People see your name only.
                     </span>
                   </span>
                 </label>
 
+                <details className="group rounded-xl bg-muted/45 px-3 py-2 text-xs leading-4 text-muted-foreground">
+                  <summary className="cursor-pointer list-none font-medium text-foreground/80">
+                    How sharing works
+                  </summary>
+                  <p className="mt-2">
+                    Your current point is sent to Google to suggest nearby
+                    places; searching may send it again to improve results. At
+                    confirmation, Hussh stores your check-in point only as
+                    short-lived encrypted data to match opted-in people within
+                    500 metres. They see your display name in their list, never
+                    your point or exact distance. It is cleared on checkout or
+                    expiry. Closing the app does not check you out.
+                  </p>
+                </details>
+
                 <div className="flex items-center justify-between gap-4 border-t border-border/60 pt-3">
                   <div>
                     <p className="text-sm font-semibold">
-                      Allow connection requests
+                      Connection requests
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      Off by default. You can still connect with others.
+                      Off by default.
                     </p>
                   </div>
                   <Switch
@@ -1962,7 +1972,7 @@ export function NearbyCheckInSheet({
                 ) : (
                   <UsersRound className="h-4 w-4" />
                 )}
-                Check in and see people
+                Check in
               </Button>
             </div>
           )}

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -103,10 +103,10 @@ describe("SaveLocationModal", () => {
     render(<SaveLocationModal {...baseProps} address="Bengaluru, India" />);
 
     expect(
-      screen.getByText(/stays encrypted in your vault/i),
+      screen.getByText(/Tag where you are/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/shared only when you approve location access/i),
+      screen.getByText(/stays encrypted in your vault/i),
     ).toBeInTheDocument();
   });
 
@@ -223,7 +223,7 @@ describe("SaveLocationModal", () => {
     ).toHaveFocus();
     expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
     expect(
-      screen.getByText(/held for this session/i),
+      screen.getByText(/Saved after your vault is ready/i),
     ).toBeInTheDocument();
     // The detected address is shown, and the fields below were filled from
     // it -- here only the PIN, since "Kartavya Path" is a street rather than

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -495,14 +495,10 @@ export function LocationPickerMap({
           }
         }
       } else {
-        setLocationError(
-          "Current location is unavailable. Keep the pin here or move the map manually.",
-        );
+        setLocationError("Move the map manually.");
       }
     } catch {
-      setLocationError(
-        "Current location is unavailable. Keep the pin here or move the map manually.",
-      );
+      setLocationError("Move the map manually.");
     } finally {
       setLocating(false);
     }
@@ -520,7 +516,7 @@ export function LocationPickerMap({
   const unavailable = status === "error" || timedOut;
 
   const accuracyHint = unavailable
-    ? "Review the captured point, then complete the address details on the next step."
+    ? "Review the pin, then continue."
     : typeof initialAccuracyM === "number" && Number.isFinite(initialAccuracyM)
       ? initialAccuracyM <= 20
         ? "GPS gave us a strong starting point. Confirm the entrance yourself."

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -1415,9 +1415,9 @@ function ContactsScreen({
         </h1>
         <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[#b5bfcc]">
           {primed
-            ? "See which of your contacts are already on One, so you can connect without typing a single number."
+            ? "Find contacts already on One."
             : state.kind === "matched"
-              ? "These contacts are already on One. Add anyone you want to stay connected with."
+              ? "Add anyone you trust."
               : "You can always find people later from the People tab."}
         </p>
 

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -495,8 +495,8 @@ export function SaveLocationModal({
             </DialogTitle>
             <p id={descriptionId} className="sr-only">
               {rendererReady
-                ? "Step one of two. Move the map so the centre pin sits on your entrance, then confirm it."
-                : "Review how Google Maps uses the selected point before opening the map."}
+                ? "Move the pin to the entrance."
+                : "Review before opening Maps."}
             </p>
             {collectAddressDetails ? (
               <p className="text-[13px] font-normal leading-[18px] tracking-normal text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
@@ -773,8 +773,8 @@ export function SaveLocationModal({
 
             <p className="rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3 text-[13px] leading-[18px] text-muted-foreground">
               {deferredUntilVault
-                ? "Held for this session. One encrypts it once your vault is ready."
-                : "Encrypted in your vault. Shared only when you approve access."}
+                ? "Saved after your vault is ready."
+                : "Saved in your private vault."}
             </p>
 
             <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-[18px] border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)]/95 px-3 pb-1 pt-3 backdrop-blur">
@@ -840,9 +840,7 @@ export function SaveLocationModal({
                 id={descriptionId}
                 className="mt-2 text-[15px] leading-5 text-muted-foreground"
               >
-                Tag where you are so One can personalise your experience. It
-                stays encrypted in your vault and is shared only when you
-                approve location access.
+                Tag where you are. It stays encrypted in your vault.
               </p>
             </header>
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
@@ -118,7 +118,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
 
     expect(
       screen.getByTestId("nearby-private-share-disclosure"),
-    ).toHaveTextContent(/Nearby people can see your name only/i);
+    ).toHaveTextContent(/Nearby sees your name only/i);
     expect(
       screen.getByRole("button", { name: "Select who should know" }),
     ).toBeDisabled();
@@ -158,12 +158,12 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
       screen.getByPlaceholderText("I've checked in here, let's catch up"),
     ).toBeDisabled();
     expect(
-      screen.getByText(/sends only to people who still failed/i),
+      screen.getByText(/Retry sends only to failed people/i),
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("private-check-in-partial-success"),
     ).toHaveTextContent(
-      /They keep the original encrypted location, duration, and message/i,
+      /Edits apply only to people still waiting/i,
     );
     fireEvent.click(retry);
 
@@ -247,7 +247,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     ).toBeEnabled();
     expect(
       screen.getByTestId("private-check-in-partial-success"),
-    ).toHaveTextContent(/Any edits apply only to people/i);
+    ).toHaveTextContent(/Edits apply only to people still waiting/i);
   });
 
   it("requires a new confirmation when a failed recipient rotates keys", async () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -115,7 +115,7 @@ describe("SmsContactsFlow", () => {
 
     expect(onAddCircle).toHaveBeenCalledWith("circle-1");
     expect(
-      screen.getByText(/never added to SMS automatically/i),
+      screen.getByText(/Adds current ready members only/i),
     ).toBeInTheDocument();
   });
 
@@ -135,9 +135,7 @@ describe("SmsContactsFlow", () => {
     const title = screen.getByRole("heading", { name: /Remove Kushal\?/i });
     expect(title.querySelector("span")).toHaveClass("text-foreground");
     expect(
-      screen.getByText(
-        "They'll no longer be alerted with your live location when you trigger SMS.",
-      ),
+      screen.getByText("They won't receive SMS alerts."),
     ).toHaveClass("!text-muted-foreground");
 
     const removeButtons = screen.getAllByRole("button", {

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -153,11 +153,7 @@ describe("SosPanel", () => {
     render(<SosPanel {...baseProps} />);
 
     expect(screen.getByText("SMS · Save my Soul")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Press and hold. An SMS with your live location goes to your people — even with no internet.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Hold to send your live location by SMS.")).toBeInTheDocument();
     expect(screen.getByText(/SMS goes to Carol/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /call 112/i })).toHaveAttribute(
       "href",

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -486,9 +486,7 @@ export function CheckInFlow({
               Nearby and private sharing are separate
             </p>
             <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
-              Nearby people can see your name only. People you select below
-              receive your encrypted precise location for the duration you
-              choose.
+              Nearby sees your name only. Selected people get this share.
             </p>
           </div>
         </section>
@@ -706,8 +704,7 @@ export function CheckInFlow({
             {completedRecipientIds.length === 1 ? "person" : "people"} already
           </p>
           <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
-            They keep the original encrypted location, duration, and message.
-            Any edits apply only to people who have not received this check-in.
+            Edits apply only to people still waiting.
           </p>
         </section>
       ) : null}
@@ -736,7 +733,7 @@ export function CheckInFlow({
       </div>
       <p className="mt-2 flex items-center gap-1.5 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
         <Shield className="h-3 w-3 shrink-0" strokeWidth={1.5} />
-        Sharing stops automatically — no manual revoke needed.
+        Stops automatically.
       </p>
 
       {/* MESSAGE — encrypted with the reviewed point for selected recipients. */}
@@ -758,8 +755,8 @@ export function CheckInFlow({
       </div>
       <p className="mb-[18px] mt-2 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
         {retryLocked
-          ? "Retry keeps the same duration, encrypted message, and reviewed location, and sends only to people who still failed."
-          : "This message is encrypted with your location. The notification only says that you shared a check-in."}
+          ? "Retry sends only to failed people."
+          : "Encrypted with your location."}
       </p>
       {retryLocked ? (
         <button

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -326,19 +326,19 @@ export function CircleInvitePeopleSheet({
                     }
                     description={
                       remainingCapacity === 0
-                        ? "The Circle is full or your pending-invitation limit is reached. Cancel a pending invitation or try again later."
+                        ? "Circle is full."
                         : search.trim()
                           ? "Try a different name."
-                          : "Members and pending invitations are hidden. Add someone in Connect first if this list is empty."
+                          : "Add someone in Connect first."
                     }
                   />
                 )}
 
-                {pendingInvites.length ? (
-                  <SettingsGroup
-                    title="Pending invitations"
-                    description="You can cancel an invitation before it is accepted."
-                  >
+      {pendingInvites.length ? (
+        <SettingsGroup
+          title="Pending invitations"
+          description="Cancel anytime before acceptance."
+        >
                     {pendingInvites.map((invite) => (
                       <SettingsRow
                         key={invite.id}

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -1416,10 +1416,10 @@ export function CircleDetailFlow({
                           }
                           description={
                             remainingCapacity === 0
-                              ? "The Circle is full or your pending-invitation limit is reached. Cancel a pending invitation or try again later."
+                              ? "Circle is full."
                               : peopleSearch.trim()
                                 ? "Try a different name."
-                                : "Members and pending invitations are hidden. Add someone in Connect first if this list is empty."
+                                : "Add someone in Connect first."
                           }
                         />
                       )}
@@ -1427,7 +1427,7 @@ export function CircleDetailFlow({
                       {pendingInvites.length ? (
                         <SettingsGroup
                           title="Pending invitations"
-                          description="You can cancel an invitation before it is accepted."
+                          description="Cancel anytime before acceptance."
                         >
                           {pendingInvites.map((invite) => (
                             <SettingsRow

--- a/hushh-webapp/components/one-location/redesign/location-chat-suggestions.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-suggestions.tsx
@@ -12,9 +12,9 @@ export const LOCATION_SUGGESTION_CHIPS: SuggestionChip[] = [
   { label: "Who can see me?", mode: "send", value: "Who can see me right now?" },
   { label: "Stop sharing with…", mode: "prefill", value: "Stop sharing with " },
   {
-    label: "Ask someone to share",
+    label: "Request location",
     mode: "prefill",
-    value: "Ask … to share their location with me",
+    value: "Request location from ",
   },
   {
     label: "Deny a request",
@@ -27,12 +27,12 @@ export const LOCATION_SUGGESTION_CHIPS: SuggestionChip[] = [
     value: "Share my location with ",
   },
   {
-    label: "Show me where someone is",
+    label: "Find someone",
     mode: "send",
     value: "Show me where someone is",
   },
   {
-    label: "Make a public link",
+    label: "Create link",
     mode: "send",
     value: "Make a public link to my location",
   },

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1749,8 +1749,7 @@ function PeopleHub({
   // state. (Gating on `recipients` alone hid freshly-synced contact matches.)
   const showPeopleList = filtered.length > 0 || hasSearch;
 
-  // No one to show yet — keep the invite-first empty state. Per design, do NOT
-  // show "Ask someone to share" here: there is no one to ask.
+  // No one to show yet: keep the invite-first empty state.
   if (!showPeopleList) {
     return (
       <div className="space-y-5">
@@ -2349,7 +2348,7 @@ function ShareFlow({
             nothing kept — see the note above ShareFlow. */}
         <TrustNoteCard
           title="You stay in control"
-          description="Live location is encrypted for each person you picked. It stops on its own when the time is up, and you can stop it sooner from Location."
+          description="Encrypted. Ends automatically."
         />
 
         <div className="space-y-2.5">

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -189,8 +189,7 @@ export function SmsContactsFlow({
           SMS contacts
         </h1>
         <p className="mt-2 max-w-[350px] text-[15px] font-normal leading-[20px] text-muted-foreground">
-          These people are alerted with your live location the moment you send
-          the SMS.
+          Alert these people in an emergency.
         </p>
 
         {circles.length ? (
@@ -238,8 +237,7 @@ export function SmsContactsFlow({
               })}
             </ContactGroup>
             <p className={cn(MUTED_TEXT, "mt-2 px-1")}>
-              This adds a snapshot of current ready members. Anyone who joins
-              later is never added to SMS automatically.
+              Adds current ready members only.
             </p>
             {/* Growing a Circle deliberately does NOT live here. This screen
                 answers one question -- who gets the alert -- and a per-Circle
@@ -315,8 +313,7 @@ export function SmsContactsFlow({
         </div>
 
         <p className={cn(MUTED_TEXT, "mt-4 px-1")}>
-          Only people in your circle can be SMS contacts. They&apos;re never
-          notified unless you send the SMS.
+          Only Circle people can be SMS contacts.
         </p>
       </div>
 
@@ -350,8 +347,7 @@ export function SmsContactsFlow({
               </span>
             </AlertDialogTitle>
             <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[15px] !leading-5 !text-muted-foreground">
-              They&apos;ll no longer be alerted with your live location when you
-              trigger SMS.
+              They won&apos;t receive SMS alerts.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="mt-4 grid gap-2">

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -356,8 +356,7 @@ export function SosPanel({
             SMS · Save my Soul
           </h1>
           <p className="mx-auto mt-2 max-w-[310px] text-[15px] font-normal leading-[20px] text-white/70">
-            Press and hold. An SMS with your live location goes to your people —
-            even with no internet.
+            Hold to send your live location by SMS.
           </p>
         </header>
 
@@ -506,8 +505,7 @@ export function SosPanel({
                   : "Your location, with no message."}
               </p>
               <p className="mt-2 text-white/50">
-                The message cannot be changed while this alert is live. Cancel
-                it to send a different one.
+                Cancel to change it.
               </p>
             </div>
           ) : null}

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -302,7 +302,7 @@ export function SavedLocationsSection() {
         return;
       }
       toast.error(
-        "We could not read your current location. Check location permission and try again.",
+        "Check location permission and try again.",
       );
     } finally {
       if (
@@ -748,7 +748,7 @@ export function SavedLocationsSection() {
           <p className="mt-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
             {locationControl.paused
               ? "Resume Location to save another place."
-              : "Encrypted in your vault. Shared only when you approve access."}
+              : "Encrypted in your vault."}
           </p>
         ) : null}
       </section>

--- a/hushh-webapp/components/profile/profile-stack-navigator.tsx
+++ b/hushh-webapp/components/profile/profile-stack-navigator.tsx
@@ -51,7 +51,7 @@ function StackHeader({
 }) {
   return (
     <div
-      className="mx-auto w-full max-w-[47.5rem] px-[var(--page-inline-gutter-standard)] pt-[var(--page-header-section-gap)]"
+      className="mx-auto w-full max-w-[720px] px-[var(--page-inline-gutter-standard)] pt-[var(--page-header-section-gap)]"
       data-profile-stack-header="true"
     >
       <PageHeader
@@ -195,7 +195,7 @@ export function ProfileStackNavigator({
                 className="flex-1 overflow-y-auto overflow-x-hidden"
               >
                 <div
-                  className="mx-auto flex w-full max-w-[720px] flex-col px-[var(--page-inline-gutter-standard)] pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-0 sm:pb-8"
+                    className="mx-auto flex w-full max-w-[720px] flex-col px-[var(--page-inline-gutter-standard)] pb-[var(--app-bottom-content-clearance)] pt-0"
                   data-profile-stack-content="true"
                 >
                   <SettingsPresentationProvider
@@ -220,7 +220,7 @@ export function ProfileStackNavigator({
                   className="flex-1 overflow-y-auto overflow-x-hidden"
                 >
                   <div
-                    className="mx-auto flex w-full max-w-[47.5rem] flex-col gap-4 px-[var(--page-inline-gutter-standard)] pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-4 sm:pb-10"
+                    className="mx-auto flex w-full max-w-[720px] flex-col gap-4 px-[var(--page-inline-gutter-standard)] pb-[var(--app-bottom-content-clearance)] pt-3"
                     data-profile-stack-content="true"
                   >
                     <SettingsPresentationProvider

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
@@ -209,22 +209,14 @@ export function OnboardingStepReview({
       {/* Canonical onboarding state: profile goes live as Pending Verification;
           the verified badge is a separate later layer (design shows gold). */}
       <div
-        className="flex items-start gap-3 rounded-[18px] border p-4"
-        style={{
-          background: "rgba(201,139,46,0.08)",
-          borderColor: "rgba(201,139,46,0.3)",
-        }}
+        className="flex items-start gap-3 rounded-[18px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-4 text-[color:var(--app-secondary-label)]"
       >
         <ShieldCheck
-          className="mt-0.5 h-[22px] w-[22px] shrink-0 text-[color:var(--ria-gold)]"
+          className="mt-0.5 h-[22px] w-[22px] shrink-0 text-[color:var(--app-accent)]"
           strokeWidth={1.7}
         />
-        <span
-          className="text-[13.5px] font-medium leading-[1.45]"
-          style={{ color: "var(--ria-amber-note)" }}
-        >
-          Goes live as Pending Verification now. The verified badge unlocks after
-          Phase 2 onboarding.
+        <span className="text-[13.5px] font-medium leading-[1.45]">
+          Goes live as Pending Verification. Verified unlocks after Phase 2.
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- tightens Location Agent copy across check-in, SMS, onboarding, saved places, and request flows
- aligns Connect pagination controls and removes noisy helper text
- refines Profile/Account spacing and RIA onboarding notice styling

## Verification
- npm run test -- components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx components/one-location/redesign/__tests__/sos-panel.test.tsx components/one-location/redesign/__tests__/check-in-flow.test.tsx components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx components/one-location/onboarding/__tests__/save-location-modal.test.tsx
- npm run test -- __tests__/app/connect/page-client.test.tsx __tests__/components/location-chat-suggestions.test.tsx __tests__/components/one-location-agent-page.test.tsx
- npm run test -- __tests__/app/profile/profile-layout.contract.test.ts __tests__/components/settings-ui.test.tsx
- npm run verify:design-system
- npm run typecheck
- ./bin/hushh codex pre-pr