### PR TITLE
fix(gemini): sanitize thinking level for gemini 3.x flash generation config

### DIFF
--- a/consent-protocol/hushh_mcp/runtime_providers/gemini_config.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/gemini_config.py
@@ -41,12 +41,42 @@ def is_gemini_flash_v3(model: str | None) -> bool:
     }
 
 
+def _sanitize_thinking_config_for_flash_v3(thinking_cfg: Any) -> Any:
+    if thinking_cfg is None:
+        return None
+    if isinstance(thinking_cfg, dict):
+        cleaned = {k: v for k, v in thinking_cfg.items() if k != "thinking_level" and v is not None}
+        return cleaned or None
+    if hasattr(thinking_cfg, "thinking_level"):
+        include_thoughts = getattr(thinking_cfg, "include_thoughts", None)
+        thinking_budget = getattr(thinking_cfg, "thinking_budget", None)
+        thinking_type = type(thinking_cfg)
+        kwargs_tc: dict[str, Any] = {}
+        if include_thoughts is not None:
+            kwargs_tc["include_thoughts"] = include_thoughts
+        if thinking_budget is not None:
+            kwargs_tc["thinking_budget"] = thinking_budget
+        if kwargs_tc:
+            try:
+                return thinking_type(**kwargs_tc)
+            except Exception:
+                return None
+        return None
+    return thinking_cfg
+
+
 def generation_config_kwargs(model: str | None, **kwargs: Any) -> dict[str, Any]:
     """Return provider-compatible kwargs without changing non-3.x flash callers."""
     result = {key: value for key, value in kwargs.items() if value is not None}
     if is_gemini_flash_v3(model):
         for field in _GEMINI_FLASH_UNSUPPORTED_FIELDS:
             result.pop(field, None)
+        if "thinking_config" in result:
+            sanitized = _sanitize_thinking_config_for_flash_v3(result["thinking_config"])
+            if sanitized is not None:
+                result["thinking_config"] = sanitized
+            else:
+                result.pop("thinking_config", None)
     return result
 
 

--- a/consent-protocol/tests/test_one_runtime_configuration.py
+++ b/consent-protocol/tests/test_one_runtime_configuration.py
@@ -73,7 +73,8 @@ async def test_gemini_validation_proves_generation_quota(monkeypatch: pytest.Mon
     assert call.kwargs["model"] == "gemini-3.7-flash"
     assert call.kwargs["contents"] == "Reply OK."
     assert call.kwargs["config"].max_output_tokens == 4
-    assert call.kwargs["config"].thinking_config.thinking_level.value == "MINIMAL"
+    assert call.kwargs["config"].thinking_config.include_thoughts is False
+    assert getattr(call.kwargs["config"].thinking_config, "thinking_level", None) is None
     assert call.kwargs["config"].temperature is None
 
 


### PR DESCRIPTION
## Summary
- Sanitize thinking_level for Gemini 3.x Flash generation config to ensure Vertex ADC readiness probe succeeds.
- Preserve include_thoughts and token budgets while stripping unsupported thinking_level values.