### PR TITLE
fix(UI): Load all places at once in nearby check-in

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1472,7 +1472,7 @@ export default function ConnectPageClient() {
                               disabled={cta.disabled || busyId === person.userId}
                               onClick={() => void handleConnect(person)}
                             >
-                              {busyId === person.userId ? "Sending…" : cta.label}
+                              {busyId === person.userId ? "Sending..." : cta.label}
                             </Button>
                           )
                         }

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -1808,9 +1808,9 @@ export function NearbyCheckInSheet({
                             variant="ghost"
                             size="sm"
                             className="w-full text-muted-foreground"
-                            onClick={() => setVisiblePlacesCount((c) => c + 3)}
+                            onClick={() => setVisiblePlacesCount(places.length)}
                           >
-                            More places
+                            Show all places
                           </Button>
                         </div>
                       ) : null}


### PR DESCRIPTION
## Description
This PR updates the "Nearby Check-in" feature to immediately load all available places when expanded, instead of trickling them in three at a time. 

## Changes
- Changed the `onClick` handler in `nearby-check-in-sheet.tsx` to set the visible places count to `places.length` instead of incrementing by 3.
- Renamed the button from **"More places"** to **"Show all places"** for better clarity.