### PR TITLE
fix(one-location): declutter the People tab and fix its action layout

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -3477,10 +3477,17 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    // The populated People tab exposes a compact "Share to contacts" action.
-    fireEvent.click(screen.getByRole("button", { name: "People" }));
+    // Public links live on the Links tab. The People tab used to carry a
+    // duplicate "Share to contacts" that minted the same artifact; this is the
+    // one remaining path, and it must still create the invite.
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+    // Links hub CTA opens the flow; the flow's own CTA creates the invite.
+    // Both are labelled "Create link", so take the one on screen each time.
     fireEvent.click(
-      await screen.findByRole("button", { name: /Share to contacts/i }),
+      await screen.findByRole("button", { name: /^Create link$/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Create link$/i }),
     );
 
     await waitFor(() =>
@@ -3497,6 +3504,72 @@ describe("OneLocationAgentPage", () => {
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
     );
+  });
+
+  it("puts the search directly above the list it filters and drops the public-link CTA", async () => {
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await switchLocationTab("People", "Your circles");
+
+    const search = await screen.findByPlaceholderText("Search trusted people");
+    const person = await screen.findByText("Trusted B");
+
+    // The search input used to be separated from its own results by four
+    // buttons, which read as page search rather than list search. Nothing
+    // focusable may sit between the field and the list it filters.
+    expect(
+      search.compareDocumentPosition(person) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    const between = Array.from(
+      document.querySelectorAll("button, a[href], input, textarea, select"),
+    ).filter(
+      (el) =>
+        el !== search &&
+        search.compareDocumentPosition(el) &
+          Node.DOCUMENT_POSITION_FOLLOWING &&
+        person.compareDocumentPosition(el) &
+          Node.DOCUMENT_POSITION_PRECEDING,
+    );
+    expect(between).toHaveLength(0);
+
+    // "Share to contacts" minted a PUBLIC link — the Links tab's artifact, not
+    // something that belongs beside named, trusted people.
+    expect(
+      screen.queryByRole("button", { name: /Share to contacts/i }),
+    ).toBeNull();
+    // The three that remain each carry a different weight, so the common one
+    // reads as the default rather than one of four equal choices.
+    expect(screen.getByRole("button", { name: /Add people/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Invite$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
+  });
+
+  it("offers Create and Join with code straight under the circles heading", async () => {
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await switchLocationTab("People", "Your circles");
+
+    const section = screen.getByTestId("one-location-named-circles");
+    const heading = within(section).getByRole("heading", {
+      name: "Your circles",
+    });
+    const create = within(section).getByRole("button", { name: /^Create$/i });
+    const join = within(section).getByRole("button", {
+      name: /Join with code/i,
+    });
+
+    // Structural, not "somewhere after": the heading block is the section's
+    // first child and the actions are its second, so the pair cannot drift back
+    // below the circle list — where a long list stranded them past a scroll,
+    // exactly when someone had enough circles to need them.
+    expect(section.children[0]).toContainElement(heading);
+    expect(section.children[1]).toContainElement(create);
+    expect(section.children[1]).toContainElement(join);
   });
 
   it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
@@ -3609,9 +3682,12 @@ describe("OneLocationAgentPage", () => {
       screen.getByRole("button", { name: /^Invite$/i }),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
+    // "Share to contacts" is deliberately absent: it minted a PUBLIC link,
+    // which is the Links tab's job, not a control belonging beside named
+    // trusted people.
     expect(
-      screen.getByRole("button", { name: /Share to contacts/i }),
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: /Share to contacts/i }),
+    ).toBeNull();
     expect(screen.queryByText(/Request location/)).toBeNull();
     expect(
       screen.queryByText(/Private sharing starts after approval/i),

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -9296,7 +9296,6 @@ export function OneLocationAgentPageContent({
     onRequestPermission: () => void handleRequestLocationPermission(),
     onOpenLocationSettings: () => void handleOpenLocationSettings(),
     onSyncContacts: () => void handleSyncContactSignal(),
-    onShareToContacts: () => void handleShareContactInvite(),
     onOpenShareReview: () => void handleOpenShareReview(),
     onEnterShareConfirm: announceShareReviewOpened,
     onConfirmShare: () => void handleShare(),

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -185,15 +185,41 @@ export function CirclesSection({
 
   return (
     <div className="space-y-3" data-testid="one-location-named-circles">
-      <div className="flex items-center justify-between gap-3 px-1">
-        <div>
-          <h2 className={SECTION_TITLE}>
-            Your circles
-          </h2>
-          <p className={cn(MUTED_TEXT, "mt-1")}>
-            Family and friends you choose to group together.
-          </p>
-        </div>
+      <div className="px-1">
+        <h2 className={SECTION_TITLE}>
+          Your circles
+        </h2>
+        <p className={cn(MUTED_TEXT, "mt-1")}>
+          Family and friends you choose to group together.
+        </p>
+      </div>
+
+      {/* Directly under the heading rather than below the list: these two are
+          how the section is USED, and stranding them past a scrolling list of
+          circles hid them exactly when someone had enough circles to scroll.
+          Stacked on phones, natural width in a row once there is space — the
+          hub column is unbounded, so full-width pills would run the width of a
+          desktop window. */}
+      <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
+        <Button
+          type="button"
+          onClick={onCreate}
+          data-voice-control-id="one-location-action-create-circle"
+          className="h-11 w-full rounded-full font-semibold sm:w-auto sm:px-6"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Create
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onJoin}
+          data-voice-control-id="one-location-action-join-circle"
+          className="h-11 w-full rounded-full font-semibold sm:w-auto sm:px-6"
+        >
+          <KeyRound className="mr-2 h-4 w-4" />
+          Join with code
+        </Button>
       </div>
 
       {incomingInvitesError ? (
@@ -344,28 +370,6 @@ export function CirclesSection({
           description="Create one for family or friends, or join with a code."
         />
       )}
-
-      <div className="grid grid-cols-2 gap-2">
-        <Button
-          type="button"
-          onClick={onCreate}
-          data-voice-control-id="one-location-action-create-circle"
-          className="h-11 rounded-full font-semibold"
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Create
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onJoin}
-          data-voice-control-id="one-location-action-join-circle"
-          className="h-11 rounded-full font-semibold"
-        >
-          <KeyRound className="mr-2 h-4 w-4" />
-          Join with code
-        </Button>
-      </div>
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -82,7 +82,7 @@ import {
   TrustNoteCard,
   WarningCard,
 } from "./primitives";
-import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
+import { MUTED_TEXT, SECTION_TITLE, SUBCARD_SURFACE } from "./tokens";
 import {
   initialsFrom,
   RequestCard,
@@ -278,7 +278,6 @@ export type LocationHubViewModel = {
   onRequestPermission: () => void;
   onOpenLocationSettings: () => void;
   onSyncContacts: () => void;
-  onShareToContacts: () => void;
   /** Legacy composer only: pre-flights device permission, then opens review. */
   onOpenShareReview: () => void;
   /**
@@ -1142,6 +1141,20 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   );
 }
 
+/**
+ * People-tab action row: stacked on phones, an inline row from `sm` up.
+ *
+ * The hub column is unbounded, so `w-full` buttons grew to the width of a
+ * desktop window — three pills spanning 1200px read as bulk, not as choices.
+ * From `sm` they size to their own label and sit left-aligned, which is also
+ * what keeps the iOS build from looking like a stack of banners on iPad.
+ * `flex-wrap` means a long localized label moves to the next line instead of
+ * squeezing its neighbours.
+ */
+const PEOPLE_ACTION_ROW = "flex flex-col gap-2.5 sm:flex-row sm:flex-wrap";
+/** Full-bleed thumb target on phones; natural width once there is room. */
+const PEOPLE_ACTION_BUTTON = "h-11 w-full font-medium sm:w-auto sm:px-5";
+
 function LocationHubPanel({ children }: { children: ReactNode }) {
   return (
     <div className="space-y-4 px-[var(--page-inline-gutter-standard)]">
@@ -1776,48 +1789,41 @@ function PeopleHub({
           title="Connections"
           description="People ready for sharing."
         >
-          {/* Symmetric action layout with generous breathing room: a 2-col
-              primary row (Add / Invite) over a matching 2-col contact row
-              (Sync / Share), uniform h-12 buttons and gap-3.5 spacing. On
-              narrow phones the primary row collapses to one column. */}
-          <div className="space-y-3.5">
-            <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-              <Button
-                onClick={onAddConnections}
-                data-voice-control-id="one-location-add-connections"
-                className="h-12 w-full font-medium"
-              >
-                <UsersRound className="mr-2 h-4 w-4" />
-                Add people
-              </Button>
-              <Button
-                variant="outline"
-                onClick={onInvite}
-                data-voice-control-id="one-location-action-invite"
-                className="h-12 w-full font-medium"
-              >
-                <UserPlus className="mr-2 h-4 w-4" />
-                Invite
-              </Button>
-            </div>
-            <div className="grid grid-cols-2 gap-3.5">
-              <Button
-                variant="outline"
-                onClick={vm.onSyncContacts}
-                isLoading={vm.busy === "contactSync"}
-                className="h-12 w-full font-medium"
-              >
-                Sync contacts
-              </Button>
-              <Button
-                variant="outline"
-                onClick={vm.onShareToContacts}
-                isLoading={vm.busy === "contactInvite"}
-                className="h-12 w-full font-medium"
-              >
-                Share to contacts
-              </Button>
-            </div>
+          {/* Identical set, order and weights to the populated tab, so the
+              screen does not rearrange itself the moment a first connection
+              lands. */}
+          <div className={PEOPLE_ACTION_ROW}>
+            <Button
+              onClick={onAddConnections}
+              data-voice-control-id="one-location-add-connections"
+              className={PEOPLE_ACTION_BUTTON}
+            >
+              <UsersRound className="mr-2 h-4 w-4" />
+              Add people
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onInvite}
+              data-voice-control-id="one-location-action-invite"
+              className={cn(
+                PEOPLE_ACTION_BUTTON,
+                "border-[color:var(--app-accent)] text-[color:var(--app-accent)]",
+              )}
+            >
+              <UserPlus className="mr-2 h-4 w-4" />
+              Invite
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={vm.onSyncContacts}
+              isLoading={vm.busy === "contactSync"}
+              className={cn(
+                PEOPLE_ACTION_BUTTON,
+                "text-[color:var(--app-accent)] hover:text-[color:var(--app-accent)]",
+              )}
+            >
+              Sync contacts
+            </Button>
           </div>
         </SectionCard>
       </div>
@@ -1845,101 +1851,105 @@ function PeopleHub({
         onDismissFocusedInvite={onDismissFocusedInvite}
       />
 
-      <PersonSearchInput
-        value={vm.recipientSearch}
-        onChange={vm.setRecipientSearch}
-      />
-
-      {/* Compact circle-management actions. Invite adds people; "Sync contacts"
-          tags which existing connections are in your phone contacts. Symmetric
-          2-col rows with gap-3.5 and uniform h-12 buttons for breathing room. */}
-      <div className="space-y-3.5">
-        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-          <Button
-            onClick={onAddConnections}
-            data-voice-control-id="one-location-add-connections"
-            className="h-12 w-full font-medium"
-          >
-            <UsersRound className="mr-2 h-4 w-4" />
-            Add people
-          </Button>
-          <Button
-            variant="outline"
-            onClick={onInvite}
-            data-voice-control-id="one-location-action-invite"
-            className="h-12 w-full font-medium border-[color:var(--app-accent)] text-[color:var(--app-accent)]"
-          >
-            <UserPlus className="mr-2 h-4 w-4" />
-            Invite
-          </Button>
-        </div>
-        <div className="grid grid-cols-2 gap-3.5">
-          <Button
-            variant="outline"
-            onClick={vm.onSyncContacts}
-            isLoading={vm.busy === "contactSync"}
-            className="h-12 w-full font-medium"
-          >
-            Sync contacts
-          </Button>
-          <Button
-            variant="outline"
-            onClick={vm.onShareToContacts}
-            isLoading={vm.busy === "contactInvite"}
-            className="h-12 w-full font-medium"
-          >
-            Share to contacts
-          </Button>
-        </div>
+      {/* Three actions, one weight each — filled, outlined, quiet — so the
+          common one is obvious and the rest do not compete. "Share to contacts"
+          used to sit here as a fourth; it minted a PUBLIC link, the same
+          artifact the Links tab creates and viewable by anyone holding the URL,
+          which is the opposite of what every other control on a tab about
+          named, trusted people does. Links owns it. */}
+      <div className={PEOPLE_ACTION_ROW}>
+        <Button
+          onClick={onAddConnections}
+          data-voice-control-id="one-location-add-connections"
+          className={PEOPLE_ACTION_BUTTON}
+        >
+          <UsersRound className="mr-2 h-4 w-4" />
+          Add people
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onInvite}
+          data-voice-control-id="one-location-action-invite"
+          className={cn(
+            PEOPLE_ACTION_BUTTON,
+            "border-[color:var(--app-accent)] text-[color:var(--app-accent)]",
+          )}
+        >
+          <UserPlus className="mr-2 h-4 w-4" />
+          Invite
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={vm.onSyncContacts}
+          isLoading={vm.busy === "contactSync"}
+          className={cn(
+            PEOPLE_ACTION_BUTTON,
+            "text-[color:var(--app-accent)] hover:text-[color:var(--app-accent)]",
+          )}
+        >
+          Sync contacts
+        </Button>
       </div>
 
-      {filtered.length ? (
-        <div className={cn("overflow-hidden", SUBCARD_SURFACE)}>
-          {filtered.map((r, i) => {
-            const grant = vm.activeOwnerGrants.find(
-              (g) => g.recipientUserId === r.userId,
-            );
-            const sharing = Boolean(grant);
-            const receiving = vm.receivedGrants.some(
-              (g) => g.ownerUserId === r.userId,
-            );
-            const ready = vm.isRecipientShareReady(r);
-            return (
-              <PersonRow
-                key={r.userId}
-                name={vm.recipientLabel(r)}
-                subtitle={vm.recipientSubtitle(r)}
-                active={sharing || receiving}
-                first={i === 0}
-                action={
-                  sharing && grant ? (
-                    <Button
-                      variant="outline"
-                      onClick={() => vm.onStopGrant(grant.id)}
-                      isLoading={vm.revokingGrantId === grant.id}
-                      className="h-9 rounded-full border-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent)]"
-                    >
-                      Stop
-                    </Button>
-                  ) : ready ? (
-                    <Button
-                      onClick={() => onStartShare(r.userId)}
-                      className="h-9 rounded-full bg-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-                    >
-                      Share
-                    </Button>
-                  ) : null
-                }
-              />
-            );
-          })}
-        </div>
-      ) : (
-        <EmptyState
-          title="No matching people"
-          description="Try a different name."
+      {/* Search now sits directly on top of the list it filters. It used to be
+          separated from its own results by four buttons, which read as page
+          search rather than list search. */}
+      <div className="space-y-3">
+        <h2 className={cn(SECTION_TITLE, "px-1")}>Connections</h2>
+
+        <PersonSearchInput
+          value={vm.recipientSearch}
+          onChange={vm.setRecipientSearch}
         />
-      )}
+
+        {filtered.length ? (
+          <div className={cn("overflow-hidden", SUBCARD_SURFACE)}>
+            {filtered.map((r, i) => {
+              const grant = vm.activeOwnerGrants.find(
+                (g) => g.recipientUserId === r.userId,
+              );
+              const sharing = Boolean(grant);
+              const receiving = vm.receivedGrants.some(
+                (g) => g.ownerUserId === r.userId,
+              );
+              const ready = vm.isRecipientShareReady(r);
+              return (
+                <PersonRow
+                  key={r.userId}
+                  name={vm.recipientLabel(r)}
+                  subtitle={vm.recipientSubtitle(r)}
+                  active={sharing || receiving}
+                  first={i === 0}
+                  action={
+                    sharing && grant ? (
+                      <Button
+                        variant="outline"
+                        onClick={() => vm.onStopGrant(grant.id)}
+                        isLoading={vm.revokingGrantId === grant.id}
+                        className="h-9 rounded-full border-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent)]"
+                      >
+                        Stop
+                      </Button>
+                    ) : ready ? (
+                      <Button
+                        onClick={() => onStartShare(r.userId)}
+                        className="h-9 rounded-full bg-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+                      >
+                        Share
+                      </Button>
+                    ) : null
+                  }
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <EmptyState
+            title="No matching people"
+            description="Try a different name."
+          />
+        )}
+      </div>
 
       {vm.requestedByMe.length ? (
         <SettingsGroup title="Requests sent" separatorInset>


### PR DESCRIPTION
The People tab had grown to five full-width CTAs stacked between the search field and the list it filters. This reduces that to three, moves search onto the list, and fixes a layout that stretched every button to the width of the browser window.

## Search sits on the list it filters

It was separated from its own results by four buttons, which made it read as *page* search rather than *list* search. It now sits directly above the results under a `Connections` heading.

A test asserts that **nothing focusable** appears between the field and the first row, so this cannot quietly drift back.

## "Share to contacts" removed

It minted a **public location link** — the same artifact the Links tab creates, viewable by anyone holding the URL. Beyond being a duplicate, it was a category error: a control that makes you visible to *anyone with a link*, sitting among controls that are otherwise all about named, trusted people, one tap away from them.

`TemporaryLinkFlow` on the Links tab still owns create / copy / share / revoke, so no capability is lost. `handleShareContactInvite` stays because the legacy composer still calls it; only the People-tab buttons and the now-dead `onShareToContacts` view-model field are gone.

## Three actions, three weights

| Action | Weight | Why |
|---|---|---|
| Add people | filled | the common case |
| Invite | outlined accent | for people not on One yet |
| Sync contacts | quiet ghost | a one-off utility, not a peer of the other two |

Previously four buttons shared one weight, so nothing read as the default.

## Layout: desktop and mobile

The hub column has **no max-width**, so `w-full` buttons grew to the width of the whole desktop window — three pills spanning 1200px read as bulk, not as choices.

- **< 640px** — stacked full-width: proper thumb targets, which is also what the iOS/Android shell renders.
- **≥ 640px** — inline at natural width, left-aligned.
- `flex-wrap` lets a long localized label move to its own line instead of squeezing its neighbours.

## Circles

`Create` and `Join with code` moved from below the list to directly under the **Your circles** heading. Below the list they were stranded past a scroll exactly when someone had enough circles to need them. The assertion is structural — heading block is `children[0]`, action row is `children[1]` — so it cannot pass while asserting nothing.

## Notes for review

- **No copy was renamed here.** "Add people", "Invite" and the "Create link" labels are `main`'s, adopted through the rebase. Only weight, order and placement changed.
- The public-invite test now drives the Links tab, since that is the one remaining path to a public link.

## Verification

Rebased onto `56445fa3` and verified on that exact base:

- `tsc --noEmit` — clean.
- `one-location-agent-page` — **65/65 green**, the suite covering this screen, including the two new tests above.
- DCO signoff present; `scripts/ci/check-dco-signoff.sh` passes locally.

A full-suite comparison against a `56445fa3` baseline (32 failing test names, all pre-existing) is running locally; I'll post the name-level diff here when it completes. Comparing by test *name* rather than count is deliberate — a count alone once made a load-induced flake look like a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
