### PR TITLE
fix(one-location): translucent blue public-location badge, not opaque green

### DIFF
--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -74,8 +74,8 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
           allowFullScreen
           className="h-full w-full border-0"
         />
-        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full bg-[color:var(--app-success)] px-3 py-1.5 text-[12px] font-semibold leading-4 text-white backdrop-blur-xl">
-          <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full bg-[color:var(--app-accent)]/80 px-3 py-1.5 text-[12px] font-semibold leading-4 text-white backdrop-blur-xl">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-sky-300" />
           Public location
         </div>
         <Button


### PR DESCRIPTION
# Description

The "Public location" pill overlaid on the map preview (shared public-location page, `/one/location/request/[token]`) used the solid success-green token at full opacity. Despite `backdrop-blur-xl` already being applied to it, the opaque background meant the map underneath never actually showed through, and the color didn't match the accent blue used everywhere else on the same page (the icon badge in the header directly above it).

Switched the badge to the app's accent blue (`--app-accent`, the same token used by the header icon badge on this page) at 80% opacity, so the map is visible through it without losing legibility, and recolored the pulsing status dot to match the new blue family instead of green.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location/request/[token]` (public shared-location view)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — shared TS component, this route is a plain web page (public link, opened outside the app)

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable — pure CSS class change, no logic path affected

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `/one/location/request/[token]`; `hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx`

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` (no new errors)
  - [x] `cd hushh-webapp && npm test` — `public-request-page.test.tsx`: 1/1 passing
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable surface: `app/one/location/request/[token]/page-client.tsx`.
- [x] Reachable production attach point: this is the live badge rendered on the public shared-location page.
- [x] Existing test exercises the real page component, not a mock.
- [x] No new helpers/components — a two-line class-name change on an existing element.
- [x] Production surface proved: verified locally against a live backend.
- [ ] Required checks are current on this head, commits are signed off (commit is signed off with `-s`), and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — `app/one/location/request/[token]/page-client.tsx`
- [x] **iOS**: not applicable — this route is a public web link, not part of the native app shell
- [x] **Android**: not applicable — same reason

## 🧪 Testing

- [x] Tested on Web (Chrome, local dev against a live backend)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Verified locally: the badge is now translucent blue (matches the header icon's accent color) with the map visible through it, instead of opaque green.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — purely visual styling of an existing badge.
- [ ] N/A — no new consent surface
- [x] Sensitive surface touched: none
- [x] Error path / safe-failure behavior proved: not applicable, no logic changed

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes