### PR TITLE
fix(one-location): put SOS on the shared Location header system

### DIFF
--- a/.claude/skills/location-header-system/SKILL.md
+++ b/.claude/skills/location-header-system/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: location-header-system
+description: The header contract for every One Location screen — the top-bar breadcrumb, the single back control, and the eyebrow/title pair. Use when adding, renaming, or redesigning any Location surface (a new `?action=` flow, a `/one/location/*` route, a check-in or SOS or settings screen), when a screen shows two back buttons, when a screen has no breadcrumb, when a breadcrumb label disagrees with the on-screen title, or when a Location flow renders full-bleed over the app shell. Also use before changing `oneLocationActionLabel` or any Location `TaskFlowHeader`.
+---
+
+# One Location header system
+
+**A Location screen has exactly one back control, one breadcrumb, and one title — and the breadcrumb's last crumb is that title.**
+
+Every screen under `/one/location` is a *task flow inside the signed-in shell*, not a
+screen of its own. The shell already draws the top bar, the back control, and the
+breadcrumb. A flow that draws any of those itself produces the two bugs this skill
+exists to prevent: a screen with **no breadcrumb**, and a screen with **two back
+buttons**.
+
+The Location Settings flow is the reference implementation. Copy it.
+
+---
+
+## The three layers, and who owns each
+
+A Location screen's header is assembled from three places. A flow author writes
+**only** the third.
+
+| Layer | Owner | File |
+|---|---|---|
+| 1. Top bar chrome (back arrow, avatar, container) | Shell | `components/app-ui/top-app-bar.tsx` |
+| 2. Breadcrumb trail + back target | Route config | `lib/navigation/top-shell-breadcrumbs.ts` |
+| 3. Eyebrow + title + description | The flow | `TaskFlowHeader` in `lib/morphy-ux/ui/surface-primitives.tsx` |
+
+Layer 2 is derived from the URL, not from the component. `resolveTopShellBreadcrumb()`
+reads `pathname` + `searchParams` and returns `{ backHref, items, width, align }`.
+A component cannot influence it, and must not try.
+
+---
+
+## The contract
+
+### 1. Render inside the shell. Never over it.
+
+```tsx
+// ✅ A Location flow
+<section data-testid="one-location-thing">
+  <TaskFlowHeader eyebrow="Location" title="Thing" />
+  …
+</section>
+```
+
+```tsx
+// ❌ Escapes the shell — kills the breadcrumb and the top-bar back button
+<section className="fixed inset-0 z-[540] h-[100dvh] bg-black text-white">
+```
+
+Any of `fixed inset-0`, an explicit `z-[…]`, `h-[100dvh]`, or a forced canvas color on a
+flow root means the flow has left the shell. The top bar is still mounted underneath,
+but it is now covered — so the user sees a screen with no trail and no way back except
+whatever the flow drew for itself.
+
+This is exactly what SOS did until PR #5251. The symptom the user reports is *"the
+header system isn't working on this screen"*; the cause is always this line.
+
+**Corollary:** once the shell owns the canvas, the flow cannot hardcode dark-only
+colors. Use `foreground` / `muted-foreground` / `border` / `--app-card-surface-compact`
+/ `--app-destructive`, never `text-white`, `bg-black`, `#1c1c1e`, `#ff3b30`. A
+dark-only flow is invisible in light mode.
+
+### 2. The top bar owns back. The flow draws none.
+
+The in-content back arrows were deliberately removed across Location to fix a
+"two back buttons" UX. Do not add one back.
+
+```tsx
+// ❌ never in a Location flow
+<button aria-label="Back to Location"><ChevronLeft /></button>
+<TaskFlowHeader onBack={…} />   // the onBack prop exists for non-Location callers
+```
+
+A **Cancel** button at the bottom of the flow is fine and is not a back control — it is
+a decision ("do not do this thing"), and it may do more than navigate (SOS's Cancel
+also stops a live share).
+
+`resolveTopShellBreadcrumb` computes the back target for you, including the cases a
+component could not know about:
+
+- strips `?action=` to return to the hub;
+- preserves the originating hub tab via `?view=` (opened from **Links** → back to
+  **Links**, not to the default **Now** tab);
+- `sms-contacts` retraces to `?action=settings`, because that is its only entry point;
+- a nearby private check-in returns to the map, not the hub;
+- `?from=/one/profile` swaps the first crumb to **Profile**.
+
+### 3. Eyebrow = route name. Title = screen name. Title = last crumb.
+
+```tsx
+<TaskFlowHeader
+  eyebrow="Location"        // the route the user is inside
+  title="SOS"               // this screen — MUST equal the last breadcrumb crumb
+  description="Hold to send your live location by SMS."
+/>
+```
+
+Renders as `One › Location › SOS` in the bar, and `Location` / **SOS** in the content.
+
+Never write a route-local `<h1>`. `TaskFlowHeader` owns the `<h1>` and applies
+`SCREEN_TITLE` / `EYEBROW` from `lib/morphy-ux/tokens/surfaces.ts`.
+
+### 4. Adding a flow means editing two files, not one
+
+A new `?action=<slug>` needs a crumb label or the breadcrumb falls back to a titleized
+slug (`private-check-in` → "Private Check In" — wrong dash, wrong casing).
+
+```ts
+// lib/navigation/top-shell-breadcrumbs.ts → oneLocationActionLabel()
+const labels: Record<string, string> = {
+  …
+  "my-new-flow": "My New Flow",   // must equal the flow's TaskFlowHeader title
+};
+```
+
+Then add the case to `__tests__/utils/top-shell-breadcrumbs.test.ts`, which asserts the
+full `action → label` table.
+
+---
+
+## Current state of every Location surface
+
+Audited at PR #5251. Fix drift when you touch a row, don't leave it.
+
+| Surface | Crumb | On-screen title | Eyebrow | Status |
+|---|---|---|---|---|
+| `/one/location` (hub) | Location | Location Agent | — | Hub, uses `PageHeader` — not a flow |
+| `?action=settings` | Settings | Settings | `Location` | ✅ **reference implementation** |
+| `?action=sos` | SOS | SOS | `Location` | ✅ fixed in #5251 |
+| `?action=shared-with-me` | Shared with me | Shared with me | *none* | ⚠️ title matches crumb; eyebrow missing |
+| `?action=active-shares` | Active shares | Active shares | *none* | ⚠️ same |
+| `?action=needs-review` | Needs my review | Needs my review | *none* | ⚠️ same |
+| `?action=check-in` | Check-In | *raw `<h1>`* | *none* | ❌ no `TaskFlowHeader` |
+| `?action=sms-contacts` | Settings→(slug) | *raw `<h1>`* | *none* | ❌ raw `<h1>` **and** its own `ChevronLeft` |
+| `?action=share` | Share location | Who can see you? / Ready to share? | `Step 1 of 2 · …` | ⚠️ eyebrow is a step, title ≠ crumb |
+| `?action=ask` | Ask someone | Ask clearly | `Request with context` | ⚠️ title ≠ crumb |
+| `?action=invite` | Invite to Circle | Invite to Circle | `Invite to One / Circle` | ⚠️ title ✅, eyebrow is a tagline |
+| `?action=temp-link` | Public link | Public location link active / Share outside your Circle | `Copy, share or revoke` / *none* | ⚠️ two titles, neither is the crumb |
+| `/one/location/map` | Your Map | — | — | Map route, own chrome |
+
+**The two rows the user reported as broken are the two `❌` rows.** They are broken the
+same way SOS was: no `TaskFlowHeader`, so no eyebrow, no shared title treatment — and
+`sms-contacts` additionally re-adds the second back button.
+
+### The eyebrow is being used two ways
+
+This is the real inconsistency underneath the drift. Settings and SOS use the eyebrow
+for the **route** (`Location`). Share, Ask, Invite and Temp-link use it for a **step or
+tagline** (`Step 1 of 2 · Choose people`, `Request with context`).
+
+Both are defensible in isolation; together they mean the eyebrow tells the user nothing
+reliable. When resolving a row: multi-step flows may keep the step in the eyebrow —
+a step marker is genuinely more useful mid-flow than repeating the route the breadcrumb
+already shows — but a single-screen flow uses `eyebrow="Location"`, and in every case
+**the title must equal the crumb.**
+
+---
+
+## Fixing a broken screen
+
+1. Find its `?action=` slug in `ACTION_TO_FLOW` in `location-redesign-hub.tsx`.
+2. Confirm its crumb in `oneLocationActionLabel()`. Make it read like the screen title.
+3. In the flow component, delete the flow root's overlay classes, any in-content back
+   button, and the raw `<h1>`/`<header>`.
+4. Add `<TaskFlowHeader eyebrow="Location" title="<crumb>" description="…" />` as the
+   first child.
+5. Replace hardcoded dark-only colors with theme tokens.
+6. Move any inline `<style>` keyframes into `app/globals.css` with a
+   `prefers-reduced-motion` guard — a component-level style island is a second motion
+   engine, which `lib/morphy-ux/README.md` forbids.
+
+---
+
+## Verify
+
+```bash
+cd hushh-webapp
+npx vitest run __tests__/utils/top-shell-breadcrumbs.test.ts
+npx vitest run __tests__/components/one-location-sos-emergency.contract.test.tsx
+npm run verify:design-system     # accent tokens + Apple hierarchy
+npm run typecheck
+```
+
+The SOS contract test in `__tests__/components/one-location-sos-emergency.contract.test.tsx`
+is the template for locking a header fix. It scans the component source, because the
+regression it guards is structural rather than behavioral — a screen can render every
+control correctly and still be wrong by covering the shell:
+
+```ts
+expect(SOURCE).not.toContain("fixed inset-0");
+expect(SOURCE).not.toMatch(/\bz-\[\d+\]/);
+expect(SOURCE).toContain('eyebrow="Location"');
+expect(SOURCE).not.toContain("<h1");
+expect(SOURCE).not.toContain("ChevronLeft");
+```
+
+Copy that block when you fix Check-In and SMS contacts.
+
+**Baseline before you claim green.** The Location suite has pre-existing failures on
+`main` (`one-location-onboarding-flow`, `one-location-settings-placement`,
+`nearby-check-in-sheet`, `shared-with-me-card`). Run the suite on your branch *and* on
+`origin/main`, and compare the failing sets — do not report a count.
+
+Related: `safe-changes`, `hushh-research-ship`, `impeccable`.

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1739,7 +1739,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /SMS.*Save my soul/i }));
 
     expect(
-      await screen.findByRole("heading", { name: /Save my soul/i }),
+      await screen.findByRole("heading", { name: "SOS", level: 1 }),
     ).toBeTruthy();
     await waitFor(() =>
       expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1),
@@ -1817,7 +1817,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: /Save my soul/i }),
+      await screen.findByRole("heading", { name: "SOS", level: 1 }),
     ).toBeTruthy();
     await expectEmergencyAction("112", "India");
     expect(
@@ -1863,7 +1863,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: /Save my soul/i }),
+      await screen.findByRole("heading", { name: "SOS", level: 1 }),
     ).toBeTruthy();
     expect(
       await screen.findByRole("button", {
@@ -1906,7 +1906,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: /Save my soul/i }),
+      await screen.findByRole("heading", { name: "SOS", level: 1 }),
     ).toBeTruthy();
     expect(
       await screen.findByRole("button", {

--- a/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
@@ -17,6 +17,10 @@ const SMS_PANEL_SOURCE = fs.readFileSync(
   ),
   "utf8",
 );
+const GLOBALS_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../../app/globals.css"),
+  "utf8",
+);
 
 describe("One Location SMS emergency actions", () => {
   it("renders a dialer only after the local emergency number resolves", () => {
@@ -37,5 +41,43 @@ describe("One Location SMS emergency actions", () => {
   it("keeps ambient tint sampling outside every Location action flow", () => {
     expect(HUB_SOURCE).toContain('data-testid="one-location-action-flow"');
     expect(HUB_SOURCE).toContain("data-ambient-chrome-ignore");
+  });
+
+  // SOS is a Location task flow, not a second app. These assertions are on the
+  // source because the failure they guard against is structural: the panel used
+  // to paint itself over the entire viewport, which removed the shell's top-bar
+  // breadcrumb and forced a duplicate back arrow into the content.
+  it("renders SOS inside the shell rather than over it", () => {
+    expect(SMS_PANEL_SOURCE).not.toContain("fixed inset-0");
+    expect(SMS_PANEL_SOURCE).not.toMatch(/\bz-\[\d+\]/);
+    expect(SMS_PANEL_SOURCE).not.toContain("100dvh");
+  });
+
+  it("uses the shared TaskFlowHeader with the Location eyebrow", () => {
+    expect(SMS_PANEL_SOURCE).toContain("TaskFlowHeader");
+    expect(SMS_PANEL_SOURCE).toContain('eyebrow="Location"');
+    expect(SMS_PANEL_SOURCE).toContain('title="SOS"');
+    // No route-local <h1>: the header primitive owns the title element.
+    expect(SMS_PANEL_SOURCE).not.toContain("<h1");
+  });
+
+  it("leaves the single back control to the top bar", () => {
+    expect(SMS_PANEL_SOURCE).not.toContain("ChevronLeft");
+    expect(SMS_PANEL_SOURCE).not.toContain('aria-label="Back to Location"');
+  });
+
+  it("keeps SOS motion in the app's single motion driver", () => {
+    // Keyframes belong in app/globals.css, never an inline <style> island.
+    expect(SMS_PANEL_SOURCE).not.toContain("@keyframes");
+    expect(SMS_PANEL_SOURCE).not.toContain("<style>");
+    expect(GLOBALS_SOURCE).toContain("@keyframes sosRadarPulse");
+    expect(GLOBALS_SOURCE).toContain("@keyframes sosCorePulse");
+    expect(GLOBALS_SOURCE).toContain("[data-sos-pulse]");
+  });
+
+  it("keeps the emergency red on the theme-aware destructive token", () => {
+    expect(SMS_PANEL_SOURCE).toContain("var(--app-destructive)");
+    // Raw Apple hexes reintroduce a light-mode-blind surface.
+    expect(SMS_PANEL_SOURCE).not.toMatch(/#(ff3b30|ff453a|1c1c1e|d70015)/i);
   });
 });

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -543,7 +543,8 @@ describe("top shell breadcrumbs", () => {
     const cases: Array<[string, string]> = [
       ["check-in", "Check-In"],
       ["private-check-in", "Private Check-In"],
-      ["sos", "Safety"],
+      // The crumb mirrors the screen's own <h1>, which reads "SOS".
+      ["sos", "SOS"],
       ["share", "Share location"],
       ["ask", "Ask someone"],
       ["invite", "Invite to Circle"],

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -4907,6 +4907,50 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
   animation: stage-pulse 1.5s ease-in-out infinite;
 }
 
+/* ---------------------------------------------------------------------------
+ * One Location · SOS radar
+ *
+ * The alarm rings and the breathing core of the SOS hold control. These used to
+ * live in an inline <style> block inside sos-panel.tsx, which made the SOS
+ * screen the only surface in the app running its own motion engine (see the
+ * "one driver per concern" rule in lib/morphy-ux/README.md). They are declared
+ * here so the SOS screen shares the app's single motion source, and so the
+ * reduced-motion guard below cannot be forgotten by a future edit.
+ * ------------------------------------------------------------------------- */
+@keyframes sosRadarPulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+  80% {
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.62);
+    opacity: 0;
+  }
+}
+
+@keyframes sosCorePulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.045);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-sos-pulse] {
+    animation: none !important;
+    opacity: 0 !important;
+  }
+  [data-sos-core] {
+    animation: none !important;
+  }
+}
+
 /* Ensure spinner utilities always rotate in runtime (vault/auth/load states). */
 @keyframes hushh-spin-fallback {
   to {

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -118,7 +124,9 @@ describe("SosPanel", () => {
         expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
           "112 copied",
           expect.objectContaining({
-            description: expect.stringContaining("Call 112 from your phone now"),
+            description: expect.stringContaining(
+              "Call 112 from your phone now",
+            ),
           }),
         ),
       );
@@ -132,13 +140,17 @@ describe("SosPanel", () => {
       navigatorUserAgent.mockRestore();
       navigatorPlatform.mockRestore();
       if (clipboardDescriptor) {
-        Object.defineProperty(window.navigator, "clipboard", clipboardDescriptor);
+        Object.defineProperty(
+          window.navigator,
+          "clipboard",
+          clipboardDescriptor,
+        );
       } else {
-        delete (window.navigator as unknown as { clipboard?: unknown }).clipboard;
+        delete (window.navigator as unknown as { clipboard?: unknown })
+          .clipboard;
       }
       vi.useFakeTimers();
     }
-
   });
 
   it("renders the Save My Soul UI, selected recipients, and local dialer", () => {
@@ -150,22 +162,31 @@ describe("SosPanel", () => {
       .mockReturnValue("Linux x86_64");
 
     try {
-    render(<SosPanel {...baseProps} />);
+      render(<SosPanel {...baseProps} />);
 
-    expect(screen.getByText("SMS · Save my Soul")).toBeInTheDocument();
-    expect(screen.getByText("Hold to send your live location by SMS.")).toBeInTheDocument();
-    expect(screen.getByText(/SMS goes to Carol/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /call 112/i })).toHaveAttribute(
-      "href",
-      "tel:112",
-    );
-    expect(screen.getByText("India")).toBeInTheDocument();
-    expect(screen.queryByText(/voice note/i)).not.toBeInTheDocument();
-    expect(screen.getByTestId("sms-safety-screen")).toHaveClass(
-      "fixed",
-      "inset-0",
-      "bg-black",
-    );
+      // Header grammar shared with every other Location task flow: the route
+      // name is the eyebrow, the screen name is the <h1>.
+      expect(screen.getByText("Location")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { level: 1, name: "SOS" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Hold to send your live location by SMS."),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/SMS goes to Carol/)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /call 112/i })).toHaveAttribute(
+        "href",
+        "tel:112",
+      );
+      expect(screen.getByText("India")).toBeInTheDocument();
+      expect(screen.queryByText(/voice note/i)).not.toBeInTheDocument();
+      // SOS renders INSIDE the signed-in shell so the top bar keeps the
+      // "One › Location › SOS" breadcrumb. It must never re-open itself as a
+      // fullscreen overlay, which is what hid the breadcrumb before.
+      const screenEl = screen.getByTestId("sms-safety-screen");
+      expect(screenEl).not.toHaveClass("fixed");
+      expect(screenEl.className).not.toMatch(/\binset-0\b/);
+      expect(screenEl.className).not.toMatch(/\bbg-black\b/);
     } finally {
       navigatorUserAgent.mockRestore();
       navigatorPlatform.mockRestore();
@@ -337,9 +358,7 @@ describe("SosPanel", () => {
       screen.queryByRole("textbox", { name: "Short text message" }),
     ).toBeNull();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Short text message" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Short text message" }));
     const composer = screen.getByRole("textbox", {
       name: "Short text message",
     });
@@ -373,9 +392,7 @@ describe("SosPanel", () => {
     const onTrigger = vi.fn();
     render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Short text message" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Short text message" }));
     fireEvent.change(
       screen.getByRole("textbox", { name: "Short text message" }),
       { target: { value: "  Meet me by the north entrance.  " } },
@@ -390,9 +407,7 @@ describe("SosPanel", () => {
     act(() => vi.advanceTimersByTime(2_000));
 
     expect(onTrigger).toHaveBeenCalledTimes(1);
-    expect(onTrigger).toHaveBeenCalledWith(
-      "Meet me by the north entrance.",
-    );
+    expect(onTrigger).toHaveBeenCalledWith("Meet me by the north entrance.");
   });
 
   it("fails closed and prompts to add a contact when none are ready", () => {
@@ -445,9 +460,7 @@ describe("SosPanel", () => {
 
   it("disables 'Cancel the alert' and shows a spinner while stopping", () => {
     const onStopSos = vi.fn();
-    render(
-      <SosPanel {...baseProps} active stopBusy onStopSos={onStopSos} />,
-    );
+    render(<SosPanel {...baseProps} active stopBusy onStopSos={onStopSos} />);
     const cancel = screen.getByTestId("sos-cancel-alert");
     expect(cancel).toBeDisabled();
     expect(cancel).toHaveTextContent("Cancelling…");
@@ -468,16 +481,54 @@ describe("SosPanel", () => {
 
   it("keeps the SMS action in one centered stack on large screens", () => {
     const { container } = render(<SosPanel {...baseProps} />);
-    const screenEl = screen.getByTestId("sms-safety-screen");
-    // Mobile behavior preserved: still the full-screen black overlay.
-    expect(screenEl).toHaveClass("fixed", "inset-0", "bg-black");
-    // The inner container keeps the mobile strip and widens only enough to
-    // keep the emergency action centered beneath the title/subtitle.
-    const inner = screenEl.firstElementChild as HTMLElement;
-    expect(inner).toHaveClass("max-w-[407px]", "lg:max-w-[520px]");
-    // The press ring + controls must not split into a desktop grid.
+    // The press ring + controls must not split into a desktop grid. Width is
+    // owned by the shell's AppPageShell container, not by this panel.
     expect(container.querySelector('[class*="lg:grid-cols-"]')).toBeNull();
     expect(container.querySelector('[class*="lg:grid-cols_"]')).toBeNull();
+  });
+});
+
+describe("SosPanel — shell header contract", () => {
+  // The regression this locks: SOS used to paint itself over the whole
+  // viewport, which removed the top-bar breadcrumb and forced a second back
+  // arrow into the content. Every Location task flow renders inside the shell
+  // and lets the top bar own the single back control.
+  it("renders inside the shell instead of a fullscreen overlay", () => {
+    render(<SosPanel {...baseProps} />);
+    const screenEl = screen.getByTestId("sms-safety-screen");
+
+    expect(screenEl.className).not.toMatch(/\bfixed\b/);
+    expect(screenEl.className).not.toMatch(/\binset-0\b/);
+    expect(screenEl.className).not.toMatch(/\bz-\[/);
+    expect(screenEl.className).not.toMatch(/\b(min-)?h-\[100dvh\]/);
+  });
+
+  it("uses the Location eyebrow + screen title used by the other flows", () => {
+    render(<SosPanel {...baseProps} />);
+
+    const heading = screen.getByRole("heading", { level: 1, name: "SOS" });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText("Location")).toBeInTheDocument();
+  });
+
+  it("exposes no in-content back control — the top bar owns back", () => {
+    render(<SosPanel {...baseProps} />);
+
+    expect(screen.queryByRole("button", { name: /^back/i })).toBeNull();
+    expect(screen.queryByLabelText("Back to Location")).toBeNull();
+  });
+
+  it("keeps a Cancel control that returns to the Location hub", () => {
+    const onClose = vi.fn();
+    render(<SosPanel {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("declares no inline <style> block — motion lives in globals.css", () => {
+    const { container } = render(<SosPanel {...baseProps} />);
+    expect(container.querySelector("style")).toBeNull();
   });
 });
 

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -9,10 +9,12 @@ import {
   type KeyboardEvent,
   type PointerEvent,
 } from "react";
-import { ChevronLeft, Loader2, Phone, SendHorizontal } from "lucide-react";
+import { Loader2, Phone, SendHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
+import { TaskFlowHeader } from "./primitives";
+import { SUBCARD_SURFACE } from "./tokens";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
 import type {
   EmergencyInfo,
@@ -26,12 +28,10 @@ type SmsMessageSelection = SmsQuickMessage | "custom" | null;
 
 type WindowsFallbackCopyStatus = "idle" | "copied" | "error";
 
-export function isWindowsDesktopEmCallUnsupported(
-  options?: {
-    userAgent?: string;
-    platform?: string;
-  },
-) {
+export function isWindowsDesktopEmCallUnsupported(options?: {
+  userAgent?: string;
+  platform?: string;
+}) {
   const userAgent = (options?.userAgent ?? navigator.userAgent).toLowerCase();
   const platform = (options?.platform ?? navigator.platform).toLowerCase();
   const isWindows =
@@ -74,7 +74,6 @@ export type SosPanelProps = {
   onResolveEmergencyNumber: () => void;
 };
 
-
 function firstNameOf(label: string): string {
   return label.trim().split(/\s+/)[0] || label.trim();
 }
@@ -102,7 +101,6 @@ export function SosPanel({
   emergencyStatus,
   onResolveEmergencyNumber,
 }: SosPanelProps) {
-
   const [messageSelection, setMessageSelection] =
     useState<SmsMessageSelection>(null);
   const [customMessage, setCustomMessage] = useState("");
@@ -158,13 +156,13 @@ export function SosPanel({
   // Full guard used by the hold-completion path so a hold can never actually
   // send an SMS while there are no ready recipients.
   const disabled = hardDisabled || noReadyRecipients;
-  const shouldFallbackWindowsEmergencyCall = isWindowsDesktopEmCallUnsupported();
+  const shouldFallbackWindowsEmergencyCall =
+    isWindowsDesktopEmCallUnsupported();
   // Radar pulse is active the moment the user starts pressing, and keeps
   // emanating continuously while the SMS is sending and after it goes live.
   const showPulse = active || busy || progress > 0;
   // Editing is closed from the moment the alert is sent until it is cancelled.
   const messageLocked = active || busy;
-
 
   // The alert ending is the only thing that releases the record and the lock.
   // Cancelling is deliberately the single escape: an editable picker over a
@@ -336,39 +334,30 @@ export function SosPanel({
   }, [emergency?.number]);
 
   return (
-    <section
-      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-black text-white"
-      data-ambient-chrome-ignore
-      data-testid="sms-safety-screen"
-    >
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(44px,env(safe-area-inset-top))] lg:max-w-[520px]">
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Back to Location"
-          className="press-scale flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white"
-        >
-          <ChevronLeft className="h-6 w-6" strokeWidth={2} />
-        </button>
+    // SOS is a Location task flow, not a separate app. It renders INSIDE the
+    // signed-in shell like every other `?action=…` flow (Settings, Check-In,
+    // Shared with me), so the top bar keeps showing the single back control and
+    // the "One › Location › SOS" breadcrumb. It used to escape the shell as a
+    // pinned full-viewport black overlay, which is what removed the breadcrumb
+    // and forced a second, in-content back button onto the screen.
+    <section data-testid="sms-safety-screen">
+      {/* Same header grammar as the Location Settings flow: the route name is
+          the eyebrow, the screen name is the title. Back lives in the top bar
+          only — never a second arrow in the content. */}
+      <TaskFlowHeader
+        eyebrow="Location"
+        title="SOS"
+        description="Hold to send your live location by SMS."
+      />
 
-        <header className="mt-4 px-3 text-center">
-          <h1 className="whitespace-nowrap !text-[28px] !font-bold !leading-[34px] !tracking-normal">
-            SMS · Save my Soul
-          </h1>
-          <p className="mx-auto mt-2 max-w-[310px] text-[15px] font-normal leading-[20px] text-white/70">
-            Hold to send your live location by SMS.
-          </p>
-        </header>
-
-        {/* The emergency action is one centered stack: title/subtitle, then the
-            hold button immediately beneath it, then the message and recovery
-            controls. Keeping this single column prevents the SMS action from
-            reading like a separate desktop panel. */}
-        <div className="flex flex-col items-center gap-4 pt-5">
-          <div className="flex items-center justify-center">
-            <div className="relative flex h-[204px] w-[204px] items-center justify-center">
-            <span className="absolute inset-0 rounded-full border border-white/10" />
-            <span className="absolute inset-[24px] rounded-full border border-white/15" />
+      {/* The emergency action is one centered stack: the hold control, then the
+          message and recovery controls beneath it. Keeping this single column
+          prevents the SMS action from reading like a separate desktop panel. */}
+      <div className="mt-6 flex flex-col items-center gap-4">
+        <div className="flex items-center justify-center">
+          <div className="relative flex h-[204px] w-[204px] items-center justify-center">
+            <span className="absolute inset-0 rounded-full border border-border" />
+            <span className="absolute inset-[24px] rounded-full border border-border" />
 
             {/* Radar / alarm rings that emanate continuously from the red core
                 while the SMS is being held, sent, and after it goes live. */}
@@ -411,10 +400,12 @@ export function SosPanel({
               onKeyDown={handleKeyDown}
               onKeyUp={handleKeyUp}
               onContextMenu={(event) => event.preventDefault()}
+              data-sos-core={active || busy ? "" : undefined}
               className={cn(
-                "relative z-10 flex h-[128px] w-[128px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
+                "relative z-10 flex h-[128px] w-[128px] touch-none select-none flex-col items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background",
                 progress > 0 && progress < 1 && "scale-[1.035]",
-                (active || busy) && "[animation:sosCorePulse_2.2s_ease-in-out_infinite]",
+                (active || busy) &&
+                  "[animation:sosCorePulse_2.2s_ease-in-out_infinite]",
                 disabled && "cursor-not-allowed",
               )}
               style={{
@@ -437,24 +428,12 @@ export function SosPanel({
                       : "Hold 2 s"}
               </span>
             </button>
-            </div>
           </div>
+        </div>
 
-        <style>{`
-          @keyframes sosRadarPulse {
-            0% { transform: scale(1); opacity: 0.55; }
-            80% { opacity: 0; }
-            100% { transform: scale(1.62); opacity: 0; }
-          }
-          @keyframes sosCorePulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.045); }
-          }
-          @media (prefers-reduced-motion: reduce) {
-            [data-sos-pulse] { animation: none !important; opacity: 0 !important; }
-          }
-        `}</style>
-
+        {/* `sosRadarPulse` / `sosCorePulse` and their reduced-motion guard live
+            in app/globals.css with the rest of the app's motion, never in a
+            style island declared by this component. */}
 
         <div className="w-full max-w-[360px]">
           {/* While an SMS/SOS session is live, the primary action becomes
@@ -468,7 +447,7 @@ export function SosPanel({
               disabled={stopBusy}
               aria-label="Cancel the alert and stop sharing your location"
               data-testid="sos-cancel-alert"
-              className="press-scale mb-4 flex h-12 w-full items-center justify-center gap-2 rounded-full bg-white text-[15px] font-semibold text-[#d70015] shadow-sm disabled:opacity-60"
+              className="press-scale mb-4 flex h-12 w-full items-center justify-center gap-2 rounded-full border border-[color:var(--app-destructive)] bg-[color:var(--app-card-surface-default-solid)] text-[15px] font-semibold text-[color:var(--app-destructive)] disabled:opacity-60"
             >
               {stopBusy ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -477,7 +456,7 @@ export function SosPanel({
             </button>
           ) : null}
 
-          <p className="truncate px-2 text-center text-[13px] text-white/70">
+          <p className="truncate px-2 text-center text-[13px] text-muted-foreground">
             {names ? `SMS goes to ${names}` : "No SMS contacts selected"} ·{" "}
             <button
               type="button"
@@ -496,15 +475,18 @@ export function SosPanel({
             <div
               role="status"
               data-testid="sos-sent-message"
-              className="mt-3 rounded-2xl border border-white/10 bg-white/[0.06] p-3 text-[13px] leading-relaxed text-white"
+              className={cn(
+                SUBCARD_SURFACE,
+                "mt-3 p-3 text-[13px] leading-relaxed text-foreground",
+              )}
             >
               <p className="font-semibold">{busy ? "Sending" : "Sent"}</p>
-              <p className="mt-1 text-white/70">
+              <p className="mt-1 text-muted-foreground">
                 {sentMessage
                   ? `“${sentMessage}”`
                   : "Your location, with no message."}
               </p>
-              <p className="mt-2 text-white/50">
+              <p className="mt-2 text-muted-foreground/70">
                 Cancel to change it.
               </p>
             </div>
@@ -525,8 +507,8 @@ export function SosPanel({
                 className={cn(
                   "press-scale h-11 rounded-full border text-[15px] font-semibold leading-5",
                   messageSelection === option
-                    ? "border-white bg-white text-black"
-                    : "border-white/5 bg-[#1c1c1e] text-white",
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-foreground",
                   messageLocked && "cursor-not-allowed opacity-50",
                 )}
               >
@@ -545,8 +527,8 @@ export function SosPanel({
               className={cn(
                 "press-scale col-span-2 h-11 rounded-full border text-[15px] font-semibold leading-5",
                 messageSelection === "custom"
-                  ? "border-white bg-white text-black"
-                  : "border-white/5 bg-[#1c1c1e] text-white",
+                  ? "border-foreground bg-foreground text-background"
+                  : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-foreground",
                 messageLocked && "cursor-not-allowed opacity-50",
               )}
             >
@@ -576,10 +558,10 @@ export function SosPanel({
                   className={cn(
                     // pr-14 reserves the send button's column so typed text
                     // never runs underneath it.
-                    "min-h-[72px] w-full resize-none rounded-2xl border bg-[#1c1c1e] py-3 pl-3.5 pr-14 text-[17px] leading-[22px] text-white outline-none placeholder:text-white/40 focus:border-white/55",
+                    "min-h-[72px] w-full resize-none rounded-2xl border bg-[color:var(--app-card-surface-compact)] py-3 pl-3.5 pr-14 text-[17px] leading-[22px] text-foreground outline-none placeholder:text-muted-foreground focus:border-ring",
                     customMessageLimitExceeded
                       ? "border-[color:var(--app-destructive)]"
-                      : "border-white/10",
+                      : "border-border",
                     messageLocked && "cursor-not-allowed opacity-60",
                   )}
                 />
@@ -595,14 +577,17 @@ export function SosPanel({
                   className={cn(
                     "press-scale absolute bottom-2.5 right-2.5 flex h-10 w-10 items-center justify-center rounded-full transition-colors",
                     hardDisabled || !selectedMessage
-                      ? "bg-white/10 text-white/35"
+                      ? "bg-muted text-muted-foreground/50"
                       : "bg-[color:var(--app-destructive)] text-white",
                   )}
                 >
                   {busy ? (
                     <Loader2 className="h-[18px] w-[18px] animate-spin" />
                   ) : (
-                    <SendHorizontal className="h-[18px] w-[18px]" strokeWidth={2} />
+                    <SendHorizontal
+                      className="h-[18px] w-[18px]"
+                      strokeWidth={2}
+                    />
                   )}
                 </button>
               </div>
@@ -612,7 +597,7 @@ export function SosPanel({
                   "mt-1 text-right text-[12px]",
                   customMessageLimitExceeded
                     ? "text-[color:var(--app-destructive)]"
-                    : "text-white/55",
+                    : "text-muted-foreground",
                 )}
               >
                 {customMessageLength}/{ONE_LOCATION_SHARE_NOTE_MAX_LENGTH}
@@ -703,16 +688,14 @@ export function SosPanel({
               </button>
             )}
 
-
             <button
               type="button"
               onClick={onClose}
-              className="press-scale h-12 rounded-full border border-white/55 text-[15px] font-semibold text-white"
+              className="press-scale h-12 rounded-full border border-border text-[15px] font-semibold text-foreground"
             >
               Cancel
             </button>
           </div>
-        </div>
         </div>
       </div>
     </section>

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -63,7 +63,10 @@ function oneLocationActionLabel(action: string): string {
     "active-shares": "Active shares",
     "shared-with-me": "Shared with me",
     "needs-review": "Needs my review",
-    sos: "Safety",
+    // The crumb must match the on-screen title of the flow it names. The SOS
+    // screen's TaskFlowHeader reads "SOS", so the crumb reads "SOS" — a crumb
+    // saying "Safety" for a screen titled "SOS" breaks the trail.
+    sos: "SOS",
     settings: "Settings",
     privacy: "Settings",
   };


### PR DESCRIPTION
## What changed

SOS was the only Location task flow that painted itself over the whole viewport (`fixed inset-0` + a forced black canvas). That escape removed the signed-in shell's top bar, so the screen lost the `One › Location › SOS` breadcrumb that Settings, Check-In and Shared-with-me all show, and it had to carry its own in-content back arrow — exactly the "two back buttons" pattern the rest of the feature deliberately removed.

SOS now renders inside the shell like its siblings:

- `TaskFlowHeader` with eyebrow **Location** and title **SOS** — the same header grammar `LocationSettingsFlow` uses.
- No route-local `<h1>`, no in-content back control. The top bar owns the single back affordance.
- Breadcrumb crumb for `?action=sos` renamed `Safety` → `SOS`, so the trail matches the screen's own title.

Because the shell now owns the canvas, the panel's hardcoded dark-only colors would have been invisible in light mode, so they move onto theme tokens (`--app-card-surface-compact`, `border`, `foreground`, `muted-foreground`, `--app-destructive`). The emergency red stays red in both themes.

The SOS keyframes move out of the component's inline `<style>` island into `app/globals.css` alongside the rest of the app's motion, and gain a reduced-motion guard for the breathing core as well as the radar rings.

## Behavior preserved

Hold-to-send physics and the 2s timer, radar pulse, quick messages, custom message + counter + limit error, send button, live/cancel states, sent-message record, emergency number lookup with the Windows clipboard fallback, and every `aria-label` / `data-testid` the callers use.

## Edge cases covered

- Light **and** dark theme (previously dark-only by force).
- `prefers-reduced-motion` — now guards the core pulse too, not just the rings.
- Deep link straight to `?action=sos` — breadcrumb and back target resolve from the URL.
- Alert live: message editing stays locked, Cancel remains the single escape.
- No SMS contacts: hold stays pressable and still surfaces the actionable toast.
- Emergency number unresolved / unavailable: no invented number, retry preserved.

## Tests

New shell-header contract: no overlay chrome, eyebrow + title, no in-content back, no style island, destructive-token colors, and keyframes present in `globals.css`. Existing assertions that pinned the old fullscreen chrome were rewritten to the new contract.

- `sos-panel.test.tsx` — 32 passed
- `one-location-sos-emergency.contract.test.tsx` — passed
- `top-shell-breadcrumbs.test.ts` — passed
- `one-location-agent-page.test.tsx` — 63 passed
- `npm run typecheck` — clean
- `npm run verify:design-system` — passed (incl. `verify-accent-tokens`, `verify-apple-hierarchy`)
- `npm run verify:surface-map` — current
- `eslint --max-warnings=0` on all changed files — clean

Baseline check: the Location + navigation sweep fails identically on `origin/main` and on this branch (`one-location-onboarding-flow`, `one-location-settings-placement`, `nearby-check-in-sheet`, `shared-with-me-card` — 6 failures, all pre-existing and untouched by this change).

## Risk / rollback

Presentation-only; no API, schema, permission or data change. Rollback is a straight revert of this commit.