### PR TITLE
fix(one-location): stop the shell blanking chrome on SOS and SMS contacts

### DIFF
--- a/.claude/skills/location-header-system/SKILL.md
+++ b/.claude/skills/location-header-system/SKILL.md
@@ -56,8 +56,32 @@ flow root means the flow has left the shell. The top bar is still mounted undern
 but it is now covered — so the user sees a screen with no trail and no way back except
 whatever the flow drew for itself.
 
-This is exactly what SOS did until PR #5251. The symptom the user reports is *"the
-header system isn't working on this screen"*; the cause is always this line.
+This is exactly what SOS did until PR #5251.
+
+### 1b. Check the shell rule too — a component fix cannot reach it
+
+There is a second, higher place a screen can lose its header, and it is the one that
+wastes an afternoon: **the shell can be told to blank the chrome for a specific
+`?action=` value.** Until PR #5253, `app-route-layout.ts` exported
+`shouldSuppressPersistentChromeForRouteState`, which returned `true` for `sos` and
+`sms-contacts`. `providers.tsx` OR-ed it into `hidesPersistentChrome`.
+
+The failure mode: you remove the overlay from the component, every test passes, the
+screen is perfectly in-flow — and it still renders with **no back control, no trail and
+no avatar**, because the shell never mounted them. Nothing in the component is wrong.
+
+So when a Location screen has no header, check **both** layers before editing anything:
+
+```bash
+grep -rn "persistentChrome\|SuppressPersistentChrome" hushh-webapp/lib/navigation hushh-webapp/app/providers.tsx
+grep -n "fixed inset-0\|100dvh\|z-\[" <the flow component>
+```
+
+Chrome visibility is a property of the **route**, declared once as
+`persistentChrome` in `app-route-layout.contract.json` where it sits beside every other
+route's. It is never a property of the `?action=` flow open inside that route. "It is an
+emergency screen so it owns the viewport" is the argument that produced this bug; an
+emergency is not a reason to make someone re-learn how to leave a screen.
 
 **Corollary:** once the shell owns the canvas, the flow cannot hardcode dark-only
 colors. Use `foreground` / `muted-foreground` / `border` / `--app-card-surface-compact`
@@ -160,16 +184,24 @@ Audited at PR #5251. Fix drift when you touch a row, don't leave it.
 | `?action=active-shares` | Active shares | Active shares | *none* | ⚠️ same |
 | `?action=needs-review` | Needs my review | Needs my review | *none* | ⚠️ same |
 | `?action=check-in` | Check-In | *raw `<h1>`* | *none* | ❌ no `TaskFlowHeader` |
-| `?action=sms-contacts` | Settings→(slug) | *raw `<h1>`* | *none* | ❌ raw `<h1>` **and** its own `ChevronLeft` |
+| `?action=sms-contacts` | SMS contacts | SMS contacts | *none* | ✅ fixed in #5253 |
 | `?action=share` | Share location | Who can see you? / Ready to share? | `Step 1 of 2 · …` | ⚠️ eyebrow is a step, title ≠ crumb |
 | `?action=ask` | Ask someone | Ask clearly | `Request with context` | ⚠️ title ≠ crumb |
 | `?action=invite` | Invite to Circle | Invite to Circle | `Invite to One / Circle` | ⚠️ title ✅, eyebrow is a tagline |
 | `?action=temp-link` | Public link | Public location link active / Share outside your Circle | `Copy, share or revoke` / *none* | ⚠️ two titles, neither is the crumb |
 | `/one/location/map` | Your Map | — | — | Map route, own chrome |
 
-**The two rows the user reported as broken are the two `❌` rows.** They are broken the
-same way SOS was: no `TaskFlowHeader`, so no eyebrow, no shared title treatment — and
-`sms-contacts` additionally re-adds the second back button.
+**Check-In is the one row still broken**, the same way SOS was: no `TaskFlowHeader`, so
+no shared title treatment.
+
+Note what `sms-contacts` needed on top of the component fix. Its back target is not the
+hub — it is reachable from Settings *and* from the middle of an SOS, and returning that
+second person to Settings drops them out of the emergency flow at the worst possible
+moment. The hub records the origin as `?source=sos`; `resolveSmsContactsBackAction` in
+`top-shell-breadcrumbs.ts` is the single implementation of that rule, and the hub's
+`resolveSmsContactsBackFlow` delegates to it. **When you delete a flow's in-content back
+button, check what that button knew that the breadcrumb does not** — a hardcoded
+`backHref` will silently lose it.
 
 ### The eyebrow is being used two ways
 

--- a/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
@@ -21,6 +21,21 @@ const GLOBALS_SOURCE = fs.readFileSync(
   path.resolve(__dirname, "../../app/globals.css"),
   "utf8",
 );
+const SMS_CONTACTS_SOURCE = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../components/one-location/redesign/sms-contacts-flow.tsx",
+  ),
+  "utf8",
+);
+const ROUTE_LAYOUT_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/navigation/app-route-layout.ts"),
+  "utf8",
+);
+const PROVIDERS_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../../app/providers.tsx"),
+  "utf8",
+);
 
 describe("One Location SMS emergency actions", () => {
   it("renders a dialer only after the local emergency number resolves", () => {
@@ -87,6 +102,32 @@ describe("One Location SMS emergency actions", () => {
   it("leaves the single back control to the top bar", () => {
     expect(SMS_PANEL_SOURCE).not.toContain("ChevronLeft");
     expect(SMS_PANEL_SOURCE).not.toContain('aria-label="Back to Location"');
+  });
+
+  // The deeper cause of the missing header, and the one a component-level fix
+  // could not reach: the shell had a rule that blanked the top and bottom
+  // chrome for these two `?action=` values, so the panel could be perfectly
+  // in-flow and still render with no back control, no trail and no avatar.
+  it("never hides the shell chrome for a Location action flow", () => {
+    expect(ROUTE_LAYOUT_SOURCE).not.toContain(
+      "shouldSuppressPersistentChromeForRouteState",
+    );
+    expect(PROVIDERS_SOURCE).not.toContain(
+      "shouldSuppressPersistentChromeForRouteState",
+    );
+    // Chrome visibility stays a property of the route, decided in one place.
+    expect(PROVIDERS_SOURCE).toContain(
+      'routeLayout.persistentChrome === "none"',
+    );
+  });
+
+  it("keeps SMS contacts — reachable from SOS — on the same header system", () => {
+    expect(SMS_CONTACTS_SOURCE).toContain("TaskFlowHeader");
+    expect(SMS_CONTACTS_SOURCE).toContain('title="SMS contacts"');
+    expect(SMS_CONTACTS_SOURCE).not.toContain("<h1");
+    expect(SMS_CONTACTS_SOURCE).not.toContain("ChevronLeft");
+    expect(SMS_CONTACTS_SOURCE).not.toContain("fixed inset-0");
+    expect(SMS_CONTACTS_SOURCE).not.toContain("100dvh");
   });
 
   it("keeps SOS motion in the app's single motion driver", () => {

--- a/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
+++ b/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { resolveTopShellMetrics } from "@/components/app-ui/top-shell-metrics";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import {
-  resolveAppRouteLayout,
-  shouldSuppressPersistentChromeForRouteState,
-} from "@/lib/navigation/app-route-layout";
+import { resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
 import { ROUTES } from "@/lib/navigation/routes";
 
 describe("home shell contract", () => {
@@ -33,19 +30,22 @@ describe("home shell contract", () => {
     expect(resolveTopShellMetrics(ROUTES.CONNECT).hasTabs).toBe(false);
   });
 
-  it("suppresses persistent chrome only for immersive SMS safety surfaces", () => {
-    expect(
-      shouldSuppressPersistentChromeForRouteState(ROUTES.ONE_LOCATION, "sos"),
-    ).toBe(true);
-    expect(
-      shouldSuppressPersistentChromeForRouteState(
-        ROUTES.ONE_LOCATION,
-        "sms-contacts",
-      ),
-    ).toBe(true);
-    expect(
-      shouldSuppressPersistentChromeForRouteState(ROUTES.ONE_LOCATION, "share"),
-    ).toBe(false);
+  it("keeps the persistent chrome on every Location task flow", () => {
+    // SOS and SMS contacts used to hide the top and bottom chrome, which took
+    // the back control, the "Location › …" trail and the profile avatar off
+    // exactly two screens and forced each to draw a private back button.
+    // Chrome visibility is a property of the ROUTE, so `?action=` never
+    // changes it — a route that needs a bare canvas says so in the layout
+    // contract instead.
+    for (const action of ["sos", "sms-contacts", "share", "settings", null]) {
+      const query = action ? `?action=${action}` : "";
+      expect(
+        resolveTopShellMetrics(`${ROUTES.ONE_LOCATION}${query}`).shellVisible,
+      ).toBe(true);
+    }
+    expect(resolveAppRouteLayout(ROUTES.ONE_LOCATION).persistentChrome).not.toBe(
+      "none",
+    );
   });
 
   it("keeps auth-only routes out of the shared command surface", () => {

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -545,6 +545,9 @@ describe("top shell breadcrumbs", () => {
       ["private-check-in", "Private Check-In"],
       // The crumb mirrors the screen's own <h1>, which reads "Save my Soul".
       ["sos", "Save my Soul"],
+      // NOTE: sms-contacts is deliberately absent from this table — it is the
+      // one flow whose back target is not the hub (it retraces to whoever
+      // opened it), so its label and back href are asserted separately below.
       ["share", "Share location"],
       ["ask", "Ask someone"],
       ["invite", "Invite to Circle"],
@@ -646,6 +649,24 @@ describe("top shell breadcrumbs", () => {
     fromSettings.set("action", "sms-contacts");
     expect(
       resolveTopShellBreadcrumb("/one/location", fromSettings)?.backHref,
+    ).toBe("/one/location?action=settings");
+
+    // SOS → SMS contacts → back to SOS. Contacts is reachable mid-emergency,
+    // and returning that person to Settings drops them out of the flow they
+    // were in the middle of, at the worst possible moment.
+    const fromSos = new URLSearchParams();
+    fromSos.set("action", "sms-contacts");
+    fromSos.set("source", "sos");
+    expect(resolveTopShellBreadcrumb("/one/location", fromSos)?.backHref).toBe(
+      "/one/location?action=sos",
+    );
+
+    // An unrecognised source is not an emergency; Settings stays the default.
+    const fromUnknown = new URLSearchParams();
+    fromUnknown.set("action", "sms-contacts");
+    fromUnknown.set("source", "nearby");
+    expect(
+      resolveTopShellBreadcrumb("/one/location", fromUnknown)?.backHref,
     ).toBe("/one/location?action=settings");
   });
 

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -21,10 +21,7 @@ import { CacheProvider } from "@/lib/cache/cache-context";
 import { ConsentNotificationProvider } from "@/components/consent/notification-provider";
 import { ConsentSheetProvider } from "@/components/consent/consent-sheet-controller";
 import { resolveTopShellRouteProfile } from "@/components/app-ui/top-shell-metrics";
-import {
-  resolveAppRouteLayout,
-  shouldSuppressPersistentChromeForRouteState,
-} from "@/lib/navigation/app-route-layout";
+import { resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
 import { AppTopShell } from "@/components/app-ui/top-app-bar";
 import { AppEdgeBackGesture } from "@/components/app-ui/app-edge-back-gesture";
 import { TopShellRouteSwipe } from "@/components/app-ui/top-shell-route-swipe";
@@ -124,12 +121,10 @@ function AppShellFrame({ children }: ProvidersProps) {
     [shellPathname],
   );
   const routeLayoutMode = routeLayout.mode;
-  const hidesPersistentChrome =
-    routeLayout.persistentChrome === "none" ||
-    shouldSuppressPersistentChromeForRouteState(
-      shellPathname,
-      searchParams?.get("action"),
-    );
+  // Chrome visibility is a property of the ROUTE, not of the `?action=` flow
+  // open inside it. Every Location task flow keeps the shell's back control,
+  // breadcrumb and avatar.
+  const hidesPersistentChrome = routeLayout.persistentChrome === "none";
   const topShellRouteProfile = useMemo(() => {
     const query = searchParams?.toString() ?? "";
     return resolveTopShellRouteProfile(

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -164,7 +164,7 @@ describe("SmsContactsFlow", () => {
     expect(screen.getByText("Remove Kushal?")).toBeInTheDocument();
   });
 
-  it("owns a full-screen settings canvas and a bottom-sheet confirmation", () => {
+  it("renders inside the shell and confirms removal in a bottom sheet", () => {
     render(
       <SmsContactsFlow
         {...baseProps}
@@ -172,11 +172,23 @@ describe("SmsContactsFlow", () => {
       />,
     );
 
-    expect(screen.getByTestId("sms-contacts-screen")).toHaveClass(
-      "fixed",
-      "inset-0",
-      "bg-background",
-    );
+    // It used to pin itself over the whole viewport, which hid the top bar's
+    // back control, "Location › SMS contacts" trail and profile avatar, and
+    // forced this screen to draw its own back arrow.
+    const screenEl = screen.getByTestId("sms-contacts-screen");
+    expect(screenEl.className).not.toMatch(/\bfixed\b/);
+    expect(screenEl.className).not.toMatch(/\binset-0\b/);
+    expect(screenEl.className).not.toMatch(/\bz-\[/);
+    expect(screenEl.className).not.toMatch(/100dvh/);
+
+    // Back belongs to the top bar; this screen exposes none of its own.
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+
+    // The title comes from the shared header primitive, matching its crumb.
+    expect(
+      screen.getByRole("heading", { level: 1, name: "SMS contacts" }),
+    ).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
     expect(screen.getByRole("alertdialog")).toHaveClass(
       "!bottom-0",

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -108,6 +108,7 @@ import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { ROUTES } from "@/lib/navigation/routes";
+import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
   CircleDetailFlow,
   CirclesSection,
@@ -467,7 +468,9 @@ const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
 export function resolveSmsContactsBackFlow(
   source: string | null | undefined,
 ): "sos" | "settings" {
-  return source === SOS_FLOW_SOURCE ? "sos" : "settings";
+  // Delegates so the rule has ONE implementation: the top bar is what actually
+  // performs this navigation now, and it resolves the target the same way.
+  return resolveSmsContactsBackAction(source);
 }
 
 const RETIRED_ACTIONS = new Set([
@@ -617,11 +620,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const nearbyPrivateCheckIn =
     searchParams.get(FLOW_ACTION_PARAM) === PRIVATE_CHECK_IN_ACTION &&
     searchParams.get(FLOW_SOURCE_PARAM) === NEARBY_CHECK_IN_SOURCE;
-  const smsContactsBackFlow = resolveSmsContactsBackFlow(
-    searchParams.get(FLOW_ACTION_PARAM) === FLOW_TO_ACTION["sms-contacts"]
-      ? searchParams.get(FLOW_SOURCE_PARAM)
-      : null,
-  );
   const nearbyReturnToken = searchParams.get(NEARBY_PRIVATE_RETURN_TOKEN_PARAM);
   const nearbyCheckInReturnHref =
     nearbyPrivateCheckIn && isNearbyPrivateReturnToken(nearbyReturnToken)
@@ -977,12 +975,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             circles={vm.circles}
             selectedUserIds={vm.smsContactUserIds}
             busyKey={vm.busy}
-            // Emergency contacts is opened from Settings and from SOS, so the
-            // back arrow follows whoever opened it rather than a fixed target.
-            // Sending someone from SOS back to Settings drops them out of the
-            // emergency flow they were in the middle of, which is the worst
-            // moment to make them find their way back.
-            onBack={() => openFlow(smsContactsBackFlow)}
+            // Back is the shell's, not this screen's. The top bar resolves the
+            // target from `?source=`, so opening contacts mid-SOS still returns
+            // to SOS rather than dropping the person into Settings.
             onAdd={vm.onAddSmsContact}
             onAddCircle={vm.onAddSmsCircle}
             onRemove={vm.onRemoveSmsContact}

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState, type ReactNode } from "react";
-import { ChevronLeft, Loader2, UsersRound } from "lucide-react";
+import { Loader2, UsersRound } from "lucide-react";
 
 import {
   AlertDialog,
@@ -18,6 +18,7 @@ import type {
   OneLocationRecipient,
 } from "@/lib/one-location/types";
 import { MUTED_TEXT, SECTION_HEADING } from "@/components/one-location/redesign/tokens";
+import { TaskFlowHeader } from "@/components/one-location/redesign/primitives";
 
 const AVATAR_TONES = [
   "bg-[#2f80ed]",
@@ -32,7 +33,6 @@ type SmsContactsFlowProps = {
   circles: OneLocationCircleSummary[];
   selectedUserIds: string[];
   busyKey: string | null;
-  onBack: () => void;
   onAdd: (recipientUserId: string) => void;
   onAddCircle: (circleId: string) => Promise<void>;
   onRemove: (recipientUserId: string) => Promise<boolean>;
@@ -131,7 +131,6 @@ export function SmsContactsFlow({
   circles,
   selectedUserIds,
   busyKey,
-  onBack,
   onAdd,
   onAddCircle,
   onRemove,
@@ -165,32 +164,22 @@ export function SmsContactsFlow({
   };
 
   return (
-    <section
-      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-background text-foreground"
-      data-ambient-chrome-ignore
-      data-testid="sms-contacts-screen"
-    >
+    // Renders inside the signed-in shell like every other Location task flow,
+    // so the top bar keeps the single back control, the
+    // "Location › SMS contacts" trail and the profile avatar. It used to pin
+    // itself over the whole viewport, which hid all three and left it drawing
+    // its own back arrow.
+    <section data-testid="sms-contacts-screen">
       {/* 430px is a phone, not a layout. Held at every width it left most of a
           tablet or a desktop window as empty grey while the lists below scrolled
           inside a narrow ribbon. The column grows with the viewport instead, and
           stops at 960px so the rows never stretch into unreadable full-bleed
           lines. */}
-      <div className="mx-auto min-h-[100dvh] w-full max-w-[430px] px-3.5 pb-[max(28px,env(safe-area-inset-bottom))] pt-[max(38px,env(safe-area-inset-top))] md:max-w-[720px] md:px-6 xl:max-w-[960px]">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Back"
-          className="press-scale flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)]"
-        >
-          <ChevronLeft className="h-[19px] w-[19px]" />
-        </button>
-
-        <h1 className="mt-3 !text-[28px] !font-bold !leading-[34px] !tracking-normal">
-          SMS contacts
-        </h1>
-        <p className="mt-2 max-w-[350px] text-[15px] font-normal leading-[20px] text-muted-foreground">
-          Alert these people in an emergency.
-        </p>
+      <div className="mx-auto w-full max-w-[430px] md:max-w-[720px] xl:max-w-[960px]">
+        <TaskFlowHeader
+          title="SMS contacts"
+          description="Alert these people in an emergency."
+        />
 
         {circles.length ? (
           <>

--- a/hushh-webapp/lib/navigation/app-route-layout.ts
+++ b/hushh-webapp/lib/navigation/app-route-layout.ts
@@ -143,17 +143,18 @@ export function resolveAppRouteLayoutMode(
   return resolveAppRouteLayout(pathname).mode;
 }
 
-/**
- * These focused Location safety surfaces own the complete viewport and their
- * own exit controls. Persistent top/bottom chrome would obscure their actions.
+/*
+ * There is deliberately no per-action chrome suppression here.
+ *
+ * `?action=sos` and `?action=sms-contacts` used to hide the persistent top and
+ * bottom chrome on the theory that a safety surface "owns the complete viewport
+ * and its own exit controls". In practice that removed the one thing every
+ * other Location screen gives you — the back control, the
+ * "Location › …" trail and the profile avatar — and forced each of those two
+ * screens to grow a private back button instead. An emergency screen is not a
+ * reason to make someone re-learn how to leave a screen.
+ *
+ * A route that genuinely needs a bare canvas declares
+ * `persistentChrome: "none"` in the route layout contract, where the decision
+ * is visible next to every other route's.
  */
-export function shouldSuppressPersistentChromeForRouteState(
-  pathname: string,
-  action: string | null | undefined,
-): boolean {
-  const normalizedAction = String(action || "").trim();
-  return (
-    normalizePathname(pathname) === "/one/location" &&
-    (normalizedAction === "sos" || normalizedAction === "sms-contacts")
-  );
-}

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -67,10 +67,28 @@ function oneLocationActionLabel(action: string): string {
     // screen's TaskFlowHeader reads "Save my Soul", so the crumb does too — a
     // crumb saying "Safety" for a screen titled otherwise breaks the trail.
     sos: "Save my Soul",
+    "sms-contacts": "SMS contacts",
     settings: "Settings",
     privacy: "Settings",
   };
   return labels[action] ?? titleizeSegment(action);
+}
+
+/**
+ * Which Location flow the SMS-contacts screen returns to.
+ *
+ * It is reachable from Settings AND from the middle of an SOS, so a fixed
+ * target is wrong: sending someone from SOS back to Settings drops them out of
+ * the emergency flow at the worst possible moment. The hub records the origin
+ * as `?source=sos` when it opens the screen; anything else (including an
+ * absent or unrecognised source) means Settings, where the other entry points
+ * live. This is the single implementation — `resolveSmsContactsBackFlow` in
+ * the Location hub delegates here so the two cannot drift.
+ */
+export function resolveSmsContactsBackAction(
+  source: string | null | undefined,
+): "sos" | "settings" {
+  return source === "sos" ? "sos" : "settings";
 }
 
 function profilePanelLabel(panel: ProfilePanel | null): string | null {
@@ -723,11 +741,14 @@ function resolveTopShellBreadcrumbInner(
       // from People returns to People — instead of always dropping to the
       // default "Now" tab. `openFlow` keeps the current `?view=` tab in the URL
       // when it appends `?action=`, so it is available here. SMS contacts is
-      // only ever reached from Settings, so it retraces to the Settings flow.
+      // reached from Settings AND from the middle of an SOS, so it retraces to
+      // whichever one opened it (see resolveSmsContactsBackAction).
       const hubView = String(searchParams?.get("view") || "").trim();
       const hubBackHref =
         action === "sms-contacts"
-          ? `${ROUTES.ONE_LOCATION}?action=settings`
+          ? `${ROUTES.ONE_LOCATION}?action=${resolveSmsContactsBackAction(
+              searchParams?.get("source"),
+            )}`
           : hubView
             ? `${ROUTES.ONE_LOCATION}?view=${encodeURIComponent(hubView)}`
             : ROUTES.ONE_LOCATION;


### PR DESCRIPTION
## The bug my last two PRs did not fix

SOS still rendered with **no back control, no `Location › …` trail and no profile avatar** — because the cause was a layer above the component.

`lib/navigation/app-route-layout.ts` exported `shouldSuppressPersistentChromeForRouteState`, which returned `true` for `?action=sos` and `?action=sms-contacts`. `app/providers.tsx` OR-ed it into `hidesPersistentChrome`. So the panel could be perfectly in-flow, every test green, and the shell would still never mount its chrome.

#5251 removed the component's `fixed inset-0` overlay. #5252 rebuilt the body to the design. Neither could reach this.

## Fix

The suppression is removed. Chrome visibility is a property of the **route**, declared once as `persistentChrome` in the route layout contract beside every other route's — never a property of the `?action=` flow open inside it.

The original comment argued these surfaces "own the complete viewport and their own exit controls". That is the argument that produced the bug: it took the back control, the trail and the avatar off exactly two screens and made each grow a private back button. An emergency is not a reason to make someone re-learn how to leave a screen.

## SMS contacts comes along

It is reached **from SOS** via `+ Contacts`. Leaving it suppressed meant tapping from a screen with a header onto one without. It now renders in-flow with a `TaskFlowHeader` (`SMS contacts`, matching its new crumb) and drops its private back arrow and full-viewport canvas.

### The thing that back arrow knew

SMS contacts is reachable from Settings **and** from the middle of an SOS, and the breadcrumb hardcoded a return to Settings. Returning someone to Settings mid-emergency drops them out of the flow they were in — which is exactly what the deleted button's comment warned about.

`resolveSmsContactsBackAction` in `top-shell-breadcrumbs.ts` is now the single implementation, reading the `?source=sos` marker the hub already writes. The hub's exported `resolveSmsContactsBackFlow` delegates to it, so the two cannot drift.

## Edge cases covered

`?action=sos` deep link · SOS → Contacts → back returns to SOS · Settings → Contacts → back returns to Settings · unrecognised `?source=` falls back to Settings · every other Location action flow keeps its chrome unchanged · routes that genuinely want a bare canvas still get it via `persistentChrome: "none"`.

## Tests

- `home-shell-contract.test.ts` — now asserts **every** Location action flow keeps `shellVisible`
- `top-shell-breadcrumbs.test.ts` — both SMS-contacts return paths + unrecognised source + the `SMS contacts` crumb
- `one-location-sos-emergency.contract.test.tsx` — scans `providers.tsx` and `app-route-layout.ts` so the suppression cannot come back, and holds SMS contacts to the same header system
- `sms-contacts-flow.test.tsx` — rewritten off the old fullscreen assertion onto the in-shell contract
- `npm run typecheck` · `verify:design-system` · `verify:surface-map` — all clean
- `eslint --max-warnings=0` on all changed files — clean

Baseline: the Location + navigation sweep fails identically on `origin/main` and here (`one-location-onboarding-flow`, `one-location-settings-placement` ×2, `shared-with-me-card`) — all pre-existing.

## Risk / rollback

Navigation chrome and presentation only; no API, schema, permission or data change. Straight revert.