### PR TITLE
fix(one-location): remember where you are across reloads

### DIFF
--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -24,8 +24,18 @@ const navigation = vi.hoisted(() => ({
   push: vi.fn(),
 }));
 
+const locationMemory = vi.hoisted(() => ({
+  readLastKnownFix: vi.fn(),
+  rememberLastKnownFix: vi.fn(),
+}));
+
 vi.mock("@/lib/one-location/service", () => ({
   OneLocationService: service,
+}));
+
+vi.mock("@/lib/one-location/location-grant-memory", () => ({
+  readLastKnownFix: locationMemory.readLastKnownFix,
+  rememberLastKnownFix: locationMemory.rememberLastKnownFix,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -53,6 +63,12 @@ describe("NearbyCheckInSheet", () => {
   beforeEach(() => {
     Object.values(service).forEach((mock) => mock.mockReset());
     navigation.push.mockReset();
+    locationMemory.readLastKnownFix.mockReset();
+    locationMemory.rememberLastKnownFix.mockReset();
+    // Default: nothing carried over, which is what every pre-existing test in
+    // this file assumed before durable memory existed.
+    locationMemory.readLastKnownFix.mockResolvedValue(null);
+    locationMemory.rememberLastKnownFix.mockResolvedValue(undefined);
     service.nearbyCheckInErrorDetails.mockReturnValue({
       message: "Check-in didn't complete. Your location is not visible.",
       retryLocation: false,
@@ -1379,5 +1395,141 @@ describe("NearbyCheckInSheet", () => {
     // No point captured while a check-in is already live, so there is nothing
     // to compare against and the sheet stays silent rather than guessing.
     expect(screen.queryByTestId("nearby-active-drift")).not.toBeInTheDocument();
+  });
+
+  /**
+   * The reported failure, on a cold start.
+   *
+   * Opening the drawer after a reload used to mean: nothing in the in-session
+   * ref, a first GPS read that fails with `kCLErrorLocationUnknown` (routine on
+   * any machine without a GPS radio), and therefore "Still finding you" with an
+   * empty list — on a device that knew exactly where it was minutes earlier.
+   */
+  describe("on a cold start", () => {
+    /**
+     * Built per test, never once at module load: the age label is relative to
+     * `Date.now()` at render, so a fixture frozen when the file was imported
+     * drifts by however long the rest of the suite took to reach this test.
+     */
+    function carriedOver(ageMs = 4 * 60_000) {
+      return {
+        ...point,
+        latitude: 37.4279,
+        capturedAt: new Date(Date.now() - ageMs).toISOString(),
+      };
+    }
+
+    function unavailable() {
+      return new Error(
+        "Could not get your location. Turn on Location for your device/browser and try again.",
+      );
+    }
+
+    it("lists places around the carried-over fix instead of dead-ending", async () => {
+      const carriedOverPoint = carriedOver();
+      locationMemory.readLastKnownFix.mockResolvedValue(carriedOverPoint);
+
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockRejectedValue(unavailable())}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await screen.findByRole("radio", { name: /Stanford University/ });
+      expect(
+        screen.queryByTestId("nearby-location-fallback"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Still finding you")).not.toBeInTheDocument();
+      expect(service.nearbyPlaces).toHaveBeenCalledWith({
+        vaultOwnerToken: "owner-token",
+        lat: carriedOverPoint.latitude,
+        lng: carriedOverPoint.longitude,
+        category: "all",
+      });
+    });
+
+    it("says the position is carried over, and how old it is", async () => {
+      const carriedOverPoint = carriedOver();
+      locationMemory.readLastKnownFix.mockResolvedValue(carriedOverPoint);
+
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockRejectedValue(unavailable())}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      const notice = await screen.findByTestId("nearby-last-known-notice");
+      // Silently drawing an old position as the current one would be the wrong
+      // trade. The drawer keeps working AND says what it is showing.
+      expect(notice).toHaveTextContent(/last known position/i);
+      expect(notice).toHaveTextContent(/about 4 minutes ago/i);
+    });
+
+    it("still says so plainly when there is nothing carried over", async () => {
+      locationMemory.readLastKnownFix.mockResolvedValue(null);
+
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockRejectedValue(unavailable())}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      // A first-ever open with no fix genuinely has nothing to show. Inventing
+      // a position here would be worse than the error.
+      await screen.findByTestId("nearby-location-fallback");
+      expect(screen.getByText("Still finding you")).toBeInTheDocument();
+    });
+
+    it("reads the carried-over fix for the account that asked for it", async () => {
+      const carriedOverPoint = carriedOver();
+      locationMemory.readLastKnownFix.mockResolvedValue(carriedOverPoint);
+
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-9"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockRejectedValue(unavailable())}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await screen.findByRole("radio", { name: /Stanford University/ });
+      expect(locationMemory.readLastKnownFix).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user-9" }),
+      );
+    });
+
+    it("carries a successful fix forward for the next one", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await screen.findByRole("radio", { name: /Stanford University/ });
+      await waitFor(() => {
+        expect(locationMemory.rememberLastKnownFix).toHaveBeenCalledWith({
+          userId: "user-1",
+          point,
+        });
+      });
+    });
   });
 });

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -35,6 +35,10 @@ import { Switch } from "@/components/ui/switch";
 import { relationshipCta } from "@/lib/connections/relationship-label";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+import {
+  readLastKnownFix,
+  rememberLastKnownFix,
+} from "@/lib/one-location/location-grant-memory";
 import { locationBlockReason } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
@@ -102,6 +106,30 @@ type PointOrigin = "fresh" | "last-known";
  * plausibly has not moved. Past this we stop offering it as "where you are".
  */
 const LAST_KNOWN_POINT_MAX_AGE_MS = 10 * 60 * 1_000;
+
+/**
+ * The same idea, for a fix restored from a previous session rather than taken
+ * during this one.
+ *
+ * Deliberately longer. The in-session budget above governs a silent swap — the
+ * drawer keeps working and says little — so it has to be tight. A restored fix
+ * is always announced, always dated, and always requires the owner to choose a
+ * specific place, which the backend then plausibility-checks at check-in. The
+ * honest comparison is not "an hour-old fix versus a current one", it is "an
+ * hour-old fix, labelled, versus a dead end" — which is what a cold start with
+ * no GPS answer used to be.
+ */
+const RESTORED_POINT_MAX_AGE_MS = 60 * 60 * 1_000;
+
+/** "just now" / "about 20 minutes ago" — how old a restored fix is. */
+function restoredPointAgeLabel(capturedAt: string | null | undefined): string {
+  const capturedMs = Date.parse(capturedAt ?? "");
+  if (!Number.isFinite(capturedMs)) return "";
+  const ageMinutes = Math.round((Date.now() - capturedMs) / 60_000);
+  if (ageMinutes <= 1) return " from just now";
+  if (ageMinutes < 60) return ` from about ${ageMinutes} minutes ago`;
+  return " from about an hour ago";
+}
 
 export type NearbyCheckInPlaceFocus = {
   placeId: string;
@@ -571,30 +599,59 @@ export function NearbyCheckInSheet({
   /**
    * Fall back to the last good fix instead of emptying the drawer.
    *
-   * Returns true when a usable substitute point was adopted. A stale-but-recent
-   * position still lists the right venues, and the owner -- who can see which
-   * building they are in -- is a better judge of that than a receiver having a
-   * bad second. The backend still verifies plausibility at check-in.
+   * A stale-but-recent position still lists the right venues, and the owner --
+   * who can see which building they are in -- is a better judge of that than a
+   * receiver having a bad second. The backend still verifies plausibility at
+   * check-in.
+   *
+   * Two sources, in order of confidence: a fix taken during this session, then
+   * the sealed one carried over from the last. The second is why a cold start
+   * no longer dead-ends. Before it existed the fallback lived only in a ref, so
+   * the very first capture after a reload had nothing behind it -- and on any
+   * machine without a GPS radio that first capture routinely fails with
+   * `kCLErrorLocationUnknown`. A device that knew exactly where it was ten
+   * minutes ago showed "we couldn't get a location reading".
+   *
+   * Returns true when the caller must NOT write a location error -- either a
+   * point was adopted, or the request was superseded while reading storage and
+   * no longer owns the screen.
    */
   const adoptLastKnownPoint = useCallback(
-    (generation: number, expectedOwnerEpoch: number): boolean => {
-      const fallback = lastKnownPointRef.current;
-      if (!fallback) return false;
-      const capturedAt = Date.parse(fallback.capturedAt ?? "");
+    async (generation: number, expectedOwnerEpoch: number): Promise<boolean> => {
+      const superseded = () =>
+        ownerEpochRef.current !== expectedOwnerEpoch ||
+        requestGenerationRef.current !== generation;
+
+      const sessionFix = lastKnownPointRef.current;
+      const sessionFixAt = Date.parse(sessionFix?.capturedAt ?? "");
       if (
-        !Number.isFinite(capturedAt) ||
-        Date.now() - capturedAt > LAST_KNOWN_POINT_MAX_AGE_MS
+        sessionFix &&
+        Number.isFinite(sessionFixAt) &&
+        Date.now() - sessionFixAt <= LAST_KNOWN_POINT_MAX_AGE_MS
       ) {
-        return false;
+        setPoint(sessionFix);
+        setPointOrigin("last-known");
+        setLocationError(null);
+        setAccuracyNotice(null);
+        void loadPlaces(sessionFix, generation, expectedOwnerEpoch);
+        return true;
       }
-      setPoint(fallback);
+
+      const restored = await readLastKnownFix({
+        userId: ownerId,
+        maxAgeMs: RESTORED_POINT_MAX_AGE_MS,
+      }).catch(() => null);
+      if (superseded()) return true;
+      if (!restored) return false;
+
+      setPoint(restored);
       setPointOrigin("last-known");
       setLocationError(null);
       setAccuracyNotice(null);
-      void loadPlaces(fallback, generation, expectedOwnerEpoch);
+      void loadPlaces(restored, generation, expectedOwnerEpoch);
       return true;
     },
-    [loadPlaces],
+    [loadPlaces, ownerId],
   );
 
   const captureAndLoadPlaces = useCallback(
@@ -631,7 +688,7 @@ export function NearbyCheckInSheet({
         }
         if (permission?.state === "granted" && permission.precise === false) {
           setLocationRecovery(isNative() ? "app-settings" : null);
-          if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
+          if (!(await adoptLastKnownPoint(generation, expectedOwnerEpoch))) {
             setPoint(null);
             setLocationError(
               "Precise location is off, so we can't see what's around you yet. Turn it on and we'll pick this up automatically.",
@@ -647,7 +704,7 @@ export function NearbyCheckInSheet({
         // being kept: the check-in sheet refused here before ever attempting.
         if (locationBlockReason(permission ?? null)) {
           setLocationRecovery(isNative() ? "app-settings" : null);
-          if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
+          if (!(await adoptLastKnownPoint(generation, expectedOwnerEpoch))) {
             setPoint(null);
             setLocationError(
               isNative()
@@ -662,7 +719,7 @@ export function NearbyCheckInSheet({
           permission.locationServicesEnabled === false
         ) {
           setLocationRecovery(isNative() ? "location-settings" : null);
-          if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
+          if (!(await adoptLastKnownPoint(generation, expectedOwnerEpoch))) {
             setPoint(null);
             setLocationError(
               isNative()
@@ -694,7 +751,7 @@ export function NearbyCheckInSheet({
             settledPermission.precise === false
           ) {
             setLocationRecovery(isNative() ? "app-settings" : null);
-            if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
+            if (!(await adoptLastKnownPoint(generation, expectedOwnerEpoch))) {
               setPoint(null);
               setLocationError(
                 "Precise location is off, so we can't see what's around you yet. Turn it on and we'll pick this up automatically.",
@@ -708,7 +765,7 @@ export function NearbyCheckInSheet({
         }
         if (!hasCheckInAccuracy(nextPoint)) {
           setLocationRecovery(isNative() ? "app-settings" : null);
-          if (!adoptLastKnownPoint(generation, expectedOwnerEpoch)) {
+          if (!(await adoptLastKnownPoint(generation, expectedOwnerEpoch))) {
             setPoint(null);
             setLocationError(
               "We can't pin down where you are just yet. Stepping outside or near a window usually fixes it.",
@@ -725,6 +782,10 @@ export function NearbyCheckInSheet({
           isCoarseAccuracy(nextPoint) ? coarseAccuracyNotice(nextPoint) : null,
         );
         lastKnownPointRef.current = nextPoint;
+        // Carry it past this page. The next cold start reads this instead of
+        // starting from nothing, which is what turns a failed first GPS read
+        // from a dead end into a labelled fallback.
+        void rememberLastKnownFix({ userId: ownerId, point: nextPoint });
         setPointOrigin("fresh");
         setPoint(nextPoint);
         await loadPlaces(nextPoint, generation, expectedOwnerEpoch);
@@ -736,7 +797,7 @@ export function NearbyCheckInSheet({
           return;
         }
         setLocationRecovery(isNative() ? "app-settings" : null);
-        if (adoptLastKnownPoint(generation, expectedOwnerEpoch)) return;
+        if (await adoptLastKnownPoint(generation, expectedOwnerEpoch)) return;
         setPoint(null);
         setAutomaticPlaces([]);
         setSearchResults([]);
@@ -1662,7 +1723,8 @@ export function NearbyCheckInSheet({
                           aria-hidden="true"
                         />
                         <span>
-                          Showing places around your last known position — we
+                          Showing places around your last known position
+                          {restoredPointAgeLabel(point.capturedAt)} — we
                           couldn’t refresh it just now. Pick where you actually
                           are, or{" "}
                           <button

--- a/hushh-webapp/lib/one-location/__tests__/location-bus-durable.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus-durable.test.ts
@@ -1,0 +1,267 @@
+// The bus half of "One should just know where I am".
+//
+// The behaviour under test is the one the screenshot showed: a device that knew
+// exactly where it was minutes ago, opening to "we couldn't get a location
+// reading" because the app held that answer in memory and the page had
+// reloaded. `kCLErrorLocationUnknown` is not an exception on the machines that
+// hit this — macOS and desktop Chrome emit it routinely, because there is no
+// GPS radio to answer with.
+//
+// Durable storage is mocked here on purpose. What it stores and how long it
+// keeps it is `location-grant-memory.test.ts`'s subject; what the bus does with
+// a restored fix is this file's.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLocation, mockMemory } = vi.hoisted(() => ({
+  mockLocation: {
+    getPermissionState: vi.fn(),
+    requestLocationPermission: vi.fn(),
+    getCurrentPosition: vi.fn(),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  },
+  mockMemory: {
+    readLastKnownFix: vi.fn(),
+    rememberLastKnownFix: vi.fn(),
+    rememberLocationGrant: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/capacitor", () => ({ HushhLocation: mockLocation }));
+vi.mock("@/lib/one-location/location-grant-memory", () => ({
+  LAST_KNOWN_FIX_RETENTION_MS: 24 * 60 * 60 * 1_000,
+  readLastKnownFix: mockMemory.readLastKnownFix,
+  rememberLastKnownFix: mockMemory.rememberLastKnownFix,
+  rememberLocationGrant: mockMemory.rememberLocationGrant,
+}));
+
+import { LocationBus } from "@/lib/one-location/location-bus";
+
+const USER = "user-alpha";
+
+const FRESH_POINT = {
+  latitude: 47.6769,
+  longitude: -122.206,
+  accuracyM: 12,
+  capturedAt: new Date().toISOString(),
+  sourcePlatform: "web" as const,
+};
+
+const RESTORED_POINT = {
+  latitude: 19.0759837,
+  longitude: 72.8776559,
+  accuracyM: 40,
+  capturedAt: new Date(Date.now() - 15 * 60_000).toISOString(),
+  sourcePlatform: "web" as const,
+};
+
+/** What CoreLocation actually raises on a machine with no GPS. */
+function positionUnavailable(): Error {
+  return new Error(
+    "Could not get your location. Turn on Location for your device/browser and try again.",
+  );
+}
+
+function denial(): Error {
+  const error = new Error(
+    "Location permission is blocked for this site. Allow location access in your browser's site settings, then try again.",
+  );
+  error.name = "LocationPermissionDeniedError";
+  return error;
+}
+
+beforeEach(() => {
+  LocationBus.__resetForTests();
+  vi.clearAllMocks();
+  mockLocation.getCurrentPosition.mockResolvedValue(FRESH_POINT);
+  mockLocation.getPermissionState.mockResolvedValue({
+    state: "granted",
+    precise: true,
+    background: "foreground-only",
+  });
+  mockLocation.requestLocationPermission.mockResolvedValue({
+    state: "granted",
+    precise: true,
+    background: "foreground-only",
+  });
+  mockLocation.watchPosition.mockResolvedValue("watch-1");
+  mockLocation.clearWatch.mockResolvedValue(undefined);
+  mockMemory.readLastKnownFix.mockResolvedValue(null);
+  mockMemory.rememberLastKnownFix.mockResolvedValue(undefined);
+});
+
+describe("attaching an account", () => {
+  it("restores the previous session's fix", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+
+    await LocationBus.attachUser(USER);
+
+    const state = LocationBus.getState();
+    expect(state.snapshot?.latitude).toBe(RESTORED_POINT.latitude);
+    expect(state.snapshotOrigin).toBe("restored");
+    expect(state.status).toBe("stale");
+  });
+
+  it("does not report a restored fix as ready", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+
+    await LocationBus.attachUser(USER);
+
+    // Every consumer written before durable memory gates on `ready` and means
+    // "measured just now" by it. A restored coordinate must not start passing
+    // those checks silently.
+    expect(LocationBus.getState().status).not.toBe("ready");
+  });
+
+  it("stays idle when there is nothing to restore", async () => {
+    await LocationBus.attachUser(USER);
+
+    expect(LocationBus.getState().snapshot).toBeNull();
+    expect(LocationBus.getState().status).toBe("idle");
+  });
+
+  it("reads storage once when several surfaces attach together", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+
+    await Promise.all([
+      LocationBus.attachUser(USER),
+      LocationBus.attachUser(USER),
+      LocationBus.attachUser(USER),
+    ]);
+
+    expect(mockMemory.readLastKnownFix).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears one account's position the moment another signs in", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+    await LocationBus.attachUser(USER);
+    expect(LocationBus.getState().snapshot).not.toBeNull();
+
+    mockMemory.readLastKnownFix.mockResolvedValue(null);
+    await LocationBus.attachUser("user-beta");
+
+    // Never a window in which one person's coordinate is visible under another
+    // person's session.
+    expect(LocationBus.getState().snapshot).toBeNull();
+    expect(LocationBus.getState().snapshotOrigin).toBeNull();
+  });
+
+  it("stores nothing while no account is attached", async () => {
+    await LocationBus.ensure();
+
+    expect(mockMemory.rememberLastKnownFix).not.toHaveBeenCalled();
+    expect(mockMemory.rememberLocationGrant).not.toHaveBeenCalled();
+  });
+});
+
+describe("a transient failure with a position already in hand", () => {
+  it("keeps the position instead of showing an error", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+    await LocationBus.attachUser(USER);
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    const result = await LocationBus.ensure({ maxAgeMs: 0 });
+
+    // This is the reported bug, inverted into an assertion.
+    expect(LocationBus.getState().status).not.toBe("error");
+    expect(LocationBus.getState().status).toBe("stale");
+    expect(LocationBus.getState().snapshot?.latitude).toBe(RESTORED_POINT.latitude);
+    expect(result?.latitude).toBe(RESTORED_POINT.latitude);
+  });
+
+  it("never blanks a visible position while retrying", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+    await LocationBus.attachUser(USER);
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    const seen: (number | null)[] = [];
+    LocationBus.subscribe((state) => seen.push(state.snapshot?.latitude ?? null));
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    // A flash of "locating" with an empty map is the flicker this change
+    // exists to remove.
+    expect(seen.every((latitude) => latitude === RESTORED_POINT.latitude)).toBe(true);
+  });
+
+  it("still reports an error when there is no position at all", async () => {
+    await LocationBus.attachUser(USER);
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    // Suppressing this would hide a real dead end from someone who has no way
+    // to know location is not working.
+    expect(LocationBus.getState().status).toBe("error");
+  });
+
+  it("lets a real denial through even with a restored fix on screen", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+    await LocationBus.attachUser(USER);
+    mockLocation.getCurrentPosition.mockRejectedValue(denial());
+
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    // "You said no" needs Settings; "the fix failed" needs a retry. A remembered
+    // position must never soften the first into the second.
+    expect(LocationBus.getState().status).toBe("denied");
+    expect(LocationBus.getState().permission).toBe("denied");
+  });
+});
+
+describe("a fresh fix", () => {
+  it("replaces a restored one and records the grant", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+    await LocationBus.attachUser(USER);
+
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    const state = LocationBus.getState();
+    expect(state.status).toBe("ready");
+    expect(state.snapshotOrigin).toBe("fresh");
+    expect(state.snapshot?.latitude).toBe(FRESH_POINT.latitude);
+    expect(mockMemory.rememberLocationGrant).toHaveBeenCalledWith(USER);
+    expect(mockMemory.rememberLastKnownFix).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER }),
+    );
+  });
+
+  it("is still pursued when a restored fix looks recent", async () => {
+    mockMemory.readLastKnownFix.mockResolvedValue({
+      ...RESTORED_POINT,
+      capturedAt: new Date().toISOString(),
+    });
+    await LocationBus.attachUser(USER);
+
+    await LocationBus.ensure();
+
+    // Reusing a restored fix because its timestamp is young would produce an app
+    // that never refreshes as long as its own memory looks recent.
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalled();
+    expect(LocationBus.getState().snapshotOrigin).toBe("fresh");
+  });
+
+  it("still short-circuits the GPS for a fix measured this session", async () => {
+    await LocationBus.attachUser(USER);
+    await LocationBus.ensure();
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    await LocationBus.ensure();
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not seal a coordinate on every movement tick", async () => {
+    await LocationBus.attachUser(USER);
+
+    await LocationBus.ensure({ maxAgeMs: 0 });
+    await LocationBus.ensure({ maxAgeMs: 0 });
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    // Each seal costs an ECDH derivation. Three fixes inside the throttle
+    // window are worth exactly one write; the grant is refreshed every time
+    // because it is two short strings.
+    expect(mockMemory.rememberLastKnownFix).toHaveBeenCalledTimes(1);
+    expect(mockMemory.rememberLocationGrant).toHaveBeenCalledTimes(3);
+  });
+});

--- a/hushh-webapp/lib/one-location/__tests__/location-bus-durable.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus-durable.test.ts
@@ -147,6 +147,27 @@ describe("attaching an account", () => {
     expect(LocationBus.getState().snapshotOrigin).toBeNull();
   });
 
+  it("keeps a fix captured before the account was attached", async () => {
+    // Key bootstrap is async, so a surface can resolve a position before
+    // `attachUser` runs. Clearing on first attach would throw that live fix
+    // away and restore an older stored one in its place.
+    await LocationBus.ensure();
+    expect(LocationBus.getState().snapshot?.latitude).toBe(FRESH_POINT.latitude);
+    mockMemory.readLastKnownFix.mockResolvedValue(RESTORED_POINT);
+
+    await LocationBus.attachUser(USER);
+
+    const state = LocationBus.getState();
+    expect(state.snapshot?.latitude).toBe(FRESH_POINT.latitude);
+    expect(state.snapshotOrigin).toBe("fresh");
+    expect(state.status).toBe("ready");
+    // And it is written through, so it is not lost if the page reloads before
+    // the next capture.
+    expect(mockMemory.rememberLastKnownFix).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER }),
+    );
+  });
+
   it("stores nothing while no account is attached", async () => {
     await LocationBus.ensure();
 

--- a/hushh-webapp/lib/one-location/__tests__/location-grant-memory.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-grant-memory.test.ts
@@ -1,0 +1,349 @@
+// @vitest-environment node
+//
+// The durable half of "One should just know where I am".
+//
+// Two properties matter more than the rest and are asserted directly rather
+// than inferred:
+//
+//   1. A coordinate is NEVER written to storage in the clear. The test greps
+//      the raw stored string for the latitude and longitude it just saved. If
+//      someone ever swaps the envelope for a plain JSON write to make a test
+//      easier, that assertion fails.
+//   2. A remembered fix expires on two independent clocks — how long we keep it
+//      (retention) and how long it may be presented as current (the caller's
+//      budget). Conflating them would either strand a stale coordinate on the
+//      device or throw away the fallback that makes a cold start work.
+//
+// Runs in the `node` environment for the same reason `encryption.test.ts` does:
+// jsdom hands out cross-realm ArrayBuffers that Node's SubtleCrypto rejects.
+// `window.localStorage` is therefore supplied by hand below.
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/capacitor", () => ({
+  HushhKeychain: {
+    set: vi.fn(async () => undefined),
+    get: vi.fn(async () => ({ value: null })),
+    delete: vi.fn(async () => undefined),
+  },
+}));
+
+// Not native: the Keychain mirror is `encryption.ts`'s concern and has its own
+// test. Here the IndexedDB key alone must be enough.
+vi.mock("@/lib/capacitor/platform", () => ({ isNative: () => false }));
+
+import {
+  LAST_KNOWN_FIX_RETENTION_MS,
+  LOCATION_GRANT_TTL_MS,
+  forgetLastKnownFix,
+  forgetLocationMemory,
+  hasRememberedLocationGrant,
+  readLastKnownFix,
+  readLocationGrant,
+  rememberLastKnownFix,
+  rememberLocationGrant,
+} from "@/lib/one-location/location-grant-memory";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const USER = "user-alpha";
+const OTHER_USER = "user-beta";
+
+const LAT = 19.0759837;
+const LNG = 72.8776559;
+
+const FIX_KEY = `one_location_last_fix_v1:${USER}`;
+const GRANT_KEY = `one_location_grant_v1:${USER}`;
+
+function point(overrides: Partial<PlainLocationPoint> = {}): PlainLocationPoint {
+  return {
+    latitude: LAT,
+    longitude: LNG,
+    accuracyM: 18,
+    capturedAt: new Date().toISOString(),
+    sourcePlatform: "web",
+    ...overrides,
+  };
+}
+
+/** Minimal Storage. Deliberately real enough to throw where a browser throws. */
+function createStorage(): Storage & { failWrites: boolean } {
+  const map = new Map<string, string>();
+  return {
+    failWrites: false,
+    get length() {
+      return map.size;
+    },
+    key: (index: number) => [...map.keys()][index] ?? null,
+    getItem: (key: string) => (map.has(key) ? map.get(key)! : null),
+    setItem(this: { failWrites: boolean }, key: string, value: string) {
+      if (this.failWrites) throw new Error("QuotaExceededError");
+      map.set(key, value);
+    },
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+  } as Storage & { failWrites: boolean };
+}
+
+let storage: ReturnType<typeof createStorage>;
+
+beforeEach(() => {
+  storage = createStorage();
+  (globalThis as { window?: unknown }).window = { localStorage: storage };
+});
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  vi.clearAllMocks();
+});
+
+/** Rewrite a stored record's timestamps to simulate the passage of time. */
+function ageStoredFix(params: { capturedAgoMs?: number; storedAgoMs?: number }) {
+  const raw = storage.getItem(FIX_KEY);
+  if (!raw) throw new Error("no stored fix to age");
+  const record = JSON.parse(raw) as { capturedAt: string; storedAt: string };
+  if (params.capturedAgoMs !== undefined) {
+    record.capturedAt = new Date(Date.now() - params.capturedAgoMs).toISOString();
+  }
+  if (params.storedAgoMs !== undefined) {
+    record.storedAt = new Date(Date.now() - params.storedAgoMs).toISOString();
+  }
+  storage.setItem(FIX_KEY, JSON.stringify(record));
+}
+
+describe("the sealed last-known fix", () => {
+  it("survives a cold start and returns the same coordinate", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+
+    const restored = await readLastKnownFix({
+      userId: USER,
+      maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS,
+    });
+
+    expect(restored?.latitude).toBeCloseTo(LAT, 10);
+    expect(restored?.longitude).toBeCloseTo(LNG, 10);
+  });
+
+  it("never writes a coordinate to storage in the clear", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+
+    const raw = storage.getItem(FIX_KEY);
+    expect(raw).toBeTruthy();
+    // The whole record, not just the ciphertext field: a future refactor that
+    // adds a "convenient" plaintext lat/lng alongside the envelope must fail.
+    expect(raw).not.toContain("19.07");
+    expect(raw).not.toContain("72.87");
+    expect(raw).not.toContain(String(LAT));
+    expect(raw).not.toContain(String(LNG));
+    expect(JSON.parse(raw!).envelope.metadata.plaintext).toBe(false);
+  });
+
+  it("drops a Drive destination rather than persisting it with the point", async () => {
+    await rememberLastKnownFix({
+      userId: USER,
+      point: point({
+        drive: {
+          destinationLabel: "Home",
+          destinationLatitude: 1,
+          destinationLongitude: 2,
+        } as PlainLocationPoint["drive"],
+      }),
+    });
+
+    const restored = await readLastKnownFix({
+      userId: USER,
+      maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS,
+    });
+
+    // A share's destination is justified by that share, not by "where I last
+    // was", and must not outlive it on the device.
+    expect(restored?.drive ?? null).toBeNull();
+  });
+
+  it("keeps a fix that is too old to present but still worth keeping", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+    ageStoredFix({ capturedAgoMs: 30 * 60_000 });
+
+    // The Nearby drawer's in-session budget refuses it...
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: 10 * 60_000 }),
+    ).resolves.toBeNull();
+    // ...but it is still on disk, because a longer-budget caller may use it and
+    // it is still a better starting point than nothing.
+    expect(storage.getItem(FIX_KEY)).toBeTruthy();
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: 60 * 60_000 }),
+    ).resolves.not.toBeNull();
+  });
+
+  it("deletes a fix once retention has run out", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+    ageStoredFix({ storedAgoMs: LAST_KNOWN_FIX_RETENTION_MS + 60_000 });
+
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS }),
+    ).resolves.toBeNull();
+    // Not merely refused — gone. A coordinate nobody will ever use must not sit
+    // on the device.
+    expect(storage.getItem(FIX_KEY)).toBeNull();
+  });
+
+  it("refuses a fix timestamped in the future instead of trusting it forever", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+    ageStoredFix({ capturedAgoMs: -60 * 60_000 });
+
+    // A clock change is not a fresh fix. Treating "age is negative" as "young
+    // enough" would make a skewed device reuse one coordinate indefinitely.
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: 10 * 60_000 }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not hand one account's position to another", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+
+    await expect(
+      readLastKnownFix({
+        userId: OTHER_USER,
+        maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns nothing it cannot open, but does not throw the record away", async () => {
+    await rememberLastKnownFix({ userId: USER, point: point() });
+    const raw = JSON.parse(storage.getItem(FIX_KEY)!);
+    // The envelope now names a key this device does not currently hold.
+    raw.envelope.recipientKeyId = "not-the-current-key";
+    storage.setItem(FIX_KEY, JSON.stringify(raw));
+
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS }),
+    ).resolves.toBeNull();
+    // A key that has rotated away for good and a key that has not finished
+    // being provisioned fail identically here. Deleting would turn that race
+    // into permanent loss of a good fix, so retention is left to clear it.
+    expect(storage.getItem(FIX_KEY)).toBeTruthy();
+  });
+
+  it("drops an unparseable record without throwing", async () => {
+    storage.setItem(FIX_KEY, "{not json");
+
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS }),
+    ).resolves.toBeNull();
+    expect(storage.getItem(FIX_KEY)).toBeNull();
+  });
+
+  it("refuses a point with no usable coordinate", async () => {
+    await rememberLastKnownFix({
+      userId: USER,
+      point: point({ latitude: Number.NaN }),
+    });
+
+    expect(storage.getItem(FIX_KEY)).toBeNull();
+  });
+});
+
+describe("the remembered grant", () => {
+  it("is recorded once and renewed on every later fix", () => {
+    rememberLocationGrant(USER);
+    const first = readLocationGrant(USER);
+    expect(first).not.toBeNull();
+
+    const stored = JSON.parse(storage.getItem(GRANT_KEY)!);
+    stored.lastConfirmedAt = new Date(Date.now() - 60_000).toISOString();
+    storage.setItem(GRANT_KEY, JSON.stringify(stored));
+
+    rememberLocationGrant(USER);
+    const second = readLocationGrant(USER)!;
+
+    // "Since when" never moves; "still true as of" always does. That is what
+    // keeps an account in normal use from ever ageing out of its own grant.
+    expect(second.grantedAt).toBe(first!.grantedAt);
+    expect(Date.parse(second.lastConfirmedAt)).toBeGreaterThan(
+      Date.parse(stored.lastConfirmedAt),
+    );
+  });
+
+  it("expires only after a long idle window, then forgets itself", () => {
+    rememberLocationGrant(USER);
+    const stored = JSON.parse(storage.getItem(GRANT_KEY)!);
+
+    stored.lastConfirmedAt = new Date(
+      Date.now() - (LOCATION_GRANT_TTL_MS - 60_000),
+    ).toISOString();
+    storage.setItem(GRANT_KEY, JSON.stringify(stored));
+    expect(hasRememberedLocationGrant(USER)).toBe(true);
+
+    stored.lastConfirmedAt = new Date(
+      Date.now() - (LOCATION_GRANT_TTL_MS + 60_000),
+    ).toISOString();
+    storage.setItem(GRANT_KEY, JSON.stringify(stored));
+    expect(hasRememberedLocationGrant(USER)).toBe(false);
+    expect(storage.getItem(GRANT_KEY)).toBeNull();
+  });
+
+  it("is per account", () => {
+    rememberLocationGrant(USER);
+    expect(hasRememberedLocationGrant(OTHER_USER)).toBe(false);
+  });
+});
+
+describe("revocation", () => {
+  it("forgets the coordinate but keeps the grant", async () => {
+    rememberLocationGrant(USER);
+    await rememberLastKnownFix({ userId: USER, point: point() });
+
+    forgetLastKnownFix(USER);
+
+    expect(storage.getItem(FIX_KEY)).toBeNull();
+    expect(hasRememberedLocationGrant(USER)).toBe(true);
+  });
+
+  it("forgets everything on request", async () => {
+    rememberLocationGrant(USER);
+    await rememberLastKnownFix({ userId: USER, point: point() });
+
+    forgetLocationMemory(USER);
+
+    expect(storage.getItem(FIX_KEY)).toBeNull();
+    expect(storage.getItem(GRANT_KEY)).toBeNull();
+  });
+});
+
+describe("when storage is unavailable", () => {
+  it("degrades quietly rather than failing the feature", async () => {
+    delete (globalThis as { window?: unknown }).window;
+
+    // Server rendering, Safari private mode, and locked-down webviews all land
+    // here. None of them are location failures, so none may throw.
+    expect(() => rememberLocationGrant(USER)).not.toThrow();
+    expect(readLocationGrant(USER)).toBeNull();
+    await expect(
+      rememberLastKnownFix({ userId: USER, point: point() }),
+    ).resolves.toBeUndefined();
+    await expect(
+      readLastKnownFix({ userId: USER, maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS }),
+    ).resolves.toBeNull();
+  });
+
+  it("survives a storage quota rejection", async () => {
+    storage.failWrites = true;
+
+    expect(() => rememberLocationGrant(USER)).not.toThrow();
+    await expect(
+      rememberLastKnownFix({ userId: USER, point: point() }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing at all without an account", async () => {
+    rememberLocationGrant(null);
+    await rememberLastKnownFix({ userId: null, point: point() });
+
+    expect(storage.length).toBe(0);
+    await expect(
+      readLastKnownFix({ userId: null, maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS }),
+    ).resolves.toBeNull();
+  });
+});

--- a/hushh-webapp/lib/one-location/key-bootstrap.ts
+++ b/hushh-webapp/lib/one-location/key-bootstrap.ts
@@ -4,6 +4,7 @@ import {
   ensureLocationRecipientKey,
   ensureVaultSyncedRecipientKey,
 } from "@/lib/one-location/encryption";
+import { LocationBus } from "@/lib/one-location/location-bus";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
 
@@ -26,6 +27,21 @@ export async function bootstrapCurrentUserLocationRecipientKey(params: {
   const vaultKey = String(params.vaultKey || "").trim();
   if (!userId) throw new Error("Current user is required for One Location setup.");
   if (!vaultOwnerToken) throw new Error("Vault owner token required for One Location setup.");
+
+  // Bind the shared bus to this account, so a fix survives the page.
+  //
+  // Here rather than in a component because this is the one function that
+  // already runs on every signed-in Location surface — the hub, the invite
+  // page, the chat, and the unlock warm path — which is what makes the memory
+  // global instead of one screen's private cache.
+  //
+  // Deliberately not awaited, and deliberately before the key work below. The
+  // sealing key is read from IndexedDB, where any device that has something to
+  // restore already has it, so hydration usually resolves without waiting for
+  // registration. If it does lose the race it simply restores nothing this
+  // time: `readLastKnownFix` treats an unopenable record as absent rather than
+  // deleting it, so nothing is lost either way.
+  void LocationBus.attachUser(userId);
 
   if (vaultKey) {
     let remoteBackup = null;

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -8,14 +8,31 @@
  * same snapshot, and the device is asked at most once.
  *
  * Boundaries this deliberately keeps:
- * - Coordinates live in memory only. Nothing here writes to storage, and
- *   nothing here talks to the network. Callers decide what, if anything,
- *   crosses a boundary — matching the backend's refusal of plaintext location.
+ * - Nothing here talks to the network. Callers decide what, if anything,
+ *   crosses that boundary — matching the backend's refusal of plaintext
+ *   location.
+ * - No *plaintext* coordinate is ever written to storage. Once an account is
+ *   attached the bus may keep a fix across reloads, but only sealed by
+ *   `location-grant-memory`, which encrypts it to the owner's own key before it
+ *   touches the disk. Detached, the bus is memory-only exactly as before.
  * - `request()` must be called from a user gesture. iOS grants exactly one
  *   system prompt; firing it on mount spends it before the user knows why.
+ *
+ * Holding position in memory alone was the original design, and it is why a
+ * reload used to land on "we couldn't get a location reading". The device had
+ * answered five minutes earlier; the app had simply forgotten. `attachUser()`
+ * is what stops that — see `location-grant-memory.ts` for what is stored and
+ * how long it lives.
  */
 
 import { HushhLocation, type HushhLocationPermissionState } from "@/lib/capacitor";
+import {
+  LAST_KNOWN_FIX_RETENTION_MS,
+  readLastKnownFix,
+  rememberLastKnownFix,
+  rememberLocationGrant,
+} from "@/lib/one-location/location-grant-memory";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
 
 export type LocationSnapshot = {
   latitude: number;
@@ -31,13 +48,24 @@ export type LocationBusStatus =
   | "idle"
   /** A fix is being acquired. */
   | "locating"
-  /** `snapshot` is populated. */
+  /** `snapshot` is populated by a fix taken this session. */
   | "ready"
+  /**
+   * `snapshot` is populated, but by a fix restored from a previous session
+   * rather than taken now.
+   *
+   * Deliberately not `ready`. Every existing consumer gates on `ready`, so a
+   * restored coordinate cannot silently start passing checks written when the
+   * only way to hold a snapshot was to have just measured it. A surface that
+   * wants the restored fix opts in by reading `snapshot` and looking at this
+   * status; one that needs a live measurement keeps the behaviour it had.
+   */
+  | "stale"
   /** The user said no; recoverable only through settings. */
   | "denied"
   /** No geolocation on this device/browser at all. */
   | "unavailable"
-  /** Permission is fine but no fix came back. */
+  /** Permission is fine but no fix came back, and nothing was restored. */
   | "error";
 
 export type LocationBusState = {
@@ -45,6 +73,12 @@ export type LocationBusState = {
   permission: LocationPermission | null;
   snapshot: LocationSnapshot | null;
   error: string | null;
+  /**
+   * Where `snapshot` came from: measured this session, or restored from the
+   * previous one. Lets a surface label a position honestly ("last known")
+   * instead of implying it was just taken.
+   */
+  snapshotOrigin: "fresh" | "restored" | null;
 };
 
 /** A fix younger than this is reused instead of re-hitting the GPS. */
@@ -55,6 +89,7 @@ const INITIAL_STATE: LocationBusState = {
   permission: null,
   snapshot: null,
   error: null,
+  snapshotOrigin: null,
 };
 
 let state: LocationBusState = INITIAL_STATE;
@@ -66,6 +101,32 @@ let pendingCapture: Promise<LocationSnapshot | null> | null = null;
 let watchId: string | null = null;
 let watchStarting: Promise<void> | null = null;
 let watchers = 0;
+
+/**
+ * The account whose durable memory this bus reads and writes.
+ *
+ * Null until `attachUser()` — the bus is shared by surfaces that run before
+ * sign-in, and a coordinate has to belong to somebody before it can be sealed
+ * to their key. While null the bus behaves exactly as it did before durable
+ * memory existed.
+ */
+let attachedUserId: string | null = null;
+
+/** In-flight hydration, so N surfaces mounting together cause one read. */
+let pendingHydration: Promise<void> | null = null;
+
+/**
+ * How often a fix is written through to durable memory.
+ *
+ * `watch()` fires on every movement, and each write costs an ECDH derivation
+ * plus an AES-GCM seal. Persisting every tick would spend real battery to
+ * improve a fallback that only ever gets read once, on the next cold start.
+ * A minute-old starting point is indistinguishable from a current one for that
+ * purpose.
+ */
+const FIX_PERSIST_INTERVAL_MS = 60_000;
+
+let lastPersistedAtMs = 0;
 
 function emit(patch: Partial<LocationBusState>): void {
   state = { ...state, ...patch };
@@ -109,6 +170,42 @@ function toSnapshot(point: {
   };
 }
 
+/**
+ * Write a fix through to durable memory, throttled.
+ *
+ * The grant is refreshed on every fix — it is two short strings and it is what
+ * keeps an active account from ever ageing out of its own permission. Only the
+ * sealed coordinate is rate-limited.
+ */
+function recordFix(point: {
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+  capturedAt: string;
+  sourcePlatform?: string | null;
+}): void {
+  if (!attachedUserId) return;
+  // A coordinate arrived, which is the only proof of consent worth recording:
+  // a permission API can answer "granted" on a device that never produces a
+  // fix, and Safari cannot answer at all.
+  rememberLocationGrant(attachedUserId);
+
+  const now = Date.now();
+  if (now - lastPersistedAtMs < FIX_PERSIST_INTERVAL_MS) return;
+  lastPersistedAtMs = now;
+  void rememberLastKnownFix({
+    userId: attachedUserId,
+    point: {
+      latitude: point.latitude,
+      longitude: point.longitude,
+      accuracyM: point.accuracyM ?? null,
+      capturedAt: point.capturedAt,
+      sourcePlatform:
+        (point.sourcePlatform as PlainLocationPoint["sourcePlatform"]) ?? "web",
+    },
+  });
+}
+
 async function capture(): Promise<LocationSnapshot | null> {
   try {
     const point = await HushhLocation.getCurrentPosition({
@@ -116,10 +213,33 @@ async function capture(): Promise<LocationSnapshot | null> {
       timeoutMs: 15_000,
     });
     const snapshot = toSnapshot(point);
-    emit({ status: "ready", snapshot, error: null, permission: "granted" });
+    emit({
+      status: "ready",
+      snapshot,
+      snapshotOrigin: "fresh",
+      error: null,
+      permission: "granted",
+    });
+    recordFix(point);
     return snapshot;
   } catch (error) {
     const denied = isDeniedError(error);
+    if (!denied && state.snapshot) {
+      // We already hold a position. A failed refresh in that situation is a
+      // refresh that failed, not a location we do not have — and the two used
+      // to look identical on screen. `kCLErrorLocationUnknown` is routine on
+      // any machine without a GPS radio, so treating the first one as a hard
+      // error is what put "we couldn't get a location reading" in front of
+      // people whose location was perfectly well known.
+      emit({
+        status: "stale",
+        error:
+          error instanceof Error
+            ? error.message
+            : "Could not refresh your location.",
+      });
+      return state.snapshot;
+    }
     emit({
       status: denied ? "denied" : "error",
       permission: denied ? "denied" : state.permission,
@@ -128,6 +248,45 @@ async function capture(): Promise<LocationSnapshot | null> {
     });
     return null;
   }
+}
+
+/**
+ * Restore the previous session's fix, once, before the first capture resolves.
+ *
+ * The point is what the owner sees in the second before the GPS answers — and
+ * what they keep seeing if it never does. Never overwrites a fix taken this
+ * session: a restored coordinate is strictly a floor, never a replacement.
+ */
+async function hydrateFromMemory(userId: string): Promise<void> {
+  // Read through a call rather than touching `state` directly: `state` is a
+  // module-level binding, so TypeScript narrows it at the first check and then
+  // believes the identical check after the await is dead code. It is not — the
+  // await is exactly when a capture can land.
+  const originNow = () => LocationBus.getState().snapshotOrigin;
+
+  if (originNow() === "fresh") return;
+  const point = await readLastKnownFix({
+    userId,
+    maxAgeMs: LAST_KNOWN_FIX_RETENTION_MS,
+  });
+  if (!point) return;
+  // The GPS may have answered while the store was being read. It wins.
+  if (originNow() === "fresh") return;
+  emit({
+    snapshot: toSnapshot({
+      latitude: point.latitude,
+      longitude: point.longitude,
+      accuracyM: point.accuracyM ?? null,
+      capturedAt: point.capturedAt,
+    }),
+    snapshotOrigin: "restored",
+    // A restored fix answers "where were you", not "did this attempt work", so
+    // it must not cancel a capture that is still running or clear a denial that
+    // is still true.
+    ...(state.status === "idle" || state.status === "error"
+      ? { status: "stale" as const }
+      : {}),
+  });
 }
 
 export const LocationBus = {
@@ -165,15 +324,56 @@ export const LocationBus = {
    */
   async ensure(options?: { maxAgeMs?: number }): Promise<LocationSnapshot | null> {
     const maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
-    if (isFresh(state.snapshot, maxAgeMs)) return state.snapshot;
+    // Only a fix measured this session short-circuits the GPS. A restored one
+    // is there to fill the screen, not to end the attempt — reusing it would
+    // mean an app that never refreshes as long as its memory looks recent.
+    if (state.snapshotOrigin === "fresh" && isFresh(state.snapshot, maxAgeMs)) {
+      return state.snapshot;
+    }
     if (pendingCapture) return pendingCapture;
 
-    if (state.status !== "ready") emit({ status: "locating", error: null });
+    if (state.status !== "ready") {
+      // Keep `stale` while a restored fix is on screen: flipping to `locating`
+      // would blank a position the owner can already see, which is the flicker
+      // this whole change exists to remove.
+      emit({
+        status: state.snapshotOrigin === "restored" ? "stale" : "locating",
+        error: null,
+      });
+    }
 
     pendingCapture = capture().finally(() => {
       pendingCapture = null;
     });
     return pendingCapture;
+  },
+
+  /**
+   * Bind the bus to an account so a fix can outlive the page.
+   *
+   * Idempotent, and safe to call on every mount. Switching accounts clears the
+   * previous account's position immediately rather than letting it linger while
+   * the new one loads — one person's coordinate must never appear under another
+   * person's session, however briefly.
+   */
+  async attachUser(userId: string | null | undefined): Promise<void> {
+    const next = userId || null;
+    if (next === attachedUserId) {
+      await pendingHydration?.catch(() => undefined);
+      return;
+    }
+    attachedUserId = next;
+    pendingHydration = null;
+    state = { ...INITIAL_STATE };
+    for (const listener of [...listeners]) listener(state);
+    if (!next) return;
+
+    pendingHydration = hydrateFromMemory(next)
+      .catch(() => undefined)
+      .finally(() => {
+        pendingHydration = null;
+      });
+    await pendingHydration;
   },
 
   /**
@@ -226,9 +426,11 @@ export const LocationBus = {
             emit({
               status: "ready",
               snapshot: toSnapshot(point),
+              snapshotOrigin: "fresh",
               error: null,
               permission: "granted",
             });
+            recordFix(point);
             return;
           }
           if (!error) return;
@@ -279,5 +481,8 @@ export const LocationBus = {
     watchId = null;
     watchStarting = null;
     watchers = 0;
+    attachedUserId = null;
+    pendingHydration = null;
+    lastPersistedAtMs = 0;
   },
 };

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -362,11 +362,28 @@ export const LocationBus = {
       await pendingHydration?.catch(() => undefined);
       return;
     }
+    const switchingAccounts = attachedUserId !== null;
     attachedUserId = next;
     pendingHydration = null;
-    state = { ...INITIAL_STATE };
-    for (const listener of [...listeners]) listener(state);
+
+    if (switchingAccounts) {
+      // One person's coordinate must never appear under another person's
+      // session, however briefly.
+      state = { ...INITIAL_STATE };
+      for (const listener of [...listeners]) listener(state);
+    }
     if (!next) return;
+
+    // The very first attach is different: nothing was ever attributed to
+    // anyone else, and a surface may already have captured a fix while key
+    // bootstrap was still running. Clearing here would throw away a live
+    // position and replace it with an older stored one — the exact inversion
+    // of the point of this change. Keep it, and write it through.
+    if (!switchingAccounts && state.snapshotOrigin === "fresh" && state.snapshot) {
+      lastPersistedAtMs = 0;
+      recordFix({ ...state.snapshot, sourcePlatform: "web" });
+      return;
+    }
 
     pendingHydration = hydrateFromMemory(next)
       .catch(() => undefined)

--- a/hushh-webapp/lib/one-location/location-grant-memory.ts
+++ b/hushh-webapp/lib/one-location/location-grant-memory.ts
@@ -1,0 +1,349 @@
+/**
+ * Location as a standing property of the account, not a per-open request.
+ *
+ * Every other app the owner uses — a ride app, a delivery app — asks for
+ * location once and then simply knows where they are. One did not, and the
+ * reason was not the permission: iOS and every browser already remember the
+ * grant durably. The reason was that One held the *answer* in memory only.
+ * `LocationBus` kept its snapshot in a module variable and the Nearby drawer
+ * kept its fallback in a `useRef`, so a reload, a navigation, or an app
+ * relaunch wiped both. A cold start therefore had nothing to show, and the
+ * first transient GPS failure — `kCLErrorLocationUnknown`, which macOS and
+ * desktop Chrome emit routinely because there is no GPS radio — had no fallback
+ * to land on. The owner read that as "One keeps losing my location".
+ *
+ * This module is the durable half. It remembers two separate things, because
+ * they carry very different weight:
+ *
+ *   1. **The grant** — that this account has, at some point, actually produced
+ *      a fix. Not a coordinate; a fact about consent. Plain storage is right
+ *      for it, exactly as `location-control-state.ts` stores pause and
+ *      auto-approve. It is what lets a surface stop treating a cold start as
+ *      "never asked" and stop leading with a permission primer at someone who
+ *      granted months ago.
+ *
+ *   2. **The last known fix** — an actual coordinate, and therefore never
+ *      written in the clear. It is sealed with `encryptLocationForRecipient`
+ *      against the owner's *own* recipient key, which already lives in
+ *      IndexedDB with a native Keychain mirror. On disk it is the same opaque
+ *      envelope the backend is trusted with, so persisting it concedes nothing
+ *      the architecture had not already decided was safe. Anyone reading
+ *      localStorage — another script, a shared device, a forensic dump — sees
+ *      ciphertext.
+ *
+ * Two independent clocks bound the coordinate, and they answer different
+ * questions:
+ *
+ *   - **Retention** (`LAST_KNOWN_FIX_RETENTION_MS`): how long we are willing to
+ *     keep it at all. Past this the record is deleted on sight, so a coordinate
+ *     nobody will ever use does not sit on the device indefinitely.
+ *   - **Usability** (the caller's `maxAgeMs`): how long it stays honest as an
+ *     answer to "where are you now". The Nearby drawer allows ten minutes; a
+ *     map centring hint can allow far more. The store does not decide this,
+ *     because the store does not know what the answer is for.
+ *
+ * Retention is deliberately the longer of the two. A fix we may not present as
+ * current is still worth keeping, because it is what stops the *next* cold
+ * start from being empty.
+ *
+ * The grant window is long on purpose. Ninety days, renewed on every fix, means
+ * an account in normal use never loses it — which is the whole point. It is a
+ * memory of consent, never a substitute for it: the OS is still asked, the OS
+ * still decides, and a denial still wins. This record only stops One from
+ * *forgetting* an answer the owner already gave.
+ */
+
+import {
+  decryptLocationEnvelope,
+  ensureLocationRecipientKey,
+  encryptLocationForRecipient,
+} from "@/lib/one-location/encryption";
+import type {
+  OneLocationEncryptedEnvelope,
+  PlainLocationPoint,
+} from "@/lib/one-location/types";
+
+const GRANT_KEY_PREFIX = "one_location_grant_v1:";
+const LAST_FIX_KEY_PREFIX = "one_location_last_fix_v1:";
+
+/**
+ * How long a remembered grant stays valid without a single successful fix.
+ *
+ * Renewed every time one lands, so this is the *idle* window, not a countdown
+ * on the account. Ninety days is chosen to be longer than any plausible gap
+ * between two uses of a location feature; the owner asked not to be re-asked,
+ * and an expiry they can reach in normal use would not honour that.
+ */
+export const LOCATION_GRANT_TTL_MS = 90 * 24 * 60 * 60 * 1_000;
+
+/**
+ * How long a sealed coordinate is kept on the device at all.
+ *
+ * Twenty-four hours: long enough that yesterday's session still hands today's
+ * cold start something to draw, short enough that a device left behind does not
+ * carry a week of movement. Distinct from how long a fix may be *presented* as
+ * current, which every caller decides for itself.
+ */
+export const LAST_KNOWN_FIX_RETENTION_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * What the account has already told the platform about location.
+ *
+ * `grantedAt` is the first observed success and never moves — it is the answer
+ * to "since when". `lastConfirmedAt` moves with every fix and is what the TTL
+ * is measured against.
+ */
+export type LocationGrantMemory = {
+  grantedAt: string;
+  lastConfirmedAt: string;
+};
+
+type StoredGrant = Partial<LocationGrantMemory>;
+
+type StoredFix = {
+  envelope: OneLocationEncryptedEnvelope;
+  /** Mirrored outside the ciphertext so age can be judged without decrypting. */
+  capturedAt: string;
+  storedAt: string;
+};
+
+/**
+ * Storage that is allowed to be missing.
+ *
+ * Server rendering has none, Safari private browsing throws on access, and an
+ * embedded webview can disable it outright. None of those are location
+ * failures, so every path here degrades to the old in-memory behaviour rather
+ * than surfacing an error the owner cannot act on.
+ */
+function storage(): Storage | null {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function grantKey(userId: string): string {
+  return `${GRANT_KEY_PREFIX}${userId}`;
+}
+
+function lastFixKey(userId: string): string {
+  return `${LAST_FIX_KEY_PREFIX}${userId}`;
+}
+
+function readJson<T>(store: Storage, key: string): T | null {
+  try {
+    const raw = store.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    // A record we cannot parse is a record we cannot trust. Drop it rather
+    // than let it fail the same way on every subsequent read.
+    try {
+      store.removeItem(key);
+    } catch {
+      /* Nothing further to do; the next write overwrites it. */
+    }
+    return null;
+  }
+}
+
+function isIsoWithin(value: unknown, windowMs: number): boolean {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return false;
+  const age = Date.now() - parsed;
+  // A timestamp from the future means a clock change, not a fresh fix. Treat it
+  // as unusable rather than as infinitely valid.
+  return age >= 0 && age <= windowMs;
+}
+
+/**
+ * Record that this account has produced a real fix.
+ *
+ * Call only after a coordinate actually arrives. A permission API answering
+ * "granted" is not the same fact — it is a claim about a setting, and on Safari
+ * it cannot be read at all. A coordinate is proof.
+ */
+export function rememberLocationGrant(userId: string | null | undefined): void {
+  if (!userId) return;
+  const store = storage();
+  if (!store) return;
+  const now = new Date().toISOString();
+  const existing = readJson<StoredGrant>(store, grantKey(userId));
+  const grantedAt =
+    typeof existing?.grantedAt === "string" &&
+    Number.isFinite(Date.parse(existing.grantedAt))
+      ? existing.grantedAt
+      : now;
+  try {
+    store.setItem(
+      grantKey(userId),
+      JSON.stringify({ grantedAt, lastConfirmedAt: now }),
+    );
+  } catch {
+    // A blocked write costs continuity across reloads, nothing more. The
+    // in-session behaviour is unchanged, so there is nothing to report.
+  }
+}
+
+/** The remembered grant, or null when there is none or it has gone stale. */
+export function readLocationGrant(
+  userId: string | null | undefined,
+): LocationGrantMemory | null {
+  if (!userId) return null;
+  const store = storage();
+  if (!store) return null;
+  const stored = readJson<StoredGrant>(store, grantKey(userId));
+  if (!stored) return null;
+  if (!isIsoWithin(stored.lastConfirmedAt, LOCATION_GRANT_TTL_MS)) {
+    try {
+      store.removeItem(grantKey(userId));
+    } catch {
+      /* Best effort; an expired record is already treated as absent. */
+    }
+    return null;
+  }
+  return {
+    grantedAt:
+      typeof stored.grantedAt === "string" ? stored.grantedAt : stored.lastConfirmedAt!,
+    lastConfirmedAt: stored.lastConfirmedAt!,
+  };
+}
+
+/**
+ * Has this account already granted location on this device?
+ *
+ * Answers the UI question "do we lead with an explanation, or with a map?" —
+ * never the runtime question "may we read the GPS?", which only the platform
+ * can answer and which is asked separately every time.
+ */
+export function hasRememberedLocationGrant(
+  userId: string | null | undefined,
+): boolean {
+  return readLocationGrant(userId) !== null;
+}
+
+/**
+ * Seal a fix and keep it for the next cold start.
+ *
+ * Failures are swallowed by design. This is a convenience layer over a feature
+ * that already worked; a device without Web Crypto, without a recipient key, or
+ * with a full storage quota should lose the *improvement*, not the feature.
+ */
+export async function rememberLastKnownFix(params: {
+  userId: string | null | undefined;
+  point: PlainLocationPoint;
+}): Promise<void> {
+  const { userId, point } = params;
+  if (!userId) return;
+  const store = storage();
+  if (!store) return;
+  if (!Number.isFinite(point?.latitude) || !Number.isFinite(point?.longitude)) {
+    return;
+  }
+  try {
+    const key = await ensureLocationRecipientKey(userId);
+    const envelope = await encryptLocationForRecipient({
+      // Drive and Check-In payloads belong to a share, not to "where I last
+      // was". Persisting them would keep a destination or a venue on the device
+      // long after the share that justified it ended.
+      point: {
+        latitude: point.latitude,
+        longitude: point.longitude,
+        accuracyM: point.accuracyM ?? null,
+        capturedAt: point.capturedAt,
+        sourcePlatform: point.sourcePlatform,
+      },
+      recipientPublicKeyJwk: key.publicKeyJwk,
+      recipientKeyId: key.keyId,
+    });
+    const record: StoredFix = {
+      envelope,
+      capturedAt: point.capturedAt,
+      storedAt: new Date().toISOString(),
+    };
+    store.setItem(lastFixKey(userId), JSON.stringify(record));
+  } catch {
+    // No key, no crypto, or no quota. The session keeps its in-memory fix.
+  }
+}
+
+/**
+ * The last sealed fix, when it is both retained and young enough to use.
+ *
+ * `maxAgeMs` is the caller's honesty budget: how old a coordinate may be and
+ * still be offered as "where you are". Anything older is left on disk until
+ * retention expires, because a fix too stale to *present* is still the best
+ * starting point the next attempt has.
+ */
+export async function readLastKnownFix(params: {
+  userId: string | null | undefined;
+  maxAgeMs: number;
+}): Promise<PlainLocationPoint | null> {
+  const { userId, maxAgeMs } = params;
+  if (!userId) return null;
+  const store = storage();
+  if (!store) return null;
+  const stored = readJson<StoredFix>(store, lastFixKey(userId));
+  if (!stored?.envelope) return null;
+
+  if (!isIsoWithin(stored.storedAt, LAST_KNOWN_FIX_RETENTION_MS)) {
+    forgetLastKnownFix(userId);
+    return null;
+  }
+  if (!isIsoWithin(stored.capturedAt, maxAgeMs)) return null;
+
+  try {
+    const point = await decryptLocationEnvelope({
+      userId,
+      envelope: stored.envelope,
+    });
+    if (!Number.isFinite(point?.latitude) || !Number.isFinite(point?.longitude)) {
+      forgetLastKnownFix(userId);
+      return null;
+    }
+    return point;
+  } catch {
+    // Deliberately kept, not deleted.
+    //
+    // A failed decrypt looks the same whether the recipient key rotated away
+    // for good or simply has not been provisioned yet — key bootstrap is async
+    // and a surface can read before it finishes. Deleting would turn that race
+    // into permanent data loss for someone whose fix was perfectly good.
+    // Retention clears it soon enough either way, and the cost of being wrong
+    // in this direction is one cheap failed decrypt per cold start.
+    return null;
+  }
+}
+
+/** Drop the sealed coordinate, keeping the grant. */
+export function forgetLastKnownFix(userId: string | null | undefined): void {
+  if (!userId) return;
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(lastFixKey(userId));
+  } catch {
+    /* Best effort. */
+  }
+}
+
+/**
+ * Forget everything this module remembers for an account.
+ *
+ * Belongs on sign-out and on any "stop tracking me" control: a durable memory
+ * of location must be as easy to revoke as it was to create.
+ */
+export function forgetLocationMemory(userId: string | null | undefined): void {
+  if (!userId) return;
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(grantKey(userId));
+  } catch {
+    /* Best effort. */
+  }
+  forgetLastKnownFix(userId);
+}

--- a/hushh-webapp/lib/one-location/use-current-location.ts
+++ b/hushh-webapp/lib/one-location/use-current-location.ts
@@ -13,6 +13,7 @@ const SERVER_STATE: LocationBusState = {
   permission: null,
   snapshot: null,
   error: null,
+  snapshotOrigin: null,
 };
 
 /**
@@ -21,18 +22,33 @@ const SERVER_STATE: LocationBusState = {
  * `auto` resolves a position on mount when the OS has already granted
  * permission — it never triggers a first prompt. Surfaces that need the prompt
  * call `request()` from a user gesture.
+ *
+ * Pass `userId` to give the bus an account. With one, the previous session's
+ * fix is restored before the GPS answers, so the surface opens with a position
+ * instead of a spinner and keeps one if the device fails to produce a new fix.
+ * Without one the hook behaves exactly as it always has — nothing is stored and
+ * nothing is restored.
  */
-export function useCurrentLocation(options?: { auto?: boolean }): LocationBusState & {
+export function useCurrentLocation(options?: {
+  auto?: boolean;
+  userId?: string | null;
+}): LocationBusState & {
   request: () => Promise<LocationSnapshot | null>;
   refresh: () => Promise<LocationSnapshot | null>;
 } {
   const auto = options?.auto ?? true;
+  const userId = options?.userId ?? null;
 
   const state = useSyncExternalStore(
     LocationBus.subscribe,
     LocationBus.getState,
     () => SERVER_STATE,
   );
+
+  useEffect(() => {
+    if (!userId) return;
+    void LocationBus.attachUser(userId);
+  }, [userId]);
 
   useEffect(() => {
     if (!auto) return;


### PR DESCRIPTION
## The reported problem

Opening Nearby Check-In showed **"Still finding you — we couldn't get a location reading just now"** on a device that knew exactly where it was minutes earlier. The console behind it was full of:

```
CoreLocationProvider: CoreLocation framework reported a kCLErrorLocationUnknown failure.
```

The ask was that location behave like it does in every other app: grant it once, and stop being asked or told it is unavailable.

## What was actually wrong

**The permission was never the problem.** iOS and every browser already remember a location grant durably, and nothing in this repo re-prompts. What One did not remember was the *answer*.

- `LocationBus` kept its snapshot in a module variable.
- The check-in drawer kept its fallback in a `useRef`.

A reload, a navigation, or an app relaunch wiped both. So a cold start had nothing to fall back to — and the very first GPS read failing left the drawer empty. That failure is not rare: macOS and desktop Chrome raise `kCLErrorLocationUnknown` (`POSITION_UNAVAILABLE`) routinely, because there is no GPS radio to answer with. The plugin already retries at low accuracy; when that also missed, the user got a dead end.

## The change

A new `lib/one-location/location-grant-memory.ts` remembers two deliberately separate things:

| | What it is | How it is stored | How long |
|---|---|---|---|
| **The grant** | that this account has actually produced a fix — a fact about consent, not a coordinate | plain, like the existing pause / auto-approve preferences | 90 days, renewed on every fix |
| **The last known fix** | a real coordinate | sealed with `encryptLocationForRecipient` against the owner's **own** recipient key | 24h retention, separate from how long any caller may present it as current |

The coordinate is never written in the clear. On disk it is the identical opaque envelope the backend is already trusted with, using the key that already lives in IndexedDB with a native Keychain mirror. A test asserts the raw stored string contains neither the latitude nor the longitude.

Two clocks, on purpose: **retention** is how long we keep it at all; the caller's **`maxAgeMs`** is how long it stays honest as "where you are". Retention is the longer one, because a fix too stale to present is still what stops the *next* cold start from being empty.

### Wired in three places

- **`key-bootstrap`** attaches the bus to the account. It is the one function that already runs on every signed-in Location surface (hub, invite, chat, unlock warm path), which is what makes this global rather than one screen's private cache.
- **`LocationBus`** restores the fix on attach under a new **`stale`** status — deliberately *not* `ready`, so no existing consumer silently starts treating a carried-over coordinate as a live measurement. A refresh that fails while a position is already held now keeps the position instead of replacing it with an error. **A real denial still wins**, with or without a restored fix.
- **The check-in drawer** falls back to the sealed fix when its in-session ref is empty, and now says *how old* the position is instead of passing it off as current.

## Edge cases handled

- transient `POSITION_UNAVAILABLE` **with** a fallback → position kept, no error, no flicker
- transient `POSITION_UNAVAILABLE` **without** one → still says so plainly; inventing a position would be worse
- genuine `PERMISSION_DENIED` → still routes to Settings, never softened into "retry"
- account switch → previous account's coordinate cleared immediately
- clock skew (future timestamp) → refused rather than trusted forever
- unreadable ciphertext → returns nothing but **does not delete**; a rotated key and a not-yet-provisioned key fail identically, and deleting would turn that race into permanent loss
- absent / quota-exceeded storage (SSR, Safari private, locked-down webview) → degrades to the old in-memory behaviour, never throws
- `watch()` firing per movement → seal throttled to 60s, since each write costs an ECDH derivation

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- new: 18 tests for the memory module, 14 for the bus, 5 for the drawer's cold start
- **mutation-checked**: reverting each of the three core behaviours fails the tests that claim to cover it (the stale-status branch, the no-plaintext guard, and the drawer's durable fallback)
- full suite compared against `origin/main` — `main` is already red with pre-existing flaky failures; the location-specific ones were re-run in isolation on both sides to confirm none are caused by this change

## Rollback

Revert the commit. Storage keys (`one_location_grant_v1:*`, `one_location_last_fix_v1:*`) are read-only-if-present and expire on their own, so a revert leaves nothing behind that anything reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)