### PR TITLE
fix(one-location): stop the shell thrashing layout while the live map animates

### DIFF
--- a/hushh-webapp/__tests__/components/live-map-disposal.test.tsx
+++ b/hushh-webapp/__tests__/components/live-map-disposal.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const mapsHarness = vi.hoisted(() => ({
+  status: "ready" as "loading" | "ready" | "error",
+}));
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: () => ({ status: mapsHarness.status }),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+import { LiveMap } from "@/components/one-location/live-map";
+
+const POINT: PlainLocationPoint = {
+  latitude: 28.6139,
+  longitude: 77.209,
+  accuracyM: 12,
+  capturedAt: "2026-08-14T12:00:00.000Z",
+  sourcePlatform: "web",
+} as PlainLocationPoint;
+
+type MarkerStub = {
+  setMap: ReturnType<typeof vi.fn>;
+  setPosition: ReturnType<typeof vi.fn>;
+  getPosition: ReturnType<typeof vi.fn>;
+};
+
+let createdMaps: object[] = [];
+let createdMarkers: MarkerStub[] = [];
+let clearInstanceListeners: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mapsHarness.status = "ready";
+  createdMaps = [];
+  createdMarkers = [];
+  clearInstanceListeners = vi.fn();
+
+  class MapStub {
+    constructor() {
+      createdMaps.push(this);
+    }
+    panTo = vi.fn();
+    setZoom = vi.fn();
+  }
+
+  class MarkerStubImpl {
+    setMap = vi.fn();
+    setPosition = vi.fn();
+    getPosition = vi.fn(() => null);
+    constructor() {
+      createdMarkers.push(this as unknown as MarkerStub);
+    }
+  }
+
+  (globalThis as unknown as { google: unknown }).google = {
+    maps: {
+      Map: MapStub,
+      Marker: MarkerStubImpl,
+      event: { clearInstanceListeners },
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  delete (globalThis as unknown as { google?: unknown }).google;
+  vi.restoreAllMocks();
+});
+
+describe("LiveMap disposes its Google Maps instances", () => {
+  // A Maps instance is not garbage just because the React ref dropped it. It
+  // keeps its own listeners, tile requests and resize handlers running, so an
+  // undisposed map goes on doing work for the life of the page. On One Location
+  // that work lands on the same main thread the back control needs.
+  it("detaches the marker and clears listeners on unmount", () => {
+    const { unmount } = render(<LiveMap point={POINT} />);
+
+    expect(createdMaps).toHaveLength(1);
+    expect(createdMarkers).toHaveLength(1);
+
+    unmount();
+
+    expect(createdMarkers[0].setMap).toHaveBeenCalledWith(null);
+    expect(clearInstanceListeners).toHaveBeenCalledWith(createdMarkers[0]);
+    expect(clearInstanceListeners).toHaveBeenCalledWith(createdMaps[0]);
+  });
+
+  it("does not leave the previous map running when the theme re-keys the container", async () => {
+    const themes = await import("next-themes");
+    const useTheme = vi.spyOn(themes, "useTheme");
+
+    useTheme.mockReturnValue({
+      resolvedTheme: "dark",
+    } as ReturnType<typeof themes.useTheme>);
+    const { rerender, unmount } = render(<LiveMap point={POINT} />);
+    expect(createdMaps).toHaveLength(1);
+
+    useTheme.mockReturnValue({
+      resolvedTheme: "light",
+    } as ReturnType<typeof themes.useTheme>);
+    rerender(<LiveMap point={POINT} />);
+
+    // The scheme flip builds a second map; the first one must have been torn
+    // down rather than left animating behind it.
+    expect(createdMaps).toHaveLength(2);
+    expect(clearInstanceListeners).toHaveBeenCalledWith(createdMaps[0]);
+    expect(createdMarkers[0].setMap).toHaveBeenCalledWith(null);
+
+    unmount();
+  });
+});

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -365,4 +365,70 @@ describe("Top app bar responsive contract", () => {
     expect(source).toContain("selected: null");
     expect(source).toContain("notificationAction: null");
   });
+
+  // The shared top bar watches the whole app scroll root for DOM mutations so
+  // it can find a late-mounting or swapped primary page header. That watcher
+  // sits on the critical path of every animating surface: One Location keeps a
+  // live map whose marker glide and Google's own tile updates mutate the DOM
+  // every frame. When the watcher re-measured on each of those mutations, the
+  // main thread stayed saturated with forced reflows and a tap on the back
+  // arrow could not be serviced promptly.
+  describe("mutation watcher stays off the animation hot path", () => {
+    const source = read("components/app-ui/top-app-bar.tsx");
+    const watcher = source.slice(
+      source.indexOf("const scheduleHeaderRefresh"),
+      source.indexOf("const retryFindHeader"),
+    );
+
+    it("re-queries only when the known header actually went away", () => {
+      // A still-connected header cannot have been swapped, so the steady state
+      // must not pay for a document-wide lookup.
+      expect(watcher).toContain("if (!header?.isConnected)");
+    });
+
+    it("never runs the full measure-and-write pass straight off a mutation", () => {
+      // `refreshHeader()` re-queries AND calls updateHeaderVisibility(), which
+      // forces layout and writes custom properties on <html>. It belongs to the
+      // scroll/attach paths, never to the per-mutation path.
+      expect(watcher).not.toContain("refreshHeader()");
+    });
+
+    it("rate-limits re-measurement when the header did not change", () => {
+      // Content can still reflow the header out of view with no scroll, so this
+      // must keep tracking — just never once per animation frame.
+      expect(source).toContain("const MUTATION_RECHECK_MS = 250;");
+      expect(watcher).toContain("const previous = header;");
+      expect(watcher).toContain(
+        "if (header === previous && now - lastMutationCheckAt < MUTATION_RECHECK_MS)",
+      );
+      expect(watcher).toContain("lastMutationCheckAt = now;");
+    });
+
+    it("keeps re-querying unbounded so a closing flow restores header tracking", () => {
+      // TaskFlowHeader does not mark itself primary, so `header` is null for the
+      // whole life of a `?action=` flow. Giving up on a retry budget here would
+      // strand the hub with stale tracking when the flow closes.
+      expect(watcher).not.toContain("MAX_HEADER_RETRIES");
+      expect(watcher).not.toContain("disconnect()");
+    });
+  });
+
+  // `--top-chrome-collapse-px` feeds `--top-shell-live-height` and
+  // `--top-shell-mask-solid-height`, which route content consumes for layout.
+  // Writing it invalidates layout for the whole document, so an unchanged value
+  // must not be rewritten — this runs on every scroll frame.
+  it("writes the top-chrome custom properties only when they change", () => {
+    const source = read("components/app-ui/top-app-bar.tsx");
+    const update = source.slice(
+      source.indexOf("const updateHeaderVisibility"),
+      source.indexOf("const detachListeners"),
+    );
+
+    expect(update).toContain("if (nextProgress !== lastWrittenProgress)");
+    expect(update).toContain("if (nextCollapsePx !== lastWrittenCollapsePx)");
+    // The bar row is measured on every call; re-querying it each time is a
+    // document-wide lookup for a node that almost never changes.
+    expect(update).toContain("if (!barRow?.isConnected)");
+    expect(update).toContain("barRow?.getBoundingClientRect().height");
+  });
 });

--- a/hushh-webapp/__tests__/lib/one-location/location-workspace-point-equality.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/location-workspace-point-equality.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import { samePlainLocationPoint } from "@/lib/one-location/location-workspace-memory";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+function point(overrides: Partial<PlainLocationPoint> = {}): PlainLocationPoint {
+  return {
+    latitude: 28.6139,
+    longitude: 77.209,
+    accuracyM: 141,
+    capturedAt: "2026-08-14T17:31:00.000Z",
+    sourcePlatform: "web",
+    ...overrides,
+  } as PlainLocationPoint;
+}
+
+describe("samePlainLocationPoint", () => {
+  it("treats a republished identical point as unchanged", () => {
+    // The case that matters: a stationary owner's heartbeat decrypts to the
+    // same values every few seconds. This is what stops the live poll from
+    // re-rendering the whole Location surface for no visible change.
+    expect(samePlainLocationPoint(point(), point())).toBe(true);
+  });
+
+  it("is reference-safe and null-safe", () => {
+    const p = point();
+    expect(samePlainLocationPoint(p, p)).toBe(true);
+    expect(samePlainLocationPoint(null, null)).toBe(true);
+    expect(samePlainLocationPoint(undefined, undefined)).toBe(true);
+    expect(samePlainLocationPoint(p, null)).toBe(false);
+    expect(samePlainLocationPoint(null, p)).toBe(false);
+  });
+
+  it("detects movement", () => {
+    expect(
+      samePlainLocationPoint(point(), point({ latitude: 28.62 })),
+    ).toBe(false);
+    expect(
+      samePlainLocationPoint(point(), point({ longitude: 77.3 })),
+    ).toBe(false);
+  });
+
+  it("detects a fresh fix at the same coordinates", () => {
+    // Standing still still produces new readings; the timestamp is what drives
+    // the "Live · 11s ago" freshness label.
+    expect(
+      samePlainLocationPoint(
+        point(),
+        point({ capturedAt: "2026-08-14T17:31:20.000Z" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("detects an accuracy change, including to and from null", () => {
+    expect(samePlainLocationPoint(point(), point({ accuracyM: 12 }))).toBe(
+      false,
+    );
+    expect(samePlainLocationPoint(point(), point({ accuracyM: null }))).toBe(
+      false,
+    );
+    // Absent and explicit-null are the same absence, not a change.
+    expect(
+      samePlainLocationPoint(
+        point({ accuracyM: null }),
+        point({ accuracyM: undefined }),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a platform change", () => {
+    expect(
+      samePlainLocationPoint(point(), point({ sourcePlatform: "ios" })),
+    ).toBe(false);
+  });
+
+  describe("Drive-To shares", () => {
+    const drive = {
+      destination: {
+        label: "Office",
+        latitude: 28.7,
+        longitude: 77.1,
+        placeId: "place-1",
+      },
+      etaSeconds: 900,
+      distanceMeters: 4200,
+      etaComputedAt: "2026-08-14T17:31:00.000Z",
+    };
+
+    it("detects an ETA recomputed at unchanged coordinates", () => {
+      // The regression a coordinates-only check would cause: the ETA is
+      // recomputed on its own schedule, so a driver stopped at a light would
+      // see the countdown freeze while the point looked "unchanged".
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({ drive: { ...drive, etaSeconds: 780 } }),
+        ),
+      ).toBe(false);
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({ drive: { ...drive, distanceMeters: 3100 } }),
+        ),
+      ).toBe(false);
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({
+            drive: { ...drive, etaComputedAt: "2026-08-14T17:32:00.000Z" },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("detects a changed destination", () => {
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({
+            drive: { ...drive, destination: { ...drive.destination, label: "Home" } },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({
+            drive: {
+              ...drive,
+              destination: { ...drive.destination, latitude: 28.8 },
+            },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        samePlainLocationPoint(
+          point({ drive }),
+          point({
+            drive: {
+              ...drive,
+              destination: { ...drive.destination, placeId: "place-2" },
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("detects a share starting or ending a drive", () => {
+      expect(samePlainLocationPoint(point(), point({ drive }))).toBe(false);
+      expect(samePlainLocationPoint(point({ drive }), point())).toBe(false);
+      expect(
+        samePlainLocationPoint(point({ drive }), point({ drive: null })),
+      ).toBe(false);
+    });
+
+    it("treats an identical drive payload as unchanged", () => {
+      expect(
+        samePlainLocationPoint(point({ drive }), point({ drive: { ...drive } })),
+      ).toBe(true);
+    });
+  });
+
+  describe("Check-In shares", () => {
+    it("detects an edited note at unchanged coordinates", () => {
+      expect(
+        samePlainLocationPoint(
+          point({ checkIn: { message: "At the cafe" } }),
+          point({ checkIn: { message: "Leaving now" } }),
+        ),
+      ).toBe(false);
+    });
+
+    it("detects a note being added or cleared", () => {
+      expect(
+        samePlainLocationPoint(point(), point({ checkIn: { message: "Here" } })),
+      ).toBe(false);
+      expect(
+        samePlainLocationPoint(point({ checkIn: { message: "Here" } }), point()),
+      ).toBe(false);
+    });
+
+    it("treats an identical note as unchanged", () => {
+      expect(
+        samePlainLocationPoint(
+          point({ checkIn: { message: "At the cafe" } }),
+          point({ checkIn: { message: "At the cafe" } }),
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -186,6 +186,7 @@ import { buildOneLocationRequestMessage } from "@/lib/one-location/request-messa
 import {
   clearLocationWorkspaceMemory,
   readLocationWorkspaceMemory,
+  samePlainLocationPoint,
   writeLocationWorkspaceMemory,
   type LocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
@@ -2237,6 +2238,10 @@ export function OneLocationAgentPageContent({
     ) => {
       setLocationWorkspace((current) => {
         const next = updater(current);
+        // An updater that decided nothing changed hands back the same object.
+        // Honouring that is what lets React bail out instead of re-rendering
+        // this surface on every live poll.
+        if (next === current) return current;
         writeLocationWorkspaceMemory(auth.userId, next);
         return next;
       });
@@ -2288,17 +2293,20 @@ export function OneLocationAgentPageContent({
   const decryptedPoints = locationWorkspace.decryptedPoints;
   const setDecryptedPoints = useCallback(
     (next: SetStateAction<Record<string, PlainLocationPoint>>) => {
-      updateLocationWorkspace((current) => ({
-        ...current,
-        decryptedPoints:
+      updateLocationWorkspace((current) => {
+        const resolved =
           typeof next === "function"
             ? (
                 next as (
                   value: Record<string, PlainLocationPoint>,
                 ) => Record<string, PlainLocationPoint>
               )(current.decryptedPoints)
-            : next,
-      }));
+            : next;
+        // Propagate the updater's "nothing changed" verdict instead of
+        // allocating a fresh workspace around an unchanged map.
+        if (resolved === current.decryptedPoints) return current;
+        return { ...current, decryptedPoints: resolved };
+      });
     },
     [updateLocationWorkspace],
   );
@@ -4251,7 +4259,15 @@ export function OneLocationAgentPageContent({
             }
           },
         });
-        setDecryptedPoints((current) => ({ ...current, [grant.id]: point }));
+        // A stationary owner republishes the same point every heartbeat, so most
+        // ticks decrypt to something identical to what is already on screen.
+        // Writing it anyway would allocate a new workspace object and re-render
+        // this whole surface every few seconds for no visible change.
+        setDecryptedPoints((current) =>
+          samePlainLocationPoint(current[grant.id], point)
+            ? current
+            : { ...current, [grant.id]: point },
+        );
         // Recovered — clear any prior "ask them to share again" state.
         setGrantViewErrors((current) => {
           if (!(grant.id in current)) return current;

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -550,11 +550,25 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
     let headerRetryCount = 0;
     let lastScrollY: number | null = null;
     let topChromeProgress = 0;
+    let barRow: HTMLElement | null = null;
+    // Last values actually written to <html>. `--top-chrome-collapse-px` feeds
+    // `--top-shell-live-height` / `--top-shell-mask-solid-height`, which route
+    // content consumes for layout — so rewriting it invalidates layout for the
+    // whole document. Re-writing an unchanged value is pure thrash, and this
+    // runs on every scroll frame.
+    let lastWrittenProgress: string | null = null;
+    let lastWrittenCollapsePx: string | null = null;
     // Routes with no primary page header (e.g. an immersive full-bleed
     // layout) never satisfy this query, so retrying must stop eventually.
     // 10 tries (~1.5s) is generous for a late-mounting header while still
     // giving up cleanly for routes that will never have one.
     const MAX_HEADER_RETRIES = 10;
+    // Ceiling on how often a DOM mutation may re-measure the chrome. A live map
+    // mutates the DOM every frame, and measuring at that rate is what pinned the
+    // main thread; 250ms keeps reflow-driven title handoff correct at ~1/15th
+    // the cost, and is imperceptible for a change the user did not initiate.
+    const MUTATION_RECHECK_MS = 250;
+    let lastMutationCheckAt = 0;
 
     const updateHeaderVisibility = () => {
       const scrollY = scrollRoot?.scrollTop ?? window.scrollY ?? 0;
@@ -567,19 +581,23 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
               nextY: scrollY,
             });
       lastScrollY = scrollY;
-      const rowHeight =
-        document
-          .querySelector<HTMLElement>('[data-testid="top-app-bar-row"]')
-          ?.getBoundingClientRect().height ?? 0;
+      if (!barRow?.isConnected) {
+        barRow = document.querySelector<HTMLElement>(
+          '[data-testid="top-app-bar-row"]',
+        );
+      }
+      const rowHeight = barRow?.getBoundingClientRect().height ?? 0;
       const root = document.documentElement;
-      root.style.setProperty(
-        "--top-chrome-progress",
-        String(topChromeProgress),
-      );
-      root.style.setProperty(
-        "--top-chrome-collapse-px",
-        `${Math.max(0, rowHeight * topChromeProgress)}px`,
-      );
+      const nextProgress = String(topChromeProgress);
+      if (nextProgress !== lastWrittenProgress) {
+        lastWrittenProgress = nextProgress;
+        root.style.setProperty("--top-chrome-progress", nextProgress);
+      }
+      const nextCollapsePx = `${Math.max(0, rowHeight * topChromeProgress)}px`;
+      if (nextCollapsePx !== lastWrittenCollapsePx) {
+        lastWrittenCollapsePx = nextCollapsePx;
+        root.style.setProperty("--top-chrome-collapse-px", nextCollapsePx);
+      }
       const fullyCollapsed = topChromeProgress >= 0.999;
       setTopChromeFullyCollapsed((current) =>
         current === fullyCollapsed ? current : fullyCollapsed,
@@ -604,11 +622,51 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
       updateHeaderVisibility();
     };
 
+    // Mutation-driven path ONLY. Its single job is to notice a primary page
+    // header that mounted late or was swapped — which is how a query-only flow
+    // switch behaves here: `/one/location?action=…` keeps the pathname, so the
+    // effect never re-runs when PageHeader is replaced by a flow's
+    // TaskFlowHeader.
+    //
+    // This must stay O(1) when nothing relevant changed. It used to run the
+    // full `refreshHeader()` on EVERY mutation under the scroll root, once per
+    // animation frame. On a surface that animates continuously — One Location
+    // with a live map, whose marker glide and Google's own tile/attribution
+    // updates mutate the DOM every frame — that was three document-wide
+    // `querySelector`s and three `getBoundingClientRect()` forced reflows per
+    // frame, each followed by a custom-property write on <html> that
+    // invalidates layout for everything consuming `--top-shell-live-height`.
+    // The main thread never got a clear slot, so a tap on the back arrow sat
+    // queued behind the thrash instead of navigating.
+    //
+    // A swap is recomputed at once. Otherwise content can still reflow the
+    // header out of view with no scroll and no resize, so that keeps being
+    // tracked — at a fixed low rate rather than once per animation frame.
+    // Re-querying is deliberately unbounded: a header appearing is itself a
+    // mutation, and this is the only thing that notices the hub's PageHeader
+    // returning when a flow closes. Because TaskFlowHeader does not mark itself
+    // primary, `header` is legitimately null for the whole life of a flow
+    // screen, so giving up on a retry budget would strand the hub with stale
+    // header tracking on return.
     const scheduleHeaderRefresh = () => {
       if (refreshFrame !== null) return;
       refreshFrame = window.requestAnimationFrame(() => {
         refreshFrame = null;
-        refreshHeader();
+        const previous = header;
+        if (!header?.isConnected) {
+          header = document.querySelector<HTMLElement>(
+            '[data-slot="page-header"][data-page-primary="true"]',
+          );
+        }
+        const now = Date.now();
+        // Recompute on any identity change, including present -> null, so
+        // `primaryHeaderOutOfView` cannot keep asserting a header that a flow
+        // switch just unmounted.
+        if (header === previous && now - lastMutationCheckAt < MUTATION_RECHECK_MS) {
+          return;
+        }
+        lastMutationCheckAt = now;
+        updateHeaderVisibility();
       });
     };
 

--- a/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
@@ -21,6 +21,11 @@ const point: PlainLocationPoint = {
   sourcePlatform: "web",
 };
 
+// `google.maps.event` is real API surface: cleanup detaches the marker and
+// clears listeners on both instances, because dropping a ref does not stop a
+// Maps instance from running. A mock without it passes only by omission.
+const mapsEvent = () => ({ clearInstanceListeners: vi.fn() });
+
 afterEach(() => {
   mockStatus.current = "loading";
   // @ts-expect-error test cleanup
@@ -60,13 +65,13 @@ describe("LiveMap", () => {
   it("creates an interactive map + marker when ready", () => {
     // vitest 4.x requires non-arrow implementations for mocks called with `new`.
     const Marker = vi.fn(function () {
-      return { getPosition: () => null, setPosition: vi.fn() };
+      return { getPosition: () => null, setPosition: vi.fn(), setMap: vi.fn() };
     });
     const Map = vi.fn(function () {
       return { panTo: vi.fn() };
     });
     // @ts-expect-error test global
-    globalThis.google = { maps: { Map, Marker } };
+    globalThis.google = { maps: { Map, Marker, event: mapsEvent() } };
     mockStatus.current = "ready";
 
     render(<LiveMap point={point} />);
@@ -78,13 +83,13 @@ describe("LiveMap", () => {
 
   it("constructs a quiet preview map with the app theme's color scheme", () => {
     const Marker = vi.fn(function () {
-      return { getPosition: () => null, setPosition: vi.fn() };
+      return { getPosition: () => null, setPosition: vi.fn(), setMap: vi.fn() };
     });
     const Map = vi.fn(function () {
       return { panTo: vi.fn() };
     });
     // @ts-expect-error test global
-    globalThis.google = { maps: { Map, Marker } };
+    globalThis.google = { maps: { Map, Marker, event: mapsEvent() } };
     mockStatus.current = "ready";
     mockTheme.current = "dark";
 
@@ -118,13 +123,14 @@ describe("LiveMap", () => {
           lng: () => point.longitude,
         }),
         setPosition: markerSetPosition,
+        setMap: vi.fn(),
       };
     });
     const Map = vi.fn(function () {
       return { panTo: mapPanTo, setZoom: mapSetZoom };
     });
     // @ts-expect-error test global
-    globalThis.google = { maps: { Map, Marker } };
+    globalThis.google = { maps: { Map, Marker, event: mapsEvent() } };
     mockStatus.current = "ready";
 
     const { rerender } = render(
@@ -187,6 +193,7 @@ describe("LiveMap", () => {
                 }
               : null,
           setPosition: markerSetPositionSpy,
+          setMap: vi.fn(),
         };
       });
 
@@ -195,7 +202,7 @@ describe("LiveMap", () => {
       });
 
       // @ts-expect-error test global
-      globalThis.google = { maps: { Map, Marker } };
+      globalThis.google = { maps: { Map, Marker, event: mapsEvent() } };
       mockStatus.current = "ready";
 
       // Fix performance.now() so `start` is always 0 for deterministic t calculation.

--- a/hushh-webapp/components/one-location/live-map.tsx
+++ b/hushh-webapp/components/one-location/live-map.tsx
@@ -96,12 +96,26 @@ export function LiveMap({ point, className, viewportResetKey }: LiveMapProps) {
     });
     mapRef.current = map;
     markerRef.current = new google.maps.Marker({ map, position: target });
+    // Captured while the API is known to be present. Cleanup runs during
+    // unmount, and reaching for the global there would make teardown depend on
+    // a script that may already be gone — a throw in a cleanup function aborts
+    // React's unmount for the whole tree.
+    const mapsEvent = google.maps.event;
     // Created once per scheme; movement handled by the glide effect below.
     return () => {
       if (frameRef.current !== null) {
         cancelAnimationFrame(frameRef.current);
         frameRef.current = null;
       }
+      // Dropping the refs is not disposal. A Maps instance keeps its own
+      // listeners, tile requests and resize handlers alive, so an orphaned map
+      // goes on doing work — and on a theme flip the container div is re-keyed,
+      // which builds a second one on top of the first. Detach explicitly.
+      if (markerRef.current) {
+        markerRef.current.setMap(null);
+        mapsEvent?.clearInstanceListeners(markerRef.current);
+      }
+      mapsEvent?.clearInstanceListeners(map);
       mapRef.current = null;
       markerRef.current = null;
     };

--- a/hushh-webapp/lib/one-location/location-workspace-memory.ts
+++ b/hushh-webapp/lib/one-location/location-workspace-memory.ts
@@ -1,4 +1,7 @@
-import type { PlainLocationPoint } from "@/lib/one-location/types";
+import type {
+  DriveSharePayload,
+  PlainLocationPoint,
+} from "@/lib/one-location/types";
 
 /**
  * Volatile presentation state shared by the Location hub and nested Map. It is
@@ -28,6 +31,54 @@ function cloneWorkspace(workspace: LocationWorkspaceMemory): LocationWorkspaceMe
       ]),
     ),
   };
+}
+
+function sameDrivePayload(
+  a: DriveSharePayload | null | undefined,
+  b: DriveSharePayload | null | undefined,
+): boolean {
+  if (!a || !b) return !a && !b;
+  return (
+    a.etaSeconds === b.etaSeconds &&
+    a.distanceMeters === b.distanceMeters &&
+    a.etaComputedAt === b.etaComputedAt &&
+    a.destination.label === b.destination.label &&
+    a.destination.latitude === b.destination.latitude &&
+    a.destination.longitude === b.destination.longitude &&
+    (a.destination.placeId ?? null) === (b.destination.placeId ?? null)
+  );
+}
+
+/**
+ * Exact value equality for a decrypted point.
+ *
+ * A recipient's live-view poll re-decrypts every visible grant on a fixed
+ * cadence, and a stationary owner republishes the same coordinates — so most
+ * ticks carry a point identical to the one already on screen. Storing it anyway
+ * allocates a new workspace object, which defeats React's bail-out and
+ * re-renders the whole Location surface every few seconds for no visible
+ * change.
+ *
+ * Every field is compared, not just the coordinates. `drive` carries an ETA
+ * that is recomputed on its own schedule and `checkIn` carries the author's
+ * note; a coordinates-only check would freeze both at their first value while
+ * the point still looked "unchanged".
+ */
+export function samePlainLocationPoint(
+  a: PlainLocationPoint | null | undefined,
+  b: PlainLocationPoint | null | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.latitude === b.latitude &&
+    a.longitude === b.longitude &&
+    (a.accuracyM ?? null) === (b.accuracyM ?? null) &&
+    a.capturedAt === b.capturedAt &&
+    a.sourcePlatform === b.sourcePlatform &&
+    (a.checkIn?.message ?? null) === (b.checkIn?.message ?? null) &&
+    sameDrivePayload(a.drive, b.drive)
+  );
 }
 
 export function readLocationWorkspaceMemory(


### PR DESCRIPTION
## What was reported

On `/one/location`, the surface is fine at first. After sitting on it for a few
minutes — once the live map has come up — the screen goes sluggish and tapping the
header back arrow does not navigate promptly. Reported against UAT on both the hub
and `?action=shared-with-me`.

## Root cause

Three separate things, all landing on the same main thread the back tap needs.

**1. The shared top bar re-measured the chrome on every DOM mutation.**
`components/app-ui/top-app-bar.tsx` watches the whole app scroll root with a
`MutationObserver` (`childList` + `subtree`) so it can notice a primary page header
that mounted late or was swapped. That watcher is genuinely needed here: a
`?action=` flow keeps the pathname, so the effect never re-runs when the hub's
`PageHeader` is replaced by a flow's `TaskFlowHeader`.

The problem was what it did on each mutation — the full `refreshHeader()` pass:

- `document.querySelector` for the page header,
- `document.querySelector` for the top bar row, then `getBoundingClientRect()`,
- `isPrimaryHeaderOutOfView()` → another `getBoundingClientRect()`,
- `readTopShellReservedHeight()` → a third query and a third `getBoundingClientRect()`,
- then `style.setProperty` for `--top-chrome-progress` and `--top-chrome-collapse-px`
  on `<html>`.

Those last two are not cosmetic. `--top-chrome-collapse-px` feeds
`--top-shell-live-height` and `--top-shell-mask-solid-height`, which route content
consumes for layout — so writing it invalidates layout for the whole document.

One Location keeps a live map. The marker glide runs a `requestAnimationFrame` loop
and Google's own tile and attribution updates mutate the DOM continuously, so the
observer fired every frame: three forced reflows plus two layout-invalidating writes,
at 60 Hz, for values that had not changed. That is why the page was fine until the map
came up and degraded from there, and why a tap sat queued instead of navigating.

**2. `LiveMap` never disposed its Google Maps instances.**
`components/one-location/live-map.tsx` dropped `mapRef`/`markerRef` on cleanup. A Maps
instance keeps its own listeners, tile requests and resize handlers running regardless,
and a theme flip re-keys the container div and builds a second map on top of the first.

**3. The live poll re-rendered the whole surface every tick for no change.**
`viewGrantEnvelope` stored each decrypted point unconditionally. A stationary owner
republishes the same coordinates, so most ticks wrote an identical point — which still
allocated a new workspace object through `updateLocationWorkspace` and defeated React's
bail-out, reconciling the 8k-line page and the hub on a fixed heartbeat.

## The fix

- The mutation path now costs one `isConnected` check in the steady state. A header
  swap is still recomputed immediately. Content can also reflow the header out of view
  with no scroll and no resize, so that keeps being tracked — throttled to 250ms
  instead of once per frame.
- The header element and bar row are re-queried only once the cached node leaves the
  document; the two custom properties are written only when their value changes.
- `LiveMap` detaches the marker and clears listeners on both instances.
- Point storage bails when nothing changed, and both `setDecryptedPoints` and
  `updateLocationWorkspace` propagate that verdict so React can bail out.

Re-querying in the mutation path is deliberately left unbounded: a header appearing is
itself a mutation, and this is the only thing that notices the hub's `PageHeader`
returning when a flow closes. `TaskFlowHeader` does not mark itself primary, so
`header` is legitimately null for the whole life of a flow screen, and giving up on a
retry budget would strand the hub with stale tracking on return.

## Correctness held

Point equality compares **every** field, not just the coordinates. `drive` carries an
ETA recomputed on its own schedule and `checkIn` carries the author's note; a
coordinates-only check would have frozen a driver's ETA countdown at a red light while
the point still looked "unchanged". That specific regression is covered by test.

The 20s publish heartbeat, the movement watch, background share, and grant/consent
semantics are untouched.

## Tests

`__tests__/lib/one-location/location-workspace-point-equality.test.ts` (13) —
movement, fresh fix at unchanged coordinates, accuracy incl. null/absent, platform,
drive ETA / distance / destination / start / end, check-in note added / edited / cleared.

`__tests__/components/live-map-disposal.test.tsx` (2) — unmount disposal, and the
theme re-key not leaving the previous map running.

`__tests__/components/top-app-bar.contract.test.ts` (+4) — the mutation path stays off
the hot path, and the custom properties are written only on change.

All were mutation-checked: reverting each fix fails them (7/13, 2/2, 3/4 respectively).
In particular, substituting the naive coordinates-only equality fails 7 of the 13.

## Known, not addressed here

Back navigation has a fixed floor independent of this bug: `beginRouteTransition` in
`lib/morphy-ux/hooks/use-route-transition.ts` waits `EXIT_MS = 300` before calling the
router and then plays `ENTER_MS = 360`, so every back tap costs ~660ms by design. That
is the app-wide motion envelope, not a Location defect, and changing it is a design
decision rather than part of this fix. Flagging it because it sets the floor on how
"quick and fast" back can feel once the thrash is gone.
