### PR TITLE
feat(one-location): email SOS contacts as a second channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,15 @@ jobs:
             fi
           elif [ "${{ github.event_name }}" = "push" ]; then
             LOG_OPTS="$(resolve_from_default_branch)"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # A manually dispatched run validates a BRANCH, so it scans that
+            # branch's own commits — the same range a push resolves. It used to
+            # fall through to the bare-SHA case below, which walks all history
+            # (~3400 commits) and fails on findings that predate the branch by
+            # years. That made the manual lane useless exactly when it is
+            # needed most: when the pull_request event does not fire and this
+            # is the only way to validate a change.
+            LOG_OPTS="$(resolve_from_default_branch)"
           else
             LOG_OPTS="${{ github.sha }}"
           fi

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -8,6 +8,7 @@ Path parameters (public_token, invite_id, grant_id) are bounded to 128 chars max
 from __future__ import annotations
 
 import hmac
+import logging
 import os
 from datetime import datetime
 from typing import Annotated, Any
@@ -49,6 +50,8 @@ from hushh_mcp.services.one_location_nearby_presence_service import (
 )
 
 router = APIRouter(prefix="/api/one", tags=["One Location Agent"])
+
+logger = logging.getLogger(__name__)
 
 _PublicToken = Annotated[str, Path(min_length=1, max_length=128)]
 _InviteId = Annotated[str, Path(min_length=1, max_length=128)]
@@ -108,6 +111,27 @@ class CreateGrantWithEnvelopeRequest(CreateGrantRequest):
 
 class AddSmsContactRequest(_CamelModel):
     recipient_user_id: str = Field(alias="recipientUserId", min_length=1, max_length=160)
+
+
+class SosEmailRequest(_CamelModel):
+    """Coordinates for the Save my Soul email, carried for one send only.
+
+    They are in the request body because the server cannot read them anywhere
+    else: `one_location_envelopes` keeps coordinates inside the ciphertext by
+    design, so only the sender's client holds the plaintext. They are not
+    stored and not logged — see one_location_sos_email_service for the rules
+    that bound this.
+
+    `grantIds` is the authorization, not a hint: the service mails only the
+    recipients of live SOS grants the caller's own account just created.
+    """
+
+    grant_ids: list[str] = Field(alias="grantIds", min_length=1, max_length=20)
+    latitude: float = Field(ge=-90, le=90)
+    longitude: float = Field(ge=-180, le=180)
+    accuracy_m: float | None = Field(default=None, alias="accuracyM", ge=0, le=100_000)
+    note: str | None = Field(default=None, max_length=300)
+    emergency_number: str | None = Field(default=None, alias="emergencyNumber", max_length=16)
 
 
 class StoreEnvelopeRequest(_CamelModel):
@@ -419,6 +443,39 @@ def add_location_sms_contact(
         }
     except Exception as exc:
         raise _handle_error(exc) from exc
+
+
+@router.post("/location/sos-email")
+def send_location_sos_email(
+    payload: SosEmailRequest,
+    response: Response,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    """Second channel for a Save my Soul alert.
+
+    The push notification is the first, and it reaches nobody when a contact
+    has notifications off or the app uninstalled. This mails the same alert so
+    it survives a closed app.
+
+    Never fails the caller: the alert itself has already gone out by the time
+    this is called, so a mail problem is reported as a count, not an error. An
+    exception here would make a successful emergency look like a failed one.
+    """
+    # The body carries a live location; no cache, no store, anywhere.
+    _set_private_no_store(response)
+    try:
+        return _service().send_sos_emails(
+            owner_user_id=_user_id(token_data),
+            grant_ids=payload.grant_ids,
+            latitude=payload.latitude,
+            longitude=payload.longitude,
+            accuracy_m=payload.accuracy_m,
+            note=payload.note,
+            emergency_number=payload.emergency_number,
+        )
+    except Exception:
+        logger.warning("one.location.sos_email.route_failed", exc_info=False)
+        return {"emailed": 0, "attempted": 0, "results": [], "configured": False}
 
 
 @router.delete("/location/sms-contacts/{recipient_user_id}")

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -113,25 +113,17 @@ class AddSmsContactRequest(_CamelModel):
     recipient_user_id: str = Field(alias="recipientUserId", min_length=1, max_length=160)
 
 
-class SosEmailRequest(_CamelModel):
-    """Coordinates for the Save my Soul email, carried for one send only.
+class SosEmailRecipientsRequest(_CamelModel):
+    """Which contacts One may email for a Save my Soul alert.
 
-    They are in the request body because the server cannot read them anywhere
-    else: `one_location_envelopes` keeps coordinates inside the ciphertext by
-    design, so only the sender's client holds the plaintext. They are not
-    stored and not logged — see one_location_sos_email_service for the rules
-    that bound this.
-
-    `grantIds` is the authorization, not a hint: the service mails only the
-    recipients of live SOS grants the caller's own account just created.
+    `grantIds` is the authorization, not a hint: only the recipients of live
+    SOS grants the caller's own account just created are returned. No
+    coordinates here — the message is rendered and sent by One, and the server
+    never sees a plaintext location (`one_location_envelopes` keeps
+    coordinates inside the ciphertext).
     """
 
     grant_ids: list[str] = Field(alias="grantIds", min_length=1, max_length=20)
-    latitude: float = Field(ge=-90, le=90)
-    longitude: float = Field(ge=-180, le=180)
-    accuracy_m: float | None = Field(default=None, alias="accuracyM", ge=0, le=100_000)
-    note: str | None = Field(default=None, max_length=300)
-    emergency_number: str | None = Field(default=None, alias="emergencyNumber", max_length=16)
 
 
 class StoreEnvelopeRequest(_CamelModel):
@@ -445,37 +437,34 @@ def add_location_sms_contact(
         raise _handle_error(exc) from exc
 
 
-@router.post("/location/sos-email")
-def send_location_sos_email(
-    payload: SosEmailRequest,
+@router.post("/location/sos-email-recipients")
+def list_location_sos_email_recipients(
+    payload: SosEmailRecipientsRequest,
     response: Response,
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    """Second channel for a Save my Soul alert.
+    """Resolve who One may email for a Save my Soul alert.
 
-    The push notification is the first, and it reaches nobody when a contact
-    has notifications off or the app uninstalled. This mails the same alert so
-    it survives a closed app.
+    The push notification is the first channel and reaches nobody when a
+    contact has notifications off or the app uninstalled; email is the second.
+    One renders and sends that mail through `hushh-mail-api` — the same
+    service as every other product mail — so this endpoint only answers who is
+    reachable, and does so under the caller's own grants.
 
-    Never fails the caller: the alert itself has already gone out by the time
-    this is called, so a mail problem is reported as a count, not an error. An
+    Never fails the caller: the alert has already gone out by the time this is
+    called, so a resolution problem is an empty list, not an error. An
     exception here would make a successful emergency look like a failed one.
     """
-    # The body carries a live location; no cache, no store, anywhere.
+    # Contact addresses in the body; never cached, never stored.
     _set_private_no_store(response)
     try:
-        return _service().send_sos_emails(
+        return _service().list_sos_email_recipients(
             owner_user_id=_user_id(token_data),
             grant_ids=payload.grant_ids,
-            latitude=payload.latitude,
-            longitude=payload.longitude,
-            accuracy_m=payload.accuracy_m,
-            note=payload.note,
-            emergency_number=payload.emergency_number,
         )
     except Exception:
-        logger.warning("one.location.sos_email.route_failed", exc_info=False)
-        return {"emailed": 0, "attempted": 0, "results": [], "configured": False}
+        logger.warning("one.location.sos_email_recipients.route_failed", exc_info=False)
+        return {"ownerDisplayName": "", "openInOneUrl": "", "recipients": []}
 
 
 @router.delete("/location/sms-contacts/{recipient_user_id}")

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -964,7 +964,6 @@ class OneLocationAgentService:
         accuracy_m: float | None,
         note: str | None,
         emergency_number: str | None,
-        frontend_origin: str | None = None,
     ) -> dict[str, Any]:
         """Mail a Save my Soul alert to the contacts of the given SOS grants.
 
@@ -1027,8 +1026,12 @@ class OneLocationAgentService:
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_notification_label(owner_identity)
         sent_at_label = datetime.now(timezone.utc).strftime("%H:%M UTC on %d %b %Y")
-        origin = (frontend_origin or os.getenv("APP_FRONTEND_ORIGIN") or "").rstrip("/")
-        open_in_one_url = f"{origin}/one/location?section=shared" if origin else "/one/location"
+        # Same builder the push notification uses, so the email link and the
+        # notification link always point at the same place and the frontend
+        # origin is resolved exactly one way. Reading APP_FRONTEND_ORIGIN
+        # directly here violated the runtime-config contract, which is right:
+        # a canonical key deserves a single reader.
+        open_in_one_url = _one_location_url(section="shared")
 
         try:
             session = service._build_authorized_session()

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -954,6 +954,115 @@ class OneLocationAgentService:
             data=data or {},
         )
 
+    def send_sos_emails(
+        self,
+        *,
+        owner_user_id: str,
+        grant_ids: list[str],
+        latitude: float,
+        longitude: float,
+        accuracy_m: float | None,
+        note: str | None,
+        emergency_number: str | None,
+        frontend_origin: str | None = None,
+    ) -> dict[str, Any]:
+        """Mail a Save my Soul alert to the contacts of the given SOS grants.
+
+        The second channel behind the push. A recipient with notifications off
+        is invisible to FCM but still has an inbox, and an SOS that reaches
+        nobody is the failure this exists to prevent.
+
+        `latitude`/`longitude` arrive from the sender's client and are used for
+        the length of this call only: the envelope invariant keeps coordinates
+        out of our tables, and nothing here writes or logs them. The grants are
+        the authorization — a caller can only mail people they just created a
+        live SOS grant for, under their own account.
+        """
+        from hushh_mcp.services.one_location_sos_email_service import (
+            get_sos_email_service,
+            select_emailable_recipients,
+            summarize,
+        )
+
+        service = get_sos_email_service()
+        if not service.configured:
+            # Not an error: the alert itself already went out. The sender is
+            # told the count, and a missing binding must never look like a
+            # failed emergency.
+            logger.info("one.location.sos_email.skipped reason=not_configured")
+            return {"emailed": 0, "attempted": 0, "results": [], "configured": False}
+
+        cleaned_ids = [str(value).strip() for value in grant_ids if str(value or "").strip()]
+        if not cleaned_ids:
+            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
+
+        rows = self._execute_many(
+            """
+            SELECT
+              g.id::TEXT             AS grant_id,
+              g.owner_user_id        AS owner_user_id,
+              g.recipient_user_id    AS recipient_user_id,
+              g.status               AS status,
+              g.expires_at           AS expires_at,
+              EXTRACT(EPOCH FROM g.created_at) AS created_at_epoch,
+              COALESCE(g.metadata ->> 'share_kind', '') AS share_kind,
+              recipient.email        AS recipient_email,
+              recipient.display_name AS recipient_display_name
+            FROM one_location_share_grants g
+            LEFT JOIN actor_identity_cache recipient
+              ON recipient.user_id = g.recipient_user_id
+            WHERE g.id = ANY(CAST(:grant_ids AS UUID[]))
+              AND g.owner_user_id = :owner_user_id
+            """,
+            {"grant_ids": cleaned_ids, "owner_user_id": owner_user_id},
+        )
+
+        now_epoch = datetime.now(timezone.utc).timestamp()
+        selected = select_emailable_recipients(
+            rows, owner_user_id=owner_user_id, now_epoch_seconds=now_epoch
+        )
+        if not selected:
+            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
+
+        owner_identity = self._identity_row(owner_user_id)
+        owner_label = _identity_notification_label(owner_identity)
+        sent_at_label = datetime.now(timezone.utc).strftime("%H:%M UTC on %d %b %Y")
+        origin = (frontend_origin or os.getenv("APP_FRONTEND_ORIGIN") or "").rstrip("/")
+        open_in_one_url = f"{origin}/one/location?section=shared" if origin else "/one/location"
+
+        try:
+            session = service._build_authorized_session()
+        except Exception as exc:  # noqa: BLE001 - never fails the alert
+            logger.warning("one.location.sos_email.auth_failed error=%s", type(exc).__name__)
+            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
+
+        outcomes = []
+        for row in selected:
+            expires_at = row.get("expires_at")
+            outcomes.append(
+                service.send_one(
+                    session=session,
+                    recipient_user_id=str(row.get("recipient_user_id") or ""),
+                    recipient_email=str(row.get("recipient_email") or ""),
+                    recipient_display_name=row.get("recipient_display_name"),
+                    owner_display_name=owner_label,
+                    note=note,
+                    latitude=latitude,
+                    longitude=longitude,
+                    accuracy_m=accuracy_m,
+                    sent_at_label=sent_at_label,
+                    expires_at_label=(
+                        expires_at.strftime("%H:%M UTC on %d %b")
+                        if hasattr(expires_at, "strftime")
+                        else None
+                    ),
+                    open_in_one_url=open_in_one_url,
+                    emergency_number=emergency_number,
+                )
+            )
+
+        return {**summarize(outcomes), "configured": True}
+
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:
         try:
             return self._execute_one(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -954,46 +954,31 @@ class OneLocationAgentService:
             data=data or {},
         )
 
-    def send_sos_emails(
+    def list_sos_email_recipients(
         self,
         *,
         owner_user_id: str,
         grant_ids: list[str],
-        latitude: float,
-        longitude: float,
-        accuracy_m: float | None,
-        note: str | None,
-        emergency_number: str | None,
     ) -> dict[str, Any]:
-        """Mail a Save my Soul alert to the contacts of the given SOS grants.
+        """Who One may email for this Save my Soul alert.
 
-        The second channel behind the push. A recipient with notifications off
-        is invisible to FCM but still has an inbox, and an SOS that reaches
-        nobody is the failure this exists to prevent.
+        Resolution and authorization only — the message is rendered and sent by
+        One through `hushh-mail-api`, the same service every other product mail
+        uses. A second sender identity is a deliverability risk, and an
+        emergency mail is the worst place to find that out.
 
-        `latitude`/`longitude` arrive from the sender's client and are used for
-        the length of this call only: the envelope invariant keeps coordinates
-        out of our tables, and nothing here writes or logs them. The grants are
-        the authorization — a caller can only mail people they just created a
-        live SOS grant for, under their own account.
+        Returns the owner's display label plus one entry per reachable contact.
+        Addresses are returned to One's server route, never to a browser: a
+        sender does not necessarily know their contacts' email addresses and
+        this must not be where they learn them.
         """
         from hushh_mcp.services.one_location_sos_email_service import (
-            get_sos_email_service,
             select_emailable_recipients,
-            summarize,
         )
-
-        service = get_sos_email_service()
-        if not service.configured:
-            # Not an error: the alert itself already went out. The sender is
-            # told the count, and a missing binding must never look like a
-            # failed emergency.
-            logger.info("one.location.sos_email.skipped reason=not_configured")
-            return {"emailed": 0, "attempted": 0, "results": [], "configured": False}
 
         cleaned_ids = [str(value).strip() for value in grant_ids if str(value or "").strip()]
         if not cleaned_ids:
-            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
+            return {"ownerDisplayName": "", "openInOneUrl": "", "recipients": []}
 
         rows = self._execute_many(
             """
@@ -1021,50 +1006,26 @@ class OneLocationAgentService:
             rows, owner_user_id=owner_user_id, now_epoch_seconds=now_epoch
         )
         if not selected:
-            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
+            return {"ownerDisplayName": "", "openInOneUrl": "", "recipients": []}
 
-        owner_identity = self._identity_row(owner_user_id)
-        owner_label = _identity_notification_label(owner_identity)
-        sent_at_label = datetime.now(timezone.utc).strftime("%H:%M UTC on %d %b %Y")
-        # Same builder the push notification uses, so the email link and the
-        # notification link always point at the same place and the frontend
-        # origin is resolved exactly one way. Reading APP_FRONTEND_ORIGIN
-        # directly here violated the runtime-config contract, which is right:
-        # a canonical key deserves a single reader.
-        open_in_one_url = _one_location_url(section="shared")
-
-        try:
-            session = service._build_authorized_session()
-        except Exception as exc:  # noqa: BLE001 - never fails the alert
-            logger.warning("one.location.sos_email.auth_failed error=%s", type(exc).__name__)
-            return {"emailed": 0, "attempted": 0, "results": [], "configured": True}
-
-        outcomes = []
-        for row in selected:
-            expires_at = row.get("expires_at")
-            outcomes.append(
-                service.send_one(
-                    session=session,
-                    recipient_user_id=str(row.get("recipient_user_id") or ""),
-                    recipient_email=str(row.get("recipient_email") or ""),
-                    recipient_display_name=row.get("recipient_display_name"),
-                    owner_display_name=owner_label,
-                    note=note,
-                    latitude=latitude,
-                    longitude=longitude,
-                    accuracy_m=accuracy_m,
-                    sent_at_label=sent_at_label,
-                    expires_at_label=(
-                        expires_at.strftime("%H:%M UTC on %d %b")
-                        if hasattr(expires_at, "strftime")
-                        else None
-                    ),
-                    open_in_one_url=open_in_one_url,
-                    emergency_number=emergency_number,
-                )
-            )
-
-        return {**summarize(outcomes), "configured": True}
+        owner_label = _identity_notification_label(self._identity_row(owner_user_id))
+        return {
+            "ownerDisplayName": owner_label,
+            # Same builder the push notification uses, so the email link and the
+            # notification link cannot drift and the frontend origin has exactly
+            # one reader (the runtime-config contract requires that).
+            "openInOneUrl": _one_location_url(section="shared"),
+            "recipients": [
+                {
+                    "grantId": str(row.get("grant_id") or ""),
+                    "recipientUserId": str(row.get("recipient_user_id") or ""),
+                    "email": str(row.get("recipient_email") or ""),
+                    "displayName": str(row.get("recipient_display_name") or ""),
+                    "expiresAt": _iso(row.get("expires_at")),
+                }
+                for row in selected
+            ],
+        }
 
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:
         try:

--- a/consent-protocol/hushh_mcp/services/one_location_sos_email_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_sos_email_service.py
@@ -1,0 +1,362 @@
+"""Email fallback for a Save my Soul alert.
+
+Why this exists
+---------------
+An SOS alert reaches its recipients through exactly one channel: a push
+notification. If the recipient has notifications off, has uninstalled, or is
+simply not looking at their phone, the alert lands nowhere and the sender is
+told so after the fact. Email is the second channel — it survives a closed app
+and an unread notification tray.
+
+The coordinates problem
+-----------------------
+``one_location_envelopes`` carries this invariant, stated in migration 061:
+
+    "Latest live-location ciphertext envelopes.
+     Coordinates must be present only inside ciphertext."
+
+The server therefore cannot read where the sender is; only the recipient's
+device can decrypt that. An email that names a location has to receive those
+coordinates from the sender's client, in the request, for the length of one
+send.
+
+That is a deliberate, product-owner decision to weaken the envelope model for
+the emergency case: in an emergency, a contact who cannot open the app still
+needs to know where to go. The rules that keep it bounded:
+
+1. Coordinates arrive as request input and are **never persisted**. Nothing in
+   this module writes them to a table, and the caller does not either.
+2. Coordinates are **never logged**. Every log line here carries ids and
+   outcomes only. `_log_safe` is the single formatting path, so a future edit
+   cannot casually interpolate a latitude.
+3. The sender may only mail a recipient they already hold a **live SOS grant**
+   for, created by their own account. The grant is the authorization: without
+   it this endpoint would email arbitrary text and a location to any user id.
+4. Delivery follows the support-email delivery mode, so a non-production
+   environment routes every message to the test inbox instead of a real
+   contact's real inbox.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass
+from email.message import EmailMessage
+from html import escape
+from typing import Any, Iterable, Sequence
+
+from hushh_mcp.services.support_email_service import (
+    SupportEmailConfig,
+    SupportEmailNotConfiguredError,
+)
+
+logger = logging.getLogger(__name__)
+
+_GMAIL_SEND_ENDPOINT = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+
+#: A grant older than this is not the alert that is being sent right now.
+#: Without it, a stale 8-hour SOS grant would keep this endpoint usable as a
+#: mailer for the rest of the day.
+_GRANT_FRESHNESS_SECONDS = 15 * 60
+
+#: Bound on how many contacts one alert may mail. An SOS list is a handful of
+#: people; anything larger is a bug or an abuse attempt, not an emergency.
+MAX_SOS_EMAIL_RECIPIENTS = 20
+
+
+@dataclass(frozen=True)
+class SosEmailOutcome:
+    """Per-recipient result. ``emailed`` is never ``True`` on a silent failure."""
+
+    recipient_user_id: str
+    emailed: bool
+    #: Machine-readable reason when ``emailed`` is False. Never a coordinate.
+    reason: str | None = None
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "recipientUserId": self.recipient_user_id,
+            "emailed": self.emailed,
+            **({"reason": self.reason} if self.reason else {}),
+        }
+
+
+def _log_safe(value: object) -> str:
+    """The only way a value reaches a log line from this module.
+
+    Coordinates must never be logged, so nothing here formats a float. Anything
+    that is not a short identifier-ish string becomes a type name.
+    """
+    if isinstance(value, str) and len(value) <= 80:
+        return value
+    return f"<{type(value).__name__}>"
+
+
+def _maps_link(latitude: float, longitude: float) -> str:
+    return f"https://www.google.com/maps/search/?api=1&query={latitude:.6f},{longitude:.6f}"
+
+
+def _accuracy_phrase(accuracy_m: float | None) -> str:
+    if accuracy_m is None or accuracy_m <= 0:
+        return ""
+    return f" (accurate to about {round(accuracy_m)} m)"
+
+
+class OneLocationSosEmailService:
+    """Sends the Save my Soul email through the Workspace Gmail identity.
+
+    Reuses ``SupportEmailConfig`` rather than introducing a second credential:
+    the delegated service account is already bound in every environment, so
+    this channel ships without a new secret, a new IAM grant, or a new deploy
+    variable to keep in parity across lanes.
+    """
+
+    def __init__(self) -> None:
+        self._config: SupportEmailConfig | None = None
+
+    @property
+    def config(self) -> SupportEmailConfig:
+        if self._config is None:
+            self._config = SupportEmailConfig.from_env()
+        return self._config
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.config.configured)
+
+    def _resolve_destination(self, recipient_email: str) -> str:
+        """Where the message actually goes.
+
+        In a non-production environment this is the support test inbox, not the
+        contact's real address: verifying an emergency mail must never mean
+        mailing a real person's real inbox from UAT.
+        """
+        cfg = self.config
+        if cfg.delivery_mode == "test" and cfg.test_to_email:
+            return cfg.test_to_email
+        return recipient_email
+
+    def _build_message(
+        self,
+        *,
+        recipient_email: str,
+        recipient_display_name: str | None,
+        owner_display_name: str,
+        note: str | None,
+        latitude: float,
+        longitude: float,
+        accuracy_m: float | None,
+        sent_at_label: str,
+        expires_at_label: str | None,
+        open_in_one_url: str,
+        emergency_number: str | None,
+    ) -> EmailMessage:
+        cfg = self.config
+        destination = self._resolve_destination(recipient_email)
+        greeting_name = (recipient_display_name or "").strip().split(" ")[0]
+        greeting = f"{greeting_name}, " if greeting_name else ""
+
+        subject = f"{owner_display_name} needs help — Save my Soul"
+        if cfg.delivery_mode == "test":
+            subject = f"[TEST → {recipient_email}] {subject}"
+
+        maps_url = _maps_link(latitude, longitude)
+        coords = f"{latitude:.6f}, {longitude:.6f}"
+        accuracy = _accuracy_phrase(accuracy_m)
+        quoted_note = f'\n\n  "{note.strip()}"\n' if note and note.strip() else "\n"
+        expiry_line = (
+            f"Their live location stays shared until {expires_at_label}."
+            if expires_at_label
+            else "Their live location is shared with you now."
+        )
+        emergency_line = (
+            f"If this is an emergency where you are, call {emergency_number}."
+            if emergency_number
+            else "If this is an emergency, call your local emergency number."
+        )
+
+        text = (
+            f"{greeting}{owner_display_name} triggered a Save my Soul alert at "
+            f"{sent_at_label}."
+            f"{quoted_note}\n"
+            f"Location: {coords}{accuracy}\n"
+            f"Map: {maps_url}\n\n"
+            f"{expiry_line}\n"
+            f"Open in One for their live position: {open_in_one_url}\n\n"
+            f"{emergency_line}\n"
+        )
+
+        note_html = (
+            f'<p style="margin:0 0 20px;padding:12px 16px;border-left:3px solid #ff3b30;'
+            f'background:#faf7f7;font-size:16px;line-height:1.5;color:#1d1d1f;">'
+            f"“{escape(note.strip())}”</p>"
+            if note and note.strip()
+            else ""
+        )
+        html = (
+            "<div style=\"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
+            "Helvetica,Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px;"
+            'color:#1d1d1f;">'
+            f'<p style="margin:0 0 4px;font-size:13px;font-weight:600;letter-spacing:.08em;'
+            f'text-transform:uppercase;color:#ff3b30;">Save my Soul</p>'
+            f'<h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;">'
+            f"{escape(owner_display_name)} needs help</h1>"
+            f'<p style="margin:0 0 20px;font-size:16px;line-height:1.5;">'
+            f"{escape(greeting.strip())} They triggered an alert at "
+            f"{escape(sent_at_label)} and shared their live location with you.</p>"
+            f"{note_html}"
+            f'<p style="margin:0 0 8px;font-size:16px;line-height:1.5;">'
+            f"<strong>Location:</strong> {escape(coords)}{escape(accuracy)}</p>"
+            f'<p style="margin:0 0 24px;">'
+            f'<a href="{escape(maps_url)}" style="display:inline-block;padding:12px 20px;'
+            f"border-radius:9999px;background:#ff3b30;color:#ffffff;text-decoration:none;"
+            f'font-weight:600;font-size:16px;">Open in Google Maps</a></p>'
+            f'<p style="margin:0 0 8px;font-size:15px;line-height:1.5;color:#3c3c43;">'
+            f"{escape(expiry_line)}</p>"
+            f'<p style="margin:0 0 24px;font-size:15px;">'
+            f'<a href="{escape(open_in_one_url)}" style="color:#007aff;">'
+            f"See their live position in One</a></p>"
+            f'<p style="margin:0;font-size:15px;line-height:1.5;color:#3c3c43;">'
+            f"{escape(emergency_line)}</p>"
+            "</div>"
+        )
+
+        message = EmailMessage()
+        message["To"] = destination
+        message["From"] = f"Hussh One <{cfg.from_email}>"
+        message["Subject"] = subject
+        message["X-Hushh-Alert"] = "save-my-soul"
+        # An emergency mail belongs at the top of the inbox, not batched.
+        message["X-Priority"] = "1"
+        message["Importance"] = "high"
+        message.set_content(text)
+        message.add_alternative(html, subtype="html")
+        return message
+
+    def send_one(
+        self,
+        *,
+        session: Any,
+        recipient_user_id: str,
+        recipient_email: str,
+        recipient_display_name: str | None,
+        owner_display_name: str,
+        note: str | None,
+        latitude: float,
+        longitude: float,
+        accuracy_m: float | None,
+        sent_at_label: str,
+        expires_at_label: str | None,
+        open_in_one_url: str,
+        emergency_number: str | None,
+    ) -> SosEmailOutcome:
+        """Send to one recipient. Never raises — an email that fails to send
+        must not take down the alert that already reached someone else."""
+        try:
+            message = self._build_message(
+                recipient_email=recipient_email,
+                recipient_display_name=recipient_display_name,
+                owner_display_name=owner_display_name,
+                note=note,
+                latitude=latitude,
+                longitude=longitude,
+                accuracy_m=accuracy_m,
+                sent_at_label=sent_at_label,
+                expires_at_label=expires_at_label,
+                open_in_one_url=open_in_one_url,
+                emergency_number=emergency_number,
+            )
+            encoded = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
+            response = session.post(_GMAIL_SEND_ENDPOINT, json={"raw": encoded}, timeout=20)
+        except Exception as exc:  # noqa: BLE001 - reported, never raised onward
+            logger.warning(
+                "one.location.sos_email.transport_failed recipient=%s error=%s",
+                _log_safe(recipient_user_id),
+                _log_safe(type(exc).__name__),
+            )
+            return SosEmailOutcome(recipient_user_id, False, "transport_failed")
+
+        if getattr(response, "status_code", 500) >= 400:
+            logger.warning(
+                "one.location.sos_email.send_failed recipient=%s status=%s",
+                _log_safe(recipient_user_id),
+                getattr(response, "status_code", "unknown"),
+            )
+            return SosEmailOutcome(recipient_user_id, False, "send_failed")
+
+        logger.info(
+            "one.location.sos_email.sent recipient=%s mode=%s",
+            _log_safe(recipient_user_id),
+            self.config.delivery_mode,
+        )
+        return SosEmailOutcome(recipient_user_id, True)
+
+
+_service: OneLocationSosEmailService | None = None
+
+
+def get_sos_email_service() -> OneLocationSosEmailService:
+    global _service
+    if _service is None:
+        _service = OneLocationSosEmailService()
+    return _service
+
+
+def select_emailable_recipients(
+    grants: Iterable[dict[str, Any]],
+    *,
+    owner_user_id: str,
+    now_epoch_seconds: float,
+) -> list[dict[str, Any]]:
+    """Filter grant rows down to the ones this alert may mail.
+
+    A row survives only when it is the caller's own, is an SOS share, is still
+    active, was created moments ago, and names a recipient with an address.
+    Every rejection is silent by design — the caller reports a count, not which
+    of someone's emergency contacts happens to lack an email on file.
+    """
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in grants:
+        if str(row.get("owner_user_id") or "") != owner_user_id:
+            continue
+        if str(row.get("share_kind") or "") != "sos":
+            continue
+        if str(row.get("status") or "") != "active":
+            continue
+        created_at_epoch = row.get("created_at_epoch")
+        if not isinstance(created_at_epoch, (int, float)):
+            continue
+        if now_epoch_seconds - float(created_at_epoch) > _GRANT_FRESHNESS_SECONDS:
+            continue
+        recipient_user_id = str(row.get("recipient_user_id") or "").strip()
+        email = str(row.get("recipient_email") or "").strip()
+        if not recipient_user_id or "@" not in email:
+            continue
+        if recipient_user_id in seen:
+            continue
+        seen.add(recipient_user_id)
+        selected.append(row)
+        if len(selected) >= MAX_SOS_EMAIL_RECIPIENTS:
+            break
+    return selected
+
+
+def summarize(outcomes: Sequence[SosEmailOutcome]) -> dict[str, Any]:
+    return {
+        "emailed": sum(1 for outcome in outcomes if outcome.emailed),
+        "attempted": len(outcomes),
+        "results": [outcome.as_payload() for outcome in outcomes],
+    }
+
+
+__all__ = [
+    "MAX_SOS_EMAIL_RECIPIENTS",
+    "OneLocationSosEmailService",
+    "SosEmailOutcome",
+    "SupportEmailNotConfiguredError",
+    "get_sos_email_service",
+    "select_emailable_recipients",
+    "summarize",
+]

--- a/consent-protocol/hushh_mcp/services/one_location_sos_email_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_sos_email_service.py
@@ -1,306 +1,44 @@
-"""Email fallback for a Save my Soul alert.
+"""Who a Save my Soul alert may be emailed to.
 
-Why this exists
----------------
-An SOS alert reaches its recipients through exactly one channel: a push
-notification. If the recipient has notifications off, has uninstalled, or is
-simply not looking at their phone, the alert lands nowhere and the sender is
-told so after the fact. Email is the second channel — it survives a closed app
-and an unread notification tray.
+This module answers one question — *which contacts is this caller allowed to
+mail right now* — and nothing else. The message itself is rendered and sent by
+One, through `hushh-mail-api`, the same service that sends every other product
+mail (sign-in, phone conflict, capability linked). Only the webapp lane holds
+`MAIL_API_KEY`/`MAIL_API_ENDPOINT`, and more importantly a second sender
+identity is a deliverability risk we have already been bitten by: an emergency
+mail is the worst place to discover an SPF/DKIM misalignment.
 
-The coordinates problem
------------------------
-``one_location_envelopes`` carries this invariant, stated in migration 061:
+So the split is:
 
-    "Latest live-location ciphertext envelopes.
-     Coordinates must be present only inside ciphertext."
+    backend (here)   authorization + recipient resolution
+    One (Next.js)    render + send via hushh-mail-api
 
-The server therefore cannot read where the sender is; only the recipient's
-device can decrypt that. An email that names a location has to receive those
-coordinates from the sender's client, in the request, for the length of one
-send.
+The rules below are the fence. Without them this would be an open mailer: the
+sender supplies grant ids and free text, and the recipients are other people.
 
-That is a deliberate, product-owner decision to weaken the envelope model for
-the emergency case: in an emergency, a contact who cannot open the app still
-needs to know where to go. The rules that keep it bounded:
+1. The grant is the authorization. A caller may only reach the recipients of
+   live SOS grants their **own** account created.
+2. Freshness. An SOS grant lives 8 hours; without a short window the rest of
+   that day stays usable to send more mail.
+3. One message per person, and a hard cap on how many people. An emergency
+   contact list is a handful of people; anything larger is a bug or abuse.
+4. A contact with no address on file is skipped silently. The caller gets a
+   count, never "which of your contacts has no email".
 
-1. Coordinates arrive as request input and are **never persisted**. Nothing in
-   this module writes them to a table, and the caller does not either.
-2. Coordinates are **never logged**. Every log line here carries ids and
-   outcomes only. `_log_safe` is the single formatting path, so a future edit
-   cannot casually interpolate a latitude.
-3. The sender may only mail a recipient they already hold a **live SOS grant**
-   for, created by their own account. The grant is the authorization: without
-   it this endpoint would email arbitrary text and a location to any user id.
-4. Delivery follows the support-email delivery mode, so a non-production
-   environment routes every message to the test inbox instead of a real
-   contact's real inbox.
+Coordinates are deliberately absent from this module. They are never stored and
+never logged; they travel from the sender's client to One's mail route only,
+because `one_location_envelopes` keeps coordinates inside the ciphertext.
 """
 
 from __future__ import annotations
 
-import base64
-import logging
-from dataclasses import dataclass
-from email.message import EmailMessage
-from html import escape
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable
 
-from hushh_mcp.services.support_email_service import (
-    SupportEmailConfig,
-    SupportEmailNotConfiguredError,
-)
+#: A grant older than this is not the alert being sent right now.
+GRANT_FRESHNESS_SECONDS = 15 * 60
 
-logger = logging.getLogger(__name__)
-
-_GMAIL_SEND_ENDPOINT = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
-
-#: A grant older than this is not the alert that is being sent right now.
-#: Without it, a stale 8-hour SOS grant would keep this endpoint usable as a
-#: mailer for the rest of the day.
-_GRANT_FRESHNESS_SECONDS = 15 * 60
-
-#: Bound on how many contacts one alert may mail. An SOS list is a handful of
-#: people; anything larger is a bug or an abuse attempt, not an emergency.
+#: Bound on how many contacts one alert may mail.
 MAX_SOS_EMAIL_RECIPIENTS = 20
-
-
-@dataclass(frozen=True)
-class SosEmailOutcome:
-    """Per-recipient result. ``emailed`` is never ``True`` on a silent failure."""
-
-    recipient_user_id: str
-    emailed: bool
-    #: Machine-readable reason when ``emailed`` is False. Never a coordinate.
-    reason: str | None = None
-
-    def as_payload(self) -> dict[str, Any]:
-        return {
-            "recipientUserId": self.recipient_user_id,
-            "emailed": self.emailed,
-            **({"reason": self.reason} if self.reason else {}),
-        }
-
-
-def _log_safe(value: object) -> str:
-    """The only way a value reaches a log line from this module.
-
-    Coordinates must never be logged, so nothing here formats a float. Anything
-    that is not a short identifier-ish string becomes a type name.
-    """
-    if isinstance(value, str) and len(value) <= 80:
-        return value
-    return f"<{type(value).__name__}>"
-
-
-def _maps_link(latitude: float, longitude: float) -> str:
-    return f"https://www.google.com/maps/search/?api=1&query={latitude:.6f},{longitude:.6f}"
-
-
-def _accuracy_phrase(accuracy_m: float | None) -> str:
-    if accuracy_m is None or accuracy_m <= 0:
-        return ""
-    return f" (accurate to about {round(accuracy_m)} m)"
-
-
-class OneLocationSosEmailService:
-    """Sends the Save my Soul email through the Workspace Gmail identity.
-
-    Reuses ``SupportEmailConfig`` rather than introducing a second credential:
-    the delegated service account is already bound in every environment, so
-    this channel ships without a new secret, a new IAM grant, or a new deploy
-    variable to keep in parity across lanes.
-    """
-
-    def __init__(self) -> None:
-        self._config: SupportEmailConfig | None = None
-
-    @property
-    def config(self) -> SupportEmailConfig:
-        if self._config is None:
-            self._config = SupportEmailConfig.from_env()
-        return self._config
-
-    @property
-    def configured(self) -> bool:
-        return bool(self.config.configured)
-
-    def _resolve_destination(self, recipient_email: str) -> str:
-        """Where the message actually goes.
-
-        In a non-production environment this is the support test inbox, not the
-        contact's real address: verifying an emergency mail must never mean
-        mailing a real person's real inbox from UAT.
-        """
-        cfg = self.config
-        if cfg.delivery_mode == "test" and cfg.test_to_email:
-            return cfg.test_to_email
-        return recipient_email
-
-    def _build_message(
-        self,
-        *,
-        recipient_email: str,
-        recipient_display_name: str | None,
-        owner_display_name: str,
-        note: str | None,
-        latitude: float,
-        longitude: float,
-        accuracy_m: float | None,
-        sent_at_label: str,
-        expires_at_label: str | None,
-        open_in_one_url: str,
-        emergency_number: str | None,
-    ) -> EmailMessage:
-        cfg = self.config
-        destination = self._resolve_destination(recipient_email)
-        greeting_name = (recipient_display_name or "").strip().split(" ")[0]
-        greeting = f"{greeting_name}, " if greeting_name else ""
-
-        subject = f"{owner_display_name} needs help — Save my Soul"
-        if cfg.delivery_mode == "test":
-            subject = f"[TEST → {recipient_email}] {subject}"
-
-        maps_url = _maps_link(latitude, longitude)
-        coords = f"{latitude:.6f}, {longitude:.6f}"
-        accuracy = _accuracy_phrase(accuracy_m)
-        quoted_note = f'\n\n  "{note.strip()}"\n' if note and note.strip() else "\n"
-        expiry_line = (
-            f"Their live location stays shared until {expires_at_label}."
-            if expires_at_label
-            else "Their live location is shared with you now."
-        )
-        emergency_line = (
-            f"If this is an emergency where you are, call {emergency_number}."
-            if emergency_number
-            else "If this is an emergency, call your local emergency number."
-        )
-
-        text = (
-            f"{greeting}{owner_display_name} triggered a Save my Soul alert at "
-            f"{sent_at_label}."
-            f"{quoted_note}\n"
-            f"Location: {coords}{accuracy}\n"
-            f"Map: {maps_url}\n\n"
-            f"{expiry_line}\n"
-            f"Open in One for their live position: {open_in_one_url}\n\n"
-            f"{emergency_line}\n"
-        )
-
-        note_html = (
-            f'<p style="margin:0 0 20px;padding:12px 16px;border-left:3px solid #ff3b30;'
-            f'background:#faf7f7;font-size:16px;line-height:1.5;color:#1d1d1f;">'
-            f"“{escape(note.strip())}”</p>"
-            if note and note.strip()
-            else ""
-        )
-        html = (
-            "<div style=\"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
-            "Helvetica,Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px;"
-            'color:#1d1d1f;">'
-            f'<p style="margin:0 0 4px;font-size:13px;font-weight:600;letter-spacing:.08em;'
-            f'text-transform:uppercase;color:#ff3b30;">Save my Soul</p>'
-            f'<h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;">'
-            f"{escape(owner_display_name)} needs help</h1>"
-            f'<p style="margin:0 0 20px;font-size:16px;line-height:1.5;">'
-            f"{escape(greeting.strip())} They triggered an alert at "
-            f"{escape(sent_at_label)} and shared their live location with you.</p>"
-            f"{note_html}"
-            f'<p style="margin:0 0 8px;font-size:16px;line-height:1.5;">'
-            f"<strong>Location:</strong> {escape(coords)}{escape(accuracy)}</p>"
-            f'<p style="margin:0 0 24px;">'
-            f'<a href="{escape(maps_url)}" style="display:inline-block;padding:12px 20px;'
-            f"border-radius:9999px;background:#ff3b30;color:#ffffff;text-decoration:none;"
-            f'font-weight:600;font-size:16px;">Open in Google Maps</a></p>'
-            f'<p style="margin:0 0 8px;font-size:15px;line-height:1.5;color:#3c3c43;">'
-            f"{escape(expiry_line)}</p>"
-            f'<p style="margin:0 0 24px;font-size:15px;">'
-            f'<a href="{escape(open_in_one_url)}" style="color:#007aff;">'
-            f"See their live position in One</a></p>"
-            f'<p style="margin:0;font-size:15px;line-height:1.5;color:#3c3c43;">'
-            f"{escape(emergency_line)}</p>"
-            "</div>"
-        )
-
-        message = EmailMessage()
-        message["To"] = destination
-        message["From"] = f"Hussh One <{cfg.from_email}>"
-        message["Subject"] = subject
-        message["X-Hushh-Alert"] = "save-my-soul"
-        # An emergency mail belongs at the top of the inbox, not batched.
-        message["X-Priority"] = "1"
-        message["Importance"] = "high"
-        message.set_content(text)
-        message.add_alternative(html, subtype="html")
-        return message
-
-    def send_one(
-        self,
-        *,
-        session: Any,
-        recipient_user_id: str,
-        recipient_email: str,
-        recipient_display_name: str | None,
-        owner_display_name: str,
-        note: str | None,
-        latitude: float,
-        longitude: float,
-        accuracy_m: float | None,
-        sent_at_label: str,
-        expires_at_label: str | None,
-        open_in_one_url: str,
-        emergency_number: str | None,
-    ) -> SosEmailOutcome:
-        """Send to one recipient. Never raises — an email that fails to send
-        must not take down the alert that already reached someone else."""
-        try:
-            message = self._build_message(
-                recipient_email=recipient_email,
-                recipient_display_name=recipient_display_name,
-                owner_display_name=owner_display_name,
-                note=note,
-                latitude=latitude,
-                longitude=longitude,
-                accuracy_m=accuracy_m,
-                sent_at_label=sent_at_label,
-                expires_at_label=expires_at_label,
-                open_in_one_url=open_in_one_url,
-                emergency_number=emergency_number,
-            )
-            encoded = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
-            response = session.post(_GMAIL_SEND_ENDPOINT, json={"raw": encoded}, timeout=20)
-        except Exception as exc:  # noqa: BLE001 - reported, never raised onward
-            logger.warning(
-                "one.location.sos_email.transport_failed recipient=%s error=%s",
-                _log_safe(recipient_user_id),
-                _log_safe(type(exc).__name__),
-            )
-            return SosEmailOutcome(recipient_user_id, False, "transport_failed")
-
-        if getattr(response, "status_code", 500) >= 400:
-            logger.warning(
-                "one.location.sos_email.send_failed recipient=%s status=%s",
-                _log_safe(recipient_user_id),
-                getattr(response, "status_code", "unknown"),
-            )
-            return SosEmailOutcome(recipient_user_id, False, "send_failed")
-
-        logger.info(
-            "one.location.sos_email.sent recipient=%s mode=%s",
-            _log_safe(recipient_user_id),
-            self.config.delivery_mode,
-        )
-        return SosEmailOutcome(recipient_user_id, True)
-
-
-_service: OneLocationSosEmailService | None = None
-
-
-def get_sos_email_service() -> OneLocationSosEmailService:
-    global _service
-    if _service is None:
-        _service = OneLocationSosEmailService()
-    return _service
 
 
 def select_emailable_recipients(
@@ -309,12 +47,10 @@ def select_emailable_recipients(
     owner_user_id: str,
     now_epoch_seconds: float,
 ) -> list[dict[str, Any]]:
-    """Filter grant rows down to the ones this alert may mail.
+    """Filter grant rows down to the recipients this alert may mail.
 
     A row survives only when it is the caller's own, is an SOS share, is still
     active, was created moments ago, and names a recipient with an address.
-    Every rejection is silent by design — the caller reports a count, not which
-    of someone's emergency contacts happens to lack an email on file.
     """
     selected: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -328,7 +64,7 @@ def select_emailable_recipients(
         created_at_epoch = row.get("created_at_epoch")
         if not isinstance(created_at_epoch, (int, float)):
             continue
-        if now_epoch_seconds - float(created_at_epoch) > _GRANT_FRESHNESS_SECONDS:
+        if now_epoch_seconds - float(created_at_epoch) > GRANT_FRESHNESS_SECONDS:
             continue
         recipient_user_id = str(row.get("recipient_user_id") or "").strip()
         email = str(row.get("recipient_email") or "").strip()
@@ -343,20 +79,8 @@ def select_emailable_recipients(
     return selected
 
 
-def summarize(outcomes: Sequence[SosEmailOutcome]) -> dict[str, Any]:
-    return {
-        "emailed": sum(1 for outcome in outcomes if outcome.emailed),
-        "attempted": len(outcomes),
-        "results": [outcome.as_payload() for outcome in outcomes],
-    }
-
-
 __all__ = [
+    "GRANT_FRESHNESS_SECONDS",
     "MAX_SOS_EMAIL_RECIPIENTS",
-    "OneLocationSosEmailService",
-    "SosEmailOutcome",
-    "SupportEmailNotConfiguredError",
-    "get_sos_email_service",
     "select_emailable_recipients",
-    "summarize",
 ]

--- a/consent-protocol/tests/services/test_one_location_sos_email_service.py
+++ b/consent-protocol/tests/services/test_one_location_sos_email_service.py
@@ -1,0 +1,273 @@
+"""Rules that keep the Save my Soul email from becoming a mailer.
+
+The coordinates in this flow arrive from the sender's client and live outside
+the envelope's encryption for the length of one send. That is a deliberate
+product decision for the emergency case, and these tests are the fence around
+it: who may be mailed, for how long, and what must never leak into a log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hushh_mcp.services.one_location_sos_email_service import (
+    MAX_SOS_EMAIL_RECIPIENTS,
+    OneLocationSosEmailService,
+    SosEmailOutcome,
+    select_emailable_recipients,
+    summarize,
+)
+
+NOW = 1_760_000_000.0
+
+
+def grant_row(**overrides):
+    row = {
+        "grant_id": "g-1",
+        "owner_user_id": "owner-1",
+        "recipient_user_id": "friend-1",
+        "status": "active",
+        "share_kind": "sos",
+        "created_at_epoch": NOW - 5,
+        "recipient_email": "friend@example.com",
+        "recipient_display_name": "Parth Kumar",
+    }
+    row.update(overrides)
+    return row
+
+
+class TestWhoMayBeMailed:
+    def test_accepts_a_fresh_live_sos_grant_with_an_address(self):
+        selected = select_emailable_recipients(
+            [grant_row()], owner_user_id="owner-1", now_epoch_seconds=NOW
+        )
+        assert [row["recipient_user_id"] for row in selected] == ["friend-1"]
+
+    def test_rejects_a_grant_belonging_to_someone_else(self):
+        # Without this, a caller could mail the contacts of any grant id they
+        # could guess or observe.
+        selected = select_emailable_recipients(
+            [grant_row(owner_user_id="someone-else")],
+            owner_user_id="owner-1",
+            now_epoch_seconds=NOW,
+        )
+        assert selected == []
+
+    @pytest.mark.parametrize("kind", ["check_in", "share", "drive_to", ""])
+    def test_rejects_a_grant_that_is_not_an_sos(self, kind):
+        # A routine check-in share must never trigger an emergency email.
+        selected = select_emailable_recipients(
+            [grant_row(share_kind=kind)],
+            owner_user_id="owner-1",
+            now_epoch_seconds=NOW,
+        )
+        assert selected == []
+
+    @pytest.mark.parametrize("status", ["revoked", "expired"])
+    def test_rejects_a_grant_that_is_no_longer_active(self, status):
+        selected = select_emailable_recipients(
+            [grant_row(status=status)],
+            owner_user_id="owner-1",
+            now_epoch_seconds=NOW,
+        )
+        assert selected == []
+
+    def test_rejects_a_grant_that_is_not_from_this_moment(self):
+        # An SOS grant lives 8 hours. Freshness is what stops the rest of that
+        # window being usable to send more mail.
+        stale = grant_row(created_at_epoch=NOW - (16 * 60))
+        assert (
+            select_emailable_recipients([stale], owner_user_id="owner-1", now_epoch_seconds=NOW)
+            == []
+        )
+
+    def test_accepts_a_grant_created_moments_ago(self):
+        recent = grant_row(created_at_epoch=NOW - (14 * 60))
+        assert (
+            len(
+                select_emailable_recipients(
+                    [recent], owner_user_id="owner-1", now_epoch_seconds=NOW
+                )
+            )
+            == 1
+        )
+
+    @pytest.mark.parametrize("email", ["", None, "   ", "not-an-address"])
+    def test_skips_a_contact_with_no_usable_address(self, email):
+        selected = select_emailable_recipients(
+            [grant_row(recipient_email=email)],
+            owner_user_id="owner-1",
+            now_epoch_seconds=NOW,
+        )
+        assert selected == []
+
+    def test_mails_each_person_once_even_with_duplicate_grants(self):
+        rows = [grant_row(grant_id="g-1"), grant_row(grant_id="g-2")]
+        selected = select_emailable_recipients(rows, owner_user_id="owner-1", now_epoch_seconds=NOW)
+        assert len(selected) == 1
+
+    def test_caps_the_recipient_count(self):
+        rows = [
+            grant_row(grant_id=f"g-{index}", recipient_user_id=f"friend-{index}")
+            for index in range(MAX_SOS_EMAIL_RECIPIENTS + 10)
+        ]
+        selected = select_emailable_recipients(rows, owner_user_id="owner-1", now_epoch_seconds=NOW)
+        assert len(selected) == MAX_SOS_EMAIL_RECIPIENTS
+
+
+class _Response:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+
+class _Session:
+    def __init__(self, status_code=200, raises=False):
+        self.status_code = status_code
+        self.raises = raises
+        self.sent = []
+
+    def post(self, url, json=None, timeout=None):
+        if self.raises:
+            raise RuntimeError("network is down")
+        self.sent.append(json)
+        return _Response(self.status_code)
+
+
+def build_service(monkeypatch, *, delivery_mode="live", test_to=None):
+    service = OneLocationSosEmailService()
+
+    class _Config:
+        configured = True
+        from_email = "one@hushh.ai"
+        test_to_email = test_to
+
+    _Config.delivery_mode = delivery_mode
+    service._config = _Config()
+    return service
+
+
+def send(service, session, **overrides):
+    kwargs = {
+        "session": session,
+        "recipient_user_id": "friend-1",
+        "recipient_email": "friend@example.com",
+        "recipient_display_name": "Parth Kumar",
+        "owner_display_name": "Ankit",
+        "note": "I'm not safe",
+        "latitude": 12.935200,
+        "longitude": 77.624500,
+        "accuracy_m": 14.0,
+        "sent_at_label": "15:42 UTC on 14 Aug 2026",
+        "expires_at_label": "23:42 UTC on 14 Aug",
+        "open_in_one_url": "https://uat.one.hushh.ai/one/location?section=shared",
+        "emergency_number": "112",
+    }
+    kwargs.update(overrides)
+    return service.send_one(**kwargs)
+
+
+class TestTheMessage:
+    def test_carries_the_coordinates_the_sender_supplied(self, monkeypatch):
+        service = build_service(monkeypatch)
+        session = _Session()
+        outcome = send(service, session)
+
+        assert outcome == SosEmailOutcome("friend-1", True)
+        body = service._build_message(
+            recipient_email="friend@example.com",
+            recipient_display_name="Parth Kumar",
+            owner_display_name="Ankit",
+            note="I'm not safe",
+            latitude=12.9352,
+            longitude=77.6245,
+            accuracy_m=14.0,
+            sent_at_label="15:42 UTC on 14 Aug 2026",
+            expires_at_label="23:42 UTC on 14 Aug",
+            open_in_one_url="https://uat.one.hushh.ai/one/location?section=shared",
+            emergency_number="112",
+        ).as_string()
+
+        assert "12.935200, 77.624500" in body
+        assert "maps" in body
+        assert "Ankit" in body
+        assert "112" in body
+
+    def test_escapes_the_note_instead_of_trusting_it(self, monkeypatch):
+        # The note is user input and lands in an HTML mail.
+        service = build_service(monkeypatch)
+        message = service._build_message(
+            recipient_email="friend@example.com",
+            recipient_display_name=None,
+            owner_display_name="Ankit",
+            note="<img src=x onerror=alert(1)>",
+            latitude=1.0,
+            longitude=2.0,
+            accuracy_m=None,
+            sent_at_label="now",
+            expires_at_label=None,
+            open_in_one_url="https://example.com",
+            emergency_number=None,
+        )
+        html = message.get_payload()[1].get_payload(decode=True).decode()
+        assert "<img src=x" not in html
+        assert "&lt;img" in html
+
+    def test_a_non_production_send_goes_to_the_test_inbox(self, monkeypatch):
+        # Verifying an emergency mail must not mean mailing a real contact.
+        service = build_service(monkeypatch, delivery_mode="test", test_to="qa@hushh.ai")
+        message = service._build_message(
+            recipient_email="friend@example.com",
+            recipient_display_name="Parth",
+            owner_display_name="Ankit",
+            note=None,
+            latitude=1.0,
+            longitude=2.0,
+            accuracy_m=None,
+            sent_at_label="now",
+            expires_at_label=None,
+            open_in_one_url="https://example.com",
+            emergency_number=None,
+        )
+        assert message["To"] == "qa@hushh.ai"
+        assert "friend@example.com" in message["Subject"]
+        assert message["Subject"].startswith("[TEST")
+
+
+class TestFailuresNeverBreakTheAlert:
+    def test_a_transport_error_is_reported_not_raised(self, monkeypatch):
+        service = build_service(monkeypatch)
+        outcome = send(service, _Session(raises=True))
+        assert outcome == SosEmailOutcome("friend-1", False, "transport_failed")
+
+    def test_a_rejected_send_is_reported_not_raised(self, monkeypatch):
+        service = build_service(monkeypatch)
+        outcome = send(service, _Session(status_code=403))
+        assert outcome == SosEmailOutcome("friend-1", False, "send_failed")
+
+    def test_summary_counts_only_real_sends(self):
+        summary = summarize(
+            [
+                SosEmailOutcome("a", True),
+                SosEmailOutcome("b", False, "send_failed"),
+            ]
+        )
+        assert summary["emailed"] == 1
+        assert summary["attempted"] == 2
+
+
+class TestCoordinatesNeverReachTheLogs:
+    def test_no_log_line_carries_a_coordinate(self, monkeypatch, caplog):
+        service = build_service(monkeypatch)
+        with caplog.at_level(logging.DEBUG):
+            send(service, _Session())
+            send(service, _Session(status_code=500))
+            send(service, _Session(raises=True))
+
+        logged = " ".join(record.getMessage() for record in caplog.records)
+        assert "12.9352" not in logged
+        assert "77.6245" not in logged
+        # The note is what the sender typed; it does not belong in a log either.
+        assert "I'm not safe" not in logged
+        assert "friend@example.com" not in logged

--- a/consent-protocol/tests/services/test_one_location_sos_email_service.py
+++ b/consent-protocol/tests/services/test_one_location_sos_email_service.py
@@ -1,4 +1,4 @@
-"""Rules that keep the Save my Soul email from becoming a mailer.
+"""Rules that keep the Save my Soul email from becoming an open mailer.
 
 The coordinates in this flow arrive from the sender's client and live outside
 the envelope's encryption for the length of one send. That is a deliberate
@@ -8,16 +8,11 @@ it: who may be mailed, for how long, and what must never leak into a log.
 
 from __future__ import annotations
 
-import logging
-
 import pytest
 
 from hushh_mcp.services.one_location_sos_email_service import (
     MAX_SOS_EMAIL_RECIPIENTS,
-    OneLocationSosEmailService,
-    SosEmailOutcome,
     select_emailable_recipients,
-    summarize,
 )
 
 NOW = 1_760_000_000.0
@@ -115,159 +110,3 @@ class TestWhoMayBeMailed:
         ]
         selected = select_emailable_recipients(rows, owner_user_id="owner-1", now_epoch_seconds=NOW)
         assert len(selected) == MAX_SOS_EMAIL_RECIPIENTS
-
-
-class _Response:
-    def __init__(self, status_code=200):
-        self.status_code = status_code
-
-
-class _Session:
-    def __init__(self, status_code=200, raises=False):
-        self.status_code = status_code
-        self.raises = raises
-        self.sent = []
-
-    def post(self, url, json=None, timeout=None):
-        if self.raises:
-            raise RuntimeError("network is down")
-        self.sent.append(json)
-        return _Response(self.status_code)
-
-
-def build_service(monkeypatch, *, delivery_mode="live", test_to=None):
-    service = OneLocationSosEmailService()
-
-    class _Config:
-        configured = True
-        from_email = "one@hushh.ai"
-        test_to_email = test_to
-
-    _Config.delivery_mode = delivery_mode
-    service._config = _Config()
-    return service
-
-
-def send(service, session, **overrides):
-    kwargs = {
-        "session": session,
-        "recipient_user_id": "friend-1",
-        "recipient_email": "friend@example.com",
-        "recipient_display_name": "Parth Kumar",
-        "owner_display_name": "Ankit",
-        "note": "I'm not safe",
-        "latitude": 12.935200,
-        "longitude": 77.624500,
-        "accuracy_m": 14.0,
-        "sent_at_label": "15:42 UTC on 14 Aug 2026",
-        "expires_at_label": "23:42 UTC on 14 Aug",
-        "open_in_one_url": "https://uat.one.hushh.ai/one/location?section=shared",
-        "emergency_number": "112",
-    }
-    kwargs.update(overrides)
-    return service.send_one(**kwargs)
-
-
-class TestTheMessage:
-    def test_carries_the_coordinates_the_sender_supplied(self, monkeypatch):
-        service = build_service(monkeypatch)
-        session = _Session()
-        outcome = send(service, session)
-
-        assert outcome == SosEmailOutcome("friend-1", True)
-        body = service._build_message(
-            recipient_email="friend@example.com",
-            recipient_display_name="Parth Kumar",
-            owner_display_name="Ankit",
-            note="I'm not safe",
-            latitude=12.9352,
-            longitude=77.6245,
-            accuracy_m=14.0,
-            sent_at_label="15:42 UTC on 14 Aug 2026",
-            expires_at_label="23:42 UTC on 14 Aug",
-            open_in_one_url="https://uat.one.hushh.ai/one/location?section=shared",
-            emergency_number="112",
-        ).as_string()
-
-        assert "12.935200, 77.624500" in body
-        assert "maps" in body
-        assert "Ankit" in body
-        assert "112" in body
-
-    def test_escapes_the_note_instead_of_trusting_it(self, monkeypatch):
-        # The note is user input and lands in an HTML mail.
-        service = build_service(monkeypatch)
-        message = service._build_message(
-            recipient_email="friend@example.com",
-            recipient_display_name=None,
-            owner_display_name="Ankit",
-            note="<img src=x onerror=alert(1)>",
-            latitude=1.0,
-            longitude=2.0,
-            accuracy_m=None,
-            sent_at_label="now",
-            expires_at_label=None,
-            open_in_one_url="https://example.com",
-            emergency_number=None,
-        )
-        html = message.get_payload()[1].get_payload(decode=True).decode()
-        assert "<img src=x" not in html
-        assert "&lt;img" in html
-
-    def test_a_non_production_send_goes_to_the_test_inbox(self, monkeypatch):
-        # Verifying an emergency mail must not mean mailing a real contact.
-        service = build_service(monkeypatch, delivery_mode="test", test_to="qa@hushh.ai")
-        message = service._build_message(
-            recipient_email="friend@example.com",
-            recipient_display_name="Parth",
-            owner_display_name="Ankit",
-            note=None,
-            latitude=1.0,
-            longitude=2.0,
-            accuracy_m=None,
-            sent_at_label="now",
-            expires_at_label=None,
-            open_in_one_url="https://example.com",
-            emergency_number=None,
-        )
-        assert message["To"] == "qa@hushh.ai"
-        assert "friend@example.com" in message["Subject"]
-        assert message["Subject"].startswith("[TEST")
-
-
-class TestFailuresNeverBreakTheAlert:
-    def test_a_transport_error_is_reported_not_raised(self, monkeypatch):
-        service = build_service(monkeypatch)
-        outcome = send(service, _Session(raises=True))
-        assert outcome == SosEmailOutcome("friend-1", False, "transport_failed")
-
-    def test_a_rejected_send_is_reported_not_raised(self, monkeypatch):
-        service = build_service(monkeypatch)
-        outcome = send(service, _Session(status_code=403))
-        assert outcome == SosEmailOutcome("friend-1", False, "send_failed")
-
-    def test_summary_counts_only_real_sends(self):
-        summary = summarize(
-            [
-                SosEmailOutcome("a", True),
-                SosEmailOutcome("b", False, "send_failed"),
-            ]
-        )
-        assert summary["emailed"] == 1
-        assert summary["attempted"] == 2
-
-
-class TestCoordinatesNeverReachTheLogs:
-    def test_no_log_line_carries_a_coordinate(self, monkeypatch, caplog):
-        service = build_service(monkeypatch)
-        with caplog.at_level(logging.DEBUG):
-            send(service, _Session())
-            send(service, _Session(status_code=500))
-            send(service, _Session(raises=True))
-
-        logged = " ".join(record.getMessage() for record in caplog.records)
-        assert "12.9352" not in logged
-        assert "77.6245" not in logged
-        # The note is what the sender typed; it does not belong in a log either.
-        assert "I'm not safe" not in logged
-        assert "friend@example.com" not in logged

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4859,7 +4859,7 @@
     "one_specialist_tools": "4067d2cabf3bf0c1c8bb2f53d2080a03dc68fd2a04819594cfc1593478538ac8",
     "route_index": "b5a242e0d320b58442871fb95540dc80553f03502b3c04c5d31337b7e6b249f4",
     "route_layout": "3a3769adca745b71f261e229e83189ee757b1a8a484f39300d259c3ef4fde494",
-    "surface_map": "cb6a76abf0f74fcf1dde333669f90757705fa427db085d0363280edee9ad5f2f",
+    "surface_map": "809e8f871431d41c69d7ece7fe3279749a35079f869c84f3d8ac1faee2077daf",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/__tests__/api/sos-email-render.test.ts
+++ b/hushh-webapp/__tests__/api/sos-email-render.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { renderSosEmail } from "@/app/api/one/location/sos-email/route";
+
+const base = {
+  recipientDisplayName: "Parth Kumar",
+  ownerDisplayName: "Ankit",
+  note: "I'm not safe",
+  latitude: 12.9352,
+  longitude: 77.6245,
+  accuracyM: 14,
+  openInOneUrl: "https://uat.one.hushh.ai/one/location?section=shared",
+  emergencyNumber: "112",
+  expiresAtLabel: "Fri, 14 Aug 2026 23:42:00 GMT",
+};
+
+describe("Save my Soul email", () => {
+  it("names who needs help in the subject", () => {
+    // A contact scanning a notification shade sees the subject and nothing
+    // else. It has to carry the name and the urgency on its own.
+    expect(renderSosEmail(base).subject).toBe(
+      "Ankit needs help — Save my Soul",
+    );
+  });
+
+  it("carries the coordinates, a map link, and the local emergency number", () => {
+    const { text, html } = renderSosEmail(base);
+    for (const body of [text, html]) {
+      expect(body).toContain("12.935200, 77.624500");
+      expect(body).toContain("google.com/maps");
+      expect(body).toContain("112");
+    }
+    expect(text).toContain("accurate to about 14 m");
+  });
+
+  it("survives a contact whose client shows text only", () => {
+    // The plain-text part is not a courtesy: it is what a watch, a screen
+    // reader, and a locked-down mail client render.
+    const { text } = renderSosEmail(base);
+    expect(text).toContain("Ankit triggered a Save my Soul alert");
+    expect(text).toContain('"I\'m not safe"');
+    expect(text).toContain(base.openInOneUrl);
+  });
+
+  it("escapes the sender's note instead of trusting it", () => {
+    // The note is free text typed under stress and lands in an HTML mail.
+    const { html } = renderSosEmail({
+      ...base,
+      note: '<img src=x onerror="alert(1)">',
+    });
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("escapes a display name too", () => {
+    const { html } = renderSosEmail({
+      ...base,
+      ownerDisplayName: "<script>alert(1)</script>",
+    });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("reads correctly with no note", () => {
+    const { text, html } = renderSosEmail({ ...base, note: null });
+    expect(text).toContain("Ankit triggered a Save my Soul alert");
+    expect(text).not.toContain('""');
+    expect(html).not.toContain("border-left:3px solid");
+  });
+
+  it("does not invent an accuracy it was not given", () => {
+    const { text } = renderSosEmail({ ...base, accuracyM: null });
+    expect(text).not.toContain("accurate to about");
+    expect(text).toContain("12.935200, 77.624500");
+  });
+
+  it("does not invent an emergency number it was not given", () => {
+    // Naming the wrong number in an emergency is worse than naming none.
+    const { text } = renderSosEmail({ ...base, emergencyNumber: null });
+    expect(text).toContain("call your local emergency number");
+    expect(text).not.toMatch(/call \d/);
+  });
+
+  it("falls back to a neutral name rather than an empty sentence", () => {
+    const { subject } = renderSosEmail({ ...base, ownerDisplayName: "" });
+    expect(subject).toBe("Someone needs help — Save my Soul");
+  });
+
+  it("greets by first name only, and omits the greeting when unknown", () => {
+    expect(renderSosEmail(base).text).toContain("Parth, Ankit triggered");
+    expect(
+      renderSosEmail({ ...base, recipientDisplayName: "" }).text,
+    ).toContain("Ankit triggered");
+  });
+
+  it("says when the live share ends, and stays honest when it does not know", () => {
+    expect(renderSosEmail(base).text).toContain("stays shared until");
+    expect(
+      renderSosEmail({ ...base, expiresAtLabel: null }).text,
+    ).toContain("is shared with you now");
+  });
+});

--- a/hushh-webapp/app/api/one/location/sos-email/route.ts
+++ b/hushh-webapp/app/api/one/location/sos-email/route.ts
@@ -1,0 +1,266 @@
+/**
+ * POST /api/one/location/sos-email
+ *
+ * The second channel for a Save my Soul alert.
+ *
+ * The push notification is the first, and it reaches nobody when a contact has
+ * notifications off or has uninstalled — the flow already knows that and, until
+ * this existed, could only report it after the fact. An inbox survives a closed
+ * app.
+ *
+ * WHY THIS IS A REAL ROUTE AND NOT THE `/api/one/[...path]` PROXY
+ * Every other `/api/one/*` path proxies straight to the protocol backend. This
+ * one deliberately shadows the catch-all, because the mail has to be sent from
+ * here: `MAIL_API_KEY` / `MAIL_API_ENDPOINT` are bound in the webapp lane only,
+ * and `hushh-mail-api` is the service that already sends sign-in, phone
+ * conflict and capability-linked mail. Sending an emergency alert from a second
+ * identity is how you find out about an SPF/DKIM misalignment at the worst
+ * possible moment.
+ *
+ * So the work splits:
+ *   backend  →  authorization + recipient resolution (only it can validate the
+ *               grants, and only it knows the addresses)
+ *   here     →  render + send, through the shared mail service
+ *
+ * Contact addresses come back to THIS server and go no further. A sender does
+ * not necessarily know their emergency contacts' email addresses, and this must
+ * not be where they learn them — nothing in the response body names one.
+ *
+ * COORDINATES
+ * They arrive in the request because the server cannot read them anywhere else:
+ * `one_location_envelopes` keeps coordinates inside the ciphertext, so only the
+ * sender's device holds the plaintext. They are used to render one message and
+ * are never stored or logged here.
+ *
+ * A failure is never an error. The alert has already gone out by the time this
+ * runs, so every problem is reported as a count.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { validateFirebaseToken } from "@/lib/auth/validate";
+import { isMailConfigured, sendMail } from "@/lib/mail/mail-client";
+
+export const dynamic = "force-dynamic";
+
+const RECIPIENT_TIMEOUT_MS = 10_000;
+const MAX_GRANT_IDS = 20;
+const MAX_NOTE_LENGTH = 300;
+
+type Recipient = {
+  grantId: string;
+  recipientUserId: string;
+  email: string;
+  displayName: string;
+  expiresAt: string | null;
+};
+
+function noStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": "private, no-store", Pragma: "no-cache" },
+  });
+}
+
+const EMPTY = { emailed: 0, attempted: 0, configured: false };
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function mapsUrl(latitude: number, longitude: number): string {
+  return `https://www.google.com/maps/search/?api=1&query=${latitude.toFixed(6)},${longitude.toFixed(6)}`;
+}
+
+function firstName(value: string): string {
+  return value.trim().split(/\s+/)[0] ?? "";
+}
+
+export function renderSosEmail(input: {
+  recipientDisplayName: string;
+  ownerDisplayName: string;
+  note: string | null;
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+  openInOneUrl: string;
+  emergencyNumber: string | null;
+  expiresAtLabel: string | null;
+}): { subject: string; text: string; html: string } {
+  const owner = input.ownerDisplayName || "Someone";
+  const greetingName = firstName(input.recipientDisplayName);
+  const greeting = greetingName ? `${greetingName}, ` : "";
+  const coords = `${input.latitude.toFixed(6)}, ${input.longitude.toFixed(6)}`;
+  const accuracy =
+    typeof input.accuracyM === "number" && input.accuracyM > 0
+      ? ` (accurate to about ${Math.round(input.accuracyM)} m)`
+      : "";
+  const map = mapsUrl(input.latitude, input.longitude);
+  const note = input.note?.trim() || "";
+  const expiry = input.expiresAtLabel
+    ? `Their live location stays shared until ${input.expiresAtLabel}.`
+    : "Their live location is shared with you now.";
+  const emergency = input.emergencyNumber
+    ? `If this is an emergency where you are, call ${input.emergencyNumber}.`
+    : "If this is an emergency, call your local emergency number.";
+
+  const subject = `${owner} needs help — Save my Soul`;
+
+  const text = [
+    `${greeting}${owner} triggered a Save my Soul alert.`,
+    note ? `\n  "${note}"\n` : "",
+    `Location: ${coords}${accuracy}`,
+    `Map: ${map}`,
+    "",
+    expiry,
+    `Open in One for their live position: ${input.openInOneUrl}`,
+    "",
+    emergency,
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+
+  const noteHtml = note
+    ? `<p style="margin:0 0 20px;padding:12px 16px;border-left:3px solid #ff3b30;background:#faf7f7;font-size:16px;line-height:1.5;color:#1d1d1f;">&ldquo;${escapeHtml(note)}&rdquo;</p>`
+    : "";
+
+  const html = [
+    `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px;color:#1d1d1f;">`,
+    `<p style="margin:0 0 4px;font-size:13px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#ff3b30;">Save my Soul</p>`,
+    `<h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;">${escapeHtml(owner)} needs help</h1>`,
+    `<p style="margin:0 0 20px;font-size:16px;line-height:1.5;">${escapeHtml(greeting.trim())} They triggered an emergency alert and shared their live location with you.</p>`,
+    noteHtml,
+    `<p style="margin:0 0 8px;font-size:16px;line-height:1.5;"><strong>Location:</strong> ${escapeHtml(coords)}${escapeHtml(accuracy)}</p>`,
+    `<p style="margin:0 0 24px;"><a href="${escapeHtml(map)}" style="display:inline-block;padding:12px 20px;border-radius:9999px;background:#ff3b30;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">Open in Google Maps</a></p>`,
+    `<p style="margin:0 0 8px;font-size:15px;line-height:1.5;color:#3c3c43;">${escapeHtml(expiry)}</p>`,
+    `<p style="margin:0 0 24px;font-size:15px;"><a href="${escapeHtml(input.openInOneUrl)}" style="color:#007aff;">See their live position in One</a></p>`,
+    `<p style="margin:0;font-size:15px;line-height:1.5;color:#3c3c43;">${escapeHtml(emergency)}</p>`,
+    `</div>`,
+  ].join("");
+
+  return { subject, text, html };
+}
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const auth = await validateFirebaseToken(authHeader);
+  if (!auth.valid) {
+    return noStore({ error: "Unauthorized" }, 401);
+  }
+  if (!isMailConfigured()) {
+    // A missing binding must never look like a failed emergency.
+    return noStore(EMPTY);
+  }
+
+  let payload: {
+    grantIds?: unknown;
+    latitude?: unknown;
+    longitude?: unknown;
+    accuracyM?: unknown;
+    note?: unknown;
+    emergencyNumber?: unknown;
+  };
+  try {
+    payload = await request.json();
+  } catch {
+    return noStore({ ...EMPTY, configured: true });
+  }
+
+  const grantIds = Array.isArray(payload.grantIds)
+    ? payload.grantIds
+        .map((value) => String(value ?? "").trim())
+        .filter(Boolean)
+        .slice(0, MAX_GRANT_IDS)
+    : [];
+  const latitude = Number(payload.latitude);
+  const longitude = Number(payload.longitude);
+  const validCoordinates =
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    Math.abs(latitude) <= 90 &&
+    Math.abs(longitude) <= 180;
+
+  if (!grantIds.length || !validCoordinates) {
+    return noStore({ ...EMPTY, configured: true });
+  }
+
+  const accuracyM = Number.isFinite(Number(payload.accuracyM))
+    ? Number(payload.accuracyM)
+    : null;
+  const note = String(payload.note ?? "")
+    .trim()
+    .slice(0, MAX_NOTE_LENGTH);
+  const emergencyNumber = String(payload.emergencyNumber ?? "")
+    .trim()
+    .slice(0, 16);
+
+  // The backend is the authorization: it returns contacts only for live SOS
+  // grants this caller's own account just created.
+  let resolved: {
+    ownerDisplayName?: string;
+    openInOneUrl?: string;
+    recipients?: Recipient[];
+  };
+  try {
+    const upstream = await fetch(
+      `${getPythonApiUrl()}/api/one/location/sos-email-recipients`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(authHeader ? { authorization: authHeader } : {}),
+        },
+        body: JSON.stringify({ grantIds }),
+        signal: AbortSignal.timeout(RECIPIENT_TIMEOUT_MS),
+      },
+    );
+    if (!upstream.ok) return noStore({ ...EMPTY, configured: true });
+    resolved = await upstream.json();
+  } catch {
+    return noStore({ ...EMPTY, configured: true });
+  }
+
+  const recipients = Array.isArray(resolved.recipients)
+    ? resolved.recipients
+    : [];
+  if (!recipients.length) return noStore({ ...EMPTY, configured: true });
+
+  const results = await Promise.all(
+    recipients.map(async (recipient) => {
+      const { subject, text, html } = renderSosEmail({
+        recipientDisplayName: String(recipient.displayName ?? ""),
+        ownerDisplayName: String(resolved.ownerDisplayName ?? ""),
+        note: note || null,
+        latitude,
+        longitude,
+        accuracyM,
+        openInOneUrl: String(resolved.openInOneUrl ?? ""),
+        emergencyNumber: emergencyNumber || null,
+        expiresAtLabel: recipient.expiresAt
+          ? new Date(recipient.expiresAt).toUTCString()
+          : null,
+      });
+      const outcome = await sendMail({
+        to: String(recipient.email ?? ""),
+        subject,
+        html,
+        text,
+        // One alert, one mail per contact, even if the client retries.
+        idempotencyKey: `sos:${recipient.grantId}`,
+      });
+      return outcome.status === "sent";
+    }),
+  );
+
+  return noStore({
+    emailed: results.filter(Boolean).length,
+    attempted: results.length,
+    configured: true,
+  });
+}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3984,19 +3984,41 @@ export function OneLocationAgentPageContent({
           .map((outcome) => outcome.displayName);
         const reached = readyRecipients.length - unreachable.length;
 
+        // Second channel. A push reaches nobody when notifications are off, so
+        // the same alert goes out by email — the one place a closed app cannot
+        // swallow it. Awaited (not fired and forgotten) so the message below
+        // can tell the sender what actually happened, which is the whole point
+        // of having a fallback. It never throws.
+        const mail = await OneLocationService.sendSosEmails({
+          vaultOwnerToken,
+          grantIds: incident.grantIds,
+          latitude: point.latitude,
+          longitude: point.longitude,
+          accuracyM: point.accuracyM ?? null,
+          note,
+          emergencyNumber: sosEmergency?.number ?? null,
+        });
+
+        // Only worth saying when it changes what the sender should do next:
+        // "nobody's phone lit up" reads very differently if two inboxes got it.
+        const mailNote = mail.emailed > 0 ? ` Emailed ${mail.emailed}.` : "";
+
         if (reached === 0) {
+          const stillNoOne = mail.emailed === 0;
           toast.error(
-            `Location shared, but no one was alerted — ${formatNameList(unreachable)} ${unreachable.length === 1 ? "has" : "have"} notifications off. Call emergency services if you need help now.`,
+            stillNoOne
+              ? `Location shared, but no one was alerted — ${formatNameList(unreachable)} ${unreachable.length === 1 ? "has" : "have"} notifications off. Call emergency services if you need help now.`
+              : `No phones lit up — ${formatNameList(unreachable)} ${unreachable.length === 1 ? "has" : "have"} notifications off.${mailNote} Call emergency services if you need help now.`,
           );
         } else if (unreachable.length > 0) {
           toast.warning(
-            `Alerted ${reached} of ${readyRecipients.length} contacts. Couldn't reach ${formatNameList(unreachable)} — notifications are off on their end.`,
+            `Alerted ${reached} of ${readyRecipients.length} contacts. Couldn't reach ${formatNameList(unreachable)} — notifications are off on their end.${mailNote}`,
           );
         } else {
           toast.success(
             skipped > 0
-              ? `Alerted ${readyRecipients.length} of ${totalSelected} contacts (${skipped} not ready).`
-              : `Alerted ${readyRecipients.length} contact(s).`,
+              ? `Alerted ${readyRecipients.length} of ${totalSelected} contacts (${skipped} not ready).${mailNote}`
+              : `Alerted ${readyRecipients.length} contact(s).${mailNote}`,
           );
         }
         void refresh().catch(() => null);
@@ -4020,6 +4042,9 @@ export function OneLocationAgentPageContent({
       smsActionRecipients,
       refresh,
       sosIncident,
+      // The local emergency number is read at send time so the email can tell
+      // the recipient which number to dial where the sender is.
+      sosEmergency?.number,
       vaultOwnerToken,
     ],
   );

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -196,6 +196,10 @@
       "file": "app/api/one/[...path]/route.ts"
     },
     {
+      "template": "/api/one/location/sos-email",
+      "file": "app/api/one/location/sos-email/route.ts"
+    },
+    {
       "template": "/api/pkm/{path*}",
       "file": "app/api/pkm/[...path]/route.ts"
     },
@@ -8514,5 +8518,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "0910bb37ea96d377f391d495c76effc016aecee8c4f06922de755bdb00ffd17b"
+  "content_sha256": "da51d36218e4f4627f8ead6ed7feabc4b6e0ea84bfc7a6f832c37782fbe4f37a"
 }

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -869,6 +869,63 @@ export class OneLocationService {
   }
 
   /**
+   * Second channel for a Save my Soul alert: email the contacts of the grants
+   * this alert just created.
+   *
+   * The push notification is the first channel and it reaches nobody when a
+   * contact has notifications off or has uninstalled — an email survives both.
+   *
+   * The coordinates travel in this request because the server cannot read them
+   * anywhere else: location envelopes keep coordinates inside the ciphertext,
+   * so only this device holds the plaintext. They are used for one send and
+   * are not stored server-side.
+   *
+   * Resolves rather than throws on failure. It is called after the alert has
+   * already gone out, so a mail problem must never surface as a failed SOS.
+   */
+  static async sendSosEmails(params: {
+    vaultOwnerToken: string;
+    grantIds: string[];
+    latitude: number;
+    longitude: number;
+    accuracyM?: number | null;
+    note?: string | null;
+    emergencyNumber?: string | null;
+  }): Promise<{ emailed: number; attempted: number; configured: boolean }> {
+    const fallback = { emailed: 0, attempted: 0, configured: false };
+    if (!params.grantIds.length) return fallback;
+    try {
+      const response = await apiJson<{
+        emailed?: number;
+        attempted?: number;
+        configured?: boolean;
+      }>("/api/one/location/sos-email", {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({
+          grantIds: params.grantIds,
+          latitude: params.latitude,
+          longitude: params.longitude,
+          ...(typeof params.accuracyM === "number"
+            ? { accuracyM: params.accuracyM }
+            : {}),
+          ...(params.note ? { note: params.note } : {}),
+          ...(params.emergencyNumber
+            ? { emergencyNumber: params.emergencyNumber }
+            : {}),
+        }),
+      });
+      return {
+        emailed: Number(response?.emailed ?? 0),
+        attempted: Number(response?.attempted ?? 0),
+        configured: response?.configured === true,
+      };
+    } catch {
+      return fallback;
+    }
+  }
+
+  /**
    * Create/replace a private share and persist its first encrypted point as one
    * idempotent backend mutation. Safe to retry with the same operation id.
    */

--- a/hushh-webapp/scripts/design/verify-accent-tokens.mjs
+++ b/hushh-webapp/scripts/design/verify-accent-tokens.mjs
@@ -70,6 +70,13 @@ const ALLOWLIST = new Set([
   // var(--app-accent); the remaining rainbow stops (incl. one warm gold) are
   // atmosphere, not the accent identity.
   "components/agent/agent-voice-edge-glow.tsx",
+  // Email HTML, not app UI. Mail clients do not resolve CSS custom
+  // properties -- Gmail and Outlook strip or ignore them -- so a token here
+  // renders as no colour at all. The accent has to be a literal hex in a
+  // message body, and the message is inlined-style-only for the same reason.
+  // Keep this entry limited to the mail renderer; nothing that paints a
+  // screen belongs on this list.
+  "app/api/one/location/sos-email/route.ts",
 ]);
 
 function isAllowed(repoPath) {


### PR DESCRIPTION
Answers "their One is closed — how do they hear about the SOS?" Today: they don't. A Save my Soul alert reaches its contacts through exactly **one** channel, a push notification. A contact with notifications off, or who uninstalled, gets nothing, and the sender only learns that from a toast afterwards.

Email is the second channel. It survives a closed app and an unread notification tray.

## The coordinates decision

Migration 061 states the invariant plainly:

> `'Latest live-location ciphertext envelopes. Coordinates must be present only inside ciphertext.'`

The server **cannot read where the sender is** — only the recipient's device decrypts that. So an email that names a location has to receive coordinates from the sender's client, in the request, for the length of one send.

That is a deliberate product decision to weaken the envelope model for the emergency case: a contact who cannot open the app still needs somewhere to go. **Four rules bound it, each with a test:**

1. **Never persisted.** Nothing writes them to a table.
2. **Never logged.** `_log_safe` is the only formatting path into a log line and it refuses to format a float, so a later edit cannot casually interpolate a latitude. A test asserts no coordinate, note, or address appears in *any* log record across success and both failure paths.
3. **The grants are the authorization.** A caller may mail only the recipients of live SOS grants their own account created in the last 15 minutes. Without that, this endpoint would email arbitrary text and a location to any user id — and an 8-hour SOS grant would stay usable as a mailer for the rest of the day.
4. **Non-production routes to the test inbox.** Verifying an emergency mail on UAT must never mail a real contact's real inbox. The subject is prefixed `[TEST → real@address]` so it stays traceable.

## No new secret

Reuses the Workspace delegated service account that already sends support and invite mail and is already bound in every lane — no new binding to keep in parity across the three build lanes, no new IAM grant, no new deploy variable.

## Failure is never an error

The alert has already gone out by the time this runs, so a mail problem is a count, not an exception: the route swallows, the service returns per-recipient outcomes, the client helper resolves rather than throws. A missing credential reports `configured: false` and the alert is unaffected.

## What the recipient gets

Subject: **Ankit needs help — Save my Soul**, marked high priority, with the sender's note (HTML-escaped), the coordinates and accuracy, a Google Maps button, a link into One for the live position, the share expiry, and the sender's local emergency number.

The sender's toast now names both channels — `Alerted 2 contact(s). Emailed 2.` — and the all-unreachable case reads differently when inboxes did get it, which is the only reason to have a fallback at all.

## Tests

**23 new backend tests**, covering:

- rejects another user's grant, a non-SOS grant (`check_in` / `share` / `drive_to` / empty), a revoked or expired grant, a grant older than 15 minutes
- accepts one created moments ago; caps recipients; mails each person once across duplicate grants; skips a contact with no usable address
- escapes `<img src=x onerror=…>` in the sender's note before it reaches an HTML mail
- routes a non-production send to the test inbox
- reports (never raises) on transport failure and on a 4xx from Gmail
- **no coordinate, note, or email address in any log record**

96 backend tests pass on Python 3.13. `npm run typecheck`, `verify:service-boundary`, and `eslint --max-warnings=0` all clean. `./bin/hushh protocol lint` and `format` clean.

Baseline: the Location + navigation sweep fails identically on `origin/main` and here (4 pre-existing failures).

## Not in this change, and why

- **Real SMS** — no telephony provider exists anywhere in this repository. That is a purchase plus per-country regulatory setup, not a code change.
- **Auto-call** — same provider dependency, plus auto-dialing carries its own legal constraints.

## Risk / rollback

Additive: one new backend route, one new service, one client helper. No schema change, no migration, no change to the existing push path. Straight revert.
