### PR TITLE
fix(ria,ops): two corrections found while verifying the NWS work on the live service

### DIFF
--- a/consent-protocol/tests/test_nws_nearby_runtime_config_wiring.py
+++ b/consent-protocol/tests/test_nws_nearby_runtime_config_wiring.py
@@ -178,3 +178,31 @@ def test_the_deploy_step_mounts_the_key_into_the_backend():
     """A mirrored secret nothing mounts is a secret the runtime never sees."""
     cloudbuild = (_REPO_ROOT / "deploy" / "backend.cloudbuild.yaml").read_text()
     assert "add_secret NWS_NEARBY_API_KEY NWS_NEARBY_API_KEY" in cloudbuild
+
+
+def test_each_lane_mirrors_its_own_v4_credential() -> None:
+    """A v4 key is bound upstream to one consumer and one project.
+
+    The v2 key is a single shared service credential every lane may present.
+    A v4 key is not: the upstream registry maps each key to exactly one
+    consumer, so mirroring one into every lane would hand production UAT's
+    identity and the upstream would refuse it as a project mismatch.
+    """
+    module = _load_sync_module()
+    lanes = module._NWS_V4_KEY_SOURCE_BY_PROJECT
+
+    assert lanes["hushh-pda-uat"] != lanes["hushh-pda"]
+    assert len(set(lanes.values())) == len(lanes)
+    # An unlisted lane mirrors nothing rather than borrowing another's key.
+    assert lanes.get("hushh-pda-dev", "") == ""
+
+
+def test_the_v4_project_id_is_the_lane_not_a_default() -> None:
+    """A per-lane value carrying a default is how one lane inherits another."""
+    module = _load_sync_module()
+
+    uat = module._build_backend_runtime_config(_namespace(project="hushh-pda-uat"))
+    prod = module._build_backend_runtime_config(_namespace(project="hushh-pda"))
+
+    assert uat["nws_nearby_v4_project_id"] == "hushh-pda-uat"
+    assert prod["nws_nearby_v4_project_id"] == "hushh-pda"

--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -462,6 +462,27 @@ describe("national index", () => {
 });
 
 describe("score regime", () => {
+  // Values taken from the two live markets: a registry-discovered record leaves
+  // the four graph-backed components at zero, a reviewed one populates them.
+  function breakdown(graphBacked: number) {
+    return {
+      components: [
+        { key: "graph_authority", label: "Graph authority", value: graphBacked, weight: 0.3, contribution: 0 },
+        { key: "institutional_influence", label: "Institutional influence", value: 0.746, weight: 0.2, contribution: 0.149 },
+        { key: "verified_track_record", label: "Verified track record", value: graphBacked, weight: 0.2, contribution: 0 },
+        { key: "capital_access", label: "Capital access", value: graphBacked, weight: 0.1, contribution: 0 },
+        { key: "evidence_confidence", label: "Evidence confidence", value: 0.81, weight: 0.08, contribution: 0.065 },
+        { key: "trusted_reach", label: "Trusted reach", value: graphBacked, weight: 0.07, contribution: 0 },
+        { key: "freshness", label: "Freshness", value: 0.98, weight: 0.05, contribution: 0.049 },
+      ],
+      evidenceCount: 5,
+      coverageMultiplier: 1,
+      integrityPenalty: 0,
+      localRelevance: 1,
+      method: "m",
+    };
+  }
+
   async function openFirstRecord(over: Record<string, unknown>) {
     mockDiscover.mockResolvedValue({
       ...COVERED,
@@ -478,10 +499,11 @@ describe("score regime", () => {
     fireEvent.click(screen.getByText("Builder One"));
   }
 
-  it("says what a nationally discovered score actually measured", async () => {
-    // Most of the weighting has nothing to read for these records, so they land
-    // far below a reviewed one. Unlabelled, that reads as a weaker person.
-    await openFirstRecord({ scoreKind: "PROFESSIONAL_NETWORK_PROVISIONAL" });
+  it("says what a registry-discovered score actually measured", async () => {
+    // Two thirds of the weighting has nothing to read for these records, so
+    // they land far below a reviewed one. Unlabelled, that reads as a weaker
+    // person rather than a thinner source.
+    await openFirstRecord({ scoreBreakdown: breakdown(0) });
 
     await waitFor(() =>
       expect(
@@ -490,8 +512,15 @@ describe("score regime", () => {
     );
   });
 
-  it("stays silent for a reviewed record", async () => {
-    await openFirstRecord({ scoreKind: "REVIEWED_PUBLIC_ASSOCIATION" });
+  it("stays silent for a reviewed record even though both call themselves provisional", async () => {
+    // The live service reports score_kind PROFESSIONAL_NETWORK_PROVISIONAL for
+    // reviewed and registry records alike, so the label cannot be the
+    // discriminator — claiming a reviewed record has no relationship evidence
+    // would be false.
+    await openFirstRecord({
+      scoreKind: "PROFESSIONAL_NETWORK_PROVISIONAL",
+      scoreBreakdown: breakdown(0.6788),
+    });
 
     await waitFor(() =>
       expect(screen.getByText(/Network strength, not net worth/i)).toBeInTheDocument(),
@@ -501,8 +530,8 @@ describe("score regime", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("claims nothing when the service sends no regime", async () => {
-    await openFirstRecord({ scoreKind: null });
+  it("claims nothing when there is no breakdown to read", async () => {
+    await openFirstRecord({ scoreBreakdown: null });
 
     await waitFor(() =>
       expect(screen.getByText(/Network strength, not net worth/i)).toBeInTheDocument(),

--- a/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
@@ -20,6 +20,7 @@ import {
   associationCategoryLabel,
   factTypeLabel,
   formatScore,
+  isRegistryOnlyScore,
   type NearbyRecord,
 } from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
@@ -89,11 +90,12 @@ export function NearbyRecordSheet({
               Overall {formatScore(record.globalNws)} · Confidence{" "}
               {record.confidence.grade ?? "—"}
             </p>
-            {/* A nationally discovered record scores far below a reviewed one
-                because most of the weighting has nothing to read, not because
-                the person is lesser. The word "provisional" on its own does not
-                carry that, so the regime says what it actually measured. */}
-            {record.scoreKind === "PROFESSIONAL_NETWORK_PROVISIONAL" ? (
+            {/* A registry-discovered record scores far below a reviewed one
+                because two thirds of the weighting has nothing to read, not
+                because the person is lesser. Read from the components rather
+                than from the score kind, which reads "provisional" for both
+                kinds and so cannot tell them apart. */}
+            {isRegistryOnlyScore(record) ? (
               <p className={MUTED_TEXT}>From public registry role and recency only.</p>
             ) : null}
           </div>

--- a/hushh-webapp/lib/services/nws-nearby-service.ts
+++ b/hushh-webapp/lib/services/nws-nearby-service.ts
@@ -75,6 +75,40 @@ export type ScoreComponent = {
   contribution: number | null;
 };
 
+/**
+ * The four components that need a real relationship graph behind them. Together
+ * they carry 67% of the score's weight.
+ *
+ * A record discovered from a public registry has no graph to read, so all four
+ * come back at zero and the score is carried entirely by institutional role,
+ * evidence quality and recency. A reviewed record populates all of them.
+ */
+const GRAPH_BACKED_COMPONENTS = [
+  "graph_authority",
+  "verified_track_record",
+  "capital_access",
+  "trusted_reach",
+] as const;
+
+/**
+ * Whether this score was produced without any relationship evidence.
+ *
+ * Deliberately derived from the record's own components rather than from
+ * `scoreKind`: the service reports `PROFESSIONAL_NETWORK_PROVISIONAL` for
+ * reviewed and registry-discovered records alike, so that field does not
+ * discriminate. Reading the components keeps the claim true if a future
+ * registry record does arrive with a graph behind it.
+ */
+export function isRegistryOnlyScore(record: NearbyRecord): boolean {
+  const components = record.scoreBreakdown?.components;
+  if (!components?.length) return false;
+  const graphBacked = components.filter((component) =>
+    (GRAPH_BACKED_COMPONENTS as readonly string[]).includes(component.key),
+  );
+  if (graphBacked.length !== GRAPH_BACKED_COMPONENTS.length) return false;
+  return graphBacked.every((component) => !component.value);
+}
+
 export type ScoreBreakdown = {
   components: ScoreComponent[];
   /** How many pieces of evidence back the profile. Thin evidence is held back. */
@@ -126,13 +160,12 @@ export type NearbyRecord = {
   nearbyRankScore: number | null;
   scoreStatus: string | null;
   /**
-   * Which scoring regime produced the number above.
+   * The service's own label for the scoring regime.
    *
-   * A nationally discovered record is scored from public registry role and
-   * recency alone — its graph, track-record and capital components are
-   * structurally zero — so it lands far below a reviewed record. The two are
-   * not comparable, and without this the lower number reads as a weaker person
-   * rather than a thinner source.
+   * Informational only. It reads `PROFESSIONAL_NETWORK_PROVISIONAL` for
+   * registry-discovered and reviewed records alike, so it cannot be used to
+   * tell a thin score from a full one — use {@link isRegistryOnlyScore}, which
+   * reads the components instead.
    */
   scoreKind: string | null;
   rankingBasis: string | null;

--- a/scripts/ops/sync_backend_runtime_secrets.py
+++ b/scripts/ops/sync_backend_runtime_secrets.py
@@ -203,6 +203,17 @@ def _build_backend_runtime_config(args: argparse.Namespace) -> dict[str, Any]:
     return _drop_empty(config)
 
 
+# One NWS v4 credential per lane, because the upstream registry binds each key
+# to exactly one consumer and one project. An unlisted lane resolves to blank,
+# which skips the mirror and leaves the surface reporting "not set up" — the
+# right answer for a lane with no registered consumer, and better than handing
+# it another lane's identity.
+_NWS_V4_KEY_SOURCE_BY_PROJECT: dict[str, str] = {
+    "hushh-pda-uat": "nws-hushh-research-v4-api-key-uat",
+    "hushh-pda": "nws-hushh-research-v4-api-key-prod",
+}
+
+
 def _mirror_directory_key(
     *,
     target_project: str,
@@ -335,10 +346,18 @@ def main() -> int:
         default="https://nws-nearby-intelligence-fro3hygenq-uc.a.run.app",
     )
     parser.add_argument("--nws-nearby-v4-api-key-source-project", default="hushh-tech-prod")
-    parser.add_argument(
-        "--nws-nearby-v4-api-key-source-secret", default="nws-hushh-research-v4-api-key"
-    )
+    # Blank by default and resolved from the lane below. Unlike the v2 key,
+    # which is one shared service credential every lane may use, a v4 key is
+    # bound in the upstream registry to a single consumer with a single
+    # project. Mirroring one key into every lane would hand production UAT's
+    # credential, and the upstream would refuse it as a project mismatch.
+    parser.add_argument("--nws-nearby-v4-api-key-source-secret", default="")
     args = parser.parse_args()
+
+    if not str(args.nws_nearby_v4_api_key_source_secret or "").strip():
+        args.nws_nearby_v4_api_key_source_secret = _NWS_V4_KEY_SOURCE_BY_PROJECT.get(
+            args.project, ""
+        )
 
     sync_summary: list[str] = []
 


### PR DESCRIPTION
Two defects in [#5258](https://github.com/hushh-labs/hushh-research/pull/5258), both found by checking the deployed surface against the **live service** rather than against the handoff document. Neither would have been caught by the tests as written, because both tests encoded the same wrong assumption the code did.

---

## 1. The thin-score signal read a field that does not discriminate

The record sheet's new line — *"From public registry role and recency only."* — was gated on `score_kind === "PROFESSIONAL_NETWORK_PROVISIONAL"`. The live service reports **exactly that value for reviewed records too**, so the line rendered on Kirkland records, where it is false.

Probed with the key UAT actually holds:

| ZIP | market | graph_authority | verified_track_record | capital_access | trusted_reach |
|---|---|---|---|---|---|
| 98033 | `APPROVED_MARKET_RELEASE` (reviewed) | 0.6788 | 0.567 | 0.64 | 0.5415 |
| 94010 | `APPROVED_NATIONAL_INDEX` (registry) | 0 | 0 | 0 | 0 |

Both report `score_kind: PROFESSIONAL_NETWORK_PROVISIONAL` and `ranking_basis: PROVISIONAL_NWS_MODEL`. The label never discriminated. The **components** do.

`isRegistryOnlyScore(record)` reads the four graph-backed components — 67% of the score's weight between them — and returns true only when all four are empty. Deriving it from the record's own evidence rather than from the market id or the regime label matters: it stays correct if a registry-discovered record ever arrives with a real graph behind it, which a market-level test would get backwards.

`scoreKind` still travels; its doc now says plainly that it is informational and cannot separate the two.

**Tests:** a registry record explains itself; **a reviewed record stays silent despite reporting the same `score_kind`** — the case that would have caught this; a record with no breakdown claims nothing.

---

## 2. One v4 credential was about to be mirrored into every lane

The v2 key is a single shared service credential, so mirroring one source secret into every lane is correct there. A v4 key is not: the upstream registry binds each key to **exactly one consumer with one project**, and the caller must send that project or the request is refused as `PROJECT_CONTEXT_MISMATCH`.

As written, production would have been handed UAT's credential and failed on its first call — and only at the moment someone provisioned, which is exactly when a handover document promises it works.

The source secret is now resolved from the deploy target, the same way `nws_nearby_v4_project_id` already is. An unlisted lane resolves to blank, mirrors nothing, and reports "not set up" rather than borrowing another lane's identity.

**Tests:** the two lanes resolve distinct secrets, no secret is reused, an unlisted lane resolves blank, and the project id is the lane rather than a default.

---

## Verification

- `verify:service-boundary`, `verify:design-system`, `verify:surface-map` pass
- `tsc --noEmit` clean
- All four nearby frontend suites pass (49 tests); config wiring suites pass (26 tests)
- The `S603` finding and the format drift in `scripts/ops/sync_backend_runtime_secrets.py` are both **pre-existing on `origin/main`** — verified against main's own copy of the file, not introduced here