### PR TITLE
fix(connect): make People search an alphabetical index, not a filtered page

### DIFF
--- a/consent-protocol/api/routes/one/connections.py
+++ b/consent-protocol/api/routes/one/connections.py
@@ -58,7 +58,9 @@ class LinkCircleInviteBody(BaseModel):
 
 @router.get("/connections/directory")
 def connections_directory(
-    query: str = Query(default=""),
+    # Bounded like the information-scope search below it. A name is short; an
+    # unbounded query string is just an unbounded LIKE pattern to build.
+    query: str = Query(default="", max_length=160),
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=20, ge=1, le=50),
     firebase_uid: str = Depends(require_firebase_auth),

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -1821,11 +1821,49 @@ class ConnectionsService:
             people = directory_page.get("items") or []
             has_more = bool(directory_page.get("hasMore"))
         else:
+            # The in-memory fallback has to answer the same question the SQL
+            # path answers, or the two disagree about who is findable depending
+            # on which one a deployment happens to take. Same two tiers, same
+            # A-Z within each, and the same rule that ranking and matching
+            # finish BEFORE the page is cut.
             people = self._directory_lookup(user_id) or []
             if needle:
-                people = [
-                    p for p in people if needle in str(p.get("displayName") or "").strip().lower()
-                ]
+                # Same separator folding as the SQL path's TRANSLATE. Without
+                # it the two paths disagree about "Abdul-Rashid": Python's
+                # bare split() sees one word, the SQL sees two, and whether a
+                # person is findable comes down to which branch a deployment
+                # happened to take.
+                def _folded(value: str) -> str:
+                    folded = value.strip().lower()
+                    for separator in "-'._/,":
+                        folded = folded.replace(separator, " ")
+                    return folded
+
+                def _tier(person: dict[str, Any]) -> int | None:
+                    name = _folded(str(person.get("displayName") or ""))
+                    if name.startswith(needle):
+                        return 0
+                    if any(word.startswith(needle) for word in name.split()):
+                        return 1
+                    return None
+
+                ranked = [(tier, p) for p in people if (tier := _tier(p)) is not None]
+                ranked.sort(
+                    key=lambda entry: (
+                        entry[0],
+                        str(entry[1].get("displayName") or "").strip().lower(),
+                        str(entry[1].get("userId") or ""),
+                    )
+                )
+                people = [p for _, p in ranked]
+            else:
+                people = sorted(
+                    people,
+                    key=lambda p: (
+                        str(p.get("displayName") or "").strip().lower(),
+                        str(p.get("userId") or ""),
+                    ),
+                )
             offset = (page - 1) * limit
             has_more = offset + limit < len(people)
             people = people[offset : offset + limit]

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1691,7 +1691,21 @@ class OneLocationAgentService:
         *,
         owner_user_id: str,
         recipients: list[dict[str, Any]],
+        preserve_order: bool = False,
     ) -> list[dict[str, Any]]:
+        """Annotate recipients with Kai recommendation signals.
+
+        ``preserve_order`` keeps the caller's incoming order instead of
+        re-ranking by score. The Location screen wants the ranking -- "who
+        should I share with" is exactly a recommendation question. A paged
+        directory search does not: its order was decided by SQL, ahead of
+        LIMIT, and re-sorting the slice here would reorder rows *within* a page
+        while the page boundaries stayed alphabetical. That inconsistency was
+        survivable only while the Connect client re-sorted the page itself;
+        the moment that client sort was removed, the A-Z index the reader was
+        promised became recommendation-score order wearing alphabetical page
+        breaks.
+        """
         if not recipients:
             return []
         recipient_ids = {str(recipient.get("userId") or "") for recipient in recipients}
@@ -1832,14 +1846,15 @@ class OneLocationAgentService:
                 }
             )
 
-        enriched.sort(
-            key=lambda item: (
-                -int(item.get("recommendationScore") or 0),
-                0 if item.get("canReceiveLocation") else 1,
-                str(item.get("displayName") or "").lower(),
-                str(item.get("userId") or ""),
+        if not preserve_order:
+            enriched.sort(
+                key=lambda item: (
+                    -int(item.get("recommendationScore") or 0),
+                    0 if item.get("canReceiveLocation") else 1,
+                    str(item.get("displayName") or "").lower(),
+                    str(item.get("userId") or ""),
+                )
             )
-        )
         for index, recipient in enumerate(enriched, start=1):
             recipient["recommendationRank"] = index
         return enriched
@@ -3066,6 +3081,22 @@ class OneLocationAgentService:
         This preserves the existing discovery policy while preventing callers
         from being limited by an in-memory first page.  The result remains a
         safe profile projection; it is not an all-account directory.
+
+        Matching, ranking and ordering all happen HERE, in one statement, ahead
+        of ``LIMIT``.  That placement is the contract, not an implementation
+        detail: this used to match any substring (``LIKE '%n%'``) and leave the
+        caller to narrow the result, so Connect asked for 8 rows for "n", got
+        the 8 alphabetically-first names that merely CONTAIN an n -- Anand,
+        Ankit, Arun -- and then discarded all 8 client-side because none of
+        them START with n.  Nilesh and Nirmal existed and were real, and were
+        several pages further into a result set nobody could reach.  A filter
+        applied after ``LIMIT`` can only ever subtract from a page that was
+        already chosen wrongly, so no caller-side rule could have fixed it.
+
+        The order is: name-prefix matches first, then word-prefix matches, and
+        A-Z (case-insensitively) within each tier.  Paging is therefore paging
+        through one stable, fully-ranked list, and ``hasMore`` describes the
+        same rows the reader is looking at.
         """
         page = max(1, int(page or 1))
         # Keep the legacy Ready People caller's 100-item ceiling intact. The
@@ -3075,6 +3106,36 @@ class OneLocationAgentService:
         offset = (page - 1) * limit
         needle = (query or "").strip().lower()
         target = (candidate_user_id or "").strip() or None
+        # LIKE metacharacters in a typed name are literal characters, not
+        # wildcards. Unescaped, a single "%" typed into Connect matches every
+        # row in the directory and "_" matches any letter, so the escape is
+        # what keeps the pattern describing the name the person actually typed.
+        #
+        # "!" is the escape character rather than the conventional backslash on
+        # purpose: a backslash would have to survive both Python's string
+        # escaping and Postgres' standard_conforming_strings, and getting
+        # either wrong degrades silently into a pattern that still runs.
+        escaped_needle = needle.replace("!", "!!").replace("%", "!%").replace("_", "!_")
+        # Two patterns, because a directory search is answered in two tiers.
+        #   name_prefix -- the name STARTS with what was typed. Typing "n" is
+        #     an index request: every N person, A-Z. This is the tier the
+        #     Connect screen exists to serve.
+        #   word_prefix -- some later word starts with it, so "rashid" still
+        #     finds "Abdul Rashid". An earlier version matched surnames with no
+        #     ranking at all, which is why "r" felt random; here the tier is
+        #     strictly below name_prefix, so a first-name hit always outranks a
+        #     surname hit and the list never reads as shuffled.
+        #
+        # Both patterns are applied to a name that has been trimmed, lowered,
+        # and had its separators folded to spaces (see the TRANSLATE in the
+        # statement). Names are not stored tidily: " Nilesh" with a leading
+        # space would fail a `n%` test and get demoted to the surname tier,
+        # and "Abdul-Rashid" or "Abdul R." would put their second word behind
+        # a character that `% r%` cannot see. Fold once, match once, and the
+        # tier a person lands in is about their name rather than about the
+        # punctuation someone typed into a profile field.
+        name_prefix_pattern = f"{escaped_needle}%"
+        word_prefix_pattern = f"% {escaped_needle}%"
         rows = self._execute_many(
             """
             SELECT
@@ -3132,15 +3193,28 @@ class OneLocationAgentService:
               )
               AND (
                 :query = ''
-                OR LOWER(COALESCE(a.display_name, '')) LIKE '%' || :query || '%'
+                OR TRANSLATE(LOWER(BTRIM(COALESCE(a.display_name, ''))), '-''._/,', '      ')
+                     LIKE :name_prefix ESCAPE '!'
+                OR TRANSLATE(LOWER(BTRIM(COALESCE(a.display_name, ''))), '-''._/,', '      ')
+                     LIKE :word_prefix ESCAPE '!'
               )
-            ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
+            ORDER BY
+              CASE
+                WHEN :query = '' THEN 0
+                WHEN TRANSLATE(LOWER(BTRIM(COALESCE(a.display_name, ''))), '-''._/,', '      ')
+                       LIKE :name_prefix ESCAPE '!' THEN 0
+                ELSE 1
+              END,
+              LOWER(COALESCE(NULLIF(BTRIM(a.display_name), ''), a.phone_number, a.user_id)),
+              a.user_id
             LIMIT :fetch_limit OFFSET :offset
             """,
             {
                 "owner_user_id": owner_user_id,
                 "candidate_user_id": target,
                 "query": needle,
+                "name_prefix": name_prefix_pattern,
+                "word_prefix": word_prefix_pattern,
                 "fetch_limit": limit + 1,
                 "offset": offset,
             },
@@ -3151,6 +3225,11 @@ class OneLocationAgentService:
         items = self._apply_kai_circle_recommendations(
             owner_user_id=owner_user_id,
             recipients=recipients,
+            # The SQL above already decided rank and A-Z, across the whole
+            # matched set rather than this slice of it. Re-sorting here would
+            # only ever shuffle one page against boundaries drawn by a
+            # different ordering.
+            preserve_order=True,
         )
         return {"items": items, "page": page, "hasMore": has_more}
 

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -26,6 +26,8 @@ tests/test_pkm_upgrade_service.py
 tests/test_vault_keys_metadata.py
 tests/test_one_location_routes.py
 tests/services/test_one_location_agent_service.py
+tests/services/test_connections_service.py
+tests/routes/test_connections_route.py
 tests/test_adk_a2a_compliance_script.py
 tests/test_ria_claim_flow.py
 tests/test_ria_iam_service_architecture.py

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -568,6 +568,75 @@ def test_search_directory_filters_by_query_against_display_name():
     assert [i["userId"] for i in out["items"]] == ["user-c"]
 
 
+def test_search_directory_fallback_matches_prefixes_and_ranks_them():
+    """The in-memory fallback answers the same question as the SQL path.
+
+    Typing one letter is an index request. A substring match answers a
+    different question -- "Anand" contains an n -- and the two paths disagreeing
+    would mean findability depended on which branch a deployment took.
+    """
+    svc = _svc()
+    svc._directory_lookup = lambda owner_user_id: [
+        {"userId": "u-anand", "displayName": "Anand"},  # contains n, starts with a
+        {"userId": "u-nirmal", "displayName": "Nirmal"},
+        {"userId": "u-abdul", "displayName": "Abdul Nasser"},  # second word starts with n
+        {"userId": "u-nilesh", "displayName": "Nilesh"},
+    ]
+    db = _RecordingDB([[], [], []])
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.search_directory("user-a", query="n", page=1, limit=20)
+
+    # Anand is gone: it only ever matched as a substring. Name-prefix names
+    # come first and A-Z within the tier; the surname match ranks below them
+    # rather than being mixed in, which is what made the earlier version of
+    # this read as random.
+    assert [i["displayName"] for i in out["items"]] == ["Nilesh", "Nirmal", "Abdul Nasser"]
+
+
+def test_search_directory_fallback_folds_separators_like_the_sql_path():
+    svc = _svc()
+    svc._directory_lookup = lambda owner_user_id: [
+        {"userId": "u-hyphen", "displayName": "Abdul-Rashid"},
+        {"userId": "u-initial", "displayName": "Abdul R."},
+        {"userId": "u-spaced", "displayName": "  Rashid Ahmed"},
+    ]
+    db = _RecordingDB([[], [], []])
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.search_directory("user-a", query="r", page=1, limit=20)
+
+    # "  Rashid Ahmed" is trimmed, so it earns the first tier rather than being
+    # demoted by a leading space. The hyphen and the full stop are separators,
+    # so both reach the second tier instead of hiding their second word.
+    #
+    # Asserted as tiers rather than one exact sequence on purpose: how "Abdul
+    # R." and "Abdul-Rashid" order against each other depends on whether
+    # punctuation is significant in the active collation, and pinning that here
+    # would be pinning the database's locale, not this code's behaviour.
+    found = [i["userId"] for i in out["items"]]
+    assert found[0] == "u-spaced"
+    assert sorted(found[1:]) == ["u-hyphen", "u-initial"]
+
+
+def test_search_directory_fallback_pages_the_ranked_list_not_the_raw_one():
+    svc = _svc()
+    svc._directory_lookup = lambda owner_user_id: [
+        {"userId": f"u-{name}", "displayName": name}
+        for name in ["Nolan", "Anand", "Nilesh", "Chandan", "Nirmal"]
+    ]
+    db = _RecordingDB([[], [], []])
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        first = svc.search_directory("user-a", query="n", page=1, limit=2)
+        second = svc.search_directory("user-a", query="n", page=2, limit=2)
+
+    # Ranking finishes before the slice, so page 1 holds the first two N names
+    # and page 2 continues the same list. Slicing first and ranking after is
+    # exactly the bug this replaced.
+    assert [i["displayName"] for i in first["items"]] == ["Nilesh", "Nirmal"]
+    assert first["hasMore"] is True
+    assert [i["displayName"] for i in second["items"]] == ["Nolan"]
+    assert second["hasMore"] is False
+
+
 def test_search_directory_delegates_pagination_to_eligible_directory_query():
     calls: list[tuple[str, dict[str, object]]] = []
 

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2332,16 +2332,149 @@ def test_directory_candidate_search_filters_before_pagination(
     )
 
     assert result == {"items": [], "page": 3, "hasMore": False}
-    assert "LOWER(COALESCE(a.display_name, '')) LIKE '%' || :query || '%'" in service.sql
     assert "a.user_id, a.display_name, a.email" in service.sql
     assert "LIMIT :fetch_limit OFFSET :offset" in service.sql
     assert service.params == {
         "owner_user_id": "owner",
         "candidate_user_id": None,
         "query": "cara",
+        "name_prefix": "cara%",
+        "word_prefix": "% cara%",
         "fetch_limit": 21,
         "offset": 40,
     }
+    # The substring predicate is what made a single letter return an empty
+    # screen: it selected the page under one rule while the caller narrowed it
+    # under another. It must not come back.
+    assert "LIKE '%' || :query || '%'" not in service.sql
+
+
+def test_directory_search_matches_prefixes_not_substrings() -> None:
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="n", limit=8)
+
+    # Two tiers, both prefix-anchored: the name starts with the query, or one
+    # of its later words does. Typing "n" is an index request, and an index
+    # that also returns "Anand" because it contains an n is not an index.
+    assert service.params["name_prefix"] == "n%"
+    assert service.params["word_prefix"] == "% n%"
+    assert service.sql.count("LIKE :name_prefix ESCAPE '!'") == 2
+    assert "LIKE :word_prefix ESCAPE '!'" in service.sql
+
+
+def test_directory_search_ranks_name_prefix_above_word_prefix_then_alphabetically() -> None:
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="r")
+
+    # rsplit, not split: the recipient-key LEFT JOIN LATERAL carries its own
+    # ORDER BY, and asserting against that one would pass while saying nothing
+    # about how the directory is ranked.
+    ordering = service.sql.rsplit("ORDER BY", 1)[1].rsplit("LIMIT", 1)[0]
+    # Tier first, then A-Z. Ranking has to be inside the ORDER BY, because
+    # LIMIT/OFFSET is applied to whatever this clause decides -- a ranking
+    # applied to the page afterwards can only reshuffle rows that were already
+    # chosen wrongly.
+    assert "CASE" in ordering
+    assert "LIKE :name_prefix ESCAPE '!' THEN 0" in ordering
+    assert "ELSE 1" in ordering
+    assert "LOWER(COALESCE(NULLIF(BTRIM(a.display_name), '')" in ordering
+    # Deterministic tie-break, or OFFSET paging duplicates and skips rows.
+    assert ordering.strip().endswith("a.user_id")
+
+
+def test_directory_search_folds_separators_so_tiering_is_about_the_name() -> None:
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="r")
+
+    # " Nilesh" must not be demoted out of the first tier by a leading space,
+    # and "Abdul-Rashid" / "Abdul R." must still reach the second one.
+    assert (
+        service.sql.count(
+            "TRANSLATE(LOWER(BTRIM(COALESCE(a.display_name, ''))), '-''._/,', '      ')"
+        )
+        == 3
+    )
+
+
+@pytest.mark.parametrize(
+    ("typed", "expected_name_prefix"),
+    [
+        ("%", "!%%"),
+        ("_", "!_%"),
+        ("!", "!!%"),
+        ("50%_off", "50!%!_off%"),
+    ],
+)
+def test_directory_search_escapes_like_metacharacters(
+    typed: str, expected_name_prefix: str
+) -> None:
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query=typed)
+
+    # Unescaped, a typed "%" is a wildcard that matches the entire directory
+    # and "_" matches any single character. They are characters someone typed
+    # into a name box, not query syntax.
+    assert service.params["name_prefix"] == expected_name_prefix
+    assert service.params["word_prefix"] == f"% {expected_name_prefix}"
+
+
+def test_directory_search_preserves_sql_order_against_recommendation_ranking() -> None:
+    """The directory page keeps the order SQL gave it.
+
+    ``_apply_kai_circle_recommendations`` re-sorts by recommendation score for
+    the Location screen, where "who should I share with" is the question. Here
+    the question is "show me the N people, A-Z", and the rows have already been
+    ranked and cut by the statement above. Re-sorting the slice would reorder
+    rows *within* a page while the page boundaries stayed alphabetical.
+    """
+    captured: dict[str, object] = {}
+
+    class OrderProbe(RecipientDirectoryProbe):
+        def _execute_many(self, sql: str, params: dict | None = None) -> list[dict]:
+            super()._execute_many(sql, params)
+            return [
+                {"user_id": "u-nilesh", "display_name": "Nilesh", "phone_verified": True},
+                {"user_id": "u-nirmal", "display_name": "Nirmal", "phone_verified": True},
+            ]
+
+        def _apply_kai_circle_recommendations(self, **kwargs: object) -> list[dict]:
+            captured.update(kwargs)
+            return list(kwargs["recipients"])  # type: ignore[arg-type]
+
+    service = OrderProbe()
+    result = service.search_directory_candidates(owner_user_id="owner", query="n", limit=8)
+
+    assert captured["preserve_order"] is True
+    assert [item["displayName"] for item in result["items"]] == ["Nilesh", "Nirmal"]
+
+
+def test_recommendations_preserve_order_only_when_asked() -> None:
+    service = OneLocationAgentService()
+    # Deliberately ordered so the two modes cannot agree: A-Z puts Abel first,
+    # score puts Zoe first (she is location-ready, he is not). A fixture where
+    # both orderings coincide would pass whether or not preserve_order is
+    # honoured, and prove nothing.
+    recipients = [
+        {"userId": "u-abel", "displayName": "Abel", "canReceiveLocation": False},
+        {"userId": "u-zoe", "displayName": "Zoe", "canReceiveLocation": True},
+    ]
+
+    preserved = service._apply_kai_circle_recommendations(
+        owner_user_id="owner",
+        recipients=[dict(r) for r in recipients],
+        preserve_order=True,
+    )
+    assert [r["displayName"] for r in preserved] == ["Abel", "Zoe"]
+    # Rank is still assigned, because the Location screen reads it.
+    assert [r["recommendationRank"] for r in preserved] == [1, 2]
+
+    # Default stays the score-ranked behaviour the Location screen depends on:
+    # a location-ready recipient outranks one that is not.
+    reranked = service._apply_kai_circle_recommendations(
+        owner_user_id="owner",
+        recipients=[dict(r) for r in recipients],
+    )
+    assert [r["displayName"] for r in reranked] == ["Zoe", "Abel"]
 
 
 def test_terminal_location_work_is_deleted_after_twelve_hour_retention() -> None:

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -183,13 +183,18 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Page 1")).toBeTruthy();
   });
 
-  it("matches the first name, not the surname, when filtering search results", async () => {
-    // The directory API matches a substring anywhere in the name, so a
-    // search for "R" server-side returns both people below -- one whose
-    // surname happens to start with R, one whose first name does. The
-    // client-side filter must keep only the first-name match.
+  it("renders every person the directory returned, in the order it returned them", async () => {
+    // Matching and ranking belong to the server, which applies them before
+    // LIMIT/OFFSET. This screen renders the page it was given.
+    //
+    // It used to re-filter here instead, keeping only first-name matches. That
+    // ran on rows the server had ALREADY cut to a page under a different rule,
+    // so it could only ever subtract -- and dropping "Abdul Rashid" from a
+    // page of 8 does not promote a ninth row to replace it. The server now
+    // ranks first-name matches above surname matches across the whole result
+    // set, which is the only place that ranking can be applied truthfully.
     mocks.searchDirectory.mockResolvedValue({
-      items: [person("u1", "Abdul Rashid"), person("u2", "Rashid Ahmed")],
+      items: [person("u2", "Rashid Ahmed"), person("u1", "Abdul Rashid")],
       hasMore: false,
       page: 1,
     });
@@ -202,7 +207,121 @@ describe("Connect — People", () => {
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
 
     expect(await screen.findByText("Rashid Ahmed")).toBeTruthy();
-    expect(screen.queryByText("Abdul Rashid")).toBeNull();
+    expect(screen.getByText("Abdul Rashid")).toBeTruthy();
+  });
+
+  it("shows every match for a single typed letter", async () => {
+    // The reported bug, as a test. Typing "N" showed nothing at all: the
+    // server returned a page of substring matches and the client hid all of
+    // them, so real people named Nilesh and Nirmal were invisible behind an
+    // empty list with a live "Next" button.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [
+        person("u-nilesh", "Nilesh"),
+        person("u-nirmal", "Nirmal"),
+        person("u-nolan", "Nolan"),
+      ],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "N" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+
+    expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({
+      query: "N",
+      page: 1,
+      limit: 8,
+    });
+    for (const name of ["Nilesh", "Nirmal", "Nolan"]) {
+      expect(await screen.findByText(name)).toBeTruthy();
+    }
+    expect(screen.queryByText('No one matches "N"')).toBeNull();
+  });
+
+  it("preserves the directory's A-Z order rather than re-sorting the page", async () => {
+    // A client sort can only order the rows it can see, so re-sorting one page
+    // of a paged list makes the index lie at every page boundary: a name on
+    // page 2 could sort ahead of one on page 1. The order arrives correct.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [
+        person("u-a", "Nilesh"),
+        person("u-b", "Nirmal"),
+        person("u-c", "Abdul Nasser"),
+      ],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "N" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+
+    await screen.findByText("Abdul Nasser");
+    // "Abdul Nasser" is a surname match, ranked last by the server. A local
+    // alphabetical sort would pull it to the top, so its position is the whole
+    // assertion.
+    const order = ["Nilesh", "Nirmal", "Abdul Nasser"].map((name) =>
+      screen.getByText(name),
+    );
+    expect(
+      order[0].compareDocumentPosition(order[1]) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      order[1].compareDocumentPosition(order[2]) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("says so when a search matches nobody", async () => {
+    // The empty state used to be gated on the raw server page while the rows
+    // came from a filtered copy of it, so "8 rows, all hidden" rendered as
+    // blank space under a heading -- no rows, no message, and a pager.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Zzz" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+
+    expect(await screen.findByText('No one matches "Zzz"')).toBeTruthy();
+  });
+
+  it("asks for page one once when the query changes while paged", async () => {
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+    expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({ page: 2 });
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "N" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(3));
+
+    // One request, for page 1. Resetting the page in an effect landed a render
+    // too late and fired page 2 of the new query first -- a wasted round trip
+    // that was also free to resolve last and paint a page nobody asked for.
+    expect(mocks.searchDirectory.mock.calls[2][0]).toMatchObject({
+      query: "N",
+      page: 1,
+    });
+    expect(mocks.searchDirectory).toHaveBeenCalledTimes(3);
   });
 
   it("runs a spoken name through the governed Connect search handler", async () => {
@@ -454,8 +573,8 @@ describe("Connect — People", () => {
     expect(await screen.findByText('No one matches "Nobody"')).toBeTruthy();
   });
 
-  it("caps bulk connection requests at 20 people", async () => {
-    const bulkPeople = Array.from({ length: 21 }, (_, index) =>
+  it("caps bulk connection requests at 5 people", async () => {
+    const bulkPeople = Array.from({ length: 6 }, (_, index) =>
       person(`bulk-${index}`, `Bulk person ${index}`),
     );
     mocks.searchDirectory.mockResolvedValue({
@@ -469,32 +588,37 @@ describe("Connect — People", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
 
-    for (let index = 0; index < 20; index += 1) {
+    for (let index = 0; index < 5; index += 1) {
       fireEvent.click(screen.getByLabelText(`Select Bulk person ${index}`));
     }
 
-    expect(screen.getByText("Connect selected (20/20)")).toBeTruthy();
+    expect(screen.getByText("Connect selected (5/5)")).toBeTruthy();
     expect(
-      (screen.getByLabelText("Select Bulk person 20") as HTMLButtonElement)
+      (screen.getByLabelText("Select Bulk person 5") as HTMLButtonElement)
         .disabled,
     ).toBe(true);
 
     fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
     expect(
-      (screen.getByLabelText("Select Bulk person 20") as HTMLButtonElement)
+      (screen.getByLabelText("Select Bulk person 5") as HTMLButtonElement)
         .disabled,
     ).toBe(false);
     fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
 
-    fireEvent.click(screen.getByRole("button", { name: "Connect selected (20/20)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Connect selected (5/5)" }));
 
-    await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(20));
+    // Selecting opens the scope-review dialog; sending is a second, deliberate
+    // act. This test predated that dialog and stopped at the first click, so
+    // it had been asserting against a dispatch that no longer happened there.
+    fireEvent.click(await screen.findByRole("button", { name: "Send requests" }));
+
+    await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(5));
 
     expect(mocks.sendRequest).toHaveBeenCalledWith(
       expect.objectContaining({ addresseeUserId: "bulk-0" }),
     );
     expect(mocks.sendRequest).not.toHaveBeenCalledWith(
-      expect.objectContaining({ addresseeUserId: "bulk-20" }),
+      expect.objectContaining({ addresseeUserId: "bulk-5" }),
     );
   });
 
@@ -504,7 +628,7 @@ describe("Connect — People", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
     fireEvent.click(screen.getByLabelText("Select Person 0"));
-    expect(screen.getByText("Connect selected (1/20)")).toBeTruthy();
+    expect(screen.getByText("Connect selected (1/5)")).toBeTruthy();
 
     mocks.searchDirectory.mockResolvedValue({
       items: [person("u9", "Person 9")],
@@ -517,7 +641,7 @@ describe("Connect — People", () => {
 
     expect(await screen.findByText("Person 9")).toBeTruthy();
     await waitFor(() =>
-      expect(screen.queryByText("Connect selected (1/20)")).toBeNull(),
+      expect(screen.queryByText("Connect selected (1/5)")).toBeNull(),
     );
   });
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -320,9 +320,20 @@ export default function ConnectPageClient() {
 
   // A new query, or a new page size, is a new result set: go back to page one
   // rather than asking for page 4 of something the reader has just redefined.
-  useEffect(() => {
+  //
+  // Adjusted during render rather than in an effect. As an effect this reset
+  // landed one render too late: the fetch below runs in the same commit and
+  // would already have requested page 3 of the new query, then re-run and
+  // request page 1 of it -- two round trips per keystroke for anyone who had
+  // paged, with the discarded one free to resolve last and paint a page the
+  // reader never asked for. React re-renders on a state change made during
+  // render before running effects, so the stale page is never requested.
+  const resultSetKey = `${pageSize}:${trimmedQuery}`;
+  const [renderedResultSetKey, setRenderedResultSetKey] = useState(resultSetKey);
+  if (renderedResultSetKey !== resultSetKey) {
+    setRenderedResultSetKey(resultSetKey);
     setCurrentPage(1);
-  }, [trimmedQuery, pageSize]);
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -668,44 +679,34 @@ export default function ConnectPageClient() {
   // Present connections in a stable, predictable order: alphabetical by the
   // name the user sees (case-insensitive), falling back to the userId when a
   // display name is absent. Locale compare keeps accented names sensibly placed.
-  // Present the People directory in the same predictable order as connections:
-  // alphabetical (A-Z) by the visible name, case/accent-insensitive. When a
-  // search query is active, names that START with the query rank above inner
-  // matches (so "Ab" surfaces "Abdul" before "Zab…"), then A-Z within each
-  // group. The server can return directory rows in relevance/insertion order,
-  // which read as unsorted in the list; this makes the rendered order stable.
-  const sortedPeople = useMemo(() => {
-    const q = trimmedQuery.toLowerCase();
-    const nameOf = (person: DirectoryPerson) =>
-      (person.displayName || person.email || person.userId)
-        .trim()
-        .toLowerCase();
-    // Strict prefix filter. The directory API matches a substring anywhere
-    // (`LIKE '%q%'`), so typing "z" returned "Abdul Zalil" and "shankz".
-    // Constrain the rendered list to entries whose FIRST NAME or EMAIL
-    // local-part starts with the query -- matching on the last/middle name
-    // too (as an earlier version of this did) meant searching "r" surfaced
-    // "Abdul Rashid" and "Divya Rajendran" on their surnames, which reads as
-    // random to someone searching by first name. Applied on top of the
-    // server result, so it never fetches more; it only hides non-matches.
-    const prefixMatches = (person: DirectoryPerson): boolean => {
-      if (!q) return true;
-      const name = nameOf(person);
-      if (name.startsWith(q)) return true;
-      const email = (person.email || "").trim().toLowerCase();
-      return email.startsWith(q) || email.split("@")[0]?.startsWith(q) === true;
-    };
-    return [...people].filter(prefixMatches).sort((a, b) => {
-      const nameA = nameOf(a);
-      const nameB = nameOf(b);
-      if (q) {
-        const startsA = nameA.startsWith(q);
-        const startsB = nameB.startsWith(q);
-        if (startsA !== startsB) return startsA ? -1 : 1;
-      }
-      return nameA.localeCompare(nameB, undefined, { sensitivity: "base" });
-    });
-  }, [people, trimmedQuery]);
+  // The server owns matching, ranking and order; this renders the page it
+  // returned, unchanged.
+  //
+  // It used to re-filter here -- keep only rows whose name starts with the
+  // query -- on top of a server that matched any substring. Filtering AFTER
+  // the server has already applied LIMIT/OFFSET can only subtract from a page
+  // that was chosen by the wrong rule, and it did: typing "n" asked for 8
+  // rows, got the 8 alphabetically-first names merely CONTAINING an n (Anand,
+  // Ankit, Arun...), and hid every one of them. The list rendered empty while
+  // Nilesh and Nirmal sat pages deeper in a result set the reader could not
+  // walk to, and "Next" stayed lit because `hasMore` described the rows the
+  // server sent rather than the rows that survived. No amount of client
+  // cleverness fixes that; the query itself had to select the right page.
+  //
+  // Both tiers the filter used to approximate now live in the SQL, so "n"
+  // returns every N person A-Z and "rashid" still finds "Abdul Rashid",
+  // ranked below the first-name matches rather than mixed in with them.
+  //
+  // Re-sorting here would reintroduce the same class of bug in a quieter
+  // form: a client sort can only order the current page, so a name on page 2
+  // could sort ahead of one on page 1 and the A-Z index would be a lie at
+  // every boundary. One ordering, applied where the paging happens.
+  //
+  // `people` is therefore rendered directly, and there is deliberately no
+  // second derived list. The original bug needed two: the empty state counted
+  // one and the rows came from the other, so "8 rows, all hidden" was
+  // indistinguishable from "8 rows" to every guard on the screen. With one
+  // list there is nothing left to disagree.
 
   const sortedConnections = useMemo(
     () =>
@@ -1351,6 +1352,13 @@ export default function ConnectPageClient() {
                     tone="destructive"
                   />
                 ) : people.length === 0 ? (
+                  // Tested against the list that is actually rendered below,
+                  // never against the raw server page. Those were two
+                  // different lists once: the server returned 8 rows, a
+                  // client-side filter hid all 8, and this branch checked the
+                  // 8 -- so the "no one matches" row never appeared and the
+                  // section rendered as blank space under its own heading.
+                  // An empty result has to say so.
                   hasQuery ? (
                     <SettingsRow
                       title={`No one matches "${trimmedQuery}"`}
@@ -1367,7 +1375,7 @@ export default function ConnectPageClient() {
                     />
                   )
                 ) : (
-                  sortedPeople.map((person) => {
+                  people.map((person) => {
                     const cta = relationshipCta(person.relationship);
                     const title =
                       person.displayName || person.email || person.userId;


### PR DESCRIPTION
## The bug

Typing one letter into Connect → People returned an empty list. Typing **N** showed no rows at all, while Nilesh and Nirmal existed in the directory and were reachable by nobody.

<img width="420" alt="empty People list under a live pager" src="https://github.com/user-attachments/assets/placeholder" />

Three independent defects had to line up to produce that screen.

### 1. The page was chosen by one rule and narrowed by another

The directory matched a **substring** (`LIKE '%n%'`), ordered A–Z across that whole set, then cut `LIMIT 8`. The client then kept only rows whose name **started with** the query.

So page 1 of "n" was the eight alphabetically-first names that merely *contain* an n — Anand, Ankit, Arun, Chandan… — and the client hid all eight. Nilesh and Nirmal sat several pages deeper in a result set no one could walk to.

Filtering after `LIMIT/OFFSET` can only subtract from a page that was already chosen wrongly. Dropping a row from a page of 8 does not promote a 9th to replace it, so no client-side rule could have fixed this.

### 2. The empty state counted a different list than the one it rendered

`people.length === 0` gated the "No one matches" row, while the rows came from a filtered copy. "Eight rows, all hidden" was indistinguishable from "eight rows", so the section rendered as blank space under its own heading — no rows, no message.

### 3. The pager described rows the reader could not see

`hasMore` came from the server's pre-filter page, so **Next** stayed lit and led to more blank pages.

## The fix

Matching, ranking and ordering now happen in one statement **ahead of `LIMIT`**, so paging walks one stable, fully-ranked list.

Two tiers:

| Tier | Matches | Example |
|---|---|---|
| 0 | the name starts with the query | "n" → Nilesh, Nirmal, Nolan |
| 1 | a later word starts with it | "rashid" → Abdul Rashid |

A–Z within each tier. Tier 0 always outranks tier 1, which is the difference from the earlier surname-matching attempt that was reverted for reading as random — those results were unranked and mixed in.

Names are trimmed and their separators folded to spaces first, so `" Nilesh"` is not demoted out of tier 0 by a leading space and `"Abdul R."` is still findable by its initial. LIKE metacharacters are escaped — a typed `%` was previously a wildcard over the entire directory.

The client renders that page unchanged. There is deliberately **no second derived list**: the original bug needed two lists to disagree with each other.

## Also fixed, found while proving the above

- **`_apply_kai_circle_recommendations` re-sorted by recommendation score after the SQL had ranked.** The client's own sort had been masking this. Removing that sort without this would have shipped a list ordered by score wearing alphabetical page breaks — i.e. the reported symptom, quieter. It now takes `preserve_order`, which the directory sets and the Location screen deliberately does not (that screen reads `recommendationRank`).
- **The page reset moved out of an effect.** It landed a render too late and fired two requests per keystroke for anyone who had paged — the discarded one free to resolve last and paint a page nobody asked for.
- **`query` is length-bounded**, matching the information-scope search beside it.
- **`test_connections_service.py` and `test_connections_route.py` were absent from the CI manifest**, so neither ran in the blocking Protocol lane. Added.
- **Two bulk-selection tests asserted a cap of 20 against code that says 5**, and one stopped before the confirmation dialog that now exists. Both were already red on `main`.

## Not in this PR

`actor_identity_cache` has no index on `display_name`, so directory search is a sequential scan. That is unchanged here — a substring `LIKE '%n%'` could never use an index either, so this is neutral-to-better, not a regression. A `text_pattern_ops` functional index is worth a follow-up.

Raw `email` and `photoUrl` are still projected as permanently `null` (the payload emits `maskedEmail`/`maskedPhone` by design). Search deliberately does **not** match on email: matching a value the directory refuses to return would allow prefix-probing for addresses.

## Verification

Full suites, branch vs `main` at the same base:

| Suite | `main` | this branch |
|---|---|---|
| `consent-protocol` `test-ci` | — | **901 passed, 0 failed** |
| `hushh-webapp` connect suite | 19 passed, **2 failed** | **25 passed, 0 failed** |

`tsc --noEmit` clean; `eslint --max-warnings=0` clean on the touched files.

**Every fix is mutation-checked** — each of these reverts fails a test that names the behaviour:

| Mutation | Caught by |
|---|---|
| `name_prefix` widened back to a substring | 6 tests |
| LIKE escaping removed | 4 tests |
| `preserve_order` ignored | `test_recommendations_preserve_order_only_when_asked` |
| client-side filter + sort restored | 2 tests |
| page reset back in an effect | `asks for page one once when the query changes while paged` |

New coverage: single-letter search, rendered A–Z order, empty-result state, LIKE metacharacters (`%`, `_`, `!`), separator folding, page-boundary continuity, and one-request-per-query-change.