### PR TITLE
fix(one-location): record the location grant where the fix is captured

### DIFF
--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -27,6 +27,7 @@ const navigation = vi.hoisted(() => ({
 const locationMemory = vi.hoisted(() => ({
   readLastKnownFix: vi.fn(),
   rememberLastKnownFix: vi.fn(),
+  rememberLocationGrant: vi.fn(),
 }));
 
 vi.mock("@/lib/one-location/service", () => ({
@@ -36,6 +37,7 @@ vi.mock("@/lib/one-location/service", () => ({
 vi.mock("@/lib/one-location/location-grant-memory", () => ({
   readLastKnownFix: locationMemory.readLastKnownFix,
   rememberLastKnownFix: locationMemory.rememberLastKnownFix,
+  rememberLocationGrant: locationMemory.rememberLocationGrant,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -65,6 +67,7 @@ describe("NearbyCheckInSheet", () => {
     navigation.push.mockReset();
     locationMemory.readLastKnownFix.mockReset();
     locationMemory.rememberLastKnownFix.mockReset();
+    locationMemory.rememberLocationGrant.mockReset();
     // Default: nothing carried over, which is what every pre-existing test in
     // this file assumed before durable memory existed.
     locationMemory.readLastKnownFix.mockResolvedValue(null);
@@ -1510,6 +1513,45 @@ describe("NearbyCheckInSheet", () => {
       expect(locationMemory.readLastKnownFix).toHaveBeenCalledWith(
         expect.objectContaining({ userId: "user-9" }),
       );
+    });
+
+    it("records the account's location grant, not just the position", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await screen.findByRole("radio", { name: /Stanford University/ });
+      // This drawer talks to the device directly and is often the first place
+      // an account ever produces a coordinate. A live UAT run proved the sealed
+      // fix was being written here while the grant was not, because the grant
+      // was only recorded by the bus, which this surface never attaches.
+      await waitFor(() => {
+        expect(locationMemory.rememberLocationGrant).toHaveBeenCalledWith("user-1");
+      });
+    });
+
+    it("records no grant when the device never produces a fix", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockRejectedValue(unavailable())}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await screen.findByTestId("nearby-location-fallback");
+      // A grant is a record that location genuinely worked for this account.
+      // A failed attempt is not that, and recording one would let the app claim
+      // a capability it has never actually observed.
+      expect(locationMemory.rememberLocationGrant).not.toHaveBeenCalled();
     });
 
     it("carries a successful fix forward for the next one", async () => {

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -38,6 +38,7 @@ import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-
 import {
   readLastKnownFix,
   rememberLastKnownFix,
+  rememberLocationGrant,
 } from "@/lib/one-location/location-grant-memory";
 import { locationBlockReason } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
@@ -786,6 +787,13 @@ export function NearbyCheckInSheet({
         // starting from nothing, which is what turns a failed first GPS read
         // from a dead end into a labelled fallback.
         void rememberLastKnownFix({ userId: ownerId, point: nextPoint });
+        // The grant belongs next to the fix, not to whichever surface happens
+        // to run key bootstrap. This drawer reaches the device directly and is
+        // routinely the FIRST place an account ever produces a coordinate, so
+        // omitting it here left the account's own record of "location works for
+        // me" empty on the surface most likely to prove it. Verified against
+        // live UAT: the sealed fix was written and the grant was not.
+        rememberLocationGrant(ownerId);
         setPointOrigin("fresh");
         setPoint(nextPoint);
         await loadPlaces(nextPoint, generation, expectedOwnerEpoch);


### PR DESCRIPTION
## How this was found

By driving the **real signed-in journey on live UAT**, not by trusting unit tests.

Using the repository's reviewer test identity and Playwright, I signed in to `https://uat.one.hushh.ai`, opened Nearby Check-In with a working device, and then inspected what the app had actually stored:

```
one_location_last_fix_v1:<uid>   724 bytes   ✅ written (sealed envelope)
one_location_grant_v1:<uid>                  ❌ never written
```

## The gap

The grant was only recorded by `LocationBus`, and the bus is attached inside `key-bootstrap`. But `app/one/location/check-in/page.tsx` never calls `bootstrapCurrentUserLocationRecipientKey`.

So the surface most likely to be the **first place an account ever produces a coordinate** was the one surface that never recorded that it had. The drawer wrote the sealed position directly (which is why the fix key existed) and skipped the grant entirely.

## The change

One call, next to the existing one: the grant is recorded where the fix is captured, not by whichever surface happens to run key bootstrap.

A failed capture still records nothing. A grant is a record that location genuinely *worked* for this account; a failed attempt is not that, and recording one would let the app claim a capability it has never observed.

## What is and is not affected

Nothing reads the grant yet — `hasRememberedLocationGrant` has no consumer in the app today. So this corrects the **record**, not a visible behaviour. The user-visible half (showing the carried-over position instead of "Still finding you") already works and is verified live; see below.

## Verification

Live, signed in, on UAT — one browser context, a genuine reload, and geolocation forced to fail with `POSITION_UNAVAILABLE` (code 2), which is what `kCLErrorLocationUnknown` surfaces as in a browser:

```
PASS  signed in                                              (vault_unlocked)
PASS  first visit lists places (device answering)
PASS  a position was saved for next time
PASS  device is refusing after reload                        (failed code=2)
PASS  THE FIX: no "Still finding you" after a failed reading
PASS  THE FIX: shows the carried-over position
PASS  THE FIX: states its age
7/7
```

The drawer rendered:

> Showing places around your last known position **from just now** — we couldn't refresh it just now. Pick where you actually are, or update your location.

Also confirmed live: the stored position is **724 bytes of ciphertext** with `envelope.metadata.plaintext === false`, and contains neither the latitude nor the longitude in readable form.

For this PR specifically:
- `npx tsc --noEmit` — clean
- 67 tests pass across the three affected files
- Both new tests **mutation-checked**: removing the one-line fix fails `records the account's location grant, not just the position`

## Rollback

Revert the commit. The storage key expires on its own and nothing reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)