### PR TITLE
Revamp One Location People UI across responsive themes

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1557,7 +1557,9 @@ describe("OneLocationAgentPage", () => {
       await screen.findByPlaceholderText("Search trusted people"),
       { target: { value: "Investor" } },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Share with Investor D/i }),
+    );
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
@@ -3511,27 +3513,29 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Your circles");
+    await switchLocationTab("People", "Circles");
 
     const search = await screen.findByPlaceholderText("Search trusted people");
     const person = await screen.findByText("Trusted B");
+    expect(screen.getByTestId("one-location-people-list")).toHaveClass(
+      "max-h-[50vh]",
+      "overflow-y-auto",
+      "overflow-x-hidden",
+    );
 
     // The search input used to be separated from its own results by four
     // buttons, which read as page search rather than list search. Nothing
     // focusable may sit between the field and the list it filters.
     expect(
-      search.compareDocumentPosition(person) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      search.compareDocumentPosition(person) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     const between = Array.from(
       document.querySelectorAll("button, a[href], input, textarea, select"),
     ).filter(
       (el) =>
         el !== search &&
-        search.compareDocumentPosition(el) &
-          Node.DOCUMENT_POSITION_FOLLOWING &&
-        person.compareDocumentPosition(el) &
-          Node.DOCUMENT_POSITION_PRECEDING,
+        search.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING &&
+        person.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_PRECEDING,
     );
     expect(between).toHaveLength(0);
 
@@ -3542,34 +3546,90 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     // The three that remain each carry a different weight, so the common one
     // reads as the default rather than one of four equal choices.
-    expect(screen.getByRole("button", { name: /Add people/i })).toBeTruthy();
+    const addPeople = screen.getByRole("button", { name: /Add people/i });
+    const syncContacts = screen.getByRole("button", {
+      name: /Sync contacts/i,
+    });
+    expect(addPeople).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Invite$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
+    expect(syncContacts).toBeTruthy();
+    expect(
+      syncContacts.compareDocumentPosition(search) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      person.compareDocumentPosition(addPeople) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Stop sharing with Trusted B/i,
+      }),
+    ).toBeTruthy();
   });
 
-  it("offers Create and Join with code straight under the circles heading", async () => {
+  it("keeps desktop People actions in the same visual and keyboard order", async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(min-width: 640px)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    try {
+      render(<OneLocationAgentPage />);
+      await skipLocationEntryFlow();
+      await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+      await switchLocationTab("People", "Circles");
+
+      const addPeople = screen.getByRole("button", { name: /Add people/i });
+      const search = await screen.findByPlaceholderText("Search trusted people");
+      const person = await screen.findByText("Trusted B");
+      const syncContacts = screen.getByRole("button", {
+        name: /Sync contacts/i,
+      });
+
+      expect(
+        addPeople.compareDocumentPosition(search) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(
+        person.compareDocumentPosition(syncContacts) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it("offers New circle and Join with code beside the circles heading", async () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Your circles");
+    await switchLocationTab("People", "Circles");
 
     const section = screen.getByTestId("one-location-named-circles");
     const heading = within(section).getByRole("heading", {
-      name: "Your circles",
+      name: "Circles",
     });
-    const create = within(section).getByRole("button", { name: /^Create$/i });
+    const create = within(section).getByRole("button", {
+      name: /^New circle$/i,
+    });
     const join = within(section).getByRole("button", {
       name: /Join with code/i,
     });
 
-    // Structural, not "somewhere after": the heading block is the section's
-    // first child and the actions are its second, so the pair cannot drift back
-    // below the circle list — where a long list stranded them past a scroll,
-    // exactly when someone had enough circles to need them.
+    // Structural, not "somewhere after": the compact heading row owns both
+    // actions, so a long circle list cannot strand them below the fold.
     expect(section.children[0]).toContainElement(heading);
-    expect(section.children[1]).toContainElement(create);
-    expect(section.children[1]).toContainElement(join);
+    expect(section.children[0]).toContainElement(create);
+    expect(section.children[0]).toContainElement(join);
   });
 
   it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
@@ -3671,16 +3731,12 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Your circles");
+    await switchLocationTab("People", "Circles");
     // Empty state keeps connection management and invite/sync/share actions.
     // Request-location affordances are populated-state-only, and the redundant
     // approval explainer must not add another card below these actions.
-    expect(
-      screen.getByRole("button", { name: /Add people/i }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: /^Invite$/i }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Add people/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Invite$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
     // "Share to contacts" is deliberately absent: it minted a PUBLIC link,
     // which is the Links tab's job, not a control belonging beside named

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -3589,17 +3589,21 @@ describe("OneLocationAgentPage", () => {
 
       const addPeople = screen.getByRole("button", { name: /Add people/i });
       const search = await screen.findByPlaceholderText("Search trusted people");
-      const person = await screen.findByText("Trusted B");
       const syncContacts = screen.getByRole("button", {
         name: /Sync contacts/i,
       });
+      const invite = screen.getByRole("button", { name: /^Invite$/i });
 
       expect(
-        addPeople.compareDocumentPosition(search) &
+        syncContacts.compareDocumentPosition(invite) &
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
       expect(
-        person.compareDocumentPosition(syncContacts) &
+        invite.compareDocumentPosition(addPeople) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(
+        addPeople.compareDocumentPosition(search) &
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
     } finally {

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -45,7 +45,7 @@ import {
   TaskFlowHeader,
   TrustNoteCard,
 } from "@/components/one-location/redesign/primitives";
-import { MUTED_TEXT, SECTION_TITLE } from "@/components/one-location/redesign/tokens";
+import { MUTED_TEXT } from "@/components/one-location/redesign/tokens";
 import type {
   OneLocationCircleDetail,
   OneLocationCircleEligibleConnection,
@@ -58,6 +58,12 @@ import type {
   OneLocationCircleSummary,
 } from "@/lib/one-location/types";
 import { cn } from "@/lib/utils";
+
+const CIRCLES_GROUP_SURFACE =
+  "[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-[var(--app-card-shadow-standard)]";
+
+const CIRCLES_EMPTY_STATE_WRAPPER =
+  "[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]";
 
 function circleInitials(value: string): string {
   return value
@@ -184,61 +190,58 @@ export function CirclesSection({
   };
 
   return (
-    <div className="space-y-3" data-testid="one-location-named-circles">
-      <div className="px-1">
-        <h2 className={SECTION_TITLE}>
-          Your circles
+    <div className="space-y-[14px]" data-testid="one-location-named-circles">
+      <div className="flex items-baseline justify-between gap-4">
+        <h2 className="text-[13px] font-normal leading-[18px] tracking-[-0.2px] text-[color:var(--app-section-label)]">
+          Circles
         </h2>
-        <p className={cn(MUTED_TEXT, "mt-1")}>
-          Family and friends you choose to group together.
-        </p>
-      </div>
 
-      {/* Directly under the heading rather than below the list: these two are
-          how the section is USED, and stranding them past a scrolling list of
-          circles hid them exactly when someone had enough circles to scroll.
-          Stacked on phones, natural width in a row once there is space — the
-          hub column is unbounded, so full-width pills would run the width of a
-          desktop window. */}
-      <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
-        <Button
-          type="button"
-          onClick={onCreate}
-          data-voice-control-id="one-location-action-create-circle"
-          className="h-11 w-full rounded-full font-semibold sm:w-auto sm:px-6"
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Create
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onJoin}
-          data-voice-control-id="one-location-action-join-circle"
-          className="h-11 w-full rounded-full font-semibold sm:w-auto sm:px-6"
-        >
-          <KeyRound className="mr-2 h-4 w-4" />
-          Join with code
-        </Button>
+        {/* The static phone reference omits Join, but it remains a shipped
+            action. Both controls keep their handlers and voice IDs while the
+            quiet treatment matches the reference hierarchy. */}
+        <div className="flex flex-wrap items-baseline justify-end gap-x-4 gap-y-2 sm:gap-x-6">
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            onClick={onCreate}
+            data-voice-control-id="one-location-action-create-circle"
+            className="relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]"
+          >
+            New circle
+          </Button>
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            onClick={onJoin}
+            data-voice-control-id="one-location-action-join-circle"
+            className="relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] text-[color:var(--app-secondary-label)] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] hover:text-foreground sm:text-[15px]"
+          >
+            Join with code
+          </Button>
+        </div>
       </div>
 
       {incomingInvitesError ? (
-        <EmptyState
-          title="Circle invitations unavailable"
-          description={incomingInvitesError}
-          action={
-            <Button
-              type="button"
-              variant="outline"
-              disabled={incomingInvitesLoading}
-              isLoading={incomingInvitesLoading}
-              onClick={onRetryInvites}
-              className="h-11 rounded-full px-5"
-            >
-              Retry
-            </Button>
-          }
-        />
+        <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
+          <EmptyState
+            title="Circle invitations unavailable"
+            description={incomingInvitesError}
+            action={
+              <Button
+                type="button"
+                variant="outline"
+                disabled={incomingInvitesLoading}
+                isLoading={incomingInvitesLoading}
+                onClick={onRetryInvites}
+                className="h-11 rounded-full px-5"
+              >
+                Retry
+              </Button>
+            }
+          />
+        </div>
       ) : null}
 
       {incomingInvitesLoading &&
@@ -246,7 +249,7 @@ export function CirclesSection({
       !incomingInvitesError ? (
         <div
           role="status"
-          className="flex min-h-16 items-center justify-center gap-2 rounded-2xl bg-muted/35 text-sm text-muted-foreground"
+          className="flex min-h-16 items-center justify-center gap-2 rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] text-sm text-[color:var(--app-secondary-label)] shadow-[var(--app-card-shadow-standard)]"
         >
           <Loader2 className="h-5 w-5 animate-spin" />
           Checking Circle invitations…
@@ -257,6 +260,7 @@ export function CirclesSection({
         <SettingsGroup
           title="Circle invitations"
           description="Join first. Sharing stays private."
+          shellClassName={CIRCLES_GROUP_SURFACE}
           testId="one-location-circle-member-invites"
         >
           {incomingInvites.map((invite) => {
@@ -317,38 +321,35 @@ export function CirclesSection({
       !focusedInvite &&
       !incomingInvitesLoading &&
       !incomingInvitesError ? (
-        <EmptyState
-          title="Circle invitation no longer available"
-          description="It may have expired, been cancelled or already been answered."
-          action={
-            <Button
-              type="button"
-              variant="outline"
-              onClick={onDismissFocusedInvite}
-              className="h-11 rounded-full px-5"
-            >
-              Dismiss
-            </Button>
-          }
-        />
+        <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
+          <EmptyState
+            title="Circle invitation no longer available"
+            description="It may have expired, been cancelled or already been answered."
+            action={
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onDismissFocusedInvite}
+                className="h-11 rounded-full px-5"
+              >
+                Dismiss
+              </Button>
+            }
+          />
+        </div>
       ) : null}
 
       {circles.length ? (
-        <SettingsGroup separatorInset testId="one-location-circle-list">
+        <SettingsGroup
+          separatorInset
+          shellClassName={CIRCLES_GROUP_SURFACE}
+          testId="one-location-circle-list"
+        >
           {circles.map((circle) => (
             <SettingsRow
               key={circle.id}
               leading={
-                <span
-                  className={cn(
-                    "flex h-10 w-10 items-center justify-center rounded-xl",
-                    circle.kind === "family"
-                      ? "bg-violet-500/12 text-violet-700 dark:text-violet-200"
-                      : circle.kind === "friends"
-                        ? "bg-sky-500/12 text-sky-700 dark:text-sky-200"
-                        : "bg-emerald-500/12 text-emerald-700 dark:text-emerald-200",
-                  )}
-                >
+                <span className="flex h-11 w-11 items-center justify-center rounded-[12px] bg-[color:var(--app-neutral-fill)] text-[color:var(--app-secondary-label)]">
                   <UsersRound className="h-5 w-5" />
                 </span>
               }
@@ -360,15 +361,23 @@ export function CirclesSection({
               trailing={circle.role === "owner" ? "Owner" : "Member"}
               chevron
               onClick={() => onOpen(circle.id)}
+              className={cn(
+                "[--settings-row-gap:16px] [--settings-row-px:20px] [--settings-row-py:20px] sm:[--settings-row-gap:18px] sm:[--settings-row-px:24px] sm:[--settings-row-py:22px]",
+                "[&>button]:min-h-[84px] sm:[&>button]:min-h-[92px]",
+                "[&_[data-slot=settings-row-title]]:!text-[18px] [&_[data-slot=settings-row-title]]:!font-semibold [&_[data-slot=settings-row-title]]:!leading-[22px] [&_[data-slot=settings-row-title]]:!tracking-[-0.35px] sm:[&_[data-slot=settings-row-title]]:!text-[19px] sm:[&_[data-slot=settings-row-title]]:!leading-6 sm:[&_[data-slot=settings-row-title]]:!tracking-[-0.4px]",
+                "[&_[data-slot=settings-row-description]]:!text-[14px] [&_[data-slot=settings-row-description]]:!leading-[18px] [&_[data-slot=settings-row-description]]:!tracking-[-0.2px] sm:[&_[data-slot=settings-row-description]]:!text-[15px] sm:[&_[data-slot=settings-row-description]]:!leading-5 sm:[&_[data-slot=settings-row-description]]:!tracking-[-0.24px]",
+              )}
               testId={`one-location-circle-${circle.id}`}
             />
           ))}
         </SettingsGroup>
       ) : (
-        <EmptyState
-          title="No circles yet"
-          description="Create one for family or friends, or join with a code."
-        />
+        <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
+          <EmptyState
+            title="No circles yet"
+            description="Create one for family or friends, or join with a code."
+          />
+        </div>
       )}
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1798,7 +1798,7 @@ function PeopleHub({
         <div className="space-y-10 sm:space-y-12">
           <section
             aria-labelledby="one-location-connections-heading"
-            className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-4 sm:gap-x-6"
+            className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-4 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:gap-x-6"
             data-testid="one-location-people-connections"
           >
             <h2
@@ -1807,6 +1807,12 @@ function PeopleHub({
             >
               Connections
             </h2>
+
+            {isDesktopPeopleLayout ? (
+              <div className="col-start-2 row-start-1 justify-self-end">
+                {syncContactsAction}
+              </div>
+            ) : null}
 
             {/* The reference omits Invite, but it remains a first-class action.
                 Keeping it quiet preserves the callback without recreating the
@@ -1819,13 +1825,13 @@ function PeopleHub({
               data-voice-control-id="one-location-action-invite"
               className={cn(
                 PEOPLE_HEADER_ACTION,
-                "col-start-2 row-start-1 justify-self-end text-[color:var(--app-secondary-label)] hover:text-foreground",
+                "col-start-2 row-start-1 justify-self-end text-[color:var(--app-secondary-label)] hover:text-foreground sm:col-start-3",
               )}
             >
               Invite
             </Button>
 
-            <div className="col-start-3 row-start-1 justify-self-end">
+            <div className="col-start-3 row-start-1 justify-self-end sm:col-start-4">
               {isDesktopPeopleLayout
                 ? addPeopleAction
                 : syncContactsAction}
@@ -1833,7 +1839,7 @@ function PeopleHub({
 
             <div
               className={cn(
-                "col-span-3 row-start-2 mt-3 sm:mt-3.5",
+                "col-span-3 row-start-2 mt-3 sm:col-span-4 sm:mt-3.5",
                 "[&_input]:h-[46px] [&_input]:rounded-full [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[17px] [&_input]:leading-[22px] [&_input]:tracking-[-0.3px]",
                 "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
                 "sm:[&_input]:h-12 sm:[&_input]:rounded-[var(--app-radius-md)] sm:[&_input]:pl-12 sm:[&_input]:pr-5 sm:[&_input]:text-base sm:[&_svg]:left-5",
@@ -1846,7 +1852,7 @@ function PeopleHub({
               />
             </div>
 
-            <div className="col-span-3 row-start-3 mt-3 sm:mt-3.5">
+            <div className="col-span-3 row-start-3 mt-3 sm:col-span-4 sm:mt-3.5">
               {filtered.length ? (
                 <div
                   className={PEOPLE_GROUP_SURFACE}
@@ -1912,16 +1918,11 @@ function PeopleHub({
               )}
             </div>
 
-            <div
-              className={cn(
-                "col-span-3 col-start-1 row-start-4 mt-6",
-                isDesktopPeopleLayout ? "justify-self-center" : "w-full",
-              )}
-            >
-              {isDesktopPeopleLayout
-                ? syncContactsAction
-                : addPeopleAction}
-            </div>
+            {!isDesktopPeopleLayout ? (
+              <div className="col-span-3 col-start-1 row-start-4 mt-6 w-full">
+                {addPeopleAction}
+              </div>
+            ) : null}
           </section>
 
           {vm.requestedByMe.length ? (

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -82,7 +82,7 @@ import {
   TrustNoteCard,
   WarningCard,
 } from "./primitives";
-import { MUTED_TEXT, SECTION_TITLE, SUBCARD_SURFACE } from "./tokens";
+import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
 import {
   initialsFrom,
   RequestCard,
@@ -127,6 +127,7 @@ import type {
 } from "@/lib/one-location/emergency-numbers";
 import { ONE_LOCATION_SHARE_NOTE_MAX_LENGTH } from "@/lib/one-location/message-limits";
 import { CIRCLE_JOIN_CODE_PARAM } from "@/lib/one-location/circle-join-url";
+import { useMediaQuery } from "@/lib/morphy-ux/use-media-query";
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
@@ -1136,19 +1137,13 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   );
 }
 
-/**
- * People-tab action row: stacked on phones, an inline row from `sm` up.
- *
- * The hub column is unbounded, so `w-full` buttons grew to the width of a
- * desktop window — three pills spanning 1200px read as bulk, not as choices.
- * From `sm` they size to their own label and sit left-aligned, which is also
- * what keeps the iOS build from looking like a stack of banners on iPad.
- * `flex-wrap` means a long localized label moves to the next line instead of
- * squeezing its neighbours.
- */
-const PEOPLE_ACTION_ROW = "flex flex-col gap-2.5 sm:flex-row sm:flex-wrap";
-/** Full-bleed thumb target on phones; natural width once there is room. */
-const PEOPLE_ACTION_BUTTON = "h-11 w-full font-medium sm:w-auto sm:px-5";
+/** Quiet text actions used by the reference-style People section headers. */
+const PEOPLE_HEADER_ACTION =
+  "relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]";
+
+/** People-only grouped surface: compact geometry, shared semantic theme. */
+const PEOPLE_GROUP_SURFACE =
+  "max-h-[50vh] overflow-y-auto overflow-x-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)]";
 
 function LocationHubPanel({ children }: { children: ReactNode }) {
   return (
@@ -1701,25 +1696,23 @@ function PersonRow({
   return (
     <div
       className={cn(
-        "flex min-h-[60px] items-center gap-3 p-3.5",
+        "flex min-h-[74px] items-center gap-3.5 px-[18px] py-2 transition-colors hover:bg-[color:var(--app-neutral-fill)] motion-reduce:transition-none sm:min-h-[76px] sm:gap-[18px] sm:px-6",
         !first && "border-t border-[color:var(--app-separator)]",
       )}
     >
       <div className="relative shrink-0">
-        <span
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--app-accent-surface)] text-[14px] font-semibold text-[color:var(--app-accent-deep)]"
-        >
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--app-accent-surface)] text-[14px] font-semibold text-[color:var(--app-accent-deep)]">
           {personInitials(name)}
         </span>
         {active ? (
-          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-white bg-[color:var(--app-success)] dark:border-[color:var(--app-card-surface-default-solid)]" />
+          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]" />
         ) : null}
       </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[17px] font-normal leading-[22px] text-foreground">
+      <div className="min-w-0 flex-1 sm:flex sm:items-baseline sm:gap-3">
+        <p className="truncate text-[17px] font-normal leading-[22px] tracking-[-0.37px] text-foreground">
           {name}
         </p>
-        <p className="truncate text-[15px] leading-5 text-muted-foreground">
+        <p className="truncate text-[14px] leading-[18px] tracking-[-0.22px] text-[color:var(--app-tertiary-label)]">
           {subtitle}
         </p>
       </div>
@@ -1751,16 +1744,38 @@ function PeopleHub({
 }) {
   const hasSearch = vm.recipientSearch.trim().length > 0;
   const filtered = vm.visibleRecipients;
-  // Show the people list whenever there's anyone to show — this includes
-  // contact-sync matches (which live in visibleRecipients, not `recipients`) —
-  // or while a search is active. Otherwise fall back to the invite-first empty
-  // state. (Gating on `recipients` alone hid freshly-synced contact matches.)
-  const showPeopleList = filtered.length > 0 || hasSearch;
+  const isDesktopPeopleLayout = useMediaQuery("(min-width: 640px)");
+  const addPeopleAction = (
+    <Button
+      type="button"
+      onClick={onAddConnections}
+      data-voice-control-id="one-location-add-connections"
+      className={cn(
+        "rounded-full font-semibold",
+        isDesktopPeopleLayout
+          ? "h-10 min-h-10 px-[22px] text-[15px]"
+          : "h-[54px] min-h-[54px] w-full px-6 text-[16px]",
+      )}
+    >
+      Add people
+    </Button>
+  );
+  const syncContactsAction = (
+    <Button
+      type="button"
+      variant="link"
+      size="sm"
+      onClick={vm.onSyncContacts}
+      isLoading={vm.busy === "contactSync"}
+      className={PEOPLE_HEADER_ACTION}
+    >
+      Sync contacts
+    </Button>
+  );
 
-  // No one to show yet: keep the invite-first empty state.
-  if (!showPeopleList) {
-    return (
-      <div className="space-y-5">
+  return (
+    <div className="pt-6 sm:pt-[52px]" data-testid="one-location-people-hub">
+      <div className="space-y-10 sm:space-y-[72px]">
         <CirclesSection
           circles={vm.circles}
           incomingInvites={vm.incomingCircleMemberInvites}
@@ -1780,191 +1795,160 @@ function PeopleHub({
           onDismissFocusedInvite={onDismissFocusedInvite}
         />
 
-        <SectionCard
-          title="Connections"
-          description="People ready for sharing."
-        >
-          {/* Identical set, order and weights to the populated tab, so the
-              screen does not rearrange itself the moment a first connection
-              lands. */}
-          <div className={PEOPLE_ACTION_ROW}>
-            <Button
-              onClick={onAddConnections}
-              data-voice-control-id="one-location-add-connections"
-              className={PEOPLE_ACTION_BUTTON}
+        <div className="space-y-10 sm:space-y-12">
+          <section
+            aria-labelledby="one-location-connections-heading"
+            className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-4 sm:gap-x-6"
+            data-testid="one-location-people-connections"
+          >
+            <h2
+              id="one-location-connections-heading"
+              className="col-start-1 row-start-1 text-[13px] font-normal leading-[18px] tracking-[-0.2px] text-[color:var(--app-section-label)]"
             >
-              <UsersRound className="mr-2 h-4 w-4" />
-              Add people
-            </Button>
+              Connections
+            </h2>
+
+            {/* The reference omits Invite, but it remains a first-class action.
+                Keeping it quiet preserves the callback without recreating the
+                old banner-like action stack. */}
             <Button
-              variant="outline"
+              type="button"
+              variant="link"
+              size="sm"
               onClick={onInvite}
               data-voice-control-id="one-location-action-invite"
               className={cn(
-                PEOPLE_ACTION_BUTTON,
-                "border-[color:var(--app-accent)] text-[color:var(--app-accent)]",
+                PEOPLE_HEADER_ACTION,
+                "col-start-2 row-start-1 justify-self-end text-[color:var(--app-secondary-label)] hover:text-foreground",
               )}
             >
-              <UserPlus className="mr-2 h-4 w-4" />
               Invite
             </Button>
-            <Button
-              variant="ghost"
-              onClick={vm.onSyncContacts}
-              isLoading={vm.busy === "contactSync"}
+
+            <div className="col-start-3 row-start-1 justify-self-end">
+              {isDesktopPeopleLayout
+                ? addPeopleAction
+                : syncContactsAction}
+            </div>
+
+            <div
               className={cn(
-                PEOPLE_ACTION_BUTTON,
-                "text-[color:var(--app-accent)] hover:text-[color:var(--app-accent)]",
+                "col-span-3 row-start-2 mt-3 sm:mt-3.5",
+                "[&_input]:h-[46px] [&_input]:rounded-full [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[17px] [&_input]:leading-[22px] [&_input]:tracking-[-0.3px]",
+                "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
+                "sm:[&_input]:h-12 sm:[&_input]:rounded-[var(--app-radius-md)] sm:[&_input]:pl-12 sm:[&_input]:pr-5 sm:[&_input]:text-base sm:[&_svg]:left-5",
+              )}
+              data-testid="one-location-people-search"
+            >
+              <PersonSearchInput
+                value={vm.recipientSearch}
+                onChange={vm.setRecipientSearch}
+              />
+            </div>
+
+            <div className="col-span-3 row-start-3 mt-3 sm:mt-3.5">
+              {filtered.length ? (
+                <div
+                  className={PEOPLE_GROUP_SURFACE}
+                  data-testid="one-location-people-list"
+                >
+                  {filtered.map((r, i) => {
+                    const grant = vm.activeOwnerGrants.find(
+                      (g) => g.recipientUserId === r.userId,
+                    );
+                    const sharing = Boolean(grant);
+                    const receiving = vm.receivedGrants.some(
+                      (g) => g.ownerUserId === r.userId,
+                    );
+                    const ready = vm.isRecipientShareReady(r);
+                    const name = vm.recipientLabel(r);
+                    return (
+                      <PersonRow
+                        key={r.userId}
+                        name={name}
+                        subtitle={vm.recipientSubtitle(r)}
+                        active={sharing || receiving}
+                        first={i === 0}
+                        action={
+                          sharing && grant ? (
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() => vm.onStopGrant(grant.id)}
+                              isLoading={vm.revokingGrantId === grant.id}
+                              aria-label={`Stop sharing with ${name}`}
+                              className="relative h-9 min-h-9 rounded-full px-4 text-[15px] font-semibold after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] sm:px-5"
+                            >
+                              Stop
+                            </Button>
+                          ) : ready ? (
+                            <Button
+                              size="sm"
+                              onClick={() => onStartShare(r.userId)}
+                              aria-label={`Share with ${name}`}
+                              className="relative h-9 min-h-9 rounded-full bg-[color:var(--app-accent)] px-4 text-[15px] font-semibold text-[color:var(--app-accent-fg)] after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] hover:bg-[color:var(--app-accent-hover)] sm:px-5"
+                            >
+                              Share
+                            </Button>
+                          ) : null
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]">
+                  <EmptyState
+                    title={
+                      hasSearch ? "No matching people" : "No connections yet"
+                    }
+                    description={
+                      hasSearch
+                        ? "Try a different name."
+                        : "Add people or send an invite to start sharing."
+                    }
+                  />
+                </div>
+              )}
+            </div>
+
+            <div
+              className={cn(
+                "col-span-3 col-start-1 row-start-4 mt-6",
+                isDesktopPeopleLayout ? "justify-self-center" : "w-full",
               )}
             >
-              Sync contacts
-            </Button>
-          </div>
-        </SectionCard>
-      </div>
-    );
-  }
+              {isDesktopPeopleLayout
+                ? syncContactsAction
+                : addPeopleAction}
+            </div>
+          </section>
 
-  return (
-    <div className="space-y-4">
-      <CirclesSection
-        circles={vm.circles}
-        incomingInvites={vm.incomingCircleMemberInvites}
-        incomingInvitesLoading={vm.incomingCircleMemberInvitesLoading}
-        incomingInvitesError={vm.incomingCircleMemberInvitesError}
-        focusedInviteId={focusedInviteId}
-        focusedInviteResolutionReady={
-          vm.incomingCircleMemberInviteFocusResolved
-        }
-        inviteBusy={vm.busy === "circleMemberInvite"}
-        onCreate={onCreateCircle}
-        onJoin={onJoinCircle}
-        onOpen={onOpenCircle}
-        onAcceptInvite={vm.onAcceptNamedCircleMemberInvite}
-        onDeclineInvite={vm.onDeclineNamedCircleMemberInvite}
-        onRetryInvites={vm.onRetryNamedCircleMemberInvites}
-        onDismissFocusedInvite={onDismissFocusedInvite}
-      />
-
-      {/* Three actions, one weight each — filled, outlined, quiet — so the
-          common one is obvious and the rest do not compete. "Share to contacts"
-          used to sit here as a fourth; it minted a PUBLIC link, the same
-          artifact the Links tab creates and viewable by anyone holding the URL,
-          which is the opposite of what every other control on a tab about
-          named, trusted people does. Links owns it. */}
-      <div className={PEOPLE_ACTION_ROW}>
-        <Button
-          onClick={onAddConnections}
-          data-voice-control-id="one-location-add-connections"
-          className={PEOPLE_ACTION_BUTTON}
-        >
-          <UsersRound className="mr-2 h-4 w-4" />
-          Add people
-        </Button>
-        <Button
-          variant="outline"
-          onClick={onInvite}
-          data-voice-control-id="one-location-action-invite"
-          className={cn(
-            PEOPLE_ACTION_BUTTON,
-            "border-[color:var(--app-accent)] text-[color:var(--app-accent)]",
-          )}
-        >
-          <UserPlus className="mr-2 h-4 w-4" />
-          Invite
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={vm.onSyncContacts}
-          isLoading={vm.busy === "contactSync"}
-          className={cn(
-            PEOPLE_ACTION_BUTTON,
-            "text-[color:var(--app-accent)] hover:text-[color:var(--app-accent)]",
-          )}
-        >
-          Sync contacts
-        </Button>
-      </div>
-
-      {/* Search now sits directly on top of the list it filters. It used to be
-          separated from its own results by four buttons, which read as page
-          search rather than list search. */}
-      <div className="space-y-3">
-        <h2 className={cn(SECTION_TITLE, "px-1")}>Connections</h2>
-
-        <PersonSearchInput
-          value={vm.recipientSearch}
-          onChange={vm.setRecipientSearch}
-        />
-
-        {filtered.length ? (
-          <div className={cn("max-h-[50vh] overflow-y-auto overflow-x-hidden", SUBCARD_SURFACE)}>
-            {filtered.map((r, i) => {
-              const grant = vm.activeOwnerGrants.find(
-                (g) => g.recipientUserId === r.userId,
-              );
-              const sharing = Boolean(grant);
-              const receiving = vm.receivedGrants.some(
-                (g) => g.ownerUserId === r.userId,
-              );
-              const ready = vm.isRecipientShareReady(r);
-              return (
-                <PersonRow
-                  key={r.userId}
-                  name={vm.recipientLabel(r)}
-                  subtitle={vm.recipientSubtitle(r)}
-                  active={sharing || receiving}
-                  first={i === 0}
-                  action={
-                    sharing && grant ? (
-                      <Button
-                        variant="outline"
-                        onClick={() => vm.onStopGrant(grant.id)}
-                        isLoading={vm.revokingGrantId === grant.id}
-                        className="h-9 rounded-full border-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent)]"
-                      >
-                        Stop
-                      </Button>
-                    ) : ready ? (
-                      <Button
-                        onClick={() => onStartShare(r.userId)}
-                        className="h-9 rounded-full bg-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-                      >
-                        Share
-                      </Button>
-                    ) : null
+          {vm.requestedByMe.length ? (
+            <SettingsGroup
+              title="Requests sent"
+              separatorInset
+              shellClassName="[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-[var(--app-card-shadow-standard)]"
+            >
+              {vm.requestedByMe.map((request) => (
+                <SettingsRow
+                  key={request.id}
+                  icon={Send}
+                  iconTone="blue"
+                  title={vm.requestOwnerLabel(request)}
+                  description={vm.formatDateTime(request.requestedAt)}
+                  trailing={
+                    /active|approved|shared|granted/i.test(request.status)
+                      ? "Active"
+                      : "Pending"
                   }
+                  density="compact"
                 />
-              );
-            })}
-          </div>
-        ) : (
-          <EmptyState
-            title="No matching people"
-            description="Try a different name."
-          />
-        )}
+              ))}
+            </SettingsGroup>
+          ) : null}
+        </div>
       </div>
-
-      {vm.requestedByMe.length ? (
-        <SettingsGroup title="Requests sent" separatorInset>
-          {vm.requestedByMe.map((request) => (
-            <SettingsRow
-              key={request.id}
-              icon={Send}
-              iconTone="blue"
-              title={vm.requestOwnerLabel(request)}
-              description={vm.formatDateTime(request.requestedAt)}
-              trailing={
-                /active|approved|shared|granted/i.test(request.status)
-                  ? "Active"
-                  : "Pending"
-              }
-              density="compact"
-            />
-          ))}
-        </SettingsGroup>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- revamp only One Location → People to match the supplied mobile and desktop references
- add responsive mobile/desktop hierarchy, compact circles and connection rows, and semantic light/dark surfaces
- preserve every existing action, handler, voice control ID, loading/error/empty state, and list scroll boundary
- improve repeated Share/Stop accessible names and add responsive ordering coverage

## Validation
- scoped ESLint: passed
- TypeScript typecheck: passed
- focused People test suite: 66/66 passed
- design-system, accent-token, and Apple-hierarchy checks: passed
- DCO signoff: passed
- gitleaks: passed
- final regression review: no P0/P1 findings

## Local environment note
The repo-wide Windows CI wrapper exits after its successful secret scan because its inline Python stage is not Windows-safe. The changed-surface checks above pass on the latest main. Authenticated reviewer visual proof was not run because reviewer credentials were unavailable; no secrets were fetched or persisted.