### PR TITLE
ui(one-location): refine Check in surface

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -1181,6 +1181,66 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(navigationHarness.push).not.toHaveBeenCalled();
   });
 
+  it("keeps the dedicated Check in header controls and active-share meaning", async () => {
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "source=map";
+    serviceHarness.getState.mockResolvedValue({
+      recipients: [],
+      ownerGrants: [
+        {
+          id: "active-location-share",
+          ownerUserId: "test-user",
+          recipientUserId: "trusted-person",
+          recipientKeyId: "trusted-person-key",
+          status: "active",
+          consentScope: "location",
+          capabilityScopes: ["location.read"],
+          durationHours: 1,
+        },
+      ],
+    });
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to Your Map" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    const header = screen.getByRole("banner", {
+      name: "Check in map controls",
+    });
+    expect(header).toContainElement(
+      screen.getByTestId("one-location-map-close"),
+    );
+    expect(screen.getByTestId("one-location-map-close")).toHaveAccessibleName(
+      "Back to Location",
+    );
+    expect(
+      screen.getByTestId("one-location-map-nearby-check-in"),
+    ).toHaveAccessibleName("Check in nearby");
+    expect(screen.getByTestId("one-location-map-locate")).toHaveAccessibleName(
+      "Show my location",
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("one-location-map-sharing-status"),
+      ).toHaveTextContent("Sharing with 1");
+    });
+    expect(
+      screen.getByTestId("one-location-map-sharing-status"),
+    ).toHaveAttribute("role", "status");
+    expect(
+      screen.getByTestId("one-location-map-sharing-status"),
+    ).toHaveAccessibleName("You are sharing your location with 1 person");
+  });
+
   it("does not build a synthetic history boundary on the check-in route", async () => {
     // The sheet used to have no URL of its own, so it faked a history entry to
     // make Back close it. A real route already is one; re-creating the boundary

--- a/hushh-webapp/__tests__/navigation/location-map-route-layout.test.ts
+++ b/hushh-webapp/__tests__/navigation/location-map-route-layout.test.ts
@@ -13,4 +13,13 @@ describe("Location Your Map route contract", () => {
     });
     expect(resolveTopShellTabSet(ROUTES.ONE_LOCATION_MAP)).toBeNull();
   });
+
+  it("keeps Check in immersive so its map controls stay the single header", () => {
+    expect(resolveAppRouteLayout(ROUTES.ONE_LOCATION_CHECK_IN)).toMatchObject({
+      mode: "hidden",
+      persistentChrome: "none",
+      interactionLayerPolicy: { allowedFamilies: [] },
+    });
+    expect(resolveTopShellTabSet(ROUTES.ONE_LOCATION_CHECK_IN)).toBeNull();
+  });
 });

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -337,7 +337,7 @@ export function LocationImmersiveMap({
   const initialDemoMode = isLocationMapDemoEnabled(searchParams.get("demo"));
   const mapElement = useRef<HTMLElement | null>(null);
   const mapRef = useRef<GoogleMap | null>(null);
-  const topControlsRef = useRef<HTMLDivElement | null>(null);
+  const topControlsRef = useRef<HTMLElement | null>(null);
   const peopleTrayRef = useRef<HTMLElement | null>(null);
   const markerIdsRef = useRef<string[]>([]);
   const markerGenerationRef = useRef(0);
@@ -1849,8 +1849,11 @@ export function LocationImmersiveMap({
           closing ? "pointer-events-none" : ""
         }`}
       />
-      <div
+      <header
         ref={topControlsRef}
+        aria-label={
+          isCheckInSurface ? "Check in map controls" : "Location map controls"
+        }
         // z-30 (above the z-20 map loading/error overlay and people tray): at
         // equal z-index the later-in-DOM full-screen overlay painted on top of
         // the close X and could swallow the tap that dismisses the map. Keeping
@@ -1902,6 +1905,8 @@ export function LocationImmersiveMap({
             aria-label={`You are sharing your location with ${activeShareCount} ${
               activeShareCount === 1 ? "person" : "people"
             }`}
+            role="status"
+            aria-live="polite"
             className="pointer-events-none hidden min-w-0 shrink items-center gap-1.5 truncate rounded-full border border-[var(--app-accent-border)] bg-background/85 px-3 py-1.5 text-[12px] font-semibold text-[var(--app-accent-deep)] shadow-lg backdrop-blur-md md:flex dark:text-[var(--app-accent-bright)]"
           >
             <span
@@ -1932,7 +1937,7 @@ export function LocationImmersiveMap({
             )}
           </ShellActionSurface>
         ) : null}
-      </div>
+      </header>
       {/*
         Two pins on one map need naming, or the owner cannot tell which is
         "me" and which is "the place I'm checking in to" -- and those are

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -137,6 +137,71 @@ describe("NearbyCheckInSheet", () => {
     });
   });
 
+  it("uses the compact Check in header and a count-aware place expansion", async () => {
+    service.nearbyPlaces.mockResolvedValue([
+      {
+        placeId: "long-name-cafe",
+        text: "An exceptionally long nearby cafe name that should stay on one line",
+        name: "An exceptionally long nearby cafe name that should stay on one line",
+        address: "1 Main Street",
+        category: "Cafe",
+        distanceMeters: 42,
+        latitude: 37.4276,
+        longitude: -122.1697,
+      },
+      {
+        placeId: "place-two",
+        text: "Place Two",
+        distanceMeters: 80,
+        latitude: 37.4277,
+        longitude: -122.1698,
+      },
+      {
+        placeId: "place-three",
+        text: "Place Three",
+        distanceMeters: 110,
+        latitude: 37.4278,
+        longitude: -122.1699,
+      },
+      {
+        placeId: "place-four",
+        text: "Place Four",
+        distanceMeters: 140,
+        latitude: 37.4279,
+        longitude: -122.17,
+      },
+    ]);
+
+    render(
+      <NearbyCheckInSheet
+        open
+        ownerId="user-1"
+        vaultOwnerToken="owner-token"
+        captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Check in" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a real place within 500 m of your current location."),
+    ).not.toBeInTheDocument();
+
+    const longName = await screen.findByText(
+      "An exceptionally long nearby cafe name that should stay on one line",
+    );
+    expect(longName).toHaveClass("truncate");
+    expect(
+      screen.getByRole("button", { name: "Show all 4 places" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all 4 places" }));
+    expect(await screen.findByRole("radio", { name: /Place Four/ })).toBeInTheDocument();
+  });
+
   it("captures a fresh point, preselects the nearest place, and keeps consent explicit", async () => {
     const confirmationPoint = {
       ...point,
@@ -1348,7 +1413,7 @@ describe("NearbyCheckInSheet", () => {
     // The mall sits at 920 m and is dropped by the 500 m bound before this.
     expect(empty).toHaveTextContent("2 other places are nearby.");
 
-    fireEvent.click(screen.getByRole("button", { name: "Show all places" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show all 2 places" }));
     expect(
       await screen.findByRole("radio", { name: /Stanford University/ }),
     ).toBeInTheDocument();

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -27,7 +27,6 @@ import { Input } from "@/components/ui/input";
 import {
   Sheet,
   SheetContent,
-  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -1484,22 +1483,12 @@ export function NearbyCheckInSheet({
         data-testid="one-location-nearby-check-in-sheet"
         data-one-location-nearby-check-in-sheet=""
       >
-        <SheetHeader className="border-b border-border/60 px-5 pb-4 text-left">
-          <div className="flex items-center gap-2 pr-10">
-            <span className="grid h-9 w-9 place-items-center rounded-full bg-[var(--app-accent-surface-strong)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]">
-              <UsersRound className="h-4 w-4" />
+        <SheetHeader className="gap-0 border-b border-border/60 px-5 py-4 text-left">
+          <div className="flex min-h-9 items-center gap-2 pr-10">
+            <SheetTitle className="text-[17px] leading-6">Check in</SheetTitle>
+            <span className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+              Preview
             </span>
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <SheetTitle>Check in nearby</SheetTitle>
-                <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
-                  Preview
-                </span>
-              </div>
-              <SheetDescription>
-                Choose a real place within 500 m of your current location.
-              </SheetDescription>
-            </div>
           </div>
         </SheetHeader>
 
@@ -1837,6 +1826,7 @@ export function NearbyCheckInSheet({
                             ),
                           ),
                         );
+                        const metadataLabel = metadata.join(" · ");
                         return (
                           <button
                             key={place.placeId}
@@ -1853,12 +1843,18 @@ export function NearbyCheckInSheet({
                           >
                             <MapPin className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
                             <span className="min-w-0 flex-1">
-                              <span className="block break-words text-sm font-semibold leading-5">
+                              <span
+                                title={name}
+                                className="block truncate text-sm font-semibold leading-5"
+                              >
                                 {name}
                               </span>
                               {metadata.length ? (
-                                <span className="mt-0.5 block break-words text-xs leading-4 text-muted-foreground">
-                                  {metadata.join(" · ")}
+                                <span
+                                  title={metadataLabel}
+                                  className="mt-0.5 block truncate text-xs leading-4 text-muted-foreground"
+                                >
+                                  {metadataLabel}
                                 </span>
                               ) : null}
                             </span>
@@ -1880,7 +1876,7 @@ export function NearbyCheckInSheet({
                             className="w-full text-muted-foreground"
                             onClick={() => setVisiblePlacesCount(places.length)}
                           >
-                            Show all places
+                            Show all {places.length} places
                           </Button>
                         </div>
                       ) : null}
@@ -1924,7 +1920,7 @@ export function NearbyCheckInSheet({
                           className="mt-3"
                           onClick={() => selectCategory("all")}
                         >
-                          Show all places
+                          Show all {automaticPlaces.length} places
                         </Button>
                       </div>
                     ) : null}


### PR DESCRIPTION
## Summary
- Compact the nearby Check in sheet header to `Check in` with its existing Preview badge.
- Keep place rows calm and scannable with one-line truncation and full-value hover titles.
- Make the existing expansion affordance count-aware (for example, `Show all 80 places`).
- Preserve the single immersive map header and add semantics for its existing close, Check in, sharing, and locate controls.

## Contract and scope
- Frontend presentation only: no API, service, schema, persistence, consent, cache, or native-map lifecycle changes.
- `/one/location/check-in` remains an immersive route with no duplicate global chrome.
- Existing close/back, sheet dismissal/reopen, active-share count, locate busy state, 500 m picker, duration choices, recovery state, and Check in CTA handlers remain unchanged.

## Verification
- Focused Check in/map/route suite: 66 passed.
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run verify:design-system`, `npm run verify:service-boundary`, `npm run verify:surface-map`, and `npm run verify:capacitor:static` passed.
- The full local PR mirror also ran; its broad `web-full` stage currently reports failures in 30 unrelated existing test files outside this diff. The focused changed-surface suite is green.

## Rollback
Revert `bf7788ebf`.