### PR TITLE
fix(one-location): give a blocked location permission a way out (and stop the nearby-presence 429s)

### DIFF
--- a/hushh-webapp/components/one-location/__tests__/location-permission-recovery-card.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/location-permission-recovery-card.test.tsx
@@ -1,0 +1,176 @@
+// The card that replaces a dead end.
+//
+// Before it, a blocked browser permission produced a toast reading "Allow
+// location permission before sharing" plus an "Open Location Settings" button
+// that resolves `{ opened: false }` on the web. The toast then vanished, and
+// the Location screen was left saying "blocked" with nothing to act on.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const platform = vi.hoisted(() => ({
+  isNative: vi.fn(() => false),
+  getPlatform: vi.fn(() => "web"),
+}));
+
+const service = vi.hoisted(() => ({
+  getPermissionState: vi.fn(),
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: platform.isNative,
+  getPlatform: platform.getPlatform,
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: service,
+}));
+
+import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
+
+const CHROME_MAC =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36";
+
+function setUserAgent(value: string) {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  platform.isNative.mockReturnValue(false);
+  platform.getPlatform.mockReturnValue("web");
+  service.getPermissionState.mockResolvedValue({ state: "denied" });
+  setUserAgent(CHROME_MAC);
+  // Not implemented in jsdom; the Safari path (query rejects) is the default.
+  Object.defineProperty(navigator, "permissions", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("when location is not blocked", () => {
+  it("renders nothing at all", () => {
+    render(
+      <LocationPermissionRecoveryCard blocked={false} onRetry={vi.fn()} />,
+    );
+    // Someone whose location works must never be told it is blocked.
+    expect(
+      screen.queryByTestId("location-permission-recovery"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("when the browser is blocking location", () => {
+  it("names the browser doing the blocking", () => {
+    render(<LocationPermissionRecoveryCard blocked onRetry={vi.fn()} />);
+    // "Something went wrong" leaves the person guessing. Naming Chrome is what
+    // turns this into a ten-second fix.
+    expect(screen.getByText(/chrome is blocking location/i)).toBeInTheDocument();
+  });
+
+  it("gives the actual click path, not just 'allow location'", () => {
+    render(<LocationPermissionRecoveryCard blocked onRetry={vi.fn()} />);
+    const steps = screen.getByTestId("location-permission-recovery-steps");
+    expect(steps).toHaveTextContent(/left of the web address/i);
+    expect(steps).toHaveTextContent(/turn location on/i);
+  });
+
+  it("promises the page will notice by itself", () => {
+    render(<LocationPermissionRecoveryCard blocked onRetry={vi.fn()} />);
+    expect(
+      screen.getByTestId("location-permission-recovery-steps"),
+    ).toHaveTextContent(/turns on by itself/i);
+  });
+
+  it("offers no Settings button on the web", () => {
+    // `openLocationSettings()` is a hard-coded no-op in a browser. A button
+    // that does nothing is worse than no button.
+    render(
+      <LocationPermissionRecoveryCard
+        blocked
+        onRetry={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /open settings/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /check again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers Settings inside the native app, where it genuinely opens", () => {
+    platform.isNative.mockReturnValue(true);
+    platform.getPlatform.mockReturnValue("ios");
+    render(
+      <LocationPermissionRecoveryCard
+        blocked
+        onRetry={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /open settings/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/iphone settings is blocking/i)).toBeInTheDocument();
+  });
+});
+
+describe("healing itself", () => {
+  it("retries on its own once permission becomes granted", async () => {
+    const onRetry = vi.fn();
+    service.getPermissionState.mockResolvedValue({ state: "granted" });
+
+    render(<LocationPermissionRecoveryCard blocked onRetry={onRetry} />);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // The person fixed it in browser settings and came back. Asking them to
+    // press a button as well would be one instruction too many.
+    await waitFor(() => expect(onRetry).toHaveBeenCalled());
+  });
+
+  it("does not retry while permission is still refused", async () => {
+    const onRetry = vi.fn();
+    service.getPermissionState.mockResolvedValue({ state: "denied" });
+
+    render(<LocationPermissionRecoveryCard blocked onRetry={onRetry} />);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Retrying into a standing denial spends a prompt on iOS and produces a
+    // failure toast on every tab switch.
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("retries only once even when the signal repeats", async () => {
+    const onRetry = vi.fn();
+    service.getPermissionState.mockResolvedValue({ state: "granted" });
+
+    render(<LocationPermissionRecoveryCard blocked onRetry={onRetry} />);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(onRetry).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    // A second capture while the first is still running doubles the GPS work
+    // and, on iOS, can spend a second system prompt.
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("watches nothing while the person is not stuck", async () => {
+    const onRetry = vi.fn();
+    render(
+      <LocationPermissionRecoveryCard blocked={false} onRetry={onRetry} />,
+    );
+    document.dispatchEvent(new Event("visibilitychange"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(service.getPermissionState).not.toHaveBeenCalled();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/components/one-location/location-permission-recovery-card.tsx
+++ b/hushh-webapp/components/one-location/location-permission-recovery-card.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Loader2, MapPinOff } from "lucide-react";
+import { useCallback, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { isNative, getPlatform } from "@/lib/capacitor/platform";
+import { resolveLocationRecoveryGuide } from "@/lib/one-location/location-permission-recovery";
+import { useLocationPermissionHealing } from "@/lib/one-location/use-location-permission-healing";
+
+/**
+ * The way out of a blocked location permission.
+ *
+ * It exists because the previous answer was a toast reading "Allow location
+ * permission before sharing" beside an "Open Location Settings" button that
+ * resolves `{ opened: false }` in every browser. The one instruction was the
+ * one thing the person could not act on, the button did nothing, and the toast
+ * was gone within seconds — leaving the Location screen with the word
+ * "blocked" on it and no way forward. Someone who did not already know that
+ * browsers keep a per-site location switch behind an icon in the address bar
+ * had no path at all.
+ *
+ * Rendered in the neutral surface style rather than as an alert, deliberately:
+ * the person has done nothing wrong and this is a state to work through, which
+ * is the same reasoning the Nearby drawer's fallback follows.
+ *
+ * It never claims to be able to ask again, because it cannot. Once a browser
+ * has recorded a block, no website may reopen that dialog — a security rule,
+ * not a limitation of this app. So the card does the only two useful things
+ * left: say precisely where the switch is, and notice the moment it moves.
+ */
+export function LocationPermissionRecoveryCard({
+  blocked,
+  busy = false,
+  onRetry,
+  onOpenSettings,
+}: {
+  /** An observed refusal, not merely a permission API reporting "denied". */
+  blocked: boolean;
+  busy?: boolean;
+  /** Re-attempt a capture. Also what runs when healing is detected. */
+  onRetry: () => void;
+  /** Native only. Absent on web, where no settings pane can be opened. */
+  onOpenSettings?: () => void;
+}) {
+  const guide = useMemo(
+    () =>
+      resolveLocationRecoveryGuide({
+        userAgent:
+          typeof navigator === "undefined" ? "" : navigator.userAgent,
+        isNativeApp: isNative(),
+        nativePlatform: getPlatform(),
+      }),
+    [],
+  );
+
+  const handleGranted = useCallback(() => {
+    onRetry();
+  }, [onRetry]);
+
+  useLocationPermissionHealing({ enabled: blocked, onGranted: handleGranted });
+
+  if (!blocked) return null;
+
+  const canOpenSettings = guide.canOpenSettings && Boolean(onOpenSettings);
+
+  return (
+    <div
+      className="rounded-2xl border border-border/60 bg-muted/50 p-4"
+      role="status"
+      data-testid="location-permission-recovery"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full bg-background text-muted-foreground"
+          aria-hidden="true"
+        >
+          <MapPinOff className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold">{guide.title}</p>
+          <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
+            We can&rsquo;t turn this on for you — only you can, and it takes a
+            few seconds.
+          </p>
+          <ol
+            className="mt-2.5 list-decimal space-y-1 pl-4 text-sm leading-5 text-muted-foreground"
+            data-testid="location-permission-recovery-steps"
+          >
+            {guide.steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button type="button" size="sm" disabled={busy} onClick={onRetry}>
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          Check again
+        </Button>
+        {canOpenSettings ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={onOpenSettings}
+          >
+            Open Settings
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -1639,4 +1639,125 @@ describe("NearbyCheckInSheet", () => {
       });
     });
   });
+
+  /**
+   * The presence poller and the server's 8-requests-per-minute budget.
+   *
+   * The poller's guard is `state.presence`, not `open`, and the sheet is
+   * mounted by every map surface. A checked-in owner therefore had a CLOSED
+   * drawer polling every 15 seconds -- 4 reads a minute each, against a limit
+   * of 8 a minute keyed per ACCOUNT, not per tab. Two mounted-but-closed
+   * sheets spent the whole allowance on nobody looking at anything, and the
+   * Location hub's own read came back 429.
+   */
+  describe("presence polling and the request budget", () => {
+    const activePresence = {
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: false,
+        consentVersion: "one-location-nearby-presence-v3",
+        checkedInAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        placeLabel: "Stanford University",
+      },
+      attendees: [],
+    };
+
+    it("does not poll on a timer while the drawer is closed", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        service.getNearbyPresence.mockResolvedValue(activePresence);
+
+        render(
+          <NearbyCheckInSheet
+            open={false}
+            ownerId="user-1"
+            vaultOwnerToken="owner-token"
+            captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+            onOpenChange={vi.fn()}
+          />,
+        );
+
+        await waitFor(() =>
+          expect(service.getNearbyPresence).toHaveBeenCalled(),
+        );
+        const afterMount = service.getNearbyPresence.mock.calls.length;
+
+        // Two full minutes. At the old cadence this is 8 reads - the entire
+        // per-account budget - burned by a drawer nobody opened.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(120_000);
+        });
+
+        expect(service.getNearbyPresence.mock.calls.length).toBe(afterMount);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still polls while the drawer is open", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        service.getNearbyPresence.mockResolvedValue(activePresence);
+
+        render(
+          <NearbyCheckInSheet
+            open
+            ownerId="user-1"
+            vaultOwnerToken="owner-token"
+            captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+            onOpenChange={vi.fn()}
+          />,
+        );
+
+        await screen.findByTestId("nearby-presence-active");
+        const afterMount = service.getNearbyPresence.mock.calls.length;
+
+        // Someone watching the attendee list needs it live; that is what the
+        // budget is for.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(35_000);
+        });
+
+        expect(service.getNearbyPresence.mock.calls.length).toBeGreaterThan(
+          afterMount,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still refreshes a closed drawer when the tab becomes visible", async () => {
+      service.getNearbyPresence.mockResolvedValue(activePresence);
+
+      render(
+        <NearbyCheckInSheet
+          open={false}
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(service.getNearbyPresence).toHaveBeenCalled());
+      const afterMount = service.getNearbyPresence.mock.calls.length;
+
+      // Dispatched inside the retry loop on purpose: `poll()` declines while
+      // the mount read is still in flight, so a single dispatch races the
+      // fixture and fails only under load. Re-dispatching until the count
+      // moves tests the behaviour rather than the timing.
+      //
+      // Dropping the timer must not mean a stale presence survives a return to
+      // the tab - that is the moment staleness actually matters.
+      await waitFor(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(service.getNearbyPresence.mock.calls.length).toBeGreaterThan(
+          afterMount,
+        );
+      });
+    });
+  });
 });

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -984,10 +984,27 @@ export function NearbyCheckInSheet({
         requestGenerationRef.current += 1;
         searchGenerationRef.current += 1;
       });
-    const timer = window.setInterval(() => void poll(), 15_000);
+    // Poll on a timer ONLY while the drawer is actually on screen.
+    //
+    // The guard above is `state.presence`, not `open`, so this effect also runs
+    // for a checked-in owner who has the sheet mounted but closed — and the
+    // sheet is mounted by every map surface. At 15s that is 4 reads a minute
+    // each, against a server budget of 8 a minute for this route, keyed per
+    // ACCOUNT rather than per tab. Two mounted-but-closed sheets therefore
+    // spend the entire allowance on nobody looking at anything, and the hub's
+    // own presence read comes back 429. That is what put three
+    // "429 (Too Many Requests)" lines on the Location screen.
+    //
+    // Closed, the sheet still refreshes on the two events that actually matter
+    // — the tab becoming visible and the app returning to the foreground —
+    // which is where a stale presence would otherwise be noticed. Nothing is
+    // lost except requests nobody was waiting for.
+    const timer = open
+      ? window.setInterval(() => void poll(), 15_000)
+      : null;
     document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
-      window.clearInterval(timer);
+      if (timer !== null) window.clearInterval(timer);
       document.removeEventListener("visibilitychange", refreshWhenVisible);
       removeLifecycleListener();
     };

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -47,6 +47,7 @@ import { requestRecipientStatus } from "@/lib/one-location/request-recipient-sta
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   RowDescription,
@@ -1077,6 +1078,20 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         titleRole="agent"
         actionsInlineMobile
         actions={<LocationHeaderActions vm={vm} />}
+      />
+
+      {/*
+        Directly under the header, above the tabs, because a blocked permission
+        is not a detail of one tab — it is the reason every Location feature
+        below is inert. It used to be announced only by the word "blocked" in
+        the header status and a toast that had already gone, which is how
+        someone ended up on this screen with nothing to act on.
+      */}
+      <LocationPermissionRecoveryCard
+        blocked={vm.locationBlocked}
+        busy={vm.locationAcquiring}
+        onRetry={vm.onShowMyLocation}
+        onOpenSettings={vm.onOpenLocationSettings}
       />
 
 

--- a/hushh-webapp/lib/one-location/__tests__/location-permission-recovery.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-permission-recovery.test.ts
@@ -1,0 +1,207 @@
+// The instructions someone sees when their browser is blocking location and no
+// website is allowed to ask again.
+//
+// The property that matters most is not which browser we detect — it is that
+// we NEVER hand someone a dead end. Every branch must name who is blocking and
+// say where the switch is, because "allow location permission" alone is what
+// stranded people who did not already know browsers keep that switch behind an
+// address-bar icon.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  detectLocationRecoveryTarget,
+  locationRecoveryGuide,
+  resolveLocationRecoveryGuide,
+  shouldShowLocationRecovery,
+  type LocationRecoveryTarget,
+} from "@/lib/one-location/location-permission-recovery";
+
+const UA = {
+  chromeMac:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+  chromeWindows:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+  edge: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0",
+  chromeAndroid:
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36",
+  safariMac:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+  safariIphone:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+  chromeIphone:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/151.0.0.0 Mobile/15E148 Safari/604.1",
+  firefox:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0",
+};
+
+describe("which instructions apply", () => {
+  it("recognises desktop Chrome — the browser in the reported failure", () => {
+    expect(detectLocationRecoveryTarget({ userAgent: UA.chromeMac })).toBe(
+      "chromium-desktop",
+    );
+    expect(detectLocationRecoveryTarget({ userAgent: UA.chromeWindows })).toBe(
+      "chromium-desktop",
+    );
+  });
+
+  it("treats Edge as Chrome", () => {
+    // It announces both. They share the address-bar control this advice points
+    // at, so splitting them would only create a branch that can rot.
+    expect(detectLocationRecoveryTarget({ userAgent: UA.edge })).toBe(
+      "chromium-desktop",
+    );
+  });
+
+  it("separates Chrome on Android from Chrome on a computer", () => {
+    expect(detectLocationRecoveryTarget({ userAgent: UA.chromeAndroid })).toBe(
+      "chromium-android",
+    );
+  });
+
+  it("sends every iPhone browser to Safari's settings", () => {
+    // Chrome and Firefox on iOS are Safari's engine and share Safari's
+    // per-site permission. Naming Chrome there would send someone hunting for
+    // a setting that does not exist on that device.
+    expect(detectLocationRecoveryTarget({ userAgent: UA.safariIphone })).toBe(
+      "safari-ios",
+    );
+    expect(detectLocationRecoveryTarget({ userAgent: UA.chromeIphone })).toBe(
+      "safari-ios",
+    );
+  });
+
+  it("recognises Safari and Firefox on a computer", () => {
+    expect(detectLocationRecoveryTarget({ userAgent: UA.safariMac })).toBe(
+      "safari-desktop",
+    );
+    expect(detectLocationRecoveryTarget({ userAgent: UA.firefox })).toBe(
+      "firefox",
+    );
+  });
+
+  it("puts the native app ahead of its user agent", () => {
+    // The Capacitor WebView reports Safari/Chrome. Sniffing the agent alone
+    // would send an app user into browser settings they do not have.
+    expect(
+      detectLocationRecoveryTarget({
+        userAgent: UA.safariIphone,
+        isNativeApp: true,
+        nativePlatform: "ios",
+      }),
+    ).toBe("ios-app");
+    expect(
+      detectLocationRecoveryTarget({
+        userAgent: UA.chromeAndroid,
+        isNativeApp: true,
+        nativePlatform: "android",
+      }),
+    ).toBe("android-app");
+  });
+
+  it("falls back to advice that is true everywhere", () => {
+    expect(detectLocationRecoveryTarget({ userAgent: "" })).toBe("browser");
+    expect(detectLocationRecoveryTarget({})).toBe("browser");
+    expect(detectLocationRecoveryTarget({ userAgent: "Lynx/2.9" })).toBe(
+      "browser",
+    );
+  });
+});
+
+const ALL_TARGETS: LocationRecoveryTarget[] = [
+  "chromium-desktop",
+  "chromium-android",
+  "safari-desktop",
+  "safari-ios",
+  "firefox",
+  "ios-app",
+  "android-app",
+  "browser",
+];
+
+describe("every guide is actionable", () => {
+  it.each(ALL_TARGETS)("%s names who is blocking and what to do", (target) => {
+    const guide = locationRecoveryGuide(target);
+
+    // Naming the blocker is what turns "the app is broken" into a ten-second
+    // fix, so it is asserted rather than left to review.
+    expect(guide.title).toMatch(/blocking/i);
+    expect(guide.steps.length).toBeGreaterThanOrEqual(2);
+    expect(guide.steps.length).toBeLessThanOrEqual(4);
+    for (const step of guide.steps) {
+      expect(step.trim().length).toBeGreaterThan(0);
+      // A step that only repeats the old dead-end copy helps nobody.
+      expect(step).not.toMatch(/^allow location permission\.?$/i);
+    }
+  });
+
+  it("never offers a Settings button on the web", () => {
+    // `openLocationSettings()` resolves `{ opened: false }` in a browser. A
+    // button that does nothing spends trust it cannot earn back.
+    for (const target of [
+      "chromium-desktop",
+      "chromium-android",
+      "safari-desktop",
+      "safari-ios",
+      "firefox",
+      "browser",
+    ] as LocationRecoveryTarget[]) {
+      expect(locationRecoveryGuide(target).canOpenSettings).toBe(false);
+    }
+  });
+
+  it("offers a Settings button only where one genuinely opens", () => {
+    expect(locationRecoveryGuide("ios-app").canOpenSettings).toBe(true);
+    expect(locationRecoveryGuide("android-app").canOpenSettings).toBe(true);
+  });
+
+  it("tells desktop Chrome users about the icon beside the address", () => {
+    // The precise control in the reported case: the panel behind that icon
+    // carries a Location switch. Without this sentence there is nothing on
+    // screen connecting the failure to the fix.
+    const guide = resolveLocationRecoveryGuide({ userAgent: UA.chromeMac });
+    expect(guide.steps[0]).toMatch(/left of the web address/i);
+    expect(guide.steps.join(" ")).toMatch(/location/i);
+  });
+
+  it("promises the page will heal itself rather than demanding a reload", () => {
+    // The recovery listener re-checks on focus, so asking for a manual reload
+    // would be one instruction more than the person actually needs.
+    for (const target of [
+      "chromium-desktop",
+      "chromium-android",
+      "ios-app",
+      "android-app",
+      "browser",
+    ] as LocationRecoveryTarget[]) {
+      expect(locationRecoveryGuide(target).steps.join(" ")).toMatch(
+        /turns on by itself/i,
+      );
+    }
+  });
+});
+
+describe("when to show it at all", () => {
+  it("shows only after an attempt actually failed with a denial", () => {
+    expect(
+      shouldShowLocationRecovery({ observedDenial: true, hasFix: false }),
+    ).toBe(true);
+  });
+
+  it("stays hidden when nothing has been attempted", () => {
+    // A permission API reporting "denied" is a hint, not proof: Safari cannot
+    // report it, and Android re-prompts. Sending someone to settings on a hint
+    // teaches them to ignore the message.
+    expect(
+      shouldShowLocationRecovery({ observedDenial: false, hasFix: false }),
+    ).toBe(false);
+  });
+
+  it("stays hidden once a position is in hand", () => {
+    // A device that just produced a coordinate is working, whatever any
+    // earlier denial said.
+    expect(
+      shouldShowLocationRecovery({ observedDenial: true, hasFix: true }),
+    ).toBe(false);
+  });
+});

--- a/hushh-webapp/lib/one-location/location-permission-recovery.ts
+++ b/hushh-webapp/lib/one-location/location-permission-recovery.ts
@@ -1,0 +1,221 @@
+/**
+ * What to tell someone whose device is refusing location, when asking again is
+ * not an option.
+ *
+ * There are two refusals and they need opposite responses. Everything before
+ * this module conflated them.
+ *
+ * **Not yet asked.** The browser will show its own dialog — but only from
+ * `getCurrentPosition()`, and only from a real user gesture. Nothing here is
+ * needed: tap the control, the dialog appears. `ensureForegroundLocationReady`
+ * already does exactly that, which is why the first-time flow works.
+ *
+ * **Already blocked.** No website can reopen that dialog. Chrome, Safari and
+ * Firefox all treat a block as final until the person changes it in browser UI
+ * the page cannot reach, script, or even point at. This is a security rule, not
+ * a gap in our code, and no amount of retrying changes it.
+ *
+ * The app's response to the second case used to be a toast reading "Allow
+ * location permission before sharing", followed by `openLocationSettings()` —
+ * which on web is a hard-coded `{ opened: false }`. So the one instruction we
+ * gave was the one thing the person could not act on, and the button that
+ * looked like help did nothing. Someone who does not already know that browsers
+ * keep a per-site location switch behind an icon in the address bar had no way
+ * to find it. That is the whole failure: not that we could not ask again, but
+ * that we never said where the switch was.
+ *
+ * So this module produces the exact words for the exact browser: what to click,
+ * what it looks like, and what to do after. It says "Chrome is blocking this",
+ * because naming who is blocking is the difference between a person fixing it
+ * in ten seconds and concluding the app is broken.
+ *
+ * Detection is deliberately coarse. A wrong-but-close instruction ("look for
+ * the icon at the left of the address bar") still lands, because every desktop
+ * browser puts it there. A missing instruction never does.
+ */
+
+export type LocationRecoveryTarget =
+  /** Chrome, Edge, Brave, Arc, Opera — anything Chromium, on a computer. */
+  | "chromium-desktop"
+  /** Chrome on Android: permission lives in the browser AND in Android. */
+  | "chromium-android"
+  | "safari-desktop"
+  | "safari-ios"
+  | "firefox"
+  /** Our own iOS app. Here a Settings button genuinely works. */
+  | "ios-app"
+  /** Our own Android app. Same. */
+  | "android-app"
+  /** Unrecognised browser: keep the advice true for all of them. */
+  | "browser";
+
+export type LocationRecoveryGuide = {
+  target: LocationRecoveryTarget;
+  /** Names who is refusing. Never blames the person. */
+  title: string;
+  /** Two to four steps, in order, each a single action. */
+  steps: string[];
+  /**
+   * True only where an in-app button can genuinely open the OS settings pane.
+   * On the web it is always false — offering a dead button is worse than
+   * offering none, because it spends the person's trust on a no-op.
+   */
+  canOpenSettings: boolean;
+};
+
+type DetectParams = {
+  userAgent?: string | null;
+  /** Running inside our Capacitor shell rather than a browser tab. */
+  isNativeApp?: boolean;
+  /** `ios` | `android` when known. */
+  nativePlatform?: string | null;
+};
+
+/**
+ * Which set of instructions applies.
+ *
+ * Order matters: the native shell is checked first because its WebView reports
+ * a Safari/Chrome user agent, so user-agent sniffing alone would send an app
+ * user to browser settings that do not exist for them.
+ */
+export function detectLocationRecoveryTarget(
+  params: DetectParams = {},
+): LocationRecoveryTarget {
+  const ua = String(params.userAgent ?? "").toLowerCase();
+
+  if (params.isNativeApp) {
+    const platform = String(params.nativePlatform ?? "").toLowerCase();
+    if (platform === "android") return "android-app";
+    if (platform === "ios") return "ios-app";
+    return /android/.test(ua) ? "android-app" : "ios-app";
+  }
+
+  if (!ua) return "browser";
+
+  // Every iPhone/iPad browser is Safari's engine and shares Safari's settings,
+  // so CriOS/FxiOS deliberately land here too.
+  if (/iphone|ipad|ipod/.test(ua)) return "safari-ios";
+
+  if (/firefox|fxios/.test(ua)) return "firefox";
+
+  // Edge and Opera announce Chrome as well; treat the whole family alike
+  // because they share the address-bar control this advice points at.
+  const chromium = /chrome|chromium|crios|edg\//.test(ua);
+  if (chromium) return /android/.test(ua) ? "chromium-android" : "chromium-desktop";
+
+  if (/safari/.test(ua)) return "safari-desktop";
+
+  return "browser";
+}
+
+const GUIDES: Record<LocationRecoveryTarget, Omit<LocationRecoveryGuide, "target">> = {
+  "chromium-desktop": {
+    title: "Chrome is blocking location for this site",
+    steps: [
+      "Click the icon just left of the web address, at the top of this window.",
+      "Turn Location on.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: false,
+  },
+  "chromium-android": {
+    title: "Chrome is blocking location for this site",
+    steps: [
+      "Tap the lock or icon left of the web address.",
+      "Tap Permissions, then turn Location on.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: false,
+  },
+  "safari-desktop": {
+    title: "Safari is blocking location for this site",
+    steps: [
+      "Open Safari, then Settings, then Websites, then Location.",
+      "Set this site to Allow.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: false,
+  },
+  "safari-ios": {
+    title: "Safari is blocking location for this site",
+    steps: [
+      "Tap the aA icon in the address bar, then Website Settings.",
+      "Set Location to Allow.",
+      "If it is still off, open Settings, then Privacy & Security, then Location Services, and turn on Safari Websites.",
+    ],
+    canOpenSettings: false,
+  },
+  firefox: {
+    title: "Firefox is blocking location for this site",
+    steps: [
+      "Click the lock icon left of the web address.",
+      "Next to Blocked, for Access your location, click the X to clear it.",
+      "Reload this page and turn location on again.",
+    ],
+    canOpenSettings: false,
+  },
+  "ios-app": {
+    title: "iPhone Settings is blocking location for Hussh",
+    steps: [
+      "Open Settings.",
+      "Set Location to While Using the App.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: true,
+  },
+  "android-app": {
+    title: "Android Settings is blocking location for Hussh",
+    steps: [
+      "Open Settings.",
+      "Tap Permissions, then Location, then Allow only while using the app.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: true,
+  },
+  browser: {
+    title: "Your browser is blocking location for this site",
+    steps: [
+      "Open this site's settings from the icon left of the web address.",
+      "Allow location.",
+      "Come back here — it turns on by itself.",
+    ],
+    canOpenSettings: false,
+  },
+};
+
+/** The exact words for one situation. */
+export function locationRecoveryGuide(
+  target: LocationRecoveryTarget,
+): LocationRecoveryGuide {
+  return { target, ...GUIDES[target] };
+}
+
+/** Convenience: detect and resolve in one call. */
+export function resolveLocationRecoveryGuide(
+  params: DetectParams = {},
+): LocationRecoveryGuide {
+  return locationRecoveryGuide(detectLocationRecoveryTarget(params));
+}
+
+/**
+ * Should the recovery guide be shown at all?
+ *
+ * Only for an *observed* denial — a capture that actually failed with
+ * PERMISSION_DENIED — never for a permission API that merely reports "denied".
+ * Safari cannot report the value at all, Android re-prompts unless the person
+ * chose "don't ask again", and a stale read is common. Showing "your browser is
+ * blocking this" to someone who would have got a dialog teaches them to
+ * distrust the message, and sends them into settings for no reason.
+ *
+ * The rule this encodes, and the reason it is a separate function rather than
+ * an inline `if`: **a query is a hint, an attempt is the truth.** It is the
+ * same rule `location-readiness.ts` enforces on the way in; this is that rule
+ * on the way out.
+ */
+export function shouldShowLocationRecovery(params: {
+  observedDenial: boolean;
+  hasFix: boolean;
+}): boolean {
+  if (params.hasFix) return false;
+  return params.observedDenial;
+}

--- a/hushh-webapp/lib/one-location/use-location-permission-healing.ts
+++ b/hushh-webapp/lib/one-location/use-location-permission-healing.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { OneLocationService } from "@/lib/one-location/service";
+
+/**
+ * Notice the moment someone un-blocks location, without making them tell us.
+ *
+ * The recovery instructions send a person out of the page and into browser
+ * settings. Every second they spend back here wondering whether it worked is a
+ * second the fix looks broken, and "now reload the page" is one instruction
+ * more than they should have to carry.
+ *
+ * Two signals, because no single one covers every browser:
+ *
+ * 1. **`PermissionStatus.onchange`** — the exact event. Chromium fires it the
+ *    instant the site's Location switch flips, even while the tab sits in the
+ *    background, so the page heals before the person has finished looking back
+ *    at it. Safari does not implement `permissions.query('geolocation')` at all
+ *    and rejects, which is why it cannot be the only signal.
+ *
+ * 2. **Returning to the tab** — `visibilitychange` and `focus`. Coarser, but it
+ *    works everywhere, and it is exactly when someone comes back from settings.
+ *
+ * Both paths only ever *read* permission. Neither attempts a capture, so
+ * nothing here can trigger a prompt, a toast, or a GPS read behind the person's
+ * back — this hook observes, and hands the decision to act to its caller.
+ */
+export function useLocationPermissionHealing(params: {
+  /** Only watch while the person is actually stuck. */
+  enabled: boolean;
+  /** Called once, when permission is observed to have become usable. */
+  onGranted: () => void;
+}): void {
+  const { enabled, onGranted } = params;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    let settled = false;
+    let status: PermissionStatus | null = null;
+
+    // Fire at most once. A second call would re-enter the caller's capture
+    // while the first is still running, which on iOS spends a prompt and on
+    // web doubles the GPS work for one recovery.
+    const grant = () => {
+      if (cancelled || settled) return;
+      settled = true;
+      onGranted();
+    };
+
+    const check = async () => {
+      if (cancelled || settled) return;
+      try {
+        const permission = await OneLocationService.getPermissionState();
+        if (permission?.state === "granted") grant();
+      } catch {
+        // Unreadable permission is not a failure to recover from. The person
+        // can still press the button, and the visibility path will try again.
+      }
+    };
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void check();
+    };
+
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+
+    void (async () => {
+      try {
+        const query = navigator.permissions?.query;
+        if (!query) return;
+        const next = await navigator.permissions.query({
+          name: "geolocation" as PermissionName,
+        });
+        if (cancelled) return;
+        status = next;
+        // Already fixed before this mounted — for instance the person un-blocked
+        // it, then navigated back rather than switching tabs.
+        if (next.state === "granted") {
+          grant();
+          return;
+        }
+        next.onchange = () => {
+          if (next.state === "granted") grant();
+        };
+      } catch {
+        // WebKit rejects this query outright. The visibility listeners above
+        // are the whole recovery path there, and they are already attached.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+      if (status) status.onchange = null;
+    };
+  }, [enabled, onGranted]);
+}


### PR DESCRIPTION
## What was reported

Turning the **Location** toggle on at `/one/location` did nothing useful, the Nearby drawer kept saying it could not find you, and the console showed repeated `429 (Too Many Requests)` on `nearby-presence`.

The ask: *"prompt me when I toggle it on — a six-year-old or an eighty-year-old will not know to go and find the icon in the Chrome toolbar."*

## The honest split

**The first-time ask was never broken.** The toggle already reaches `getCurrentPosition()` — the only thing that makes a browser show its permission dialog — so someone who has not been asked *does* get asked. Verified by tracing `Switch → vm.onShowMyLocation → handleShowMyLiveLocation → ensureForegroundLocationReady → captureCurrentPosition`.

**The other refusal was broken.** Once a browser records a *block*, no website may reopen that dialog. That is a security rule, not a gap in our code, and no change here can alter it.

What we could control, and got wrong:

| | Before | After |
|---|---|---|
| Instruction | "Allow location permission before sharing" — never says *where* | The exact click path for the browser in use |
| Recovery button | "Open Location Settings" → `openLocationSettings()` returns a hard-coded `{ opened: false }` on web | No button on web; a real one in the native app |
| Persistence | A toast, gone in seconds | A card that stays until it is fixed |
| After fixing it | Reload and hope | Heals itself |

Anyone who did not already know browsers keep a per-site location switch behind an address-bar icon had **no path at all**.

## The change

**A recovery card** under the Location header, above the tabs — a blocked permission is why every feature below it is inert, so it does not belong inside one tab. It names who is blocking ("Chrome is blocking location for this site"), gives two-to-four single-action steps, and offers a Settings button only where one genuinely opens.

**It heals itself.** `PermissionStatus.onchange` fires the instant the site's Location switch flips, so Chromium recovers before the person has finished looking back at the tab. `visibilitychange` + `focus` cover WebKit, which does not implement that query at all and rejects. Neither path captures, so nothing can prompt or read GPS behind the person's back — the hook observes and hands the decision to its caller.

**It only shows on an observed denial**, never on a permission API merely reporting `denied`. Safari cannot report the value, Android re-prompts, and a stale read is common; telling someone their browser is blocking them when they would have got a dialog teaches them to distrust the message. Same rule `location-readiness.ts` enforces on the way in — a query is a hint, an attempt is the truth.

## The 429s, same screenshots

`GET /api/one/location/nearby-presence` is limited to **8/minute keyed per account** (`rate_limit.py:110`), not per tab. The check-in sheet's 15-second poller is guarded on `state.presence`, **not** `open` — and the sheet is mounted by every map surface.

So a checked-in owner had a **closed** drawer spending 4 reads a minute. Two mounted-but-closed sheets consumed the entire allowance on nobody looking at anything, and the hub's own presence read came back 429.

The timer now runs only while the drawer is open. Closed, it still refreshes on tab visibility and app lifecycle resume — the moments staleness actually matters.

## Verification

- `npx tsc --noEmit` clean; `npm run lint` clean
- 69 tests across the three affected areas
- **All three behaviours mutation-checked** — reverting each fix fails the test that claims to cover it:
  - restore the unconditional interval → `does not poll on a timer while the drawer is closed` fails
  - drop the `granted` guard in the healer → `does not retry while permission is still refused` fails
  - replace the click path with "Allow location permission." → 3 copy tests fail
- Remaining 4 failures in the location suite are **pre-existing on `origin/main`** (verified against a baseline run earlier today; the settings-placement one greps `NowHub` source for `title="Request Location"`, a stale contract unrelated to this card)

## What this does not do

It cannot make Chrome re-prompt after a block. Nothing can. It makes the ten seconds of manual recovery obvious, and then notices the moment it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)