### PR TITLE
fix(identity): resolve a contact's email from their sign-in provider

### DIFF
--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -27,6 +27,54 @@ _ALIAS_CODE_PATTERN = re.compile(r"\s+")
 _ALIAS_VERIFICATION_TTL_SECONDS = 15 * 60
 
 
+def resolve_firebase_email(user_record: Any) -> str | None:
+    """The best email Firebase knows for this account.
+
+    The identity shadow used to read `user_record.email` and nothing else, so
+    an account whose top-level email was empty was cached with no address at
+    all. That is not an edge case here: people sign in with Google, with Apple,
+    and with a phone number, and only the first reliably populates the
+    top-level field.
+
+    - Apple, especially with Hide My Email, frequently leaves the top-level
+      email empty while the provider entry carries the relay address.
+    - A phone-first account that later links Google has the address on the
+      provider entry before the top-level field catches up.
+
+    Every downstream feature that needs to reach someone by email inherited
+    that blank -- including the Save my Soul alert, which silently skipped any
+    contact with no address and reported "Emailed 0" without saying why.
+
+    Order: the top-level field, then Google, then Apple, then any provider that
+    has one. Providers are only consulted when the field above is empty, so a
+    verified top-level address always wins.
+
+    Returns None when the account genuinely has no email anywhere -- a
+    phone-only signup. That case is real and cannot be papered over; the caller
+    has to handle "this person is not reachable by mail".
+    """
+    direct = str(getattr(user_record, "email", "") or "").strip()
+    if direct:
+        return direct
+
+    providers = getattr(user_record, "provider_data", None) or []
+    by_provider: dict[str, str] = {}
+    for entry in providers:
+        email = str(getattr(entry, "email", "") or "").strip()
+        if not email or "@" not in email:
+            continue
+        provider_id = str(getattr(entry, "provider_id", "") or "").strip().lower()
+        by_provider.setdefault(provider_id, email)
+
+    for provider_id in ("google.com", "apple.com"):
+        if by_provider.get(provider_id):
+            return by_provider[provider_id]
+
+    for email in by_provider.values():
+        return email
+    return None
+
+
 class ActorIdentityAliasError(RuntimeError):
     def __init__(
         self,
@@ -1110,7 +1158,7 @@ class ActorIdentityService:
         updated = await self.upsert_identity(
             user_id=normalized_user_id,
             display_name=getattr(user_record, "display_name", None),
-            email=getattr(user_record, "email", None),
+            email=resolve_firebase_email(user_record),
             phone_number=firebase_phone_number,
             photo_url=getattr(user_record, "photo_url", None),
             email_verified=getattr(user_record, "email_verified", None),

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1005,8 +1005,28 @@ class OneLocationAgentService:
         selected = select_emailable_recipients(
             rows, owner_user_id=owner_user_id, now_epoch_seconds=now_epoch
         )
+
+        # Who this alert could NOT reach by mail, and why. Skipping them
+        # silently is what made a broken email channel look like a working one:
+        # the sender saw "Emailed 0" with nothing to act on. A phone-only
+        # contact has no address anywhere, and the only fix is for them to add
+        # one -- which the sender can only ask for if they are told.
+        emailable_ids = {str(row.get("recipient_user_id") or "") for row in selected}
+        without_email = [
+            str(row.get("recipient_display_name") or "").strip() or "A contact"
+            for row in rows
+            if str(row.get("recipient_user_id") or "") not in emailable_ids
+            and str(row.get("share_kind") or "") == "sos"
+            and "@" not in str(row.get("recipient_email") or "")
+        ]
+
         if not selected:
-            return {"ownerDisplayName": "", "openInOneUrl": "", "recipients": []}
+            return {
+                "ownerDisplayName": "",
+                "openInOneUrl": "",
+                "recipients": [],
+                "withoutEmail": without_email,
+            }
 
         owner_label = _identity_notification_label(self._identity_row(owner_user_id))
         return {
@@ -1025,6 +1045,7 @@ class OneLocationAgentService:
                 }
                 for row in selected
             ],
+            "withoutEmail": without_email,
         }
 
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:

--- a/consent-protocol/tests/services/test_actor_identity_email_resolution.py
+++ b/consent-protocol/tests/services/test_actor_identity_email_resolution.py
@@ -1,0 +1,97 @@
+"""Where an account's email actually comes from.
+
+The identity shadow read `user_record.email` and nothing else. People sign in
+with Google, with Apple, and with a phone number, and only the first reliably
+fills that top-level field -- so accounts were cached with no address at all,
+and every feature that mails someone inherited the blank. Save my Soul is how
+it surfaced: it skipped those contacts and reported "Emailed 0" without saying
+why.
+"""
+
+from __future__ import annotations
+
+from hushh_mcp.services.actor_identity_service import resolve_firebase_email
+
+
+class _Provider:
+    def __init__(self, provider_id: str, email: str | None = None):
+        self.provider_id = provider_id
+        self.email = email
+
+
+class _User:
+    def __init__(self, email=None, provider_data=None):
+        self.email = email
+        self.provider_data = provider_data or []
+
+
+class TestTopLevelWins:
+    def test_uses_the_top_level_email_when_present(self):
+        user = _User(
+            email="ankit@hushh.ai",
+            provider_data=[_Provider("google.com", "other@gmail.com")],
+        )
+        assert resolve_firebase_email(user) == "ankit@hushh.ai"
+
+    def test_a_blank_top_level_field_does_not_win(self):
+        user = _User(email="   ", provider_data=[_Provider("google.com", "real@gmail.com")])
+        assert resolve_firebase_email(user) == "real@gmail.com"
+
+
+class TestProviderFallback:
+    def test_finds_a_google_address_when_the_top_level_is_empty(self):
+        # A phone-first account that later links Google carries the address on
+        # the provider entry before the top-level field catches up.
+        user = _User(provider_data=[_Provider("google.com", "real@gmail.com")])
+        assert resolve_firebase_email(user) == "real@gmail.com"
+
+    def test_finds_an_apple_relay_address(self):
+        # Apple with Hide My Email leaves the top-level empty and puts the
+        # relay address on the provider entry. Without this the contact simply
+        # has no address and is skipped.
+        user = _User(provider_data=[_Provider("apple.com", "abc123@privaterelay.appleid.com")])
+        assert resolve_firebase_email(user) == "abc123@privaterelay.appleid.com"
+
+    def test_prefers_google_over_apple_when_both_are_linked(self):
+        # A real mailbox beats a relay that may refuse mail from an
+        # unregistered sender.
+        user = _User(
+            provider_data=[
+                _Provider("apple.com", "abc@privaterelay.appleid.com"),
+                _Provider("google.com", "real@gmail.com"),
+            ]
+        )
+        assert resolve_firebase_email(user) == "real@gmail.com"
+
+    def test_falls_back_to_any_provider_that_has_one(self):
+        user = _User(provider_data=[_Provider("microsoft.com", "work@contoso.com")])
+        assert resolve_firebase_email(user) == "work@contoso.com"
+
+    def test_ignores_provider_entries_with_no_usable_address(self):
+        user = _User(
+            provider_data=[
+                _Provider("phone", None),
+                _Provider("phone", ""),
+                _Provider("google.com", "not-an-address"),
+                _Provider("apple.com", "real@icloud.com"),
+            ]
+        )
+        assert resolve_firebase_email(user) == "real@icloud.com"
+
+
+class TestPhoneOnlyIsHonestlyUnreachable:
+    def test_returns_none_when_the_account_has_no_email_anywhere(self):
+        # This case is real and must not be papered over: a phone-only signup
+        # cannot be emailed, and the caller has to say so rather than silently
+        # skipping the person.
+        user = _User(provider_data=[_Provider("phone")])
+        assert resolve_firebase_email(user) is None
+
+    def test_returns_none_for_an_account_with_no_provider_data_at_all(self):
+        assert resolve_firebase_email(_User()) is None
+
+    def test_survives_a_record_that_does_not_expose_provider_data(self):
+        class _Bare:
+            email = None
+
+        assert resolve_firebase_email(_Bare()) is None

--- a/hushh-webapp/app/api/one/location/sos-email/route.ts
+++ b/hushh-webapp/app/api/one/location/sos-email/route.ts
@@ -63,7 +63,12 @@ function noStore(body: unknown, status = 200) {
   });
 }
 
-const EMPTY = { emailed: 0, attempted: 0, configured: false };
+const EMPTY = {
+  emailed: 0,
+  attempted: 0,
+  configured: false,
+  withoutEmail: [] as string[],
+};
 
 function escapeHtml(value: string): string {
   return value
@@ -206,6 +211,7 @@ export async function POST(request: NextRequest) {
     ownerDisplayName?: string;
     openInOneUrl?: string;
     recipients?: Recipient[];
+    withoutEmail?: string[];
   };
   try {
     const upstream = await fetch(
@@ -226,10 +232,18 @@ export async function POST(request: NextRequest) {
     return noStore({ ...EMPTY, configured: true });
   }
 
+  // Contacts on this alert who have no address anywhere. Named so the sender
+  // can act on it, rather than being shown a bare "Emailed 0".
+  const withoutEmail = Array.isArray(resolved.withoutEmail)
+    ? resolved.withoutEmail.map((name) => String(name ?? "")).filter(Boolean)
+    : [];
+
   const recipients = Array.isArray(resolved.recipients)
     ? resolved.recipients
     : [];
-  if (!recipients.length) return noStore({ ...EMPTY, configured: true });
+  if (!recipients.length) {
+    return noStore({ ...EMPTY, configured: true, withoutEmail });
+  }
 
   const results = await Promise.all(
     recipients.map(async (recipient) => {
@@ -262,5 +276,6 @@ export async function POST(request: NextRequest) {
     emailed: results.filter(Boolean).length,
     attempted: results.length,
     configured: true,
+    withoutEmail,
   });
 }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4001,7 +4001,14 @@ export function OneLocationAgentPageContent({
 
         // Only worth saying when it changes what the sender should do next:
         // "nobody's phone lit up" reads very differently if two inboxes got it.
-        const mailNote = mail.emailed > 0 ? ` Emailed ${mail.emailed}.` : "";
+        // And a contact with no address is named rather than skipped in
+        // silence — "Emailed 0" with no reason is what made a broken email
+        // channel look like a working one.
+        const mailNote =
+          (mail.emailed > 0 ? ` Emailed ${mail.emailed}.` : "") +
+          (mail.withoutEmail.length > 0
+            ? ` No email on file for ${formatNameList(mail.withoutEmail)}.`
+            : "");
 
         if (reached === 0) {
           const stillNoOne = mail.emailed === 0;

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -891,14 +891,26 @@ export class OneLocationService {
     accuracyM?: number | null;
     note?: string | null;
     emergencyNumber?: string | null;
-  }): Promise<{ emailed: number; attempted: number; configured: boolean }> {
-    const fallback = { emailed: 0, attempted: 0, configured: false };
+  }): Promise<{
+    emailed: number;
+    attempted: number;
+    configured: boolean;
+    /** Contacts on this alert with no email on file, by display name. */
+    withoutEmail: string[];
+  }> {
+    const fallback = {
+      emailed: 0,
+      attempted: 0,
+      configured: false,
+      withoutEmail: [] as string[],
+    };
     if (!params.grantIds.length) return fallback;
     try {
       const response = await apiJson<{
         emailed?: number;
         attempted?: number;
         configured?: boolean;
+        withoutEmail?: string[];
       }>("/api/one/location/sos-email", {
         method: "POST",
         headers: jsonAuthHeaders(params.vaultOwnerToken),
@@ -919,6 +931,9 @@ export class OneLocationService {
         emailed: Number(response?.emailed ?? 0),
         attempted: Number(response?.attempted ?? 0),
         configured: response?.configured === true,
+        withoutEmail: Array.isArray(response?.withoutEmail)
+          ? response.withoutEmail.map(String).filter(Boolean)
+          : [],
       };
     } catch {
       return fallback;


### PR DESCRIPTION
## Why no Save my Soul email ever arrived

The identity shadow was built from `user_record.email` and nothing else ([actor_identity_service.py](consent-protocol/hushh_mcp/services/actor_identity_service.py)). People sign into One three ways, and only one of them reliably fills that top-level field:

| Sign-in | Firebase top-level `email` | Result |
|---|---|---|
| **Google** | populated | ✅ worked |
| **Apple** | empty with Hide My Email; the relay address sits on the **provider entry** | ❌ cached with NO email |
| **Phone** | nothing, anywhere | ❌ cached with NO email |

So `actor_identity_cache.email` was `NULL` for a large share of real accounts, and every feature that reaches someone by mail inherited that blank.

Save my Soul is where it surfaced. The resolver skips any contact without an address, so the alert reported `Emailed 0` and sent nothing — while the **push notification went out fine**. That combination is exactly what made it look like the mail code was broken rather than the address simply being absent.

## The fix

`resolve_firebase_email()` reads, in order:

1. the top-level field
2. the **Google** provider entry
3. the **Apple** provider entry
4. any provider carrying an address

A provider is consulted only when the field above is empty, so a verified top-level address always wins. Google is preferred over Apple deliberately: a real mailbox beats a relay that may refuse mail from an unregistered sender.

It returns `None` for a phone-only account, because that is the truth — there is no address to send to.

## The silent half

Skipping unreachable contacts without a word was the second half of the bug: `Emailed 0` carried no reason and nothing to act on. The resolver now returns the display names of contacts with no email on file, and the alert's own toast names them:

> Alerted 2 contact(s). Emailed 1. **No email on file for Rashid.**

The sender can then ask that person to add one — which is the only remedy available for a phone-only contact.

## Tests

10 new, one per provider shape:

- top-level wins over a provider entry; a blank/whitespace top-level falls through
- Google address found when the top-level is empty (phone-first account that later linked Google)
- Apple relay address harvested from the provider entry
- Google preferred when both Apple and Google are linked
- any other provider used as a last resort
- provider entries with `None`, `""`, or a non-address ignored
- **phone-only honestly returns `None`** — not papered over
- a record with no `provider_data` attribute at all does not explode

Backend `pytest` on the touched suites: **101 passed**. Frontend: 112 passed, `typecheck` clean, `eslint --max-warnings=0` clean, `verify:surface-map`, `verify:design-system`, `protocol lint`, `protocol format` and repo governance all clean.

Baseline: `tests/services/` fails identically on `origin/main` and here — 5 failures in `test_vault_keys_service_pure_helpers.py`, untouched by this change.

## Known limitation, not fixed here

Harvesting the Apple relay address gets us somewhere to send. **Delivery** to `@privaterelay.appleid.com` additionally requires the sending domain to be registered as an Apple *Email Source* with aligned SPF/DKIM — a portal + DNS task outside this repository. Until that is done, an Apple-relay contact resolves to an address that may still bounce with `550 unauthorized sender`.

## Risk / rollback

Additive resolution with an unchanged precedence for accounts that already had an address, plus a diagnostic field. No schema change, no migration. Straight revert.
