### PR TITLE
fix(deploy): select the newest proven SHA for UAT, never the branch tip

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -74,18 +74,29 @@ jobs:
         shell: bash
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      # A branch tip is "whatever happened most recently", which is a different
+      # question from "what is proven". On 2026-08-14 those answers differed by
+      # seconds: a green merge, then a teammate's merge whose own post-merge
+      # gate had not finished, and this step resolved to that unproven tip. The
+      # validator below caught it — but only after the dispatch, and only by
+      # luck of ordering. Selecting is the fix; validating is the backstop.
+      #
+      # A blank input now means "pick the newest commit that has its OWN
+      # successful post-merge gate", never `git rev-parse origin/main`.
       - name: Resolve deployment SHA
         id: resolve-sha
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ -n "${{ github.event.inputs.sha }}" ]; then
-            DEPLOY_SHA="${{ github.event.inputs.sha }}"
-          else
-            git fetch --no-tags origin main
-            DEPLOY_SHA="$(git rev-parse origin/main)"
+            # An explicit SHA is a request, not a permission: it still has to
+            # clear the exact-gate validator in the next step.
+            echo "sha=${{ github.event.inputs.sha }}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          echo "sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+          node hushh-webapp/scripts/ci/select-uat-target.mjs --limit 20 --github-output
 
       - name: Validate deployment SHA against main
         env:

--- a/hushh-webapp/__tests__/services/uat-target-selection.test.ts
+++ b/hushh-webapp/__tests__/services/uat-target-selection.test.ts
@@ -1,0 +1,206 @@
+// The UAT deployment selector.
+//
+// Every case below is one row of the agreed stale-candidate policy. They are
+// tests rather than a runbook because the rule that was broken in the real
+// incident - "deploy the newest eligible green SHA, never latest main" - is
+// exactly the kind of rule that reads as obvious and gets violated under time
+// pressure by someone typing a SHA by hand.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertDeployable,
+  assertRuntimeIdentity,
+  reconcileUatTarget,
+} from "@/scripts/ci/uat-target-selection.mjs";
+
+const A = "a".repeat(40); // older
+const B = "b".repeat(40); // newer
+const LIVE = "c".repeat(40); // what UAT runs now
+
+const base = {
+  mainTipSha: B,
+  uatActualSha: LIVE,
+  uatDeployingSha: null,
+  candidates: [],
+};
+
+describe("the stale-candidate policy", () => {
+  it("A is green, newer B is pending -> deploy A, never B", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [
+        { sha: B, gate: "pending" },
+        { sha: A, gate: "success" },
+      ],
+    });
+    // The exact substitution that caused the incident: a pending tip must never
+    // stand in for a proven ancestor.
+    expect(result.decision).toBe("DEPLOY_EXACT_SHA");
+    expect(result.targetSha).toBe(A);
+  });
+
+  it("A is green and B becomes green first -> deploy B, coalescing A", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [
+        { sha: B, gate: "success" },
+        { sha: A, gate: "success" },
+      ],
+    });
+    // B contains A and has its own gate, so the older queued candidate is
+    // safely superseded rather than deployed twice.
+    expect(result.targetSha).toBe(B);
+  });
+
+  it("a deployment is already running -> never cancel or retarget it", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      uatDeployingSha: A,
+      candidates: [{ sha: B, gate: "success" }],
+    });
+    expect(result.decision).toBe("DEPLOY_IN_FLIGHT");
+    expect(result.targetSha).toBeNull();
+    expect(result.reason).toMatch(/never cancelled or retargeted/i);
+  });
+
+  it("A is green and newer B failed -> deploy A, and report main blocked at B", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [
+        { sha: B, gate: "failure" },
+        { sha: A, gate: "success" },
+      ],
+    });
+    // A failure downstream says nothing about A, which passed its own gate.
+    expect(result.decision).toBe("DEPLOY_EXACT_SHA");
+    expect(result.targetSha).toBe(A);
+    expect(result.blockedAtSha).toBe(B);
+  });
+
+  it("nothing green yet -> wait, and leave UAT alone", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [
+        { sha: B, gate: "pending" },
+        { sha: A, gate: "pending" },
+      ],
+    });
+    expect(result.decision).toBe("AUTOMATIC_WAIT");
+    expect(result.targetSha).toBeNull();
+  });
+
+  it("everything failed -> blocked, and UAT stays put", () => {
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [{ sha: B, gate: "failure" }],
+    });
+    expect(result.decision).toBe("BLOCKED");
+    expect(result.targetSha).toBeNull();
+    expect(result.blockedAtSha).toBe(B);
+  });
+
+  it("no candidates -> no move", () => {
+    expect(reconcileUatTarget({ ...base, candidates: [] }).decision).toBe("NO_OP");
+  });
+
+  it("ignores a commit that has no gate of its own", () => {
+    // Non-merge commits carried in by a merge get no post-merge gate. Treating
+    // `absent` as deployable would ship an unproven commit; the live
+    // reconciliation run hit exactly this case.
+    const result = reconcileUatTarget({
+      ...base,
+      candidates: [
+        { sha: B, gate: "absent" },
+        { sha: A, gate: "success" },
+      ],
+    });
+    expect(result.targetSha).toBe(A);
+  });
+});
+
+describe("the pre-deploy gate", () => {
+  const ok = {
+    targetSha: B,
+    uatActualSha: LIVE,
+    targetGate: "success" as const,
+    reachableFromMain: true,
+    descendsFromUatActual: true,
+  };
+
+  it("accepts a proven, forward-moving, exact SHA", () => {
+    expect(assertDeployable(ok).ok).toBe(true);
+  });
+
+  it("refuses a branch name", () => {
+    // "Never deploy a branch name" has to be enforced, not documented: the
+    // existing workflow resolves a blank input to `git rev-parse origin/main`.
+    for (const bad of ["main", "origin/main", "HEAD", "", "abc123"]) {
+      const result = assertDeployable({ ...ok, targetSha: bad });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/full 40-character commit SHA/i);
+    }
+  });
+
+  it("refuses a commit whose own gate is not green", () => {
+    for (const gate of ["pending", "failure", "absent", "unknown"] as const) {
+      expect(assertDeployable({ ...ok, targetGate: gate }).ok).toBe(false);
+    }
+  });
+
+  it("refuses a commit that is not on protected main", () => {
+    expect(assertDeployable({ ...ok, reachableFromMain: false }).ok).toBe(false);
+  });
+
+  it("refuses to move UAT backward", () => {
+    // Redeploying an ancestor would roll teammates' merged work out of UAT
+    // while every check still looked green.
+    const result = assertDeployable({ ...ok, descendsFromUatActual: false });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/never moves backward/i);
+  });
+
+  it("treats a redeploy of the live commit as a no-op", () => {
+    expect(assertDeployable({ ...ok, targetSha: LIVE }).ok).toBe(false);
+  });
+
+  it("holds a manual target to the same bar as a selected one", () => {
+    // A hand-typed SHA is a request, not a permission - the incident began with
+    // exactly such a request.
+    expect(
+      assertDeployable({ ...ok, targetSha: B, targetGate: "pending" }).ok,
+    ).toBe(false);
+  });
+});
+
+describe("proving what actually ended up running", () => {
+  it("accepts only when smoke passed AND the runtime reports the target", () => {
+    expect(
+      assertRuntimeIdentity({ targetSha: B, runtimeSha: B, smokePassed: true }).ok,
+    ).toBe(true);
+  });
+
+  it("rejects a green smoke check with the wrong build live", () => {
+    // HTTP 200 proves a server answered, not which build answered. This is the
+    // stale-rollout and mutable-tag failure mode.
+    const result = assertRuntimeIdentity({
+      targetSha: B,
+      runtimeSha: A,
+      smokePassed: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/investigate tagging or rollout/i);
+  });
+
+  it("rejects a runtime that cannot say what it is", () => {
+    expect(
+      assertRuntimeIdentity({ targetSha: B, runtimeSha: null, smokePassed: true }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects a failed smoke check even when identity matches", () => {
+    expect(
+      assertRuntimeIdentity({ targetSha: B, runtimeSha: B, smokePassed: false }).ok,
+    ).toBe(false);
+  });
+});

--- a/hushh-webapp/scripts/ci/select-uat-target.mjs
+++ b/hushh-webapp/scripts/ci/select-uat-target.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Choose the commit UAT should move to, and prove it is allowed to move there.
+ *
+ * Replaces `git rev-parse origin/main` as the answer to "what do we deploy?".
+ * A branch tip is whatever happened most recently, which is not the same
+ * question as what is proven — and on 2026-08-14 those two answers differed:
+ * a green merge was followed seconds later by a teammate's merge whose own
+ * post-merge gate had not finished, and the tip was dispatched.
+ *
+ * Sources of truth, deliberately independent of each other:
+ *   - what UAT runs now  -> the GitHub Deployment record for environment `uat`
+ *   - whether a commit is proven -> that commit's OWN post-merge check run
+ *   - what is on main    -> `git rev-list` against the fetched remote ref
+ *
+ * The decision logic lives in `uat-target-selection.mjs` so it can be tested
+ * without a network. This file only gathers state and reports.
+ *
+ * Usage:
+ *   node hushh-webapp/scripts/ci/select-uat-target.mjs [--limit 20] [--github-output]
+ *
+ * Requires GITHUB_TOKEN and GITHUB_REPOSITORY (both present in Actions).
+ * Exits non-zero when there is nothing safe to deploy, so a caller that
+ * wants a target can fail closed.
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+import { assertDeployable, reconcileUatTarget } from "./uat-target-selection.mjs";
+
+const GATE_NAME = "Main Post-Merge Smoke";
+const REPO = process.env.GITHUB_REPOSITORY || "hushh-labs/hushh-research";
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+
+const args = process.argv.slice(2);
+const limit = Number(valueOf("--limit") || 20);
+const writeGithubOutput = args.includes("--github-output");
+
+function valueOf(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function git(...a) {
+  return execFileSync("git", a, { encoding: "utf8" }).trim();
+}
+
+async function api(path) {
+  if (!TOKEN) throw new Error("GITHUB_TOKEN is required to read check runs.");
+  // The fetch ban targets app code ("native platforms have no Next.js
+  // server"). This file is a Node CI script on a GitHub runner: there is no
+  // ApiService to route through and no browser to break.
+  // eslint-disable-next-line no-restricted-syntax
+  const response = await fetch(`https://api.github.com/repos/${REPO}${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${TOKEN}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} -> ${response.status}`);
+  }
+  return response.json();
+}
+
+/** That commit's own gate — never a branch status, never a PR check. */
+async function gateFor(sha) {
+  const payload = await api(`/commits/${sha}/check-runs?per_page=100`);
+  const runs = (payload.check_runs || []).filter((run) =>
+    String(run.name || "").includes(GATE_NAME),
+  );
+  if (!runs.length) return "absent";
+  if (runs.some((r) => r.status === "completed" && r.conclusion === "success")) {
+    return "success";
+  }
+  if (runs.some((r) => r.status !== "completed")) return "pending";
+  if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
+    return "failure";
+  }
+  return "unknown";
+}
+
+async function uatActualSha() {
+  const deployments = await api("/deployments?environment=uat&per_page=10");
+  for (const deployment of deployments) {
+    const statuses = await api(`/deployments/${deployment.id}/statuses?per_page=10`);
+    if (statuses.some((s) => s.state === "success")) return deployment.sha;
+  }
+  // Fall back to the newest record. Better a slightly conservative baseline
+  // than none: an over-cautious `uat_actual` can only make the selector refuse
+  // to move, never make it move somewhere unproven.
+  return deployments[0]?.sha ?? null;
+}
+
+async function main() {
+  git("fetch", "--no-tags", "origin", "main");
+  const mainTipSha = git("rev-parse", "origin/main");
+  const uatActual = await uatActualSha();
+
+  const range = uatActual ? `${uatActual}..origin/main` : `origin/main~${limit}..origin/main`;
+  let shas = [];
+  try {
+    shas = git("rev-list", `--max-count=${limit}`, range).split("\n").filter(Boolean);
+  } catch {
+    // `uatActual` is not an ancestor of main — a force-push or a rebased
+    // history. Treat as a hard block rather than guessing a range.
+    report({
+      mainTipSha,
+      uatActual,
+      decision: "BLOCKED",
+      reason: `Cannot enumerate commits after ${uatActual}; main history diverged from the live UAT commit.`,
+      targetSha: null,
+      candidates: [],
+    });
+    process.exit(2);
+  }
+
+  const candidates = [];
+  for (const sha of shas) {
+    candidates.push({ sha, gate: await gateFor(sha) });
+  }
+
+  const result = reconcileUatTarget({
+    mainTipSha,
+    uatActualSha: uatActual,
+    // The deploy workflow's own concurrency group guarantees single-flight, so
+    // an in-flight check here would only ever see this run itself.
+    uatDeployingSha: null,
+    candidates,
+  });
+
+  if (result.targetSha) {
+    const guard = assertDeployable({
+      targetSha: result.targetSha,
+      uatActualSha: uatActual,
+      targetGate: "success",
+      reachableFromMain: true,
+      descendsFromUatActual: uatActual
+        ? isAncestor(uatActual, result.targetSha)
+        : true,
+    });
+    if (!guard.ok) {
+      report({ mainTipSha, uatActual, ...result, decision: "BLOCKED", reason: guard.reason, candidates });
+      process.exit(2);
+    }
+  }
+
+  report({ mainTipSha, uatActual, ...result, candidates });
+
+  if (writeGithubOutput && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `sha=${result.targetSha ?? ""}\ndecision=${result.decision}\n`,
+    );
+  }
+  process.exit(result.targetSha ? 0 : 3);
+}
+
+function isAncestor(ancestor, descendant) {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestor, descendant]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function report({ mainTipSha, uatActual, decision, targetSha, reason, blockedAtSha, candidates }) {
+  const tip = candidates.find((c) => c.sha === mainTipSha);
+  console.log(`repository: ${REPO}`);
+  console.log(`main_tip_sha: ${mainTipSha}`);
+  console.log(`main_tip_gate: ${tip ? tip.gate : uatActual === mainTipSha ? "already-deployed" : "unknown"}`);
+  console.log(`uat_actual_sha: ${uatActual ?? "unknown"}`);
+  console.log(`target_sha: ${targetSha ?? "none"}`);
+  console.log(`target_gate_name: ${GATE_NAME}`);
+  console.log(`decision: ${decision}`);
+  console.log(`reason: ${reason}`);
+  if (blockedAtSha) console.log(`blocked_at_sha: ${blockedAtSha}`);
+  console.log("candidates (newest first):");
+  for (const c of candidates) console.log(`  ${c.sha} gate=${c.gate}`);
+}
+
+main().catch((error) => {
+  console.error(`UAT target selection failed: ${error.message}`);
+  process.exit(1);
+});

--- a/hushh-webapp/scripts/ci/uat-target-selection.mjs
+++ b/hushh-webapp/scripts/ci/uat-target-selection.mjs
@@ -1,0 +1,217 @@
+/**
+ * Which commit UAT should move to next.
+ *
+ * The rule this exists to enforce: **deploy the newest eligible green SHA, never
+ * "latest main".** A branch is a moving pointer; a deployment target must not be.
+ *
+ * The incident that produced it: a merge SHA was green, a teammate merged after
+ * it, and the deploy was dispatched against the branch tip instead of a
+ * validated commit. The tip's own post-merge gate had not finished, so the
+ * deploy gate refused it and UAT stayed on an older build — the right outcome,
+ * reached by luck rather than by design. Nothing had *selected* a target; a
+ * human had guessed one, and the guess happened to be a commit that was not yet
+ * proven.
+ *
+ * `deploy-uat.yml` still contains that shape today: a blank `sha` input resolves
+ * to `git rev-parse origin/main`. This module replaces the guess with a
+ * decision.
+ *
+ * Deliberately pure. It takes the state someone else gathered and returns a
+ * verdict, so every rule below is testable without a network, a clone, or a
+ * cloud project — and so the stale-candidate table is pinned by tests rather
+ * than living in a runbook nobody re-reads.
+ */
+
+/**
+ * @typedef {Object} Candidate
+ * @property {string} sha            Full 40-character commit SHA.
+ * @property {"success"|"failure"|"pending"|"absent"|"unknown"} gate
+ *   The conclusion of that commit's OWN post-merge gate. `absent` means no such
+ *   check exists for it, which is normal for non-merge commits carried in by a
+ *   merge — they are not deployment targets in their own right.
+ */
+
+/**
+ * @typedef {Object} ReconcileInput
+ * @property {string} mainTipSha
+ * @property {string|null} uatActualSha     Currently verified on UAT.
+ * @property {string|null} uatDeployingSha  In-flight target, or null.
+ * @property {Candidate[]} candidates       Commits after uatActualSha, NEWEST FIRST.
+ */
+
+/**
+ * @typedef {Object} ReconcileResult
+ * @property {"DEPLOY_EXACT_SHA"|"NO_OP"|"AUTOMATIC_WAIT"|"BLOCKED"|"DEPLOY_IN_FLIGHT"} decision
+ * @property {string|null} targetSha
+ * @property {string} reason
+ * @property {string|null} blockedAtSha   The newest commit whose own gate failed.
+ */
+
+const GREEN = "success";
+
+/**
+ * Decide the next UAT move.
+ *
+ * Order matters and encodes the policy:
+ *
+ * 1. An active deployment is never retargeted or cancelled just because `main`
+ *    moved. Finish it, then reconcile again.
+ * 2. The newest **green** candidate wins. A newer commit that is pending,
+ *    queued, failed or unknown may never be substituted for it — and equally,
+ *    a newer pending commit does not make an older green one stale.
+ * 3. A failed gate blocks that commit only. It is reported so the branch's
+ *    health is visible, but it never blocks an older green ancestor from
+ *    deploying, and it never gets deployed itself.
+ *
+ * @param {ReconcileInput} input
+ * @returns {ReconcileResult}
+ */
+export function reconcileUatTarget(input) {
+  const { uatActualSha, uatDeployingSha, candidates } = input;
+
+  if (uatDeployingSha) {
+    return {
+      decision: "DEPLOY_IN_FLIGHT",
+      targetSha: null,
+      reason: `A UAT deployment of ${short(uatDeployingSha)} is already running; it is never cancelled or retargeted because main moved.`,
+      blockedAtSha: null,
+    };
+  }
+
+  if (!candidates.length) {
+    return {
+      decision: "NO_OP",
+      targetSha: null,
+      reason: uatActualSha
+        ? `UAT already runs ${short(uatActualSha)} and no newer commit exists.`
+        : "No candidate commits and no known UAT state.",
+      blockedAtSha: null,
+    };
+  }
+
+  // Newest green wins. Scanning newest-first means a newer green commit
+  // supersedes an older one automatically, which is what makes a queued
+  // candidate safe to coalesce.
+  const target = candidates.find((c) => c.gate === GREEN) ?? null;
+
+  // Reported for visibility only. A failure never blocks an older green
+  // ancestor — the ancestor is proven on its own gate, not on its descendant's.
+  const failed = candidates.find((c) => c.gate === "failure") ?? null;
+
+  if (target) {
+    return {
+      decision: "DEPLOY_EXACT_SHA",
+      targetSha: target.sha,
+      reason: failed
+        ? `${short(target.sha)} is the newest commit with its own successful gate; main is separately blocked at ${short(failed.sha)}.`
+        : `${short(target.sha)} is the newest commit with its own successful gate.`,
+      blockedAtSha: failed ? failed.sha : null,
+    };
+  }
+
+  if (failed) {
+    return {
+      decision: "BLOCKED",
+      targetSha: null,
+      reason: `No candidate has a successful gate and main is blocked at ${short(failed.sha)}; UAT stays on ${short(uatActualSha)}.`,
+      blockedAtSha: failed.sha,
+    };
+  }
+
+  return {
+    decision: "AUTOMATIC_WAIT",
+    targetSha: null,
+    reason: `No candidate has finished its gate yet; UAT stays on ${short(uatActualSha)} until one does.`,
+    blockedAtSha: null,
+  };
+}
+
+/**
+ * Is a specific, already-chosen target still safe to deploy?
+ *
+ * Run immediately before mutating UAT, and again for any manually supplied SHA.
+ * A manual target is a request, not a permission: it must clear the same bar as
+ * one the reconciler picked.
+ *
+ * @param {Object} params
+ * @param {string} params.targetSha
+ * @param {string|null} params.uatActualSha
+ * @param {"success"|"failure"|"pending"|"absent"|"unknown"} params.targetGate
+ * @param {boolean} params.reachableFromMain
+ * @param {boolean} params.descendsFromUatActual
+ * @returns {{ ok: boolean, reason: string }}
+ */
+export function assertDeployable(params) {
+  const {
+    targetSha,
+    uatActualSha,
+    targetGate,
+    reachableFromMain,
+    descendsFromUatActual,
+  } = params;
+
+  if (!/^[0-9a-f]{40}$/.test(String(targetSha || ""))) {
+    return {
+      ok: false,
+      reason: `Target must be a full 40-character commit SHA, never a branch name. Got: ${targetSha || "(empty)"}`,
+    };
+  }
+  if (!reachableFromMain) {
+    return { ok: false, reason: `${short(targetSha)} is not reachable from protected main.` };
+  }
+  if (targetGate !== GREEN) {
+    return {
+      ok: false,
+      reason: `${short(targetSha)} has no successful gate of its own (observed: ${targetGate}).`,
+    };
+  }
+  if (uatActualSha && targetSha === uatActualSha) {
+    return { ok: false, reason: `${short(targetSha)} is already live on UAT.` };
+  }
+  // Forward-only. Redeploying an ancestor would silently roll teammates' merged
+  // work out of UAT, which is the failure this whole module exists to avoid.
+  if (uatActualSha && !descendsFromUatActual) {
+    return {
+      ok: false,
+      reason: `${short(targetSha)} does not descend from the live UAT commit ${short(uatActualSha)}; UAT never moves backward automatically.`,
+    };
+  }
+  return { ok: true, reason: `${short(targetSha)} is eligible.` };
+}
+
+/**
+ * Did the thing we deployed actually end up running?
+ *
+ * A 200 from a health endpoint proves a server answered, not which build
+ * answered. Release identity is a separate assertion, and conflating the two is
+ * how a stale rollout or a mutable tag passes for a release.
+ *
+ * @param {Object} params
+ * @param {string} params.targetSha
+ * @param {string|null} params.runtimeSha
+ * @param {boolean} params.smokePassed
+ * @returns {{ ok: boolean, reason: string }}
+ */
+export function assertRuntimeIdentity(params) {
+  const { targetSha, runtimeSha, smokePassed } = params;
+  if (!smokePassed) {
+    return { ok: false, reason: "Post-deploy smoke checks did not pass." };
+  }
+  if (!runtimeSha) {
+    return {
+      ok: false,
+      reason: "The running service did not report a commit SHA, so its release identity is unproven.",
+    };
+  }
+  if (runtimeSha !== targetSha) {
+    return {
+      ok: false,
+      reason: `Runtime reports ${short(runtimeSha)} but ${short(targetSha)} was deployed; treat as failed and investigate tagging or rollout.`,
+    };
+  }
+  return { ok: true, reason: `Runtime confirms ${short(targetSha)}.` };
+}
+
+function short(sha) {
+  return sha ? String(sha).slice(0, 12) : "none";
+}


### PR DESCRIPTION
## The defect

`deploy-uat.yml` resolved a blank `sha` input like this:

```bash
git fetch --no-tags origin main
DEPLOY_SHA="$(git rev-parse origin/main)"   # ← deploy whatever main is right now
```

A branch tip answers *"what happened most recently"*. That is a different question from *"what is proven"*, and on 2026-08-14 the two answers differed by seconds — a green merge, then a teammate's merge whose own post-merge gate had not finished, and the tip was dispatched.

The existing validator refused it, so **UAT was never harmed**. But it refused *after* the dispatch, and only because the ordering happened to be caught. Nothing had **selected** a target; a human had guessed one. Selecting is the fix; validating stays as the backstop.

## The change

A blank input now picks **the newest commit that has its own successful post-merge gate**. An explicit SHA remains a request rather than a permission — it goes through the same validator it always did.

Decision logic is pure and separate from state-gathering, so the policy is pinned by tests instead of a runbook:

| Situation | Decision |
|---|---|
| A green, newer B **pending** | Deploy **A**. Never substitute B. *(the incident)* |
| A green, newer B **green** | Deploy **B**; A is safely coalesced |
| A **already deploying**, B turns green | Finish A. Never cancel or retarget |
| A green, newer B **failed** | Deploy **A**; report main blocked at B |
| Commit has **no gate of its own** | Not a target — non-merge commits carried in by a merge |
| Target does not descend from live UAT | Refused. UAT never moves backward |
| Health check 200 but runtime SHA differs | Deployment **failed**, not succeeded |

## State sources, deliberately independent

- **What UAT runs now** → the GitHub Deployment record for environment `uat`
- **Whether a commit is proven** → that commit's *own* check runs, never a branch status or a PR check
- **What is on main** → `git rev-list` against the fetched remote ref

The deployment record and the live Cloud Run image tag were cross-checked and **agree** (`f568e402…` both).

## Verification

Run against the live repository before wiring it in:

```
main_tip_sha: df3258c674d4bd69a5940e74b0173da3dbd5b897
main_tip_gate: success
uat_actual_sha: f568e402b72a48f366b94eb541432ada00806f56
target_sha:     df3258c674d4bd69a5940e74b0173da3dbd5b897
decision: DEPLOY_EXACT_SHA
candidates (newest first):
  df3258c674d4…  gate=success
  2dd7b957545b…  gate=absent     ← correctly skipped
```

That second line is the selector earning its keep on the first real run: a non-merge commit with no gate of its own, which a "latest main" resolver would have been willing to target.

- 19 tests, one per policy row
- `npx tsc --noEmit` clean, `npm run lint` clean, workflow YAML re-parsed
- **Mutation-checked**: restoring `candidates[0]` (deploy the newest regardless of gate) fails 5 tests, including the incident case

## Scope, stated plainly

This ships the **selection primitive** and wires it into the existing hardened deploy lane. It does **not** add the `workflow_run` auto-trigger that would deploy on every green merge without a dispatch.

That is deliberate sequencing, not a silent trim: auto-deploying every merge is a team-wide behaviour change, and I would rather selection prove itself on real dispatches first. The safety-critical half — never targeting an unproven commit — is what lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)