### PR TITLE
fix(one): polish calendar confirmations and local startup

### DIFF
--- a/consent-protocol/hushh_mcp/agents/calendar/tools.py
+++ b/consent-protocol/hushh_mcp/agents/calendar/tools.py
@@ -282,7 +282,15 @@ async def _propose(
     plan = proposal["plan"]
     verb = {"create": "Schedule", "reschedule": "Reschedule", "cancel": "Cancel"}[action]
     conflicts = plan.get("conflicts") if isinstance(plan.get("conflicts"), list) else []
-    summary = _proposal_summary(action=action, plan=plan, conflicts=conflicts)
+    # Presentation belongs to the active chat session, not to the provider's
+    # event payload.  A proposal can legitimately contain UTC instants while
+    # the person is using One in another local timezone.
+    summary = _proposal_summary(
+        action=action,
+        plan=plan,
+        conflicts=conflicts,
+        display_time_zone=_timezone(tool_context),
+    )
     confirm_label = f"{verb} anyway" if conflicts else verb
     tool_context.state[f"{_STATE_PENDING_DIRECTIVE}:calendar"] = {
         "kind": "action",
@@ -310,13 +318,19 @@ async def _propose(
     }
 
 
-def _proposal_summary(*, action: str, plan: dict[str, Any], conflicts: list[object]) -> str:
+def _proposal_summary(
+    *,
+    action: str,
+    plan: dict[str, Any],
+    conflicts: list[object],
+    display_time_zone: str,
+) -> str:
     verb = {"create": "Schedule", "reschedule": "Reschedule", "cancel": "Cancel"}[action]
     title = str(plan.get("title") or plan.get("event_id") or "this event")
     timing = (
         ""
         if action == "cancel"
-        else f" for {_display_time(plan.get('start_at'), plan.get('time_zone'))}"
+        else f" for {_display_time(plan.get('start_at'), display_time_zone)}"
     )
     attendee_note = (
         f" and notify {len(plan.get('attendees', []))} attendee(s)"
@@ -324,7 +338,7 @@ def _proposal_summary(*, action: str, plan: dict[str, Any], conflicts: list[obje
         else " without sending updates"
     )
     details = [
-        _conflict_detail(item, time_zone=str(plan.get("time_zone") or "UTC"))
+        _conflict_detail(item, time_zone=display_time_zone)
         for item in conflicts
         if isinstance(item, dict)
     ]

--- a/consent-protocol/tests/agents/test_calendar_agent_tools.py
+++ b/consent-protocol/tests/agents/test_calendar_agent_tools.py
@@ -149,6 +149,49 @@ def test_calendar_conflict_requires_an_explicit_schedule_anyway_choice(monkeypat
     assert directive["payload"]["confirmLabel"] == "Schedule anyway"
 
 
+def test_calendar_confirmation_uses_the_chat_users_timezone_not_plan_utc(monkeypatch) -> None:  # noqa: ANN001
+    context = _context()
+    calendar = _Calendar()
+
+    async def propose(**kwargs: object) -> dict[str, object]:
+        return {
+            "proposal_id": "gcal_example",
+            "expires_at": "2026-08-11T12:00:00Z",
+            "plan": {
+                "title": "Client call",
+                "start_at": "2026-08-11T04:30:00Z",
+                "end_at": "2026-08-11T05:00:00Z",
+                # Google/provider plan data is allowed to be UTC. It must not
+                # dictate the confirmation display timezone.
+                "time_zone": "UTC",
+                "attendees": [],
+                "send_updates": True,
+                "conflicts": [
+                    {
+                        "title": "Design review",
+                        "start": {"dateTime": "2026-08-11T04:30:00Z"},
+                    }
+                ],
+            },
+        }
+
+    calendar.propose = propose  # type: ignore[method-assign]
+    monkeypatch.setattr(tools, "get_google_calendar_service", lambda: calendar)
+
+    asyncio.run(
+        tools.propose_calendar_event(
+            context,
+            title="Client call",
+            start_at="2026-08-11T10:00:00+05:30",
+            end_at="2026-08-11T10:30:00+05:30",
+        )
+    )
+
+    summary = context.state["hussh:pending_directive:calendar"]["payload"]["summary"]
+    assert "10:00 AM IST" in summary
+    assert "UTC" not in summary
+
+
 class _ReadOnlyCalendar:
     async def propose(self, **kwargs: object) -> dict[str, object]:
         raise GoogleConnectionError(

--- a/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
@@ -70,11 +70,12 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).not.toContain("Writing in expanded composer");
   });
 
-  it("uses the nested stream response surface only when a turn has supporting context", () => {
+  it("keeps stream panels for normal assistant turns and bypasses them only for calendar status", () => {
     const workspace = read("components/agent/agent-chat-workspace.tsx");
 
-    expect(workspace).toContain("const hasSupportingTurnContext =");
-    expect(workspace).toContain("Boolean(message.sources?.length);");
-    expect(workspace).not.toContain("Boolean(message.text.trim());\n  const shouldRenderStreamPanel");
+    expect(workspace).toContain("const hasStreamContent =");
+    expect(workspace).toContain("Boolean(message.text.trim());");
+    expect(workspace).toContain("!message.renderAsPlainAssistantMessage;");
+    expect(workspace).toContain("renderAsPlainAssistantMessage: true,");
   });
 });

--- a/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
@@ -27,7 +27,7 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).toContain("ShellActionSurface");
     expect(workspace).toContain('"motion-step-enter flex w-full"');
     expect(workspace).not.toContain("animate-in fade-in slide-in-from-bottom-1");
-    expect(workspace).toContain("rounded-[var(--app-radius-pill)]");
+    expect(workspace).toContain('className="flex min-h-16 items-end gap-2 rounded-2xl');
     expect(history).toContain("bg-foreground/[0.025]");
   });
 
@@ -50,7 +50,7 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).not.toContain("streamAbortControllerRef.current?.abort();\n    streamAbortControllerRef.current = streamAbortController");
   });
 
-  it("keeps compact composer text inside its pill-safe inset and opens a separate long-form editor", () => {
+  it("keeps compact composer controls inside a rectangular editor and opens a separate long-form editor", () => {
     const workspace = read("components/agent/agent-chat-workspace.tsx");
 
     expect(workspace).toContain("agent-chat-composer-expand");
@@ -59,7 +59,8 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).toContain("overflow-y-auto");
     expect(workspace).toContain("px-7 py-3 pr-14");
     expect(workspace).toContain("sm:px-8 sm:pr-14");
-    expect(workspace).toContain("rounded-[var(--app-radius-pill)]");
+    expect(workspace).toContain("rounded-2xl border border-border/70 bg-foreground/[0.04]");
+    expect(workspace).toContain('className="flex shrink-0 self-end items-center gap-2"');
     expect(workspace).toContain("max-h-28");
     expect(workspace).toContain("sm:max-h-36");
     expect(workspace).toContain("h-[min(38dvh,18rem)]");
@@ -67,5 +68,13 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).toContain("composerLong ?");
     expect(workspace).not.toContain("Expanded message</span>");
     expect(workspace).not.toContain("Writing in expanded composer");
+  });
+
+  it("uses the nested stream response surface only when a turn has supporting context", () => {
+    const workspace = read("components/agent/agent-chat-workspace.tsx");
+
+    expect(workspace).toContain("const hasSupportingTurnContext =");
+    expect(workspace).toContain("Boolean(message.sources?.length);");
+    expect(workspace).not.toContain("Boolean(message.text.trim());\n  const shouldRenderStreamPanel");
   });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -173,6 +173,10 @@ type AgentMessage = {
   status?: "streaming" | "done" | "error";
   ephemeral?: boolean;
   kind?: "selection";
+  // Calendar proposal status is already a bounded confirmation/result. Keep
+  // that one message on the regular assistant surface instead of wrapping it
+  // in the generic turn stream panel.
+  renderAsPlainAssistantMessage?: boolean;
   specialistDirective?: SpecialistDirectiveEvent | null;
   streamEvents?: AgentVisibleStreamEvent[];
   thought?: string;
@@ -845,16 +849,18 @@ function AgentBubble({
   const isStreaming = message.status === "streaming";
   const isError = message.status === "error";
   const streamEvents = message.streamEvents ?? [];
-  // The stream panel owns its own response card. Plain assistant completions
-  // (for example, "Scheduled Client call.") therefore stay on the normal
-  // single-bubble path rather than rendering as a card inside another card.
-  const hasSupportingTurnContext =
+  // Preserve the normal turn stream panel for every assistant response so
+  // Working Notes and Sources remain available. Calendar proposal status is
+  // the narrow exception: it has its own explicit confirmation lifecycle.
+  const hasStreamContent =
     streamEvents.length > 0 ||
     Boolean(message.thought?.trim()) ||
-    Boolean(message.sources?.length);
+    Boolean(message.sources?.length) ||
+    Boolean(message.text.trim());
   const shouldRenderStreamPanel =
     !isUser &&
-    hasSupportingTurnContext;
+    hasStreamContent &&
+    !message.renderAsPlainAssistantMessage;
   const animated = useAnimatedAssistantText(message.text, !isUser && isStreaming);
   const assistantText = isUser ? message.text : animated.displayedText;
   const consentActionsPayload = !isUser
@@ -3659,6 +3665,7 @@ export function AgentChatWorkspace({
       text: "Scheduling…",
       timestamp: formatNow(),
       status: "streaming",
+      renderAsPlainAssistantMessage: true,
     });
     setPendingSpecialistDirective(null);
     setSpecialistBusy(true);

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -845,14 +845,16 @@ function AgentBubble({
   const isStreaming = message.status === "streaming";
   const isError = message.status === "error";
   const streamEvents = message.streamEvents ?? [];
-  const hasStreamContent =
+  // The stream panel owns its own response card. Plain assistant completions
+  // (for example, "Scheduled Client call.") therefore stay on the normal
+  // single-bubble path rather than rendering as a card inside another card.
+  const hasSupportingTurnContext =
     streamEvents.length > 0 ||
     Boolean(message.thought?.trim()) ||
-    Boolean(message.sources?.length) ||
-    Boolean(message.text.trim());
+    Boolean(message.sources?.length);
   const shouldRenderStreamPanel =
     !isUser &&
-    hasStreamContent;
+    hasSupportingTurnContext;
   const animated = useAnimatedAssistantText(message.text, !isUser && isStreaming);
   const assistantText = isUser ? message.text : animated.displayedText;
   const consentActionsPayload = !isUser
@@ -3918,7 +3920,7 @@ export function AgentChatWorkspace({
       <Button
         type="submit"
         size="icon"
-        className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 max-sm:rounded-full max-sm:enabled:bg-[color:var(--app-accent)] max-sm:enabled:text-[color:var(--app-accent-fg)] max-sm:enabled:shadow-[var(--app-accent-ring)] max-sm:enabled:hover:bg-[color:var(--app-accent-hover)] max-sm:focus-visible:ring-[color:var(--app-accent-ring)] disabled:bg-black/[0.06] disabled:text-[rgba(0,0,0,0.36)] disabled:shadow-none dark:disabled:bg-white/[0.08] dark:disabled:text-zinc-500 dark:max-sm:enabled:bg-[color:var(--app-accent)] dark:max-sm:enabled:text-[color:var(--app-accent-fg)]"
+        className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 max-sm:enabled:bg-[color:var(--app-accent)] max-sm:enabled:text-[color:var(--app-accent-fg)] max-sm:enabled:shadow-[var(--app-accent-ring)] max-sm:enabled:hover:bg-[color:var(--app-accent-hover)] max-sm:focus-visible:ring-[color:var(--app-accent-ring)] disabled:bg-black/[0.06] disabled:text-[rgba(0,0,0,0.36)] disabled:shadow-none dark:disabled:bg-white/[0.08] dark:disabled:text-zinc-500 dark:max-sm:enabled:bg-[color:var(--app-accent)] dark:max-sm:enabled:text-[color:var(--app-accent-fg)]"
         disabled={!canSend}
         aria-label="Send message"
       >
@@ -4816,7 +4818,7 @@ export function AgentChatWorkspace({
                   {!composerExpanded ? (
                     <div
                       data-testid="agent-chat-composer"
-                      className="flex min-h-16 items-end gap-2 rounded-[var(--app-radius-pill)] border border-border/70 bg-foreground/[0.04] px-3 py-2 shadow-[var(--app-card-shadow-standard)] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 max-sm:focus-within:border-[color:var(--app-accent)] max-sm:focus-within:ring-[color:var(--app-accent-ring)]"
+                      className="flex min-h-16 items-end gap-2 rounded-2xl border border-border/70 bg-foreground/[0.04] px-3 py-2 shadow-[var(--app-card-shadow-standard)] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 max-sm:focus-within:border-[color:var(--app-accent)] max-sm:focus-within:ring-[color:var(--app-accent-ring)]"
                     >
                       <div className="relative min-w-0 flex-1 self-stretch">
                         <textarea
@@ -4854,7 +4856,9 @@ export function AgentChatWorkspace({
                           </Button>
                         ) : null}
                       </div>
-                      {composerActionRail}
+                      <div className="flex shrink-0 self-end items-center gap-2">
+                        {composerActionRail}
+                      </div>
                     </div>
                   ) : null}
                 </>

--- a/scripts/runtime/run_local_fast.sh
+++ b/scripts/runtime/run_local_fast.sh
@@ -83,7 +83,7 @@ wait_for_http() {
   start="$(date +%s)"
 
   until curl -fsS "$url" >/dev/null 2>&1; do
-    if [ $(( "$(date +%s)" - start )) -ge "$timeout_seconds" ]; then
+    if [ $(( $(date +%s) - start )) -ge "$timeout_seconds" ]; then
       echo "Timed out waiting for ${label}: ${url}" >&2
       return 1
     fi


### PR DESCRIPTION
## Summary
- display calendar proposal/conflict confirmation times in the active user timezone
- render plain assistant completion statuses as a single surface and keep the composer controls contained in a rectangular editor
- repair the local fast-runtime health wait so Cloud SQL/backend startup can complete

## Verification
- `consent-protocol/.venv/bin/python -m pytest tests/agents/test_calendar_agent_tools.py -q`
- `hushh-webapp: npm test -- --run __tests__/components/agent-chat-shell.contract.test.ts`
- focused ESLint, Ruff, shell syntax, and full local runtime doctor/health smoke
