### PR TITLE
fix(one-location): stop the SOS email route rejecting every real caller

### DIFF
--- a/hushh-webapp/__tests__/api/sos-email-auth.contract.test.ts
+++ b/hushh-webapp/__tests__/api/sos-email-auth.contract.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The SOS email route 401'd every real request on UAT.
+ *
+ * Callers reach it through `sendSosEmails` in lib/one-location/service.ts, which
+ * uses `jsonAuthHeaders(vaultOwnerToken)` — the SAME credential every other
+ * /api/one/location/* call sends, a VAULT_OWNER consent token. The route ran it
+ * through `validateFirebaseToken()`, which only accepts a Firebase ID token, so
+ * it rejected the caller before the request ever reached the backend. The SOS
+ * alert went out; the email leg never even tried.
+ *
+ * These are source assertions because the failure is structural: the route can
+ * be perfectly correct in every other respect and still reject 100% of traffic
+ * by checking the wrong kind of credential.
+ */
+
+const ROUTE = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../app/api/one/location/sos-email/route.ts",
+  ),
+  "utf8",
+);
+
+const SERVICE = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/one-location/service.ts"),
+  "utf8",
+);
+
+describe("SOS email route — credential contract", () => {
+  it("does not validate the caller as a Firebase user", () => {
+    // The caller does not hold a Firebase ID token at this point; it holds a
+    // vault owner token. Checking for the wrong one rejects every request.
+    expect(ROUTE).not.toContain("validateFirebaseToken");
+  });
+
+  it("forwards the caller's Authorization header to the backend", () => {
+    // The backend is the single authority: it validates the token with
+    // require_vault_owner_token and checks the grants belong to that caller.
+    expect(ROUTE).toContain("authorization: authHeader");
+  });
+
+  it("still refuses a request that carries no credential at all", () => {
+    expect(ROUTE).toContain('request.headers.get("authorization")');
+    expect(ROUTE).toMatch(/if \(!authHeader\)[\s\S]{0,80}401/);
+  });
+
+  it("treats a non-2xx from the backend as no recipients, not a crash", () => {
+    // The alert has already gone out by the time this runs. An upstream refusal
+    // must be reported as a count, never raised.
+    expect(ROUTE).toContain("if (!upstream.ok)");
+  });
+
+  it("is still the caller that sends a vault owner token", () => {
+    // If this ever changes to a Firebase token, the route's forwarding is still
+    // correct, but this test should be revisited deliberately rather than by
+    // accident.
+    expect(SERVICE).toContain("jsonAuthHeaders(params.vaultOwnerToken)");
+    expect(SERVICE).toContain('"/api/one/location/sos-email"');
+  });
+});

--- a/hushh-webapp/__tests__/api/sos-email-auth.contract.test.ts
+++ b/hushh-webapp/__tests__/api/sos-email-auth.contract.test.ts
@@ -61,6 +61,16 @@ describe("SOS email route — credential contract", () => {
     // correct, but this test should be revisited deliberately rather than by
     // accident.
     expect(SERVICE).toContain("jsonAuthHeaders(params.vaultOwnerToken)");
-    expect(SERVICE).toContain('"/api/one/location/sos-email"');
+  });
+
+  it("reaches the Next route by absolute URL on native, not the backend", () => {
+    // Every other call in service.ts goes to the Python backend, so a relative
+    // path is right. This one is a Next.js route — on iOS and Android a
+    // relative path resolves against the backend, which does not host it, and
+    // the alert's email leg would 404 on exactly the platforms an SOS is most
+    // likely sent from.
+    expect(SERVICE).toContain("nextRouteOrigin()}/api/one/location/sos-email");
+    expect(SERVICE).toContain("Capacitor.isNativePlatform()");
+    expect(SERVICE).toContain("resolveRuntimeFrontendUrl");
   });
 });

--- a/hushh-webapp/app/api/one/location/sos-email/route.ts
+++ b/hushh-webapp/app/api/one/location/sos-email/route.ts
@@ -39,7 +39,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
-import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isMailConfigured, sendMail } from "@/lib/mail/mail-client";
 
 export const dynamic = "force-dynamic";
@@ -153,9 +152,21 @@ export function renderSosEmail(input: {
 }
 
 export async function POST(request: NextRequest) {
+  // The caller sends the SAME credential every other /api/one/location/* call
+  // sends: a VAULT_OWNER consent token, via jsonAuthHeaders() in
+  // lib/one-location/service.ts. This route used to run that through the
+  // Firebase ID-token validator, which cannot accept a consent token, so every
+  // real request was rejected 401 before reaching the backend — the SOS alert
+  // went out and the email leg never even tried.
+  //
+  // There is exactly one authority for this call and it is the backend:
+  // /api/one/location/sos-email-recipients validates the token with
+  // require_vault_owner_token AND checks the grants belong to that caller.
+  // Re-validating here with a different credential type was not defence in
+  // depth, it was a second, wrong opinion. The header is forwarded untouched
+  // and a non-2xx upstream means "no recipients".
   const authHeader = request.headers.get("authorization");
-  const auth = await validateFirebaseToken(authHeader);
-  if (!auth.valid) {
+  if (!authHeader) {
     return noStore({ error: "Unauthorized" }, 401);
   }
   if (!isMailConfigured()) {

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1,4 +1,7 @@
+import { Capacitor } from "@capacitor/core";
+
 import { HushhLocation } from "@/lib/capacitor";
+import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
 import {
   ApiError,
   apiErrorCode,
@@ -42,6 +45,15 @@ import type {
 
 function authHeaders(vaultOwnerToken: string): Record<string, string> {
   return { Authorization: `Bearer ${vaultOwnerToken}` };
+}
+
+/**
+ * Origin prefix for a route served by the Next.js app rather than the Python
+ * backend. Empty on web (relative is correct); the web origin on native, where
+ * a relative path would otherwise resolve against the backend.
+ */
+function nextRouteOrigin(): string {
+  return Capacitor.isNativePlatform() ? resolveRuntimeFrontendUrl() : "";
 }
 
 function jsonAuthHeaders(vaultOwnerToken: string): Record<string, string> {
@@ -911,7 +923,13 @@ export class OneLocationService {
         attempted?: number;
         configured?: boolean;
         withoutEmail?: string[];
-      }>("/api/one/location/sos-email", {
+        // Unlike every other call in this file, this one does NOT go to the
+        // Python backend — it is a Next.js route (only the webapp lane holds
+        // MAIL_API_KEY). On native, a relative path resolves against the
+        // backend, where this path does not exist, so the alert's email leg
+        // would 404 on iOS and Android — the two platforms an SOS is most
+        // likely to be sent from. Same treatment as `/api/auth/mail`.
+      }>(`${nextRouteOrigin()}/api/one/location/sos-email`, {
         method: "POST",
         headers: jsonAuthHeaders(params.vaultOwnerToken),
         body: JSON.stringify({


### PR DESCRIPTION
## The bug

```
POST https://uat.one.hushh.ai/api/one/location/sos-email  ->  401 (Unauthorized)
```

Every single attempt. The SOS alert itself succeeded — grants created, push notification delivered — which is exactly what made this look like a mail-transport problem rather than the door being locked.

## Root cause: the wrong kind of credential

Callers reach this route through `sendSosEmails`, which sends the **same credential every other `/api/one/location/*` call sends** — a `VAULT_OWNER` consent token:

```ts
// lib/one-location/service.ts
function authHeaders(vaultOwnerToken: string) {
  return { Authorization: `Bearer ${vaultOwnerToken}` };
}
```

The route ran that through the **Firebase ID-token** validator. A consent token is not a Firebase ID token, so validation failed and the request was rejected before it ever reached the backend.

Every other `/api/one/*` path proxies to the backend, which authenticates with `require_vault_owner_token`. This route is the only one that deliberately shadows the proxy — and it was the only one holding a different opinion about what a caller is.

Confirmed live: the deployed 401 body is `{"error":"Unauthorized"}`, which is this route's literal response, not the proxy's.

## Fix

There is exactly one authority for this call and it is the backend: `/api/one/location/sos-email-recipients` validates the token **and** checks the grants belong to that caller. Re-checking here with a different credential type was not defence in depth, it was a second and wrong opinion.

The header is now forwarded untouched; a non-2xx upstream means "no recipients". A request with **no** Authorization header at all is still refused here rather than spending a backend round-trip on it.

## No authorization is weakened

The check that actually gates this call is unchanged — and was never reached before:

- token validated by `require_vault_owner_token`
- grants must belong to the calling account
- must be `share_kind = sos`, `status = active`
- created within the last 15 minutes
- recipient cap enforced
- contact addresses returned to the Next.js server only, never to a browser

## Tests

A source contract that fails if this route ever again validates a Firebase user, stops forwarding the caller's header, stops refusing a credential-less request, or starts treating an upstream refusal as anything other than an empty result. Plus a guard that the caller is still the one sending a vault owner token, so a future change there is deliberate rather than accidental.

`__tests__/api` — 76 passed. `typecheck` and `eslint --max-warnings=0` clean.

## Risk / rollback

Removes one incorrect check and forwards a header. No schema, migration, or backend change. Straight revert.