### PR TITLE
fix(one-location): recover from a blocked permission on SOS too, and stop the map warning

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-recovery-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-recovery-placement.contract.test.ts
@@ -1,0 +1,77 @@
+// Where the blocked-location recovery card has to appear.
+//
+// The card was added to the Location hub and nowhere else, so opening Save my
+// Soul with location blocked still produced the original dead end: a toast that
+// vanished, two console warnings, and a send button that refuses - with nothing
+// on screen saying why or what to do. On a personal-safety surface that is the
+// worst possible screen to leave unexplained.
+//
+// A source contract rather than a render test because `SosFlow` is an internal
+// of a 2900-line module and depends on the whole view model; widening its
+// export surface purely to assert one line of wiring would be a worse trade.
+// This repo already guards placement this way.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const HUB = path.join(
+  process.cwd(),
+  "components/one-location/redesign/location-redesign-hub.tsx",
+);
+
+const source = readFileSync(HUB, "utf8");
+
+/** The body of a top-level `function <name>(` declaration. */
+function functionBody(name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  expect(start, `${name} not found in the hub`).toBeGreaterThan(-1);
+  // Next top-level declaration, or end of file.
+  const next = source.indexOf("\nfunction ", start + 1);
+  return source.slice(start, next === -1 ? source.length : next);
+}
+
+describe("blocked-location recovery placement", () => {
+  it("is rendered by the SOS flow", () => {
+    // The screen in the report. Location failing here is the difference between
+    // an alert that sends a position and one that cannot.
+    expect(functionBody("SosFlow")).toContain("LocationPermissionRecoveryCard");
+  });
+
+  it("is rendered by the Location hub", () => {
+    expect(functionBody("LocationRedesignHub")).toContain(
+      "LocationPermissionRecoveryCard",
+    );
+  });
+
+  it("is gated on an observed block, never shown unconditionally", () => {
+    // Telling someone their browser is blocking location when it is not sends
+    // them into settings for no reason and teaches them to ignore the message.
+    for (const fn of ["SosFlow", "LocationRedesignHub"]) {
+      const body = functionBody(fn);
+      const index = body.indexOf("LocationPermissionRecoveryCard");
+      const around = body.slice(Math.max(0, index - 400), index + 400);
+      expect(around, `${fn} must gate the card on locationBlocked`).toMatch(
+        /locationBlocked/,
+      );
+    }
+  });
+});
+
+describe("the immersive map does not fight its own mapId", () => {
+  const MAP = path.join(
+    process.cwd(),
+    "components/one-location/location-immersive-map.tsx",
+  );
+  const mapSource = readFileSync(MAP, "utf8");
+
+  it("passes no styles to a map the plugin gives a mapId", () => {
+    // @capacitor/google-maps sets a mapId because advanced markers need one,
+    // and Google ignores `styles` whenever a mapId is present - logging
+    // "A Map's styles property cannot be set when a mapId is present" on every
+    // map create. The styling never applied; only the warning did.
+    expect(mapSource).not.toMatch(/^\s*styles:/m);
+    expect(mapSource).not.toContain("DARK_MAP_STYLES,");
+  });
+});

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -42,7 +42,6 @@ import {
 } from "@/lib/one-location/location-workspace-memory";
 import { updateOneLocationControlState } from "@/lib/one-location/location-control-state";
 import {
-  DARK_MAP_STYLES,
   getBrowserMapsApiKey,
   getNativeMapsApiKey,
 } from "@/lib/one-location/maps-config";
@@ -988,15 +987,19 @@ export function LocationImmersiveMap({
               ? 11
               : 2,
           disableDefaultUI: true,
-          // Open dark to match the mobile dark theme. Read the resolved theme
-          // from the <html> `dark` class that next-themes sets, so no
-          // camera-recreating hook dependency is introduced; a cloud-styled
-          // mapId can supersede this.
-          styles:
-            typeof document !== "undefined" &&
-            document.documentElement.classList.contains("dark")
-              ? DARK_MAP_STYLES
-              : undefined,
+          // `styles` is deliberately NOT passed.
+          //
+          // @capacitor/google-maps sets its own `mapId` because advanced
+          // markers require one, and Google ignores `styles` entirely whenever
+          // a mapId is present — logging "A Map's styles property cannot be
+          // set when a mapId is present" on every single map create. So this
+          // was never theming anything: it was dead config that produced a
+          // warning each time the map mounted, and made the console look like
+          // the map was failing when it was not.
+          //
+          // Restoring a dark map means styling the mapId in the Google Cloud
+          // console, which is where a mapId's appearance now lives. Passing
+          // DARK_MAP_STYLES here cannot do it.
         },
       });
       if (superseded()) {

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2111,24 +2111,43 @@ function SosFlow({
   }, [onResolveSosLocation]);
 
   return (
-    <SosPanel
-      recipients={vm.smsRecipients}
-      active={vm.sosActive}
-      busy={vm.sosBusy}
-      onTrigger={vm.onTriggerSos}
-      onStopSos={vm.onStopSos}
-      stopBusy={vm.sosBusy}
-      onClose={onClose}
-      onEditContacts={onEditContacts}
-      recipientLabel={vm.recipientLabel}
-      isRecipientShareReady={vm.isRecipientShareReady}
-      emergency={lookupStartedForMount ? vm.sosEmergency : null}
-      emergencyStatus={
-        lookupStartedForMount ? vm.sosEmergencyStatus : "idle"
-      }
-      onResolveEmergencyNumber={onResolveSosLocation}
-    />
-
+    <>
+      {/*
+        SOS is the surface where a blocked permission costs the most and was
+        explained the least. The recovery card lived only on the hub, so
+        someone who opened Save my Soul with location blocked got a toast that
+        vanished, two console warnings, and a button that refuses to send —
+        with nothing on screen saying why or what to do. The card belongs
+        wherever location can fail, not only where it was first added.
+      */}
+      {vm.locationBlocked ? (
+        <div className="mb-4">
+          <LocationPermissionRecoveryCard
+            blocked
+            busy={vm.sosBusy}
+            onRetry={onResolveSosLocation}
+            onOpenSettings={vm.onOpenLocationSettings}
+          />
+        </div>
+      ) : null}
+      <SosPanel
+        recipients={vm.smsRecipients}
+        active={vm.sosActive}
+        busy={vm.sosBusy}
+        onTrigger={vm.onTriggerSos}
+        onStopSos={vm.onStopSos}
+        stopBusy={vm.sosBusy}
+        onClose={onClose}
+        onEditContacts={onEditContacts}
+        recipientLabel={vm.recipientLabel}
+        isRecipientShareReady={vm.isRecipientShareReady}
+        emergency={lookupStartedForMount ? vm.sosEmergency : null}
+        emergencyStatus={
+          lookupStartedForMount ? vm.sosEmergencyStatus : "idle"
+        }
+        onResolveEmergencyNumber={onResolveSosLocation}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Triage of the reported console

Three different things, and only two were ours.

| Message | Whose | Status |
|---|---|---|
| `[OneLocationAgent] Foreground live update skipped / Live watch error` | **ours** | Symptom of the browser blocking location. The screen had no recovery — **fixed here** |
| `A Map's styles property cannot be set when a mapId is present` | **ours** | Dead config that never applied — **fixed here** |
| `<gmp-pin>` / `<gmp-advanced-marker>` deprecations | `@capacitor/google-maps` v8 internals | Not our code. Left alone rather than papered over |

## 1. Recovery was only on the hub

The card shipped in #5267 renders on the Location hub and nowhere else. Opening **Save my Soul** with location blocked still produced the original dead end: a toast that vanishes, two console warnings, and a send button that refuses — with nothing on screen saying why or what to do.

On a personal-safety surface that is the worst possible screen to leave unexplained. The card now renders there too, gated on the same *observed* block.

## 2. The map was fighting its own mapId

`location-immersive-map` passed `styles: DARK_MAP_STYLES`. But `@capacitor/google-maps` sets a `mapId` (advanced markers require one), and **Google ignores `styles` entirely when a mapId is present**.

So the dark styling never applied. It only logged a warning on every map create — which is a meaningful share of the noise that made this console look like a failing app. Removed the dead config and the warning with it.

`DARK_MAP_STYLES` stays exported: the onboarding picker is a raw Maps JS map with no mapId, where it genuinely works. Restoring a dark immersive map means styling that mapId in the Cloud console; passing `styles` here cannot do it.

## Checked and deliberately not changed

**SOS already refuses honestly.** `resolveSosLocation()` returning null shows an error and returns without sending — it never claims to have sent a location it does not have. I verified this before touching anything, because "SOS says sent but sent nothing" would have outranked everything else in this PR.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` clean
- 4 new placement-contract tests
- **Mutation-checked**: renaming the card inside `SosFlow` fails two tests

Live verification on UAT to follow on the actual SOS screen with a genuinely blocked browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)