### PR TITLE
fix(ria): stop presenting professional scores as NWS

### DIFF
--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -269,7 +269,7 @@ describe("what the list actually shows", () => {
     // count says so rather than implying the list is complete.
     expect(screen.getByText("Builder Four")).toBeInTheDocument();
     expect(screen.queryByText("Builder Five")).not.toBeInTheDocument();
-    expect(screen.getByText(/top 5 of 7/i)).toBeInTheDocument();
+    expect(screen.getByText(/showing 5 of 7/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /show 2 more/i }));
     expect(screen.getByText("Builder Five")).toBeInTheDocument();
@@ -461,28 +461,7 @@ describe("national index", () => {
   });
 });
 
-describe("score regime", () => {
-  // Values taken from the two live markets: a registry-discovered record leaves
-  // the four graph-backed components at zero, a reviewed one populates them.
-  function breakdown(graphBacked: number) {
-    return {
-      components: [
-        { key: "graph_authority", label: "Graph authority", value: graphBacked, weight: 0.3, contribution: 0 },
-        { key: "institutional_influence", label: "Institutional influence", value: 0.746, weight: 0.2, contribution: 0.149 },
-        { key: "verified_track_record", label: "Verified track record", value: graphBacked, weight: 0.2, contribution: 0 },
-        { key: "capital_access", label: "Capital access", value: graphBacked, weight: 0.1, contribution: 0 },
-        { key: "evidence_confidence", label: "Evidence confidence", value: 0.81, weight: 0.08, contribution: 0.065 },
-        { key: "trusted_reach", label: "Trusted reach", value: graphBacked, weight: 0.07, contribution: 0 },
-        { key: "freshness", label: "Freshness", value: 0.98, weight: 0.05, contribution: 0.049 },
-      ],
-      evidenceCount: 5,
-      coverageMultiplier: 1,
-      integrityPenalty: 0,
-      localRelevance: 1,
-      method: "m",
-    };
-  }
-
+describe("professional-directory boundary", () => {
   async function openFirstRecord(over: Record<string, unknown>) {
     mockDiscover.mockResolvedValue({
       ...COVERED,
@@ -499,45 +478,21 @@ describe("score regime", () => {
     fireEvent.click(screen.getByText("Builder One"));
   }
 
-  it("says what a registry-discovered score actually measured", async () => {
-    // Two thirds of the weighting has nothing to read for these records, so
-    // they land far below a reviewed one. Unlabelled, that reads as a weaker
-    // person rather than a thinner source.
-    await openFirstRecord({ scoreBreakdown: breakdown(0) });
-
-    await waitFor(() =>
-      expect(
-        screen.getByText(/From public registry role and recency only/i),
-      ).toBeInTheDocument(),
-    );
-  });
-
-  it("stays silent for a reviewed record even though both call themselves provisional", async () => {
-    // The live service reports score_kind PROFESSIONAL_NETWORK_PROVISIONAL for
-    // reviewed and registry records alike, so the label cannot be the
-    // discriminator — claiming a reviewed record has no relationship evidence
-    // would be false.
+  it("never presents legacy professional scores as NWS or net worth", async () => {
     await openFirstRecord({
-      scoreKind: "PROFESSIONAL_NETWORK_PROVISIONAL",
-      scoreBreakdown: breakdown(0.6788),
+      globalNws: 91.2,
+      nearbyRankScore: 87.6,
     });
 
     await waitFor(() =>
-      expect(screen.getByText(/Network strength, not net worth/i)).toBeInTheDocument(),
+      expect(screen.getByText(/Record confidence · B/i)).toBeInTheDocument(),
     );
-    expect(
-      screen.queryByText(/From public registry role and recency only/i),
-    ).not.toBeInTheDocument();
-  });
-
-  it("claims nothing when there is no breakdown to read", async () => {
-    await openFirstRecord({ scoreBreakdown: null });
-
-    await waitFor(() =>
-      expect(screen.getByText(/Network strength, not net worth/i)).toBeInTheDocument(),
-    );
-    expect(
-      screen.queryByText(/From public registry role and recency only/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("87.6")).not.toBeInTheDocument();
+    expect(screen.queryByText("91.2")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Network strength/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Net Worth Score/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/How this score is built/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/reviewed facts/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Management/i })).toBeInTheDocument();
   });
 });

--- a/hushh-webapp/__tests__/services/nws-nearby-service.test.ts
+++ b/hushh-webapp/__tests__/services/nws-nearby-service.test.ts
@@ -239,6 +239,8 @@ describe("NwsNearbyService.shortlist", () => {
     expect(snapshot).not.toHaveProperty("reasons");
     expect(snapshot).not.toHaveProperty("sources");
     expect(snapshot).not.toHaveProperty("warnings");
+    expect(snapshot).not.toHaveProperty("globalNws");
+    expect(snapshot).not.toHaveProperty("nearbyRankScore");
   });
 
   it("expresses un-shortlisting as a pass, matching the deck vocabulary", async () => {

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -203,7 +203,7 @@ export default function RiaClientsPage() {
             </span>
           }
           // The roster count and its description belong to Connected. Carrying
-          // them over to Around you labelled a list of public records with a
+          // them over to Public records labelled a list of public records with a
           // count of the advisor's own clients.
           description={view === "connected" ? RIA_COPY.clients.description : undefined}
           icon={UserRound}
@@ -215,7 +215,7 @@ export default function RiaClientsPage() {
         <RiaVerificationGate>
         <div className="flex flex-col gap-8">
           {/* Connected is the roster of investors who already granted access.
-              Around you is prospecting against public records — a different
+              Public records is prospecting against public records — a different
               kind of person entirely, which is why they are separate views on
               one screen rather than one merged list. */}
           <div data-voice-control-id="ria_clients_view_switch">
@@ -224,7 +224,7 @@ export default function RiaClientsPage() {
               onValueChange={(next) => setView(next as ClientsView)}
               options={[
                 { value: "connected", label: "Connected" },
-                { value: "nearby", label: "Around you" },
+                { value: "nearby", label: "Public records" },
               ]}
             />
           </div>

--- a/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
@@ -31,7 +31,6 @@ import {
   NwsNearbyService,
   availableGrades,
   availableTags,
-  formatScore,
   laneCounts as computeLaneCounts,
   type NearbyAnchor,
   type NearbyDiscoverResult,
@@ -282,7 +281,7 @@ export function NearbyAroundYou() {
             {covered ? (
               <p className={MUTED_TEXT}>
                 {hidden > 0
-                  ? `Top ${visible.length} of ${records.length}`
+                  ? `Showing ${visible.length} of ${records.length}`
                   : `${records.length} public ${records.length === 1 ? "record" : "records"}`}
               </p>
             ) : null}
@@ -347,18 +346,12 @@ export function NearbyAroundYou() {
               description={[record.headline, record.organization].filter(Boolean).join(" · ")}
               onClick={() => setSelected(record)}
               trailing={
-                <span className="flex items-center gap-2">
-                  {shortlisted.has(record.personId) ? (
-                    <Star
-                      className="h-3.5 w-3.5 fill-current text-[color:var(--app-accent-fg)]"
-                      aria-label="Shortlisted"
-                    />
-                  ) : null}
-                  {/* Ranked by nearbyRankScore, so that is the number shown. */}
-                  <span className="type-footnote tabular-nums">
-                    {formatScore(record.nearbyRankScore)}
-                  </span>
-                </span>
+                shortlisted.has(record.personId) ? (
+                  <Star
+                    className="h-3.5 w-3.5 fill-current text-[color:var(--app-accent-fg)]"
+                    aria-label="Shortlisted"
+                  />
+                ) : undefined
               }
             />
           ))}
@@ -376,7 +369,7 @@ export function NearbyAroundYou() {
 
       {covered && records.length > 0 ? (
         <div className="flex flex-col gap-0.5 px-1">
-          <p className={MUTED_TEXT}>Public work associations. Not homes, not net worth.</p>
+          <p className={MUTED_TEXT}>Public professional records.</p>
           {/* Sixty records in one postcode reads like everyone there. It is a
               reviewed set from a stated number of organisations, and saying so
               is the difference between a shortlist and a false census. */}
@@ -403,7 +396,6 @@ export function NearbyAroundYou() {
         open={Boolean(selected)}
         onOpenChange={(next) => !next && setSelected(null)}
         onShortlist={handleShortlist}
-        capitalAccessNote={result?.financialContext?.capitalAccessNote}
         shortlisted={selected ? shortlisted.has(selected.personId) : false}
       />
       {picker}

--- a/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-record-sheet.tsx
@@ -12,15 +12,12 @@ import { ExternalLink, Star } from "lucide-react";
 
 import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
 import { NearbyEvidencePanel } from "@/components/ria/nearby/nearby-evidence-panel";
-import { NearbyScoreExplainer } from "@/components/ria/nearby/nearby-score-explainer";
 import { Button } from "@/lib/morphy-ux/button";
 import { AvatarBubble, StatusPill } from "@/lib/morphy-ux/ui/surface-primitives";
-import { EYEBROW, MUTED_TEXT, SUBCARD_SURFACE } from "@/lib/morphy-ux/tokens/surfaces";
+import { EYEBROW, MUTED_TEXT } from "@/lib/morphy-ux/tokens/surfaces";
 import {
   associationCategoryLabel,
   factTypeLabel,
-  formatScore,
-  isRegistryOnlyScore,
   type NearbyRecord,
 } from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
@@ -42,7 +39,6 @@ export function NearbyRecordSheet({
   onShortlist,
   shortlisted,
   saving = false,
-  capitalAccessNote,
 }: {
   record: NearbyRecord | null;
   open: boolean;
@@ -50,7 +46,6 @@ export function NearbyRecordSheet({
   onShortlist: (record: NearbyRecord) => void;
   shortlisted: boolean;
   saving?: boolean;
-  capitalAccessNote?: string | null;
 }) {
   if (!record) return null;
 
@@ -80,27 +75,6 @@ export function NearbyRecordSheet({
       }
     >
       <div className="flex flex-col gap-4">
-        <div className={cn(SUBCARD_SURFACE, "flex items-baseline gap-4 p-4")}>
-          <span className="type-display tabular-nums">
-            {formatScore(record.nearbyRankScore)}
-          </span>
-          <div className="min-w-0">
-            <p className={MUTED_TEXT}>Network strength, not net worth.</p>
-            <p className={MUTED_TEXT}>
-              Overall {formatScore(record.globalNws)} · Confidence{" "}
-              {record.confidence.grade ?? "—"}
-            </p>
-            {/* A registry-discovered record scores far below a reviewed one
-                because two thirds of the weighting has nothing to read, not
-                because the person is lesser. Read from the components rather
-                than from the score kind, which reads "provisional" for both
-                kinds and so cannot tell them apart. */}
-            {isRegistryOnlyScore(record) ? (
-              <p className={MUTED_TEXT}>From public registry role and recency only.</p>
-            ) : null}
-          </div>
-        </div>
-
         {record.publicLocation.label ? (
           <div className="flex flex-col gap-0.5">
             <p className="type-footnote">
@@ -123,27 +97,8 @@ export function NearbyRecordSheet({
           </div>
         ) : null}
 
-        {record.scoreBreakdown ? (
-          <div className="flex flex-col gap-2">
-            <span className={EYEBROW}>How this score is built</span>
-            <NearbyScoreExplainer
-              breakdown={record.scoreBreakdown}
-              capitalAccessNote={capitalAccessNote}
-            />
-          </div>
-        ) : record.reasons.length > 0 ? (
-          // Older service revisions publish prose but no arithmetic. Show the
-          // prose rather than nothing, and never both — they say the same thing.
-          <div className="flex flex-col gap-1.5">
-            <span className={EYEBROW}>Why this ranked</span>
-            <ul className="flex flex-col gap-1">
-              {record.reasons.map((reason) => (
-                <li key={reason} className="type-footnote">
-                  {reason}
-                </li>
-              ))}
-            </ul>
-          </div>
+        {record.confidence.grade ? (
+          <p className={MUTED_TEXT}>Record confidence · {record.confidence.grade}</p>
         ) : null}
 
         {record.evidence ? (

--- a/hushh-webapp/lib/services/nws-nearby-service.ts
+++ b/hushh-webapp/lib/services/nws-nearby-service.ts
@@ -1,5 +1,5 @@
 /**
- * NWS Nearby client — public-association records near a place an advisor chose.
+ * Legacy v2 nearby client — public-association records near a place an advisor chose.
  *
  * The upstream API key is server-side only, so every call goes to our own
  * `/api/ria/nearby/*`. The backend also caches responses, because the upstream
@@ -7,10 +7,11 @@
  *
  * Two product facts this module exists to keep straight:
  *
- * NWS is public *professional network strength*, not financial net worth. And
- * "nearby" means a public professional, institutional, civic or opt-in
- * association — never physical presence, never a residence. Nothing here should
- * be renamed or reshaped in a way that lets a screen imply either.
+ * NWS means Net Worth Score. This module does not provide it: it consumes the
+ * separate v2 professional-directory contract. "Nearby" here means a public
+ * professional, institutional, civic or opt-in association — never physical
+ * presence, never a residence. Its legacy score fields must not be rendered as
+ * NWS or used to imply wealth.
  */
 
 import { ApiService } from "@/lib/services/api-service";
@@ -154,9 +155,9 @@ export type NearbyRecord = {
   headline: string | null;
   organization: string | null;
   lane: NearbyLane | null;
-  /** The person's standing score. Not what the list is ordered by. */
+  /** Legacy professional score. Never render as NWS or financial net worth. */
   globalNws: number | null;
-  /** What the upstream ranks by, and therefore what the list shows. */
+  /** Legacy professional ordering signal. Never present as a wealth ranking. */
   nearbyRankScore: number | null;
   scoreStatus: string | null;
   /**
@@ -391,8 +392,6 @@ export class NwsNearbyService {
       headline: opts.record.headline,
       organization: opts.record.organization,
       lane: opts.record.lane,
-      globalNws: opts.record.globalNws,
-      nearbyRankScore: opts.record.nearbyRankScore,
       confidenceGrade: opts.record.confidence.grade,
       locationLabel: opts.record.publicLocation.label,
       modelVersion: opts.record.modelVersion,


### PR DESCRIPTION
# Description

Removes the legacy professional ranking number from the RIA public-records UI. NWS means Net Worth Score; the v2 public-association directory does not contain financial net-worth evidence and must not present its role-based score as NWS or wealth.

## 📌 Impact Map (Required)

- Routes touched: RIA clients public-records view at /ria/clients
- API / schema / type changes: None; existing v2 response remains compatible
- Cache keys touched: None
- Runtime DB data-plane changes: None
- World-model domain summary effects: None
- Mobile parity impacts: Responsive web copy and list/detail presentation only
- Docs updated: None
- Top-level / devex / config / generated / ignore files touched: None
- Trust boundary touched: Finance presentation boundary; removes a professional score that could be mistaken for wealth
- Caller / proxy / backend pairing: Existing v2 caller retained; UI no longer renders globalNws or nearbyRankScore and new shortlist snapshots omit both fields
- Rollback or safe-failure behavior: Revert this single commit; API and stored legacy snapshots remain readable
- UI browser or Playwright proof: UAT browser is vault-gated; production-code regression recreates the reported score payload
- Verification commands executed:
  - Focused Vitest: 30 passed
  - TypeScript typecheck: passed
  - Changed-file ESLint: passed
  - Next production build under Node 24: passed
  - Design-system, docs, service-boundary, and diff checks: passed
  - Local all-repository pre-PR mirror: DCO/build/lint passed; test:ci remains red on 27 unrelated current-main tests, so GitHub PR Validation is the release gate

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related work were checked; this does not duplicate the v4 Net Worth API.
- [x] Current reachable surface: /ria/clients public-records view.
- [x] New tests exercise the production components and service snapshot code.
- [x] Production surface proved by focused component and service tests.
- [ ] Required GitHub checks are current on this head.
- [x] Maintainer edits are enabled.
- [x] Not a stacked PR.

## 🛑 Tri-Flow Architecture Check

- [x] Web: affected and covered
- [x] iOS: not applicable; no native contract changed
- [x] Android: not applicable; no native contract changed

## 🧪 Testing

- [x] Tested on Web through component integration tests and production build
- [x] iOS not applicable
- [x] Android not applicable
- [x] Commit is signed off
- [x] No generated files changed

## 📸 Screenshots / Video

The reported detail state is vault-gated in UAT. The regression test recreates the same 91.2 global / 87.6 nearby professional-score payload and proves neither number, Network strength, Net Worth Score, nor the score explainer is rendered.

## 🛡️ Privacy & Consent

- [x] This change does not expand access to user data.
- [x] Sensitive surface: finance presentation.
- [x] Safe failure: professional evidence remains visible while the unsupported wealth-like score is omitted.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or notice changes.