### PR TITLE
fix(one-location): stop the recipient envelope poll from storming the backend

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1388,12 +1388,22 @@ def store_location_envelope(
 @router.get("/location/grants/{grant_id}/envelope")
 def view_latest_location_envelope(
     grant_id: _GrantId,
+    allow_empty: bool = Query(
+        False,
+        description=(
+            "Treat 'grant is live but the owner has not published yet' as a "
+            "success (200 with envelope=null) instead of a 404. Opt-in so "
+            "already-shipped clients keep the legacy LOCATION_ENVELOPE_MISSING "
+            "error contract they branch on."
+        ),
+    ),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     try:
         return _service().view_latest_envelope(
             recipient_user_id=_user_id(token_data),
             grant_id=grant_id,
+            allow_empty=allow_empty,
         )
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4874,7 +4874,9 @@ class OneLocationAgentService:
                 )
         return envelope_payload
 
-    def view_latest_envelope(self, *, recipient_user_id: str, grant_id: str) -> dict[str, Any]:
+    def view_latest_envelope(
+        self, *, recipient_user_id: str, grant_id: str, allow_empty: bool = False
+    ) -> dict[str, Any]:
         self._expire_stale_grants(recipient_user_id)
         grant_row = self._execute_one(
             """
@@ -4923,6 +4925,18 @@ class OneLocationAgentService:
             {"recipient_user_id": recipient_user_id, "grant_id": grant_id},
         )
         if not row:
+            # "The share is live, the owner just hasn't published a point yet"
+            # is a normal state on the happy path — the recipient opens One the
+            # moment they are granted access, before the owner's first GPS fix
+            # lands. Callers that opt in get that as a success with a null
+            # envelope so it never surfaces as a failed request; callers that
+            # do not keep the original 404 contract they already branch on.
+            if allow_empty:
+                return {
+                    "grant": self._grant_payload(grant_row),
+                    "envelope": None,
+                    "status": "awaiting_first_publish",
+                }
             raise OneLocationAgentError(
                 "LOCATION_ENVELOPE_MISSING",
                 "The owner has not published an encrypted location envelope yet.",
@@ -4940,6 +4954,7 @@ class OneLocationAgentService:
         return {
             "grant": self._grant_payload(grant_row),
             "envelope": self._envelope_payload(row),
+            "status": "published",
         }
 
     def get_map_preferences(self, *, user_id: str) -> dict[str, Any]:

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -647,6 +647,10 @@ def test_list_verified_recipients_sources_from_connections(
 
 
 class EnvelopeReadProbe(OneLocationAgentService):
+    #: When False the grant is live but no envelope row exists yet — the state a
+    #: recipient sits in between being granted access and the owner's first fix.
+    has_envelope = True
+
     def __init__(self) -> None:
         self.calls: list[str] = []
 
@@ -656,6 +660,8 @@ class EnvelopeReadProbe(OneLocationAgentService):
 
     def _execute_one(self, sql: str, params: dict | None = None) -> dict | None:
         self.calls.append(sql)
+        if "FROM one_location_envelopes" in sql and not self.has_envelope:
+            return None
         if "FROM one_location_share_grants g" in sql:
             return {
                 "id": "00000000-0000-0000-0000-000000000001",
@@ -698,8 +704,137 @@ def test_view_latest_envelope_returns_ciphertext_only_payload() -> None:
     assert "RETURNING\n              target_grant.id" in stale_cleanup_sql
     assert response["grant"]["recipientUserId"] == "user_b"
     assert response["envelope"]["ciphertext"] == "ciphertext-only"
+    assert response["status"] == "published"
     assert "latitude" not in json.dumps(response)
     assert "longitude" not in json.dumps(response)
+
+
+class _AwaitingFirstPublishProbe(EnvelopeReadProbe):
+    has_envelope = False
+
+
+def test_view_latest_envelope_without_allow_empty_keeps_legacy_404() -> None:
+    """Clients already in the field branch on this error code; it must not move."""
+
+    service = _AwaitingFirstPublishProbe()
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        service.view_latest_envelope(
+            recipient_user_id="user_b",
+            grant_id="00000000-0000-0000-0000-000000000001",
+        )
+
+    assert excinfo.value.code == "LOCATION_ENVELOPE_MISSING"
+    assert excinfo.value.status_code == 404
+
+
+def test_view_latest_envelope_allow_empty_returns_awaiting_first_publish() -> None:
+    """A live grant with no point yet is a success, not a failed request.
+
+    The recipient almost always opens One before the owner's first GPS fix
+    lands. Reporting that as 404 made the browser log a failed request on every
+    poll for a state nothing had gone wrong in.
+    """
+
+    service = _AwaitingFirstPublishProbe()
+    response = service.view_latest_envelope(
+        recipient_user_id="user_b",
+        grant_id="00000000-0000-0000-0000-000000000001",
+        allow_empty=True,
+    )
+
+    assert response["envelope"] is None
+    assert response["status"] == "awaiting_first_publish"
+    # The grant itself still comes back so the recipient keeps the owner label
+    # and expiry on screen while waiting.
+    assert response["grant"]["recipientUserId"] == "user_b"
+    # Waiting must never leak coordinates, same as the published path.
+    assert "latitude" not in json.dumps(response)
+    assert "longitude" not in json.dumps(response)
+
+
+def test_view_latest_envelope_allow_empty_does_not_mask_a_missing_grant() -> None:
+    """allow_empty relaxes 'no point yet' only — never 'no such share'."""
+
+    class _NoGrantProbe(EnvelopeReadProbe):
+        def _execute_one(self, sql: str, params: dict | None = None) -> dict | None:
+            self.calls.append(sql)
+            if "FROM one_location_share_grants g" in sql:
+                return None
+            return None
+
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        _NoGrantProbe().view_latest_envelope(
+            recipient_user_id="user_b",
+            grant_id="00000000-0000-0000-0000-000000000001",
+            allow_empty=True,
+        )
+
+    assert excinfo.value.code == "LOCATION_GRANT_NOT_FOUND"
+    assert excinfo.value.status_code == 404
+
+
+def test_view_latest_envelope_allow_empty_does_not_mask_a_revoked_grant() -> None:
+    """A revoked/expired share must still be rejected, not reported as waiting."""
+
+    class _RevokedGrantProbe(EnvelopeReadProbe):
+        has_envelope = False
+
+        def _execute_one(self, sql: str, params: dict | None = None) -> dict | None:
+            row = super()._execute_one(sql, params)
+            if row and "FROM one_location_share_grants g" in sql:
+                return {**row, "status": "revoked"}
+            return row
+
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        _RevokedGrantProbe().view_latest_envelope(
+            recipient_user_id="user_b",
+            grant_id="00000000-0000-0000-0000-000000000001",
+            allow_empty=True,
+        )
+
+    assert excinfo.value.code == "LOCATION_GRANT_NOT_ACTIVE"
+    assert excinfo.value.status_code == 410
+
+
+def test_view_latest_envelope_allow_empty_does_not_mask_a_rotated_recipient_key() -> None:
+    """A key rotation still needs the 'ask them to share again' signal."""
+
+    class _RotatedKeyProbe(EnvelopeReadProbe):
+        has_envelope = False
+
+        def _execute_one(self, sql: str, params: dict | None = None) -> dict | None:
+            row = super()._execute_one(sql, params)
+            if row and "FROM one_location_share_grants g" in sql:
+                return {**row, "recipient_key_active": False}
+            return row
+
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        _RotatedKeyProbe().view_latest_envelope(
+            recipient_user_id="user_b",
+            grant_id="00000000-0000-0000-0000-000000000001",
+            allow_empty=True,
+        )
+
+    assert excinfo.value.code == "LOCATION_GRANT_NOT_ACTIVE"
+    assert excinfo.value.status_code == 410
+
+
+def test_view_latest_envelope_awaiting_first_publish_records_no_view_event() -> None:
+    """No ciphertext was released, so the audit trail must not claim a view."""
+
+    service = _AwaitingFirstPublishProbe()
+    inserted: list[str] = []
+    service._insert_event = lambda **kwargs: inserted.append(  # type: ignore[method-assign]
+        str(kwargs.get("event_type"))
+    )
+
+    service.view_latest_envelope(
+        recipient_user_id="user_b",
+        grant_id="00000000-0000-0000-0000-000000000001",
+        allow_empty=True,
+    )
+
+    assert "location_share_viewed" not in inserted
 
 
 class FourUserMemoryService(OneLocationAgentService):

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -137,6 +137,39 @@ def test_atomic_private_share_route_binds_owner_from_token(monkeypatch) -> None:
     assert service.calls[0]["enforce_connection"] is True
 
 
+def test_view_envelope_route_threads_allow_empty_query_param(monkeypatch) -> None:
+    """The opt-in must reach the service, and must default to off.
+
+    Off by default is the whole point: native bundles already in the field
+    branch on the 404 LOCATION_ENVELOPE_MISSING contract, so a request that does
+    not ask for the relaxed shape must keep getting the old one.
+    """
+
+    class ViewRouteProbe:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def view_latest_envelope(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"grant": {"id": "grant-1"}, "envelope": None, "status": "awaiting"}
+
+    service = ViewRouteProbe()
+    current_user = {"user_id": "recipient-from-token"}
+    client = _client(service, current_user, monkeypatch)  # type: ignore[arg-type]
+    grant_id = "123e4567-e89b-12d3-a456-426614174000"
+
+    default_response = client.get(f"/api/one/location/grants/{grant_id}/envelope")
+    opted_in = client.get(f"/api/one/location/grants/{grant_id}/envelope?allow_empty=1")
+
+    assert default_response.status_code == 200
+    assert opted_in.status_code == 200
+    assert service.calls[0]["allow_empty"] is False
+    assert service.calls[1]["allow_empty"] is True
+    # The recipient is always bound from the token, never from the query string.
+    assert service.calls[1]["recipient_user_id"] == "recipient-from-token"
+    assert service.calls[1]["grant_id"] == grant_id
+
+
 def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(monkeypatch) -> None:
     service = FourUserMemoryService()
     current_user = {"user_id": "user_a"}

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -245,6 +245,13 @@ vi.mock("@/lib/one-location/encryption", () => ({
   ensureLocationRecipientKey: mockEnsureKey,
   encryptLocationForRecipient: mockEncryptLocationForRecipient,
   decryptLocationEnvelope: mockDecryptLocationEnvelope,
+  // Mirrors the real export. The page reads this constant inside its view-error
+  // handler, so omitting it made every recipient-side failure path throw a
+  // vitest "no export is defined" error from inside the catch block — which
+  // Promise.allSettled then swallowed, hiding the whole branch from these tests.
+  RECIPIENT_KEY_UNAVAILABLE_MESSAGE:
+    "Recipient key unavailable for this location share.",
+  ensureVaultSyncedRecipientKey: vi.fn(async () => {}),
 }));
 
 vi.mock("@/lib/one-location/service", () => ({
@@ -2782,6 +2789,236 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     expect(screen.queryByText("Activity history")).toBeNull();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
+  });
+
+  /**
+   * Recipient-side polling. The page reads every visible received share on an
+   * interval so a shared dot moves in near real time. These cover the states
+   * that used to make that loop misbehave: a live share with nothing published
+   * yet (which the backend reported as 404 on every single tick), a share that
+   * keeps failing, and a read that never settles.
+   */
+  describe("received-share polling", () => {
+    const waitingGrant = {
+      id: "grant_waiting",
+      ownerUserId: "user_a",
+      recipientUserId: "user_b",
+      ownerDisplayName: "Trusted A",
+      recipientKeyId: "key_b",
+      status: "active",
+      consentScope: "cap.location.live.view",
+      capabilityScopes: ["cap.location.live.view"],
+      durationHours: 1,
+      expiresAt: "2099-05-20T08:00:00.000Z",
+      latestEnvelopeId: null,
+    };
+
+    const renderAsRecipient = async () => {
+      mockUseRequireAuth.mockReturnValue({
+        loading: false,
+        isAuthenticated: true,
+        userId: "user_b",
+        user: { uid: "user_b" },
+      });
+      window.localStorage.setItem(
+        "one_location_opened_grants_v1:user_b",
+        JSON.stringify(["grant_waiting"]),
+      );
+      window.localStorage.setItem("one_location_onboarding_v2:user_b", "1");
+      mockGetState.mockResolvedValue({
+        ...locationState(),
+        ownerGrants: [],
+        receivedGrants: [waitingGrant],
+      });
+
+      render(<OneLocationAgentPage />);
+      expect(
+        await screen.findByRole("heading", { name: "Location Agent" }),
+      ).toBeTruthy();
+      await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+      fireEvent.click(screen.getByRole("button", { name: /Shared with me/i }));
+      await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
+    };
+
+    it("treats a null envelope as a normal state, not a failure", async () => {
+      // The backend answers 200 with a null envelope (allow_empty) rather than
+      // 404 LOCATION_ENVELOPE_MISSING. Nothing failed, so nothing may be handed
+      // to the crypto layer and nothing may be shouted at the user.
+      mockViewEnvelope.mockResolvedValue({
+        grant: waitingGrant,
+        envelope: null,
+        status: "awaiting_first_publish",
+      });
+
+      await renderAsRecipient();
+
+      expect(mockDecryptLocationEnvelope).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("paces a legacy 404 as waiting, not as a failure", async () => {
+      // During a rollout the webapp can reach a Python service that predates
+      // allow_empty and still answers 404. That must map to the slow waiting
+      // cadence (30s), NOT the error backoff (10s after one failure) — the
+      // difference proves the legacy branch is still classified correctly.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        // Verbatim message from the pre-allow_empty backend. `apiErrorCode`
+        // only reads a real ApiError, so a legacy 404 surfaced through any
+        // other error shape is classified by this string — which is exactly the
+        // fallback path this test needs to hold.
+        mockViewEnvelope.mockRejectedValue(
+          new Error(
+            "The owner has not published an encrypted location envelope yet.",
+          ),
+        );
+
+        await renderAsRecipient();
+        const afterFirstRead = mockViewEnvelope.mock.calls.length;
+
+        // An error-classified grant would have retried by now; a waiting one
+        // must not.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(20_000);
+        });
+        expect(mockViewEnvelope).toHaveBeenCalledTimes(afterFirstRead);
+        expect(toast.error).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("drops a waiting share off the live cadence instead of asking every tick", async () => {
+      // The bug this fixes: 5s polling for an answer only the owner can change,
+      // which produced a request (and a console line) every tick, forever.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        mockViewEnvelope.mockResolvedValue({
+          grant: waitingGrant,
+          envelope: null,
+          status: "awaiting_first_publish",
+        });
+
+        await renderAsRecipient();
+        const afterFirstRead = mockViewEnvelope.mock.calls.length;
+
+        // Four live ticks pass. A waiting share must not be re-read on any of
+        // them; it is parked on the 30s heartbeat.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(20_000);
+        });
+        expect(mockViewEnvelope).toHaveBeenCalledTimes(afterFirstRead);
+
+        // Past the slow heartbeat it is asked exactly once more.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(15_000);
+        });
+        expect(mockViewEnvelope.mock.calls.length).toBe(afterFirstRead + 1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("backs a repeatedly failing share off exponentially", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        mockViewEnvelope.mockRejectedValue(new Error("backend unavailable"));
+
+        await renderAsRecipient();
+        const afterFirstRead = mockViewEnvelope.mock.calls.length;
+
+        // First failure parks the grant for 10s (5s * 2^1), so the 5s tick in
+        // between is skipped rather than retried at full rate.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(6_000);
+        });
+        expect(mockViewEnvelope).toHaveBeenCalledTimes(afterFirstRead);
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(6_000);
+        });
+        expect(mockViewEnvelope.mock.calls.length).toBe(afterFirstRead + 1);
+
+        // Second failure doubles again to 20s: 12s of ticks buys no retry.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(12_000);
+        });
+        expect(mockViewEnvelope.mock.calls.length).toBe(afterFirstRead + 1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("returns a recovered share to the live cadence", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        mockViewEnvelope.mockRejectedValueOnce(new Error("transient"));
+        mockViewEnvelope.mockResolvedValue({
+          grant: waitingGrant,
+          envelope: {
+            recipientKeyId: "key_b",
+            algorithm: "ECDH-P256-AES256-GCM",
+            ciphertext: "ciphertext",
+            iv: "iv",
+            senderEphemeralPublicKeyJwk: {
+              kty: "EC",
+              crv: "P-256",
+              x: "x",
+              y: "y",
+            },
+            capturedAt: "2099-01-01T00:00:00.000Z",
+            sourcePlatform: "web",
+          },
+          status: "published",
+        });
+
+        await renderAsRecipient();
+
+        // Clear the one failure's backoff, then confirm the share is read on
+        // consecutive live ticks again — backoff must not be sticky.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(11_000);
+        });
+        const afterRecovery = mockViewEnvelope.mock.calls.length;
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5_500);
+        });
+        expect(mockViewEnvelope.mock.calls.length).toBeGreaterThan(
+          afterRecovery,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("recovers polling after a read that never settles", async () => {
+      // Without the watchdog the in-flight guard latches forever and live
+      // tracking dies silently for the rest of the session.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        mockViewEnvelope.mockImplementation(() => new Promise(() => {}));
+
+        await renderAsRecipient();
+        const wedged = mockViewEnvelope.mock.calls.length;
+
+        // Ticks during the watchdog window are correctly suppressed.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(20_000);
+        });
+        expect(mockViewEnvelope).toHaveBeenCalledTimes(wedged);
+
+        // Past the watchdog the guard is released and polling resumes.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(20_000);
+        });
+        expect(mockViewEnvelope.mock.calls.length).toBeGreaterThan(wedged);
+      } finally {
+        warn.mockRestore();
+        vi.useRealTimers();
+      }
+    });
   });
 
   it("warns the recipient when the decrypted location update is stale", async () => {

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -172,8 +172,11 @@ describe("OneLocationService", () => {
       grantId: "grant_1",
     });
 
+    // allow_empty asks the backend to answer "live share, owner hasn't
+    // published a point yet" with 200 + a null envelope instead of a 404.
+    // Without it that ordinary state is a failed request on every poll.
     expect(mockApiJson).toHaveBeenCalledWith(
-      "/api/one/location/grants/grant_1/envelope",
+      "/api/one/location/grants/grant_1/envelope?allow_empty=1",
       {
         headers: {
           Authorization: "Bearer vault-token",
@@ -183,6 +186,21 @@ describe("OneLocationService", () => {
     );
     expect(mockApiJson.mock.calls[0]?.[0]).not.toContain("/api/kai");
     expect(mockApiJson.mock.calls[0]?.[0]).not.toContain("/location/shared");
+  });
+
+  it("keeps the grant id escaped ahead of the allow_empty query", async () => {
+    // The grant id is path data and the flag is query data; a grant id that
+    // contains a delimiter must not be able to smuggle in extra parameters.
+    mockApiJson.mockResolvedValueOnce({ grant: {}, envelope: null });
+
+    await OneLocationService.viewEnvelope({
+      vaultOwnerToken: "vault-token",
+      grantId: "grant/1?allow_empty=0",
+    });
+
+    expect(mockApiJson.mock.calls[0]?.[0]).toBe(
+      "/api/one/location/grants/grant%2F1%3Fallow_empty%3D0/envelope?allow_empty=1",
+    );
   });
 
   it("uses the authenticated One request route when asking someone to share", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2424,6 +2424,8 @@ export function OneLocationAgentPageContent({
   const liveViewInFlightRef = useRef(false);
   /** When the in-flight sweep began, so a wedged sweep can be timed out. */
   const liveViewStartedAtRef = useRef(0);
+  /** Identifies the sweep that currently owns the in-flight guard. */
+  const liveViewSweepIdRef = useRef(0);
   /** Per-grant read pacing: see `recordGrantPollOutcome`. */
   const grantPollScheduleRef = useRef<Map<string, OneLocationGrantPollEntry>>(
     new Map(),
@@ -4912,6 +4914,13 @@ export function OneLocationAgentPageContent({
 
     const refreshVisibleGrants = async () => {
       const now = Date.now();
+      // Checked before the watchdog: a backgrounded tab is throttled by the
+      // browser, so an in-flight sweep sitting there is expected, not wedged.
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      )
+        return;
       if (liveViewInFlightRef.current) {
         // Normal overlap: the previous sweep is still running, skip this tick.
         if (now - liveViewStartedAtRef.current < LIVE_VIEW_INFLIGHT_WATCHDOG_MS)
@@ -4924,11 +4933,6 @@ export function OneLocationAgentPageContent({
             "releasing the in-flight guard so polling can recover.",
         );
       }
-      if (
-        typeof document !== "undefined" &&
-        document.visibilityState === "hidden"
-      )
-        return;
 
       const grants = visibleReceivedGrantsRef.current;
       const schedule = grantPollScheduleRef.current;
@@ -4941,6 +4945,11 @@ export function OneLocationAgentPageContent({
       });
       if (!due.length) return;
 
+      // Claim this sweep. If the watchdog above abandoned an earlier one, that
+      // earlier sweep may still resolve later — and it must not then clear a
+      // guard it no longer owns, which would let two sweeps run concurrently.
+      const sweepId = liveViewSweepIdRef.current + 1;
+      liveViewSweepIdRef.current = sweepId;
       liveViewInFlightRef.current = true;
       liveViewStartedAtRef.current = now;
       try {
@@ -4972,7 +4981,9 @@ export function OneLocationAgentPageContent({
           }),
         );
       } finally {
-        liveViewInFlightRef.current = false;
+        if (liveViewSweepIdRef.current === sweepId) {
+          liveViewInFlightRef.current = false;
+        }
       }
     };
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -316,6 +316,29 @@ const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 // Recipients poll faster than the owner's publish heartbeat so the shared dot
 // stays fresh; the LiveMap marker interpolates between these reads.
 const LIVE_VIEW_REFRESH_INTERVAL_MS = 5_000;
+/**
+ * Cadence for a share that is live but has never published a point. There is
+ * nothing to stream yet — the owner's first GPS fix hasn't landed — so asking
+ * every 5s burns a request per grant per tick for an answer that cannot change
+ * until the owner acts. The grant row already carries the authoritative tag
+ * (`latestEnvelopeId`), so this path only exists to catch the first publish
+ * promptly when no push notification arrives to refresh state.
+ */
+const AWAITING_FIRST_PUBLISH_POLL_MS = 30_000;
+/**
+ * Per-grant backoff ceiling after consecutive failed reads. One share that is
+ * genuinely broken (pruned envelope, rotated key, backend degraded) must never
+ * keep hitting the backend at the live cadence — and must never slow down the
+ * healthy shares next to it, which is why backoff is tracked per grant.
+ */
+const LIVE_VIEW_BACKOFF_MAX_MS = 60_000;
+/**
+ * A sweep that never settles (hung fetch, throttled tab resumed mid-flight)
+ * would leave the in-flight guard latched and silently kill live tracking for
+ * the rest of the session. Past this age the guard is treated as stale and the
+ * next tick proceeds, so the poll can always recover itself.
+ */
+const LIVE_VIEW_INFLIGHT_WATCHDOG_MS = 30_000;
 const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
 const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
 // True live tracking: while a share is active and the app is foregrounded, the
@@ -926,6 +949,65 @@ function receivedGrantOwnerLabel(grant: OneLocationGrant): string {
     grant.ownerDisplayName || grant.recipientDisplayName,
     "A trusted person",
   );
+}
+
+/**
+ * Copy for a share that is genuinely live but has no point yet. Shared by the
+ * success path (backend answered `awaiting_first_publish`), the legacy 404 path,
+ * and the pre-flight skip driven by `grant.latestEnvelopeId`, so all three
+ * render byte-identical text — the state setters below compare by value to
+ * avoid re-rendering the map on every poll.
+ */
+function awaitingFirstPublishMessage(grant: OneLocationGrant): string {
+  return `${receivedGrantOwnerLabel(
+    grant,
+  )} is sharing, but hasn't sent a live location update yet. It will appear here automatically as soon as they move or open One.`;
+}
+
+/** Outcome of one recipient-side envelope read, used to pace the next poll. */
+type OneLocationViewOutcome = "published" | "awaiting" | "error" | "skipped";
+
+type OneLocationGrantPollEntry = {
+  /** Epoch ms before which this grant must not be read again. */
+  nextAttemptAt: number;
+  /** Consecutive failed reads; drives the exponential backoff. */
+  failures: number;
+};
+
+/**
+ * Pace the next recipient-side read of one share, per grant.
+ *
+ * - `published` — the dot is live and moving, so stay on the tick cadence. Zero
+ *   delay keeps the streaming path byte-for-byte as fast as it was.
+ * - `awaiting` / `skipped` — healthy share with nothing to send. Asking twelve
+ *   times a minute cannot change an answer that only the owner can change, so
+ *   drop to the slow heartbeat.
+ * - `error` — exponential backoff, capped. Tracked per grant so one broken share
+ *   can neither hammer the backend nor slow down the healthy shares beside it.
+ */
+function recordGrantPollOutcome(
+  schedule: Map<string, OneLocationGrantPollEntry>,
+  grantId: string,
+  outcome: OneLocationViewOutcome,
+  now: number,
+): OneLocationGrantPollEntry {
+  const previousFailures = schedule.get(grantId)?.failures ?? 0;
+  const failures = outcome === "error" ? previousFailures + 1 : 0;
+  let delayMs = 0;
+  if (outcome === "error") {
+    delayMs = Math.min(
+      LIVE_VIEW_REFRESH_INTERVAL_MS * 2 ** failures,
+      LIVE_VIEW_BACKOFF_MAX_MS,
+    );
+  } else if (outcome !== "published") {
+    delayMs = AWAITING_FIRST_PUBLISH_POLL_MS;
+  }
+  const entry: OneLocationGrantPollEntry = {
+    nextAttemptAt: now + delayMs,
+    failures,
+  };
+  schedule.set(grantId, entry);
+  return entry;
 }
 
 function requestLabel(request: OneLocationAccessRequest): string {
@@ -2340,6 +2422,20 @@ export function OneLocationAgentPageContent({
   const focusClearRef = useRef<number | null>(null);
   const livePublishInFlightRef = useRef(false);
   const liveViewInFlightRef = useRef(false);
+  /** When the in-flight sweep began, so a wedged sweep can be timed out. */
+  const liveViewStartedAtRef = useRef(0);
+  /** Per-grant read pacing: see `recordGrantPollOutcome`. */
+  const grantPollScheduleRef = useRef<Map<string, OneLocationGrantPollEntry>>(
+    new Map(),
+  );
+  /** Latest-value refs so the recipient poll runs on one stable interval. */
+  const visibleReceivedGrantsRef = useRef<OneLocationGrant[]>([]);
+  const viewGrantEnvelopeRef = useRef<
+    (
+      grant: OneLocationGrant,
+      options?: { silent?: boolean; trigger?: OneLocationForegroundTrigger },
+    ) => Promise<OneLocationViewOutcome>
+  >(async () => "skipped");
   const suppressAutoRecipientSelectionRef = useRef(false);
   const shareReviewAttemptRef = useRef(0);
   const shareReviewPendingRef = useRef(false);
@@ -4225,8 +4321,8 @@ export function OneLocationAgentPageContent({
     async (
       grant: OneLocationGrant,
       options?: { silent?: boolean; trigger?: OneLocationForegroundTrigger },
-    ) => {
-      if (!auth.userId || !vaultOwnerToken) return;
+    ): Promise<OneLocationViewOutcome> => {
+      if (!auth.userId || !vaultOwnerToken) return "skipped";
       const activeUserId = auth.userId;
       const silent = Boolean(options?.silent);
       const trigger =
@@ -4241,6 +4337,10 @@ export function OneLocationAgentPageContent({
               vaultOwnerToken,
               grantId: grant.id,
             });
+            // Live share, no point published yet. The backend reports this as a
+            // success (see `allow_empty` in OneLocationService.viewEnvelope), so
+            // there is nothing to decrypt and nothing has gone wrong.
+            if (!response.envelope) return null;
             try {
               return await decryptLocationEnvelope({
                 userId: activeUserId,
@@ -4269,6 +4369,19 @@ export function OneLocationAgentPageContent({
             }
           },
         });
+        if (!point) {
+          // Live share, first point not published yet. This is a success, not a
+          // failure: hold the calm waiting copy and let the caller drop this
+          // grant to the slow cadence until the owner actually publishes.
+          setGrantViewErrors((current) => {
+            const waiting = awaitingFirstPublishMessage(grant);
+            return current[grant.id] === waiting
+              ? current
+              : { ...current, [grant.id]: waiting };
+          });
+          if (!silent) toast.message(awaitingFirstPublishMessage(grant));
+          return "awaiting";
+        }
         // A stationary owner republishes the same point every heartbeat, so most
         // ticks decrypt to something identical to what is already on screen.
         // Writing it anyway would allocate a new workspace object and re-render
@@ -4285,18 +4398,16 @@ export function OneLocationAgentPageContent({
           delete next[grant.id];
           return next;
         });
+        return "published";
       } catch (error) {
         const keyUnavailable =
           error instanceof Error &&
           error.message === RECIPIENT_KEY_UNAVAILABLE_MESSAGE;
-        // The grant is active ("Live") but the owner has not published any
-        // encrypted point yet — e.g. they JUST started sharing, or haven't
-        // moved / re-opened One since. The backend returns a 404
-        // LOCATION_ENVELOPE_MISSING for this. It's a normal "not ready yet"
-        // state on the happy path, NOT a failure, so we must never surface the
-        // raw backend string ("The owner has not published an encrypted
-        // location envelope yet.") as a scary red error toast the moment the
-        // recipient lands on the page.
+        // Legacy shape of the same "not ready yet" state: a backend that predates
+        // `allow_empty` answers 404 LOCATION_ENVELOPE_MISSING instead of a 200
+        // with a null envelope. This branch must stay for as long as a client
+        // can reach an older backend — including the window during a rollout
+        // where the webapp ships ahead of the Python service.
         const envelopeMissing =
           !keyUnavailable &&
           (apiErrorCode(error) === "LOCATION_ENVELOPE_MISSING" ||
@@ -4326,13 +4437,13 @@ export function OneLocationAgentPageContent({
               grant,
             )}'s live location — the secure key changed. Ask them to share again.`,
           }));
-        } else if (envelopeMissing) {
+          return "error";
+        }
+        if (envelopeMissing) {
           // Calm, reassuring "waiting for their first update" state. The share
           // is genuinely active; the point simply hasn't arrived yet and will
           // appear automatically on the next poll once the owner publishes.
-          const waitingMessage = `${receivedGrantOwnerLabel(
-            grant,
-          )} is sharing, but hasn't sent a live location update yet. It will appear here automatically as soon as they move or open One.`;
+          const waitingMessage = awaitingFirstPublishMessage(grant);
           setGrantViewErrors((current) =>
             current[grant.id] === waitingMessage
               ? current
@@ -4343,7 +4454,9 @@ export function OneLocationAgentPageContent({
           if (!silent) {
             toast.message(waitingMessage);
           }
-        } else if (!silent) {
+          return "awaiting";
+        }
+        if (!silent) {
           toast.error(
             error instanceof Error
               ? error.message
@@ -4355,8 +4468,8 @@ export function OneLocationAgentPageContent({
             error,
           );
         }
+        return "error";
       } finally {
-
         if (!silent) setBusy(null);
       }
     },
@@ -4775,39 +4888,113 @@ export function OneLocationAgentPageContent({
     setMyLocationPoint,
   ]);
 
+  // Latest-value refs for the recipient poll below. The poll must survive on a
+  // single long-lived interval: keying its effect on the grant objects and the
+  // `viewGrantEnvelope` identity tore the timer down and rebuilt it on every
+  // render, and each rebuild fires an immediate sweep — so a render burst became
+  // a request burst at the backend (visible as clusters of back-to-back reads
+  // between the honest 5s ticks). These refs let the effect depend only on the
+  // grant id list, which changes when the set of shares genuinely changes.
   useEffect(() => {
-    if (!activeVisibleReceivedGrants.length) return;
-    if (busy && busy !== "load") return;
+    visibleReceivedGrantsRef.current = activeVisibleReceivedGrants;
+    viewGrantEnvelopeRef.current = viewGrantEnvelope;
+  });
+
+  const visibleReceivedGrantKey = useMemo(
+    () => activeVisibleReceivedGrants.map((grant) => grant.id).join(","),
+    [activeVisibleReceivedGrants],
+  );
+  const liveViewPollBlocked = Boolean(busy && busy !== "load");
+
+  useEffect(() => {
+    if (!visibleReceivedGrantKey) return;
+    if (liveViewPollBlocked) return;
 
     const refreshVisibleGrants = async () => {
-      if (liveViewInFlightRef.current) return;
+      const now = Date.now();
+      if (liveViewInFlightRef.current) {
+        // Normal overlap: the previous sweep is still running, skip this tick.
+        if (now - liveViewStartedAtRef.current < LIVE_VIEW_INFLIGHT_WATCHDOG_MS)
+          return;
+        // The previous sweep never settled. Without this escape the guard stays
+        // latched for the life of the page and live tracking dies silently, with
+        // the interval still firing into a permanent no-op.
+        console.warn(
+          "[OneLocationAgent] Live view sweep exceeded the watchdog; " +
+            "releasing the in-flight guard so polling can recover.",
+        );
+      }
       if (
         typeof document !== "undefined" &&
         document.visibilityState === "hidden"
       )
         return;
+
+      const grants = visibleReceivedGrantsRef.current;
+      const schedule = grantPollScheduleRef.current;
+      // Only read shares whose next attempt is actually due. A share that has
+      // never published, or one that keeps failing, sits on a slower cadence
+      // than a share that is streaming a moving dot.
+      const due = grants.filter((grant) => {
+        const entry = schedule.get(grant.id);
+        return !entry || now >= entry.nextAttemptAt;
+      });
+      if (!due.length) return;
+
       liveViewInFlightRef.current = true;
+      liveViewStartedAtRef.current = now;
       try {
+        const view = viewGrantEnvelopeRef.current;
         await Promise.allSettled(
-          activeVisibleReceivedGrants.map((grant) =>
-            viewGrantEnvelope(grant, {
-              silent: true,
-              trigger: "foreground_interval",
-            }),
-          ),
+          due.map(async (grant) => {
+            // Deliberately NOT gated on `grant.latestEnvelopeId`. That column is
+            // a denormalised copy of "has this share ever published", and using
+            // it to skip the read would mean one missed write permanently hides
+            // a live dot — a far worse failure than an extra request. The
+            // cadence below is driven by the response itself, so it self-heals.
+            //
+            // Defensive: viewGrantEnvelope already resolves rather than rejects
+            // for every state it knows about, but a future throw inside it must
+            // degrade this grant to backoff — never take down the whole sweep.
+            let outcome: OneLocationViewOutcome = "error";
+            try {
+              outcome = await view(grant, {
+                silent: true,
+                trigger: "foreground_interval",
+              });
+            } catch (error) {
+              console.warn(
+                "[OneLocationAgent] Live view sweep entry failed:",
+                error,
+              );
+            }
+            recordGrantPollOutcome(schedule, grant.id, outcome, now);
+          }),
         );
       } finally {
         liveViewInFlightRef.current = false;
       }
     };
 
+    // Drop schedule entries for shares that are no longer on screen so a long
+    // session cannot accumulate state for revoked/expired grants.
+    const liveIds = new Set(visibleReceivedGrantKey.split(","));
+    for (const id of [...grantPollScheduleRef.current.keys()]) {
+      if (!liveIds.has(id)) grantPollScheduleRef.current.delete(id);
+    }
+
     void refreshVisibleGrants();
-    const interval = window.setInterval(
-      () => void refreshVisibleGrants(),
-      LIVE_VIEW_REFRESH_INTERVAL_MS,
-    );
+    const interval = window.setInterval(() => {
+      // A synchronous throw here would kill the interval for the rest of the
+      // session, so nothing is allowed to escape the tick.
+      try {
+        void refreshVisibleGrants();
+      } catch (error) {
+        console.warn("[OneLocationAgent] Live view tick failed:", error);
+      }
+    }, LIVE_VIEW_REFRESH_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [activeVisibleReceivedGrants, busy, viewGrantEnvelope]);
+  }, [visibleReceivedGrantKey, liveViewPollBlocked, setGrantViewErrors]);
 
   // Keep native background publishing in sync with the opt-in toggle + grants.
   // Web returns { started:false } and this is a no-op there.

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -270,6 +270,19 @@ export function useLocationChat(params: {
           vaultOwnerToken,
           grantId,
         });
+        // Share is live but the owner hasn't published a point yet. Report the
+        // wait honestly instead of failing — nothing has gone wrong, and there
+        // is no ciphertext to decrypt.
+        if (!envelope) {
+          await report({
+            id: action.id,
+            type: action.type,
+            status: "completed",
+            detail:
+              "They're sharing, but haven't sent a live location update yet.",
+          });
+          return;
+        }
         try {
           const point = await decryptLocationEnvelope({ userId, envelope });
           setViewedPoint(point);

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -349,12 +349,19 @@ export function useFeedActionables(): UseFeedActionablesResult {
             vaultOwnerToken,
             grantId: grant.id,
           });
+          // An SOS grant whose first point hasn't landed yet. There is no
+          // address to resolve, and inventing an error here would put a red
+          // state on an emergency card that is actually working — fall through
+          // to the same empty address the catch below produces, which the
+          // filter drops without disturbing the card.
+          const envelope = response.envelope;
+          if (!envelope) return [grant.id, ""] as const;
 
           let point;
           try {
             point = await decryptLocationEnvelope({
               userId,
-              envelope: response.envelope,
+              envelope,
             });
           } catch (decryptError) {
             // Match the Location workspace recovery path: a new device
@@ -372,7 +379,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
               });
               point = await decryptLocationEnvelope({
                 userId,
-                envelope: response.envelope,
+                envelope,
               });
             } else {
               throw decryptError;

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1025,15 +1025,29 @@ export class OneLocationService {
     };
   }
 
+  /**
+   * Latest ciphertext for a share we receive.
+   *
+   * `allow_empty=1` asks the backend to answer "the share is live but the owner
+   * hasn't published a point yet" with `200 { envelope: null }` instead of a
+   * `404 LOCATION_ENVELOPE_MISSING`. That state is a normal step on the happy
+   * path — the recipient almost always opens One before the owner's first GPS
+   * fix lands — and a 404 makes the browser log a failed request every poll for
+   * something that was never an error. The flag is opt-in per request so
+   * already-shipped native bundles keep the legacy contract they branch on.
+   */
   static async viewEnvelope(params: {
     vaultOwnerToken: string;
     grantId: string;
   }): Promise<{
     grant: OneLocationGrant;
-    envelope: OneLocationEncryptedEnvelope;
+    envelope: OneLocationEncryptedEnvelope | null;
+    status?: "published" | "awaiting_first_publish" | string;
   }> {
     return apiJson(
-      `/api/one/location/grants/${encodeURIComponent(params.grantId)}/envelope`,
+      `/api/one/location/grants/${encodeURIComponent(
+        params.grantId,
+      )}/envelope?allow_empty=1`,
       {
         headers: jsonAuthHeaders(params.vaultOwnerToken),
       },


### PR DESCRIPTION
## What was happening

A recipient with a live share open saw this on repeat in the console:

```
GET /api/one/location/grants/<id>/envelope 404 (Not Found)
```

A share that is genuinely live but whose owner has not published a point yet answered **404 `LOCATION_ENVELOPE_MISSING`**. That is a normal step on the happy path — the recipient almost always opens One before the owner's first GPS fix lands — but the recipient page re-asked **every 5 seconds per share**, so an ordinary waiting state produced a failed request on every tick, forever. The red console line cannot be suppressed in the app: the browser logs 4xx at the network layer, before any JS `catch` runs.

The stack traces also showed two distinct triggers — the honest `setInterval` tick, and React commit frames. The poll effect depended on the grant objects and the `viewGrantEnvelope` identity, so a render tore the timer down and rebuilt it, and each rebuild fires an immediate sweep. That is the burst-of-8 clusters between the 5s ticks.

## What changed

**Backend** — `view_latest_envelope` gains an opt-in `allow_empty` flag. With it, a valid grant awaiting its first publish returns `200 { envelope: null, status: "awaiting_first_publish" }`. Opt-in **per request** so native bundles already in the field keep the 404 contract they branch on. Grant-missing (404), grant-inactive (410) and rotated-key (410) are unchanged and explicitly tested to stay unmasked. No view event is recorded when no ciphertext is released.

**Frontend**
- `viewEnvelope` sends `allow_empty=1`; its `envelope` is now nullable, which surfaced two other callers that assumed a point always exists (the redesign chat handler and the Feed's SOS card).
- The poll paces **each grant by its own outcome**: streaming shares stay on the 5s cadence, waiting shares drop to 30s, failing shares back off exponentially to a 60s cap and snap back on the next success. Per grant, so one broken share cannot slow the healthy ones beside it.
- The interval depends only on the joined grant-id list, so renders no longer rebuild it and re-fire an immediate sweep.
- Anti-deadlock: a sweep that never settles releases its in-flight guard after 30s instead of wedging live tracking for the session; each sweep claims a generation id so an abandoned sweep cannot release a guard it no longer owns; and no throw can escape a tick and kill the interval.

Net effect on an idle share: **~12 requests/min → ~2**, and zero failed requests.

## Deliberately not done

Not gated on `grant.latestEnvelopeId`. It is a real, maintained column, but it is a denormalised "has ever published" copy — skipping the read on it would let one missed write permanently hide a live dot. The cadence is driven by the response itself, so it self-heals.

## Tests

7 backend, 7 frontend. The backend set pins that `allow_empty` relaxes *only* the waiting case; the frontend set covers waiting-is-not-an-error, the legacy-404 rollout path, the 30s waiting cadence, exponential backoff, recovery to live, and watchdog recovery from a read that never settles.

Also adds `RECIPIENT_KEY_UNAVAILABLE_MESSAGE` to the page test's encryption mock. Reading it threw a vitest "no export defined" error from *inside* the view-error handler, which `Promise.allSettled` swallowed — hiding every recipient-side failure branch from these tests. The new defensive `try/catch` is what made it visible.

## Verification

Full suites on this branch and on the `main` tip it targets (`33c44ecf2`):

| Suite | Baseline | Branch | Regressions |
|---|---|---|---|
| Webapp vitest | 27 failed / 3814 passed | 27 failed / **3821** passed | none |
| consent-protocol pytest | 78 failed+errors / 6761 passed | 78 failed+errors / **6768** passed | none |

Failing sets are **identical** on both sides (diffed by name, not just counted). `tsc --noEmit` clean, `eslint --max-warnings=0` clean on every changed file, repo-pinned `ruff` 0.15.11 reports "All checks passed" and "928 files already formatted".

Observability route map needs no regeneration — its matchers already carry `(?:\?.*)?`, so the path still buckets to `/api/one/location/grants/{grant_id}/envelope`.