### PR TITLE
fix(one-location): center Check-in on mobile instead of grouping with Locate

### DIFF
--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -38,6 +38,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useRequireAuth } from "@/hooks/use-auth";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   decryptLocationEnvelope,
   encryptLocationForRecipient,
@@ -347,6 +348,13 @@ export function LocationImmersiveMap({
   const { vaultOwnerToken } = useVault();
   const demoAvailable = isLocationMapDemoAvailable();
   const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
+  // Below md, Check-in moves into the header's center column (Sharing steps
+  // aside there -- see the header below) instead of sitting grouped with
+  // Locate on the trailing edge. A CSS-only breakpoint can't do this: the
+  // same control can't sit centered-alone in one column and grouped with a
+  // sibling in another without literally living in two places in the tree,
+  // so this picks the one place it actually renders.
+  const isMobile = useIsMobile();
   const initialDemoMode = isLocationMapDemoEnabled(searchParams.get("demo"));
   const mapElement = useRef<HTMLElement | null>(null);
   const mapRef = useRef<GoogleMap | null>(null);
@@ -1877,6 +1885,42 @@ export function LocationImmersiveMap({
     await frameMarkers(map, visibleMarkers);
   }, [visibleMarkers]);
 
+  // Built once and placed into exactly one of two header slots below
+  // (mobile's center column, or desktop's trailing group with Locate) --
+  // never both, so it only ever mounts once.
+  const checkInPill = (
+    <ShellActionSurface
+      variant="pill"
+      // ShellActionSurface's own wrapper is shrink-0 by default (a
+      // fixed-size top-bar control never used to need to give way). On
+      // desktop this shares a grid column with Locate and can be pushed by
+      // Sharing sitting dead-center, so it needs to be the one that yields
+      // -- wrapperClassName reaches the actual flex item; min-w-0 on the
+      // trigger itself lets its own truncate span ellipsis instead of just
+      // refusing to shrink.
+      wrapperClassName="min-w-0 shrink"
+      className={`pointer-events-auto min-w-0 border shadow-lg backdrop-blur-md ${
+        nearbyPresenceState.presence
+          ? MAP_ACCENT_ACTIVE_CLASSNAME
+          : MAP_ACCENT_CONTROL_CLASSNAME
+      }`}
+      aria-label={
+        nearbyPresenceState.presence
+          ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
+          : "Check in nearby"
+      }
+      data-testid="one-location-map-nearby-check-in"
+      onClick={openNearbyCheckIn}
+    >
+      <UsersRound className="h-4 w-4 shrink-0" />
+      <span className="truncate">
+        {nearbyPresenceState.presence
+          ? `Nearby ${nearbyPresenceState.attendees.length}`
+          : "Check in"}
+      </span>
+    </ShellActionSurface>
+  );
+
   return (
     <main
       className="one-location-map relative h-[100dvh] w-full overflow-hidden bg-muted"
@@ -1911,8 +1955,14 @@ export function LocationImmersiveMap({
         // is what dragged Check-in and Sharing out of place in the first
         // place. `1fr auto 1fr` instead forces the two outer columns to the
         // same width regardless of what they contain, which puts the middle
-        // (auto) column -- Sharing -- at the header's true visual center no
-        // matter how wide the close X or the Check-in+Locate group are.
+        // (auto) column at the header's true visual center no matter how
+        // wide the close X or the trailing group are.
+        //
+        // The center column's occupant depends on viewport: on desktop it's
+        // Sharing, with Check-in grouped into the trailing edge alongside
+        // Locate; below md, Check-in takes the center column instead (see
+        // `isMobile` below) and Sharing steps aside, matching how little
+        // room a phone-width header actually has for three live pills.
         className="pointer-events-none absolute inset-x-0 top-0 z-30 grid grid-cols-[1fr_auto_1fr] items-center gap-3 p-4 pt-[max(1rem,env(safe-area-inset-top))]"
       >
         <div className="flex min-w-0 items-center">
@@ -1932,58 +1982,35 @@ export function LocationImmersiveMap({
           </ShellActionSurface>
         </div>
         <div className="flex min-w-0 items-center justify-center">
-          {!demoMode && (activeShareCount ?? 0) > 0 ? (
-            <span
-              data-testid="one-location-map-sharing-status"
-              aria-label={`You are sharing your location with ${activeShareCount} ${
-                activeShareCount === 1 ? "person" : "people"
-              }`}
-              role="status"
-              aria-live="polite"
-              className="pointer-events-none flex min-w-0 shrink items-center gap-1.5 truncate rounded-full border border-[var(--app-accent-border)] bg-background/85 px-3 py-1.5 text-[12px] font-semibold text-[var(--app-accent-deep)] shadow-lg backdrop-blur-md dark:text-[var(--app-accent-bright)]"
-            >
-              <span
-                className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--app-accent)] motion-safe:animate-pulse"
-                aria-hidden="true"
-              />
-              <span className="truncate">Sharing with {activeShareCount}</span>
-            </span>
-          ) : null}
+          {isMobile
+            ? rendererReady && nearbyCheckInAvailable && !demoMode
+              ? checkInPill
+              : null
+            : !demoMode && (activeShareCount ?? 0) > 0
+              ? (
+                <span
+                  data-testid="one-location-map-sharing-status"
+                  aria-label={`You are sharing your location with ${activeShareCount} ${
+                    activeShareCount === 1 ? "person" : "people"
+                  }`}
+                  role="status"
+                  aria-live="polite"
+                  className="pointer-events-none flex min-w-0 shrink items-center gap-1.5 truncate rounded-full border border-[var(--app-accent-border)] bg-background/85 px-3 py-1.5 text-[12px] font-semibold text-[var(--app-accent-deep)] shadow-lg backdrop-blur-md dark:text-[var(--app-accent-bright)]"
+                >
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--app-accent)] motion-safe:animate-pulse"
+                    aria-hidden="true"
+                  />
+                  <span className="truncate">Sharing with {activeShareCount}</span>
+                </span>
+              )
+              : null}
         </div>
         {rendererReady ? (
           <div className="flex min-w-0 items-center justify-end gap-3">
-            {rendererReady && nearbyCheckInAvailable && !demoMode ? (
-              <ShellActionSurface
-                variant="pill"
-                // ShellActionSurface's own wrapper is shrink-0 by default (a
-                // fixed-size top-bar control never used to need to give way).
-                // Here it shares a grid column with Locate and can be pushed
-                // by Sharing sitting dead-center, so it needs to be the one
-                // that yields -- wrapperClassName reaches the actual flex
-                // item; min-w-0 on the trigger itself lets its own truncate
-                // span ellipsis instead of just refusing to shrink.
-                wrapperClassName="min-w-0 shrink"
-                className={`pointer-events-auto min-w-0 border shadow-lg backdrop-blur-md ${
-                  nearbyPresenceState.presence
-                    ? MAP_ACCENT_ACTIVE_CLASSNAME
-                    : MAP_ACCENT_CONTROL_CLASSNAME
-                }`}
-                aria-label={
-                  nearbyPresenceState.presence
-                    ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
-                    : "Check in nearby"
-                }
-                data-testid="one-location-map-nearby-check-in"
-                onClick={openNearbyCheckIn}
-              >
-                <UsersRound className="h-4 w-4 shrink-0" />
-                <span className="truncate">
-                  {nearbyPresenceState.presence
-                    ? `Nearby ${nearbyPresenceState.attendees.length}`
-                    : "Check in"}
-                </span>
-              </ShellActionSurface>
-            ) : null}
+            {!isMobile && rendererReady && nearbyCheckInAvailable && !demoMode
+              ? checkInPill
+              : null}
             {rendererReady ? (
               <ShellActionSurface
                 className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}


### PR DESCRIPTION
## Description

Follow-up to #5279 (already merged). That PR fixed the desktop/wide-viewport header layout — ✕ alone left, Sharing true-centered, Check-in grouped with Locate on the right. This PR adds the mobile-specific behavior requested afterward: **on mobile, Check-in should be centered** rather than grouped with Locate.

Below the `md` breakpoint (768px, via the existing `useIsMobile()` hook):
- Check-in takes the header's center column (the same column Sharing occupies on desktop).
- Sharing steps aside on mobile — there isn't room for three live pills on a phone-width header, so it goes back to being desktop-only (matching its behavior before #5279 touched it).
- Locate stays alone on the trailing edge.

Desktop/wide-viewport behavior (`md` and up) is unchanged from #5279.

A single `checkInPill` element is built once and placed into exactly one of the header's two slots based on `isMobile`, so it only ever mounts in one place — a CSS-only breakpoint can't move a control between "centered alone in one column" and "grouped with a sibling in another column" without literally living in two places in the tree.

**Tests:** all 29 existing tests in `__tests__/components/location-immersive-map.test.tsx` pass (jsdom's default viewport exercises the desktop branch, matching existing test expectations). `eslint` on the changed file is clean.

Only `hushh-webapp/components/one-location/location-immersive-map.tsx` is changed.

## Category

Fix

## User story

As a user on mobile, I want the Check-in control centered in the map header so it feels balanced on a phone-width screen.

## Affected route

`/one/location/check-in` (and `/one/location/map`, which renders the same header)

## URL

https://uat.one.hushh.ai/one/location/check-in
