### PR TITLE
fix(one-location): one position, asked once — stop the live publisher reporting a location it has

### DIFF
--- a/hushh-webapp/__tests__/api/sos-email-render.test.ts
+++ b/hushh-webapp/__tests__/api/sos-email-render.test.ts
@@ -101,3 +101,50 @@ describe("Save my Soul email", () => {
     ).toContain("is shared with you now");
   });
 });
+
+describe("Save my Soul email and the age of the position", () => {
+  // Save my Soul sends the last known position rather than nothing when the
+  // device will not produce a new one — the right call in an emergency, and a
+  // dangerous one if the person reading it is not told how old it is. An
+  // unstamped twenty-minute-old coordinate presented as "now" sends help
+  // confidently to the wrong place.
+  it("stamps a position that was not measured just now", () => {
+    const capturedAt = new Date(Date.now() - 20 * 60_000).toISOString();
+    const { text, html } = renderSosEmail({ ...base, capturedAt });
+
+    for (const body of [text, html]) {
+      expect(body).toContain("measured 20 min ago");
+    }
+  });
+
+  it("says nothing extra when the position is current", () => {
+    const capturedAt = new Date(Date.now() - 15_000).toISOString();
+    const { text, html } = renderSosEmail({ ...base, capturedAt });
+
+    // The ordinary emergency — which is nearly all of them — must read exactly
+    // as it did. A stamp on every alert is noise on a message read in a hurry.
+    for (const body of [text, html]) {
+      expect(body).not.toContain("measured");
+    }
+  });
+
+  it("says nothing extra when there is no timestamp at all", () => {
+    const { text } = renderSosEmail({ ...base, capturedAt: null });
+    expect(text).not.toContain("measured");
+  });
+
+  it("treats a clock-skewed future timestamp as current, not negative", () => {
+    const capturedAt = new Date(Date.now() + 5 * 60_000).toISOString();
+    expect(renderSosEmail({ ...base, capturedAt }).text).not.toContain(
+      "measured",
+    );
+  });
+
+  it("keeps the coordinates and the map link alongside the stamp", () => {
+    const capturedAt = new Date(Date.now() - 45 * 60_000).toISOString();
+    const { text } = renderSosEmail({ ...base, capturedAt });
+
+    expect(text).toContain("12.935200, 77.624500");
+    expect(text).toContain("measured 45 min ago");
+  });
+});

--- a/hushh-webapp/__tests__/app/location-bus-account-bridge.contract.test.ts
+++ b/hushh-webapp/__tests__/app/location-bus-account-bridge.contract.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Where the shared position store gets its account.
+ *
+ * The store can keep a fix across a reload, but only for somebody — a
+ * coordinate has to belong to an account before it can be sealed to their key.
+ * That attach used to live in two places and effectively neither: the React
+ * hook only ran it when a caller passed a userId and no caller did, and key
+ * bootstrap needs a vault token, so it landed after the Location page had
+ * already taken and failed its first capture. The restored fix was missing at
+ * exactly the moment it exists to cover.
+ *
+ * Source-text assertions because the alternative is mounting the entire app
+ * shell to observe one side effect.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("location bus account bridge", () => {
+  const source = readFileSync(join(process.cwd(), "app/providers.tsx"), "utf8");
+
+  it("attaches the account for the whole app, not one screen", () => {
+    expect(source).toContain("function LocationBusAccountBridge()");
+    expect(source).toContain("void LocationBus.attachUser(userId ?? null);");
+    expect(source).toContain("<LocationBusAccountBridge />");
+  });
+
+  it("keeps the bridge outside the route Suspense boundary", () => {
+    // Inside it, a suspending navigation remounts the tree and re-attaches on
+    // every route change — the same reason the onboarding sync bridge and the
+    // voice glow sit out here.
+    expect(source.indexOf("<LocationBusAccountBridge />")).toBeLessThan(
+      source.indexOf("<Suspense"),
+    );
+  });
+
+  it("attaches from auth, so signing out clears the previous account's fix", () => {
+    // attachUser(null) is what wipes a held position at the account boundary.
+    // Reading the id from anywhere that outlives sign-out would leave one
+    // person's coordinate visible under another person's session.
+    const bridge = source.slice(
+      source.indexOf("function LocationBusAccountBridge()"),
+      source.indexOf("function AppShellFrame("),
+    );
+    expect(bridge).toContain("const { userId } = useAuth();");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -23,6 +23,8 @@ const {
   mockOpenLocationSettings,
   mockOpenAppSettings,
   mockCaptureCurrentPosition,
+  mockBusGetState,
+  mockBusEnsure,
   mockReverseGeocode,
   mockPlacesAutocomplete,
   mockPlaceDetails,
@@ -71,6 +73,8 @@ const {
   mockOpenLocationSettings: vi.fn(),
   mockOpenAppSettings: vi.fn(),
   mockCaptureCurrentPosition: vi.fn(),
+  mockBusGetState: vi.fn(),
+  mockBusEnsure: vi.fn(),
   mockReverseGeocode: vi.fn(),
   mockPlacesAutocomplete: vi.fn(),
   mockPlaceDetails: vi.fn(),
@@ -256,6 +260,26 @@ vi.mock("@/lib/one-location/encryption", () => ({
   RECIPIENT_KEY_UNAVAILABLE_MESSAGE:
     "Recipient key unavailable for this location share.",
   ensureVaultSyncedRecipientKey: vi.fn(async () => {}),
+}));
+
+// The live publisher reads the shared position store rather than reaching the
+// device itself, so the store is what these tests have to stand up. Left
+// permanently "ready" with a fix measured now: that is the state a session with
+// a running movement watch is in, and it is the precondition for every publish
+// assertion below.
+vi.mock("@/lib/one-location/location-bus", () => ({
+  LocationBus: {
+    getState: mockBusGetState,
+    ensure: mockBusEnsure,
+    subscribe: vi.fn(() => () => {}),
+    watch: vi.fn().mockResolvedValue(() => {}),
+    attachUser: vi.fn().mockResolvedValue(undefined),
+    syncPermission: vi.fn().mockResolvedValue("granted"),
+    request: vi.fn(),
+    invalidate: vi.fn(),
+    getLastCaptureError: vi.fn(() => null),
+    __resetForTests: vi.fn(),
+  },
 }));
 
 vi.mock("@/lib/one-location/service", () => ({
@@ -811,6 +835,23 @@ async function openTemporaryLinkFlow() {
 describe("OneLocationAgentPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    // The shared store, holding a fix measured now — what a session with a
+    // live movement watch looks like, and the precondition for the publisher.
+    const busSnapshot = {
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 12,
+      capturedAt: new Date().toISOString(),
+      sourcePlatform: "web" as const,
+    };
+    mockBusGetState.mockReturnValue({
+      status: "ready",
+      permission: "granted",
+      snapshot: busSnapshot,
+      snapshotOrigin: "fresh",
+      error: null,
+    });
+    mockBusEnsure.mockResolvedValue(busSnapshot);
     Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
     // Most page-flow tests are not about the optional saved-place prompt.

--- a/hushh-webapp/__tests__/services/user-local-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/user-local-state-service.test.ts
@@ -8,6 +8,15 @@ const mocks = vi.hoisted(() => ({
   clearKaiNavTour: vi.fn(),
   clearRiaOnboardingDraft: vi.fn(),
   clearVaultMethodPrompt: vi.fn(),
+  forgetLocationMemory: vi.fn(),
+}));
+
+// Mocked rather than exercised for real: location-grant-memory reaches
+// encryption -> HushhKeychain, and this file mocks only @capacitor/core.
+// location-grant-memory.test.ts owns the durable behaviour; this file owns the
+// wiring. Both are needed — either alone passes while the other half is broken.
+vi.mock("@/lib/one-location/location-grant-memory", () => ({
+  forgetLocationMemory: mocks.forgetLocationMemory,
 }));
 
 vi.mock("@/lib/services/pre-vault-onboarding-service", () => ({
@@ -68,6 +77,28 @@ describe("UserLocalStateService", () => {
     expect(mocks.clearKaiNavTour).toHaveBeenCalledWith("uid-1");
     expect(mocks.clearRiaOnboardingDraft).toHaveBeenCalledWith("uid-1");
     expect(mocks.clearVaultMethodPrompt).toHaveBeenCalledWith("uid-1");
+  });
+
+  it("forgets the remembered location grant and the sealed last-known fix", async () => {
+    // These two records are the only user-scoped local state that describes
+    // where a person physically was: a sealed coordinate kept for 24h and a
+    // grant kept for 90d. Both were shipped with no caller for the function
+    // that deletes them, so they outlived sign-out on a shared device.
+    await UserLocalStateService.clearForUser("uid-1");
+
+    expect(mocks.forgetLocationMemory).toHaveBeenCalledWith("uid-1");
+  });
+
+  it("still forgets location even when another cleanup rejects", async () => {
+    // The settled batch swallows rejections, but only for work queued after
+    // this point. Location teardown runs synchronously and ahead of it for
+    // exactly this reason: an unrelated failure must not be able to leave a
+    // coordinate behind.
+    mocks.clearRiaOnboardingDraft.mockRejectedValue(new Error("storage full"));
+
+    await UserLocalStateService.clearForUser("uid-1");
+
+    expect(mocks.forgetLocationMemory).toHaveBeenCalledWith("uid-1");
   });
 
   it("clears the setup completion latch so onboarding can re-arm", async () => {

--- a/hushh-webapp/app/api/one/location/sos-email/route.ts
+++ b/hushh-webapp/app/api/one/location/sos-email/route.ts
@@ -86,6 +86,30 @@ function firstName(value: string): string {
   return value.trim().split(/\s+/)[0] ?? "";
 }
 
+/**
+ * ", measured at 21:42 UTC" — or "" for a position taken moments ago.
+ *
+ * Empty for a fresh fix so the ordinary emergency, which is nearly all of
+ * them, reads exactly as it did. The stamp appears only when there is
+ * something the reader genuinely needs to know.
+ */
+export function sosFixAgeLabel(capturedAt: string | null | undefined): string {
+  if (!capturedAt) return "";
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return "";
+  const ageMs = Date.now() - capturedMs;
+  // Two minutes: below it, a stamp is noise on a message that has to be read
+  // in a hurry. A clock-skewed future timestamp is treated as current rather
+  // than reported as negative.
+  if (ageMs < 0 || ageMs <= 2 * 60 * 1_000) return "";
+  const time = new Date(capturedMs).toISOString().slice(11, 16);
+  const minutes = Math.round(ageMs / 60_000);
+  const ago = minutes < 60
+    ? `${minutes} min ago`
+    : `${Math.round(minutes / 60)} hr ago`;
+  return ` — measured ${ago}, at ${time} UTC`;
+}
+
 export function renderSosEmail(input: {
   recipientDisplayName: string;
   ownerDisplayName: string;
@@ -93,6 +117,17 @@ export function renderSosEmail(input: {
   latitude: number;
   longitude: number;
   accuracyM: number | null;
+  /**
+   * When the position was measured.
+   *
+   * Present so the email can stop claiming "live" for a fix it is not sure
+   * about. Save my Soul sends the last known position rather than nothing when
+   * the device will not produce a new one — the right call in an emergency,
+   * but only if the person reading it is told how old it is. An unstamped
+   * twenty-minute-old coordinate presented as "now" sends help to the wrong
+   * place with complete confidence.
+   */
+  capturedAt?: string | null;
   openInOneUrl: string;
   emergencyNumber: string | null;
   expiresAtLabel: string | null;
@@ -107,6 +142,7 @@ export function renderSosEmail(input: {
       : "";
   const map = mapsUrl(input.latitude, input.longitude);
   const note = input.note?.trim() || "";
+  const measuredAt = sosFixAgeLabel(input.capturedAt);
   const expiry = input.expiresAtLabel
     ? `Their live location stays shared until ${input.expiresAtLabel}.`
     : "Their live location is shared with you now.";
@@ -119,7 +155,7 @@ export function renderSosEmail(input: {
   const text = [
     `${greeting}${owner} triggered a Save my Soul alert.`,
     note ? `\n  "${note}"\n` : "",
-    `Location: ${coords}${accuracy}`,
+    `Location: ${coords}${accuracy}${measuredAt}`,
     `Map: ${map}`,
     "",
     expiry,
@@ -140,7 +176,7 @@ export function renderSosEmail(input: {
     `<h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;">${escapeHtml(owner)} needs help</h1>`,
     `<p style="margin:0 0 20px;font-size:16px;line-height:1.5;">${escapeHtml(greeting.trim())} They triggered an emergency alert and shared their live location with you.</p>`,
     noteHtml,
-    `<p style="margin:0 0 8px;font-size:16px;line-height:1.5;"><strong>Location:</strong> ${escapeHtml(coords)}${escapeHtml(accuracy)}</p>`,
+    `<p style="margin:0 0 8px;font-size:16px;line-height:1.5;"><strong>Location:</strong> ${escapeHtml(coords)}${escapeHtml(accuracy)}${escapeHtml(measuredAt)}</p>`,
     `<p style="margin:0 0 24px;"><a href="${escapeHtml(map)}" style="display:inline-block;padding:12px 20px;border-radius:9999px;background:#ff3b30;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">Open in Google Maps</a></p>`,
     `<p style="margin:0 0 8px;font-size:15px;line-height:1.5;color:#3c3c43;">${escapeHtml(expiry)}</p>`,
     `<p style="margin:0 0 24px;font-size:15px;"><a href="${escapeHtml(input.openInOneUrl)}" style="color:#007aff;">See their live position in One</a></p>`,
@@ -179,6 +215,7 @@ export async function POST(request: NextRequest) {
     latitude?: unknown;
     longitude?: unknown;
     accuracyM?: unknown;
+    capturedAt?: unknown;
     note?: unknown;
     emergencyNumber?: unknown;
   };
@@ -215,6 +252,7 @@ export async function POST(request: NextRequest) {
   const emergencyNumber = String(payload.emergencyNumber ?? "")
     .trim()
     .slice(0, 16);
+  const capturedAt = String(payload.capturedAt ?? "").trim() || null;
 
   // The backend is the authorization: it returns contacts only for live SOS
   // grants this caller's own account just created.
@@ -265,6 +303,7 @@ export async function POST(request: NextRequest) {
         latitude,
         longitude,
         accuracyM,
+        capturedAt,
         openInOneUrl: String(resolved.openInOneUrl ?? ""),
         emergencyNumber: emergencyNumber || null,
         expiresAtLabel: recipient.expiresAt

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7958,8 +7958,14 @@ export function OneLocationAgentPageContent({
         if (isStale()) return superseded;
         if (!result.ready || !result.point) {
           rollbackOptimisticOn();
+          // Say which of the two it was. "Needs device Location permission"
+          // was printed even when permission was fine and the device had
+          // simply not answered yet, which sent people to a settings screen
+          // with nothing to change on it.
           const message =
-            "Live location preview needs device Location permission.";
+            result.failure === "no-fix"
+              ? LOCATION_COPY.noFix
+              : LOCATION_COPY.denied;
           setMyLocationError(message);
           return { status: "blocked", summary: message };
         }
@@ -7972,7 +7978,11 @@ export function OneLocationAgentPageContent({
       } catch (error) {
         if (isStale()) return superseded;
         rollbackOptimisticOn();
-        const message = locationServicesErrorMessage(error);
+        // The gate already decided whether this was a refusal; asserting a
+        // cause from the error text guessed wrong on every timeout.
+        const message = isLocationPermissionDeniedError(error)
+          ? LOCATION_COPY.denied
+          : LOCATION_COPY.noFix;
         setMyLocationError(message);
         toast.error(message);
         return { status: "failed", summary: message };

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -165,9 +165,13 @@ import { driveEtaText } from "@/app/one/location/drive-eta";
 import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
 import {
   LOCATION_BLOCK_MESSAGE,
+  LOCATION_COPY,
+  type LocationFailure,
   isLocationPermissionDeniedError,
+  isUsableFixAge,
   locationBlockReason,
   locationReadiness as resolveLocationReadiness,
+  shouldSurfaceLocationError,
 } from "@/lib/one-location/location-readiness";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
@@ -3191,9 +3195,69 @@ export function OneLocationAgentPageContent({
        * on/off control passes this; every other caller keeps today's behaviour.
        */
       isStale?: () => boolean;
-    }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
+      /**
+       * Whether this gate may speak.
+       *
+       * False for a caller that prints its own message — nine of them do, and
+       * a shared toast on top meant one failure produced two. Also false for
+       * anything the owner did not ask for: a screen warming a position in the
+       * background does not get to interrupt them about it.
+       */
+      announce?: boolean;
+      /**
+       * Refuse a held position; only a fix measured now will do.
+       *
+       * For the small set of callers where degrading would be a lie rather
+       * than a courtesy. Un-pausing is one: pause is a privacy control, and
+       * resuming a share on a remembered coordinate would start telling people
+       * the owner is somewhere they have left. The live publisher and the
+       * check-in confirmation draw the same line for the same reason.
+       */
+      requireMeasurement?: boolean;
+    }): Promise<{
+      ready: boolean;
+      point?: PlainLocationPoint;
+      origin?: "fresh" | "restored";
+      failure?: LocationFailure;
+    }> => {
       const shouldCapturePoint = Boolean(options?.capturePoint);
       const shouldOpenSettings = options?.autoOpenSettings !== false;
+      const announce = options?.announce !== false;
+
+      const heldFix = (): PlainLocationPoint | null => {
+        const bus = LocationBus.getState();
+        if (!bus.snapshot) return null;
+        if (!isUsableFixAge(bus.snapshot.capturedAt)) return null;
+        return {
+          latitude: bus.snapshot.latitude,
+          longitude: bus.snapshot.longitude,
+          accuracyM: bus.snapshot.accuracyM ?? null,
+          capturedAt: bus.snapshot.capturedAt,
+          sourcePlatform: bus.snapshot.sourcePlatform ?? "web",
+        };
+      };
+
+      // Nothing to do but hand back what we already have.
+      //
+      // A caller that does not need a new measurement, on a session that is
+      // holding a usable position, used to pay for a permission read and a
+      // device round trip anyway — and could be toasted at for the privilege.
+      // On Safari, where the permission value is unreadable, it took that path
+      // every single time.
+      if (!shouldCapturePoint && !observedLocationDenialRef.current) {
+        const held = heldFix();
+        if (held) {
+          return {
+            ready: true,
+            point: held,
+            origin:
+              LocationBus.getState().snapshotOrigin === "fresh"
+                ? "fresh"
+                : "restored",
+          };
+        }
+      }
+
       const currentPermission = await refreshLocationPermission();
 
       // Only two things stop us before we have tried, and neither can be fixed
@@ -3207,11 +3271,11 @@ export function OneLocationAgentPageContent({
       // attempt, and let a real PERMISSION_DENIED be the thing that blocks.
       const blockReason = locationBlockReason(currentPermission);
       if (blockReason) {
-        toast.error(LOCATION_BLOCK_MESSAGE[blockReason]);
-        if (shouldOpenSettings) {
+        if (announce) toast.error(LOCATION_BLOCK_MESSAGE[blockReason]);
+        if (shouldOpenSettings && announce) {
           await OneLocationService.openLocationSettings().catch(() => null);
         }
-        return { ready: false };
+        return { ready: false, failure: "blocked" };
       }
 
       if (
@@ -3252,7 +3316,14 @@ export function OneLocationAgentPageContent({
         // so a later step in the same flow can use it instead of paying for a
         // second acquisition. `shouldCapturePoint` still governs the SIDE
         // EFFECT (activateMyLocation) above — only the return widens.
-        return { ready: true, point };
+        return {
+          ready: true,
+          point,
+          origin:
+            LocationBus.getState().snapshotOrigin === "restored"
+              ? "restored"
+              : "fresh",
+        };
       } catch (error) {
         const nextPermission =
           await OneLocationService.getPermissionState().catch(() => null);
@@ -3264,17 +3335,45 @@ export function OneLocationAgentPageContent({
         const denied = isLocationPermissionDeniedError(error);
         observedLocationDenialRef.current = denied;
         setLocationDenialObserved(denied);
-        const message = locationServicesErrorMessage(error);
-        toast.error(message);
+
+        // Not a refusal, and we are holding a position. Use it and say
+        // nothing: this is the case that produced most of the noise, because
+        // a device that declines one reading is routine and the owner has
+        // nothing to do about it.
+        const held =
+          denied || options?.requireMeasurement ? null : heldFix();
+        if (held) {
+          if (shouldCapturePoint && !options?.isStale?.()) {
+            activateMyLocation(held);
+          }
+          return { ready: true, point: held, origin: "restored" };
+        }
+
+        const failure: LocationFailure = denied
+          ? "denied"
+          : isLocationServicesDisabled(nextPermission)
+            ? "blocked"
+            : "no-fix";
         if (
-          shouldOpenSettings &&
-          (denied ||
-            isLocationServicesDisabled(nextPermission) ||
-            message.toLowerCase().includes("turn on location"))
+          shouldSurfaceLocationError({
+            hasUsableFix: false,
+            observedDenial: denied,
+            blockReason: locationBlockReason(nextPermission),
+            blocksUserIntent: announce,
+          })
         ) {
+          toast.error(
+            failure === "no-fix" ? LOCATION_COPY.noFix : LOCATION_COPY.denied,
+          );
+        }
+        // Settings only for something Settings can fix. The old trigger also
+        // fired on any message containing "turn on location" — which the web
+        // plugin puts on a TIMEOUT, so a laptop with no GPS radio was thrown
+        // at a settings pane it does not have.
+        if (shouldOpenSettings && announce && failure !== "no-fix") {
           await OneLocationService.openLocationSettings().catch(() => null);
         }
-        return { ready: false };
+        return { ready: false, failure };
       }
     },
     [activateMyLocation, refreshLocationPermission],
@@ -4000,6 +4099,11 @@ export function OneLocationAgentPageContent({
         const result = await ensureForegroundLocationReady({
           capturePoint: true,
           autoOpenSettings: false,
+          // This runs when Save my Soul is merely OPENED. Nobody has asked for
+          // anything yet, so a failure here has nothing to tell them — and on
+          // a promptable browser a toast plus a settings pane for opening a
+          // panel is how "it keeps asking me again" happens.
+          announce: false,
         });
         if (!result.ready || !result.point) {
           setSosEmergencyStatus((current) =>
@@ -4113,6 +4217,11 @@ export function OneLocationAgentPageContent({
           latitude: point.latitude,
           longitude: point.longitude,
           accuracyM: point.accuracyM ?? null,
+          // Save my Soul sends the last known position rather than nothing
+          // when the device will not produce a new one — the right call in an
+          // emergency, but only if the person reading it is told how old it
+          // is. The email stamps anything older than a couple of minutes.
+          capturedAt: point.capturedAt,
           note,
           emergencyNumber: sosEmergency?.number ?? null,
         });
@@ -4333,6 +4442,8 @@ export function OneLocationAgentPageContent({
         const readiness = await ensureForegroundLocationReady({
           capturePoint: true,
           autoOpenSettings: true,
+          // Prints its own message below.
+          announce: false,
         });
         if (!readiness.ready || !readiness.point) {
           return;
@@ -6956,6 +7067,8 @@ export function OneLocationAgentPageContent({
         const readiness = await ensureForegroundLocationReady({
           capturePoint: false,
           autoOpenSettings: true,
+          // Prints its own message below.
+          announce: false,
         });
         // The location shown on the consent screen is the only point this
         // operation may encrypt; permission is rechecked without recapturing.
@@ -7130,6 +7243,8 @@ export function OneLocationAgentPageContent({
         const readiness = await ensureForegroundLocationReady({
           capturePoint: true,
           autoOpenSettings: true,
+          // Prints its own message below.
+          announce: false,
         });
         if (!readiness.ready || !readiness.point) {
           toast.error("Couldn't get your location — drive not shared.");
@@ -7310,6 +7425,8 @@ export function OneLocationAgentPageContent({
           const readiness = await ensureForegroundLocationReady({
             capturePoint: true,
             autoOpenSettings: true,
+            // Prints its own message below.
+            announce: false,
           });
           if (!readiness.ready || !readiness.point) {
             toast.error(
@@ -7415,6 +7532,8 @@ export function OneLocationAgentPageContent({
         const readiness = await ensureForegroundLocationReady({
           capturePoint: true,
           autoOpenSettings: true,
+          // Prints its own message below.
+          announce: false,
         });
         if (!readiness.ready || !readiness.point) {
           toast.error(
@@ -7580,6 +7699,9 @@ export function OneLocationAgentPageContent({
     const readiness = await ensureForegroundLocationReady({
       capturePoint: false,
       autoOpenSettings: true,
+      // Opening the review screen is not the owner asking for a fix. Failing
+      // here used to toast before the screen they pressed had even appeared.
+      announce: false,
     });
     if (shareReviewAttemptRef.current !== attemptId) return;
     shareReviewPendingRef.current = false;
@@ -7823,6 +7945,12 @@ export function OneLocationAgentPageContent({
           capturePoint: true,
           autoOpenSettings: true,
           isStale,
+          // Renders its outcome inline on the switch itself.
+          announce: false,
+          // Turning location on must not succeed on a remembered position:
+          // pause is a privacy control, and resuming a share on a coordinate
+          // the owner has left starts telling people something untrue.
+          requireMeasurement: true,
         });
         // A newer tap owns the control now. Reporting this one's outcome would
         // describe a state the person has already moved on from, and rolling

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -129,6 +129,12 @@ import type { HushhLocationPermissionState } from "@/lib/capacitor";
 import { isWeb } from "@/lib/capacitor/platform";
 import { apiErrorCode } from "@/lib/services/api-client";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+import { LocationBus } from "@/lib/one-location/location-bus";
+import {
+  isPublishableAge,
+  publishPointFrom,
+  shouldWarnOnPublishFailure,
+} from "@/lib/one-location/live-publish-decision";
 
 
 import {
@@ -313,6 +319,39 @@ const DURATION_OPTIONS = [
 const ONE_LOCATION_SHARE_CONCURRENCY = 4;
 
 const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
+
+/**
+ * How old a fix this heartbeat may reuse without re-reading the device.
+ *
+ * One tick. The requirement has always been that a recipient watching someone
+ * move sees where they are now — `maxAgeMs: 0` was a mechanism chosen for
+ * that, and it became the wrong one once a continuous watch existed. This
+ * ceiling means a published point is never older than a single period, which
+ * is the guarantee the recipient side is already written against: it calls a
+ * share stale at three of them.
+ */
+const LIVE_HEARTBEAT_MAX_AGE_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS;
+
+/**
+ * The point this heartbeat may publish, or null to skip the tick.
+ *
+ * Reads the shared store first, and only asks the device when the store has
+ * nothing recent — which, while the movement watch is running, is almost
+ * never. Anything not measured this session is refused: `publishPointFrom`
+ * rejects a restored fix outright, because the recipient's screen says "live".
+ */
+async function liveHeartbeatPoint(): Promise<PlainLocationPoint | null> {
+  const held = LocationBus.getState();
+  if (
+    held.snapshotOrigin === "fresh" &&
+    isPublishableAge(held.snapshot?.capturedAt, LIVE_HEARTBEAT_MAX_AGE_MS)
+  ) {
+    return publishPointFrom(held);
+  }
+  await LocationBus.ensure({ maxAgeMs: LIVE_HEARTBEAT_MAX_AGE_MS });
+  return publishPointFrom(LocationBus.getState());
+}
+
 // Recipients poll faster than the owner's publish heartbeat so the shared dot
 // stays fresh; the LiveMap marker interpolates between these reads.
 const LIVE_VIEW_REFRESH_INTERVAL_MS = 5_000;
@@ -4608,12 +4647,20 @@ export function OneLocationAgentPageContent({
         return;
       livePublishInFlightRef.current = true;
       try {
-        // Never a reused fix: a recipient watching this person move must see
-        // where they are now, not where they were when a button was last
-        // pressed. One capture here still serves every grant below.
-        const point = await OneLocationService.captureCurrentPosition({
-          maxAgeMs: 0,
-        });
+        // Read the shared position rather than forcing a second acquisition.
+        //
+        // The movement watch below already feeds the bus every fix the device
+        // produces, so the bus snapshot IS the newest position that exists. A
+        // competing one-shot here made the point less current, not more: on
+        // iOS it raced that watch for the plugin's single pending-call slot,
+        // and on web getCurrentPosition can spend ~23s — longer than this
+        // interval. Every lost race threw, and this loop reported "could not
+        // get your location" once a tick while the watch was delivering.
+        const point = await liveHeartbeatPoint();
+        // Nothing measured this session. The watch will deliver; a recipient
+        // watching a live dot must never be shown a remembered coordinate,
+        // and there is nothing here to tell the owner.
+        if (!point) return;
         if (!automaticPrivatePublishingAllowedRef.current) return;
         // Every grant is published independently. Sharing this loop's failure
         // between recipients is what made "share with several people" look
@@ -4653,11 +4700,23 @@ export function OneLocationAgentPageContent({
           }),
         );
       } catch (error) {
-        void refreshLocationPermission();
-        console.warn(
-          "[OneLocationAgent] Foreground live update skipped:",
-          error,
-        );
+        // Only worth the owner's attention when the platform refused or we
+        // hold no position at all. A failed refresh while a share is running
+        // on a good fix is not news they can act on — and re-reading
+        // permission on every one of those cost a platform round trip every
+        // twenty seconds for a value nothing on this path reads.
+        if (
+          shouldWarnOnPublishFailure({
+            error,
+            snapshot: LocationBus.getState().snapshot,
+            observedDenial: observedLocationDenialRef.current,
+          })
+        ) {
+          console.warn(
+            "[OneLocationAgent] Foreground live update skipped:",
+            error,
+          );
+        }
       } finally {
         livePublishInFlightRef.current = false;
       }
@@ -4676,7 +4735,6 @@ export function OneLocationAgentPageContent({
     permission?.state,
     publishEnvelopeWithRetry,
     recipientForGrant,
-    refreshLocationPermission,
     vaultOwnerToken,
   ]);
 

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -58,6 +58,7 @@ import {
   isRiaRoute,
 } from "@/lib/navigation/routes";
 import { useAuth } from "@/hooks/use-auth";
+import { LocationBus } from "@/lib/one-location/location-bus";
 import { PersonaProvider } from "@/lib/persona/persona-context";
 import { resolveSignedInShellContentOffset } from "@/components/app-ui/signed-in-shell-content-offset";
 import { NativeTestRouter } from "@/components/app-ui/native-test-router";
@@ -77,6 +78,29 @@ interface ProvidersProps {
 function readCustomVar(style: CSSProperties, key: string): string {
   const value = (style as Record<string, string | number | undefined>)[key];
   return value === undefined || value === null ? "" : String(value).trim();
+}
+
+/**
+ * Give the shared position store an account, once, for the whole app.
+ *
+ * The store can keep a fix across a reload, but only for somebody: a
+ * coordinate has to belong to an account before it can be sealed to their key.
+ * That attach used to happen in two places and effectively neither. The hook
+ * only attached when a caller passed a `userId` and no caller did; key
+ * bootstrap needs a vault token, so it landed after the Location page had
+ * already taken — and failed — its first capture. The restored fix was
+ * therefore missing at exactly the moment it existed to cover: the cold start.
+ *
+ * Here it runs for every signed-in route, before any surface asks. Idempotent,
+ * so key bootstrap's call stays harmless; and attaching null on sign-out is
+ * what clears one person's position before the next person's session.
+ */
+function LocationBusAccountBridge() {
+  const { userId } = useAuth();
+  useEffect(() => {
+    void LocationBus.attachUser(userId ?? null);
+  }, [userId]);
+  return null;
 }
 
 function AppShellFrame({ children }: ProvidersProps) {
@@ -470,6 +494,7 @@ function AppShellFrame({ children }: ProvidersProps) {
                 app. Keeping it outside the route Suspense boundary prevents
                 fallback/resolved remounts from launching the same sync twice. */}
               <PostAuthOnboardingSyncBridge />
+              <LocationBusAccountBridge />
               <Suspense
                 fallback={
                   <>

--- a/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/capture-options-boundary.test.tsx
@@ -138,10 +138,40 @@ describe("One Location CTA latency contract", () => {
     expect(source).toContain('if (permission?.state !== "granted") return;');
   });
 
-  it("live publishing never serves a recipient a reused fix", () => {
+  it("live publishing never serves a recipient a remembered fix", () => {
     const source = page();
-    expect(source).toContain(
+    // The rule is unchanged; its evidence moved. Forcing an acquisition per
+    // tick used to be how the publisher stayed current, and it stopped being
+    // that once a continuous watch fed the shared store: the one-shot raced
+    // the watch for the device and reported a location failure every time it
+    // lost. Reading the store is both fresher and quieter, and
+    // publishPointFrom is a stronger guarantee than an age ever was — it
+    // rejects anything not measured this session, by provenance rather than
+    // by clock.
+    expect(source).toContain("const point = await liveHeartbeatPoint();");
+    expect(source).toContain("return publishPointFrom(LocationBus.getState());");
+    expect(source).not.toContain(
       "const point = await OneLocationService.captureCurrentPosition({\n          maxAgeMs: 0,\n        });",
+    );
+  });
+
+  it("the heartbeat's reuse window is one tick, not a hand-picked number", () => {
+    const source = page();
+    // A recipient calls a share stale at three publish periods, so a ceiling
+    // of one period keeps the published point inside the window the receiving
+    // side is already written against.
+    expect(source).toContain(
+      "const LIVE_HEARTBEAT_MAX_AGE_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS;",
+    );
+  });
+
+  it("a publish failure is reported only when the owner can act on it", () => {
+    const source = page();
+    expect(source).toContain("shouldWarnOnPublishFailure({");
+    // Re-reading permission after every failed GPS read cost a platform round
+    // trip every twenty seconds for a value nothing on this path consumes.
+    expect(source).not.toContain(
+      'void refreshLocationPermission();\n        console.warn(\n          "[OneLocationAgent] Foreground live update skipped:",',
     );
   });
 });

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -54,6 +54,10 @@ import {
 } from "@/lib/one-location/maps-config";
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
 import {
+  LOCATION_COPY,
+  isLocationPermissionDeniedError,
+} from "@/lib/one-location/location-readiness";
+import {
   consumeNearbyPrivateReturn,
   NEARBY_PRIVATE_RESUME_PARAM,
 } from "@/lib/one-location/nearby-private-navigation";
@@ -1609,8 +1613,26 @@ export function LocationImmersiveMap({
   const locateMe = useCallback(async () => {
     if (!vaultOwnerToken) return;
     setBusy("locate");
+    // Getting a position and telling other people about it are two different
+    // jobs that used to share one catch, so a failed network call and a device
+    // that would not answer produced the same sentence: "we could not update
+    // your location". Only one of those is about location.
+    let point: PlainLocationPoint;
     try {
-      const point = await captureCurrentLocation();
+      point = await captureCurrentLocation();
+    } catch (error) {
+      // captureCurrentLocation now answers from the shared store when the
+      // device declines, so reaching here means there is genuinely nothing to
+      // centre on — worth saying, unlike a refresh that merely failed.
+      toast.error(
+        isLocationPermissionDeniedError(error)
+          ? LOCATION_COPY.denied
+          : LOCATION_COPY.noFix,
+      );
+      setBusy(null);
+      return;
+    }
+    try {
       await focusSelfPoint(point, { animate: true, select: true });
       if (demoMode) {
         toast.success("Centered on your device location.");
@@ -1661,7 +1683,9 @@ export function LocationImmersiveMap({
         "Your active private recipients can see this foreground update.",
       );
     } catch {
-      toast.error("We could not update your location.");
+      // The map has already moved to the new position; what failed is telling
+      // the people it is shared with.
+      toast.error("Couldn't send the update.");
     } finally {
       setBusy(null);
     }

--- a/hushh-webapp/lib/one-location/__tests__/capture-degradation.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/capture-degradation.test.ts
@@ -1,0 +1,259 @@
+/**
+ * What `captureCurrentPosition` does when the device does not answer.
+ *
+ * The reported symptom was a console line every twenty seconds — "Could not
+ * get your location. Turn on Location for your device/browser and try again."
+ * — on a session where permission was granted and a movement watch was
+ * delivering fixes the whole time. The cause was two position stores: the bus,
+ * which degrades to the position it is holding, and this service's own cache,
+ * which had no such notion and simply threw. Every One Location surface was on
+ * the second one.
+ *
+ * These tests pin the degradation AND its limits. A capture that never fails
+ * loudly is worse than one that fails too often: the two cases below that must
+ * still throw are the owner's only route out of a real block.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLocation, mockMemory } = vi.hoisted(() => ({
+  mockLocation: {
+    getPermissionState: vi.fn(),
+    requestLocationPermission: vi.fn(),
+    getCurrentPosition: vi.fn(),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  },
+  mockMemory: {
+    readLastKnownFix: vi.fn(),
+    rememberLastKnownFix: vi.fn(),
+    rememberLocationGrant: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/capacitor", () => ({ HushhLocation: mockLocation }));
+vi.mock("@/lib/one-location/location-grant-memory", () => ({
+  LAST_KNOWN_FIX_RETENTION_MS: 24 * 60 * 60 * 1_000,
+  readLastKnownFix: mockMemory.readLastKnownFix,
+  rememberLastKnownFix: mockMemory.rememberLastKnownFix,
+  rememberLocationGrant: mockMemory.rememberLocationGrant,
+}));
+
+import { LocationBus } from "@/lib/one-location/location-bus";
+import {
+  CAPTURE_DEFAULT_MAX_AGE_MS,
+  CAPTURE_FRESH_MAX_AGE_MS,
+  CAPTURE_STALE_FALLBACK_MAX_AGE_MS,
+  OneLocationService,
+} from "@/lib/one-location/service";
+
+const USER = "user-alpha";
+
+function point(overrides?: {
+  capturedAt?: string;
+  sourcePlatform?: "web" | "ios" | "android";
+}) {
+  return {
+    latitude: 19.076,
+    longitude: 72.877,
+    accuracyM: 12,
+    capturedAt: overrides?.capturedAt ?? new Date().toISOString(),
+    sourcePlatform: overrides?.sourcePlatform ?? ("web" as const),
+  };
+}
+
+/** What CoreLocation raises on a machine with no GPS radio. */
+function positionUnavailable(): Error {
+  const error = new Error(
+    "Could not get your location. Turn on Location for your device/browser and try again.",
+  );
+  error.name = "LocationTimeoutError";
+  (error as Error & { code?: number }).code = 3;
+  return error;
+}
+
+function browserDenial(): Error {
+  const error = new Error("Location permission is blocked for this site.");
+  error.name = "LocationPermissionDeniedError";
+  return error;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  LocationBus.__resetForTests();
+  mockMemory.readLastKnownFix.mockResolvedValue(null);
+  mockLocation.getPermissionState.mockResolvedValue({
+    state: "granted",
+    precise: true,
+    background: "foreground-only",
+  });
+});
+
+describe("captureCurrentPosition when the device stops answering", () => {
+  it("returns the fix it is holding when a refresh fails for any reason but denial", async () => {
+    mockLocation.getCurrentPosition.mockResolvedValueOnce(point());
+    const first = await OneLocationService.captureCurrentPosition();
+
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+    const second = await OneLocationService.captureCurrentPosition({
+      maxAgeMs: 0,
+    });
+
+    expect(second.latitude).toBe(first.latitude);
+    expect(LocationBus.getState().status).toBe("stale");
+  });
+
+  it("still throws when the platform actually refused", async () => {
+    mockLocation.getCurrentPosition.mockResolvedValueOnce(point());
+    await OneLocationService.captureCurrentPosition();
+
+    mockLocation.getCurrentPosition.mockRejectedValue(browserDenial());
+
+    await expect(
+      OneLocationService.captureCurrentPosition({ maxAgeMs: 0 }),
+    ).rejects.toThrow(/blocked/i);
+    expect(LocationBus.getState().status).toBe("denied");
+  });
+
+  it("throws the original error object, so a denial stays recognisable", async () => {
+    mockLocation.getCurrentPosition.mockRejectedValue(browserDenial());
+
+    // The name is the contract three platforms publish. Rebuilding the error
+    // from a status string would erase it and leave callers matching prose.
+    await expect(
+      OneLocationService.captureCurrentPosition(),
+    ).rejects.toMatchObject({ name: "LocationPermissionDeniedError" });
+  });
+
+  it("treats the native plugins' refusal string as a refusal", async () => {
+    mockLocation.getCurrentPosition.mockResolvedValueOnce(point());
+    await OneLocationService.captureCurrentPosition();
+
+    // iOS and Android say this, and it names neither "denied" nor "blocked".
+    mockLocation.getCurrentPosition.mockRejectedValue(
+      new Error("Location permission was not granted."),
+    );
+
+    await expect(
+      OneLocationService.captureCurrentPosition({ maxAgeMs: 0 }),
+    ).rejects.toThrow(/not granted/i);
+    expect(LocationBus.getState().status).toBe("denied");
+  });
+
+  it("still throws when nothing has ever been captured", async () => {
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    await expect(OneLocationService.captureCurrentPosition()).rejects.toThrow(
+      /Could not get your location/,
+    );
+    expect(LocationBus.getState().status).toBe("error");
+  });
+
+  it("refuses to serve a fix older than the stale-fallback budget", async () => {
+    const ancient = new Date(
+      Date.now() - (CAPTURE_STALE_FALLBACK_MAX_AGE_MS + 60_000),
+    ).toISOString();
+    mockLocation.getCurrentPosition.mockResolvedValueOnce(
+      point({ capturedAt: ancient }),
+    );
+    await OneLocationService.captureCurrentPosition({ maxAgeMs: 0 });
+
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    await expect(
+      OneLocationService.captureCurrentPosition({ maxAgeMs: 0 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("captureCurrentPosition freshness policy after delegation", () => {
+  it("keeps the reuse window under the server's freshness limit", async () => {
+    // The bus allows two minutes by default; the backend rejects anything over
+    // sixty seconds between capture and confirmation. Forwarding the window
+    // explicitly is what stops a share failing for an invisible reason.
+    const ensure = vi.spyOn(LocationBus, "ensure");
+    mockLocation.getCurrentPosition.mockResolvedValue(point());
+
+    await OneLocationService.captureCurrentPosition();
+
+    expect(ensure).toHaveBeenCalledWith({ maxAgeMs: CAPTURE_DEFAULT_MAX_AGE_MS });
+    expect(CAPTURE_DEFAULT_MAX_AGE_MS).toBeLessThan(60_000);
+    ensure.mockRestore();
+  });
+
+  it("forwards a caller's fresh intent as the tight window, not zero", async () => {
+    const ensure = vi.spyOn(LocationBus, "ensure");
+    mockLocation.getCurrentPosition.mockResolvedValue(point());
+
+    await OneLocationService.captureCurrentPosition({ fresh: true });
+
+    expect(ensure).toHaveBeenCalledWith({ maxAgeMs: CAPTURE_FRESH_MAX_AGE_MS });
+    ensure.mockRestore();
+  });
+
+  it("preserves the platform the fix actually came from", async () => {
+    // sourcePlatform is sealed into the envelope and shown to the recipient.
+    // Rebuilding a point without it relabels every iPhone share as web.
+    mockLocation.getCurrentPosition.mockResolvedValue(
+      point({ sourcePlatform: "ios" }),
+    );
+
+    const captured = await OneLocationService.captureCurrentPosition();
+
+    expect(captured.sourcePlatform).toBe("ios");
+  });
+
+  it("collapses concurrent callers into one device read after delegation", async () => {
+    let release: ((value: unknown) => void) | null = null;
+    mockLocation.getCurrentPosition.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const all = Promise.all([
+      OneLocationService.captureCurrentPosition(),
+      OneLocationService.captureCurrentPosition(),
+      OneLocationService.captureCurrentPosition(),
+      OneLocationService.captureCurrentPosition(),
+    ]);
+    release?.(point());
+    const results = await all;
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(new Set(results.map((r) => r.capturedAt)).size).toBe(1);
+  });
+});
+
+describe("captureCurrentPosition and the previous session's fix", () => {
+  it("serves the restored fix rather than failing a cold start", async () => {
+    const restored = point({
+      capturedAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    });
+    mockMemory.readLastKnownFix.mockResolvedValue(restored);
+    await LocationBus.attachUser(USER);
+
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+
+    const captured = await OneLocationService.captureCurrentPosition();
+
+    expect(captured.latitude).toBe(restored.latitude);
+  });
+
+  it("does not present a restored fix as a fresh one", async () => {
+    // A surface that needs a measurement — the live publisher, a check-in
+    // confirmation — reads the origin and refuses. If a restore ever passed as
+    // "fresh", both would silently start asserting something untrue.
+    const restored = point({
+      capturedAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    });
+    mockMemory.readLastKnownFix.mockResolvedValue(restored);
+    await LocationBus.attachUser(USER);
+
+    mockLocation.getCurrentPosition.mockRejectedValue(positionUnavailable());
+    await OneLocationService.captureCurrentPosition();
+
+    expect(LocationBus.getState().snapshotOrigin).toBe("restored");
+    expect(LocationBus.getState().status).not.toBe("ready");
+  });
+});

--- a/hushh-webapp/lib/one-location/__tests__/live-publish-decision.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/live-publish-decision.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPublishableAge,
+  publishPointFrom,
+  shouldWarnOnPublishFailure,
+} from "@/lib/one-location/live-publish-decision";
+
+const SNAPSHOT = {
+  latitude: 19.076,
+  longitude: 72.877,
+  accuracyM: 14,
+  capturedAt: new Date().toISOString(),
+  sourcePlatform: "ios" as const,
+};
+
+function denial(): Error {
+  const error = new Error("Location permission is blocked for this site.");
+  error.name = "LocationPermissionDeniedError";
+  return error;
+}
+
+function timeout(): Error {
+  const error = new Error("Could not get your location.");
+  error.name = "LocationTimeoutError";
+  (error as Error & { code?: number }).code = 3;
+  return error;
+}
+
+describe("the live publisher's failure gate", () => {
+  it("stays silent while a fix is in hand and nothing was refused", () => {
+    // The reported bug, stated as a decision: a heartbeat that failed while a
+    // movement watch was delivering fixes warned once every twenty seconds
+    // about a location the app already had.
+    expect(
+      shouldWarnOnPublishFailure({ error: timeout(), snapshot: SNAPSHOT }),
+    ).toBe(false);
+  });
+
+  it("speaks up when the platform actually refused", () => {
+    expect(
+      shouldWarnOnPublishFailure({ error: denial(), snapshot: SNAPSHOT }),
+    ).toBe(true);
+  });
+
+  it("speaks up for a native refusal, which names neither denied nor blocked", () => {
+    expect(
+      shouldWarnOnPublishFailure({
+        error: new Error("Location permission was not granted."),
+        snapshot: SNAPSHOT,
+      }),
+    ).toBe(true);
+  });
+
+  it("speaks up when there is no position at all", () => {
+    expect(
+      shouldWarnOnPublishFailure({ error: timeout(), snapshot: null }),
+    ).toBe(true);
+  });
+
+  it("keeps speaking up once a denial has been observed, whatever the error says", () => {
+    // A denial proven by attempting stays true on every tick after it; the
+    // error on a later tick may well be an ordinary timeout.
+    expect(
+      shouldWarnOnPublishFailure({
+        error: timeout(),
+        snapshot: SNAPSHOT,
+        observedDenial: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("what the live publisher may send", () => {
+  it("publishes a fix measured this session", () => {
+    const point = publishPointFrom({
+      snapshot: SNAPSHOT,
+      snapshotOrigin: "fresh",
+    });
+
+    expect(point?.latitude).toBe(19.076);
+    expect(point?.capturedAt).toBe(SNAPSHOT.capturedAt);
+  });
+
+  it("refuses to publish a remembered position as a live one", () => {
+    // The recipient's screen says "live". A restored coordinate under that
+    // label shows someone standing still somewhere they already left, so
+    // skipping the tick is the honest failure — their own staleness threshold
+    // is what tells them the dot is old.
+    expect(
+      publishPointFrom({ snapshot: SNAPSHOT, snapshotOrigin: "restored" }),
+    ).toBeNull();
+  });
+
+  it("refuses to publish when there is nothing to publish", () => {
+    expect(
+      publishPointFrom({ snapshot: null, snapshotOrigin: null }),
+    ).toBeNull();
+  });
+
+  it("carries the platform that produced the fix, not a guess", () => {
+    // sourcePlatform is sealed into the envelope and rendered to the
+    // recipient. Defaulting it relabels every iPhone share as web.
+    expect(
+      publishPointFrom({ snapshot: SNAPSHOT, snapshotOrigin: "fresh" })
+        ?.sourcePlatform,
+    ).toBe("ios");
+  });
+});
+
+describe("how old a fix this tick may reuse", () => {
+  it("accepts a fix from within the heartbeat window", () => {
+    const capturedAt = new Date(Date.now() - 5_000).toISOString();
+    expect(isPublishableAge(capturedAt, 20_000)).toBe(true);
+  });
+
+  it("rejects a fix older than the heartbeat window", () => {
+    const capturedAt = new Date(Date.now() - 25_000).toISOString();
+    expect(isPublishableAge(capturedAt, 20_000)).toBe(false);
+  });
+
+  it("rejects a timestamp from the future as a clock change, not a fresh fix", () => {
+    const capturedAt = new Date(Date.now() + 60_000).toISOString();
+    expect(isPublishableAge(capturedAt, 20_000)).toBe(false);
+  });
+
+  it("rejects a timestamp it cannot read", () => {
+    expect(isPublishableAge("not-a-date", 20_000)).toBe(false);
+    expect(isPublishableAge(null, 20_000)).toBe(false);
+  });
+});

--- a/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
@@ -138,6 +138,23 @@ describe("LocationBus permission handling", () => {
 
     expect(LocationBus.getState().status).toBe("unavailable");
   });
+
+  it("recognises the native plugins' refusal, not just the browser's", async () => {
+    // iOS and Android reject with this exact sentence and no custom error
+    // name. The bus used to test the message against /denied|blocked/i, which
+    // this sentence fails — so on a phone a real refusal was filed as a
+    // transient failure. That is the one misclassification the degradation
+    // path cannot survive: it would hand the owner their last known position
+    // forever instead of the screen that gets them un-blocked.
+    mockLocation.getCurrentPosition.mockRejectedValue(
+      new Error("Location permission was not granted."),
+    );
+
+    const snapshot = await LocationBus.ensure();
+
+    expect(snapshot).toBeNull();
+    expect(LocationBus.getState().status).toBe("denied");
+  });
 });
 
 describe("LocationBus.watch", () => {

--- a/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
@@ -171,6 +171,17 @@ describe("LocationBus.watch", () => {
     expect(mockLocation.clearWatch).toHaveBeenCalledWith({ id: "watch-1" });
   });
 
+  it("starts one watch even when both surfaces mount in the same tick", async () => {
+    // The Location page starts two watches — one to publish movement, one to
+    // draw the owner's own marker — and they mount together. Sequential
+    // subscribers are caught by the watchId guard; simultaneous ones are only
+    // caught by the in-flight guard, so this is the case the test above
+    // cannot see.
+    await Promise.all([LocationBus.watch(), LocationBus.watch()]);
+
+    expect(mockLocation.watchPosition).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores a repeated stop from the same subscriber", async () => {
     const stopA = await LocationBus.watch();
     const stopB = await LocationBus.watch();

--- a/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
@@ -4,10 +4,13 @@ import type { HushhLocationPermissionState } from "@/lib/capacitor";
 import {
   canAttemptLocation,
   canPromptForLocation,
+  fixAgeLabel,
   isLocationPermissionDeniedError,
+  isUsableFixAge,
   locationBlockReason,
   locationReadiness,
   locationStatusLabel,
+  shouldSurfaceLocationError,
 } from "@/lib/one-location/location-readiness";
 
 function permission(
@@ -181,5 +184,104 @@ describe("status label", () => {
         accuracyLimited: false,
       }),
     ).toBe("Location on");
+  });
+});
+
+describe("when a location failure is worth showing", () => {
+  // The rule this replaces: toast on every capture failure, including the ones
+  // where a perfectly good position was already on screen. That is how "turn
+  // on location" ended up in front of people whose location was working.
+  it("says nothing about a failed refresh while a usable fix is held", () => {
+    expect(
+      shouldSurfaceLocationError({
+        hasUsableFix: true,
+        observedDenial: false,
+        blockReason: null,
+        blocksUserIntent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("speaks up for an observed denial even while a fix is held", () => {
+    // The owner is cut off from every future fix until they change a setting.
+    // Holding a position does not make that less true, and only saying so
+    // gets them to the screen that fixes it.
+    expect(
+      shouldSurfaceLocationError({
+        hasUsableFix: true,
+        observedDenial: true,
+        blockReason: null,
+        blocksUserIntent: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("speaks up for a platform block even while a fix is held", () => {
+    expect(
+      shouldSurfaceLocationError({
+        hasUsableFix: true,
+        observedDenial: false,
+        blockReason: "services-off",
+        blocksUserIntent: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("speaks up when the owner pressed something and got nothing", () => {
+    expect(
+      shouldSurfaceLocationError({
+        hasUsableFix: false,
+        observedDenial: false,
+        blockReason: null,
+        blocksUserIntent: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays quiet about background work the owner never asked for", () => {
+    // A screen warming a position does not get to interrupt somebody about it.
+    expect(
+      shouldSurfaceLocationError({
+        hasUsableFix: false,
+        observedDenial: false,
+        blockReason: null,
+        blocksUserIntent: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("how a position's age is judged and described", () => {
+  it("accepts a position from within the usable window", () => {
+    const capturedAt = new Date(Date.now() - 20 * 60_000).toISOString();
+    expect(isUsableFixAge(capturedAt)).toBe(true);
+  });
+
+  it("rejects a position older than the usable window", () => {
+    const capturedAt = new Date(Date.now() - 90 * 60_000).toISOString();
+    expect(isUsableFixAge(capturedAt)).toBe(false);
+  });
+
+  it("rejects a future timestamp as a clock change, not a fresh fix", () => {
+    const capturedAt = new Date(Date.now() + 10 * 60_000).toISOString();
+    expect(isUsableFixAge(capturedAt)).toBe(false);
+  });
+
+  it("says nothing about a position recent enough to need no qualifier", () => {
+    expect(fixAgeLabel(new Date(Date.now() - 30_000).toISOString())).toBe("");
+  });
+
+  it("labels an older position honestly rather than replacing it with an error", () => {
+    expect(fixAgeLabel(new Date(Date.now() - 20 * 60_000).toISOString())).toBe(
+      " · 20 min ago",
+    );
+    expect(fixAgeLabel(new Date(Date.now() - 60 * 60_000).toISOString())).toBe(
+      " · 1 hr ago",
+    );
+  });
+
+  it("says nothing when there is no timestamp to describe", () => {
+    expect(fixAgeLabel(null)).toBe("");
+    expect(fixAgeLabel("not-a-date")).toBe("");
   });
 });

--- a/hushh-webapp/lib/one-location/live-publish-decision.ts
+++ b/hushh-webapp/lib/one-location/live-publish-decision.ts
@@ -1,0 +1,87 @@
+/**
+ * What the live-share publisher does when the device does not answer.
+ *
+ * The publisher is a 20-second heartbeat inside a nine-thousand-line client
+ * component, which is the reason its behaviour went unexamined for so long: it
+ * cannot be rendered in a test, so nobody could assert on it. Extracted here
+ * for the same reason `self-preview.ts` was — a gate is a decision, decisions
+ * are testable, and this one was wrong in a way the owner saw every twenty
+ * seconds.
+ *
+ * Two questions, deliberately kept apart because they have opposite answers:
+ *
+ *   1. **Do we tell anyone?** Almost never. A failed refresh while we are
+ *      holding a position is a failed refresh, not a location we do not have,
+ *      and the owner can do nothing with that news. Only a real refusal or a
+ *      total absence of position is worth their attention.
+ *
+ *   2. **Do we publish?** Only a fix measured this session. This is the one
+ *      place in the app where degrading to a remembered position would be a
+ *      lie rather than a courtesy: the recipient's screen says "live", and a
+ *      restored coordinate under that label shows someone standing still
+ *      somewhere they already left. Silence is the honest failure here — the
+ *      recipient's own staleness threshold is what tells them the dot is old.
+ */
+
+import type { LocationBusState } from "@/lib/one-location/location-bus";
+import { isLocationPermissionDeniedError } from "@/lib/one-location/location-readiness";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+/**
+ * Should a publish failure be reported at all?
+ *
+ * `observedDenial` is the caller's own record of a refusal it has already
+ * proven by attempting; it is trusted over the error when set, because a
+ * denial observed once stays true for every tick after it.
+ */
+export function shouldWarnOnPublishFailure(params: {
+  error: unknown;
+  snapshot: { capturedAt: string } | null;
+  observedDenial?: boolean;
+}): boolean {
+  if (params.observedDenial) return true;
+  if (isLocationPermissionDeniedError(params.error)) return true;
+  // No position at all is a genuine dead end and the owner should hear about
+  // it. Holding one means the share is still working.
+  return !params.snapshot;
+}
+
+/**
+ * The point this tick may publish, or null to skip the tick.
+ *
+ * Null is not a failure and must not be reported as one. The movement watch
+ * feeds the bus continuously, so a tick with nothing fresh to say is a tick
+ * where nothing has changed — the next fix publishes on arrival.
+ */
+export function publishPointFrom(
+  state: Pick<LocationBusState, "snapshot" | "snapshotOrigin">,
+): PlainLocationPoint | null {
+  if (!state.snapshot) return null;
+  if (state.snapshotOrigin !== "fresh") return null;
+  return {
+    latitude: state.snapshot.latitude,
+    longitude: state.snapshot.longitude,
+    accuracyM: state.snapshot.accuracyM ?? null,
+    capturedAt: state.snapshot.capturedAt,
+    sourcePlatform: state.snapshot.sourcePlatform ?? "web",
+  };
+}
+
+/**
+ * Is a fix recent enough for this tick to reuse without re-reading the device?
+ *
+ * The ceiling is one heartbeat period, so a published point is never older
+ * than a single tick — which is the guarantee the recipient side is already
+ * written against, at three periods before it calls a share stale.
+ */
+export function isPublishableAge(
+  capturedAt: string | null | undefined,
+  maxAgeMs: number,
+): boolean {
+  if (!capturedAt) return false;
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return false;
+  const age = Date.now() - capturedMs;
+  // A timestamp from the future is a clock change, not a fresh fix.
+  return age >= 0 && age <= maxAgeMs;
+}

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -110,6 +110,26 @@ const listeners = new Set<(next: LocationBusState) => void>();
 /** In-flight capture, shared so N simultaneous callers cause one GPS read. */
 let pendingCapture: Promise<LocationSnapshot | null> | null = null;
 
+/**
+ * The error object from the most recent failed capture.
+ *
+ * Deliberately not on `LocationBusState`. Subscribers must not re-render for
+ * it, and more importantly `state.error` is a string: routing a failure
+ * through it drops `error.name` and `error.code`, which are the only reliable
+ * evidence of a real permission denial across three platforms. A caller that
+ * still has to throw needs the original object, not a description of it.
+ */
+let lastCaptureError: unknown = null;
+
+/**
+ * Set when a caller declares the held fix untrustworthy — the app returning
+ * from background, or a permission change. It revokes the fix's right to
+ * short-circuit the next `ensure()`, and nothing more: the position stays
+ * visible, because blanking a coordinate the owner can see is the flicker
+ * this whole design exists to avoid.
+ */
+let fixInvalidated = false;
+
 let watchId: string | null = null;
 let watchStarting: Promise<void> | null = null;
 let watchers = 0;
@@ -170,6 +190,10 @@ function statusForPermission(
 
 function isFresh(snapshot: LocationSnapshot | null, maxAgeMs: number): boolean {
   if (!snapshot) return false;
+  // A caller asking for zero age is asking for a genuinely new reading, and
+  // under fake timers — or simply within one synchronous tick — an age of
+  // exactly zero would otherwise satisfy `<=` and hand back the old fix.
+  if (maxAgeMs <= 0) return false;
   const capturedMs = Date.parse(snapshot.capturedAt);
   if (!Number.isFinite(capturedMs)) return false;
   return Date.now() - capturedMs <= maxAgeMs;
@@ -235,6 +259,8 @@ async function capture(): Promise<LocationSnapshot | null> {
       timeoutMs: 15_000,
     });
     const snapshot = toSnapshot(point);
+    lastCaptureError = null;
+    fixInvalidated = false;
     emit({
       status: "ready",
       snapshot,
@@ -245,6 +271,7 @@ async function capture(): Promise<LocationSnapshot | null> {
     recordFix(point);
     return snapshot;
   } catch (error) {
+    lastCaptureError = error;
     const denied = isDeniedError(error);
     if (!denied && state.snapshot) {
       // We already hold a position. A failed refresh in that situation is a
@@ -324,6 +351,29 @@ export const LocationBus = {
     };
   },
 
+  /**
+   * The error object behind the most recent failed capture.
+   *
+   * For a caller that must re-throw. `state.error` is a string and would lose
+   * `name` and `code`, which is how a real permission denial is told apart
+   * from a timeout on every platform.
+   */
+  getLastCaptureError(): unknown {
+    return lastCaptureError;
+  },
+
+  /**
+   * Declare the held fix untrustworthy without discarding it.
+   *
+   * For a caller that knows the device may have moved without us — a
+   * permission change, or the app returning from background. The next
+   * `ensure()` re-reads instead of short-circuiting, and nothing is emitted,
+   * so a position the owner can see stays on screen while the new one lands.
+   */
+  invalidate(): void {
+    fixInvalidated = true;
+  },
+
   /** Read the OS permission without prompting. Safe to call on mount. */
   async syncPermission(): Promise<LocationPermission | null> {
     try {
@@ -350,7 +400,11 @@ export const LocationBus = {
     // Only a fix measured this session short-circuits the GPS. A restored one
     // is there to fill the screen, not to end the attempt — reusing it would
     // mean an app that never refreshes as long as its memory looks recent.
-    if (state.snapshotOrigin === "fresh" && isFresh(state.snapshot, maxAgeMs)) {
+    if (
+      !fixInvalidated &&
+      state.snapshotOrigin === "fresh" &&
+      isFresh(state.snapshot, maxAgeMs)
+    ) {
       return state.snapshot;
     }
     if (pendingCapture) return pendingCapture;
@@ -466,6 +520,8 @@ export const LocationBus = {
         { enableHighAccuracy: true, timeoutMs: 20_000 },
         (point, error) => {
           if (point) {
+            lastCaptureError = null;
+            fixInvalidated = false;
             emit({
               status: "ready",
               snapshot: toSnapshot(point),
@@ -527,5 +583,7 @@ export const LocationBus = {
     attachedUserId = null;
     pendingHydration = null;
     lastPersistedAtMs = 0;
+    lastCaptureError = null;
+    fixInvalidated = false;
   },
 };

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -40,6 +40,17 @@ export type LocationSnapshot = {
   longitude: number;
   accuracyM: number | null;
   capturedAt: string;
+  /**
+   * Which platform produced the fix.
+   *
+   * Carried on the snapshot rather than re-derived by whoever needs it,
+   * because the snapshot is written from four places — a capture, a watch
+   * fix, a restore, and the held fix returned by a failed refresh — and only
+   * the snapshot itself is right on all four. It is required on
+   * `PlainLocationPoint`, sealed into the envelope, and shown to the
+   * recipient, so a caller that guesses "web" relabels every iPhone share.
+   */
+  sourcePlatform?: PlainLocationPoint["sourcePlatform"] | null;
 };
 
 export type LocationPermission = HushhLocationPermissionState["state"];
@@ -169,12 +180,15 @@ function toSnapshot(point: {
   longitude: number;
   accuracyM: number | null;
   capturedAt: string;
+  sourcePlatform?: string | null;
 }): LocationSnapshot {
   return {
     latitude: point.latitude,
     longitude: point.longitude,
     accuracyM: point.accuracyM ?? null,
     capturedAt: point.capturedAt,
+    sourcePlatform:
+      (point.sourcePlatform as PlainLocationPoint["sourcePlatform"]) ?? null,
   };
 }
 
@@ -286,6 +300,7 @@ async function hydrateFromMemory(userId: string): Promise<void> {
       longitude: point.longitude,
       accuracyM: point.accuracyM ?? null,
       capturedAt: point.capturedAt,
+      sourcePlatform: point.sourcePlatform,
     }),
     snapshotOrigin: "restored",
     // A restored fix answers "where were you", not "did this attempt work", so
@@ -389,7 +404,10 @@ export const LocationBus = {
     // of the point of this change. Keep it, and write it through.
     if (!switchingAccounts && state.snapshotOrigin === "fresh" && state.snapshot) {
       lastPersistedAtMs = 0;
-      recordFix({ ...state.snapshot, sourcePlatform: "web" });
+      // The snapshot knows which platform produced it. Hardcoding "web" here
+      // persisted every first-attach fix on an iPhone as a web fix, and that
+      // label is what the recipient is shown.
+      recordFix(state.snapshot);
       return;
     }
 

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -32,6 +32,7 @@ import {
   rememberLastKnownFix,
   rememberLocationGrant,
 } from "@/lib/one-location/location-grant-memory";
+import { isLocationPermissionDeniedError } from "@/lib/one-location/location-readiness";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
 
 export type LocationSnapshot = {
@@ -133,12 +134,19 @@ function emit(patch: Partial<LocationBusState>): void {
   for (const listener of [...listeners]) listener(state);
 }
 
+/**
+ * Did this failure come from a refused permission?
+ *
+ * Delegated rather than reimplemented. The local version matched
+ * `/denied|blocked/i`, and both native plugins reject a refusal with
+ * "Location permission was not granted." — which contains neither word and
+ * carries no custom `name`. So on iOS and Android a real denial read as a
+ * transient failure, and the degradation path below would have swallowed it:
+ * the owner would have been shown their last known position, indefinitely,
+ * instead of the one screen that can get them un-blocked.
+ */
 function isDeniedError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return (
-    error.name === "LocationPermissionDeniedError" ||
-    /denied|blocked/i.test(error.message)
-  );
+  return isLocationPermissionDeniedError(error);
 }
 
 function statusForPermission(

--- a/hushh-webapp/lib/one-location/location-readiness.ts
+++ b/hushh-webapp/lib/one-location/location-readiness.ts
@@ -156,3 +156,105 @@ export function locationStatusLabel(params: {
   if (params.accuracyLimited) return "Location limited";
   return "Location on";
 }
+
+/**
+ * How old a position may be and still be offered as "where you are".
+ *
+ * An hour, matching the budget the nearby drawer already chose for a restored
+ * fix. Long, deliberately: the alternative on a device that has stopped
+ * answering is not a fresher position, it is no position at all.
+ */
+export const USABLE_FIX_MAX_AGE_MS = 60 * 60 * 1_000;
+
+/** Below this a position needs no "last known" qualifier. */
+export const FRESH_FIX_MAX_AGE_MS = 2 * 60 * 1_000;
+
+/** What went wrong, in the only three kinds a surface has to tell apart. */
+export type LocationFailure =
+  /** The platform refused, proven by attempting. Settings is the way out. */
+  | "denied"
+  /** The device or its policy forbids an attempt. Settings, or nothing. */
+  | "blocked"
+  /** Nothing refused us; we simply have no position. Retry is the way out. */
+  | "no-fix";
+
+/**
+ * Should this failure be put in front of the owner?
+ *
+ * One rule, applied everywhere: **an error is shown only when the app has no
+ * usable position AND the owner can do something about it.**
+ *
+ * What that replaces is a surface that toasted on every capture failure,
+ * including the ones where a perfectly good position was already on screen. A
+ * failed refresh is not a location we do not have, and the two used to look
+ * identical — which is how "turn on location" ended up in front of people
+ * whose location was working.
+ *
+ * `blocksUserIntent` is the difference between a tap and a warm-up. A person
+ * who pressed Send and did not get a message needs to know why. A screen that
+ * quietly refreshed a position in the background does not get to interrupt
+ * them about it.
+ */
+export function shouldSurfaceLocationError(params: {
+  hasUsableFix: boolean;
+  observedDenial: boolean;
+  blockReason: LocationBlockReason | null;
+  blocksUserIntent: boolean;
+}): boolean {
+  // Actionable regardless of what we are holding: the owner is cut off from
+  // every future fix until they change a setting, and only saying so gets them
+  // there.
+  if (params.observedDenial) return true;
+  if (params.blockReason) return true;
+  if (params.hasUsableFix) return false;
+  return params.blocksUserIntent;
+}
+
+/** Is this position recent enough to present as where the owner is? */
+export function isUsableFixAge(
+  capturedAt: string | null | undefined,
+  maxAgeMs: number = USABLE_FIX_MAX_AGE_MS,
+): boolean {
+  if (!capturedAt) return false;
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return false;
+  const age = Date.now() - capturedMs;
+  // A timestamp from the future is a clock change, not a fresh fix.
+  return age >= 0 && age <= maxAgeMs;
+}
+
+/**
+ * " · 20 min ago", or "" for a position recent enough to need no qualifier.
+ *
+ * A position the app is unsure about should say so in three words, not be
+ * replaced by an error. Empty for a fresh fix so the common case stays silent.
+ */
+export function fixAgeLabel(capturedAt: string | null | undefined): string {
+  if (!capturedAt) return "";
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return "";
+  const ageMs = Date.now() - capturedMs;
+  if (ageMs < 0 || ageMs <= FRESH_FIX_MAX_AGE_MS) return "";
+  const minutes = Math.round(ageMs / 60_000);
+  if (minutes < 60) return ` · ${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  return hours === 1 ? " · 1 hr ago" : ` · ${hours} hr ago`;
+}
+
+/**
+ * The one location vocabulary.
+ *
+ * There were four — the web plugin, the bus, the Location page, and the
+ * nearby sheet each had their own — so the same failure reached the owner in
+ * four different sentences depending on which button they had pressed. These
+ * are short on purpose: the recovery card already carries the instructions,
+ * and a message that repeats them is a message people stop reading.
+ */
+export const LOCATION_COPY = {
+  /** The only message that earns a Settings button. */
+  denied: "Location is off for Hussh.",
+  /** Nothing refused us; there is simply no fix yet. */
+  noFix: "Couldn't find you. Try again.",
+  finding: "Finding you…",
+  lastKnown: (age: string) => `Last known${age}.`,
+} as const;

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1,6 +1,10 @@
 import { Capacitor } from "@capacitor/core";
 
 import { HushhLocation } from "@/lib/capacitor";
+import {
+  LocationBus,
+  type LocationSnapshot,
+} from "@/lib/one-location/location-bus";
 import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
 import {
   ApiError,
@@ -123,11 +127,55 @@ export const CAPTURE_DEFAULT_MAX_AGE_MS = 20_000;
  */
 export const CAPTURE_FRESH_MAX_AGE_MS = 5_000;
 
-/** The most recent fix, reused inside CAPTURE_DEFAULT_MAX_AGE_MS. */
-let lastCapturedPoint: PlainLocationPoint | null = null;
+/**
+ * How old a fix may be and still be served after the device failed to produce
+ * a new one.
+ *
+ * A different question from the caller's `maxAgeMs`, which asks "may I skip
+ * the GPS?" — five or twenty seconds is right for that, and using it here
+ * would make this fallback fire essentially never, which is the bug. This asks
+ * "the device just failed and I am holding a position: is it still an honest
+ * answer to where you are?" Ten minutes is the budget this codebase already
+ * chose for exactly that question, in the nearby check-in sheet.
+ */
+export const CAPTURE_STALE_FALLBACK_MAX_AGE_MS = 10 * 60 * 1_000;
 
-/** In-flight capture, shared so N simultaneous callers cause one GPS read. */
-let pendingCapture: Promise<PlainLocationPoint> | null = null;
+function resolveSourcePlatform(): PlainLocationPoint["sourcePlatform"] {
+  const platform = Capacitor.getPlatform();
+  if (platform === "ios" || platform === "android") return platform;
+  return "web";
+}
+
+/**
+ * A bus snapshot as the point every caller here expects.
+ *
+ * `sourcePlatform` falls back to the running platform only when the snapshot
+ * does not carry one — a floor, not a guess that overrides the truth. The
+ * field is sealed into the envelope and rendered to the recipient, so it must
+ * never be absent.
+ */
+function toPlainPoint(snapshot: LocationSnapshot): PlainLocationPoint {
+  return {
+    latitude: snapshot.latitude,
+    longitude: snapshot.longitude,
+    accuracyM: snapshot.accuracyM ?? null,
+    capturedAt: snapshot.capturedAt,
+    sourcePlatform: snapshot.sourcePlatform ?? resolveSourcePlatform(),
+  };
+}
+
+function withinAge(capturedAt: string, maxAgeMs: number): boolean {
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return false;
+  const age = Date.now() - capturedMs;
+  return age >= 0 && age <= maxAgeMs;
+}
+
+function captureFailure(state: { error: string | null }): Error {
+  const original = LocationBus.getLastCaptureError();
+  if (original instanceof Error) return original;
+  return new Error(state.error ?? "Could not get your location.");
+}
 
 export class OneLocationService {
   static async getPermissionState() {
@@ -151,21 +199,25 @@ export class OneLocationService {
   }
 
   /**
-   * The account's current position, held briefly and shared between callers.
+   * The account's current position, from the one store that holds it.
    *
-   * Every control on this surface used to reach the device directly, so one
-   * share wizard paid for a full GPS acquisition per step and each one cost
-   * seconds. Two guards remove that without ever serving a position stale
-   * enough to be wrong:
+   * This used to keep its own cache — a fix and an in-flight promise, twenty
+   * seconds of reuse — parallel to and unaware of `LocationBus`. Two stores
+   * for one question, and the whole One Location surface was on this one,
+   * which had none of the bus's resilience: no memory across a reload, and no
+   * answer at all when the device declined to produce a fix. Every caller here
+   * inherited that. The heartbeat published the result once every twenty
+   * seconds: "Could not get your location", while a movement watch two effects
+   * away was delivering fixes the entire time.
    *
-   * - a fix younger than `maxAgeMs` is reused instead of re-acquired;
-   * - concurrent callers share ONE in-flight acquisition rather than each
-   *   starting their own — sharing with N people used to mean N simultaneous
-   *   GPS reads, which is slower than one read for every one of them.
+   * Delegating gets all of it at once — coalescing, the restored fix from the
+   * previous session, and the distinction between a device that refused and a
+   * device that merely did not answer this time.
    *
-   * Pass `maxAgeMs: 0` to force a genuinely new fix. The live-share publisher
-   * does exactly that: a recipient watching someone move must never be handed
-   * a cached point, or the share looks paused.
+   * `maxAgeMs` is forwarded rather than left to the bus's own default: the bus
+   * allows two minutes, and the backend rejects a point older than sixty
+   * seconds between capture and confirmation, so a share built on the bus
+   * default would fail for a reason the owner cannot see.
    */
   static async captureCurrentPosition(options?: {
     maxAgeMs?: number;
@@ -185,44 +237,42 @@ export class OneLocationService {
       options?.maxAgeMs ??
       (options?.fresh ? CAPTURE_FRESH_MAX_AGE_MS : CAPTURE_DEFAULT_MAX_AGE_MS);
 
-    if (lastCapturedPoint && maxAgeMs > 0) {
-      const capturedMs = Date.parse(lastCapturedPoint.capturedAt);
-      if (Number.isFinite(capturedMs) && Date.now() - capturedMs <= maxAgeMs) {
-        return lastCapturedPoint;
-      }
+    const snapshot = await LocationBus.ensure({ maxAgeMs });
+    // Read the state AFTER the await, never a copy taken before it: a watch
+    // fix can land while this call is in flight, and the newer answer is the
+    // right one to serve.
+    const state = LocationBus.getState();
+
+    if (snapshot && state.status === "ready") return toPlainPoint(snapshot);
+
+    // The device failed and we are holding a position. A failed refresh is not
+    // a location we do not have, and until now the two were indistinguishable
+    // to every caller on this surface — which is what put "turn on location"
+    // in front of people whose location was perfectly well known.
+    if (snapshot && withinAge(snapshot.capturedAt, CAPTURE_STALE_FALLBACK_MAX_AGE_MS)) {
+      return toPlainPoint(snapshot);
     }
 
-    // An acquisition already running is fresher than anything we could start
-    // now, so every caller joins it — including one that asked for maxAgeMs: 0.
-    if (pendingCapture) return pendingCapture;
-
-    pendingCapture = HushhLocation.getCurrentPosition({
-      enableHighAccuracy: true,
-      timeoutMs: 15_000,
-    })
-      .then((point) => {
-        lastCapturedPoint = point;
-        return point;
-      })
-      .finally(() => {
-        pendingCapture = null;
-      });
-
-    return pendingCapture;
+    // Two things still throw, and both are dead ends the owner has to see: a
+    // platform that refused (the bus returns null on a denial even while
+    // holding a fix, so this is reached), and having no position at all.
+    throw captureFailure(state);
   }
 
   /**
-   * Drop the reusable fix. Call when the device may have moved without us —
-   * a permission change, or the app returning from background.
+   * Declare the held fix untrustworthy. Call when the device may have moved
+   * without us — a permission change, or the app returning from background.
+   *
+   * The position stays on screen; only its right to satisfy the next call
+   * without re-reading the device is revoked.
    */
   static invalidateCapturedPosition(): void {
-    lastCapturedPoint = null;
+    LocationBus.invalidate();
   }
 
   /** Test seam. Never call from app code. */
   static __resetCaptureCacheForTests(): void {
-    lastCapturedPoint = null;
-    pendingCapture = null;
+    LocationBus.__resetForTests();
   }
 
   /**

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -986,6 +986,14 @@ export class OneLocationService {
     latitude: number;
     longitude: number;
     accuracyM?: number | null;
+    /**
+     * When the position was measured. Save my Soul sends the last known
+     * position rather than nothing when the device will not produce a new one,
+     * so the email has to be able to say how old it is — an unstamped
+     * twenty-minute-old coordinate presented as "now" sends help confidently
+     * to the wrong place.
+     */
+    capturedAt?: string | null;
     note?: string | null;
     emergencyNumber?: string | null;
   }): Promise<{
@@ -1024,6 +1032,7 @@ export class OneLocationService {
           ...(typeof params.accuracyM === "number"
             ? { accuracyM: params.accuracyM }
             : {}),
+          ...(params.capturedAt ? { capturedAt: params.capturedAt } : {}),
           ...(params.note ? { note: params.note } : {}),
           ...(params.emergencyNumber
             ? { emergencyNumber: params.emergencyNumber }

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -171,6 +171,10 @@ function withinAge(capturedAt: string, maxAgeMs: number): boolean {
   return age >= 0 && age <= maxAgeMs;
 }
 
+/** Live bus-backed watches, keyed by the id handed to the caller. */
+const busWatches = new Map<string, () => void>();
+let busWatchSeq = 0;
+
 function captureFailure(state: { error: string | null }): Error {
   const original = LocationBus.getLastCaptureError();
   if (original instanceof Error) return original;
@@ -280,24 +284,55 @@ export class OneLocationService {
    * time the device reports a new fix (as the user moves), powering true live
    * location instead of a fixed-interval re-fetch. Returns a watch id; pass it
    * to `clearLocationWatch` to stop. Foreground-only.
+   *
+   * Backed by the bus's refcounted watch rather than a device subscription of
+   * its own. The Location page starts two of these — one to publish movement,
+   * one to draw the owner's own marker — and each used to open a separate OS
+   * watch. On iOS that matters beyond battery: the plugin holds exactly one
+   * pending location call, and a second request rejects the first with "A
+   * newer location request replaced this request", which arrived in the
+   * publisher's catch as a location failure.
+   *
+   * Adapting here rather than at the two call sites means any other caller
+   * that appears also feeds the shared store instead of competing with it.
    */
   static async watchCurrentPosition(
     onPoint: (point: PlainLocationPoint) => void,
     onError?: (error: { message: string; code?: number }) => void,
   ): Promise<string> {
-    return HushhLocation.watchPosition(
-      { enableHighAccuracy: true, timeoutMs: 20_000 },
-      (point, error) => {
-        if (point) {
-          onPoint(point);
-          return;
-        }
-        if (error && onError) onError(error);
-      },
-    );
+    const stop = await LocationBus.watch();
+    const id = `bus:${++busWatchSeq}`;
+    let lastSeenAt: string | null = null;
+
+    const unsubscribe = LocationBus.subscribe((state) => {
+      if (state.snapshot && state.snapshotOrigin === "fresh") {
+        // subscribe() fires on every emit, including a permission-only one.
+        // Without this the same coordinate would be re-delivered as movement.
+        if (state.snapshot.capturedAt === lastSeenAt) return;
+        lastSeenAt = state.snapshot.capturedAt;
+        onPoint(toPlainPoint(state.snapshot));
+        return;
+      }
+      if (state.status === "denied" && onError) {
+        onError({ message: state.error ?? "Location is off.", code: 1 });
+      }
+    });
+
+    busWatches.set(id, () => {
+      unsubscribe();
+      stop();
+    });
+    return id;
   }
 
   static async clearLocationWatch(id: string): Promise<void> {
+    const release = busWatches.get(id);
+    if (release) {
+      busWatches.delete(id);
+      release();
+      return;
+    }
+    // A raw plugin id from a watch started before this adapter existed.
     if (!id) return;
     return HushhLocation.clearWatch({ id });
   }

--- a/hushh-webapp/lib/services/user-local-state-service.ts
+++ b/hushh-webapp/lib/services/user-local-state-service.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { forgetLocationMemory } from "@/lib/one-location/location-grant-memory";
 import { KaiNavTourLocalService } from "@/lib/services/kai-nav-tour-local-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 import { PreVaultOnboardingService } from "@/lib/services/pre-vault-onboarding-service";
@@ -24,6 +25,13 @@ export class UserLocalStateService {
     OneSetupCompletionHintService.clear(userId);
     PreVaultSensitiveDraftService.clearForUser(userId);
     KycIdentityProfileDraftService.clear(userId);
+    // The sealed last-known coordinate (24h retention) and the remembered
+    // grant (90d) are the only user-scoped records here that describe where a
+    // person physically was, so they are the ones that most need to leave with
+    // them. Synchronous, and deliberately not in the settled batch below: this
+    // is two `removeItem` calls that already swallow their own failures, and an
+    // unrelated rejection must not be able to skip it.
+    forgetLocationMemory(userId);
 
     const tasks: Array<Promise<unknown>> = [
       PreVaultOnboardingService.clear(userId),


### PR DESCRIPTION
## The symptom

Permission granted once, and the One Location agent still reports it cannot find you — every twenty seconds:

```
[OneLocationAgent] Foreground live update skipped: Error: Could not get your location.
Turn on Location for your device/browser and try again.
```

Reported alongside the wider complaint: too many "turn on location" boxes across Save my Soul, check-in and the map, on a device where location works.

## Why

The app held **two position stores that never exchanged a coordinate**.

| | Store | Behaviour |
|---|---|---|
| A | `LocationBus` | durable across a reload, coalesced, refcounted watch, and **degrades** — a failed refresh while holding a fix returns the fix and marks it `stale` |
| B | `OneLocationService` module statics | a 20s cache, no memory, no degradation — **it throws** |

Store A was used by six Connect/RIA surfaces. Store B was used by everything the owner actually lives in: the Location page, the map, check-in, saved places, the chat hook, the agent directive runtime, Save my Soul. So the resilience work that shipped in #5256 protected the surfaces nobody looks at and stopped at the door of the one they do.

On top of that the heartbeat forced its own acquisition each tick while the page ran two watches of its own. On iOS the plugin holds exactly one pending location call and rejects the older one with `A newer location request replaced this request` — which arrived in the publisher's catch looking like a location failure. On web the one-shot can spend ~23s, longer than the 20s interval itself.

And `ensureForegroundLocationReady`, the gate in front of nine flows, toasted on **every** capture failure — including the ones where a good position was already on screen. Nine of those flows then printed their own message too, so one failure produced two.

## What changed

Eight commits, each green on its own:

1. **A native refusal is a refusal** — `isDeniedError` matched `/denied|blocked/i`; both native plugins say `"Location permission was not granted."`, which contains neither word. A real denial on a phone was filed as transient.
2. **Forget location on sign-out** — `forgetLocationMemory` shipped exported and called from nowhere, so a sealed coordinate (24h) and grant record (90d) survived sign-out on a shared device.
3. **Extract the publisher's failure gate** — behaviour-preserving; makes a decision inside a 9,000-line component testable.
4. **Capture through the one store** — `captureCurrentPosition` delegates to the bus. No call site changes; all ~24 inherit it. Forwards `maxAgeMs` explicitly (the bus default is 2 min, the backend rejects >60s), re-throws the **original** error object (name/code are how a denial is told from a timeout), and carries `sourcePlatform` (sealed into the envelope, shown to the recipient).
5. **The publisher stops fighting the device** — reads the store the watch is already filling; `watchCurrentPosition` adapts the refcounted bus watch so two page watches collapse to one OS subscription. Publishes only what was measured this session.
6. **The account attaches at the shell** — `useCurrentLocation({userId})` was dead code and key bootstrap lands after the page's first capture, so the restored fix was missing exactly when it was needed.
7. **The gate stops shouting** — one rule, `shouldSurfaceLocationError`: an error shows only when there is no usable position **and** the owner can act. Also deletes the auto-open-Settings trigger that fired on any message containing "turn on location" — a string the web plugin puts on a *timeout*, so a laptop with no GPS was thrown at a settings pane it does not have.
8. **Messages stop asserting a cause** — the map's single `try` covered the fix, the map move, the fetch, the encrypt and the upload, so a network failure read as a location failure.

### Two product calls, as agreed

- **Save my Soul sends the last known position rather than nothing**, and the email now carries `capturedAt` and stamps anything older than two minutes: `measured 20 min ago, at 21:42 UTC`. Sending beats silence in an emergency; sending it labelled "now" does not.
- **Not everything may degrade.** `requireMeasurement` marks where a remembered position would be a lie: un-pausing (pause is a privacy control), the live publisher, and the check-in confirmation.

## Verification

Full suite on this branch vs unmodified `origin/main`, comparing **failing sets**:

```
baseline  passed/failed/total: 3824 / 67 / 3897
candidate passed/failed/total: 3868 / 36 / 3910

PRE-EXISTING failures on both: 36
NEWLY FAILING:  0
NEWLY PASSING: 31
```

The baseline tree carried the new test files, so this single comparison is also the mutation proof: **all 31 new tests fail against unfixed source and pass against fixed source.** Among them:

- `returns the fix it is holding when a refresh fails for any reason but denial`
- `still throws when the platform actually refused` / `when nothing has ever been captured`
- `treats the native plugins' refusal string as a refusal`
- `keeps the reuse window under the server's freshness limit when it delegates`
- `preserves the platform the fix actually came from`
- `live publishing never serves a recipient a remembered fix`
- `a publish failure is reported only when the owner can act on it`
- `forgets the remembered location grant and the sealed last-known fix`
- `stamps a position that was not measured just now`

`npm run typecheck` and `npm run lint --max-warnings=0` both clean.

`__tests__/native/one-location-position-resilience.contract.test.ts` needs no change and stays green — this is TypeScript-only, so the native timeout budgets are unmoved.

## What a green build does not prove

That a fix is still being *delivered*. Every test here passes against a bus that returns a stale point forever. The assertion no unit test can make is that **the recipient's dot still moves** — zero warnings with a frozen dot would mean the publisher was silenced, not fixed. That gets checked on UAT with a second account, and on the simulator under Features → Location → City Run.

Capacitor has no over-the-air update, so this reaches an iPhone only through a new build. Landing it on UAT web first.

## Note on scope

The plan had me mount `LocationPermissionPrimerGate`. I did not: the route comment records that it and the cinematic intro were deliberately removed, taking first-run Location from five taps to three. Wiring it back would have added the second ask this change exists to remove. `hasRememberedLocationGrant` therefore stays uncalled — the bus hydrates from the same durable record, so the gate's fast path already provides the behaviour it was meant to.