### PR TITLE
fix(feed): capitalize connection notification descriptions

### DIFF
--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -255,7 +255,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
           ? "A connection was accepted."
           : actorIsSelf
             ? "You accepted the connection request"
-            : "accepted your connection request",
+            : "Accepted your connection request",
         href: ROUTES.CONNECT,
       };
     }
@@ -270,7 +270,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
           ? "A connection request was rejected."
           : actorIsSelf
             ? "You declined the connection request"
-            : "declined your connection request",
+            : "Declined your connection request",
         href: ROUTES.CONNECT,
       };
     }
@@ -285,7 +285,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
           ? "A connection was removed."
           : actorIsSelf
             ? "You removed the connection"
-            : "removed your connection",
+            : "Removed your connection",
         href: ROUTES.CONNECT,
       };
     }


### PR DESCRIPTION
# Description

Feed notification rows for `connection_accepted`, `connection_rejected`, and `connection_revoked` events rendered the counterparty-actor description with a lowercase first letter (e.g. "accepted your connection request" instead of "Accepted your connection request"). Capitalized all three so every feed row description starts with a capital letter, matching the rest of `presentFeedItem`.

File: `hushh-webapp/lib/feed/feed-item-renderers.tsx` (lines 258, 273, 288).

## 📌 Impact Map (Required)

- Routes touched: None (copy-only change on existing `/feed` route)
- API / schema / type changes: None
- Cache keys touched: None
- Runtime DB data-plane changes: None
- World-model domain summary effects: None
- Mobile parity impacts: None (shared web copy, no native code touched)
- Docs updated: None
- Top-level / devex / config / generated / ignore files touched: None
- Trust boundary touched: None
- Caller / proxy / backend pairing: Not applicable
- Rollback or safe-failure behavior: Not applicable — pure string literal change
- UI browser or Playwright proof: Verified visually against the reported feed screenshot; description strings are static literals with no logic change

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend surface (`presentFeedItem` used by `components/feed/feed-row.tsx` on the live `/feed` route).
- Reachable production attach point: `hushh-webapp/components/feed/feed-row.tsx` → `presentFeedItem()` in `hushh-webapp/lib/feed/feed-item-renderers.tsx`

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: copy fix in shared Next.js feed renderer (`lib/feed/feed-item-renderers.tsx`), consumed identically by web and the mobile webview shell — no separate iOS/Android plugin code involved.

## 🧪 Testing

- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Before: "Ankit Kumar Singh" / "accepted your connection request" (lowercase "a").
After: "Ankit Kumar Singh" / "Accepted your connection request" (capital "A"), same for the declined/removed variants.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — string literal only.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
