### PR TITLE
fix(feed): SOS alerts survive revoke, lose address, respect Clear

### DIFF
--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
@@ -1,23 +1,7 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const serviceHarness = vi.hoisted(() => ({
-  viewEnvelope: vi.fn(),
-  reverseGeocode: vi.fn(),
-}));
-
-const encryptionHarness = vi.hoisted(() => ({
-  decryptLocationEnvelope: vi.fn(),
-  ensureVaultSyncedRecipientKey: vi.fn(),
-}));
-
-const envelope = {
-  ciphertext: "ciphertext",
-  iv: "iv",
-  tag: "tag",
-  algorithm: "AES-GCM",
-  recipientKeyId: "recipient-key",
-};
+let receivedGrantsFixture: unknown[] = [];
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -70,18 +54,7 @@ vi.mock("@/lib/cache/use-stale-resource", () => ({
       return {
         data: {
           requests: [],
-          receivedGrants: [
-            {
-              id: "sos-grant-1",
-              ownerUserId: "sender-user",
-              recipientUserId: "receiver-user",
-              ownerDisplayName: "Test contact",
-              status: "active",
-              shareKind: "sos",
-              shareMessage: null,
-              createdAt: "2026-08-10T00:00:00.000Z",
-            },
-          ],
+          receivedGrants: receivedGrantsFixture,
           myRecipientKey: null,
         },
         loading: false,
@@ -154,83 +127,148 @@ vi.mock("@/lib/one-location/service", () => ({
       requests: [],
       receivedGrants: [],
     }),
-    viewEnvelope: serviceHarness.viewEnvelope,
-    reverseGeocode: serviceHarness.reverseGeocode,
   },
-}));
-
-vi.mock("@/lib/one-location/encryption", () => ({
-  RECIPIENT_KEY_UNAVAILABLE_MESSAGE:
-    "Recipient key unavailable for this location share.",
-  decryptLocationEnvelope: encryptionHarness.decryptLocationEnvelope,
-  ensureVaultSyncedRecipientKey:
-    encryptionHarness.ensureVaultSyncedRecipientKey,
 }));
 
 import { useFeedActionables } from "@/lib/feed/use-feed-actionables";
 
-describe("useFeedActionables SOS last-known address", () => {
+describe("useFeedActionables SMS · Save My Soul emergency cards", () => {
   beforeEach(() => {
-    serviceHarness.viewEnvelope.mockReset();
-    serviceHarness.reverseGeocode.mockReset();
-    encryptionHarness.decryptLocationEnvelope.mockReset();
-    encryptionHarness.ensureVaultSyncedRecipientKey.mockReset();
-
-    serviceHarness.viewEnvelope.mockResolvedValue({
-      grant: {
+    window.localStorage.clear();
+    receivedGrantsFixture = [
+      {
         id: "sos-grant-1",
+        ownerUserId: "sender-user",
+        recipientUserId: "receiver-user",
+        ownerDisplayName: "Test contact",
+        status: "active",
+        shareKind: "sos",
+        shareMessage: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
       },
-      envelope,
-    });
-
-    encryptionHarness.decryptLocationEnvelope.mockResolvedValue({
-      latitude: 12.3456,
-      longitude: 78.9012,
-      accuracyM: 18,
-      capturedAt: "2026-08-10T00:00:00.000Z",
-      sourcePlatform: "web",
-    });
-
-    serviceHarness.reverseGeocode.mockResolvedValue({
-      name: "Test Place",
-      formattedAddress: "100 Test Lane, Example City",
-      countryCode: "IN",
-    });
+    ];
   });
 
-  it("decrypts an active SOS point and adds its last-known address to the Feed tile", async () => {
-    const { result } = renderHook(() => useFeedActionables());
+  afterEach(() => {
+    window.localStorage.clear();
+  });
 
-    await waitFor(() => {
-      expect(serviceHarness.viewEnvelope).toHaveBeenCalledWith({
-        vaultOwnerToken: "test-vault-token",
-        grantId: "sos-grant-1",
-      });
-    });
+  it("shows a plain 'Emergency SMS - Sent.' body with no address for a live SOS share", async () => {
+    const { result } = renderHook(() => useFeedActionables());
 
     await waitFor(() => {
       const emergency = result.current.actionables.find(
         (item) => item.id === "sms-emergency:sos-grant-1",
       );
+      expect(emergency?.description).toBe("Emergency SMS - Sent.");
+    });
 
-      expect(emergency?.description).toContain(
-        "Last known: 100 Test Lane, Example City",
+    const emergency = result.current.actionables.find(
+      (item) => item.id === "sms-emergency:sos-grant-1",
+    );
+    expect(emergency?.description).not.toContain("Last known");
+    expect(emergency?.actions).toEqual([]);
+  });
+
+  it("keeps a revoked SOS card visible as 'Emergency SMS - Revoked' instead of dropping it", async () => {
+    receivedGrantsFixture = [
+      {
+        id: "sos-grant-1",
+        ownerUserId: "sender-user",
+        recipientUserId: "receiver-user",
+        ownerDisplayName: "Test contact",
+        status: "revoked",
+        shareKind: "sos",
+        shareMessage: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+      },
+    ];
+
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      const emergency = result.current.actionables.find(
+        (item) => item.id === "sms-emergency:sos-grant-1",
       );
+      expect(emergency?.description).toBe("Emergency SMS - Revoked");
+    });
+  });
+
+  it("does NOT put a Clear action on the card itself — the Feed page's existing Clear button owns it", async () => {
+    receivedGrantsFixture = [
+      {
+        id: "sos-grant-1",
+        ownerUserId: "sender-user",
+        recipientUserId: "receiver-user",
+        ownerDisplayName: "Test contact",
+        status: "revoked",
+        shareKind: "sos",
+        shareMessage: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+      },
+    ];
+
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      expect(result.current.hasClearableSmsEmergencies).toBe(true);
     });
 
-    expect(encryptionHarness.decryptLocationEnvelope).toHaveBeenCalledWith({
-      userId: "receiver-user",
-      envelope,
+    const emergency = result.current.actionables.find(
+      (item) => item.id === "sms-emergency:sos-grant-1",
+    );
+    expect(emergency?.actions).toEqual([]);
+  });
+
+  it("removes a revoked SOS card once clearSmsEmergencies() runs, and persists the clear", async () => {
+    receivedGrantsFixture = [
+      {
+        id: "sos-grant-1",
+        ownerUserId: "sender-user",
+        recipientUserId: "receiver-user",
+        ownerDisplayName: "Test contact",
+        status: "revoked",
+        shareKind: "sos",
+        shareMessage: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+      },
+    ];
+
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      expect(result.current.hasClearableSmsEmergencies).toBe(true);
     });
 
-    expect(serviceHarness.reverseGeocode).toHaveBeenCalledWith({
-      vaultOwnerToken: "test-vault-token",
-      lat: 12.3456,
-      lng: 78.9012,
+    act(() => {
+      result.current.clearSmsEmergencies();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.actionables.find(
+          (item) => item.id === "sms-emergency:sos-grant-1",
+        ),
+      ).toBeUndefined();
+      expect(result.current.hasClearableSmsEmergencies).toBe(false);
     });
 
     expect(
-      encryptionHarness.ensureVaultSyncedRecipientKey,
-    ).not.toHaveBeenCalled();
+      window.localStorage.getItem("hushh:feed-sms-dismissed:receiver-user"),
+    ).toContain("sos-grant-1");
+  });
+
+  it("does NOT offer a clear for a live (still-active) SOS share", async () => {
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      expect(
+        result.current.actionables.find(
+          (item) => item.id === "sms-emergency:sos-grant-1",
+        ),
+      ).toBeDefined();
+    });
+
+    expect(result.current.hasClearableSmsEmergencies).toBe(false);
   });
 });

--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isActiveSmsEmergencyGrant,
   isIncomingLocationRequestActionable,
+  isSmsEmergencyGrant,
 } from "@/lib/feed/use-feed-actionables";
 import type {
   OneLocationAccessRequest,
@@ -113,5 +114,24 @@ describe("isActiveSmsEmergencyGrant", () => {
     expect(
       isActiveSmsEmergencyGrant(grant({ shareKind: "sos", status: "revoked" })),
     ).toBe(false);
+  });
+});
+
+describe("isSmsEmergencyGrant", () => {
+  it("surfaces an SOS share regardless of status, so a revoke stays visible", () => {
+    expect(isSmsEmergencyGrant(grant({ shareKind: "sos", status: "active" }))).toBe(
+      true,
+    );
+    expect(isSmsEmergencyGrant(grant({ shareKind: "sos", status: "revoked" }))).toBe(
+      true,
+    );
+    expect(isSmsEmergencyGrant(grant({ shareKind: "sos", status: "expired" }))).toBe(
+      true,
+    );
+  });
+
+  it("does NOT surface a non-SOS share", () => {
+    expect(isSmsEmergencyGrant(grant({ shareKind: "share" }))).toBe(false);
+    expect(isSmsEmergencyGrant(grant({ shareKind: "check_in" }))).toBe(false);
   });
 });

--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -94,7 +94,8 @@ export function FeedPage() {
   }, [clearedStorageKey]);
 
 
-  const { actionables } = useFeedActionables();
+  const { actionables, hasClearableSmsEmergencies, clearSmsEmergencies } =
+    useFeedActionables();
 
   const {
     data,
@@ -187,24 +188,30 @@ export function FeedPage() {
     if (!user || clearing) return;
     setClearing(true);
     try {
-      // Persist what the backend supports today: mark everything read so the
-      // unread badge is cleared durably. Hiding the history rows is
-      // session-scoped until a real feed-delete endpoint exists.
-      const idToken = await user.getIdToken();
-      const latestId = items[0]?.id;
-      await FeedService.markRead({ idToken, upToId: latestId ?? null });
-      dispatchFeedStateChanged();
-      setAdditionalItems([]);
-      setNextCursor(null);
-      // Persist the clear as a timestamp watermark so it survives tab
-      // switches and refreshes (the old session flag reset on remount).
-      const nowIso = new Date().toISOString();
-      setClearedAt(nowIso);
-      if (clearedStorageKey) {
-        try {
-          window.localStorage.setItem(clearedStorageKey, nowIso);
-        } catch {
-          // Storage disabled: clear still applies for this session.
+      // Revoked/expired SOS cards have nothing left to act on — this is the
+      // one "Needs you" actionable type Clear also reaches.
+      if (hasClearableSmsEmergencies) clearSmsEmergencies();
+
+      if (items.length > 0) {
+        // Persist what the backend supports today: mark everything read so
+        // the unread badge is cleared durably. Hiding the history rows is
+        // session-scoped until a real feed-delete endpoint exists.
+        const idToken = await user.getIdToken();
+        const latestId = items[0]?.id;
+        await FeedService.markRead({ idToken, upToId: latestId ?? null });
+        dispatchFeedStateChanged();
+        setAdditionalItems([]);
+        setNextCursor(null);
+        // Persist the clear as a timestamp watermark so it survives tab
+        // switches and refreshes (the old session flag reset on remount).
+        const nowIso = new Date().toISOString();
+        setClearedAt(nowIso);
+        if (clearedStorageKey) {
+          try {
+            window.localStorage.setItem(clearedStorageKey, nowIso);
+          } catch {
+            // Storage disabled: clear still applies for this session.
+          }
         }
       }
       toast.success("Feed notifications cleared");
@@ -213,7 +220,14 @@ export function FeedPage() {
     } finally {
       setClearing(false);
     }
-  }, [user, clearing, items, clearedStorageKey]);
+  }, [
+    user,
+    clearing,
+    items,
+    clearedStorageKey,
+    hasClearableSmsEmergencies,
+    clearSmsEmergencies,
+  ]);
 
 
   // Present strictly newest-first by wall-clock time, then club into day
@@ -227,15 +241,29 @@ export function FeedPage() {
     );
     return groupItemsByDay(sorted);
   }, [items]);
+  // Emergency SMS cards are individually framed (rounded + bordered), so
+  // stacking them in the same divide-y list as plain rows leaves them
+  // flush against each other with only a hairline between — two SOS alerts
+  // read as one merged block. Render them in their own gapped stack instead;
+  // the sort in useFeedActionables already keeps all "emergency" items
+  // contiguous at the top, so this split never reorders anything.
+  const emergencyActionables = actionables.filter(
+    (item) => item.emphasis === "emergency",
+  );
+  const regularActionables = actionables.filter(
+    (item) => item.emphasis !== "emergency",
+  );
   const hasActionables = actionables.length > 0;
   // Once cleared this session, the loaded history rows are hidden even though
   // `items` still holds them (no backend delete yet), so the empty state shows.
   const hasHistory = items.length > 0;
   const showEmpty = !loading && !hasActionables && !hasHistory && !error;
   // The Clear affordance only makes sense when there is dismissable history
-  // showing. Actionables ("Needs you") are deliberately NOT cleared: they are
-  // pending tasks the user must still act on, not passive notifications.
-  const canClear = hasHistory;
+  // showing. Actionables ("Needs you") are otherwise deliberately NOT
+  // cleared — they're pending tasks the user must still act on — except a
+  // revoked SOS card, which has nothing left to act on and is the one
+  // actionable type Clear also removes.
+  const canClear = hasHistory || hasClearableSmsEmergencies;
 
 
   return (
@@ -248,11 +276,20 @@ export function FeedPage() {
           {hasActionables ? (
             <section aria-label="Needs you" className="bg-accent/[0.03]">
               <SectionLabel>Needs you</SectionLabel>
-              <div className="divide-y divide-[color:var(--foundation-hairline)]">
-                {actionables.map((item) => (
-                  <FeedActionableRow key={item.id} item={item} />
-                ))}
-              </div>
+              {emergencyActionables.length ? (
+                <div className="flex flex-col gap-2 px-[6px] pb-2">
+                  {emergencyActionables.map((item) => (
+                    <FeedActionableRow key={item.id} item={item} />
+                  ))}
+                </div>
+              ) : null}
+              {regularActionables.length ? (
+                <div className="divide-y divide-[color:var(--foundation-hairline)]">
+                  {regularActionables.map((item) => (
+                    <FeedActionableRow key={item.id} item={item} />
+                  ))}
+                </div>
+              ) : null}
             </section>
           ) : null}
 

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -49,11 +49,6 @@ import {
   locationConsentSummary,
 } from "@/lib/consent/location-consent";
 import { OneLocationService } from "@/lib/one-location/service";
-import {
-  RECIPIENT_KEY_UNAVAILABLE_MESSAGE,
-  decryptLocationEnvelope,
-  ensureVaultSyncedRecipientKey,
-} from "@/lib/one-location/encryption";
 import type {
   OneLocationAccessRequest,
   OneLocationCircleMemberInvite,
@@ -114,6 +109,12 @@ export interface UseFeedActionablesResult {
   actionables: FeedActionable[];
   count: number;
   loading: boolean;
+  /** A revoked/expired SOS card is sitting in `actionables` with nothing left
+   * to act on — only the Feed page's existing Clear button can remove it. */
+  hasClearableSmsEmergencies: boolean;
+  /** Dismisses every revoked/expired SOS card currently shown. Wired into the
+   * Feed page's existing Clear button so it clears SOS notifications too. */
+  clearSmsEmergencies: () => void;
 }
 
 function toTimestamp(value?: string | number | null): number {
@@ -166,6 +167,45 @@ export function isActiveSmsEmergencyGrant(grant: OneLocationGrant): boolean {
   return grant.status === "active" && grant.shareKind === "sos";
 }
 
+/**
+ * Any SOS grant a contact ever sent, live or revoked. Unlike
+ * `isActiveSmsEmergencyGrant`, this keeps a revoked/expired SOS in the "Needs
+ * you" feed as a historical alert instead of silently dropping it the instant
+ * the sender cancels — a safety event must stay visible until the recipient
+ * explicitly clears it.
+ */
+export function isSmsEmergencyGrant(grant: OneLocationGrant): boolean {
+  return grant.shareKind === "sos";
+}
+
+const SMS_EMERGENCY_DISMISSED_STORAGE_PREFIX = "hushh:feed-sms-dismissed:";
+
+function readDismissedSmsEmergencyIds(userId: string): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(
+      `${SMS_EMERGENCY_DISMISSED_STORAGE_PREFIX}${userId}`,
+    );
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((id): id is string => typeof id === "string"))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissedSmsEmergencyIds(userId: string, ids: Set<string>): void {
+  try {
+    window.localStorage.setItem(
+      `${SMS_EMERGENCY_DISMISSED_STORAGE_PREFIX}${userId}`,
+      JSON.stringify([...ids]),
+    );
+  } catch {
+    // Storage disabled — the dismiss still applies for this session via state.
+  }
+}
+
 export function notifyFeedActionResolved(): void {
   dispatchConsentStateChanged({ source: "feed_actionable" });
   dispatchFeedStateChanged();
@@ -174,12 +214,23 @@ export function notifyFeedActionResolved(): void {
 export function useFeedActionables(): UseFeedActionablesResult {
   const router = useRouter();
   const { user } = useAuth();
-  const { vaultKey, vaultOwnerToken } = useVault();
+  const { vaultOwnerToken } = useVault();
   const userId = user?.uid ?? null;
-  const [smsEmergencyAddresses, setSmsEmergencyAddresses] = useState<
-    Record<string, string>
-  >({});
+  const [dismissedSmsEmergencyIds, setDismissedSmsEmergencyIds] = useState<
+    Set<string>
+  >(() => new Set());
   const cache = useMemo(() => CacheService.getInstance(), []);
+
+  // Revoked/expired SOS cards stay in the feed as a historical alert until the
+  // recipient explicitly clears them (see the Clear action below); the
+  // per-user dismissal set persists to localStorage so it survives refreshes.
+  useEffect(() => {
+    if (!userId) {
+      setDismissedSmsEmergencyIds(new Set());
+      return;
+    }
+    setDismissedSmsEmergencyIds(readDismissedSmsEmergencyIds(userId));
+  }, [userId]);
 
   // ── Debate + background-task live stores (in-memory, synchronous) ──
   const [debateState, setDebateState] = useState(() =>
@@ -316,112 +367,39 @@ export function useFeedActionables(): UseFeedActionablesResult {
   // + the stable refresh callbacks, not the changing wrapper identity.
   const locationRequests = locationResource.data?.requests;
   const receivedGrants = locationResource.data?.receivedGrants;
-  const myRecipientKey = locationResource.data?.myRecipientKey;
   const circleMemberInvites = locationResource.data?.circleMemberInvites;
   const locationRefresh = locationResource.refresh;
   const connectionRequests = connectionsResource.data;
   const connectionsRefresh = connectionsResource.refresh;
   const consentItems = consentListResource.data?.items;
 
-  // SOS location remains end-to-end encrypted at rest. Only active SOS
-  // grants are opened here, while the recipient vault is unlocked. The
-  // decrypted coordinate exists only long enough to reverse-geocode it;
-  // Feed state retains the resulting human-readable address, never the
-  // plaintext point.
-  useEffect(() => {
-    const emergencies = (receivedGrants ?? []).filter(
-      isActiveSmsEmergencyGrant,
-    );
+  // Revoked/expired SOS cards stay in the feed as a historical alert instead
+  // of vanishing the moment the sender cancels — but there is nothing left to
+  // act on, so only the Feed page's existing Clear button removes them (no
+  // separate per-row control). The dismissal set persists to localStorage so
+  // a clear survives refreshes.
+  const clearableSmsEmergencyIds = useMemo(
+    () =>
+      (receivedGrants ?? [])
+        .filter(
+          (grant) =>
+            isSmsEmergencyGrant(grant) &&
+            !isActiveSmsEmergencyGrant(grant) &&
+            !dismissedSmsEmergencyIds.has(grant.id),
+        )
+        .map((grant) => grant.id),
+    [receivedGrants, dismissedSmsEmergencyIds],
+  );
 
-    if (!userId || !vaultOwnerToken || emergencies.length === 0) {
-      setSmsEmergencyAddresses((current) =>
-        Object.keys(current).length === 0 ? current : {},
-      );
-      return;
-    }
-
-    let cancelled = false;
-
-    void Promise.all(
-      emergencies.map(async (grant) => {
-        try {
-          const response = await OneLocationService.viewEnvelope({
-            vaultOwnerToken,
-            grantId: grant.id,
-          });
-          // An SOS grant whose first point hasn't landed yet. There is no
-          // address to resolve, and inventing an error here would put a red
-          // state on an emergency card that is actually working — fall through
-          // to the same empty address the catch below produces, which the
-          // filter drops without disturbing the card.
-          const envelope = response.envelope;
-          if (!envelope) return [grant.id, ""] as const;
-
-          let point;
-          try {
-            point = await decryptLocationEnvelope({
-              userId,
-              envelope,
-            });
-          } catch (decryptError) {
-            // Match the Location workspace recovery path: a new device
-            // may need to restore the vault-synced recipient key once.
-            if (
-              decryptError instanceof Error &&
-              decryptError.message === RECIPIENT_KEY_UNAVAILABLE_MESSAGE &&
-              vaultKey &&
-              myRecipientKey?.encryptedPrivateKeyJwk
-            ) {
-              await ensureVaultSyncedRecipientKey({
-                userId,
-                vaultKey,
-                remoteBackup: myRecipientKey,
-              });
-              point = await decryptLocationEnvelope({
-                userId,
-                envelope,
-              });
-            } else {
-              throw decryptError;
-            }
-          }
-
-          const place = await OneLocationService.reverseGeocode({
-            vaultOwnerToken,
-            lat: point.latitude,
-            lng: point.longitude,
-          });
-
-          const address =
-            place.formattedAddress?.trim() || place.name?.trim() || "";
-
-          return [grant.id, address] as const;
-        } catch {
-          // The emergency card must remain useful even while an envelope,
-          // key, or geocoder is temporarily unavailable.
-          return [grant.id, ""] as const;
-        }
-      }),
-    ).then((entries) => {
-      if (cancelled) return;
-
-      setSmsEmergencyAddresses(
-        Object.fromEntries(
-          entries.filter(([, address]) => Boolean(address)),
-        ),
-      );
+  const clearSmsEmergencies = useCallback(() => {
+    if (!userId || clearableSmsEmergencyIds.length === 0) return;
+    setDismissedSmsEmergencyIds((current) => {
+      const next = new Set(current);
+      for (const id of clearableSmsEmergencyIds) next.add(id);
+      writeDismissedSmsEmergencyIds(userId, next);
+      return next;
     });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    myRecipientKey,
-    receivedGrants,
-    userId,
-    vaultKey,
-    vaultOwnerToken,
-  ]);
+  }, [userId, clearableSmsEmergencyIds]);
 
   const actionables = useMemo<FeedActionable[]>(() => {
     if (!userId) return [];
@@ -464,27 +442,27 @@ export function useFeedActionables(): UseFeedActionablesResult {
       }
     }
 
-    // SMS · Save My Soul emergency alerts — a live share a contact started as an
-    // SOS. Rendered as pinned, emergency-styled cards at the very top of the feed
-    // so a safety alert is never buried under routine activity.
+    // SMS · Save My Soul emergency alerts — a share a contact started as an
+    // SOS. Rendered as pinned, emergency-styled cards at the very top of the
+    // feed so a safety alert is never buried under routine activity. A
+    // revoked/expired SOS stays as a historical entry ("Revoked") rather than
+    // vanishing the moment the sender cancels; the Feed page's existing Clear
+    // button (via `clearSmsEmergencies` above) is what removes it — no
+    // separate per-row control here.
     const smsEmergencies = (receivedGrants ?? []).filter(
-      isActiveSmsEmergencyGrant,
+      (grant) =>
+        isSmsEmergencyGrant(grant) && !dismissedSmsEmergencyIds.has(grant.id),
     );
     for (const grant of smsEmergencies) {
       const label = grant.ownerDisplayName?.trim() || "A contact";
-      const emergencyMessage =
-        grant.shareMessage?.trim() ||
-        "Emergency SMS — sharing live location with you now.";
-      const lastKnownAddress = smsEmergencyAddresses[grant.id]?.trim();
+      const isRevoked = !isActiveSmsEmergencyGrant(grant);
       items.push({
         id: `sms-emergency:${grant.id}`,
         icon: Siren,
         iconTone: "red",
         emphasis: "emergency",
         title: `${label} triggered an SOS`,
-        description: lastKnownAddress
-          ? `${emergencyMessage} | Last known: ${lastKnownAddress}`
-          : emergencyMessage,
+        description: isRevoked ? "Emergency SMS - Revoked" : "Emergency SMS - Sent.",
         href: buildOneLocationNotificationHref(grant.id),
         chevron: true,
         actions: [],
@@ -782,9 +760,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
     connectionsRefresh,
     consentItems,
     debateState.tasks,
+    dismissedSmsEmergencyIds,
     locationRequests,
     receivedGrants,
-    smsEmergencyAddresses,
     circleMemberInvites,
     locationRefresh,
     openAnalysis,
@@ -801,5 +779,11 @@ export function useFeedActionables(): UseFeedActionablesResult {
     locationResource.loading ||
     connectionsResource.loading;
 
-  return { actionables, count: actionables.length, loading };
+  return {
+    actionables,
+    count: actionables.length,
+    loading,
+    hasClearableSmsEmergencies: clearableSmsEmergencyIds.length > 0,
+    clearSmsEmergencies,
+  };
 }


### PR DESCRIPTION
# Description

Emergency SMS (SOS) cards in the Feed's "Needs you" zone had three bugs, all in
`hushh-webapp/lib/feed/use-feed-actionables.ts` and its render path:

1. The subtitle leaked the sender's last-known address (`Emergency SMS — sharing
   live location with you now. | Last known: <address>`). Copy is now fixed:
   `Emergency SMS - Sent.` while live, `Emergency SMS - Revoked` once the sender
   revokes/expires the share. The reverse-geocode effect that built the address
   string is removed — it fed only this subtitle and had no other consumer.
2. Revoking the share made the card vanish instantly (the actionable filter only
   kept `status === "active"` grants, and the backend never deletes a revoked
   grant row). It now stays visible as `Emergency SMS - Revoked` until the
   recipient dismisses it.
3. There was no working way to dismiss a resolved SOS card. Rather than adding a
   new per-row button, the existing Feed page "Clear" button now also clears
   revoked/expired SOS cards (`hasClearableSmsEmergencies` /
   `clearSmsEmergencies()` from `useFeedActionables`), alongside its existing job
   of clearing feed history. Live/pending SOS cards and other pending actionables
   (location/connection requests, invites) are untouched by Clear, unchanged from
   before — only a resolved SOS alert with nothing left to act on is now
   clearable.

Also fixed: two SOS cards rendered back-to-back with no gap (each is an
individually bordered/rounded card, and the shared `divide-y` hairline list gave
them a 1px line instead of real spacing). They now render in their own gapped
stack, split from the plain hairline-divided rows below.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] Listed below:
    - `UseFeedActionablesResult` (internal hook return type, not a backend
      contract) gained `hasClearableSmsEmergencies: boolean` and
      `clearSmsEmergencies: () => void`.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared Next.js/React feed UI loaded by the Capacitor webview; no
        native plugin surface involved.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — display/dismiss logic only; no change to grant read/consent
        flow. The removed effect stopped decrypting the SOS location point for
        this card, it never wrote to the vault or grant state.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Dismissal state is a per-user localStorage watermark
      (`hushh:feed-sms-dismissed:<uid>`); reads/writes are wrapped in
      try/catch, so a disabled/unavailable localStorage degrades to
      "dismiss doesn't persist across reload" rather than throwing.
- UI browser or Playwright proof:
  - [ ] Not run this session — verified via updated unit tests + typecheck +
        lint only (see commands below). Route: `/one/feed`.
- Verification commands executed:
  - [x] `cd hushh-webapp && npx tsc --noEmit -p tsconfig.json` (clean)
  - [x] `cd hushh-webapp && npx eslint lib/feed/use-feed-actionables.ts components/feed/feed-page.tsx __tests__/lib/feed/use-feed-actionables.test.ts __tests__/lib/feed/use-feed-actionables-sos-address.test.tsx` (clean)
  - [x] `cd hushh-webapp && npx vitest run __tests__/lib/feed/ __tests__/components/feed-actionable-row.test.tsx __tests__/components/feed-sticky-header.contract.test.ts` (6 files, 23 tests passed)
  - [ ] `npm run build` not run this session

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (`/one/feed` "Needs you" zone).
- [x] Reachable production attach point: `hushh-webapp/components/feed/feed-page.tsx` → `FeedPage`, mounted at `app/one/feed` (existing route, unchanged).
- [x] New tests import and exercise production code (`useFeedActionables`, `FeedActionableRow`) directly, not mock-only helpers.
- [x] New logic (`hasClearableSmsEmergencies`, `clearSmsEmergencies`) is wired to the existing Feed page Clear button, not a dangling export.
- [x] Production surface proved: unit tests assert the hook's `actionables`/`hasClearableSmsEmergencies` output for active and revoked SOS grants.
- [x] Required checks are current on this head, commits are signed off (`git commit -s`), branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [ ] Not a stacked PR.
- [ ] Not responding to prior requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`hushh-webapp/lib/feed/use-feed-actionables.ts`, `hushh-webapp/components/feed/feed-page.tsx`)
- [ ] **iOS**: Not applicable — no native Capacitor plugin surface involved; the iOS app renders this same web bundle.
- [ ] **Android**: Not applicable — same as iOS.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) — not manually clicked through this session; covered by unit tests instead.
- [ ] Tested on iOS Simulator/Device — not applicable, no native surface.
- [ ] Tested on Android Emulator/Device — not applicable, no native surface.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Not captured this session. Route: `/one/feed`, "Needs you" zone, when a contact
has sent (and optionally revoked) an SOS share. Behavior is covered by
`hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx` and
`hushh-webapp/__tests__/components/feed-actionable-row.test.tsx`.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It reads the same already-fetched
      `receivedGrants` (SOS share status/metadata) the feed already loads — no
      new data access. It **removes** a decrypt-and-reverse-geocode call that
      previously ran to build the (now-deleted) address subtitle.
- [x] Sensitive surface touched: none of auth / consent / vault / PKM / finance
      / voice-action / KYC / schema / deploy / public ingress — display/dismiss
      logic only.
- [x] Error path, rollback, or safe-failure behavior proved: localStorage
      read/write wrapped in try/catch (see Rollback section above).

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes