### PR TITLE
style(location): unify SMS contacts empty card box sizing and typography

### DIFF
--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -126,6 +126,14 @@ function ContactGroup({ children }: { children: ReactNode }) {
   );
 }
 
+function EmptyStateCard({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-[92px] w-full items-center justify-center rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-5 py-4 text-center text-[14px] font-normal leading-5 text-muted-foreground transition-all duration-200 ease-out shadow-none">
+      <p className="max-w-[280px]">{message}</p>
+    </div>
+  );
+}
+
 export function SmsContactsFlow({
   recipients,
   circles,
@@ -266,9 +274,7 @@ export function SmsContactsFlow({
                 ))}
               </ContactGroup>
             ) : (
-              <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-5 text-center text-[15px] leading-5 text-muted-foreground">
-                No SMS contacts yet. Add someone from your circle below.
-              </div>
+              <EmptyStateCard message="No SMS contacts yet. Add someone from your circle below." />
             )}
           </div>
 
@@ -294,9 +300,7 @@ export function SmsContactsFlow({
                 ))}
               </ContactGroup>
             ) : (
-              <div className="rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-5 text-center text-[15px] leading-5 text-muted-foreground">
-                Everyone in your ready circle is already selected.
-              </div>
+              <EmptyStateCard message="Everyone in your ready circle is already selected." />
             )}
           </div>
         </div>


### PR DESCRIPTION
Created a shared <EmptyStateCard> helper component to enforce 1:1 visual parity between both columns (Alerted on SMS and Add from your circle).
Standardized box width, minimum height (min-h-[92px]), border-radius (rounded-[var(--app-card-radius-compact)]), padding (px-5 py-4), font size (14px), and text color (text-muted-foreground).