### PR TITLE
fix(one-location): center Check-in on mobile instead of grouping with Locate

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -1269,6 +1269,68 @@ describe("LocationImmersiveMap demo experience", () => {
     ).toHaveAccessibleName("You are sharing your location with 1 person");
   });
 
+  it("centers Check-in in the header on mobile instead of grouping it with Locate", async () => {
+    // Regression test: Check-in used to always sit grouped with Locate on
+    // the trailing edge, even on phone-width screens where there is no room
+    // for three live pills. Below the md breakpoint it now takes the
+    // header's center column (Sharing steps aside there) instead.
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 390,
+    });
+
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+    experienceHarness.query = "source=map";
+    serviceHarness.getState.mockResolvedValue({
+      recipients: [],
+      ownerGrants: [
+        {
+          id: "active-location-share",
+          ownerUserId: "test-user",
+          recipientUserId: "trusted-person",
+          recipientKeyId: "trusted-person-key",
+          status: "active",
+          consentScope: "location",
+          capabilityScopes: ["location.read"],
+          durationHours: 1,
+        },
+      ],
+    });
+
+    try {
+      render(<LocationImmersiveMap surface="check-in" />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "Continue to Your Map" }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+          "data-map-ready",
+          "true",
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("one-location-map-nearby-check-in"),
+        ).toHaveAccessibleName("Check in nearby");
+      });
+      // Sharing steps aside on mobile -- Check-in occupies its column instead.
+      expect(
+        screen.queryByTestId("one-location-map-sharing-status"),
+      ).not.toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("does not build a synthetic history boundary on the check-in route", async () => {
     // The sheet used to have no URL of its own, so it faked a history entry to
     // make Back close it. A real route already is one; re-creating the boundary

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -38,6 +38,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useRequireAuth } from "@/hooks/use-auth";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   decryptLocationEnvelope,
   encryptLocationForRecipient,
@@ -351,6 +352,13 @@ export function LocationImmersiveMap({
   const { vaultOwnerToken } = useVault();
   const demoAvailable = isLocationMapDemoAvailable();
   const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
+  // Below md, Check-in moves into the header's center column (Sharing steps
+  // aside there -- see the header below) instead of sitting grouped with
+  // Locate on the trailing edge. A CSS-only breakpoint can't do this: the
+  // same control can't sit centered-alone in one column and grouped with a
+  // sibling in another without literally living in two places in the tree,
+  // so this picks the one place it actually renders.
+  const isMobile = useIsMobile();
   const initialDemoMode = isLocationMapDemoEnabled(searchParams.get("demo"));
   const mapElement = useRef<HTMLElement | null>(null);
   const mapRef = useRef<GoogleMap | null>(null);
@@ -1901,6 +1909,42 @@ export function LocationImmersiveMap({
     await frameMarkers(map, visibleMarkers);
   }, [visibleMarkers]);
 
+  // Built once and placed into exactly one of two header slots below
+  // (mobile's center column, or desktop's trailing group with Locate) --
+  // never both, so it only ever mounts once.
+  const checkInPill = (
+    <ShellActionSurface
+      variant="pill"
+      // ShellActionSurface's own wrapper is shrink-0 by default (a
+      // fixed-size top-bar control never used to need to give way). On
+      // desktop this shares a grid column with Locate and can be pushed by
+      // Sharing sitting dead-center, so it needs to be the one that yields
+      // -- wrapperClassName reaches the actual flex item; min-w-0 on the
+      // trigger itself lets its own truncate span ellipsis instead of just
+      // refusing to shrink.
+      wrapperClassName="min-w-0 shrink"
+      className={`pointer-events-auto min-w-0 border shadow-lg backdrop-blur-md ${
+        nearbyPresenceState.presence
+          ? MAP_ACCENT_ACTIVE_CLASSNAME
+          : MAP_ACCENT_CONTROL_CLASSNAME
+      }`}
+      aria-label={
+        nearbyPresenceState.presence
+          ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
+          : "Check in nearby"
+      }
+      data-testid="one-location-map-nearby-check-in"
+      onClick={openNearbyCheckIn}
+    >
+      <UsersRound className="h-4 w-4 shrink-0" />
+      <span className="truncate">
+        {nearbyPresenceState.presence
+          ? `Nearby ${nearbyPresenceState.attendees.length}`
+          : "Check in"}
+      </span>
+    </ShellActionSurface>
+  );
+
   return (
     <main
       className="one-location-map relative h-[100dvh] w-full overflow-hidden bg-muted"
@@ -1935,8 +1979,14 @@ export function LocationImmersiveMap({
         // is what dragged Check-in and Sharing out of place in the first
         // place. `1fr auto 1fr` instead forces the two outer columns to the
         // same width regardless of what they contain, which puts the middle
-        // (auto) column -- Sharing -- at the header's true visual center no
-        // matter how wide the close X or the Check-in+Locate group are.
+        // (auto) column at the header's true visual center no matter how
+        // wide the close X or the trailing group are.
+        //
+        // The center column's occupant depends on viewport: on desktop it's
+        // Sharing, with Check-in grouped into the trailing edge alongside
+        // Locate; below md, Check-in takes the center column instead (see
+        // `isMobile` below) and Sharing steps aside, matching how little
+        // room a phone-width header actually has for three live pills.
         className="pointer-events-none absolute inset-x-0 top-0 z-30 grid grid-cols-[1fr_auto_1fr] items-center gap-3 p-4 pt-[max(1rem,env(safe-area-inset-top))]"
       >
         <div className="flex min-w-0 items-center">
@@ -1956,58 +2006,35 @@ export function LocationImmersiveMap({
           </ShellActionSurface>
         </div>
         <div className="flex min-w-0 items-center justify-center">
-          {!demoMode && (activeShareCount ?? 0) > 0 ? (
-            <span
-              data-testid="one-location-map-sharing-status"
-              aria-label={`You are sharing your location with ${activeShareCount} ${
-                activeShareCount === 1 ? "person" : "people"
-              }`}
-              role="status"
-              aria-live="polite"
-              className="pointer-events-none flex min-w-0 shrink items-center gap-1.5 truncate rounded-full border border-[var(--app-accent-border)] bg-background/85 px-3 py-1.5 text-[12px] font-semibold text-[var(--app-accent-deep)] shadow-lg backdrop-blur-md dark:text-[var(--app-accent-bright)]"
-            >
-              <span
-                className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--app-accent)] motion-safe:animate-pulse"
-                aria-hidden="true"
-              />
-              <span className="truncate">Sharing with {activeShareCount}</span>
-            </span>
-          ) : null}
+          {isMobile
+            ? rendererReady && nearbyCheckInAvailable && !demoMode
+              ? checkInPill
+              : null
+            : !demoMode && (activeShareCount ?? 0) > 0
+              ? (
+                <span
+                  data-testid="one-location-map-sharing-status"
+                  aria-label={`You are sharing your location with ${activeShareCount} ${
+                    activeShareCount === 1 ? "person" : "people"
+                  }`}
+                  role="status"
+                  aria-live="polite"
+                  className="pointer-events-none flex min-w-0 shrink items-center gap-1.5 truncate rounded-full border border-[var(--app-accent-border)] bg-background/85 px-3 py-1.5 text-[12px] font-semibold text-[var(--app-accent-deep)] shadow-lg backdrop-blur-md dark:text-[var(--app-accent-bright)]"
+                >
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--app-accent)] motion-safe:animate-pulse"
+                    aria-hidden="true"
+                  />
+                  <span className="truncate">Sharing with {activeShareCount}</span>
+                </span>
+              )
+              : null}
         </div>
         {rendererReady ? (
           <div className="flex min-w-0 items-center justify-end gap-3">
-            {rendererReady && nearbyCheckInAvailable && !demoMode ? (
-              <ShellActionSurface
-                variant="pill"
-                // ShellActionSurface's own wrapper is shrink-0 by default (a
-                // fixed-size top-bar control never used to need to give way).
-                // Here it shares a grid column with Locate and can be pushed
-                // by Sharing sitting dead-center, so it needs to be the one
-                // that yields -- wrapperClassName reaches the actual flex
-                // item; min-w-0 on the trigger itself lets its own truncate
-                // span ellipsis instead of just refusing to shrink.
-                wrapperClassName="min-w-0 shrink"
-                className={`pointer-events-auto min-w-0 border shadow-lg backdrop-blur-md ${
-                  nearbyPresenceState.presence
-                    ? MAP_ACCENT_ACTIVE_CLASSNAME
-                    : MAP_ACCENT_CONTROL_CLASSNAME
-                }`}
-                aria-label={
-                  nearbyPresenceState.presence
-                    ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
-                    : "Check in nearby"
-                }
-                data-testid="one-location-map-nearby-check-in"
-                onClick={openNearbyCheckIn}
-              >
-                <UsersRound className="h-4 w-4 shrink-0" />
-                <span className="truncate">
-                  {nearbyPresenceState.presence
-                    ? `Nearby ${nearbyPresenceState.attendees.length}`
-                    : "Check in"}
-                </span>
-              </ShellActionSurface>
-            ) : null}
+            {!isMobile && rendererReady && nearbyCheckInAvailable && !demoMode
+              ? checkInPill
+              : null}
             {rendererReady ? (
               <ShellActionSurface
                 className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}


### PR DESCRIPTION
## Bug
Below the header's md breakpoint, the Check-in pill sat grouped with the Locate button on the trailing edge instead of taking the header's center column. On a phone-width header there's no room for three live pills crammed to one side.

## Fix
`checkInPill` (a single `ShellActionSurface`) is built once and placed into exactly one of the header's two slots based on `useIsMobile()` (existing hook, 768px breakpoint): the center column on mobile, or the trailing group with Locate on desktop. Sharing status steps aside on mobile (back to desktop-only, matching pre-existing behavior) since there's no room for it alongside Check-in.

## Root cause
A CSS-only breakpoint can't move a single control between "centered alone in a column" and "grouped with a sibling in another column" — it has to actually render in one place or the other based on viewport.

## Verification
- Typecheck: clean
- Lint: clean
- Tests: 30 passed (29 existing + 1 new regression test asserting mobile hides sharing-status and shows Check-in centered)
- Manual: verified at 752px (mobile — Check-in centered, Locate alone right) and 1283px (desktop — Sharing centered, Check-in+Locate grouped trailing, unchanged) against local dev server.