### PR TITLE
fix(connect): stack connection actions on mobile to stop name wrapping

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1189,6 +1189,7 @@ export default function ConnectPageClient() {
                     key={connection.connectionId}
                     icon={Users}
                     iconTone="blue"
+                    stackTrailingOnMobile
                     title={connection.displayName || connection.userId}
                     density="compact"
                     trailing={


### PR DESCRIPTION
# Description

On the Connect page, tapping "Remove" on a connection row swaps in "Confirm"/"Cancel" next to the existing "Scopes" button. Three inline action buttons squeezed the name column so narrow that a long name (e.g. "Ankit Kumar Singh") wrapped character-by-character down the row instead of staying on one line, breaking the row layout.

Fix: pass `stackTrailingOnMobile` to the connection row's `SettingsRow` (same prop already used elsewhere in this file, e.g. the KYC/profile rows). On narrow viewports the action buttons now drop to their own line below the name instead of squeezing it.

One-line change: `hushh-webapp/app/connect/page-client.tsx`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/connect` (Connect page, connections list row)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - This is the mobile-width layout fix itself; no native plugin/bridge changes needed since it's a shared web view.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable (pure CSS/layout prop, no behavior change)

- UI browser or Playwright proof:
  - [x] Listed below:
    - Existing contract test `hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts` ("stacks connection actions below labels on narrow screens") was failing before this change and passes after it.

- Verification commands executed:
  - [x] `cd hushh-webapp && npx vitest run __tests__/components/connect-page-layout.contract.test.ts`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: pre-existing test in `connect-page-layout.contract.test.ts` already specified this exact fix (`stackTrailingOnMobile` on the connections `SettingsRow`) and was red until this change.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `app/connect/page-client.tsx` connections list row, rendered at `/connect`.
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file. (no new test added; existing test already covered it)
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: same `SettingsRow`/`stackTrailingOnMobile` pairing already used by Profile/KYC rows in this codebase.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`. (pending CI)
- [x] Maintainer edits are enabled.
- [ ] If this is one PR in a stack, the predecessor PR is linked here: N/A
- [ ] If this responds to requested changes, the new commit or material explanation is described here: N/A

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — `app/connect/page-client.tsx`
- [ ] **iOS**: Not applicable — shared web view, no native plugin code
- [ ] **Android**: Not applicable — shared web view, no native plugin code

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) — verified via existing layout contract test
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above (N/A, no generated files touched)

## 📸 Screenshots / Video

Reported bug: on the Connect page, clicking "Remove" then seeing "Confirm"/"Cancel" appear caused the connection's name to wrap into a single narrow vertical column while the buttons took the rest of the row width. Route: `/connect` → "My connections" list → tap "Remove" on any connection.

Fix verified via `connect-page-layout.contract.test.ts`, which asserts the connections row now stacks its trailing actions below the label on narrow screens.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? No — layout-only change, no data access change.
- [ ] If yes, have you implemented `checkConsentToken()`? N/A
- Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A, pure layout prop with no behavioral branch

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed (no dependency changes)