### PR TITLE
Give One Location a place people can find it, and a line saying what it does

### DIFF
--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -123,13 +123,18 @@ describe("OneDashboardPage", () => {
       "--agent-icon-profile-bg": "rgba(88, 86, 214, 0.16)",
       "--agent-icon-profile-fg": "#5856D6",
     });
+    // Palette slots are assigned by roster position, so this list must track
+    // ONE_CAPABILITIES order. Location moved from sixth to second, which shifts
+    // the five agents it passed by one slot each — a deliberate consequence of
+    // the reorder, not an incidental one: the palette exists to keep adjacent
+    // rows distinguishable, and that property is preserved.
     const rosterPaletteOrder = [
       "finance",
+      "location",
       "ria",
       "gmail",
       "calendar",
       "email",
-      "location",
       "pkm",
       "consent",
       "connected-systems",

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -583,11 +583,28 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
           profileStyle={dashboardAgentIconStyle(mode)}
         />
       </span>
-      <span
-        data-ui-role="row-label"
-        className="ui-text-row-label relative z-10 min-w-0 truncate"
-      >
-        {mode.title}
+      <span className="relative z-10 flex min-w-0 flex-col justify-center">
+        <span
+          data-ui-role="row-label"
+          className="ui-text-row-label min-w-0 truncate"
+        >
+          {mode.title}
+        </span>
+        {/*
+          The description was carried on every capability but rendered only as a
+          `title` attribute — a hover tooltip, which does not exist on a phone.
+          A roster of nine one-word labels asks the reader to already know what
+          each agent does, and the one people do not find is the one whose name
+          explains least.
+        */}
+        {mode.description ? (
+          <span
+            data-ui-role="row-description"
+            className="min-w-0 truncate text-[12px] leading-[16px] text-[#6E6E73] dark:text-[#98989D]"
+          >
+            {mode.description}
+          </span>
+        ) : null}
       </span>
       <span className="relative z-10 flex min-w-0 max-w-[132px] justify-end">
         <AgentMetric mode={mode} />

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -144,6 +144,26 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
     requiresVault: true,
   },
   {
+    // Second, deliberately. Location was row 6 of 10 and below the fold on a
+    // phone; 391 people reached this screen in 30 days and 18 opened Location,
+    // while the feature converts at 76% once found. Unlike Finance and Consent
+    // it has no inbound entry point -- no push, no toast, no feed row reaches
+    // someone who does not already have a share -- so its only discovery path
+    // is this list.
+    id: "location",
+    setupActionId: "setup.open_location",
+    setupControlId: "one_setup_tile_location",
+    agentId: "agent_location",
+    title: "Location",
+    description: "Share where you are with people you trust.",
+    previewLabel: "Live location & Alerts",
+    href: ROUTES.ONE_LOCATION,
+    icon: lucideCapabilityIcon(MapPin),
+    tone: "location",
+    group: "workflow",
+    requiresVault: true,
+  },
+  {
     id: "ria",
     setupActionId: "setup.open_ria",
     setupControlId: "one_setup_tile_ria",
@@ -197,20 +217,6 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
     href: ROUTES.ONE_KYC,
     icon: lucideCapabilityIcon(FileCheck2),
     tone: "email",
-    group: "workflow",
-    requiresVault: true,
-  },
-  {
-    id: "location",
-    setupActionId: "setup.open_location",
-    setupControlId: "one_setup_tile_location",
-    agentId: "agent_location",
-    title: "Location",
-    description: "Live location & Alerts",
-    previewLabel: "Live location & Alerts",
-    href: ROUTES.ONE_LOCATION,
-    icon: lucideCapabilityIcon(MapPin),
-    tone: "location",
     group: "workflow",
     requiresVault: true,
   },


### PR DESCRIPTION
## The problem is discovery, not the product

Live production data, last 30 days:

| | |
|---|---|
| People who used the One app | **322** |
| People who opened One Location | **18** |
| Of those, went on to actually share | **76%** |

The product works once someone finds it. Almost nobody finds it.

`/one` renders exactly one thing — a nine-row agent list — and Location was **row six**, below the fold on a phone, showing a one-word label and a bare count.

## Why Location loses to Nav and Kai

Consent reached 79 people and Kai 73, against Location's 18. Not because they are better, but because they have **inbound** entry points that fire without the user going looking:

- **Consent** — push notifications with Approve/Deny actions, in-app toasts with a Review button, feed actionables, a Profile row, a live pending-count KPI
- **Kai** — roster slot #1, a warm-up prefetch dispatched from the dashboard itself, a live ticker KPI, completion pushes

Location has equivalents — feed rows, toasts, pushes — but **every one of them requires an existing grant.** They only reach people who already found it. That leaves this list as its only discovery path, and sixth place on the only path is the whole problem.

## Two changes

**Location moves to row two**, after Finance.

**The roster renders each capability's description** under its title. Every capability already carried one — it was passed to the row as a `title` attribute, which is a hover tooltip and therefore invisible on a phone. A list of nine one-word labels asks the reader to already know what each agent does, and the one people fail to find is the one whose name explains least.

Location's copy also changes from `"Live location & Alerts"` to **"Share where you are with people you trust"** — what it does, rather than what it contains.

## A consequence worth a designer's eye

Palette slots are assigned by **roster position**, so moving Location shifts the five agents it passed by one slot each and repaints their icons. That is real and visible. The property the palette exists for — adjacent rows staying distinguishable — is preserved, and the test that pins the order is updated with the reasoning recorded inline. But if you would rather keep each agent's colour stable, the fix is to key the palette by capability id instead of index, and I would rather you decide that than assume it.

## Deliberately not done

Adding Location to the **bottom nav**. It looked like the cheapest win available — a single array — but `resolveBottomNavSpecialistOptionKeys` states that *contextual workspace tabs belong exclusively to the unified top shell*. A fifth slot would fight that architecture rather than extend it. Worth a conversation, not a drive-by.

## Verification

- `npx tsc --noEmit` — clean
- `one-dashboard-page` — 8/8
- Wider location and setup suites at their pre-existing baseline; nothing new failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)