### PR TITLE
feat(feed): split live SOS into its own section, add day/time to every row

### DIFF
--- a/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MapPin, Siren } from "lucide-react";
 
@@ -40,10 +40,114 @@ describe("FeedActionableRow", () => {
     expect(screen.getByText("Mom triggered an SOS")).toBeInTheDocument();
   });
 
+  it("shows a small green live dot before the description on a live SOS card only", () => {
+    const { container: liveContainer } = render(
+      <FeedActionableRow
+        item={actionable({
+          icon: Siren,
+          iconTone: "red",
+          emphasis: "emergency",
+          title: "Mom triggered an SOS",
+          description: "Emergency SMS - Sent.",
+        })}
+      />,
+    );
+    expect(liveContainer.querySelector(".bg-emerald-500")).not.toBeNull();
+
+    const { container: revokedContainer } = render(
+      <FeedActionableRow
+        item={actionable({
+          icon: Siren,
+          iconTone: "red",
+          title: "Mom triggered an SOS",
+          description: "Emergency SMS - Revoked",
+        })}
+      />,
+    );
+    expect(revokedContainer.querySelector(".bg-emerald-500")).toBeNull();
+  });
+
   it("renders a routine actionable without the emergency frame", () => {
     render(<FeedActionableRow item={actionable({ title: "Routine row" })} />);
 
     expect(screen.queryByTestId("feed-sms-emergency")).toBeNull();
     expect(screen.getByText("Routine row")).toBeInTheDocument();
+  });
+
+  it("renders a revoked SOS card as a plain row (no frame) but keeps the Siren/red icon signal", () => {
+    const { container } = render(
+      <FeedActionableRow
+        item={actionable({
+          icon: Siren,
+          iconTone: "red",
+          title: "Mom triggered an SOS",
+          description: "Emergency SMS - Revoked",
+          href: "/one/location?grantId=g1&open=1&section=shared",
+          chevron: true,
+          // No `emphasis` — this is the confirmed "downgrade to plain row" behavior.
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId("feed-sms-emergency")).toBeNull();
+    expect(screen.getByText("Mom triggered an SOS")).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-icon-tone="red"]'),
+    ).not.toBeNull();
+  });
+
+  describe("time label", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 7, 12, 15, 45, 0));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows the formatted day/time label when displayTimestamp is set", () => {
+      render(
+        <FeedActionableRow
+          item={actionable({
+            title: "Has a time",
+            displayTimestamp: new Date(2026, 7, 12, 15, 45, 0).getTime(),
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/^Today - 3:45\s?PM$/i)).toBeInTheDocument();
+    });
+
+    it("shows no time label when displayTimestamp is null", () => {
+      render(
+        <FeedActionableRow
+          item={actionable({ title: "No time", displayTimestamp: null })}
+        />,
+      );
+
+      expect(screen.queryByText(/Today -|Yesterday -/i)).toBeNull();
+    });
+
+    it("shows no time label when displayTimestamp is absent", () => {
+      render(<FeedActionableRow item={actionable({ title: "No time field" })} />);
+
+      expect(screen.queryByText(/Today -|Yesterday -/i)).toBeNull();
+    });
+
+    it("keeps the spinning pulse dot and the time label together", () => {
+      render(
+        <FeedActionableRow
+          item={actionable({
+            title: "Running task",
+            spinning: true,
+            displayTimestamp: new Date(2026, 7, 12, 15, 45, 0).getTime(),
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/^Today - 3:45\s?PM$/i)).toBeInTheDocument();
+      expect(screen.getByText("Row description")).toBeInTheDocument();
+    });
   });
 });

--- a/hushh-webapp/__tests__/components/feed-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-row.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MapPin } from "lucide-react";
+
+import { FeedRow } from "@/components/feed/feed-row";
+import type { FeedItem } from "@/lib/services/feed-service";
+
+vi.mock("@/lib/feed/feed-item-renderers", () => ({
+  presentFeedItem: (item: FeedItem) => ({
+    icon: MapPin,
+    domainLabel: "Location",
+    label: "Someone shared their location",
+    description: "A routine location share.",
+    href: item.metadata.hrefEnabled ? "/one/location" : null,
+  }),
+}));
+
+function feedItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: "item-1",
+    source_domain: "location",
+    event_type: "location_share_created",
+    actor_label: "A contact",
+    metadata: {},
+    read: false,
+    created_at: "2026-08-12T15:45:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("FeedRow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T15:50:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the absolute day/time label next to the description", () => {
+    render(<FeedRow item={feedItem()} onOpen={() => {}} />);
+
+    expect(screen.getByText(/^Today - \d{1,2}:\d{2}\s?[AP]M$/i)).toBeInTheDocument();
+    expect(screen.getByText("A routine location share.")).toBeInTheDocument();
+  });
+
+  it("never renders the old relative time format", () => {
+    render(<FeedRow item={feedItem()} onOpen={() => {}} />);
+
+    expect(screen.queryByText(/^\d+[mhd]$/)).toBeNull();
+    expect(screen.queryByText("now")).toBeNull();
+  });
+
+  it("shows the unread dot when the item is unread", () => {
+    render(<FeedRow item={feedItem({ read: false })} onOpen={() => {}} />);
+
+    expect(screen.getByLabelText("Unread")).toBeInTheDocument();
+  });
+
+  it("does not show the unread dot when the item is read", () => {
+    render(<FeedRow item={feedItem({ read: true })} onOpen={() => {}} />);
+
+    expect(screen.queryByLabelText("Unread")).toBeNull();
+  });
+
+  it("shows a chevron and opens the item when a href is present", () => {
+    const onOpen = vi.fn();
+    render(
+      <FeedRow
+        item={feedItem({ metadata: { hrefEnabled: true } })}
+        onOpen={onOpen}
+      />,
+    );
+
+    screen.getByText("Someone shared their location").closest("button")?.click();
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/hushh-webapp/__tests__/lib/feed/feed-timestamp.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-timestamp.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { daysSinceToday, formatFeedTimestamp } from "@/lib/feed/feed-timestamp";
+
+describe("formatFeedTimestamp", () => {
+  beforeEach(() => {
+    // Pinned "now": Wed, 2026-08-12 15:45 local time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 12, 15, 45, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // AM/PM casing is locale-dependent (this codebase deliberately delegates
+  // locale resolution to the runtime, see local-date-time.ts) — assert the
+  // digits/day-prefix exactly and match am/pm case-insensitively.
+  it("labels a same-day instant as Today, 12-hour clock", () => {
+    const sameDay = new Date(2026, 7, 12, 15, 45, 0);
+    expect(formatFeedTimestamp(sameDay)).toMatch(/^Today - 3:45\s?PM$/i);
+  });
+
+  it("labels the previous calendar day as Yesterday", () => {
+    const yesterday = new Date(2026, 7, 11, 9, 5, 0);
+    expect(formatFeedTimestamp(yesterday)).toMatch(/^Yesterday - 9:05\s?AM$/i);
+  });
+
+  it("labels anything older with a short weekday", () => {
+    const older = new Date(2026, 7, 10, 18, 30, 0); // Mon
+    expect(formatFeedTimestamp(older)).toMatch(/^Mon - 6:30\s?PM$/i);
+  });
+
+  it("always renders 12-hour time, never 24-hour", () => {
+    const afternoon = new Date(2026, 7, 12, 15, 45, 0); // 15:45 local
+    const label = formatFeedTimestamp(afternoon);
+    expect(label).toMatch(/3:45\s?PM/i);
+    expect(label).not.toContain("15:45");
+  });
+
+  it("formats noon and midnight correctly", () => {
+    expect(formatFeedTimestamp(new Date(2026, 7, 12, 12, 0, 0))).toMatch(
+      /^Today - 12:00\s?PM$/i,
+    );
+    expect(formatFeedTimestamp(new Date(2026, 7, 12, 0, 0, 0))).toMatch(
+      /^Today - 12:00\s?AM$/i,
+    );
+  });
+
+  it("returns an empty string for an invalid or missing instant", () => {
+    expect(formatFeedTimestamp("not-a-date")).toBe("");
+    expect(formatFeedTimestamp(Number.NaN)).toBe("");
+  });
+
+  it("produces identical output for Date, ISO string, and epoch-number inputs", () => {
+    const instant = new Date(2026, 7, 12, 15, 45, 0);
+    const fromDate = formatFeedTimestamp(instant);
+    const fromIso = formatFeedTimestamp(instant.toISOString());
+    const fromEpoch = formatFeedTimestamp(instant.getTime());
+    expect(fromIso).toBe(fromDate);
+    expect(fromEpoch).toBe(fromDate);
+  });
+});
+
+describe("daysSinceToday", () => {
+  it("returns 0 for the same calendar day even across different times", () => {
+    const now = new Date(2026, 7, 12, 23, 59, 0);
+    const earlierSameDay = new Date(2026, 7, 12, 0, 1, 0);
+    expect(daysSinceToday(earlierSameDay, now)).toBe(0);
+  });
+
+  it("returns 1 across a local-midnight boundary just before/after it", () => {
+    const now = new Date(2026, 7, 12, 0, 1, 0);
+    const justBeforeMidnight = new Date(2026, 7, 11, 23, 59, 0);
+    expect(daysSinceToday(justBeforeMidnight, now)).toBe(1);
+  });
+
+  it("returns negative values for a future date", () => {
+    const now = new Date(2026, 7, 12, 12, 0, 0);
+    const tomorrow = new Date(2026, 7, 13, 12, 0, 0);
+    expect(daysSinceToday(tomorrow, now)).toBe(-1);
+  });
+});

--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables-sos-address.test.tsx
@@ -168,9 +168,13 @@ describe("useFeedActionables SMS · Save My Soul emergency cards", () => {
     );
     expect(emergency?.description).not.toContain("Last known");
     expect(emergency?.actions).toEqual([]);
+    expect(emergency?.emphasis).toBe("emergency");
+    expect(emergency?.displayTimestamp).toBe(
+      new Date("2026-08-10T00:00:00.000Z").getTime(),
+    );
   });
 
-  it("keeps a revoked SOS card visible as 'Emergency SMS - Revoked' instead of dropping it", async () => {
+  it("keeps a revoked SOS card visible as 'Emergency SMS - Revoked' instead of dropping it, and drops its emergency emphasis", async () => {
     receivedGrantsFixture = [
       {
         id: "sos-grant-1",
@@ -192,6 +196,50 @@ describe("useFeedActionables SMS · Save My Soul emergency cards", () => {
       );
       expect(emergency?.description).toBe("Emergency SMS - Revoked");
     });
+
+    const emergency = result.current.actionables.find(
+      (item) => item.id === "sms-emergency:sos-grant-1",
+    );
+    // Renders as a plain "Needs you" row now, not the pinned emergency card
+    // — with no revokedAt/updatedAt/expiresAt in this fixture, the fallback
+    // chain lands on createdAt.
+    expect(emergency?.emphasis).toBeUndefined();
+    expect(emergency?.sortAt).toBe(new Date("2026-08-10T00:00:00.000Z").getTime());
+    expect(emergency?.displayTimestamp).toBe(
+      new Date("2026-08-10T00:00:00.000Z").getTime(),
+    );
+  });
+
+  it("prefers revokedAt over createdAt for a revoked SOS card's sort/display time", async () => {
+    receivedGrantsFixture = [
+      {
+        id: "sos-grant-1",
+        ownerUserId: "sender-user",
+        recipientUserId: "receiver-user",
+        ownerDisplayName: "Test contact",
+        status: "revoked",
+        shareKind: "sos",
+        shareMessage: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+        revokedAt: "2026-08-12T09:30:00.000Z",
+      },
+    ];
+
+    const { result } = renderHook(() => useFeedActionables());
+
+    await waitFor(() => {
+      const emergency = result.current.actionables.find(
+        (item) => item.id === "sms-emergency:sos-grant-1",
+      );
+      expect(emergency?.description).toBe("Emergency SMS - Revoked");
+    });
+
+    const emergency = result.current.actionables.find(
+      (item) => item.id === "sms-emergency:sos-grant-1",
+    );
+    const revokedAtMs = new Date("2026-08-12T09:30:00.000Z").getTime();
+    expect(emergency?.sortAt).toBe(revokedAtMs);
+    expect(emergency?.displayTimestamp).toBe(revokedAtMs);
   });
 
   it("does NOT put a Clear action on the card itself — the Feed page's existing Clear button owns it", async () => {

--- a/hushh-webapp/components/feed/feed-actionable-row.tsx
+++ b/hushh-webapp/components/feed/feed-actionable-row.tsx
@@ -8,6 +8,7 @@ import { SettingsRow } from "@/components/app-ui/settings-ui";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
+import { formatFeedTimestamp } from "@/lib/feed/feed-timestamp";
 import type {
   FeedActionButton,
   FeedActionable,
@@ -99,13 +100,37 @@ function ActionButtons({ actions }: { actions: FeedActionButton[] }) {
  * trailing buttons from nesting.
  */
 export function FeedActionableRow({ item }: { item: FeedActionable }) {
-  const description = item.spinning ? (
-    <span className="inline-flex items-center gap-1.5">
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent animate-pulse motion-reduce:animate-none" />
-      {item.description}
+  const timeLabel =
+    item.displayTimestamp != null
+      ? formatFeedTimestamp(item.displayTimestamp)
+      : null;
+  const isLive = item.emphasis === "emergency";
+
+  const descriptionBody =
+    item.spinning || isLive ? (
+      <span className="inline-flex min-w-0 items-center gap-1.5">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full animate-pulse motion-reduce:animate-none",
+            isLive ? "bg-emerald-500" : "bg-accent",
+          )}
+        />
+        <span className="truncate">{item.description}</span>
+      </span>
+    ) : (
+      <span className="min-w-0 truncate">{item.description}</span>
+    );
+
+  const description = timeLabel ? (
+    <span className="flex items-center gap-2">
+      <span className="min-w-0 flex-1">{descriptionBody}</span>
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        {timeLabel}
+      </span>
     </span>
   ) : (
-    item.description
+    descriptionBody
   );
 
   const shared = {

--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -31,13 +31,12 @@ import {
   type FeedItem,
   type FeedListResponse,
 } from "@/lib/services/feed-service";
+import { daysSinceToday } from "@/lib/feed/feed-timestamp";
 
 function dayLabel(value: string): string {
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return "";
-  const startOfDay = (input: Date) =>
-    new Date(input.getFullYear(), input.getMonth(), input.getDate()).getTime();
-  const diffDays = Math.round((startOfDay(new Date()) - startOfDay(date)) / 86_400_000);
+  const diffDays = daysSinceToday(date);
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
   return date.toLocaleDateString(undefined, {
@@ -241,19 +240,21 @@ export function FeedPage() {
     );
     return groupItemsByDay(sorted);
   }, [items]);
-  // Emergency SMS cards are individually framed (rounded + bordered), so
-  // stacking them in the same divide-y list as plain rows leaves them
-  // flush against each other with only a hairline between — two SOS alerts
-  // read as one merged block. Render them in their own gapped stack instead;
-  // the sort in useFeedActionables already keeps all "emergency" items
-  // contiguous at the top, so this split never reorders anything.
-  const emergencyActionables = actionables.filter(
+  // A live SOS share gets its own "Live" section, pinned above "Needs you",
+  // so a safety alert is never mistaken for a routine pending item, and two
+  // live SOS cards never read as one merged block (each keeps its own
+  // gapped, individually framed card). A revoked/expired SOS no longer
+  // carries `emphasis: "emergency"` (see useFeedActionables) and falls
+  // straight into the regular divide-y "Needs you" list like any other row.
+  const liveActionables = actionables.filter(
     (item) => item.emphasis === "emergency",
   );
   const regularActionables = actionables.filter(
     (item) => item.emphasis !== "emergency",
   );
-  const hasActionables = actionables.length > 0;
+  const hasLiveActionables = liveActionables.length > 0;
+  const hasRegularActionables = regularActionables.length > 0;
+  const hasActionables = hasLiveActionables || hasRegularActionables;
   // Once cleared this session, the loaded history rows are hidden even though
   // `items` still holds them (no backend delete yet), so the empty state shows.
   const hasHistory = items.length > 0;
@@ -273,23 +274,25 @@ export function FeedPage() {
             arrow (see resolveTopShellBreadcrumb). Only the sticky day dividers
             below travel with the scroll. */}
         <AppPageContentRegion>
-          {hasActionables ? (
+          {hasLiveActionables ? (
+            <section aria-label="Live" className="bg-accent/[0.03]">
+              <SectionLabel>Live</SectionLabel>
+              <div className="flex flex-col gap-2 px-[6px] pb-2">
+                {liveActionables.map((item) => (
+                  <FeedActionableRow key={item.id} item={item} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {hasRegularActionables ? (
             <section aria-label="Needs you" className="bg-accent/[0.03]">
               <SectionLabel>Needs you</SectionLabel>
-              {emergencyActionables.length ? (
-                <div className="flex flex-col gap-2 px-[6px] pb-2">
-                  {emergencyActionables.map((item) => (
-                    <FeedActionableRow key={item.id} item={item} />
-                  ))}
-                </div>
-              ) : null}
-              {regularActionables.length ? (
-                <div className="divide-y divide-[color:var(--foundation-hairline)]">
-                  {regularActionables.map((item) => (
-                    <FeedActionableRow key={item.id} item={item} />
-                  ))}
-                </div>
-              ) : null}
+              <div className="divide-y divide-[color:var(--foundation-hairline)]">
+                {regularActionables.map((item) => (
+                  <FeedActionableRow key={item.id} item={item} />
+                ))}
+              </div>
             </section>
           ) : null}
 

--- a/hushh-webapp/components/feed/feed-row.tsx
+++ b/hushh-webapp/components/feed/feed-row.tsx
@@ -3,6 +3,7 @@
 import { SettingsRow } from "@/components/app-ui/settings-ui";
 import { cn } from "@/lib/utils";
 import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
+import { formatFeedTimestamp } from "@/lib/feed/feed-timestamp";
 import type { FeedIconTone } from "@/lib/feed/use-feed-actionables";
 import type { FeedItem, FeedSourceDomain } from "@/lib/services/feed-service";
 
@@ -14,23 +15,6 @@ const DOMAIN_TONE: Record<FeedSourceDomain, FeedIconTone> = {
   connected_systems: "gray",
   connections: "green",
 };
-
-function timeAgo(value: string): string {
-  const timestamp = new Date(value).getTime();
-  if (!Number.isFinite(timestamp)) return "";
-  const deltaMs = Math.max(0, Date.now() - timestamp);
-  const minutes = Math.floor(deltaMs / (60 * 1000));
-  if (minutes < 1) return "now";
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d`;
-  return new Date(value).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
 
 /**
  * A single historical activity row, built on the canonical SettingsRow so the
@@ -68,20 +52,22 @@ export function FeedRow({
         </span>
       }
       description={
-        <span className="line-clamp-1">{presentation.description}</span>
+        <span className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 line-clamp-1">
+            {presentation.description}
+          </span>
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+            {formatFeedTimestamp(item.created_at)}
+          </span>
+        </span>
       }
       trailing={
-        <span className="flex shrink-0 items-center gap-1.5">
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {timeAgo(item.created_at)}
-          </span>
-          {!read ? (
-            <span
-              aria-label="Unread"
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
-            />
-          ) : null}
-        </span>
+        !read ? (
+          <span
+            aria-label="Unread"
+            className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+          />
+        ) : null
       }
       chevron={Boolean(presentation.href)}
       onClick={presentation.href ? () => onOpen(item) : undefined}

--- a/hushh-webapp/lib/feed/feed-timestamp.ts
+++ b/hushh-webapp/lib/feed/feed-timestamp.ts
@@ -1,0 +1,36 @@
+import { formatLocalDateTime } from "@/lib/utils/local-date-time";
+
+/**
+ * Local-midnight day offset of `date` from `now`: 0 = today, 1 = yesterday,
+ * 2+ = older, negative = future. Shared by every Today/Yesterday
+ * classification in the feed so the calendar-day arithmetic exists in
+ * exactly one place.
+ */
+export function daysSinceToday(date: Date, now: Date = new Date()): number {
+  const startOfDay = (input: Date) =>
+    new Date(input.getFullYear(), input.getMonth(), input.getDate()).getTime();
+  return Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000);
+}
+
+/**
+ * Renders a feed row's right-aligned day/time label: "Today - 3:45 PM",
+ * "Yesterday - 3:45 PM", or "Mon - 3:45 PM" (short weekday) for anything
+ * older. Always a 12-hour clock, explicit regardless of locale default.
+ * Returns "" for an invalid/missing instant so callers can embed the result
+ * directly in JSX without a null-guard.
+ */
+export function formatFeedTimestamp(value: string | number | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) return "";
+  const time = formatLocalDateTime(date, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+  if (!time) return "";
+  const diffDays = daysSinceToday(date);
+  if (diffDays === 0) return `Today - ${time}`;
+  if (diffDays === 1) return `Yesterday - ${time}`;
+  const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
+  return `${weekday} - ${time}`;
+}

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -99,6 +99,15 @@ export interface FeedActionable {
   actions: FeedActionButton[];
   sortAt: number;
   /**
+   * Real-world instant to render as the row's "Today - 3:45 PM" label.
+   * Distinct from `sortAt` (which always falls back to `Date.now()` so
+   * ordering never breaks) — null/absent exactly when there is no real
+   * timestamp to show the user (a consent entry with no `issued_at`, or any
+   * connection request, whose payload carries no timestamp at all).
+   * `FeedActionableRow` omits the label entirely rather than fabricating one.
+   */
+  displayTimestamp?: number | null;
+  /**
    * High-priority visual treatment. "emergency" rows (an incoming SMS · Save My
    * Soul alert) render with prominent red styling and sort above everything else.
    */
@@ -121,6 +130,18 @@ function toTimestamp(value?: string | number | null): number {
   if (value == null) return 0;
   const ts = new Date(value).getTime();
   return Number.isFinite(ts) ? ts : 0;
+}
+
+/**
+ * Same idea as `toTimestamp` but yields `null` (not `0`) when there is no
+ * source value or it doesn't parse — used for `displayTimestamp`, where the
+ * absence of a real instant must suppress the row's time label rather than
+ * silently rendering an epoch-zero date.
+ */
+function toDisplayTimestamp(value?: string | number | null): number | null {
+  if (value == null) return null;
+  const ts = toTimestamp(value);
+  return ts > 0 ? ts : null;
 }
 
 function consentSummary(entry: ConsentCenterEntry): string {
@@ -438,6 +459,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
           // expiry), so treat pending consents as current rather than mixing
           // future expiry into the descending recency sort.
           sortAt: Date.now(),
+          // Real only when the backend happened to populate issued_at — never
+          // fabricate a "just now" time label for this type.
+          displayTimestamp: toDisplayTimestamp(entry.issued_at),
         });
       }
     }
@@ -456,17 +480,33 @@ export function useFeedActionables(): UseFeedActionablesResult {
     for (const grant of smsEmergencies) {
       const label = grant.ownerDisplayName?.trim() || "A contact";
       const isRevoked = !isActiveSmsEmergencyGrant(grant);
+      // A revoked/expired SOS sorts and displays by when it stopped
+      // mattering, not when it was triggered — mirrors the
+      // `revokedAt || updatedAt || expiresAt` "stopped" convention in
+      // lib/one-location/activity.ts, extended with a createdAt fallback so
+      // this is never 0/null.
+      const resolvedAt = isRevoked
+        ? toTimestamp(grant.revokedAt) ||
+          toTimestamp(grant.updatedAt) ||
+          toTimestamp(grant.expiresAt) ||
+          toTimestamp(grant.createdAt)
+        : toTimestamp(grant.createdAt);
       items.push({
         id: `sms-emergency:${grant.id}`,
         icon: Siren,
         iconTone: "red",
-        emphasis: "emergency",
+        // Only a still-live SOS gets the pinned "Live" emergency treatment.
+        // A revoked/expired one renders as a plain "Needs you" row (see
+        // feed-page.tsx) — Siren icon + red icon-well tint are all that's
+        // left as the "this was an SOS" signal.
+        emphasis: isRevoked ? undefined : "emergency",
         title: `${label} triggered an SOS`,
         description: isRevoked ? "Emergency SMS - Revoked" : "Emergency SMS - Sent.",
         href: buildOneLocationNotificationHref(grant.id),
         chevron: true,
         actions: [],
-        sortAt: toTimestamp(grant.createdAt) || Date.now(),
+        sortAt: resolvedAt || Date.now(),
+        displayTimestamp: resolvedAt || null,
       });
     }
 
@@ -522,6 +562,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
           },
         ],
         sortAt: toTimestamp(request.requestedAt) || Date.now(),
+        displayTimestamp: toDisplayTimestamp(request.requestedAt),
       });
     }
 
@@ -575,6 +616,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
           },
         ],
         sortAt: toTimestamp(invite.createdAt) || Date.now(),
+        displayTimestamp: toDisplayTimestamp(invite.createdAt),
       });
     }
 
@@ -645,6 +687,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
               },
             ],
         sortAt: Date.now(),
+        // ConnectionRequest (lib/services/connections-service.ts) carries no
+        // timestamp field at all — never fabricate one for the time label.
+        displayTimestamp: null,
       });
     }
 
@@ -708,6 +753,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
         chevron: running,
         actions,
         sortAt: toTimestamp(task.updatedAt || task.startedAt) || Date.now(),
+        displayTimestamp: toDisplayTimestamp(task.updatedAt || task.startedAt),
       });
     }
 
@@ -739,6 +785,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
         description: task.description || "Working in the background…",
         actions,
         sortAt: toTimestamp(task.updatedAt || task.startedAt) || Date.now(),
+        displayTimestamp: toDisplayTimestamp(task.updatedAt || task.startedAt),
       });
     }
 


### PR DESCRIPTION
# Description

Two follow-on changes to the Feed's "Needs you" zone (builds on #5289, already merged):

1. **Live section split.** A live SOS share and a revoked/expired one used to render
   together, both pinned above the plain "Needs you" list. Only a still-active SOS now
   carries `emphasis: "emergency"` (`hushh-webapp/lib/feed/use-feed-actionables.ts`), so it
   gets its own top-level "Live" section (red framed card, small green pulse dot before the
   description, unchanged gapped stack). Once revoked/expired, the card drops the
   `emphasis` flag and falls straight into the plain `divide-y` "Needs you" list like any
   other row — Siren icon + red icon-well tint are the only residual "this was an SOS"
   signal, no border/ring frame. It also now sorts/displays by
   `revokedAt || updatedAt || expiresAt || createdAt` (when it stopped mattering) instead of
   `createdAt` (when it was triggered), mirroring the existing "stopped" convention in
   `lib/one-location/activity.ts`.
2. **Row timestamps.** Every feed row — Live, Needs you (all types), and historical —
   now shows a small right-aligned `Today - 3:45 PM` / `Yesterday - 3:45 PM` /
   `Mon - 3:45 PM` label (always 12-hour clock) next to its description, via a new shared
   formatter (`hushh-webapp/lib/feed/feed-timestamp.ts`). Sourced from each row type's real
   timestamp; the two actionable types with no reliable one (consent entries without
   `issued_at`, and connection requests, whose payload has no timestamp field at all) show
   no label rather than a fabricated one. Historical rows' old relative `"5m"/"3h"/"2d"`
   chip (`feed-row.tsx`) is replaced by the same absolute format for one consistent
   treatment across the whole page.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] Listed below:
    - `FeedActionable` (internal hook type, not a backend contract) gained
      `displayTimestamp?: number | null`.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared Next.js/React feed UI loaded by the Capacitor webview; no native
        plugin surface involved.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — display/sort logic only; no change to grant read/consent flow.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - `formatFeedTimestamp` returns `""` on an invalid/missing instant (no throw); a row
      with no `displayTimestamp` simply omits the label.
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Verified live on a local dev stack (proxy/backend/frontend against UAT CloudSQL,
      `/one/feed`) with real SOS grants: Live section shows the live card with the green
      pulse; revoking moves it into "Needs you" as a plain row with "Emergency SMS -
      Revoked" and a real day/time label; location/circle-invite rows show real times;
      connection-request rows show none, as designed.
- Verification commands executed:
  - [x] `cd hushh-webapp && npx tsc --noEmit -p tsconfig.json` (clean, 0 errors)
  - [x] `cd hushh-webapp && npx eslint <touched files>` (clean)
  - [x] `cd hushh-webapp && npx vitest run __tests__/lib/feed/ __tests__/components/feed-actionable-row.test.tsx __tests__/components/feed-row.test.tsx __tests__/components/feed-sticky-header.contract.test.ts` (8 files, 45 tests passed)
  - [ ] `npm run build` not run this session

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (`/one/feed`).
- [x] Reachable production attach point: `hushh-webapp/components/feed/feed-page.tsx` → `FeedPage`, mounted at the existing `/one/feed` route.
- [x] New tests import and exercise production code (`useFeedActionables`, `FeedActionableRow`, `FeedRow`, `formatFeedTimestamp`) directly.
- [x] New logic (`displayTimestamp`, `daysSinceToday`, `formatFeedTimestamp`) is wired into the existing row components, not dangling exports.
- [x] Production surface proved: unit tests assert live-vs-revoked emphasis/sort/display behavior and the formatter's Today/Yesterday/weekday/12-hour output; manually verified on a local dev stack against real data.
- [x] Required checks are current on this head, commits are signed off (`git commit -s`), branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [ ] Not a stacked PR (builds on already-merged #5289, no open predecessor).
- [ ] Not responding to prior requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`lib/feed/use-feed-actionables.ts`, `lib/feed/feed-timestamp.ts`, `components/feed/feed-page.tsx`, `components/feed/feed-actionable-row.tsx`, `components/feed/feed-row.tsx`)
- [ ] **iOS**: Not applicable — no native Capacitor plugin surface involved.
- [ ] **Android**: Not applicable — same as iOS.

## 🧪 Testing

- [x] Tested on Web (Chrome, via local dev stack against UAT CloudSQL) — Live/Needs you split, live green dot, revoke transition, and per-row timestamps all verified against real SOS grants.
- [ ] Tested on iOS Simulator/Device — not applicable, no native surface.
- [ ] Tested on Android Emulator/Device — not applicable, no native surface.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Verified interactively on `/one/feed` against a local dev stack (real UAT-backed data) —
Live section with the green-dot live card, revoke transition into plain "Needs you" row,
and per-row day/time labels across Live, Needs you, and history. Not captured as a
screenshot this session.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It reads the same already-fetched actionable data
      (grant status/timestamps, request timestamps, etc.) the feed already loads — no new
      data access.
- [x] Sensitive surface touched: none of auth / consent / vault / PKM / finance /
      voice-action / KYC / schema / deploy / public ingress — display/sort logic only.
- [x] Error path, rollback, or safe-failure behavior proved: see Rollback section above.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes