### PR TITLE
Stop offering nearby check-in to public store users

### DIFF
--- a/hushh-webapp/.env.dev.local.example
+++ b/hushh-webapp/.env.dev.local.example
@@ -37,3 +37,11 @@ NEXT_PUBLIC_GOOGLE_MAPS_ANDROID_API_KEY=replace_with_dev_android_maps_api_key
 
 # Maintainer-only overlay values such as app-review, native signing,
 # REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE, and rehearsal toggles should live in an untracked overlay file.
+
+# Operator opt-ins. These are explicit flags, not environment checks, because
+# the App Store and Play Store binaries are stamped NEXT_PUBLIC_APP_ENV=uat and
+# an environment gate would hand both to real store users. Local UAT-stamped
+# profiles -- including every iOS simulator build, which reads this file -- need
+# them written or the feature silently disappears while you work on it.
+NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN=true
+NEXT_PUBLIC_LOCATION_MAP_DEMO=true

--- a/hushh-webapp/.env.uat.local.example
+++ b/hushh-webapp/.env.uat.local.example
@@ -35,3 +35,11 @@ NEXT_PUBLIC_GOOGLE_MAPS_ANDROID_API_KEY=replace_with_uat_android_maps_api_key
 
 # Maintainer-only overlay values such as app-review, native signing,
 # REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE, and rehearsal toggles should live in an untracked overlay file.
+
+# Operator opt-ins. These are explicit flags, not environment checks, because
+# the App Store and Play Store binaries are stamped NEXT_PUBLIC_APP_ENV=uat and
+# an environment gate would hand both to real store users. Local UAT-stamped
+# profiles -- including every iOS simulator build, which reads this file -- need
+# them written or the feature silently disappears while you work on it.
+NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN=true
+NEXT_PUBLIC_LOCATION_MAP_DEMO=true

--- a/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
@@ -1,10 +1,21 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const nativeTestHarness = vi.hoisted(() => ({ enabled: false }));
+
+vi.mock("@/lib/testing/native-test", () => ({
+  isNativeUiTestSession: () => nativeTestHarness.enabled,
+}));
 
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
 
 describe("nearby check-in availability", () => {
+  beforeEach(() => {
+    nativeTestHarness.enabled = false;
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    nativeTestHarness.enabled = false;
   });
 
   it("is available in local development without a flag", () => {
@@ -61,6 +72,36 @@ describe("nearby check-in availability", () => {
         );
       }
     }
+  });
+
+  /**
+   * The half of this change that protects the people building the product.
+   *
+   * A UAT-stamped build is not only a store binary — it is also every local UAT
+   * profile and every iOS simulator build, because
+   * `prepare-ios-ui-test-build.mjs` reads `.env.uat.local`. Tightening the gate
+   * without writing the opt-in into those profiles would have taken the feature
+   * away from the team with no error and nothing to grep for, which is a worse
+   * outcome than the bug being fixed.
+   *
+   * `scripts/env/bootstrap_profiles.sh` writes the flag for every non-production
+   * local profile, so this is the shape those builds actually have.
+   */
+  it("stays available for local UAT profiles and simulator builds", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+    vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "true");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
+  });
+
+  it("stays available during native UI automation whatever the stamp", () => {
+    // XCUITest / Espresso inject launch args a store user cannot set, so this
+    // never widens the store case it is paired with.
+    nativeTestHarness.enabled = true;
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
+
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
   });
 
   it("keeps local development open regardless of the flag", () => {

--- a/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
@@ -7,39 +7,66 @@ describe("nearby check-in availability", () => {
     vi.unstubAllEnvs();
   });
 
-  it("is available in development and UAT", () => {
+  it("is available in local development without a flag", () => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
-    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
-
-    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
     expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
   });
 
-  it("fails closed in production", () => {
+  /**
+   * This case previously asserted that any UAT-stamped build offers the flow,
+   * and that the flag is *ignored* outside production. Both assertions were the
+   * bug: the public App Store and Play Store binaries are stamped
+   * `NEXT_PUBLIC_APP_ENV=uat` because they ship against the UAT backend
+   * (`release-ios-appstore.yml`, `ship-android-playstore-v1.yml`), so "not
+   * production means safe to offer" put a presence feature the architecture doc
+   * calls a simulation in front of real store users — and against the UAT
+   * backend it does not fail closed the way production does.
+   *
+   * The contract is now explicit opt-in everywhere but local development, and
+   * this test guards the store case directly.
+   */
+  it("stays hidden in any build that has not opted in, including store builds", () => {
+    // The exact shape of a public App Store / Play Store / TestFlight build:
+    // UAT-stamped, and no lane sets the flag.
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(false);
+
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
     expect(isOneLocationNearbyCheckInAvailable()).toBe(false);
   });
 
-  it("stays closed in production for anything but an explicit opt-in", () => {
-    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
-    for (const value of ["", "false", "0", "yes", "on", "1", "TRUE "]) {
-      vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", value);
-      expect(isOneLocationNearbyCheckInAvailable()).toBe(
-        value.trim().toLowerCase() === "true",
-      );
-    }
-  });
-
-  it("opens in production only when the build opts in", () => {
-    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+  it("opens in the deployed web lanes, which do pass the flag", () => {
+    // `deploy-uat.yml` sends `_ONE_LOCATION_NEARBY_CHECK_IN=true`, and
+    // `deploy-production.yml` sends it from the cohort dispatch input. Neither
+    // deployed web surface changes behaviour under the new contract.
     vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "true");
+
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
+
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
     expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
   });
 
-  it("ignores the flag outside production", () => {
-    // The backend admits by cohort regardless, so a non-production build has
-    // nothing to gain from being able to switch this off here.
-    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+  it("treats anything but an exact opt-in as off, in every shipped environment", () => {
+    // Only the two environments a shipped build can carry. `resolveAppEnvironment`
+    // maps anything unrecognised back to development via NODE_ENV, so passing a
+    // made-up value here would assert the fallback, not this gate.
+    for (const environment of ["uat", "production"]) {
+      vi.stubEnv("NEXT_PUBLIC_APP_ENV", environment);
+      for (const value of ["", "false", "0", "yes", "on", "1", "TRUE "]) {
+        vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", value);
+        expect(isOneLocationNearbyCheckInAvailable()).toBe(
+          value.trim().toLowerCase() === "true",
+        );
+      }
+    }
+  });
+
+  it("keeps local development open regardless of the flag", () => {
+    // Turning the flow off for the people building it buys nothing; the
+    // backend still admits by cohort.
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
     vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "false");
     expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
   });

--- a/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
+++ b/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
@@ -1,4 +1,5 @@
 import { resolveAppEnvironment } from "@/lib/app-env";
+import { isNativeUiTestSession } from "@/lib/testing/native-test";
 
 /**
  * Hard ceiling for a usable check-in fix, mirroring the backend's
@@ -52,6 +53,11 @@ export const ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS = 200;
  * unless that account is admitted.
  */
 export function isOneLocationNearbyCheckInAvailable(): boolean {
+  // XCUITest / Espresso automation, which is launch-arg gated and unreachable
+  // for a real store user. Native UI tests build from `.env.uat.local` and are
+  // therefore UAT-stamped like a store binary; without this a nearby test added
+  // later would fail for a reason that has nothing to do with the feature.
+  if (isNativeUiTestSession()) return true;
   if (resolveAppEnvironment() === "development") return true;
   return (
     String(process.env.NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN ?? "")

--- a/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
+++ b/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
@@ -24,18 +24,35 @@ export const ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS = 200;
 /**
  * Whether to offer nearby check-in in this build.
  *
- * Outside production the flow is always on. Production is off unless the build
- * opts in, because the check-in point is client-supplied and cannot be
- * attested: the backend bounds a roaming attack through its continuity guard
- * but cannot prove any single check-in is honest.
+ * Every lane except local development has to opt in. The check-in point is
+ * client-supplied and cannot be attested: the backend bounds a roaming attack
+ * through its continuity guard but cannot prove any single check-in is honest,
+ * and `docs/reference/architecture/one-location-agent.md` is explicit that this
+ * is "a visibly labelled local/UAT simulation" which needs organizer admission
+ * proof, replay resistance, shared abuse limits and bidirectional Block/Report
+ * before trusted attendance or spoof resistance may be claimed.
  *
- * The backend remains authoritative and admits production callers by cohort.
- * This gate only avoids collecting a location for a flow that would then be
- * refused, so it is deliberately the looser of the two — a build with the flag
- * on still gets a 404 from the backend unless that account is admitted.
+ * The gate used to be an environment comparison against production, which
+ * offered the flow to every public App Store and Play Store install. Those
+ * binaries are stamped `NEXT_PUBLIC_APP_ENV=uat` because they ship against the
+ * UAT backend (`release-ios-appstore.yml`, `ship-android-playstore-v1.yml`), so
+ * an environment-shaped gate reads a store install as non-production and hands
+ * a real person a presence feature we do not yet claim is spoof-resistant —
+ * and against the UAT backend it does not fail closed either. Distribution and
+ * backend environment are separate facts, exactly as in
+ * `lib/testing/location-map-demo.ts`.
+ *
+ * The deployed web lanes are unaffected: both already pass
+ * `_ONE_LOCATION_NEARBY_CHECK_IN` through `deploy/frontend.cloudbuild.yaml`.
+ * The store lanes simply never set it, which is the point.
+ *
+ * The backend remains authoritative and admits callers by cohort. This gate
+ * only avoids collecting a location for a flow that would then be refused, so
+ * it stays the looser of the two — a build with the flag on still gets a 404
+ * unless that account is admitted.
  */
 export function isOneLocationNearbyCheckInAvailable(): boolean {
-  if (resolveAppEnvironment() !== "production") return true;
+  if (resolveAppEnvironment() === "development") return true;
   return (
     String(process.env.NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN ?? "")
       .trim()

--- a/scripts/ci/runtime-contract-check.sh
+++ b/scripts/ci/runtime-contract-check.sh
@@ -178,4 +178,41 @@ if grep -q '_LOCATION_MAP_DEMO=true' "$deploy_production_workflow"; then
   exit 1
 fi
 
+# --- Nearby check-in on public store builds -------------------------------
+#
+# Same failure shape as the map demo fixture above, and the same reason. The
+# architecture doc calls nearby check-in "a visibly labelled local/UAT
+# simulation" that still needs organizer admission proof, replay resistance and
+# bidirectional Block/Report before spoof resistance may be claimed. The public
+# store binaries are stamped `NEXT_PUBLIC_APP_ENV=uat`, so an
+# environment-shaped gate reads them as non-production and offers it anyway.
+#
+# The client now requires an explicit opt-in everywhere but local development.
+# Assert that, and assert the two PUBLIC store lanes never opt in. TestFlight is
+# deliberately not covered: it is an internal tester lane, and turning the flow
+# on there is a legitimate choice for whoever owns that build.
+nearby_availability="$REPO_ROOT/hushh-webapp/lib/one-location/nearby-check-in-availability.ts"
+
+# Comment lines are stripped first: the file documents the old gate on purpose,
+# and matching that prose would fail the build for explaining itself.
+if sed -e 's://.*::' -e '/^[[:space:]]*\*/d' "$nearby_availability" |
+  grep -q 'resolveAppEnvironment() !== "production"'; then
+  echo "❌ nearby check-in must not gate on an environment comparison; store builds are stamped uat."
+  exit 1
+fi
+
+if ! grep -q 'NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN' "$nearby_availability"; then
+  echo "❌ nearby check-in availability must read its explicit opt-in flag."
+  exit 1
+fi
+
+for public_store_lane in \
+  "$REPO_ROOT/.github/workflows/release-ios-appstore.yml" \
+  "$REPO_ROOT/.github/workflows/ship-android-playstore-v1.yml"; do
+  if grep -qE 'NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN[ ="]+true' "$public_store_lane"; then
+    echo "❌ $(basename "$public_store_lane") must not enable nearby check-in for public store users."
+    exit 1
+  fi
+done
+
 echo "✅ Runtime contract check passed."

--- a/scripts/env/bootstrap_profiles.sh
+++ b/scripts/env/bootstrap_profiles.sh
@@ -1048,6 +1048,31 @@ hydrate_frontend_cloud() {
   upsert_env_value "$file" "APP_RUNTIME_PROFILE" "$profile"
   upsert_env_value "$file" "NEXT_PUBLIC_APP_ENV" "$env_name"
 
+  # Two operator features are explicit opt-ins rather than environment checks,
+  # because the store binaries are UAT-stamped and an environment gate hands
+  # them to real store users: the nearby check-in flow
+  # (lib/one-location/nearby-check-in-availability.ts) and the fifty-people map
+  # fixture (lib/testing/location-map-demo.ts).
+  #
+  # The consequence lands here. Every UAT-stamped LOCAL profile needs the opt-in
+  # written for it, or the people building the product lose the feature with no
+  # error and nothing to grep for. That covers `.env.uat.local` and
+  # `.env.dev.local`, and it covers every native/simulator build, because
+  # prepare-ios-ui-test-build.mjs reads `.env.uat.local` and is therefore
+  # UAT-stamped exactly like a store binary.
+  #
+  # This cannot re-open the hole it exists to close: the store lanes compose
+  # their env inline in CI and never call this script.
+  #
+  # Deliberately not the production profile. `.env.prod.local` drives
+  # `npm run ios:prepare:prod`, and a locally built production archive has to
+  # behave like production -- the map fixture keeps a hard production floor in
+  # code for the same reason.
+  if [ "$env_name" != "production" ]; then
+    upsert_env_value "$file" "NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN" "true"
+    upsert_env_value "$file" "NEXT_PUBLIC_LOCATION_MAP_DEMO" "true"
+  fi
+
   local backend_url=""
   local frontend_url=""
   if backend_url="$(resolve_cloud_or_cached_secret_value "$project" "BACKEND_URL" "$cache_file")"; then


### PR DESCRIPTION
# Description

Every public **App Store and Play Store** user is currently offered Nearby Check-In — a flow this repo's own architecture doc calls *"a visibly labelled local/UAT simulation"* that *"fails closed in production"*.

The gate was:

```ts
if (resolveAppEnvironment() !== "production") return true;
```

Store binaries are stamped `NEXT_PUBLIC_APP_ENV=uat` because they ship against the UAT backend (`release-ios-appstore.yml:234`, `ship-android-playstore-v1.yml:145`, `ship-ios-testflight.yml:199`). So the gate reads a store install as non-production and returns `true`. **None of those three lanes sets `NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN`**, so the flag was never the deciding factor — the environment stamp was.

And "fails closed in production" does not protect a store user either: they are on the **UAT backend**, where it does not fail closed.

`docs/reference/architecture/one-location-agent.md:351` on what this feature still needs:

> Browser/device GPS is forgeable. Production requires organizer admission proof (signed QR/NFC/provider signal), replay resistance, shared abuse limits, and bidirectional Block/Report before trusted attendance or spoof resistance may be claimed.

That is not something to hand a stranger who downloaded a safety app.

This is the **same failure shape** as the map-demo fixture in #5216/#5297 — distribution and backend environment are separate facts, and an environment-shaped gate conflates them.

## The change

```ts
if (resolveAppEnvironment() === "development") return true;
return flag === "true";
```

| Surface | `APP_ENV` | flag | before | after |
|---|---|---|---|---|
| local dev | development | unset | on | **on** (unchanged) |
| UAT web | uat | `true` via `deploy-uat.yml` | on | **on** (unchanged) |
| production web | production | `true` via the cohort dispatch input | on | **on** (unchanged) |
| **App Store** | uat | unset | **on** | **off** |
| **Play Store** | uat | unset | **on** | **off** |
| **TestFlight** | uat | unset | **on** | **off** |

**No deployed web surface changes behaviour.** Both web lanes already pass `_ONE_LOCATION_NEARBY_CHECK_IN` through `deploy/frontend.cloudbuild.yaml`, so the substitution already existed — only the native lanes move, because none of them opts in.

**TestFlight is worth a decision.** It goes off with the other native lanes. If the team wants it for internal testers that is now one explicit line in that lane, rather than a side effect of how the binary is stamped. I did not add it, because that is a call for whoever owns that build — and the CI guard deliberately leaves TestFlight free.

## The old test asserted the bug

```ts
it("ignores the flag outside production", () => {
  vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
  vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "false");
  expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
});
```

That is the defect written down as a requirement — the same way the map-demo test asserted a UAT-stamped build should show fifty fictional people. Replaced with one that guards the store case directly.

## CI guard

Three assertions in `scripts/ci/runtime-contract-check.sh`, alongside the map-demo ones: the gate may not be an environment comparison, it must read the flag, and neither **public** store lane may turn it on. Each was verified to fail independently by breaking it and restoring:

```
env-shaped gate back   -> nearby check-in must not gate on an environment comparison; store builds are stamped uat.
flag read removed      -> nearby check-in availability must read its explicit opt-in flag.
appstore lane opts in  -> release-ios-appstore.yml must not enable nearby check-in for public store users.
playstore lane opts in -> ship-android-playstore-v1.yml must not enable nearby check-in for public store users.
```

The guard strips comments before matching, so the file can document the old gate without failing the build for explaining itself.

## Verification

- `npx tsc --noEmit` — clean
- `bash scripts/ci/runtime-contract-check.sh` — passes; all four new assertions proven to fail when broken
- `npx vitest run components/one-location lib/one-location …` — **740 passed, 2 failed**, and those 2 (`one-location-settings-placement.contract` — Request Location's icon and placement) are **byte-identical to the `origin/main` baseline** captured earlier today. No regressions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
  - `/one/location` — the Nearby Check-In entry point stops rendering in native store builds. No route, param or navigation change; web is untouched.

- API / schema / type changes:
  - [x] None — the function signature is unchanged.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
  - **This PR is entirely about mobile.** All three native lanes lose the flow until they opt in explicitly. That is the fix, not a side effect. The backend is unchanged and still admits by cohort, so no native client loses access to anything it was actually being granted.

- Docs updated (exact files):
  - [x] None — the reasoning is inline at the gate and in the CI guard. `one-location-agent.md` already describes the intended contract correctly; the code was what disagreed with it.

- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
  - `scripts/ci/runtime-contract-check.sh` — already run by the existing CI contract job.

- Trust boundary touched:
  - [x] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / **deploy** / public ingress listed below:
  - **deploy** (`scripts/ci/` is a protected pipeline path) and a **privacy/safety-adjacent client gate**. The change only ever *narrows* who is offered the flow; it cannot widen it.

- Caller / proxy / backend pairing:
  - [x] Not applicable — client-side availability only. The backend remains authoritative and is not modified.

- Rollback or safe-failure behavior:
  - [x] Listed below:
  - Fails closed by construction: an unset, empty or malformed flag means unavailable. The only value that opens it is the exact string `true`.
  - Rollback is a clean revert; no state, no migration, no stored data.

- UI browser or Playwright proof:
  - [x] Not applicable — the visible effect is an entry point *not* rendering in a native build, which needs a store binary to observe. Covered by unit tests over the real gate plus the CI contract.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `bash scripts/ci/runtime-contract-check.sh` (plus proven negative cases)
  - [x] `npx vitest run lib/one-location/__tests__/nearby-check-in-availability.test.ts lib/testing/__tests__/location-map-demo.test.ts` — 8 passed
  - [x] `npx vitest run components/one-location lib/one-location …` — baseline-compared, detailed above

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: #5216 fixed the map-demo half of this same class, #5297 plumbed its flag. This is the other file that carried the identical gate, named in the L2 register entry.
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: `isOneLocationNearbyCheckInAvailable()` is called by `location-redesign-hub.tsx:642`, the live Location UI, and by `location-immersive-map.tsx`.
- [x] New tests import and exercise production code, not mocks — they call the real gate; the CI assertions read the real source and the real workflows.
- [x] New helpers/components/services are wired to an existing route.
- [x] Production surface proved: every guard executed against a deliberately broken tree and observed to fail with its own message.
- [x] Required checks are current on this head, commits are signed off, branch is based directly on `main`.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [x] If this is one PR in a stack, the predecessor PR is linked here: #5297 (map-demo plumbing, same class), #5298 (open).

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: gate change in the shared client; deployed web behaviour deliberately unchanged.
- [x] **iOS**: the App Store and TestFlight lanes stop offering the flow. No Swift plugin involved.
- [x] **Android**: the Play Store lane likewise. No Kotlin plugin involved.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) — no web behaviour change by design; asserted by the test that both web lanes still open with the flag set.
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command listed above — none changed.

## 📸 Screenshots / Video

No screenshot: the change is an entry point that stops rendering in a store binary. Proof is the environment matrix asserted in `nearby-check-in-availability.test.ts` and the four CI guards demonstrated failing above.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **It reduces access.** The gate exists to avoid collecting a location for a flow that would be refused; narrowing it means fewer people are prompted for a position that was never going to be usable.
- [x] If yes, have you implemented `checkConsentToken()`? Not applicable — no new data path.
- [x] Sensitive surface touched: a **presence/location** entry point on a personal-safety product. The direction is strictly protective.
- [x] Error path, rollback, or safe-failure behavior proved: unset/empty/malformed flag → unavailable; only the literal `true` opens it; asserted across both shipped environments.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependency changes.
