### PR TITLE
fix(one-location): center the invite panel and make its share work from iOS

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -1261,6 +1261,26 @@ describe("OneLocationOnboardingFlow", () => {
       expect(map.contains(seat)).toBe(false);
     });
 
+    it("centers the invite panel on wide viewports instead of pinning it right", () => {
+      renderFlow({ mapPoint: { lat: 19.076, lng: 72.8777 } });
+      openInviteScreen();
+
+      const sheet = screen.getByTestId("one-location-onboarding-ready-panel");
+
+      // It reads as a dialog over the map, so it belongs in the middle of it.
+      // Anchored to the right edge it looked like a panel that had slid off.
+      expect(sheet.className).toContain("md:left-1/2");
+      expect(sheet.className).toContain("md:-translate-x-1/2");
+      expect(sheet.className).toContain("md:top-1/2");
+      expect(sheet.className).toContain("md:-translate-y-1/2");
+      expect(sheet.className).not.toMatch(/md:right-/u);
+
+      // Phone width -- which is what the iOS build renders at -- keeps the
+      // full-width bottom sheet untouched. The centering is a md: concern only.
+      expect(sheet.className).not.toMatch(/(^|\s)left-1\/2(\s|$)/u);
+      expect(sheet.className).not.toMatch(/(^|\s)absolute(\s|$)/u);
+    });
+
     it("yields map height on short windows so the join link stays on screen", () => {
       renderFlow({ mapPoint: { lat: 19.076, lng: 72.8777 } });
       openInviteScreen();

--- a/hushh-webapp/__tests__/one-location/circle-join-url.test.ts
+++ b/hushh-webapp/__tests__/one-location/circle-join-url.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildCircleJoinUrl,
   CIRCLE_JOIN_CODE_PARAM,
   formatCircleCodeForDisplay,
+  resolveCircleJoinOrigin,
 } from "@/lib/one-location/circle-join-url";
+
+/** Repoint the jsdom origin the way each runtime would report it. */
+function setWindowOrigin(origin: string | undefined): void {
+  if (origin === undefined) {
+    // @ts-expect-error -- exercising the server/no-window branch.
+    delete globalThis.window;
+    return;
+  }
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin },
+  });
+}
 
 describe("buildCircleJoinUrl", () => {
   it("builds a clickable join link carrying the code query param", () => {
@@ -33,6 +48,76 @@ describe("buildCircleJoinUrl", () => {
 
   it("exposes the canonical code param name", () => {
     expect(CIRCLE_JOIN_CODE_PARAM).toBe("code");
+  });
+});
+
+describe("resolveCircleJoinOrigin", () => {
+  const realLocation = window.location;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
+  });
+
+  it("keeps the live origin on the web so a UAT invite stays on UAT", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://one.hushh.ai");
+    setWindowOrigin("https://uat.one.hushh.ai");
+
+    expect(resolveCircleJoinOrigin()).toBe("https://uat.one.hushh.ai");
+  });
+
+  it("falls back to the built-in origin on iOS, where the app runs on App://", () => {
+    // capacitor.config.ts pins ios.scheme = "App". Sharing this origin sent
+    // recipients `App://localhost/circle/join?code=...`, which opens nothing.
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://uat.one.hushh.ai");
+    setWindowOrigin("App://localhost");
+
+    expect(resolveCircleJoinOrigin()).toBe("https://uat.one.hushh.ai");
+  });
+
+  it("falls back on Android too, where the origin is https but loopback", () => {
+    // androidScheme: "https" makes this pass an http(s) check while still
+    // resolving to the recipient's own device.
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://uat.one.hushh.ai");
+    setWindowOrigin("https://localhost");
+
+    expect(resolveCircleJoinOrigin()).toBe("https://uat.one.hushh.ai");
+  });
+
+  it("does not hand out a loopback link from local web dev either", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://uat.one.hushh.ai");
+    setWindowOrigin("http://127.0.0.1:3000");
+
+    expect(resolveCircleJoinOrigin()).toBe("https://uat.one.hushh.ai");
+  });
+
+  it("returns null rather than a broken link when nothing is shareable", () => {
+    // Callers then send the code on its own, which is still joinable.
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    setWindowOrigin("App://localhost");
+
+    expect(resolveCircleJoinOrigin()).toBeNull();
+  });
+
+  it("trims a trailing slash off the configured origin", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://one.hushh.ai/");
+    setWindowOrigin("App://localhost");
+
+    expect(resolveCircleJoinOrigin()).toBe("https://one.hushh.ai");
+  });
+
+  it("produces a link a recipient can actually open from an iOS share", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://uat.one.hushh.ai");
+    setWindowOrigin("App://localhost");
+
+    const origin = resolveCircleJoinOrigin();
+    expect(origin).not.toBeNull();
+    expect(buildCircleJoinUrl(origin!, "SWDX-ENDP-B954")).toBe(
+      "https://uat.one.hushh.ai/circle/join?code=SWDX-ENDP-B954",
+    );
   });
 });
 

--- a/hushh-webapp/__tests__/one-location/share-circle-code.test.ts
+++ b/hushh-webapp/__tests__/one-location/share-circle-code.test.ts
@@ -5,6 +5,7 @@ import { Capacitor } from "@capacitor/core";
 import { Share } from "@capacitor/share";
 
 import {
+  buildCircleInviteShareText,
   circleShareLabel,
   isShareCancellationError,
   shareNamedCircleCode,
@@ -147,6 +148,58 @@ describe("Circle code sharing parity", () => {
     expect(
       occurrences(vi.mocked(copyToClipboard).mock.calls[0]![0]!),
     ).toBe(1);
+  });
+});
+
+describe("buildCircleInviteShareText", () => {
+  const withLink = buildCircleInviteShareText({
+    circleLabel: "JHUMMA's Circle",
+    code: "SWDX-ENDP-B954",
+    hasJoinLink: true,
+  });
+
+  it("sends only whose Circle it is and the code", () => {
+    expect(withLink).toBe("Join my JHUMMA's Circle on One. Code SWDX-ENDP-B954");
+  });
+
+  it("stays short enough to read at a glance in a chat thread", () => {
+    // The previous copy ran to three sentences / 219 characters, all of which
+    // the join screen repeats the moment the link opens.
+    expect(withLink.length).toBeLessThanOrEqual(60);
+    expect(withLink.split(". ").length).toBeLessThanOrEqual(2);
+  });
+
+  it("drops the walkthrough the join screen already gives", () => {
+    for (const removed of [
+      "tap the link",
+      "Set up One",
+      "filled in",
+      "stay private",
+      "Location and SMS",
+    ]) {
+      expect(withLink).not.toContain(removed);
+    }
+  });
+
+  it("keeps the code, since some targets drop the url field", () => {
+    expect(withLink).toContain("SWDX-ENDP-B954");
+  });
+
+  it("never embeds a link, which would deliver it twice", () => {
+    // Share targets append `url` to `text`; a link inside the text is a dupe.
+    expect(withLink).not.toMatch(/https?:\/\//);
+  });
+
+  it("says where the code goes when there is no link to tap", () => {
+    const noLink = buildCircleInviteShareText({
+      circleLabel: "K Family Circle",
+      code: "ABCD-EFGH-IJKL",
+      hasJoinLink: false,
+    });
+
+    expect(noLink).toBe(
+      "Join my K Family Circle on One. Enter code ABCD-EFGH-IJKL under Location → People.",
+    );
   });
 });
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -232,7 +232,10 @@ import {
   type EmergencyInfo,
   type EmergencyNumberLookupStatus,
 } from "@/lib/one-location/emergency-numbers";
-import { buildCircleJoinUrl } from "@/lib/one-location/circle-join-url";
+import {
+  buildCircleJoinUrl,
+  resolveCircleJoinOrigin,
+} from "@/lib/one-location/circle-join-url";
 import type {
   DriveDestination,
   DriveSharePayload,
@@ -309,6 +312,7 @@ import {
 import { getApiBaseUrl } from "@/lib/services/api-service";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import {
+  buildCircleInviteShareText,
   circleShareLabel,
   isShareCancellationError,
   shareNamedCircleCode,
@@ -6389,18 +6393,22 @@ export function OneLocationAgentPageContent({
   const handleShareNamedCircleCode = useCallback(
     async (circle: OneLocationCircleDetail, code: string) => {
       try {
-        const joinUrl =
-          typeof window !== "undefined"
-            ? buildCircleJoinUrl(window.location.origin, code)
-            : undefined;
+        // Not window.location.origin: inside the installed iOS/Android build
+        // that is a Capacitor scheme, and the link it produced was dead.
+        const joinOrigin = resolveCircleJoinOrigin();
+        const joinUrl = joinOrigin
+          ? buildCircleJoinUrl(joinOrigin, code)
+          : undefined;
         const circleLabel = circleShareLabel(circle.name);
         const delivery = await shareNamedCircleCode({
           title: `Join ${circle.name} on One`,
           // The link lives in `url` only. Repeating it inline made share targets
           // that append `url` to `text` (WhatsApp, Messages) deliver it twice.
-          text: joinUrl
-            ? `Join my ${circleLabel} on One — tap the link to join, or enter code ${code}. Location and SMS stay private until you choose to share.`
-            : `Join my ${circleLabel} on One with code ${code}. You'll connect with current and future members, while location and SMS stay private until you choose to share.`,
+          text: buildCircleInviteShareText({
+            circleLabel,
+            code,
+            hasJoinLink: Boolean(joinUrl),
+          }),
           dialogTitle: "Share Circle code",
           url: joinUrl,
         });
@@ -6564,17 +6572,21 @@ export function OneLocationAgentPageContent({
   const handleShareOnboardingCircleInvite = useCallback(
     async (invite: OnboardingCircleInvite) => {
       try {
-        const joinUrl =
-          typeof window !== "undefined"
-            ? buildCircleJoinUrl(window.location.origin, invite.code)
-            : undefined;
+        // See handleShareNamedCircleCode: the live origin is a Capacitor scheme
+        // in the installed build, so the shared link has to come from here.
+        const joinOrigin = resolveCircleJoinOrigin();
+        const joinUrl = joinOrigin
+          ? buildCircleJoinUrl(joinOrigin, invite.code)
+          : undefined;
         const circleLabel = circleShareLabel(invite.circleName);
         const delivery = await shareNamedCircleCode({
           title: `Join ${invite.circleName} on One`,
           // Link in `url` only — see the note on handleShareNamedCircleCode.
-          text: joinUrl
-            ? `Join my ${circleLabel} on One — tap the link to join, or enter code ${invite.code}. Set up One, then the link opens the join screen with the code filled in. Location and SMS stay private until you choose to share.`
-            : `Join my ${circleLabel} on One with code ${invite.code}. Set up One, then open Location → People → Join a circle and enter it. Location and SMS stay private until you choose to share.`,
+          text: buildCircleInviteShareText({
+            circleLabel,
+            code: invite.code,
+            hasJoinLink: Boolean(joinUrl),
+          }),
           dialogTitle: "Share Circle code",
           url: joinUrl,
         });

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -1762,7 +1762,7 @@ function ReadyScreen({
       </header>
 
       <div
-        className="relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-white shadow-[0_-8px_24px_rgba(24,57,91,0.10)] dark:bg-[#14171d] md:absolute md:right-[max(44px,6vw)] md:top-1/2 md:mt-0 md:h-auto md:max-h-[calc(100dvh-96px)] md:w-[430px] md:-translate-y-1/2 md:rounded-[30px] md:shadow-[0_24px_80px_rgba(24,57,91,0.22)]"
+        className="relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-white shadow-[0_-8px_24px_rgba(24,57,91,0.10)] dark:bg-[#14171d] md:absolute md:left-1/2 md:top-1/2 md:mt-0 md:h-auto md:max-h-[calc(100dvh-96px)] md:w-[430px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[30px] md:shadow-[0_24px_80px_rgba(24,57,91,0.22)]"
         data-testid="one-location-onboarding-ready-panel"
       >
         <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4 pt-6 md:px-7 md:pb-5 md:pt-7">

--- a/hushh-webapp/lib/one-location/circle-join-url.ts
+++ b/hushh-webapp/lib/one-location/circle-join-url.ts
@@ -22,6 +22,52 @@ export function formatCircleCodeForDisplay(raw: string): string {
   return normalized.replace(/(.{4})(?=.)/g, "$1-");
 }
 
+const WEB_ORIGIN = /^https?:\/\//i;
+const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])$/i;
+
+/**
+ * An origin only counts if the person receiving the invite could open it.
+ *
+ * That rules out Capacitor's two runtime origins -- `App://localhost` on iOS
+ * (rejected on scheme) and `https://localhost` on Android (rejected on host,
+ * since it passes an http(s) check but resolves to the recipient's own device).
+ */
+function normalizeWebOrigin(value: string | null | undefined): string | null {
+  const trimmed = String(value || "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (!WEB_ORIGIN.test(trimmed)) return null;
+  try {
+    return LOOPBACK_HOST.test(new URL(trimmed).hostname) ? null : trimmed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The origin a shared join link must point at.
+ *
+ * Capacitor does not serve the installed app from a web origin: iOS runs on the
+ * custom `App://localhost` scheme (`ios.scheme` in capacitor.config.ts) and
+ * Android on `https://localhost`. Sharing `window.location.origin` from a device
+ * therefore delivered `App://localhost/circle/join?code=...` -- a link that is
+ * dead for whoever receives it, which is why the invite only ever worked when
+ * shared from a browser.
+ *
+ * The live origin still wins on the web so a UAT invite keeps pointing at UAT.
+ * Only when it is not a real web origin do we fall back to the origin baked into
+ * the build (NEXT_PUBLIC_APP_URL, set by the TestFlight/App Store/Play
+ * workflows). Returns null when neither is usable, which makes callers share the
+ * code on its own rather than a broken link.
+ */
+export function resolveCircleJoinOrigin(): string | null {
+  const live =
+    typeof window === "undefined"
+      ? null
+      : normalizeWebOrigin(window.location?.origin);
+  return live ?? normalizeWebOrigin(process.env.NEXT_PUBLIC_APP_URL);
+}
+
 export function buildCircleJoinUrl(origin: string, code: string): string {
   const base = String(origin || "").replace(/\/+$/, "");
   const trimmedCode = String(code || "").trim();

--- a/hushh-webapp/lib/one-location/share-circle-code.ts
+++ b/hushh-webapp/lib/one-location/share-circle-code.ts
@@ -32,6 +32,32 @@ export function circleShareLabel(name: string): string {
 }
 
 /**
+ * The message that goes out with a Circle invite.
+ *
+ * This is read in a chat thread, not in the product, so it carries the two
+ * things the recipient cannot get anywhere else -- whose Circle it is and the
+ * code -- and nothing else. The earlier copy also explained what tapping the
+ * link would do, how to find the join screen by hand, and what stays private;
+ * all three are answered by the join screen itself the moment the link opens,
+ * so in the message they were three sentences nobody needed to read.
+ *
+ * The code stays in the text even alongside a link, because share targets that
+ * drop the `url` field would otherwise deliver an invite with no way to join.
+ * Without a link the message has to say where the code goes, since there is
+ * nothing to tap.
+ */
+export function buildCircleInviteShareText(params: {
+  circleLabel: string;
+  code: string;
+  hasJoinLink: boolean;
+}): string {
+  const opening = `Join my ${params.circleLabel} on One.`;
+  return params.hasJoinLink
+    ? `${opening} Code ${params.code}`
+    : `${opening} Enter code ${params.code} under Location → People.`;
+}
+
+/**
  * Share a short-lived Circle invite. When a `url` is supplied it is the ONLY
  * place the join link appears: most share targets (WhatsApp, Messages) append
  * `url` to `text`, so a link repeated inside `text` is delivered twice. Callers


### PR DESCRIPTION
Three bugs from the onboarding "You're on the map" screen.

## 1. The invite panel was pinned to the right edge

On `md:` and up it was anchored with `md:right-[max(44px,6vw)]` over a full-bleed map, so it read as a panel that had slid off rather than a dialog over the map. It now centers on both axes.

Phone width — which is what the iOS build renders at — is untouched: the full-width bottom sheet keeps its existing geometry. The centering is a `md:` concern only, and the test asserts that.

## 2. The shared join link was dead when shared from the app

Both share handlers built the link from `window.location.origin`. Inside the installed build that is not a web origin:

| Runtime | Origin | Shared link |
|---|---|---|
| Web | `https://uat.one.hushh.ai` | works |
| iOS | `App://localhost` (`ios.scheme`) | `App://localhost/circle/join?code=…` — dead |
| Android | `https://localhost` (`androidScheme`) | points at the recipient's own device — dead |

So the invite only ever worked when shared from a browser.

`resolveCircleJoinOrigin()` keeps the live origin on the web (a UAT invite stays on UAT) and falls back to the origin baked into the build — `NEXT_PUBLIC_APP_URL`, already set by the TestFlight / App Store / Play workflows — when the live origin is not a real web origin. Loopback hosts are rejected as well, which is what catches Android: `https://localhost` passes an http(s) check while still resolving to the recipient's device.

When neither is usable it returns `null` and the code goes out on its own, which is still joinable — a degradation, not a broken link.

## 3. The share message was three sentences too long

Before:

> Join my JHUMMA's Circle on One — tap the link to join, or enter code SWDX-ENDP-B954. Set up One, then the link opens the join screen with the code filled in. Location and SMS stay private until you choose to share.

After:

> Join my JHUMMA's Circle on One. Code SWDX-ENDP-B954

219 chars → 51. Everything removed is answered by the join screen the moment the link opens, including the privacy line — `app/circle/join/page.tsx` already tells the recipient their location stays private, at the point where they actually decide. The code stays in the text alongside the link because share targets that drop the `url` field would otherwise deliver an invite with no way to join.

Both handlers now build copy through one helper, so the two messages cannot drift apart again (they already had).

## Verification

Automated only — no manual clicking.

- `vitest run` on the three affected suites: **80 passed**
- `tsc --noEmit`: clean
- `eslint --max-warnings=0` on all changed files: clean

Every new test was **mutation-checked** by restoring the pre-fix behavior:

| Mutation | Result |
|---|---|
| Panel back to `md:right-[…]` | 1 failed |
| Trust `window.location.origin` (the iOS bug) | 6 failed |
| Restore the long share copy | 3 failed |

## Not in this PR

`shareNamedCircleCode` passes `url` as a separate field on Android, but Android share targets drop it — `components/wallet-card/wallet-card-share.ts` already folds the url into the text for exactly this reason. Circle invites don't. Pre-existing, separate fix.