### PR TITLE
fix(one-location): prefill the entrance form, and stop the save sheet reading as a patch

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -581,6 +581,62 @@ First must be empty — any hit is a raw `tel:` template that skipped the helper
 Second must list both directory surfaces (`advisor-detail-surface.tsx` and
 `insurance-agent-detail-surface.tsx`).
 
+### R15 — An overlay's z-index is meaningless until you name what it must sit above
+
+**Incident (2026-08-16, the Location onboarding "save a place" sheet).**
+The sheet's scrim was `z-[559]` with `bg-black/45 backdrop-blur-[6px]` — correct
+CSS, correct intent, and completely invisible. Location onboarding renders as a
+full-screen **opaque** takeover at `z-[560]`, so the dim and the blur were painted
+underneath it. The sheet's own content tied at `z-[560]` and won on portal order,
+which is why it appeared at all: a white rectangle pasted onto a fully lit screen
+with no separation. Reported as "it's looking like a patch — background should be
+blur", which reads as a missing blur and is actually a buried one. Adding more
+blur would have changed nothing.
+
+**Rule.** A modal layered over a takeover, drawer, or any other full-screen
+surface must be checked against **that surface's** z-index, not against the app's
+default chrome. Before setting one, grep the z-indexes it must clear and the ones
+it must stay under, and write both into the comment. Here: above the onboarding
+takeover at 560, below the shared sheet/drawer layer at 711.
+
+**Check.**
+```bash
+git grep -nE 'fixed inset-0 z-\[[0-9]{3}\]' -- hushh-webapp/components hushh-webapp/app \
+  | grep -E 'bg-(white|\[#)' 
+git grep -nE 'overlayClassName="z-\[([0-9]{3})\]' -- hushh-webapp/components
+```
+Every overlay in the second list must outrank every opaque full-screen layer in
+the first that it can appear over. The Location pair is 600/601 vs 560.
+
+### R16 — A Tailwind arbitrary value does not always beat the class it is meant to replace
+
+**Incident (2026-08-16, giving that same sheet a real elevation.)**
+`cn(...)` merged `shadow-[var(--app-card-shadow-feature)]` from the dialog
+primitive with `shadow-[0_24px_60px_-12px_rgba(16,24,40,0.35),...]` from the
+caller. tailwind-merge kept **both** classes on the element — it cannot compare
+two opaque arbitrary values — and the base one won on stylesheet order. Typecheck,
+lint and the unit tests were all green; the class was present in the DOM; the
+shadow simply never rendered. Only reading `getComputedStyle(...).boxShadow` in a
+real browser exposed it.
+
+**Rule.** When an arbitrary-value utility overrides another arbitrary-value
+utility of the same property, assert the **computed** style, not the class list.
+If it loses, mark it `!`. This applies to any comma-bearing arbitrary value
+(`shadow-[…]`, `transition-[…]`, `bg-[image:…]`, `grid-template-columns-[…]`).
+
+**Check.**
+```bash
+# Every shared primitive that ships its own arbitrary shadow.
+git grep -lE 'shadow-\[' -- hushh-webapp/components/ui
+# Every caller trying to override one of those from the outside.
+git grep -nE 'shadow-\[0_' -- hushh-webapp/components hushh-webapp/app \
+  | grep -v 'components/ui/' | grep -v '!shadow-'
+```
+The first lists the base layers (`dialog`, `sheet`, `alert-dialog`, `card`,
+`tabs`, `sidebar`). Any hit in the second is a caller whose shadow may be silently
+losing to one of them — read `getComputedStyle(el).boxShadow` in a browser before
+believing it rendered.
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/hushh-webapp/__tests__/lib/one-location/saved-location-address-prefill.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-location-address-prefill.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSavedLocationAddress,
+  EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
+  inferHouseOrFlat,
+  inferPostalCode,
+  inferSavedLocationAddressDetails,
+  isPlusCode,
+  stripPlusCodeSegment,
+} from "@/lib/one-location/saved-location-address";
+
+/**
+ * Every case below is a way the entrance form could be prefilled with the
+ * wrong thing, or with nothing, on an address that plainly carried the
+ * answer. The reported symptom was always the same sentence -- "the address
+ * is not populating" -- so they are grouped by what actually went wrong.
+ */
+describe("prefilling the entrance form from a detected address", () => {
+  describe("plus codes are coordinates, not addresses", () => {
+    it("recognises short and full Open Location Codes", () => {
+      expect(isPlusCode("FVJ7+JR2")).toBe(true);
+      expect(isPlusCode("7JVW52GR+2V")).toBe(true);
+      expect(isPlusCode("  fvj7+jr2 ")).toBe(true);
+      expect(isPlusCode("B-284/3")).toBe(false);
+      expect(isPlusCode("Flat 4B")).toBe(false);
+      expect(isPlusCode("")).toBe(false);
+    });
+
+    it("never offers a plus code as a house number", () => {
+      // It has no spaces and it carries digits, so the old shape rule took it
+      // and wrote a coordinate into "House, flat, floor or block".
+      expect(
+        inferHouseOrFlat(
+          "FVJ7+JR2, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+        ),
+      ).toBe("");
+      expect(
+        inferSavedLocationAddressDetails(
+          "FVJ7+JR2, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+        ),
+      ).toEqual({ houseOrFlat: "", postalCode: "211004" });
+    });
+
+    it("drops the plus code from the line that is shown and saved", () => {
+      expect(
+        stripPlusCodeSegment(
+          "FVJ7+JR2, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+        ),
+      ).toBe("Teliarganj, Prayagraj, Uttar Pradesh 211004, India");
+      expect(
+        buildSavedLocationAddress(
+          "FVJ7+JR2, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+          EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
+        ),
+      ).toBe("Teliarganj, Prayagraj, Uttar Pradesh 211004, India");
+    });
+
+    it("keeps a plus code that is the only thing Google returned", () => {
+      // A coordinate in disguise still beats a blank line.
+      expect(stripPlusCodeSegment("FVJ7+JR2")).toBe("FVJ7+JR2");
+    });
+
+    it("still finds the house number hiding behind a plus code", () => {
+      expect(
+        inferSavedLocationAddressDetails(
+          "FVJ7+JR2, Qtr. No.- 123/2, Saraswati Vihar, Prayagraj 211004, India",
+        ),
+      ).toEqual({ houseOrFlat: "Qtr. No.- 123/2", postalCode: "211004" });
+    });
+
+    it("leaves an ordinary address untouched", () => {
+      const address = "B-284/3, Rd Number 1, New Delhi, Delhi 110074, India";
+      expect(stripPlusCodeSegment(address)).toBe(address);
+      expect(stripPlusCodeSegment(null)).toBeNull();
+      expect(stripPlusCodeSegment("   ")).toBeNull();
+    });
+  });
+
+  describe("house designators people actually write", () => {
+    it("reads the Indian forms the old rule threw away", () => {
+      // Each of these has a space, so the old rule required the segment to
+      // name itself -- and it only knew flat/plot/house/apt/no/#/door/shop/
+      // unit/block. "Qtr. No.- 123/2" is a real address off a real pin.
+      expect(inferHouseOrFlat("Qtr. No.- 123/2, Old Cantt, Prayagraj")).toBe(
+        "Qtr. No.- 123/2",
+      );
+      expect(inferHouseOrFlat("H. No. 45, Sector 12, Noida")).toBe(
+        "H. No. 45",
+      );
+      expect(inferHouseOrFlat("D No 12-3-45, Vijayawada")).toBe("D No 12-3-45");
+      expect(inferHouseOrFlat("Quarter 8B, Railway Colony")).toBe("Quarter 8B");
+      expect(inferHouseOrFlat("Room 210, Hostel C")).toBe("Room 210");
+      expect(inferHouseOrFlat("Suite 900, Market Street")).toBe("Suite 900");
+    });
+
+    it("keeps the forms that already worked", () => {
+      expect(inferHouseOrFlat("B-284/3, Rd Number 1, New Delhi")).toBe(
+        "B-284/3",
+      );
+      expect(inferHouseOrFlat("Flat 4B, Tower 2, Pune")).toBe("Flat 4B");
+      expect(inferHouseOrFlat("42, Some Lane, Chennai")).toBe("42");
+    });
+
+    it("still refuses a street that merely carries a number", () => {
+      // A wrong prefill is worse than an empty one: people trust prefilled
+      // fields and stop reading them.
+      expect(inferHouseOrFlat("12 MG Road, Bengaluru")).toBe("");
+      expect(inferHouseOrFlat("Kartavya Path, New Delhi")).toBe("");
+      expect(inferHouseOrFlat("Rd Number 1, Chhatarpur")).toBe("");
+      expect(inferHouseOrFlat("")).toBe("");
+      expect(inferHouseOrFlat(null)).toBe("");
+    });
+  });
+
+  describe("postal codes outside the 5- and 6-digit world", () => {
+    it("keeps finding Indian and US codes first", () => {
+      expect(inferPostalCode("New Delhi, Delhi 110001, India")).toBe("110001");
+      expect(inferPostalCode("Seattle, WA 98101-1234, USA")).toBe("98101-1234");
+    });
+
+    it("finds UK, Canadian and Dutch codes it used to miss", () => {
+      // isValidPostalCode has always ACCEPTED these. Nothing ever detected
+      // them, so anyone outside India or the US got an empty field on an
+      // address that plainly carried one.
+      expect(inferPostalCode("10 Downing St, London SW1A 2AA, UK")).toBe(
+        "SW1A 2AA",
+      );
+      expect(inferPostalCode("Ottawa, ON K1A 0B1, Canada")).toBe("K1A 0B1");
+      expect(inferPostalCode("Dam 1, 1012 JS Amsterdam, Netherlands")).toBe(
+        "1012 JS",
+      );
+    });
+
+    it("takes a bare four-digit code only from the tail of the address", () => {
+      expect(inferPostalCode("12 Pitt St, Sydney NSW, 2000")).toBe("2000");
+      // A road number at the head is not a postal code.
+      expect(inferPostalCode("2000 Marine Drive, Mumbai, Maharashtra")).toBe(
+        "",
+      );
+      expect(inferPostalCode("Address without a postal code")).toBe("");
+      expect(inferPostalCode(null)).toBe("");
+    });
+  });
+
+  describe("what the dropped address line cost", () => {
+    const details = {
+      houseOrFlat: "Qtr. No.- 123/2",
+      buildingColor: "",
+      landmark: "",
+      postalCode: "211004",
+    };
+
+    it("saves the whole line when the modal's address reaches the composer", () => {
+      expect(
+        buildSavedLocationAddress(
+          "Qtr. No.- 123/2, Saraswati Vihar, Old Cantt, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+          details,
+        ),
+      ).toBe(
+        "Qtr. No.- 123/2, Saraswati Vihar, Old Cantt, Teliarganj, Prayagraj, Uttar Pradesh 211004, India",
+      );
+    });
+
+    it("saves only fragments when it does not", () => {
+      // This is what root setup persisted for every pre-vault save: the modal
+      // passed the address line, the onboarding call site dropped it, and the
+      // state it used instead is null until a vault token exists.
+      expect(buildSavedLocationAddress(null, details)).toBe(
+        "Qtr. No.- 123/2, 211004",
+      );
+    });
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -9295,6 +9295,15 @@ export function OneLocationAgentPageContent({
       category: SavedLocationCategory,
       label: string,
       details?: SavedLocationAddressDetails,
+      /**
+       * The address line exactly as the modal had it when Save was pressed.
+       * The modal already dropped this in favour of `saveLocationAddress`
+       * state, which is null for the whole of root setup -- there is no vault
+       * token yet, so nothing ever reverse-geocodes into it. The place then
+       * saved with no address at all, which is what "address is not
+       * populating" looked like once it reached the vault.
+       */
+      addressLine?: string | null,
     ) => {
       if (
         !auth.userId ||
@@ -9309,14 +9318,18 @@ export function OneLocationAgentPageContent({
       const sessionEpoch = savedLocationSessionEpochRef.current;
       setSaveLocationSaving(true);
       try {
+        // What was on screen wins over what state happened to hold.
+        const composedFrom =
+          (typeof addressLine === "string" ? addressLine.trim() : "") ||
+          saveLocationAddress;
         const input = {
           category,
           label,
           latitude: saveLocationPoint.latitude,
           longitude: saveLocationPoint.longitude,
           address: details
-            ? buildSavedLocationAddress(saveLocationAddress, details)
-            : saveLocationAddress,
+            ? buildSavedLocationAddress(composedFrom, details)
+            : composedFrom,
         };
         const canPersistNow = Boolean(vaultKey && vaultOwnerToken);
         if (vaultKey && vaultOwnerToken) {
@@ -9911,8 +9924,13 @@ export function OneLocationAgentPageContent({
           initialAccuracyM={saveLocationPoint?.accuracyM}
           rendererDisclosureAccepted={savedLocationRendererAccepted}
           onAcceptRendererDisclosure={acceptSavedLocationMapRenderer}
-          onSave={(category, label, details) =>
-            void handleSaveOnboardingLocation(category, label, details)
+          onSave={(category, label, details, addressLine) =>
+            void handleSaveOnboardingLocation(
+              category,
+              label,
+              details,
+              addressLine,
+            )
           }
           onSkip={handleSkipSaveOnboardingLocation}
         />

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -8,50 +8,80 @@ const mapPickerMockState = vi.hoisted(() => ({
     longitude: 77.2091,
     address: "Kartavya Path, New Delhi, Delhi 110001, India",
   },
+  /** Mirrors a settled pin whose address lookup has finished. */
+  canConfirm: true,
 }));
 
-vi.mock("@/components/one-location/onboarding/location-picker-map", () => ({
-  LocationPickerMap: ({
-    onConfirm,
-    onCancel,
-    confirmLabel,
-    cancelLabel,
-    rendererDisclosureAccepted,
-    onAcceptRendererDisclosure,
-  }: {
-    onConfirm: (picked: {
-      latitude: number;
-      longitude: number;
-      address: string;
-    }) => void;
-    onCancel: () => void;
-    confirmLabel: string;
-    cancelLabel: string;
-    rendererDisclosureAccepted: boolean;
-    onAcceptRendererDisclosure: () => Promise<void>;
-  }) => {
-    if (!rendererDisclosureAccepted) {
-      return (
-        <button type="button" onClick={() => void onAcceptRendererDisclosure()}>
-          Use Google Maps
-        </button>
+vi.mock("@/components/one-location/onboarding/location-picker-map", async () => {
+  const { useEffect, useImperativeHandle } = await import("react");
+  return {
+    LocationPickerMap: ({
+      ref,
+      onConfirm,
+      onReadyChange,
+      onCancel,
+      confirmLabel,
+      cancelLabel,
+      rendererDisclosureAccepted,
+      onAcceptRendererDisclosure,
+    }: {
+      ref?: React.Ref<{ canConfirm: () => boolean; confirm: () => boolean }>;
+      onConfirm: (picked: {
+        latitude: number;
+        longitude: number;
+        address: string;
+      }) => void;
+      onReadyChange?: (ready: boolean) => void;
+      onCancel: () => void;
+      confirmLabel: string;
+      cancelLabel: string;
+      rendererDisclosureAccepted: boolean;
+      onAcceptRendererDisclosure: () => Promise<void>;
+    }) => {
+      // The real picker owns the pin, its settle state and its address, so a
+      // swipe or a dot tap has to ask it whether it may commit. The mock has
+      // to answer the same question or the carousel is untested.
+      useImperativeHandle(
+        ref,
+        () => ({
+          canConfirm: () => mapPickerMockState.canConfirm,
+          confirm: () => {
+            if (!mapPickerMockState.canConfirm) return false;
+            onConfirm(mapPickerMockState.picked);
+            return true;
+          },
+        }),
+        [onConfirm],
       );
-    }
-    return (
-      <div aria-label="Mock location picker">
-        <button
-          type="button"
-          onClick={() => onConfirm(mapPickerMockState.picked)}
-        >
-          {confirmLabel}
-        </button>
-        <button type="button" onClick={onCancel}>
-          {cancelLabel}
-        </button>
-      </div>
-    );
-  },
-}));
+      useEffect(() => {
+        onReadyChange?.(mapPickerMockState.canConfirm);
+      }, [onReadyChange]);
+      if (!rendererDisclosureAccepted) {
+        return (
+          <button
+            type="button"
+            onClick={() => void onAcceptRendererDisclosure()}
+          >
+            Use Google Maps
+          </button>
+        );
+      }
+      return (
+        <div aria-label="Mock location picker">
+          <button
+            type="button"
+            onClick={() => onConfirm(mapPickerMockState.picked)}
+          >
+            {confirmLabel}
+          </button>
+          <button type="button" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+        </div>
+      );
+    },
+  };
+});
 
 import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
 
@@ -71,6 +101,7 @@ describe("SaveLocationModal", () => {
       longitude: 77.2091,
       address: "Kartavya Path, New Delhi, Delhi 110001, India",
     };
+    mapPickerMockState.canConfirm = true;
   });
 
   it("shows address lookup progress without exposing coordinates", () => {
@@ -638,5 +669,245 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
 
     expect(baseProps.onSkip).not.toHaveBeenCalled();
+  });
+
+  describe("the pin and the details as one carousel", () => {
+    const carouselProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      mapInitial: { latitude: 28.6139, longitude: 77.209 },
+      onPickExactLocation: vi.fn(),
+      startWithMapPicker: true,
+      collectAddressDetails: true,
+    };
+
+    /**
+     * jsdom's synthetic pointer events carry no coordinates, and a swipe is
+     * nothing but coordinates. Dispatching a real MouseEvent under the
+     * pointer event's name gives React the clientX/clientY the handler reads.
+     */
+    const pointer = (
+      element: Element,
+      type: "pointerdown" | "pointerup",
+      x: number,
+      y: number,
+    ) => {
+      const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+      });
+      Object.defineProperty(event, "pointerType", { value: "touch" });
+      fireEvent(element, event);
+    };
+
+    const drag = (element: Element, deltaX: number, deltaY = 0) => {
+      pointer(element, "pointerdown", 200, 300);
+      pointer(element, "pointerup", 200 + deltaX, 300 + deltaY);
+    };
+
+    const swipe = (element: Element, deltaX: number) => drag(element, deltaX);
+
+    it("counts slides with dots instead of announcing extra steps", () => {
+      render(<SaveLocationModal {...carouselProps} />);
+
+      expect(screen.queryByText("Step 1 of 2")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("tab")).toHaveLength(2);
+      expect(
+        screen.getByRole("tab", { name: "Pin your entrance" }),
+      ).toHaveAttribute("aria-selected", "true");
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      expect(screen.queryByText("Step 2 of 2")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Address details" }),
+      ).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("moves between slides by swiping", () => {
+      render(<SaveLocationModal {...carouselProps} />);
+      const sheet = screen.getByTestId("save-location-modal");
+
+      swipe(sheet, -120);
+      expect(
+        screen.getByRole("dialog", { name: "Add your address details" }),
+      ).toBeInTheDocument();
+
+      swipe(sheet, 120);
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument();
+    });
+
+    it("leaves a gesture that started on the map to the map", () => {
+      // Panning to place the pin is a horizontal drag too. Stealing it would
+      // make the pin impossible to move.
+      render(<SaveLocationModal {...carouselProps} />);
+      const sheet = screen.getByTestId("save-location-modal");
+      const mapSurface = document.createElement("div");
+      mapSurface.setAttribute("data-location-picker-surface", "");
+      sheet.appendChild(mapSurface);
+
+      swipe(mapSurface, -120);
+
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument();
+    });
+
+    it("ignores a short drag and a vertical scroll", () => {
+      render(<SaveLocationModal {...carouselProps} />);
+      const sheet = screen.getByTestId("save-location-modal");
+
+      swipe(sheet, -30);
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument();
+
+      drag(sheet, -80, 300);
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument();
+    });
+
+    it("commits the pin when the second dot is tapped", () => {
+      const onPickExactLocation = vi.fn();
+      render(
+        <SaveLocationModal
+          {...carouselProps}
+          onPickExactLocation={onPickExactLocation}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("tab", { name: "Address details" }));
+
+      expect(onPickExactLocation).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByRole("dialog", { name: "Add your address details" }),
+      ).toBeInTheDocument();
+    });
+
+    it("will not advance while the pin is still settling", () => {
+      mapPickerMockState.canConfirm = false;
+      render(<SaveLocationModal {...carouselProps} />);
+
+      expect(
+        screen.getByRole("tab", { name: "Address details" }),
+      ).toBeDisabled();
+
+      swipe(screen.getByTestId("save-location-modal"), -120);
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("the sheet reads as a layer, not a patch", () => {
+    it("puts its scrim above the full-screen onboarding takeover", () => {
+      // Location onboarding is an OPAQUE fixed layer at z-560. The scrim used
+      // to sit at z-559, underneath it, so the dim and the blur were painted
+      // where nothing could see them and the sheet landed on a fully lit
+      // screen with no separation at all.
+      render(
+        <SaveLocationModal {...baseProps} address="Bengaluru, India" />,
+      );
+
+      const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+      const sheet = screen.getByTestId("save-location-modal");
+      const layerOf = (element: Element | null) =>
+        Number(
+          /z-\[(\d+)\]/.exec(element?.className?.toString() ?? "")?.[1] ?? "0",
+        );
+
+      expect(layerOf(overlay)).toBeGreaterThan(560);
+      expect(layerOf(sheet)).toBeGreaterThan(layerOf(overlay));
+      expect(overlay?.className).toContain("backdrop-blur");
+    });
+  });
+
+  describe("the primary button only looks live when it is", () => {
+    it("goes neutral while it cannot take you forward", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address="Kartavya Path, New Delhi, Delhi 110001, India"
+          collectAddressDetails
+        />,
+      );
+
+      // A dimmed blue still reads as the live primary action and earns a dead
+      // tap, so a blocked CTA must not be blue at all.
+      const save = screen.getByRole("button", { name: "Save location" });
+      expect(save).toBeDisabled();
+      expect(save.className).not.toContain("var(--app-accent)");
+
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      expect(save).toBeEnabled();
+      expect(save.className).toContain("var(--app-accent)");
+    });
+  });
+
+  describe("when the pin is good but no address comes back", () => {
+    // On the native build before the vault exists there is no server
+    // reverse-geocode and no browser geocoder either, so the lookup returns
+    // nothing however good the pin is. Blocking the save on a resolved STRING
+    // left that person pinned, correct, and permanently unable to finish.
+    const strandedProps = {
+      ...baseProps,
+      address: null,
+      collectAddressDetails: true,
+    };
+
+    it("asks for one thing it can actually use", () => {
+      render(<SaveLocationModal {...strandedProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+      expect(
+        screen.getByText(
+          "Add a house, landmark or PIN so this place can be found.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeDisabled();
+    });
+
+    it("saves once the person supplies it themselves", () => {
+      render(<SaveLocationModal {...strandedProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+        target: { value: "Opposite City Mall" },
+      });
+
+      const save = screen.getByRole("button", { name: "Save location" });
+      expect(save).toBeEnabled();
+      fireEvent.click(save);
+
+      expect(baseProps.onSave).toHaveBeenCalledWith(
+        "home",
+        "",
+        expect.objectContaining({ landmark: "Opposite City Mall" }),
+        null,
+      );
+    });
+  });
+
+  it("shows a plus-code address without the plus code", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="FVJ7+JR2, Teliarganj, Prayagraj, Uttar Pradesh 211004, India"
+        collectAddressDetails
+      />,
+    );
+
+    expect(
+      screen.getByText("Teliarganj, Prayagraj, Uttar Pradesh 211004, India"),
+    ).toBeInTheDocument();
+    // And it is not offered as a house number.
+    expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue("");
+    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("211004");
   });
 });

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type Ref,
+} from "react";
 import { useTheme } from "next-themes";
 import { GoogleMap } from "@capacitor/google-maps";
 import { Check, Crosshair, Loader2, MapPin, X } from "lucide-react";
@@ -28,7 +36,21 @@ export type PickedLocation = {
   address: string | null;
 };
 
+/**
+ * Lets the surrounding carousel commit the pin from a swipe or a dot tap, not
+ * only from the Confirm button. The pin, the settle state and the resolved
+ * address all live in here, so the parent cannot decide on its own whether a
+ * confirm is safe -- it has to ask.
+ */
+export type LocationPickerMapHandle = {
+  /** True when the pin has settled and its address lookup has finished. */
+  canConfirm: () => boolean;
+  /** Commit the current pin. Returns false when it was not safe to. */
+  confirm: () => boolean;
+};
+
 export interface LocationPickerMapProps {
+  ref?: Ref<LocationPickerMapHandle>;
   /** Where the map centers when it first opens. */
   initialLatitude: number;
   initialLongitude: number;
@@ -42,6 +64,12 @@ export interface LocationPickerMapProps {
   onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
   /** Emitted when the owner confirms the pin position. */
   onConfirm: (picked: PickedLocation) => void;
+  /**
+   * Fires whenever "this pin is ready to commit" changes, so a surrounding
+   * carousel can enable its own forward affordance from real state instead of
+   * reading the imperative handle during render -- where a ref is still null.
+   */
+  onReadyChange?: (ready: boolean) => void;
   /** Dismiss the map without changing the captured point. */
   onCancel: () => void;
   /**
@@ -91,6 +119,7 @@ function isValidCoordinate(lat: number, lng: number): boolean {
  *   transparency class while the pin + controls stay as regular web UI on top.
  */
 export function LocationPickerMap({
+  ref,
   initialLatitude,
   initialLongitude,
   initialAddress = null,
@@ -98,6 +127,7 @@ export function LocationPickerMap({
   reverseGeocode,
   onLocateMe,
   onConfirm,
+  onReadyChange,
   onCancel,
   rendererDisclosureAccepted = false,
   onAcceptRendererDisclosure,
@@ -504,16 +534,40 @@ export function LocationPickerMap({
     }
   }, [locating, native, onLocateMe, scheduleResolve]);
 
-  const handleConfirm = useCallback(() => {
-    const { lat, lng } = centerRef.current;
-    if (!isValidCoordinate(lat, lng)) return;
-    onConfirm({ latitude: lat, longitude: lng, address });
-  }, [address, onConfirm]);
-
   // Treat a hard SDK error OR the 5s load timeout as "unavailable" so the owner
   // is never trapped behind an infinite "Loading map…"; both fall back to the
   // captured-point confirm flow below.
   const unavailable = status === "error" || timedOut;
+
+  // The single definition of "this pin is ready to commit", so the Confirm
+  // button, its colour, the carousel swipe and the carousel dots can never
+  // disagree about it.
+  const canConfirm =
+    !dragging &&
+    !resolving &&
+    !locating &&
+    (unavailable || status === "ready") &&
+    isValidCoordinate(centerRef.current.lat, centerRef.current.lng);
+
+  const handleConfirm = useCallback(() => {
+    const { lat, lng } = centerRef.current;
+    if (!isValidCoordinate(lat, lng)) return false;
+    onConfirm({ latitude: lat, longitude: lng, address });
+    return true;
+  }, [address, onConfirm]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      canConfirm: () => canConfirm,
+      confirm: () => (canConfirm ? handleConfirm() : false),
+    }),
+    [canConfirm, handleConfirm],
+  );
+
+  useEffect(() => {
+    onReadyChange?.(canConfirm);
+  }, [canConfirm, onReadyChange]);
 
   const accuracyHint = unavailable
     ? "Review the pin, then continue."
@@ -543,6 +597,10 @@ export function LocationPickerMap({
       </div>
 
       <div
+        // Panning the map is a horizontal drag too. Marked so an enclosing
+        // carousel can ignore gestures that start here instead of stealing
+        // them and sliding the sheet while the person is moving the pin.
+        data-location-picker-surface
         className={cn(
           "relative h-[min(56vh,420px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] shadow-[0_8px_24px_rgba(16,24,40,0.12)] ring-1 ring-black/[0.02] dark:border-white/[0.1] dark:shadow-[0_8px_24px_rgba(0,0,0,0.4)]",
           // The native map draws below the WebView, so the surface must stay
@@ -722,14 +780,20 @@ export function LocationPickerMap({
       <div className="flex flex-col gap-2.5">
         <button
           type="button"
-          onClick={handleConfirm}
-          disabled={status === "loading" || dragging || resolving || locating}
+          onClick={() => void handleConfirm()}
+          disabled={!canConfirm}
           aria-describedby={
             unavailable ? mapUnavailableDescriptionId : undefined
           }
           className={cn(
-            "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-            "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+            "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed",
+            // Blue means "this will take you forward". While the pin is still
+            // settling or its address is still resolving it cannot, so it does
+            // not get to look like it can -- a dimmed blue button still reads
+            // as the live primary action and invites a dead tap.
+            canConfirm
+              ? "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]"
+              : "bg-[#e6e9ef] text-[#98a1ae] dark:bg-white/[0.08] dark:text-[#6d7787]",
           )}
         >
           <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState, type PointerEvent } from "react";
 import {
   ArrowLeft,
   Briefcase,
@@ -17,6 +17,7 @@ import {
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   LocationPickerMap,
+  type LocationPickerMapHandle,
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ import {
   inferSavedLocationAddressDetails,
   isValidPostalCode,
   normalizeSavedLocationAddressDetails,
+  stripPlusCodeSegment,
   type SavedLocationAddressDetails,
 } from "@/lib/one-location/saved-location-address";
 
@@ -37,6 +39,94 @@ const controlLabelClassName =
 
 const controlInputClassName =
   "h-12 w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] px-4 text-[15px] leading-5 text-foreground outline-none transition-colors placeholder:text-[color:var(--app-tertiary-label)] focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent)]/25 disabled:opacity-60";
+
+/**
+ * Blue is a promise that the tap moves you forward. When it cannot, the button
+ * goes neutral instead of dimming the same blue -- a 45%-opacity primary still
+ * reads as the live action and earns a dead tap.
+ */
+function primaryActionClassName(enabled: boolean): string {
+  return cn(
+    "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed",
+    enabled
+      ? "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]"
+      : "bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-tertiary-label)]",
+  );
+}
+
+/**
+ * Where you are in the pin-then-details pair, and a way to move without
+ * hunting for the button. Replaces the "Step 1 of 2" / "Step 2 of 2" labels,
+ * which announced the flow as longer than it is.
+ */
+function CarouselDots({
+  index,
+  count,
+  labels,
+  onSelect,
+  canAdvance,
+}: {
+  index: number;
+  count: number;
+  labels: string[];
+  onSelect: (next: number) => void;
+  canAdvance: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center justify-center gap-2 pt-0.5"
+      role="tablist"
+      aria-label="Save this place"
+    >
+      {Array.from({ length: count }, (_, dot) => {
+        const active = dot === index;
+        const reachable = dot <= index || canAdvance;
+        return (
+          <button
+            key={dot}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-label={labels[dot]}
+            disabled={!reachable}
+            onClick={() => onSelect(dot)}
+            className="flex h-6 items-center px-0.5 disabled:cursor-not-allowed"
+          >
+            <span
+              className={cn(
+                "block h-[7px] rounded-full transition-all duration-200",
+                active
+                  ? "w-[22px] bg-[color:var(--app-accent)]"
+                  : "w-[7px] bg-[color:var(--app-neutral-fill-strong)]",
+              )}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Distance a horizontal drag must cover before it counts as a slide. */
+const CAROUSEL_SWIPE_THRESHOLD_PX = 56;
+
+/**
+ * Only the sheet's CONTENT travels. The sheet itself is centred with a
+ * translate, so animating it would fight its own positioning.
+ */
+const CAROUSEL_KEYFRAMES = `
+@keyframes saveLocSlideFromRight {
+  from { opacity: 0; transform: translate3d(14px, 0, 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+@keyframes saveLocSlideFromLeft {
+  from { opacity: 0; transform: translate3d(-14px, 0, 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-save-location-pane] { animation: none !important; }
+}
+`;
 
 export type SavedLocationPlaceSuggestion = {
   placeId: string;
@@ -232,11 +322,19 @@ export function SaveLocationModal({
   const [rendererDisclosureReady, setRendererDisclosureReady] = useState(
     rendererDisclosureAccepted,
   );
+  /** Which edge the incoming slide travels from, so back reads as back. */
+  const [slideFrom, setSlideFrom] = useState<"right" | "left" | null>(null);
+  /** Mirrors the picker's own "this pin is ready to commit". */
+  const [mapReady, setMapReady] = useState(false);
   const rendererReady = rendererDisclosureReady || rendererDisclosureAccepted;
   const descriptionId = useId();
   const postalCodeErrorId = useId();
   const mapTitleRef = useRef<HTMLHeadingElement | null>(null);
   const detailsTitleRef = useRef<HTMLHeadingElement | null>(null);
+  // The pin, its settle state and its resolved address all live inside the
+  // picker, so a swipe or a dot tap has to ask it whether it may commit.
+  const mapPickerRef = useRef<LocationPickerMapHandle | null>(null);
+  const swipeOriginRef = useRef<{ x: number; y: number } | null>(null);
   // A field the person has typed in is theirs. The pin may fill a blank field
   // and refill it as it moves, but it must never overwrite an answer someone
   // gave -- a prefill that fights the typing is worse than no prefill.
@@ -272,6 +370,8 @@ export function SaveLocationModal({
       setPlaceSearchError(null);
       setSelectingPlaceId(null);
       setRendererDisclosureReady(false);
+      setSlideFrom(null);
+      setMapReady(false);
     }
     // Initial* props are read once per open; excluded to avoid mid-session
     // resets while the modal is open.
@@ -317,7 +417,9 @@ export function SaveLocationModal({
     };
   }, [editingPlace, onSearchPlaces, open, placeQuery]);
 
-  const resolvedAddress = (address && address.trim()) || null;
+  // A leading plus code is a coordinate wearing an address's clothes. Dropped
+  // once, here, so every place this line is shown or saved says the same thing.
+  const resolvedAddress = stripPlusCodeSegment(address);
   const changingPlace = selectingPlaceId !== null;
   const interactionBusy = saving || changingPlace;
   const canEditPlace = Boolean(onSearchPlaces && onSelectPlace);
@@ -366,7 +468,20 @@ export function SaveLocationModal({
 
   const normalizedAddressDetails =
     normalizeSavedLocationAddressDetails(addressDetails);
-  const detectedAddress = pickedAddress || resolvedAddress || "";
+  const detectedAddress =
+    stripPlusCodeSegment(pickedAddress) || resolvedAddress || "";
+  /**
+   * Something the person put in themselves. This matters because a pinned
+   * point does not always come back with an address: on the native build
+   * before the vault exists there is no server reverse-geocode and no browser
+   * geocoder either, so the lookup returns nothing however good the pin is.
+   * Blocking the save on a resolved STRING left that person pinned, correct,
+   * and permanently unable to finish.
+   */
+  const hasOwnAddressAnswer =
+    normalizedAddressDetails.houseOrFlat.length > 0 ||
+    normalizedAddressDetails.landmark.length > 0 ||
+    normalizedAddressDetails.postalCode.length > 0;
   const postalCodeInvalid =
     normalizedAddressDetails.postalCode.length > 0 &&
     !isValidPostalCode(normalizedAddressDetails.postalCode);
@@ -385,8 +500,13 @@ export function SaveLocationModal({
       ? null
       : category === null
         ? "Pick Home, Work or Other first."
-        : collectAddressDetails && detectedAddress.length === 0
-          ? "Pin a spot on the map first."
+        : collectAddressDetails &&
+            detectedAddress.length === 0 &&
+            !hasOwnAddressAnswer
+          ? // The pin is fine; only its address lookup came back empty. Name
+            // the way out that is actually open, rather than sending someone
+            // back to a map they already got right.
+            "Add a house, landmark or PIN so this place can be found."
           : postalCodeInvalid
             ? // Not the field's own wording. The invalid PIN already says
               // "Enter a valid PIN or postal code." right next to itself, and
@@ -402,6 +522,70 @@ export function SaveLocationModal({
     flowStep !== "map" &&
     !changingPlace &&
     saveBlockedReason === null;
+
+  /**
+   * The pin and the address details are two slides of one thing, not two
+   * steps of a longer setup. Only true when both slides genuinely exist for
+   * this caller; a modal with a single pane keeps its plain layout.
+   */
+  const carouselMode = collectAddressDetails && canPickOnMap;
+  const paneProps = {
+    "data-save-location-pane": "",
+    // Restores the gap the fragment used to inherit from the sheet, so the
+    // wrapper is a pure animation host and changes no spacing.
+    className: cn(
+      "flex min-h-0 flex-col gap-5",
+      slideFrom === "right" &&
+        "[animation:saveLocSlideFromRight_260ms_cubic-bezier(0.2,0,0,1)_both]",
+      slideFrom === "left" &&
+        "[animation:saveLocSlideFromLeft_260ms_cubic-bezier(0.2,0,0,1)_both]",
+    ),
+  };
+  const carouselIndex = flowStep === "details" ? 1 : 0;
+  const carouselLabels = ["Pin your entrance", "Address details"];
+
+  const goToSlide = (next: number) => {
+    if (interactionBusy || next === carouselIndex) return;
+    if (next === 1) {
+      // Moving forward commits the pin, exactly as the Confirm button does.
+      // The picker decides whether that is safe right now.
+      mapPickerRef.current?.confirm();
+      return;
+    }
+    setSlideFrom("left");
+    setMapReady(false);
+    setFlowStep("map");
+  };
+
+  /**
+   * Horizontal drags on the sheet move between the two slides. Gestures that
+   * begin on the map surface belong to the map -- panning to place a pin is a
+   * horizontal drag too, and stealing it would make the pin impossible to
+   * move. Vertical-dominant drags are left to the scroll container.
+   */
+  const handleSwipeStart = (event: PointerEvent<HTMLDivElement>) => {
+    if (!carouselMode || event.pointerType === "mouse") {
+      swipeOriginRef.current = null;
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    if (target?.closest?.("[data-location-picker-surface]")) {
+      swipeOriginRef.current = null;
+      return;
+    }
+    swipeOriginRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const handleSwipeEnd = (event: PointerEvent<HTMLDivElement>) => {
+    const origin = swipeOriginRef.current;
+    swipeOriginRef.current = null;
+    if (!origin) return;
+    const deltaX = event.clientX - origin.x;
+    const deltaY = event.clientY - origin.y;
+    if (Math.abs(deltaX) < CAROUSEL_SWIPE_THRESHOLD_PX) return;
+    if (Math.abs(deltaX) <= Math.abs(deltaY)) return;
+    goToSlide(deltaX < 0 ? carouselIndex + 1 : carouselIndex - 1);
+  };
 
   const handleSelectPlace = async (placeId: string) => {
     if (!onSelectPlace || changingPlace) return;
@@ -430,6 +614,8 @@ export function SaveLocationModal({
         }),
       );
     }
+    setSlideFrom("right");
+    setMapReady(false);
     setFlowStep(collectAddressDetails ? "details" : "summary");
   };
 
@@ -475,7 +661,18 @@ export function SaveLocationModal({
         showCloseButton={false}
         data-testid="save-location-modal"
         aria-describedby={descriptionId}
-        overlayClassName="z-[559] bg-black/45 backdrop-blur-[6px]"
+        onPointerDown={handleSwipeStart}
+        onPointerUp={handleSwipeEnd}
+        onPointerCancel={() => {
+          swipeOriginRef.current = null;
+        }}
+        // Location onboarding is a full-screen takeover at z-560 with an OPAQUE
+        // background. The scrim used to sit at z-559 -- underneath it -- so the
+        // dim and the blur were painted where nothing could see them, and the
+        // sheet landed on a fully lit screen with no separation at all. That is
+        // the "it looks like a patch": not a missing blur, a buried one.
+        // Above the takeover, below the app's sheets/drawers at z-711.
+        overlayClassName="z-[600] bg-black/55 backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)]"
         onEscapeKeyDown={(event) => {
           if (interactionBusy) event.preventDefault();
         }}
@@ -483,13 +680,21 @@ export function SaveLocationModal({
           if (interactionBusy || flowStep === "map") event.preventDefault();
         }}
         className={cn(
-          "z-[560] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
+          "z-[601] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
           "rounded-b-none rounded-t-[24px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[20px]",
-          "border border-border/60 bg-[color:var(--app-card-surface-default-solid)] p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] shadow-none sm:p-6 sm:pb-6",
+          // A real edge and a real lift, so the sheet reads as a layer above
+          // the screen rather than a rectangle pasted onto it.
+          "border border-black/[0.06] bg-[color:var(--app-card-surface-default-solid)] p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] dark:border-white/[0.08] sm:p-6 sm:pb-6",
+          // `!` because the sheet's arbitrary shadow does not merge away the
+          // dialog primitive's own `shadow-[var(--app-card-shadow-feature)]`:
+          // tailwind-merge leaves both classes on the element and the base one
+          // wins on stylesheet order, so the lift never actually rendered.
+          "!shadow-[0_24px_60px_-12px_rgba(16,24,40,0.35),0_8px_20px_-8px_rgba(16,24,40,0.24)] dark:!shadow-[0_24px_60px_-12px_rgba(0,0,0,0.7)]",
         )}
       >
+        <style>{CAROUSEL_KEYFRAMES}</style>
         {flowStep === "map" && canPickOnMap ? (
-          <>
+          <div {...paneProps}>
             <DialogTitle ref={mapTitleRef} tabIndex={-1} className="sr-only">
               {rendererReady ? "Pin your entrance" : "Before Google Maps opens"}
             </DialogTitle>
@@ -498,12 +703,8 @@ export function SaveLocationModal({
                 ? "Move the pin to the entrance."
                 : "Review before opening Maps."}
             </p>
-            {collectAddressDetails ? (
-              <p className="text-[13px] font-normal leading-[18px] tracking-normal text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
-                Step 1 of 2
-              </p>
-            ) : null}
             <LocationPickerMap
+              ref={mapPickerRef}
               initialLatitude={mapInitial!.latitude}
               initialLongitude={mapInitial!.longitude}
               initialAddress={pickedAddress || resolvedAddress}
@@ -511,6 +712,7 @@ export function SaveLocationModal({
               reverseGeocode={reverseGeocode}
               onLocateMe={onLocateMe}
               onConfirm={handleConfirmMapPick}
+              onReadyChange={setMapReady}
               onCancel={() => {
                 if (startWithMapPicker) {
                   onSkip();
@@ -525,13 +727,22 @@ export function SaveLocationModal({
               }
               cancelLabel={startWithMapPicker ? "Skip for now" : "Cancel"}
             />
-          </>
+            {carouselMode ? (
+              <CarouselDots
+                index={0}
+                count={2}
+                labels={carouselLabels}
+                canAdvance={mapReady}
+                onSelect={goToSlide}
+              />
+            ) : null}
+          </div>
         ) : flowStep === "details" && collectAddressDetails ? (
-          <>
+          <div {...paneProps}>
             <button
               type="button"
               onClick={() =>
-                canPickOnMap ? setFlowStep("map") : setFlowStep("summary")
+                canPickOnMap ? goToSlide(0) : setFlowStep("summary")
               }
               disabled={interactionBusy}
               aria-label={canPickOnMap ? "Back to map" : "Back"}
@@ -550,13 +761,10 @@ export function SaveLocationModal({
             </button>
 
             <header className="px-9 text-center">
-              <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
-                Step 2 of 2
-              </p>
               <DialogTitle
                 ref={detailsTitleRef}
                 tabIndex={-1}
-                className="mt-1 text-[28px] font-bold leading-[1.12] tracking-normal text-foreground outline-none"
+                className="text-[28px] font-bold leading-[1.12] tracking-normal text-foreground outline-none"
               >
                 Add your address details
               </DialogTitle>
@@ -587,7 +795,7 @@ export function SaveLocationModal({
               {canPickOnMap ? (
                 <button
                   type="button"
-                  onClick={() => setFlowStep("map")}
+                  onClick={() => goToSlide(0)}
                   disabled={interactionBusy}
                   className="press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
                 >
@@ -794,10 +1002,7 @@ export function SaveLocationModal({
                 onClick={handleSave}
                 disabled={!canSave}
                 aria-busy={saving || undefined}
-                className={cn(
-                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-                  "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]",
-                )}
+                className={primaryActionClassName(canSave)}
               >
                 {saving ? (
                   <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
@@ -814,11 +1019,20 @@ export function SaveLocationModal({
               >
                 Skip for now
               </button>
+              {carouselMode ? (
+                <CarouselDots
+                  index={1}
+                  count={2}
+                  labels={carouselLabels}
+                  canAdvance
+                  onSelect={goToSlide}
+                />
+              ) : null}
             </div>
-          </>
+          </div>
         ) : (
 
-          <>
+          <div {...paneProps}>
             <button
               type="button"
               onClick={onSkip}
@@ -1018,10 +1232,7 @@ export function SaveLocationModal({
                 onClick={handleSave}
                 disabled={!canSave}
                 aria-busy={saving || undefined}
-                className={cn(
-                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[17px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-                  "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]",
-                )}
+                className={primaryActionClassName(canSave)}
               >
                 {saving ? (
                   <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
@@ -1039,7 +1250,7 @@ export function SaveLocationModal({
                 Skip for now
               </button>
             </div>
-          </>
+          </div>
         )}
 
       </DialogContent>

--- a/hushh-webapp/lib/one-location/saved-location-address.ts
+++ b/hushh-webapp/lib/one-location/saved-location-address.ts
@@ -41,14 +41,80 @@ function buildingColorSegment(value: string): string {
     : `${value} building`;
 }
 
-/** Extract a likely PIN/postal code for a helpful, editable form prefill. */
+/**
+ * An Open Location Code (a Google "plus code") such as `FVJ7+JR2` or the full
+ * `7JVW52GR+2V`. Google returns one as the leading segment whenever it has no
+ * street address for the pinned point, which is common on unmapped lanes and
+ * inside large campuses.
+ *
+ * It is a coordinate in disguise, not an address. It must never be offered as
+ * a house number, and it is stripped from the line we show and save.
+ */
+const PLUS_CODE_ALPHABET = "23456789CFGHJMPQRVWX";
+const PLUS_CODE_PATTERN = new RegExp(
+  `^[${PLUS_CODE_ALPHABET}]{2,8}\\+[${PLUS_CODE_ALPHABET}]{2,3}$`,
+  "i",
+);
+
+export function isPlusCode(value: string | null | undefined): boolean {
+  return PLUS_CODE_PATTERN.test(String(value || "").trim());
+}
+
+/**
+ * Drop a leading plus code so the person reads "Teliarganj, Prayagraj, Uttar
+ * Pradesh 211004, India" instead of "FVJ7+JR2, Teliarganj, ...". The code is
+ * kept when it is the ONLY thing Google returned -- a coordinate in disguise
+ * still beats a blank line.
+ */
+export function stripPlusCodeSegment(
+  address: string | null | undefined,
+): string | null {
+  const value = String(address || "").trim();
+  if (!value) return null;
+  const segments = value.split(",").map((segment) => segment.trim());
+  const kept = segments.filter((segment) => segment && !isPlusCode(segment));
+  if (kept.length === 0) return value;
+  if (kept.length === segments.filter(Boolean).length) return value;
+  return kept.join(", ");
+}
+
+/**
+ * Extract a likely PIN/postal code for a helpful, editable form prefill.
+ *
+ * Ordered most-specific first so a six-digit Indian PIN is never beaten by a
+ * four-digit fragment, and so an alphanumeric UK/Canadian/Dutch code is found
+ * at all -- `isValidPostalCode` has always accepted those, but nothing ever
+ * detected them, so people outside the 5/6-digit world got an empty field on
+ * an address that plainly carried one.
+ */
 export function inferPostalCode(address: string | null | undefined): string {
   const value = String(address || "");
-  return (
+  const direct =
+    // India / China / Singapore and friends.
     value.match(/\b\d{6}\b/)?.[0] ??
+    // US ZIP and ZIP+4.
     value.match(/\b\d{5}(?:-\d{4})?\b/)?.[0] ??
-    ""
-  );
+    // UK: SW1A 1AA, M1 1AE, CR2 6XH.
+    value.match(/\b[A-Z]{1,2}\d[A-Z\d]?\s+\d[A-Z]{2}\b/i)?.[0] ??
+    // Canada: K1A 0B1.
+    value.match(/\b[A-Z]\d[A-Z]\s?\d[A-Z]\d\b/i)?.[0] ??
+    // Netherlands: 1012 AB.
+    value.match(/\b\d{4}\s?[A-Z]{2}\b/)?.[0] ??
+    null;
+  if (direct) return cleanText(direct, MAX_POSTAL_CODE_LENGTH);
+
+  // A bare four-digit code (AU, NZ, much of Europe) only counts when it sits
+  // in the tail of the address, where a postal code lives. Taken anywhere it
+  // would happily lift a house number or a road number instead.
+  const segments = value
+    .split(",")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  for (const segment of segments.slice(-2)) {
+    const match = segment.match(/\b\d{4}\b/)?.[0];
+    if (match) return match;
+  }
+  return "";
 }
 
 /** The part before the first comma, which is where a house number sits. */
@@ -63,19 +129,24 @@ function firstAddressSegment(address: string | null | undefined): string {
  *
  * Deliberately narrow. It accepts a first segment with no spaces that contains
  * a digit ("B-284/3", "42", "A-12"), or one that names itself ("Flat 4B",
- * "Plot 22"). It will not take "12 MG Road", which is a street that happens to
- * carry a number -- putting that in the House-flat box would be wrong, and a
- * wrong prefill is worse than an empty one because people trust prefilled
- * fields and stop reading them.
+ * "Qtr. No.- 123/2", "Plot 22"). It will not take "12 MG Road", which is a
+ * street that happens to carry a number -- putting that in the House-flat box
+ * would be wrong, and a wrong prefill is worse than an empty one because
+ * people trust prefilled fields and stop reading them.
+ *
+ * Nor will it take a plus code. `FVJ7+JR2` has no spaces and carries digits,
+ * so the old shape rule accepted it and put a coordinate in the House-flat
+ * box -- exactly the "address is not populating" the form was reported for.
  */
+const HOUSE_DESIGNATOR_PATTERN =
+  /^(flat|plot|house|apartment|apt|qtr|quarter|no\.?|h\.?\s?no|d\.?\s?no|#|door|shop|unit|block|villa|bungalow|survey|khasra|gala|room|suite|ste)\b/i;
+
 export function inferHouseOrFlat(address: string | null | undefined): string {
   const segment = firstAddressSegment(address);
   if (!segment || segment.length > MAX_HOUSE_OR_FLAT_LENGTH) return "";
   if (!/\d/.test(segment)) return "";
-  const namesItself =
-    /^(flat|plot|house|apartment|apt|no\.?|#|door|shop|unit|block)\b/i.test(
-      segment,
-    );
+  if (isPlusCode(segment)) return "";
+  const namesItself = HOUSE_DESIGNATOR_PATTERN.test(segment);
   if (!namesItself && /\s/.test(segment)) return "";
   return cleanText(segment, MAX_HOUSE_OR_FLAT_LENGTH);
 }
@@ -88,9 +159,12 @@ export function inferHouseOrFlat(address: string | null | undefined): string {
 export function inferSavedLocationAddressDetails(
   address: string | null | undefined,
 ): Pick<SavedLocationAddressDetails, "houseOrFlat" | "postalCode"> {
+  // A leading plus code hides the real opening segment. "FVJ7+JR2, Qtr. No.-
+  // 123/2, Teliarganj, ..." carries a house number; it is just not first.
+  const readable = stripPlusCodeSegment(address);
   return {
-    houseOrFlat: inferHouseOrFlat(address),
-    postalCode: inferPostalCode(address),
+    houseOrFlat: inferHouseOrFlat(readable),
+    postalCode: inferPostalCode(readable),
   };
 }
 
@@ -129,8 +203,10 @@ export function buildSavedLocationAddress(
   details: SavedLocationAddressDetails,
 ): string | null {
   const normalized = normalizeSavedLocationAddressDetails(details);
+  // Saved exactly as it was shown: the plus code is dropped on screen, so it
+  // must not reappear inside the stored line.
   const baseAddress = cleanText(
-    String(mapAddress || ""),
+    String(stripPlusCodeSegment(mapAddress) || ""),
     MAX_SAVED_ADDRESS_LENGTH,
   );
   // The house number is now prefilled FROM the address, so on most saves it is


### PR DESCRIPTION
Four defects in the Location onboarding "save a place" flow, reported together as *"address populate nahi ho rha hai"* and *"it's looking like a patch"*.

## 1. The address stopped populating the form

`inferHouseOrFlat` accepted a Google **plus code**. `FVJ7+JR2` has no spaces and carries digits, so the shape rule took it and wrote a coordinate into *House, flat, floor or block*.

At the same time it **rejected the forms people actually write**. `Qtr. No.- 123/2`, `H. No. 45`, `D No 12-3-45` all contain a space, so they had to name themselves — and the designator list only knew `flat|plot|house|apartment|apt|no|#|door|shop|unit|block`. A real house number sat on screen and never reached the box directly underneath it.

- Plus codes are refused, and stripped from the line that is shown and saved.
- The designator list covers the Indian forms (`qtr`, `quarter`, `h.no`, `d.no`, `room`, `suite`, `villa`, `bungalow`, `survey`, `khasra`, `gala`).
- `12 MG Road` is still refused — a wrong prefill is worse than an empty one.
- `inferPostalCode` learned the UK / Canadian / Dutch / four-digit shapes that `isValidPostalCode` has always *accepted* but nothing ever *detected*. The bare four-digit rule only reads the tail of an address, so a road number at the head is never lifted.

## 2. The onboarding save dropped the address entirely

The modal passes the address line as a **fourth** argument. The onboarding call site took three and used `saveLocationAddress` state instead — which is `null` for the whole of root setup, because there is no vault token yet to reverse-geocode with. Every pre-vault save persisted fragments:

```
buildSavedLocationAddress(null, details)  → "Qtr. No.- 123/2, 211004"
buildSavedLocationAddress(line, details)  → "Qtr. No.- 123/2, Saraswati Vihar, Old Cantt, … 211004, India"
```

The argument is now forwarded, and wins over state. (`saved-locations-section.tsx` already did this correctly.)

## 3. The sheet looked like a rectangle pasted onto the screen

Location onboarding is an **opaque** full-screen takeover at `z-560`. The scrim sat at `z-559` — *underneath it* — so the dim and the blur were painted where nothing could see them, and the sheet landed on a fully lit screen with no separation.

Not a missing blur. A buried one.

Overlay → `z-600`, sheet → `z-601` (above the takeover, below the app's sheets/drawers at `z-711`). The sheet's own elevation needs `!` because tailwind-merge leaves the dialog primitive's arbitrary `shadow-[var(--app-card-shadow-feature)]` on the element and it wins on stylesheet order — caught in the browser, not in review.

## 4. "Step 1 of 2" / "Step 2 of 2" announced the flow as longer than it is

The pin and the address details are now **two slides of one carousel**: dots instead of step counters, swipe or tap a dot to move. The picker owns the pin, its settle state and its address, so it decides whether a forward move may commit — the dots, the Confirm button and the swipe can never disagree. Gestures that begin on the map surface are left to the map, since panning to place a pin is a horizontal drag too.

## Also

- **A good pin with no address no longer blocks the save.** On native before the vault exists there is no server reverse-geocode and no browser geocoder either, so the lookup returns nothing however good the pin is. The gate was on that *string*, which left a person pinned, correct, and permanently unable to finish. It now accepts a house / landmark / PIN they supplied themselves.
- **A primary button that cannot take you forward goes neutral**, rather than dimming the same blue — a 45%-opacity primary still reads as the live action and earns a dead tap. Applied to both the pin Confirm and the Save CTA.
- The map's Confirm was disabled after its 5s load timeout while *showing* "Use captured point" — the fallback existed but could not be pressed. Now it can.

## Verification

| | |
|---|---|
| `tsc --noEmit` | clean |
| `eslint --max-warnings=0` (6 changed files) | clean |
| Full `vitest run` on branch | 33 failed / 3960 passed |
| Full `vitest run` on `origin/main` | 33 failed / 3949 passed |
| Failing **file sets** compared | **identical — no new failures**; +11 passing tests |
| New tests | 14 prefill + 11 modal (carousel, swipe, layering, CTA colour, stranded-pin) |
| Mutation-checked | 9 mutations reverting each fix; 8 caught, the 9th replaced with a stronger one that is |
| Real browser (Chromium, iPhone 13, dev server) | overlay `z=600` > shell `z=560`, `blur(10px)`; 2 dots, no "Step N of 2"; PIN prefilled `211004`; CTA `rgba(120,120,128,0.2)` → `rgb(0,122,255)` on category pick; swipe left/right both change slide |

**Not verified:** the authenticated onboarding journey end to end (needs a real account + vault + granted Location), and the native iOS build. The component was rendered and driven in a real browser over a stand-in for the takeover shell.