### PR TITLE
fix(one-setup): stop promising a finish the screen cannot deliver

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -809,6 +809,54 @@ describe("OneLocationOnboardingFlow", () => {
       ).toBeTruthy();
     });
 
+    it("lines the join card up with the invite card stacked above it", async () => {
+      openJoin({
+        onPrepareOnboardingCircleInvite: vi.fn().mockResolvedValue(invite),
+      });
+
+      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.change(screen.getByLabelText("Circle code"), {
+        target: { value: "ABCDEFGHJKLM" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Look up/ }));
+
+      const inviteCard = screen.getByTestId(
+        "one-location-onboarding-invite-card",
+      );
+      const joinCard = await screen.findByTestId(
+        "onboarding-join-circle-preview",
+      );
+
+      // These two are siblings at the same width, so any difference in inset
+      // or radius shows up as a ragged left edge down the panel -- the join
+      // card used to sit 4px inside the code card's text column.
+      for (const geometry of ["p-5", "rounded-[20px]"]) {
+        expect(inviteCard.className).toContain(geometry);
+        expect(joinCard.className).toContain(geometry);
+      }
+    });
+
+    it("keeps the accepted confirmation on the same left edge as the cards", async () => {
+      openJoin({
+        onPrepareOnboardingCircleInvite: vi.fn().mockResolvedValue(invite),
+      });
+
+      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.change(screen.getByLabelText("Circle code"), {
+        target: { value: "ABCDEFGHJKLM" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Look up/ }));
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Join Meena Family/ }),
+      );
+
+      const confirmation = await screen.findByRole("status");
+      // The confirmation replaces the join card in place. Its horizontal inset
+      // has to match, or the panel's left edge jumps the moment someone joins.
+      expect(confirmation.className).toContain("px-5");
+      expect(confirmation.className).toContain("rounded-[20px]");
+    });
+
     it("does not offer to join a circle the person is already in", async () => {
       const props = openJoin({
         onPreviewCircleCode: vi

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -122,6 +122,73 @@ describe("One setup hub terminal action contract", () => {
     expect(stateHook).toContain("useState(enrichRia)");
   });
 
+  it("spends the accent only on a finish that can actually go through", () => {
+    const hub = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+    const footer = readFileSync(
+      join(
+        process.cwd(),
+        "components/onboarding/setup/setup-completion-footer.tsx",
+      ),
+      "utf8",
+    );
+
+    // Both master actions are gated on the same mandatory AI access choice,
+    // and both must LOOK gated. `disabled:opacity-40/50` over the accent still
+    // reads as the blue primary action, which is what made a blocked finish
+    // look tappable and then swallow the tap.
+    expect(footer).toContain(
+      "const isBlockedFilledAction = disabled && !busy && !isQuietSetupAction",
+    );
+    expect(footer).toContain("disabled:!bg-muted/60");
+    expect(hub).toContain("disabled:text-muted-foreground");
+    expect(hub).not.toContain("disabled:opacity-40");
+
+    // The reason travels with the block on every surface. The desktop footer
+    // has a supporting line under the button; the phone header action has
+    // nothing but a `title` tooltip, which a touch device never shows -- so the
+    // header summary both layouts render has to name it too.
+    expect(hub).toContain('"Choose AI access to finish."');
+    expect(hub).toContain(
+      "${done} of ${total} ready. Choose AI access to finish.",
+    );
+    expect(
+      hub.match(/Choose AI access to finish\./g)?.length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps the mandatory-step language out of system nouns", () => {
+    const hub = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // "vault" is an implementation noun. It stays in the code (services,
+    // props, test ids) and out of anything a person reads. Every phrase below
+    // was rendered on this hub or spoken back by the setup guide.
+    const retiredCopy = [
+      "Your vault is required to finish setup.",
+      "Your vault is required. You can add more capabilities any time.",
+      "Your private vault gives One end-to-end encryption.",
+      "Your private vault is not ready yet.",
+      "Set up private vault",
+      "Set up your private vault",
+      "Continue to set up your private vault.",
+      "Choose an AI access option before continuing.",
+      "We could not protect your setup.",
+    ];
+    for (const phrase of retiredCopy) {
+      expect(hub).not.toContain(phrase);
+    }
+
+    expect(hub).toContain("Only you can open what you save.");
+    expect(hub).toContain("Not even we can read it.");
+    expect(hub).toContain('"One step left."');
+    expect(hub).toContain('"Add the rest any time."');
+  });
+
   it("keeps the quiet Morphy action legible on hover and while disabled", () => {
     const source = readFileSync(
       join(
@@ -197,7 +264,7 @@ describe("One setup hub terminal action contract", () => {
     const masterHandler = source.slice(source.indexOf("const handleMasterAck"));
     expect(masterHandler).not.toContain("acknowledgeOneSetupExit");
     expect(source).toContain('data-testid="one-setup-vault-invitation"');
-    expect(source).toContain("Set up private vault");
+    expect(source).toContain("Set a lock");
     expect(source).not.toContain("I’ll do this later");
     expect(source).not.toContain("one-setup-vault-invitation-later");
     expect(source).toContain("<VaultUnlockDialog");

--- a/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
+++ b/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-completion-footer";
+
+/**
+ * The terminal setup action promises passage. Blue is that promise.
+ *
+ * The stock disabled treatment only fades the accent fill to 50%, which on the
+ * light setup surface still reads as the primary blue button -- so a person
+ * whose mandatory step was still pending saw a blue "Finish setup", tapped it,
+ * and got nothing but a line of supporting text. These tests pin the rule:
+ * accent while the tap can finish, neutral while it cannot.
+ */
+const ACCENT_FILL = "bg-[var(--app-accent)]";
+
+function renderFooter(overrides: Partial<Parameters<typeof SetupCompletionFooter>[0]> = {}) {
+  const onComplete = vi.fn();
+  render(
+    <SetupCompletionFooter
+      label="Finish setup"
+      onComplete={onComplete}
+      controlId="one-setup-master-ack"
+      testId="one-setup-master-ack"
+      purpose="Finish setup and protect what you save."
+      variant="blue-gradient"
+      effect="fill"
+      {...overrides}
+    />,
+  );
+  return { onComplete, button: screen.getByTestId("one-setup-master-ack") };
+}
+
+describe("SetupCompletionFooter blocked state", () => {
+  it("keeps the accent fill while the action can actually finish setup", () => {
+    const { button } = renderFooter();
+
+    expect(button.className).toContain(ACCENT_FILL);
+    expect(button).not.toBeDisabled();
+  });
+
+  it("drops the accent fill for a neutral container while a step is still pending", () => {
+    const { button } = renderFooter({ disabled: true });
+
+    expect(button).toBeDisabled();
+    // The neutral container must win outright, not sit behind a half-faded
+    // accent: full opacity on a muted background is what makes "not yet"
+    // legible instead of "blue but dim".
+    expect(button.className).toContain("disabled:!bg-muted/60");
+    expect(button.className).toContain("disabled:!text-muted-foreground");
+    expect(button.className).toContain("disabled:!opacity-100");
+  });
+
+  it("does not absorb a tap while blocked", () => {
+    const { onComplete, button } = renderFooter({ disabled: true });
+
+    fireEvent.click(button);
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("states what is still needed next to the blocked action", () => {
+    renderFooter({
+      disabled: true,
+      supportingText: "Choose AI access to finish.",
+    });
+
+    // Colour is never the only signal: the reason is readable text, so it
+    // survives a screen reader and a person who cannot separate the two greys.
+    expect(screen.getByText("Choose AI access to finish.")).toBeTruthy();
+  });
+
+  it("keeps the accent while a real completion is in flight", () => {
+    // busy is a disabled button too, but it is mid-success -- fading it to a
+    // neutral "blocked" container would read as a failure the person caused.
+    const { button } = renderFooter({ busy: true });
+
+    expect(button).toBeDisabled();
+    expect(button.className).toContain(ACCENT_FILL);
+    expect(button.className).not.toContain("disabled:!bg-muted/60");
+  });
+
+  it("keeps the accent when a caller re-blocks an action that is already running", () => {
+    // A caller may flip its gate closed for the duration of the run (or race
+    // the two). In-flight still wins: the person is watching their own tap
+    // resolve, not being told it was never allowed.
+    const { button } = renderFooter({ busy: true, disabled: true });
+
+    expect(button).toBeDisabled();
+    expect(button.className).toContain(ACCENT_FILL);
+    expect(button.className).not.toContain("disabled:!bg-muted/60");
+  });
+
+  it("leaves the quiet skip action on its own established treatment", () => {
+    const { button } = renderFooter({
+      disabled: true,
+      variant: "none",
+      effect: "fade",
+    });
+
+    expect(button.className).toContain("disabled:!bg-muted/35");
+    expect(button.className).not.toContain("disabled:!bg-muted/60");
+  });
+});

--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -155,7 +155,7 @@ describe("VaultFlow create validation", () => {
 
     const passphraseInput = await screen.findByLabelText("Passphrase");
     const confirmInput = screen.getByLabelText("Confirm passphrase");
-    const createButton = screen.getByRole("button", { name: "Create private vault" }) as HTMLButtonElement;
+    const createButton = screen.getByRole("button", { name: "Create passphrase" }) as HTMLButtonElement;
 
     // iOS renders `enterKeyHint="done"` as a checkmark on the keyboard.
     // Vault confirmation uses normal submit behavior without adding that glyph.
@@ -205,7 +205,7 @@ describe("VaultFlow create validation", () => {
   it("opens fresh vault creation directly in the canonical credential layout", async () => {
     render(<VaultFlow user={user} onSuccess={vi.fn()} />);
 
-    expect(await screen.findByRole("heading", { name: "Create your private vault" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Create your passphrase" })).toBeTruthy();
     expect(screen.getByLabelText("Passphrase")).toBeTruthy();
     expect(screen.getByLabelText("Confirm passphrase")).toBeTruthy();
     expect(screen.queryByText("Secure Your Digital Vault")).toBeNull();
@@ -228,7 +228,7 @@ describe("VaultFlow create validation", () => {
     expect(
       await screen.findByRole("heading", { name: "Finish setup first" }),
     ).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Create private vault" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Create passphrase" })).toBeNull();
     expect(createVaultMock).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -211,7 +211,7 @@ export function OneSetupHub() {
       return;
     }
     if (!vaultKey || !vaultOwnerToken) {
-      throw new Error("Your private vault is not ready yet. Try again.");
+      throw new Error("Not ready yet. Try again.");
     }
     if (finalizationInFlightRef.current) {
       return finalizationInFlightRef.current;
@@ -264,7 +264,7 @@ export function OneSetupHub() {
       setFinalizationError(
         error instanceof Error
           ? error.message
-          : "We could not protect your setup. Try again.",
+          : "Couldn't save your setup. Try again.",
       );
       throw error;
     } finally {
@@ -348,7 +348,7 @@ export function OneSetupHub() {
         setVaultInvitationOpen(true);
         return {
           status: "succeeded" as const,
-          summary: "Continue to set up your private vault.",
+          summary: "One step left: set a lock.",
         };
       }
       await completeSetupAfterVault();
@@ -368,11 +368,17 @@ export function OneSetupHub() {
     return handleMasterAck();
   });
 
+  // Phones get the master action as a bare header link with no supporting line
+  // under it, so the one mandatory step has to be named somewhere they can read
+  // it before they tap. The header description is the only copy both layouts
+  // share, so the blocker rides there rather than only in the desktop footer.
   const summary = hubStateLoading
     ? "Checking what's set up…"
     : allReady
       ? "Everything's set up. You're good to go."
-      : `${done} of ${total} ready, ${remaining} left to set up.`;
+      : !runtimeChoiceComplete
+        ? `${done} of ${total} ready. Choose AI access to finish.`
+        : `${done} of ${total} ready, ${remaining} left to set up.`;
   const showVaultInvitation =
     vaultInvitationOpen && Boolean(user) && !isVaultUnlocked;
 
@@ -404,11 +410,7 @@ export function OneSetupHub() {
                   ? "You're all set"
                   : "Finish setting up One"
             }
-            description={
-              showVaultInvitation
-                ? "Your vault is required to finish setup."
-                : summary
-            }
+            description={showVaultInvitation ? "One step left." : summary}
             accent="neutral"
             className={styles.setupHeader}
           />
@@ -422,12 +424,13 @@ export function OneSetupHub() {
               onClick={() => void handleMasterAck()}
               disabled={dismissing || !runtimeChoiceComplete}
               title={
-                !runtimeChoiceComplete
-                  ? "Choose an AI access option before continuing."
-                  : undefined
+                !runtimeChoiceComplete ? "Choose AI access to finish." : undefined
               }
               data-testid="one-setup-master-ack-mobile"
-              className="mt-1 shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-semibold text-[var(--app-accent)] transition hover:bg-[var(--app-accent-tint)] disabled:pointer-events-none disabled:opacity-40 sm:hidden"
+              // Same rule as the desktop footer: the accent is reserved for a
+              // tap that can actually finish. A faded accent still reads blue,
+              // so a blocked finish goes neutral rather than dimmed.
+              className="mt-1 shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-semibold text-[var(--app-accent)] transition hover:bg-[var(--app-accent-tint)] disabled:pointer-events-none disabled:text-muted-foreground disabled:opacity-100 sm:hidden"
             >
               {masterActionLabel}
             </button>
@@ -452,11 +455,10 @@ export function OneSetupHub() {
               id="one-setup-vault-invitation-title"
               className="mt-5 text-balance type-title2 text-foreground"
             >
-              One last step: protect what you save.
+              Only you can open what you save.
             </h2>
             <p className="mt-3 max-w-[28rem] text-pretty type-subhead text-muted-foreground">
-              Your private vault gives One end-to-end encryption. Only you hold
-              the key.
+              Not even we can read it.
             </p>
             <div className="mt-8 flex w-full max-w-[24rem] flex-col gap-3">
               <Button
@@ -469,7 +471,7 @@ export function OneSetupHub() {
                 onClick={() => setVaultDialogOpen(true)}
                 data-testid="one-setup-vault-invitation-open"
               >
-                Set up private vault
+                Set a lock
               </Button>
             </div>
           </section>
@@ -586,8 +588,8 @@ export function OneSetupHub() {
                 }
                 supportingText={
                   !runtimeChoiceComplete
-                    ? "Choose an AI access option before continuing."
-                    : "Your vault is required. You can add more capabilities any time."
+                    ? "Choose AI access to finish."
+                    : "Add the rest any time."
                 }
                 variant="blue-gradient"
                 effect="fill"
@@ -619,7 +621,7 @@ export function OneSetupHub() {
           onOpenChange={setVaultDialogOpen}
           dismissible={false}
           enableGeneratedDefault
-          title="Set up your private vault"
+          title="Set a lock"
           description="Create a private place for the details you choose to save."
           onSuccess={() => undefined}
         />

--- a/hushh-webapp/components/onboarding/setup/setup-completion-footer.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-completion-footer.tsx
@@ -26,7 +26,9 @@ type SetupCompletionFooterProps = {
  * Shared terminal setup action.
  *
  * Routes may show this while a prerequisite is pending, but must keep it
- * disabled until their own completion condition is verified. The canonical
+ * disabled until their own completion condition is verified. While it is
+ * blocked it also drops the accent fill: the blue is the promise that the tap
+ * goes through, so it is spent only on an action that can. The canonical
  * bottom inset keeps it above app chrome on safe-area and keyboard-resized
  * native viewports, with the same calm full-width action cadence everywhere.
  */
@@ -49,6 +51,12 @@ export function SetupCompletionFooter({
   // action vocabulary while preventing the light-theme gray container look.
   const isQuietSetupAction = variant === "none" && effect === "fade";
   const visualVariant = isQuietSetupAction ? "blue" : variant;
+  // Accent means "this works". The stock disabled treatment only fades the
+  // accent fill to 50%, which still reads as the blue primary action on a
+  // light surface -- so a blocked finish looked tappable, absorbed the tap,
+  // and explained itself only in the supporting line underneath. A blocked
+  // action takes the same neutral container the quiet variant already uses.
+  const isBlockedFilledAction = disabled && !busy && !isQuietSetupAction;
 
   return (
     <div className="mt-6 pb-[var(--app-scroll-bottom-pad,var(--app-bottom-inset))] sm:mt-8 sm:pb-8">
@@ -72,6 +80,8 @@ export function SetupCompletionFooter({
               "h-12 text-base",
               isQuietSetupAction &&
                 "!border-0 !bg-transparent !text-[var(--app-accent)] hover:!bg-[var(--app-accent-tint)] hover:!text-[var(--app-accent)] disabled:!bg-muted/35 disabled:!text-muted-foreground disabled:!opacity-100",
+              isBlockedFilledAction &&
+                "!border-0 disabled:!bg-muted/60 disabled:!text-muted-foreground disabled:!opacity-100",
             )}
             data-testid={testId}
             data-voice-control-id={controlId}

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -1862,7 +1862,7 @@ function ReadyScreen({
           <div className="mt-4" data-testid="onboarding-join-circle">
             {joinAccepted ? (
               <p
-                className="flex items-center gap-2 rounded-[18px] border border-[color:var(--app-accent)]/25 bg-[color:var(--app-accent-soft)] px-4 py-3 text-[14px] font-medium leading-5 text-[#1f2b3d] dark:text-[#dce6f5]"
+                className="flex items-center gap-2 rounded-[20px] border border-[color:var(--app-accent)]/25 bg-[color:var(--app-accent-soft)] px-5 py-3 text-[14px] font-medium leading-5 text-[#1f2b3d] dark:text-[#dce6f5]"
                 role="status"
               >
                 <Check
@@ -1874,7 +1874,11 @@ function ReadyScreen({
               </p>
             ) : joinPreview ? (
               <div
-                className="rounded-[18px] border border-[#e4e6e9] bg-[#f8f9fb] p-4 dark:border-white/[0.08] dark:bg-[#1c212a]"
+                // Same geometry as the invite card directly above it. These two
+                // stack at the same width, so a 16px inset under a 20px one put
+                // every line of the join card 4px left of the code card's --
+                // a visibly ragged edge down the panel.
+                className="rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-5 dark:border-white/[0.08] dark:bg-[#1c212a]"
                 data-testid="onboarding-join-circle-preview"
               >
                 {/* Name, owner and size before accepting. Deciding whether to

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -937,10 +937,10 @@ export function VaultFlow({
               <VaultFlowHeader
                 icon={Lock}
                 title="Finish setup first"
-                description="Your private vault is the final step after setup."
+                description="This is the last step."
               />
               <p className="type-footnote leading-snug text-muted-foreground">
-                Finish this setup journey, then create your vault from the final security step.
+                Finish setting up, then come back here.
               </p>
             </div>
           )}
@@ -952,8 +952,8 @@ export function VaultFlow({
             >
               <VaultFlowHeader
                 icon={Lock}
-                title="Create your private vault"
-                description="End-to-end encryption starts here."
+                title="Create your passphrase"
+                description="This is what opens your private place."
               />
               <div className="space-y-1.5">
                 <Label htmlFor="passphrase" className="type-footnote font-medium text-muted-foreground">
@@ -1025,10 +1025,10 @@ export function VaultFlow({
               >
                 {isUnlocking ? (
                   <>
-                    <Icon icon={Loader2} size="md" className="mr-2 animate-spin" /> Creating vault...
+                    <Icon icon={Loader2} size="md" className="mr-2 animate-spin" /> Creating...
                   </>
                 ) : (
-                  "Create private vault"
+                  "Create passphrase"
                 )}
               </Button>
             </form>
@@ -1039,7 +1039,7 @@ export function VaultFlow({
             <div className="space-y-2.5">
               <VaultFlowHeader
                 icon={isGeneratedVaultMode ? Fingerprint : Lock}
-                title="Open your private vault"
+                title="Open your private place"
                 description={
                   isGeneratedVaultMode
                     ? "Confirm with your device."
@@ -1501,9 +1501,7 @@ export function VaultFlow({
                 onClick={handleRecoveryKeyContinue}
                 disabled={isUnlocking}
               >
-                {isUnlocking
-                  ? "Opening vault..."
-                  : "I’ve saved my recovery key"}
+                {isUnlocking ? "Opening..." : "I’ve saved my recovery key"}
               </Button>
             </div>
           ) : null}


### PR DESCRIPTION
Founder review on the fresh-user setup journey. Three fixes.

## 1. "Finish setup" was blue while it was blocked

The button is gated on the one mandatory step (AI access), but a blocked one rendered `rgb(0, 122, 255)` with white text at **full opacity** — pixel-identical to a working one. Measured in Chromium against the real compiled stylesheet: the base `disabled:opacity-50` never reached it through this button's class stack.

So the reported behaviour was exactly right — you tap a blue primary action, nothing happens, and the only explanation is a grey supporting line you already read past.

| state | before | after |
|---|---|---|
| enabled | `rgb(0, 122, 255)` | unchanged |
| blocked | `rgb(0, 122, 255)`, opacity 1 | neutral `muted/60`, muted text, opacity 1 |
| busy | accent | accent (a tap resolving is not a tap refused) |

The shared `SetupCompletionFooter` owns the rule, so every setup route inherits it. The phone header action follows it too, instead of a 40%-opacity accent.

**The reason now travels with the block on both layouts.** Desktop had a supporting line; the phone action had only a `title` tooltip, which a touch device never shows. The header summary both layouts render names it: `3 of 7 ready. Choose AI access to finish.`

## 2. No "vault" in front of a person

Per @manishushh. The word stays in the code — services, props, test ids, the prerequisite key — and leaves the copy.

| before | after |
|---|---|
| Your vault is required to finish setup. | One step left. |
| One last step: protect what you save. | Only you can open what you save. |
| Your private vault gives One end-to-end encryption. Only you hold the key. | Not even we can read it. |
| Set up private vault | Set a lock |
| Your vault is required. You can add more capabilities any time. | Add the rest any time. |
| Choose an AI access option before continuing. | Choose AI access to finish. |
| Your private vault is not ready yet. Try again. | Not ready yet. Try again. |
| Create your private vault *(one tap later)* | Create your passphrase |
| Create private vault | Create passphrase |

The create step says "passphrase" because that is the thing being made and the field labels already say so.

## 3. Join circle was not aligned

The join card sits directly under the invite code card at the same width, but carried `p-4` / `rounded-[18px]` against the code card's `p-5` / `rounded-[20px]`. Every line of it, including the Join button, sat 4px left of the column above — measured, first text line at x=41 vs x=45 on a 430px viewport. Same geometry for both now, and for the accepted confirmation that replaces it in place (which otherwise made the panel's left edge jump the moment someone joined).

Rebased on #5302 so it composes with the centering fix rather than fighting it.

## Not changed

Layout, navigation, gating logic, data flow, the completion boundary, the vault itself. This moves colour, wording, and two inset values.

## Verification

- Full suite: **27 failed / 3966 passed** vs **28 / 3954** on `origin/main` — zero regressions, +12 from the new tests. (The pre-existing failures are unrelated: profile delete, cinematic intro, route playbook.)
- `tsc --noEmit`, `eslint --max-warnings=0`, `verify:design-system` (incl. accent tokens + apple hierarchy): clean.
- Computed colours read in Chromium in light and dark against the real stylesheet, before and after.
- Card edges measured at 430px, before and after.
- New: `setup-completion-footer-blocked-state.test.tsx` (7 tests, mutation-checked against 3 mutations), plus alignment and plain-language contract tests.