### PR TITLE
fix(circle-join): stop the invite landing from colliding with the app shell

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4859,7 +4859,7 @@
     "one_specialist_tools": "4067d2cabf3bf0c1c8bb2f53d2080a03dc68fd2a04819594cfc1593478538ac8",
     "route_index": "b5a242e0d320b58442871fb95540dc80553f03502b3c04c5d31337b7e6b249f4",
     "route_layout": "3a3769adca745b71f261e229e83189ee757b1a8a484f39300d259c3ef4fde494",
-    "surface_map": "809e8f871431d41c69d7ece7fe3279749a35079f869c84f3d8ac1faee2077daf",
+    "surface_map": "daaeb8434f7ab179407d514c8bc4de44a317719a0253d86592a753c8ad22c234",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/__tests__/app/circle-join-page.test.tsx
+++ b/hushh-webapp/__tests__/app/circle-join-page.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OneLocationCircleInvitePreview } from "@/lib/one-location/types";
+
+const mockReplace = vi.fn();
+const mockPreview = vi.fn();
+let searchParams = new URLSearchParams();
+let authState: {
+  user: { getIdToken: () => Promise<string> } | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: {
+    previewOnboardingCircleCode: (params: { idToken: string; code: string }) =>
+      mockPreview(params),
+  },
+}));
+
+import CircleJoinPage from "@/app/circle/join/page";
+
+const CODE = "SWDXENDPB954";
+
+function preview(
+  overrides: Partial<OneLocationCircleInvitePreview> = {},
+): OneLocationCircleInvitePreview {
+  return {
+    name: "JHUMMA's Circle",
+    kind: "family",
+    ownerDisplayName: "JHUMMA KUMARI",
+    memberCount: 1,
+    expiresAt: "2026-09-01T00:00:00Z",
+    alreadyMember: false,
+    ...overrides,
+  } as OneLocationCircleInvitePreview;
+}
+
+function signedIn() {
+  authState = {
+    user: { getIdToken: () => Promise.resolve("id-token") },
+    isAuthenticated: true,
+    loading: false,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchParams = new URLSearchParams({ code: CODE });
+  authState = { user: null, isAuthenticated: false, loading: false };
+});
+
+describe("/circle/join landing", () => {
+  it("shows the invitation and the code to a signed-out recipient", async () => {
+    render(<CircleJoinPage />);
+
+    expect(await screen.findByTestId("circle-join-code")).toHaveTextContent(
+      /SWDX/,
+    );
+    expect(screen.getByTestId("circle-join-sign-in")).toBeInTheDocument();
+    // The trust statement is what someone weighs before signing in.
+    expect(
+      screen.getByText(
+        "Your location stays private until you choose to share it.",
+      ),
+    ).toBeInTheDocument();
+    // Nothing about the Circle is claimed before it has been looked up.
+    expect(screen.queryByTestId("circle-join-preview")).toBeNull();
+    expect(mockPreview).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing and redirects when the link carries no code", async () => {
+    searchParams = new URLSearchParams();
+
+    const { container } = render(<CircleJoinPage />);
+
+    // Effects run after paint: a codeless "You're invited" must never commit.
+    expect(container.textContent).toBe("");
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/one/location?action=join-circle",
+      ),
+    );
+  });
+
+  it("names the Circle and offers to join it once the preview resolves", async () => {
+    signedIn();
+    mockPreview.mockResolvedValue(preview());
+
+    render(<CircleJoinPage />);
+
+    expect(await screen.findByTestId("circle-join-preview")).toHaveTextContent(
+      "JHUMMA's Circle",
+    );
+    expect(screen.getByTestId("circle-join-preview")).toHaveTextContent(
+      "JHUMMA KUMARI · 1 person",
+    );
+    expect(screen.getByTestId("circle-join-continue")).toHaveTextContent(
+      "Join this Circle",
+    );
+  });
+
+  it("switches the action when the recipient is already a member", async () => {
+    signedIn();
+    mockPreview.mockResolvedValue(preview({ alreadyMember: true }));
+
+    render(<CircleJoinPage />);
+
+    expect(await screen.findByTestId("circle-join-preview")).toHaveTextContent(
+      "You're already in this Circle.",
+    );
+    expect(screen.getByTestId("circle-join-continue")).toHaveTextContent(
+      "Open One Location",
+    );
+  });
+
+  it("pluralises member counts and survives a zero count", async () => {
+    signedIn();
+    mockPreview.mockResolvedValue(preview({ memberCount: 4 }));
+
+    const { unmount } = render(<CircleJoinPage />);
+    expect(await screen.findByTestId("circle-join-preview")).toHaveTextContent(
+      "JHUMMA KUMARI · 4 people",
+    );
+    unmount();
+
+    mockPreview.mockResolvedValue(preview({ memberCount: 0 }));
+    render(<CircleJoinPage />);
+    const zero = await screen.findByTestId("circle-join-preview");
+    expect(zero).toHaveTextContent("JHUMMA KUMARI");
+    expect(zero.textContent).not.toContain("0 people");
+  });
+
+  it("falls back to readable text when the backend sends empty fields", async () => {
+    signedIn();
+    mockPreview.mockResolvedValue(
+      preview({ name: "   ", ownerDisplayName: "" }),
+    );
+
+    render(<CircleJoinPage />);
+
+    const card = await screen.findByTestId("circle-join-preview");
+    expect(card).toHaveTextContent("This Circle");
+    expect(card).toHaveTextContent("A Circle owner");
+  });
+
+  it("replaces a raw transport error with one actionable sentence", async () => {
+    signedIn();
+    mockPreview.mockRejectedValue(new Error("Request failed: 422"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(<CircleJoinPage />);
+
+    const error = await screen.findByTestId("circle-join-error");
+    expect(error).toHaveTextContent("That code didn't work. Ask for a new link.");
+    expect(screen.queryByText(/Request failed/)).toBeNull();
+    expect(screen.queryByText(/422/)).toBeNull();
+    // The detail is kept where it is useful.
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+
+    // A failed lookup is never the end of the road -- the hub takes a retype.
+    expect(screen.getByTestId("circle-join-continue")).toHaveTextContent(
+      "Open One Location",
+    );
+  });
+
+  it("keeps the code readable and the invitation intact for a long Circle name", async () => {
+    signedIn();
+    const longName = "The Extremely Long Family And Close Friends Circle Name";
+    mockPreview.mockResolvedValue(
+      preview({ name: longName, ownerDisplayName: "Ankit Kumar Singh" }),
+    );
+
+    render(<CircleJoinPage />);
+
+    const card = await screen.findByTestId("circle-join-preview");
+    // Product-owned and user-generated text wraps; it is never ellipsized, and
+    // it never leaks into the button, which stays a fixed, stable label.
+    expect(card).toHaveTextContent(longName);
+    expect(screen.getByTestId("circle-join-continue")).toHaveTextContent(
+      "Join this Circle",
+    );
+    expect(screen.getByTestId("circle-join-code")).toBeInTheDocument();
+  });
+
+  it("announces the lookup result through a pre-mounted live region", async () => {
+    signedIn();
+    mockPreview.mockResolvedValue(preview());
+
+    render(<CircleJoinPage />);
+
+    // Present from the first paint, so the result is actually announced.
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    await waitFor(() =>
+      expect(status).toHaveTextContent("JHUMMA's Circle. JHUMMA KUMARI · 1 person."),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/app/circle-join-shell-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/circle-join-shell-layout.contract.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * /circle/join renders INSIDE the signed-in shell.
+ *
+ * Its route-layout contract entry says `mode: "redirect"`, which reads like an
+ * opt-out but is a runtime no-op: only `"flow"`, `"hidden"` and the separate
+ * `persistentChrome: "none"` flag change chrome, so this route draws the top
+ * bar and the bottom "Talk to One" composer like any standard route.
+ *
+ * The shell reserves both edges on the page's behalf -- app/providers.tsx
+ * renders a `data-app-shell-top-spacer` sized to `--app-top-content-offset`
+ * ahead of the page, and the scroll root carries `--app-scroll-bottom-pad`.
+ * A viewport height on the page root therefore double-counts that reservation.
+ * That is what shipped: `min-h-[100svh] ... justify-center` centred the
+ * invitation against the whole viewport, pushing it under the header and
+ * leaving a dead scroll region above the composer on every phone.
+ *
+ * These are source-text assertions on purpose. The regression is structural --
+ * the screen can render every control correctly and still be wrong by sizing
+ * itself against the viewport instead of its content.
+ */
+const RAW = readFileSync(join(process.cwd(), "app/circle/join/page.tsx"), "utf8");
+
+/**
+ * Assert on code, not prose. Every banned token below is also a word an author
+ * needs in order to explain WHY it is banned; scanning the comments too would
+ * mean the only way to pass this gate is to delete the explanation.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\*)/.test(line))
+    .join("\n");
+}
+
+const SOURCE = stripComments(RAW);
+
+describe("/circle/join shell layout contract", () => {
+  it("measures to its content instead of the viewport", () => {
+    // The whole defect, in four assertions.
+    expect(SOURCE).not.toContain("100svh");
+    expect(SOURCE).not.toContain("100dvh");
+    expect(SOURCE).not.toContain("100vh");
+    expect(SOURCE).not.toContain("min-h-screen");
+    // Centring a whole column is the other half of the defect: it is what put
+    // the invitation under the header once the column outgrew the shell's
+    // available height. (`justify-center` alone is fine -- the icon tile
+    // centres its glyph with it.)
+    expect(SOURCE).not.toContain("flex-col justify-center");
+
+    // AppPageShell owns the measure, the inline gutters and the bottom
+    // clearance; `fitContent` is the flag written for exactly this symptom.
+    expect(SOURCE).toContain("<AppPageShell");
+    expect(SOURCE).toContain("fitContent");
+  });
+
+  it("keeps the invitation at one readable column on a laptop", () => {
+    // `.app-page-shell[data-app-shell-width="reading"]` (54rem) outranks any
+    // utility class, so a `max-w-*` here is silently dead and the invitation
+    // stretches to 864px. The measure must be an inline style to win.
+    expect(SOURCE).toContain('maxWidth: "30rem"');
+    expect(SOURCE).toContain("style={INVITE_MEASURE}");
+  });
+
+  it("never re-reserves space the shell already reserves", () => {
+    // Padding by these tokens doubles the clearance the scroll root applies.
+    expect(SOURCE).not.toContain("--app-top-content-offset");
+    expect(SOURCE).not.toContain("--app-scroll-bottom-pad");
+    expect(SOURCE).not.toContain("--onboarding-agent-bar-clearance");
+    expect(SOURCE).not.toContain("--app-bottom-fixed-ui");
+  });
+
+  it("does not escape the shell or outrank its chrome", () => {
+    // A flow that goes fixed/absolute over the viewport covers the top bar
+    // rather than scrolling beneath it.
+    expect(SOURCE).not.toContain("fixed inset-0");
+    expect(SOURCE).not.toMatch(/\bz-\[\d+\]/);
+    expect(SOURCE).not.toContain("position: fixed");
+  });
+
+  it("lets the shared header own the h1 and the icon tile", () => {
+    expect(SOURCE).toContain("<PageHeader");
+    expect(SOURCE).not.toContain("<h1");
+    // The top bar owns back on every in-shell surface.
+    expect(SOURCE).not.toContain("ChevronLeft");
+    // --app-accent-soft is referenced across the repo but defined nowhere, so
+    // a tile painted with it has no background at all. Use an accent-derived
+    // tint that actually resolves, and that follows the accent preference.
+    expect(SOURCE).not.toContain("--app-accent-soft");
+    expect(SOURCE).toContain("bg-[color:var(--app-accent)]/12");
+  });
+
+  it("uses design-system components instead of hand-rolled recipes", () => {
+    // The hand-rolled pill dropped the focus ring, the disabled state and the
+    // loading affordance that <Button> already ships.
+    expect(SOURCE).toContain("<Button");
+    expect(SOURCE).not.toContain("rounded-full bg-[color:var(--app-accent)]");
+    expect(SOURCE).not.toContain("h-14 w-full");
+    // Destructive colour is a token in both appearances, not a literal pair.
+    expect(SOURCE).toContain("var(--app-destructive)");
+    expect(SOURCE).not.toContain("#c8372d");
+    expect(SOURCE).not.toContain("#ff9a90");
+  });
+
+  it("keeps product-owned text wrapping rather than truncating", () => {
+    // A Circle name and an owner name are unbounded user content shown at a
+    // fixed measure; they wrap. Nothing here may ellipsize.
+    expect(SOURCE).not.toContain("truncate");
+    expect(SOURCE).not.toContain("text-ellipsis");
+    expect(SOURCE).not.toContain("whitespace-nowrap");
+    expect(SOURCE).not.toMatch(/line-clamp-\d/);
+    expect(SOURCE).toContain("break-words");
+    // The code is a single unbroken token at 320px.
+    expect(SOURCE).toContain("break-all");
+  });
+
+  it("never renders a raw transport error to the reader", () => {
+    // `caught.message` reaches the user as "Request failed: 422" or
+    // "Invalid Firebase ID token" if it is rendered directly.
+    expect(SOURCE).not.toMatch(/setError\(\s*caught/);
+    expect(SOURCE).not.toContain("caught.message");
+    expect(SOURCE).toContain("That code didn't work. Ask for a new link.");
+  });
+
+  it("does not paint a codeless invitation before the redirect fires", () => {
+    // Effects run after paint, so the redirect alone is not enough.
+    expect(SOURCE).toContain("if (!code) return null;");
+  });
+});

--- a/hushh-webapp/app/circle/join/page.tsx
+++ b/hushh-webapp/app/circle/join/page.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Loader2, Users } from "lucide-react";
 
+import { AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import {
+  CaptionText,
+  CardTitle,
+  RowDescription,
+} from "@/components/app-ui/typography";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import {
   CIRCLE_JOIN_CODE_PARAM,
@@ -13,6 +27,15 @@ import {
 import { OneLocationService } from "@/lib/one-location/service";
 import type { OneLocationCircleInvitePreview } from "@/lib/one-location/types";
 
+/**
+ * An invitation is one short column. `width="reading"` (54rem) stretches it
+ * into a banner on a laptop, and the measure cannot be a utility class: the
+ * shell sets its width through `.app-page-shell[data-app-shell-width="reading"]`,
+ * which outranks one. `AppPageShell` exports `APP_MEASURE_STYLES` for the same
+ * reason -- an inline max-width is the established way to narrow a shell.
+ */
+const INVITE_MEASURE: CSSProperties = { maxWidth: "30rem" };
+
 function joinPath(code: string): string {
   const query = new URLSearchParams({ action: "join-circle" });
   if (code) query.set(CIRCLE_JOIN_CODE_PARAM, code);
@@ -20,10 +43,24 @@ function joinPath(code: string): string {
 }
 
 function loginHref(code: string): string {
-  // Back to this same landing rather than to the hub, so the code survives the
-  // round trip through sign-in and the preview below is what greets them.
+  // Return to this same landing rather than to the hub, so the code survives
+  // the round trip through sign-in and the preview below is what greets them.
   const here = `/circle/join?${CIRCLE_JOIN_CODE_PARAM}=${encodeURIComponent(code)}`;
   return `/login?redirect=${encodeURIComponent(here)}`;
+}
+
+// The API types these as required, but the backend coerces a missing owner to a
+// placeholder and an unnamed Circle to "". Render what a person can read.
+function circleName(preview: OneLocationCircleInvitePreview): string {
+  return preview.name.trim() || "This Circle";
+}
+
+function memberSummary(preview: OneLocationCircleInvitePreview): string {
+  const owner = preview.ownerDisplayName.trim() || "A Circle owner";
+  if (preview.memberCount <= 0) return owner;
+  const people =
+    preview.memberCount === 1 ? "1 person" : `${preview.memberCount} people`;
+  return `${owner} · ${people}`;
 }
 
 /**
@@ -35,6 +72,16 @@ function loginHref(code: string): string {
  * only context they had. Someone deciding whether to share their live location
  * deserves to see whose Circle it is first -- which is the one thing every
  * comparable product shows at this exact moment.
+ *
+ * Layout note: this route renders INSIDE the signed-in shell. Its contract
+ * entry says `mode: "redirect"`, but only "flow", "hidden" and
+ * `persistentChrome: "none"` change chrome, so the top bar and the bottom
+ * "Talk to One" composer are both drawn here. The shell already reserves both
+ * edges -- a spacer sized to `--app-top-content-offset` precedes this page and
+ * the scroll root carries `--app-scroll-bottom-pad`. A viewport height here
+ * therefore double-counts that reservation: it pushed the invitation into the
+ * header and left a dead scroll region above the composer. `AppPageShell` with
+ * `fitContent` is the primitive that measures to its content instead.
  */
 function CircleJoinLanding() {
   const router = useRouter();
@@ -57,11 +104,13 @@ function CircleJoinLanding() {
         await OneLocationService.previewOnboardingCircleCode({ idToken, code }),
       );
     } catch (caught) {
-      setError(
-        caught instanceof Error && caught.message
-          ? caught.message
-          : "That code did not match a Circle. Ask for a fresh one.",
-      );
+      // The service rethrows the transport error untouched, so `caught.message`
+      // can be "Request failed: 422", "Rate limit exceeded: 10 per 1 minute" or
+      // "Invalid Firebase ID token". None of that is readable, and none of it
+      // tells the person what to do. Keep the detail in the console for
+      // diagnostics and show one sentence they can act on.
+      console.error("[circle-join] preview failed", caught);
+      setError("That code didn't work. Ask for a new link.");
     } finally {
       setLoading(false);
     }
@@ -77,91 +126,127 @@ function CircleJoinLanding() {
     if (!code) router.replace(joinPath(""));
   }, [code, router]);
 
+  // Effects run after paint, so rendering the invitation here would commit a
+  // codeless "You're invited" -- and a sign-in link carrying an empty code --
+  // for one frame before the redirect above fires.
+  if (!code) return null;
+
+  const showPreview = auth.isAuthenticated && !auth.loading;
+  const canJoin = Boolean(preview) && !preview?.alreadyMember;
+
   return (
-    <main className="mx-auto flex min-h-[100svh] w-full max-w-[30rem] flex-col justify-center px-6 py-12">
-      <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
-        <Users className="h-7 w-7" strokeWidth={2} />
-      </span>
+    <AppPageShell
+      as="main"
+      width="reading"
+      fitContent
+      style={INVITE_MEASURE}
+      data-testid="circle-join-landing"
+    >
+      <PageHeader
+        title="You're invited"
+        eyebrow="Circle invite"
+        description="Your location stays private until you choose to share it."
+        leading={
+          <span className="flex h-11 w-11 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+            <Users className="h-[22px] w-[22px]" aria-hidden="true" />
+          </span>
+        }
+        testId="circle-join-header"
+      />
 
-      <h1 className="ui-text-agent-title mt-5 text-balance">
-        You&apos;ve been invited to a Circle
-      </h1>
-
-      {code ? (
+      {/* One surface holds everything known about the invitation: the code the
+          sender read out, and -- once it resolves -- whose Circle it is. Three
+          floating blocks read as three unrelated things. */}
+      <section
+        className="mt-6 rounded-[var(--app-card-radius-standard)] bg-[color:var(--app-card-surface-default-solid)] p-5"
+        data-testid="circle-join-card"
+      >
+        <CaptionText className="text-muted-foreground">Invite code</CaptionText>
         <p
-          className="mt-3 select-all font-mono text-[clamp(18px,5.5vw,24px)] font-bold uppercase tracking-[0.12em]"
+          className="mt-1 select-all break-all font-mono text-[19px] font-bold uppercase leading-6 tracking-[0.1em]"
           data-testid="circle-join-code"
         >
           {formatCircleCodeForDisplay(code)}
         </p>
-      ) : null}
 
-      {auth.loading ? (
-        <p className="mt-6 flex items-center gap-2 text-sm text-muted-foreground">
+        {showPreview ? (
+          <div className="mt-4 border-t border-[color:var(--app-separator)] pt-4">
+            {loading ? (
+              <p className="flex items-center gap-2 text-[15px] leading-5 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Looking up this Circle
+              </p>
+            ) : preview ? (
+              <div className="min-w-0" data-testid="circle-join-preview">
+                <CardTitle className="break-words">
+                  {circleName(preview)}
+                </CardTitle>
+                <RowDescription className="mt-1 break-words">
+                  {memberSummary(preview)}
+                </RowDescription>
+                {preview.alreadyMember ? (
+                  <RowDescription className="mt-2">
+                    You&apos;re already in this Circle.
+                  </RowDescription>
+                ) : null}
+              </div>
+            ) : error ? (
+              <p
+                className="text-[15px] leading-5 text-[color:var(--app-destructive)]"
+                data-testid="circle-join-error"
+              >
+                {error}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      {/* Pre-mounted so a screen reader announces the lookup result. An element
+          that only exists once the message does is never announced. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {loading
+          ? "Looking up this Circle"
+          : error
+            ? error
+            : preview
+              ? `${circleName(preview)}. ${memberSummary(preview)}.`
+              : ""}
+      </p>
+
+      {showPreview ? (
+        // Always offered, even when the lookup failed: the hub can take a
+        // retyped code, so a bad preview is never the end of the road.
+        <Button
+          type="button"
+          size="lg"
+          className="mt-6 w-full"
+          onClick={() => router.replace(joinPath(code))}
+          data-testid="circle-join-continue"
+        >
+          {canJoin ? "Join this Circle" : "Open One Location"}
+        </Button>
+      ) : auth.loading ? (
+        <p className="mt-6 flex items-center gap-2 text-[15px] leading-5 text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           Checking your account
         </p>
-      ) : !auth.isAuthenticated ? (
-        <>
-          <p className="mt-4 text-[15px] leading-6 text-muted-foreground">
-            Sign in to see whose Circle this is. Your location stays private
-            until you choose to share it.
-          </p>
-          <Link
-            href={loginHref(code)}
-            className="press-scale mt-6 flex h-14 w-full items-center justify-center rounded-full bg-[color:var(--app-accent)] text-[17px] font-bold text-[color:var(--app-accent-fg)]"
-            data-testid="circle-join-sign-in"
-          >
-            Sign in to continue
-          </Link>
-        </>
       ) : (
         <>
-          {loading ? (
-            <p className="mt-6 flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-              Looking up this Circle
-            </p>
-          ) : preview ? (
-            <div
-              className="mt-6 rounded-[20px] border border-border/60 bg-muted/30 p-5"
-              data-testid="circle-join-preview"
-            >
-              <p className="text-[17px] font-bold leading-6">{preview.name}</p>
-              <p className="mt-1 text-[14px] leading-5 text-muted-foreground">
-                {preview.ownerDisplayName} &middot; {preview.memberCount}{" "}
-                {preview.memberCount === 1 ? "person" : "people"}
-              </p>
-              {preview.alreadyMember ? (
-                <p className="mt-3 text-[14px] leading-5 text-muted-foreground">
-                  You&apos;re already in this Circle.
-                </p>
-              ) : null}
-            </div>
-          ) : error ? (
-            <p
-              className="mt-6 text-[15px] leading-6 text-[#c8372d] dark:text-[#ff9a90]"
-              role="status"
-            >
-              {error}
-            </p>
-          ) : null}
-
-          {/* Always offered, even when the lookup failed: the hub can take a
-              retyped code, so a bad preview is never the end of the road. */}
-          <button
-            type="button"
-            onClick={() => router.replace(joinPath(code))}
-            className="press-scale mt-6 flex h-14 w-full items-center justify-center rounded-full bg-[color:var(--app-accent)] text-[17px] font-bold text-[color:var(--app-accent-fg)]"
-            data-testid="circle-join-continue"
+          <p className="mt-6 text-[15px] leading-5 text-muted-foreground">
+            Sign in to see whose Circle this is.
+          </p>
+          <Button
+            asChild
+            size="lg"
+            className="mt-4 w-full"
+            data-testid="circle-join-sign-in"
           >
-            {preview && !preview.alreadyMember
-              ? `Join ${preview.name}`
-              : "Open One Location"}
-          </button>
+            <Link href={loginHref(code)}>Sign in</Link>
+          </Button>
         </>
       )}
-    </main>
+    </AppPageShell>
   );
 }
 

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -609,11 +609,11 @@
       },
       "native": null,
       "shell": {
-        "app_page_shell": false,
-        "page_header": false,
+        "app_page_shell": true,
+        "page_header": true,
         "settings_ui": false,
         "shared_loader": false,
-        "back_button_pattern": "route-local-check-required"
+        "back_button_pattern": "shared-shell"
       },
       "voice_action_contract_file": null,
       "voice_action_contract_ids": [],
@@ -8518,5 +8518,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "da51d36218e4f4627f8ead6ed7feabc4b6e0ea84bfc7a6f832c37782fbe4f37a"
+  "content_sha256": "dd0b474b9c2792fda810c480e21c3d3635aaf13df57c600b54b52087c2257f8b"
 }


### PR DESCRIPTION
## What was wrong

The recipient landing for a shared Circle link renders **inside** the signed-in shell. Its route-layout entry says `mode: "redirect"`, which reads like an opt-out but is a runtime no-op — only `"flow"`, `"hidden"` and `persistentChrome: "none"` change chrome — so the top bar and the bottom "Talk to One" composer have always drawn on this route.

The shell reserves both edges *for* the page: `providers.tsx` renders a `data-app-shell-top-spacer` sized to `--app-top-content-offset` ahead of it, and the scroll root carries `--app-scroll-bottom-pad`. The page then asked for `min-h-[100svh]` and centred its column inside that, double-counting the reservation.

Measured on the running app, before:

| viewport | content top | dead scroll |
|---|---|---|
| 320×568 | 204px | 154px |
| 375×667 | 251px | 154px |
| 390×844 | 351px | 154px |
| 430×932 | 393px | 154px |
| 768×1024 | 434px | 154px |

154px of forced scroll on a screen with one card in it, and the invitation landing in a different place on every device. Scrolling it took the content under the header.

After:

| viewport | content top | dead scroll |
|---|---|---|
| every width, 100% and 200% text | **92px** | **0px** |

Content starts 32px below the reserved top-bar band, identically everywhere. No horizontal overflow at 320px.

## What changed

Rebuilt on primitives that already exist:

- `AppPageShell` with `fitContent` — the flag's own doc comment describes this exact symptom ("sparse screens … force a full-height shell, producing a large dead scroll region above the floating Talk to One bar")
- `PageHeader` for the `<h1>`, eyebrow and icon tile
- the shared `Button`, which restores the focus ring, disabled state and loading affordance the hand-rolled `h-14 rounded-full` pill dropped

Fixed along the way, all visible on this screen:

- the icon tile was painted with `--app-accent-soft`, which is referenced in eight files and **defined nowhere** — it rendered with no background at all
- preview failures rendered `caught.message` verbatim, so people could read `Request failed: 422`, `Rate limit exceeded: 10 per 1 minute` or `Invalid Firebase ID token`. Raw detail now goes to the console; one actionable sentence goes to the screen
- a codeless link painted "You've been invited to a Circle" for a frame before redirecting, because both redirects live in effects
- the trust line about location staying private was shown only to signed-out visitors — never to the person actually about to join
- the CTA interpolated the Circle name into a fixed-height pill, which burst at the 80-char name limit. The label is stable; the name wraps in the card
- empty name / empty owner / zero member count now render readable text (the API types them non-null but the backend coerces them)
- the error region is pre-mounted as a live region, so the result is announced

Copy, per the less-text rules: `You've been invited to a Circle` → `You're invited`; `Sign in to continue` → `Sign in`; `Join ${name}` → `Join this Circle`.

## Verification

- `npx vitest run` on this branch **and** on `origin/main`: both 25 failed files / 33 failed tests, and `diff` of the failing sets is **empty** — no new failures
- 18 new tests: a source-text contract gate + a 10-case rendered state matrix (signed-out, no-code, preview, already-member, 0/1/N members, empty fields, raw-error suppression, long names, live region)
- the gate was mutation-checked against the original file: **6 of its 8 cases fail** on pre-fix source
- `typecheck`, `lint`, `verify:design-system` (incl. accent-token and Apple-hierarchy checks), `verify:surface-map`: green
- rendered at 320/360/375/390/430/768 and a short 390×600, at 100% and 200% text, screenshots captured

The surface map regenerates to record the improvement: this route now reports `app_page_shell: true`, `page_header: true`, `back_button_pattern: shared-shell` (was `route-local-check-required`).

Layout contract, navigation, data flow, analytics and route config are unchanged. Complements #5302, which fixed the *sender's* link; this fixes the screen the recipient lands on.

## Known, not changed here

`OnboardingJourneyGuard` intercepts `/circle/join` — it is absent from `isOnboardingAdmissionExemptRoute` — so a signed-in user mid-setup is bounced to `/one/setup` and never sees the invitation. That is a routing/behaviour change with its own blast radius, filed as #5307 rather than smuggled into a styling fix.
