### PR TITLE
fix(one-location): show what the Location switch means on iPhone, and stop the web map zooming itself out

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -114,9 +114,15 @@ vi.mock("@/lib/vault/vault-context", () => ({
   useVault: () => ({ vaultOwnerToken: "in-memory-owner-token" }),
 }));
 
+// Mutable so a case can assert the NATIVE branch. `setPadding` is a real
+// camera inset on iOS/Android but a zoom-out on the @capacitor/google-maps web
+// shim, so the two runtimes have genuinely different contracts here and both
+// need covering.
+const platformHarness = vi.hoisted(() => ({ native: false }));
+
 vi.mock("@/lib/capacitor/platform", () => ({
-  getPlatform: () => "web",
-  isNative: () => false,
+  getPlatform: () => (platformHarness.native ? "ios" : "web"),
+  isNative: () => platformHarness.native,
 }));
 
 vi.mock("@/lib/one-location/maps-config", () => ({
@@ -321,6 +327,7 @@ Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
 });
 
 beforeEach(() => {
+  platformHarness.native = false;
   trayHeaderHeightStub = 72;
   trayContentHeightStub = 260;
   // Lanes are module state: without this a superseded claim or a queued
@@ -570,7 +577,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -621,7 +628,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -706,7 +713,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -727,7 +734,7 @@ describe("LocationImmersiveMap demo experience", () => {
     });
     expect(
       screen.getByTestId("one-location-nearby-search-area-legend"),
-    ).toHaveTextContent("500 m search area");
+    ).toHaveTextContent("500 m around you");
     expect(mapHarness.map.fitBounds).toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("clear-nearby-search-area"));
@@ -737,6 +744,39 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(
       screen.queryByTestId("one-location-nearby-search-area-legend"),
     ).not.toBeInTheDocument();
+  });
+
+  it("never sends camera padding to the web map renderer", async () => {
+    // Regression, QA "uppr gap kyu aa raha hai": on iOS/Android `setPadding` is
+    // a true camera inset — same zoom, map still edge to edge. The
+    // @capacitor/google-maps WEB shim is `fitBounds(map.getBounds(), padding)`,
+    // i.e. it re-fits the visible world into a box shrunk by the padding. That
+    // is a zoom-out, and a raster map snaps to a whole integer zoom, so the
+    // world stopped filling the container and Google's out-of-world grey showed
+    // as a band above and below the map. Web must never make this call.
+    platformHarness.native = false;
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("publish-nearby-search-area"));
+    await waitFor(() => {
+      expect(mapHarness.map.addCircles).toHaveBeenCalled();
+    });
+
+    expect(mapHarness.map.setPadding).not.toHaveBeenCalled();
+    // The container itself is untouched by the fix and still owns the viewport.
+    expect(screen.getByTestId("one-location-map").className).toContain(
+      "h-[100dvh]",
+    );
   });
 
   it("never strands markers when the set changes mid-write", async () => {
@@ -766,7 +806,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -802,7 +842,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -881,7 +921,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -910,6 +950,8 @@ describe("LocationImmersiveMap demo experience", () => {
   });
 
   it("keeps the full search circle in the visible mobile viewport above the sheet", async () => {
+    // Camera padding is a NATIVE-only bridge call, so this case runs native.
+    platformHarness.native = true;
     experienceHarness.demoMode = false;
     experienceHarness.nearbyAvailable = true;
     // Check-in is its own destination now; the legacy `?action=check-in`
@@ -956,7 +998,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -990,7 +1032,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -1031,7 +1073,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -1091,7 +1133,7 @@ describe("LocationImmersiveMap demo experience", () => {
       // correctly skipped on remount within the same session. Click it only
       // when it's actually there.
       const continueButton = screen.queryByRole("button", {
-        name: "Continue to Your Map",
+        name: "Continue",
       });
       if (continueButton) fireEvent.click(continueButton);
       await waitFor(() => {
@@ -1133,7 +1175,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
       render(<LocationImmersiveMap surface="check-in" />);
       fireEvent.click(
-        screen.getByRole("button", { name: "Continue to Your Map" }),
+        screen.getByRole("button", { name: "Continue" }),
       );
       await waitFor(() => {
         expect(
@@ -1167,7 +1209,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     const view = render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
@@ -1197,7 +1239,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("nearby-check-in-sheet-mock")).toHaveAttribute(
@@ -1248,7 +1290,7 @@ describe("LocationImmersiveMap demo experience", () => {
 
     render(<LocationImmersiveMap surface="check-in" />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
 
     await waitFor(() => {
@@ -1662,7 +1704,7 @@ describe("LocationImmersiveMap remount triggers", () => {
     render(<LocationImmersiveMap surface="check-in" />);
     // Renderer consent gates the sheet and the marker refresh alike.
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(
@@ -1733,7 +1775,7 @@ describe("LocationImmersiveMap reported map defects", () => {
   async function renderReadyMap() {
     render(<LocationImmersiveMap />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Continue to Your Map" }),
+      screen.getByRole("button", { name: "Continue" }),
     );
     await waitFor(() => {
       expect(screen.getByTestId("one-location-map")).toHaveAttribute(

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -818,7 +818,7 @@ async function openShareConfirmStep() {
 async function openAskFlow() {
   fireEvent.click(screen.getByRole("button", { name: /Request location/i }));
   expect(
-    await screen.findByRole("heading", { name: "Request with context" }),
+    await screen.findByRole("heading", { name: "Request location" }),
   ).toBeTruthy();
 }
 
@@ -1155,7 +1155,7 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     const headerActions = screen.getByRole("group", {
-      name: "Location preview control",
+      name: "Location",
     });
     expect(headerActions.className).toContain("ml-auto");
     expect(headerActions.className).toContain("justify-end");
@@ -1177,8 +1177,27 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
     ).toHaveAttribute("data-size", "ios");
-    expect(screen.getByText("Location off").className).toContain("sm:inline");
-    expect(screen.getByText("Location off").className).toContain(
+    // The status text is the ONLY thing on this screen that says what the
+    // switch is for, so it has to render at every width. It used to be
+    // `hidden … sm:inline` + aria-hidden, i.e. present on a desktop browser and
+    // absent from every iPhone and from VoiceOver — which is exactly what QA
+    // hit ("location toggle kis liye hai? iOS pe how user gonna find that?").
+    const locationStatus = screen.getByTestId("one-location-header-status");
+    expect(locationStatus.className).not.toContain("hidden");
+    // Two forms of the same state, one per breakpoint, and NEITHER is hidden at
+    // every width the way the old single `hidden … sm:inline` span was. Phones
+    // get the one-word form because the 28px title has no width to spare there
+    // (the full string measured two title lines at 320/360/375/390); from `sm`
+    // up the full string renders inline exactly as it does today.
+    const compact = locationStatus.querySelector(".sm\\:hidden");
+    const full = locationStatus.querySelector(".hidden.sm\\:inline");
+    expect(compact?.textContent).toBe("Off");
+    expect(full?.textContent).toBe("Location off");
+    expect(locationStatus).not.toHaveAttribute("aria-hidden");
+    expect(
+      screen.getByRole("switch", { name: "Turn location on" }),
+    ).toHaveAttribute("aria-describedby", locationStatus.id);
+    expect(locationStatus.className).toContain(
       "text-[color:var(--app-secondary-label)]",
     );
     expect(headerActions.innerHTML).not.toContain("--app-neutral-fill");
@@ -1482,7 +1501,7 @@ describe("OneLocationAgentPage", () => {
     await openSharePersonStep();
 
     expect(screen.queryByText("Ready for private sharing")).toBeNull();
-    expect(screen.getByText("Invite first to enable sharing")).toBeTruthy();
+    expect(screen.getByText("Invite them first")).toBeTruthy();
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -1534,16 +1553,16 @@ describe("OneLocationAgentPage", () => {
     fireEvent.change(note, { target: { value: "a".repeat(140) } });
     expect(screen.getByText("140/140")).toBeTruthy();
     expect(startButton).toBeEnabled();
-    expect(screen.queryByText("character limit exceed")).toBeNull();
+    expect(screen.queryByText("Note is too long")).toBeNull();
 
     fireEvent.change(note, { target: { value: "a".repeat(141) } });
     expect(screen.getByText("141/140")).toBeTruthy();
-    expect(screen.getByText("character limit exceed")).toBeTruthy();
+    expect(screen.getByText("Note is too long")).toBeTruthy();
     expect(startButton).toBeDisabled();
 
     fireEvent.change(note, { target: { value: "On my way" } });
     expect(screen.getByText("9/140")).toBeTruthy();
-    expect(screen.queryByText("character limit exceed")).toBeNull();
+    expect(screen.queryByText("Note is too long")).toBeNull();
     expect(startButton).toBeEnabled();
 
     expect(
@@ -2748,7 +2767,7 @@ describe("OneLocationAgentPage", () => {
 
     expect(screen.getAllByText("Advisor C").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText("Invite first to enable sharing").length,
+      screen.getAllByText("Invite them first").length,
     ).toBeGreaterThan(0);
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
@@ -3578,7 +3597,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openSharePersonStep();
     expect(screen.getByText("Advisor C")).toBeTruthy();
-    expect(screen.getByText("Invite first to enable sharing")).toBeTruthy();
+    expect(screen.getByText("Invite them first")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: /Select Advisor C/i }),
     ).toBeNull();
@@ -3688,10 +3707,12 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Requests sent" }),
     ).toBeTruthy();
-    // A live request shows a real Delete action, not a static "Active" label
-    // with no way off the list.
+    // A live request shows a real stop action, not a static "Active" label
+    // with no way off the list. The label is "Stop", not "Delete": it is the
+    // same vm.onStopGrant handler the other two revoke buttons use, and it ends
+    // access rather than erasing anything.
     expect(screen.queryByText("Active")).toBeNull();
-    const deleteButton = screen.getByRole("button", { name: "Delete" });
+    const deleteButton = screen.getByRole("button", { name: "Stop" });
     fireEvent.click(deleteButton);
     await waitFor(() =>
       expect(mockRevokeGrant).toHaveBeenCalledWith({
@@ -3942,13 +3963,13 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    // The populated People tab exposes a compact "Sync contacts" circle action.
+    // The populated People tab exposes a compact "Find contacts" circle action.
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(
       await screen.findByRole("button", { name: /Add people/i }),
     ).toBeTruthy();
     fireEvent.click(
-      await screen.findByRole("button", { name: /Sync contacts/i }),
+      await screen.findByRole("button", { name: /Find contacts/i }),
     );
 
     await waitFor(() =>
@@ -4045,7 +4066,7 @@ describe("OneLocationAgentPage", () => {
     // reads as the default rather than one of four equal choices.
     const addPeople = screen.getByRole("button", { name: /Add people/i });
     const syncContacts = screen.getByRole("button", {
-      name: /Sync contacts/i,
+      name: /Find contacts/i,
     });
     expect(addPeople).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Invite$/i })).toBeTruthy();
@@ -4087,7 +4108,7 @@ describe("OneLocationAgentPage", () => {
       const addPeople = screen.getByRole("button", { name: /Add people/i });
       const search = await screen.findByPlaceholderText("Search trusted people");
       const syncContacts = screen.getByRole("button", {
-        name: /Sync contacts/i,
+        name: /Find contacts/i,
       });
       const invite = screen.getByRole("button", { name: /^Invite$/i });
 
@@ -4238,7 +4259,7 @@ describe("OneLocationAgentPage", () => {
     // approval explainer must not add another card below these actions.
     expect(screen.getByRole("button", { name: /Add people/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Invite$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Find contacts/i })).toBeTruthy();
     // "Share to contacts" is deliberately absent: it minted a PUBLIC link,
     // which is the Links tab's job, not a control belonging beside named
     // trusted people.

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -151,6 +151,13 @@ const SETTINGS_ICON_TONE_CLASSNAME = {
     "bg-[rgba(255,159,10,0.12)] text-[#FF9F0A] dark:bg-[rgba(255,159,10,0.20)] dark:text-[#FFD60A]",
   red:
     "bg-[rgba(255,59,48,0.12)] text-[#FF3B30] dark:bg-[rgba(255,69,58,0.20)] dark:text-[#FF6961]",
+  // People, circles and private sharing. Added because the tone vocabulary was
+  // smaller than the semantics: `accent`, `blue` and `purple` are byte-identical
+  // above, so "these are PEOPLE" had no colour of its own and every row that
+  // meant it rendered as the same action blue as "Share location". iOS system
+  // indigo (#5856D6 light / #5E5CE6 dark), same 12%/20% tile recipe as the rest.
+  indigo:
+    "bg-[rgba(88,86,214,0.12)] text-[#5856D6] dark:bg-[rgba(94,92,230,0.20)] dark:text-[#5E5CE6]",
   gray:
     "bg-[#E5E5EA] text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#D1D1D6]",
 } as const;

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1269,6 +1269,25 @@ export function LocationImmersiveMap({
       // setPadding can still nudge the camera on some SDK versions.
       if (key === lastPaddingKey) return;
       lastPaddingKey = key;
+      // NATIVE ONLY. On iOS/Android `setPadding` is a true camera inset
+      // (GMSMapView.padding / GoogleMap.setPadding): the zoom is untouched and
+      // the map still paints edge to edge, it just keeps the centre and the
+      // controls clear of the floating chrome. The @capacitor/google-maps WEB
+      // shim is a different operation entirely —
+      //
+      //   async setPadding({id, padding}) {
+      //     const bounds = maps[id].map.getBounds();
+      //     if (bounds !== undefined) maps[id].map.fitBounds(bounds, padding);
+      //   }
+      //
+      // — i.e. it re-fits the already-visible world into a box shrunk by this
+      // padding. That is a ZOOM-OUT, and a raster map snaps to a whole integer
+      // zoom, so the world (z2) drops to z1 and no longer fills the container:
+      // Google's own out-of-world grey shows as a band above and below the map
+      // and the world repeats horizontally. That is the "gap at top and bottom"
+      // QA reported on uat.one.hushh.ai/one/location/map. The container itself
+      // is correct and untouched (`h-[100dvh]`, map `absolute inset-0`).
+      if (!isNative()) return;
       void map.setPadding(padding);
     };
     const schedulePadding = () => {
@@ -1711,9 +1730,9 @@ export function LocationImmersiveMap({
           });
         }),
       );
-      toast.success(
-        "Your active private recipients can see this foreground update.",
-      );
+      // Keeps the fact that other PEOPLE received it — that is the privacy-
+      // relevant half. "Location updated" would hide it.
+      toast.success("Sent to the people you share with.");
     } catch {
       // The map has already moved to the new position; what failed is telling
       // the people it is shared with.
@@ -2273,7 +2292,13 @@ export function LocationImmersiveMap({
             </span>
           ) : null}
           <span className="pl-[1.125rem] font-normal text-muted-foreground">
-            500 m {nearbyPlaceFocus?.active ? "match" : "search"} area
+            {/* "match" is the backend's word for how it pairs attendees, and it
+                also hid a real difference: the live circle is drawn around the
+                PLACE, the search circle around the PERSON (see the circle title
+                at ~1396). Naming the anchor says both things in plain words. */}
+            {nearbyPlaceFocus?.active
+              ? "500 m around your place"
+              : "500 m around you"}
           </span>
         </div>
       ) : null}
@@ -2313,16 +2338,22 @@ export function LocationImmersiveMap({
         >
           <MapPin className="h-6 w-6 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
           <h1 className="mt-3 text-xl font-semibold">Your Map</h1>
+          {/*
+            This is the renderer-consent gate: accepting it writes
+            GOOGLE_MAPS_RENDERER_CONSENT_VERSION. All three claims are
+            load-bearing and none may be dropped for brevity — private shares
+            are opened locally, Google Maps is told the minimum, and Nearby
+            Check-In is a separate opt-in. Only the wording was tightened.
+          */}
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Private shares open only on this device. Google Maps uses the
-            minimum location needed to show them. Nearby Check-In is separate
-            and starts only when you choose it.
+            Private shares open only on this device. Google Maps gets only what
+            it needs to draw them. Check-In is separate — you start it.
           </p>
           <Button
             className={`mt-4 w-full ${MAP_ACCENT_ACTIVE_CLASSNAME}`}
             onClick={() => void acceptRenderer()}
           >
-            Continue to Your Map
+            Continue
           </Button>
           {demoAvailable ? (
             <Button
@@ -2332,7 +2363,10 @@ export function LocationImmersiveMap({
               onClick={toggleDemoPeople}
             >
               <UsersRound className="h-4 w-4" />
-              Preview with fictional people
+              {/* "not real people" is not lost with the shorter label: tapping
+                  this raises the "Showing fictional people…" toast, and the map
+                  carries a Demo badge for as long as the preview is on. */}
+              See a demo
             </Button>
           ) : null}
         </section>
@@ -2352,13 +2386,17 @@ export function LocationImmersiveMap({
             <MapPin className="h-7 w-7" strokeWidth={2} aria-hidden />
           </span>
           <h1 className="relative font-semibold">
+            {/* "build" and "Maps key" are engineering words on a full-bleed
+                screen an ordinary person is looking at. The distinction the two
+                branches exist to make — this is our problem, not your device or
+                your permission — is what the replacement keeps. */}
             {unavailableReason === "maps-key"
-              ? "This build has no Maps key"
+              ? "Maps isn't available"
               : "The map could not start"}
           </h1>
           <p className="relative max-w-sm text-sm text-muted-foreground">
             {unavailableReason === "maps-key"
-              ? "Maps is not configured for this build."
+              ? "Nothing is wrong with your location."
               : "Check your connection and try again."}
           </p>
         </div>
@@ -2410,9 +2448,11 @@ export function LocationImmersiveMap({
               ].join(", "),
             }}
             aria-expanded={trayExpanded}
-            aria-label={
-              trayExpanded ? "Minimize map controls" : "Expand map controls"
-            }
+            // This control expands and collapses the PEOPLE list, not the map
+            // controls — the section it opens is labelled "People checked in
+            // nearby" / "Live locations shared with you". A screen-reader user
+            // was being told the wrong thing about what the button does.
+            aria-label={trayExpanded ? "Hide people" : "Show people"}
             data-testid="one-location-map-tray-toggle"
             onClick={() => setTrayExpanded((current) => !current)}
           >
@@ -2520,7 +2560,7 @@ export function LocationImmersiveMap({
               <div ref={trayContentRef} className="px-3 pb-3 pt-1">
               <label className="relative block">
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <span className="sr-only">Find a person on Your Map</span>
+                <span className="sr-only">Find a person</span>
                 <Input
                   className="h-11 rounded-full border-border/60 bg-muted/80 pl-9 pr-4"
                   data-testid="one-location-map-search"
@@ -2717,7 +2757,7 @@ export function LocationImmersiveMap({
                         : // The header already says no one is sharing. This
                           // line spends itself on the part the header cannot:
                           // what it takes to appear here.
-                          "Pins appear once they share and allow maps."}
+                          "Pins appear once they share with maps on."}
                     </p>
                   ) : null}
                 </div>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -21,6 +21,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type ReactNode,
@@ -576,19 +577,34 @@ export function resolveLocationDeepLinkFocus(input: {
 }
 
 function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
+  const statusId = useId();
   const locationOn = vm.locationEnabled;
   const acquiring = vm.locationAcquiring;
+  const statusReadiness = vm.locationBlocked
+    ? ("blocked" as const)
+    : locationOn
+      ? ("ready" as const)
+      : ("askable" as const);
   const statusLabel = acquiring
     ? "Finding you…"
     : locationStatusLabel({
-        readiness: vm.locationBlocked
-          ? "blocked"
-          : locationOn
-            ? "ready"
-            : "askable",
+        readiness: statusReadiness,
         previewOn: locationOn,
         paused: vm.locationPaused,
         accuracyLimited: vm.locationAccuracyLimited,
+      });
+  // One word on phones. Measured, not guessed: with the full "Location blocked"
+  // in this column the 28px "Location Agent" title wraps to two lines at every
+  // iPhone width (320/360/375/390); with the compact word the column stays the
+  // width of the switch and the title keeps its single line, exactly as today.
+  const compactStatusLabel = acquiring
+    ? "Finding…"
+    : locationStatusLabel({
+        readiness: statusReadiness,
+        previewOn: locationOn,
+        paused: vm.locationPaused,
+        accuracyLimited: vm.locationAccuracyLimited,
+        compact: true,
       });
 
   const handleLocationChange = (checked: boolean) => {
@@ -603,16 +619,16 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
   return (
     <div
       role="group"
-      aria-label="Location preview control"
-      className="ml-auto flex max-w-full shrink-0 items-center justify-end"
+      aria-label="Location"
+      // Column on phones, row from `sm` up. The status text is the only thing
+      // that says what this switch is FOR, so it has to survive the compact
+      // layout; there is not enough width on a 320px screen to keep it beside
+      // the switch without wrapping the "Location Agent" title, so it moves
+      // underneath instead. From `sm` the order props restore the original
+      // single-row arrangement exactly: status, then switch.
+      className="ml-auto flex max-w-full shrink-0 flex-col items-end justify-center gap-1 sm:flex-row sm:items-center sm:justify-end sm:gap-0"
       data-testid="one-location-header-actions"
     >
-      <span
-        className="ui-text-helper-text hidden whitespace-nowrap pr-2 text-[color:var(--app-secondary-label)] sm:inline"
-        aria-hidden="true"
-      >
-        {statusLabel}
-      </span>
       <Switch
         size="ios"
         checked={locationOn}
@@ -623,14 +639,33 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
         // finding them, which is when they are most likely to change their
         // mind. The status text carries the waiting instead.
         aria-label={locationOn ? "Turn location off" : "Turn location on"}
+        // The status text is the switch's description, not decoration. It used
+        // to be aria-hidden, so a VoiceOver user got "Turn location on" and no
+        // way to hear whether it was blocked, paused, or still finding them.
+        aria-describedby={statusId}
         // The same pair of contract actions the Settings toggle carries.
         // Both are the same control in two places, so voice can offer
         // pause/resume from the Now tab without opening Settings first.
         data-voice-control-id="one-location-updates-toggle"
         // No colour override: the shared Switch already carries the iOS
         // system green, so this toggle reads the same as every other one.
-        className={cn(acquiring && "animate-pulse")}
+        className={cn(acquiring && "animate-pulse", "sm:order-2")}
       />
+      {/*
+        Visible at every width. It used to be `hidden … sm:inline`, which meant
+        the one label explaining the switch rendered on desktop and never on a
+        phone — the exact screen the switch was designed for. What was left on
+        iOS was a bare green switch under a title that names the agent, not the
+        control, so "what is this toggle for?" had no answer on the device.
+      */}
+      <span
+        id={statusId}
+        data-testid="one-location-header-status"
+        className="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)] sm:order-1 sm:pr-2"
+      >
+        <span className="sm:hidden">{compactStatusLabel}</span>
+        <span className="hidden sm:inline">{statusLabel}</span>
+      </span>
     </div>
   );
 }
@@ -1224,8 +1259,22 @@ function NowHub({
 }) {
   const groupedShellClassName =
     "[--settings-group-radius:16px] bg-white shadow-none dark:bg-[#1C1C1E]";
+  // State beats category on every counted row: colour here means "there is
+  // something here", never "this row exists". A zero count is a neutral row.
+  // "Needs my review" already worked this way; "Active shares" and "Shared with
+  // me" were pinned to action blue, so an empty Location screen showed three
+  // saturated blue tiles reporting 0, 0, 0 — colour that carried no information
+  // and left nothing for the rows that did.
   const reviewIconTone =
     vm.pendingOwnerRequests.length > 0 ? "orange" : "gray";
+  // Green = sharing is live right now (the same meaning the header switch and
+  // Check-In carry).
+  const activeSharesIconTone =
+    vm.activeOwnerGrants.length > 0 ? "green" : "gray";
+  // Indigo = other people, matching the People tab's circles and trusted
+  // contacts, rather than the blue reserved for actions you initiate.
+  const sharedWithMeIconTone =
+    vm.receivedGrants.length > 0 ? "indigo" : "gray";
 
   return (
     <div className="space-y-4" data-testid="one-location-now-hub">
@@ -1275,7 +1324,7 @@ function NowHub({
       >
         <SettingsRow
           icon={UsersRound}
-          iconTone="blue"
+          iconTone={activeSharesIconTone}
           title="Active shares"
           density="compact"
           trailing={vm.activeOwnerGrants.length}
@@ -1286,7 +1335,7 @@ function NowHub({
         />
         <SettingsRow
           icon={MapPin}
-          iconTone="blue"
+          iconTone={sharedWithMeIconTone}
           title="Shared with me"
           density="compact"
           trailing={vm.receivedGrants.length}
@@ -1342,8 +1391,13 @@ function NowHub({
       </SettingsGroup>
 
       <QuickActionsSection title="Quick actions" columns={2}>
+        {/* Green, not blue: Check-In is a presence state you enter, the same
+            family as the header switch being on — and it is the one tile that
+            sits beside the red SMS tile, where "safe / emergency" has to read
+            at a glance. Blue here made the two tiles differ only in the second
+            colour, not the first. */}
         <QuickActionCard
-          tone="blue"
+          tone="green"
           icon={<ShieldCheck />}
           title="Check-In"
           subtitle={checkInSubtitle}
@@ -1584,7 +1638,7 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="Nothing shared with you"
-            description="Live grants appear here."
+            description="Shares appear here."
           />
         )
       ) : null}
@@ -1647,13 +1701,22 @@ function LocationToggle({
       onClick={() => onChange(!checked)}
       className={cn(
         "relative h-[31px] w-[51px] shrink-0 rounded-full transition-colors duration-200",
-        checked ? "bg-[#34c759]" : "bg-black/15 dark:bg-white/20",
+        // Same tokens as the shared `Switch size="ios"`, not private literals.
+        // This used to be `bg-[#34c759]` / `bg-black/15 dark:bg-white/20`, which
+        // held the light-mode green in dark mode (where the system value is
+        // #30d158) and used an off-track grey that matched no other switch — so
+        // the Settings toggles and the header toggle, the same control in two
+        // places, did not read as the same colour. Geometry, thumb, travel and
+        // behaviour are unchanged.
+        checked
+          ? "bg-[color:var(--switch-on)]"
+          : "bg-[color:var(--switch-off)]",
         disabled && "cursor-not-allowed opacity-60",
       )}
     >
       <span
         className={cn(
-          "absolute top-[2px] h-[27px] w-[27px] rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.15)] transition-[left] duration-200",
+          "absolute top-[2px] h-[27px] w-[27px] rounded-full bg-[color:var(--switch-thumb)] shadow-[0_1px_3px_rgba(0,0,0,0.15)] transition-[left] duration-200",
           checked ? "left-[22px]" : "left-[2px]",
         )}
       />
@@ -1861,7 +1924,7 @@ function PeopleHub({
       isLoading={vm.busy === "contactSync"}
       className={PEOPLE_HEADER_ACTION}
     >
-      Sync contacts
+      Find contacts
     </Button>
   );
 
@@ -2061,7 +2124,12 @@ function PeopleHub({
                               onClick={() => vm.onStopGrant(grantId)}
                               disabled={vm.revokingGrantId === grantId}
                             >
-                              Delete
+                              {/* Same handler as the two "Stop" buttons above
+                                  (vm.onStopGrant). One revocation must not be
+                                  described with two verbs — and "Delete" also
+                                  overstates it: this ends someone's access, it
+                                  does not erase anything. */}
+                              Stop
                             </Button>
                           </div>
                         ) : isLive ? (
@@ -2511,7 +2579,7 @@ function ShareFlow({
                   role="alert"
                   className="text-right text-xs font-medium text-destructive"
                 >
-                  character limit exceed
+                  Note is too long
                 </p>
               ) : null}
             </div>
@@ -2640,7 +2708,7 @@ function ShareFlow({
                 subtitle={
                   ready
                     ? undefined
-                    : "Invite first to enable sharing"
+                    : "Invite them first"
                 }
                 tone={ready ? "ready" : "pending"}
                 actionLabel={
@@ -2755,7 +2823,7 @@ function AskFlow({
   }, []);
   return (
     <div className="space-y-5">
-      <TaskFlowHeader title="Request with context" />
+      <TaskFlowHeader title="Request location" />
 
       {justSent ? (
         <div

--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -395,6 +395,21 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
             }
         }
 
+        // A revocation that lands while a watch is already running answers none
+        // of the pending calls above, so it used to fall straight through the
+        // guard below and return. CoreLocation just stops delivering and JS is
+        // never told: the last known point stays on the map and the Location
+        // switch stays ON for someone the OS has already cut off. Every active
+        // watch has to hear about it, and it has to hear it in the same words
+        // the start path uses so isLocationPermissionDeniedError() matches on
+        // the JS side. failWatches is a no-op when nothing is watching.
+        switch manager.authorizationStatus {
+        case .denied, .restricted:
+            failWatches("Location permission was not granted.")
+        default:
+            break
+        }
+
         guard let call = pendingLocationCall else { return }
 
         switch manager.authorizationStatus {
@@ -443,6 +458,17 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         let message = "Precise location unavailable: \(error.localizedDescription)"
         if let call = clearPendingLocationCall() {
             call.reject(message)
+        }
+        // kCLErrorLocationUnknown is TRANSIENT. CoreLocation is saying "not
+        // right now", it keeps trying on its own, and Apple's guidance is to
+        // wait it out. Ending the watch on it meant failWatches() released every
+        // saved call and called stopUpdatingLocation(), so a single blip — a
+        // lift, a tunnel, a moment indoors — permanently stopped live sharing
+        // until the person toggled Location off and on again. The one-shot path
+        // above still rejects, because it is bounded by its own timeout.
+        if let locationError = error as? CLError,
+           locationError.code == .locationUnknown {
+            return
         }
         failWatches(message)
     }

--- a/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
@@ -185,6 +185,29 @@ describe("status label", () => {
       }),
     ).toBe("Location on");
   });
+
+  it("drops the repeated 'Location' for the phone header without changing which state wins", () => {
+    // The compact form exists because the phone header puts this text under a
+    // 28px title that already says Location: the long string measured two title
+    // lines at 320/360/375/390. It must agree with the full form on every
+    // state, or the same switch would report differently on a phone and a
+    // laptop.
+    const cases = [
+      [{ readiness: "askable", previewOn: false, paused: false, accuracyLimited: false }, "Location off", "Off"],
+      [{ readiness: "blocked", previewOn: false, paused: false, accuracyLimited: false }, "Location blocked", "Blocked"],
+      [{ readiness: "blocked", previewOn: true, paused: true, accuracyLimited: true }, "Location paused", "Paused"],
+      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: true }, "Location limited", "Limited"],
+      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: false }, "Location on", "On"],
+    ] as const;
+
+    for (const [params, full, compact] of cases) {
+      expect(locationStatusLabel(params)).toBe(full);
+      expect(locationStatusLabel({ ...params, compact: true })).toBe(compact);
+      // Same state, same word — the compact form is the full one minus the
+      // repeated noun, never a different verdict.
+      expect(full.toLowerCase().endsWith(compact.toLowerCase())).toBe(true);
+    }
+  });
 });
 
 describe("when a location failure is worth showing", () => {

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -533,7 +533,16 @@ export const LocationBus = {
             return;
           }
           if (!error) return;
-          const denied = error.code === 1;
+          // `error.code === 1` is the BROWSER contract (GeolocationPositionError
+          // .PERMISSION_DENIED). Capacitor's native reject carries a `String?`
+          // code and HushhLocationPlugin passes none, so on iOS and Android that
+          // comparison could never be true: a person who revoked location while
+          // a watch was live was reported as a generic "error" — and, because
+          // the branch below swallows non-denials whenever a snapshot is held,
+          // usually not reported at all. The one-shot path already uses the
+          // helper (line 180); this is the same check, and it still matches the
+          // browser code because the helper tests `code === 1` first.
+          const denied = isLocationPermissionDeniedError(error);
           if (!denied && state.snapshot) {
             // A live watch reports POSITION_UNAVAILABLE/TIMEOUT routinely
             // between fixes. We already hold a position, so this is noise, not

--- a/hushh-webapp/lib/one-location/location-readiness.ts
+++ b/hushh-webapp/lib/one-location/location-readiness.ts
@@ -143,18 +143,31 @@ export function locationReadiness(params: {
   return "askable";
 }
 
-/** Short status text for the Location header. */
+/**
+ * Short status text for the Location header.
+ *
+ * `compact` drops the leading "Location", for the phone layout where the switch
+ * sits under a 28px title that already says Location. Two reasons, both
+ * measured rather than assumed: the word is pure repetition of the screen
+ * title, and at 320-390px the longer string is wide enough to push "Location
+ * Agent" onto a second line. The precedence lives here once so the two forms
+ * can never disagree about which state wins.
+ */
 export function locationStatusLabel(params: {
   readiness: LocationReadiness;
   previewOn: boolean;
   paused: boolean;
   accuracyLimited: boolean;
+  compact?: boolean;
 }): string {
-  if (params.paused) return "Location paused";
-  if (params.readiness === "blocked") return "Location blocked";
-  if (!params.previewOn) return "Location off";
-  if (params.accuracyLimited) return "Location limited";
-  return "Location on";
+  const prefix = params.compact ? "" : "Location ";
+  const word = (compact: string, full: string) =>
+    params.compact ? compact : `${prefix}${full}`;
+  if (params.paused) return word("Paused", "paused");
+  if (params.readiness === "blocked") return word("Blocked", "blocked");
+  if (!params.previewOn) return word("Off", "off");
+  if (params.accuracyLimited) return word("Limited", "limited");
+  return word("On", "on");
 }
 
 /**


### PR DESCRIPTION
QA asked two questions about the Location screen and Ankit raised one about how the Capacitor iOS build takes location. All three were real defects, and the map one is web-only — which is why the native build never showed it.

## 1. "location toggle kis liye hai? iOS pe how user gonna find that?"

The switch is the pause/resume control for location updates from this device (contract id `one-location-updates-toggle`, purpose "Pause or resume location updates from this device"). It never revokes a share.

Nothing on a phone said so. The status text beside it — `Location on / off / paused / blocked / limited` — carried `hidden … sm:inline`, so it rendered in a desktop browser and **never below 640px, i.e. never on an iPhone**. It was also `aria-hidden`, so VoiceOver never read it either. What shipped to iOS was a bare green switch under a title that names the agent, not the control.

The status now renders at every width and describes the switch (`aria-describedby`).

**Measured, not assumed.** Putting the full string in that column pushes the 28px "Location Agent" title onto a second line at 320 / 360 / 375 / 390 — every common iPhone. So phones get the one-word form (`Off`, `Paused`, `Blocked`, `Limited`, `Finding…`) and `sm`+ keeps the full string inline exactly as today. Chromium at the app's real geometry and type tokens:

| width | title lines before | title lines after |
|---|---|---|
| 320 | 2 | 2 |
| 360 / 375 / 390 / 430 | 1 | 1 |
| 640 / 768 | 1 | 1 |

No horizontal overflow at any width. The header row grows 32px → 52px on compact; that is the status line, and it is the point.

Dropping "Location" from the phone form is also the copy rule: the screen title already says it.

## 2. "pura map nahi aa raha hai? uppr gap kyu aa raha hai?"

The container was never at fault — `h-[100dvh]`, map `absolute inset-0`, and the route is already `persistentChrome: "none"` so the shell reserves nothing.

`map.setPadding()` is a true camera inset on the native SDKs: same zoom, map still edge to edge. The `@capacitor/google-maps` **web** shim is a different operation:

```js
async setPadding({ id, padding }) {
  const bounds = maps[id].map.getBounds();
  if (bounds !== undefined) maps[id].map.fitBounds(bounds, padding);
}
```

That re-fits the already-visible world into a box shrunk by ~100px top and ~80px bottom. It is a zoom-out, and a raster map snaps to a whole integer zoom — so z2 dropped to z1, the world stopped filling the container, and Google's own out-of-world grey showed as a band above and below with the world repeating horizontally. Exactly the screenshot.

The call is now native-only. A regression test asserts web never makes it and that the container still owns the viewport.

## 3. "in React we pick real-time location — in iOS there should be a native way. Make sure that is coupled up."

The architecture was already right, and worth stating plainly: one registered `HushhLocation` plugin, native CoreLocation on iOS (`MyViewController.swift:71`), browser geolocation **only** inside the registered web fallback. There is not a single direct `navigator.geolocation` call in `app/` or `components/`. Both `NSLocation*UsageDescription` keys are present.

But two web assumptions had leaked into the native path:

- `location-bus.ts` tested `error.code === 1` on watch errors. That is the browser's `GeolocationPositionError` contract; Capacitor's native reject carries a `String?` code and the plugin passes none, so a mid-watch revocation on iOS could never be recognised as a denial — and the branch below swallows non-denials whenever a snapshot is held, so it was usually not reported at all. Now uses the same helper the one-shot path already used.
- `HushhLocationPlugin.swift` never told JS about a revocation that arrived **while a watch was live**: `locationManagerDidChangeAuthorization` only inspected the pending calls and returned. CoreLocation stops delivering, the last point stays on the map, and the switch stays ON for someone the OS has already cut off.
- The same file ended every watch on `kCLErrorLocationUnknown`, which is transient — `failWatches()` released every saved call and called `stopUpdatingLocation()`, so one blip in a lift or a tunnel permanently stopped live sharing until the user toggled Location off and on.

## Also: the colour and copy passes on the same two screens

Semantic colour, inside the visual lock — no layout, type, or spacing changes:
- Counted rows go neutral at zero instead of sitting blue on `0`. "Active shares" is green when sharing is live, "Shared with me" indigo when someone is. ("Needs my review" already did this.) An empty Location screen showed three saturated blue tiles reporting 0, 0, 0.
- Added an `indigo` icon tone — `accent`, `blue` and `purple` were byte-identical, so "these are people" had no colour of its own.
- Check-In takes the green it shares with the switch, beside the red SMS tile.
- The Settings toggles used private hex (`bg-[#34c759]`, `bg-black/15`) and so held the light-mode green in dark mode; they now use the same `--switch-on/off/thumb` tokens as every other switch. Geometry and behaviour unchanged.

Copy — the consent card keeps all three of its claims (local decryption, Google Maps minimisation, Check-In is separate) in 4 fewer words; "Continue to Your Map" → "Continue" (the title above it already says Your Map); plus the jargon and one defect: `character limit exceed` (lowercase, verbless, `role="alert"`) → `Note is too long`; `Live grants appear here` → `Shares appear here`; `Sync contacts` → `Find contacts`; `This build has no Maps key` → `Maps isn't available`; `500 m match area` → `500 m around your place` (the code is explicit that the live circle centres on the place and the search circle on the person — the jargon hid that); and the people-tray toggle's `aria-label` said "map controls" when it opens the people list.

Two I deliberately left alone as product calls, not copy defects: the `Location Agent` title, and the `SMS` / "Save my soul" tile.

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on every changed file.
- `vitest run` full suite on this branch **and** on `origin/main` at the same commit: **identical failing sets** (27 pre-existing failures on both), 4007 passing here vs 4005 on main — the two extra are the new tests.
- Layout measured in Chromium at 320/360/375/390/430/640/768 across all six status strings.
- Not verified: the rendered signed-in screens and the installed iOS build. Both routes are auth-gated and I have no UAT credentials in this session; the Swift changes are unbuilt here (no Xcode run). Worth a device pass on the revocation and tunnel-blip paths before this is called done on native.
