### PR TITLE
fix(one-location): make the inline duration editor's Save do what it says

### DIFF
--- a/hushh-webapp/__tests__/components/grant-duration-edit.test.ts
+++ b/hushh-webapp/__tests__/components/grant-duration-edit.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GRANT_EDIT_DURATION_FALLBACK,
+  defaultEditDurationHours,
+  grantDurationEditIntent,
+  grantRemainingHours,
+} from "@/lib/one-location/grant-duration-edit";
+
+const NOW = Date.parse("2026-05-20T08:00:00.000Z");
+
+function grant(fields: { expiresAt?: string | null; durationHours?: number | null }) {
+  return {
+    expiresAt: fields.expiresAt ?? null,
+    durationHours: fields.durationHours ?? null,
+  };
+}
+
+/** `nowMs` plus this many minutes, as an ISO expiry. */
+function inMinutes(minutes: number): string {
+  return new Date(NOW + minutes * 60_000).toISOString();
+}
+
+describe("grantRemainingHours", () => {
+  it("reads what is left from the expiry", () => {
+    expect(grantRemainingHours(grant({ expiresAt: inMinutes(30) }), NOW)).toBeCloseTo(
+      0.5,
+      6,
+    );
+  });
+
+  it("clamps an already-passed expiry to zero rather than going negative", () => {
+    expect(grantRemainingHours(grant({ expiresAt: inMinutes(-10) }), NOW)).toBe(0);
+  });
+
+  it("falls back to the granted length when no expiry was sent", () => {
+    expect(grantRemainingHours(grant({ durationHours: 4 }), NOW)).toBe(4);
+  });
+
+  it("has no answer for a grant carrying neither", () => {
+    expect(grantRemainingHours(grant({}), NOW)).toBeNull();
+    expect(grantRemainingHours(null, NOW)).toBeNull();
+  });
+});
+
+describe("defaultEditDurationHours", () => {
+  // The reported bug: the editor opened on "1 hour" over a row that said
+  // "30 more min", so the field was never the share's current duration.
+  it("opens on the option nearest what is actually left", () => {
+    expect(defaultEditDurationHours(grant({ expiresAt: inMinutes(30) }), NOW)).toBe(
+      "0.5",
+    );
+    expect(defaultEditDurationHours(grant({ expiresAt: inMinutes(59) }), NOW)).toBe(
+      "1",
+    );
+    expect(defaultEditDurationHours(grant({ expiresAt: inMinutes(200) }), NOW)).toBe(
+      "4",
+    );
+    expect(defaultEditDurationHours(grant({ expiresAt: inMinutes(1200) }), NOW)).toBe(
+      "24",
+    );
+  });
+
+  it("never proposes more than the longest option, however far off the expiry is", () => {
+    expect(
+      defaultEditDurationHours(grant({ expiresAt: "2099-05-20T08:00:00.000Z" }), NOW),
+    ).toBe("24");
+  });
+
+  it("falls back when the grant says nothing usable about its length", () => {
+    expect(defaultEditDurationHours(grant({}), NOW)).toBe(
+      GRANT_EDIT_DURATION_FALLBACK,
+    );
+    expect(defaultEditDurationHours(grant({ expiresAt: "not a date" }), NOW)).toBe(
+      GRANT_EDIT_DURATION_FALLBACK,
+    );
+  });
+});
+
+describe("grantDurationEditIntent", () => {
+  it("shortens when the new duration ends the share sooner", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(60) }),
+        durationHours: 0.5,
+        nowMs: NOW,
+      }),
+    ).toBe("shorten");
+  });
+
+  it("asks the owner when the new duration would run past the current expiry", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(12) }),
+        durationHours: 1,
+        nowMs: NOW,
+      }),
+    ).toBe("request");
+  });
+
+  // A one-hour share a minute old reads "59 more min" and the picker opens on
+  // "1 hour". Save on that untouched field is not a request for one more
+  // minute of somebody's location.
+  it("treats a picker still showing what is left as no change at all", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(59) }),
+        durationHours: 1,
+        nowMs: NOW,
+      }),
+    ).toBe("unchanged");
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(24 * 60 - 10) }),
+        durationHours: 24,
+        nowMs: NOW,
+      }),
+    ).toBe("unchanged");
+  });
+
+  it("still calls a real shortening a shortening, just inside the tolerance band", () => {
+    // 45 minutes left, asked for 30: a quarter of an hour is a change.
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(45) }),
+        durationHours: 0.5,
+        nowMs: NOW,
+      }),
+    ).toBe("shorten");
+  });
+
+  it("shortens when there is no expiry to compare against", () => {
+    // A never-expiring share can only be cut short by naming a duration, and
+    // the backend's shorten endpoint agrees -- it skips its own check.
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ durationHours: null }),
+        durationHours: 1,
+        nowMs: NOW,
+      }),
+    ).toBe("shorten");
+  });
+
+  it("leaves an unreadable duration to the backend rather than guessing", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(60) }),
+        durationHours: Number.NaN,
+        nowMs: NOW,
+      }),
+    ).toBe("shorten");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -3842,24 +3842,90 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  /**
+   * A live received share, expiring `minutes` from the real clock so the
+   * inline duration editor is judged against a time that is actually left --
+   * which is the whole question it has to answer.
+   */
+  function liveReceivedGrant(minutes: number) {
+    return {
+      id: "grant_live_ask",
+      ownerUserId: "user_b",
+      recipientUserId: "user_a",
+      ownerDisplayName: "Trusted B",
+      recipientKeyId: "key_a",
+      status: "active",
+      consentScope: "cap.location.live.view",
+      capabilityScopes: ["cap.location.live.view"],
+      durationHours: minutes / 60,
+      expiresAt: new Date(Date.now() + minutes * 60_000).toISOString(),
+    };
+  }
+
   it("edits an already-live person's duration from the Ask flow's own list", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      receivedGrants: [
-        {
-          id: "grant_live_ask",
-          ownerUserId: "user_b",
-          recipientUserId: "user_a",
-          ownerDisplayName: "Trusted B",
-          recipientKeyId: "key_a",
-          status: "active",
-          consentScope: "cap.location.live.view",
-          capabilityScopes: ["cap.location.live.view"],
-          durationHours: 1,
-          expiresAt: "2099-05-20T08:00:00.000Z",
-        },
-      ],
+      receivedGrants: [liveReceivedGrant(4 * 60)],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
+    fireEvent.click(screen.getByRole("option", { name: "30 min" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockShortenGrant).toHaveBeenCalledWith({
+        vaultOwnerToken: "vault-token",
+        grantId: "grant_live_ask",
+        durationHours: 0.5,
+      }),
+    );
+    // Shortening is the recipient's own call to make -- nobody is asked.
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+  });
+
+  it("opens the duration editor on what the share actually has left", async () => {
+    // It opened on "1 hour" every time, one line under "Sharing with you,
+    // 4 more hours". So the field was never the current duration, and Save on
+    // the untouched default asked for MORE time instead of changing anything.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [liveReceivedGrant(4 * 60)],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "New duration" }).textContent,
+    ).toContain("4 hours");
+  });
+
+  it("does nothing at all when Save is pressed on an untouched duration", async () => {
+    // A one-hour share a minute old reads "59 more min" and the picker opens
+    // on "1 hour", because that is what it is. Pressing Save there is not a
+    // request for one more minute of somebody's location: it used to spend a
+    // refused shorten, then ask the owner, then report "Asked Trusted B for
+    // more time" over a row whose time never moved.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [liveReceivedGrant(59)],
     });
 
     render(<OneLocationAgentPage />);
@@ -3872,13 +3938,88 @@ describe("OneLocationAgentPage", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
+    // The editor closes, and no call goes anywhere.
     await waitFor(() =>
-      expect(mockShortenGrant).toHaveBeenCalledWith({
+      expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
+    );
+    expect(mockShortenGrant).not.toHaveBeenCalled();
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+  });
+
+  it("asks the owner for more time without first spending a refused shorten", async () => {
+    // Every ask-for-more-time used to call shorten_grant, wait for the 422,
+    // and only then send the request the user was always going to need. Two
+    // round trips to change nothing on screen is the "Save is slow" report;
+    // the expiry needed to skip the first one is already rendered as
+    // "12 more min" one line above the picker.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [liveReceivedGrant(12)],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
+    fireEvent.click(screen.getByRole("option", { name: "4 hours" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockRequestAccess).toHaveBeenCalledWith({
         vaultOwnerToken: "vault-token",
-        grantId: "grant_live_ask",
-        durationHours: 1,
+        ownerUserId: "user_b",
+        message: "Requesting more time.",
       }),
     );
+    expect(mockShortenGrant).not.toHaveBeenCalled();
+  });
+
+  it("leaves the row usable after a duration save, instead of stuck busy", async () => {
+    // The save flag was the revoke flag, and the shorten path returned
+    // without clearing it. So one successful save disabled that person's
+    // Remove button for good, and the next Edit opened with Save already
+    // spinning and permanently disabled -- the "save button taking more time
+    // after edit time" report.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [liveReceivedGrant(4 * 60)],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
+    fireEvent.click(screen.getByRole("option", { name: "30 min" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockShortenGrant).toHaveBeenCalled());
+
+    // Remove never belonged to the save in the first place.
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Remove Trusted B's access" })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+
+    // And the same person can be edited again straight away.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+    );
+    const saveAgain = await screen.findByRole("button", { name: "Save" });
+    expect(saveAgain.hasAttribute("disabled")).toBe(false);
   });
 
   it("fans out approval-first requests to multiple selected owners without coordinates", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -173,6 +173,11 @@ import {
   locationReadiness as resolveLocationReadiness,
   shouldSurfaceLocationError,
 } from "@/lib/one-location/location-readiness";
+import {
+  GRANT_EDIT_DURATION_FALLBACK,
+  defaultEditDurationHours,
+  grantDurationEditIntent,
+} from "@/lib/one-location/grant-duration-edit";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
   describeContactSyncOutcome,
@@ -2189,7 +2194,11 @@ export function OneLocationAgentPageContent({
   const [revokingGrantId, setRevokingGrantId] = useState<string | null>(null);
   /** Which grant is showing the inline duration editor, wherever it's listed. */
   const [editingGrantId, setEditingGrantId] = useState<string | null>(null);
-  const [editGrantDurationHours, setEditGrantDurationHours] = useState("1");
+  /** Which grant's duration is being saved. Separate from revoke on purpose. */
+  const [savingGrantId, setSavingGrantId] = useState<string | null>(null);
+  const [editGrantDurationHours, setEditGrantDurationHours] = useState(
+    GRANT_EDIT_DURATION_FALLBACK,
+  );
   // Opt-in: keep publishing location while the app is backgrounded (native only).
   const [backgroundShareEnabled, setBackgroundShareEnabled] = useState(false);
   // Monotonic counter bumped each time a share completes successfully, so the
@@ -5438,9 +5447,16 @@ export function OneLocationAgentPageContent({
    * Shortening is self-limiting -- the owner already agreed to be seen at
    * least this long -- so it applies immediately. Extending is a different
    * question: it grows how long the recipient can see the owner, and that
-   * is the owner's consent to give again. This tries shorten_grant first,
-   * and on the backend's explicit "that would extend it" rejection, falls
-   * back to a fresh request_access the owner has to approve like any other.
+   * is the owner's consent to give again, via a fresh request_access the
+   * owner approves like any other.
+   *
+   * Which one this is gets decided here, from the same expiry the row is
+   * already rendering as "30 more min". It used to be decided by calling
+   * shorten_grant and waiting for the backend to refuse: every ask-for-more
+   * -time paid for a doomed round trip before the real one, which is the
+   * "Save is slow" report. The refusal is still handled -- a client clock
+   * can disagree with the server's near the boundary -- but it is now the
+   * rare correction rather than the normal path.
    */
   const handleEditGrantDuration = useCallback(
     async (
@@ -5449,48 +5465,75 @@ export function OneLocationAgentPageContent({
     ) => {
       if (!vaultOwnerToken) return;
       const { ownerUserId, grantId, ownerLabel } = params;
-      setRevokingGrantId(grantId);
+      const grant = activeReceivedGrants.find((row) => row.id === grantId);
+      // Its own flag, not the revoke one. Sharing `revokingGrantId` made
+      // saving a duration disable that row's Remove button, and a save that
+      // returned early left the flag set for good -- so the next Edit on
+      // that person opened with Save already spinning and permanently
+      // disabled. That is the "save button takes more time" report.
+      setSavingGrantId(grantId);
       try {
-        await OneLocationService.shortenGrant({
-          vaultOwnerToken,
-          grantId,
+        const intent = grantDurationEditIntent({
+          grant,
           durationHours,
+          nowMs: Date.now(),
         });
-        toast.success("Access shortened.");
-        setEditingGrantId(null);
-        void refresh().catch(() => null);
-        return;
-      } catch (error) {
-        if (apiErrorCode(error) !== "LOCATION_GRANT_SHORTEN_ONLY") {
-          toast.error(
-            error instanceof Error ? error.message : "Could not update access.",
-          );
-          setRevokingGrantId(null);
+        // Save on a picker still showing what the share already has left is
+        // not a change. It used to spend a refused shorten and then ask the
+        // owner for one more minute of their location, and report that as
+        // "Asked ... for more time" over a row whose time never moved.
+        if (intent === "unchanged") {
+          setEditingGrantId(null);
           return;
         }
-      }
-      // Extending needs the owner's approval again -- send a new request
-      // rather than silently lengthening the existing grant.
-      try {
-        await OneLocationService.requestAccess({
-          vaultOwnerToken,
-          ownerUserId,
-          message: "Requesting more time.",
-        });
-        toast.success(`Asked ${ownerLabel} for more time.`);
-        setEditingGrantId(null);
-        void refresh().catch(() => null);
-      } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : `Could not ask ${ownerLabel} for more time.`,
-        );
+        if (intent === "shorten") {
+          try {
+            await OneLocationService.shortenGrant({
+              vaultOwnerToken,
+              grantId,
+              durationHours,
+            });
+            toast.success("Access shortened.");
+            setEditingGrantId(null);
+            // Held until the list has actually reconciled, so this grant is
+            // not savable again against the expiry it just replaced.
+            await refresh({ background: true }).catch(() => null);
+            return;
+          } catch (error) {
+            if (apiErrorCode(error) !== "LOCATION_GRANT_SHORTEN_ONLY") {
+              toast.error(
+                error instanceof Error
+                  ? error.message
+                  : "Could not update access.",
+              );
+              return;
+            }
+            // The backend read the clock differently. Fall through and ask.
+          }
+        }
+        // Extending needs the owner's approval again -- send a new request
+        // rather than silently lengthening the existing grant.
+        try {
+          await OneLocationService.requestAccess({
+            vaultOwnerToken,
+            ownerUserId,
+            message: "Requesting more time.",
+          });
+          toast.success(`Asked ${ownerLabel} for more time.`);
+          setEditingGrantId(null);
+          await refresh({ background: true }).catch(() => null);
+        } catch (error) {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : `Could not ask ${ownerLabel} for more time.`,
+          );
+        }
       } finally {
-        setRevokingGrantId(null);
+        setSavingGrantId(null);
       }
     },
-    [refresh, vaultOwnerToken],
+    [activeReceivedGrants, refresh, vaultOwnerToken],
   );
 
   const handleStopSos = useCallback(async () => {
@@ -10047,8 +10090,18 @@ export function OneLocationAgentPageContent({
     onStopGrant: (grantId) => void handleRevoke(grantId),
     onAskReshare: (grant) => void handleAskReshare(grant),
     editingGrantId,
+    savingGrantId,
     onEditGrantStart: (grantId) => {
-      setEditGrantDurationHours("1");
+      // Open on what the share actually has left, not on a constant. The
+      // editor used to say "1 hour" above a row reading "30 more min", so
+      // the field was never the current duration and Save on the untouched
+      // default asked for MORE time instead of changing anything.
+      setEditGrantDurationHours(
+        defaultEditDurationHours(
+          activeReceivedGrants.find((grant) => grant.id === grantId),
+          Date.now(),
+        ),
+      );
       setEditingGrantId(grantId);
     },
     onEditGrantCancel: () => setEditingGrantId(null),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -304,6 +304,12 @@ export type LocationHubViewModel = {
   onStopGrant: (grantId: string) => void;
   /** Grant currently showing the inline duration editor, or null. */
   editingGrantId: string | null;
+  /**
+   * Grant whose duration is being saved, or null. Deliberately not
+   * `revokingGrantId`: one flag for both made Save and Remove spin together,
+   * and left Save stuck spinning on the next Edit of the same person.
+   */
+  savingGrantId: string | null;
   onEditGrantStart: (grantId: string) => void;
   onEditGrantCancel: () => void;
   editGrantDurationHours: string;
@@ -2167,7 +2173,7 @@ function PeopleHub({
                                 ownerLabel,
                               })
                             }
-                            isLoading={vm.revokingGrantId === grantId}
+                            isLoading={vm.savingGrantId === grantId}
                           >
                             Save
                           </Button>
@@ -2931,7 +2937,7 @@ function AskFlow({
                               ownerLabel: recipientLabel,
                             })
                           }
-                          isLoading={vm.revokingGrantId === activeGrant.id}
+                          isLoading={vm.savingGrantId === activeGrant.id}
                         >
                           Save
                         </Button>

--- a/hushh-webapp/lib/one-location/grant-duration-edit.ts
+++ b/hushh-webapp/lib/one-location/grant-duration-edit.ts
@@ -1,0 +1,131 @@
+import type { OneLocationGrant } from "@/lib/one-location/types";
+
+/**
+ * The inline "New duration" editor on a live share: what it should open on,
+ * and what Save is actually going to do.
+ *
+ * The editor opened on "1 hour" every time, whatever the share said one line
+ * above it ("Sharing with you, 30 more min"). So the field was never the
+ * current duration, and Save on the untouched default was almost always
+ * LONGER than what was left -- which is not a change the recipient can make.
+ * Every one of those saves spent a doomed shorten_grant call, took the 422
+ * back, and turned into a fresh request the owner had to approve, while the
+ * time on screen did not move. Two round trips to change nothing visible is
+ * the "save is slow" and "time reset is not working" report.
+ *
+ * Both facts needed to fix that are already on screen -- the grant's expiry
+ * is what renders "30 more min". This decides from it, and nothing else: no
+ * fetching, no formatting, no state.
+ */
+
+/** Hours offered by the editor's picker, ascending. Mirrors REDESIGN_DURATION_OPTIONS. */
+export const GRANT_EDIT_DURATION_HOURS: readonly number[] = [0.5, 1, 4, 24];
+
+/** The picker value used when a grant tells us nothing usable about its length. */
+export const GRANT_EDIT_DURATION_FALLBACK = "1";
+
+type DurationGrantFields = Pick<OneLocationGrant, "expiresAt" | "durationHours">;
+
+/** Milliseconds, or null when the timestamp is missing or unparseable. */
+function timestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** When this grant runs out, in ms, or null for "no expiry we can read". */
+export function grantExpiryMs(
+  grant: DurationGrantFields | null | undefined,
+): number | null {
+  return timestamp(grant?.expiresAt);
+}
+
+/**
+ * How long this share still has to run, in hours -- or null when there is no
+ * readable expiry. Falls back to the granted length for a grant whose expiry
+ * has not been sent, so the picker still opens on something true.
+ */
+export function grantRemainingHours(
+  grant: DurationGrantFields | null | undefined,
+  nowMs: number,
+): number | null {
+  const expiry = grantExpiryMs(grant);
+  if (expiry !== null) {
+    const remaining = expiry - nowMs;
+    return remaining > 0 ? remaining / 3_600_000 : 0;
+  }
+  const granted = grant?.durationHours;
+  return typeof granted === "number" && granted > 0 ? granted : null;
+}
+
+/**
+ * The picker option nearest what is left, so the editor opens on the share as
+ * it stands rather than on a constant.
+ *
+ * Ties go to the shorter option: between two equally close answers, the one
+ * that exposes the owner for less time is the safer thing to preselect.
+ */
+export function defaultEditDurationHours(
+  grant: DurationGrantFields | null | undefined,
+  nowMs: number,
+): string {
+  const remaining = grantRemainingHours(grant, nowMs);
+  if (remaining === null) return GRANT_EDIT_DURATION_FALLBACK;
+  let best = GRANT_EDIT_DURATION_HOURS[0] ?? 1;
+  let bestGap = Math.abs(best - remaining);
+  for (const option of GRANT_EDIT_DURATION_HOURS) {
+    const gap = Math.abs(option - remaining);
+    if (gap < bestGap) {
+      best = option;
+      bestGap = gap;
+    }
+  }
+  return String(best);
+}
+
+/**
+ * How close a picked duration has to be to what is left before the two are
+ * the same answer: 5% of the picked duration, never under two minutes.
+ *
+ * A one-hour share that has been running a minute reads as "59 more min" and
+ * the picker opens on "1 hour", because that is what it is. Pressing Save on
+ * that untouched field is not a request for one more minute of somebody's
+ * location, and must not go out as one.
+ */
+function unchangedToleranceMs(durationHours: number): number {
+  return Math.max(120_000, durationHours * 3_600_000 * 0.05);
+}
+
+/**
+ * What Save does with this duration.
+ *
+ * "shorten" applies immediately -- the owner already agreed to be seen at
+ * least this long, so giving time back needs nobody's permission.
+ * "request" grows how long the recipient can watch the owner, which is the
+ * owner's consent to give again. "unchanged" is the untouched picker: no
+ * call, nothing to tell anyone, just close the editor.
+ *
+ * "shorten" is also the answer when the expiry is unknown, because then the
+ * only authority on it is the backend, and its explicit shorten-only
+ * rejection is what routes the call. Reading a stale or skewed clock here
+ * must never cost the recipient the ability to end a share early.
+ */
+export type GrantDurationEditIntent = "shorten" | "request" | "unchanged";
+
+export function grantDurationEditIntent(input: {
+  grant: DurationGrantFields | null | undefined;
+  durationHours: number;
+  nowMs: number;
+}): GrantDurationEditIntent {
+  const { grant, durationHours, nowMs } = input;
+  if (!Number.isFinite(durationHours) || durationHours <= 0) return "shorten";
+  const expiry = grantExpiryMs(grant);
+  // No expiry to compare against -- a share that runs until it is stopped can
+  // only ever be shortened by naming a duration, and the backend agrees.
+  if (expiry === null) return "shorten";
+  const candidate = nowMs + durationHours * 3_600_000;
+  if (Math.abs(candidate - expiry) <= unchangedToleranceMs(durationHours)) {
+    return "unchanged";
+  }
+  return candidate < expiry ? "shorten" : "request";
+}


### PR DESCRIPTION
## Reported

From the Request-with-context screen, one row apart:

- *"save button taking more time after edit time"*
- *"time reset is not working"*

## What was wrong

The inline "New duration" editor never knew what the share it was editing had left — even though the row one line above it renders exactly that (`Sharing with you, 30 more min`).

1. **The picker opened on a constant `"1"`.** So the field was never the share's current duration, and the untouched default was almost always *longer* than what remained.
2. **Save decided what it was doing by being refused.** It always called `shortenGrant` first and waited for the backend's `LOCATION_GRANT_SHORTEN_ONLY` 422, then sent the `requestAccess` it was always going to need. Two sequential round trips, ending with the time on screen unchanged — the "Save is slow" and "time reset is not working" reports.
3. **The busy flag was the revoke flag, and the shorten path `return`ed without clearing it.** One successful save left `revokingGrantId` set forever: that person's Remove button stayed disabled, and the next Edit on them opened with Save already spinning and permanently disabled (`isLoading` → `disabled`).

## What changed

A small pure module, `lib/one-location/grant-duration-edit.ts`, decides from the expiry already in the view model, before any network call:

| intent | when | what Save does |
|---|---|---|
| `shorten` | new duration ends the share sooner | `shortenGrant`, applies immediately |
| `request` | new duration would run past the current expiry | `requestAccess` — the owner's consent to give again |
| `unchanged` | picker still showing what is left (within 5%, floor 2 min) | closes the editor, no call |

- The picker now **opens on the option nearest what is actually left**.
- `unchanged` is the untouched-form case: pressing Save on a one-hour share reading "59 more min" is not a request for one more minute of somebody's location, and no longer goes out as one.
- The backend's shorten-only rejection is **still handled** as the rare clock-skew correction it should have been.
- Saving gets its own `savingGrantId`, cleared in a `finally`.

**Consent semantics are untouched.** Nothing here lets either side extend a grant without the owner approving a fresh request; the backend check is unchanged and still authoritative.

**Styling is untouched.** The only change in `location-redesign-hub.tsx` is the two Save buttons reading `savingGrantId` instead of `revokingGrantId`, plus the new field on the view-model type — a parallel lane owns this screen's visual layer.

## Verification

| check | result |
|---|---|
| `npm run typecheck` | pass |
| `eslint --max-warnings=0` (changed files) | pass |
| `npm run verify:service-boundary` | pass |
| `npm run verify:surface-map` | pass |
| `vitest __tests__/components/one-location-agent-page.test.tsx` | 81 passed |
| `vitest __tests__/components/grant-duration-edit.test.ts` | 13 passed (new) |
| `npm run test:ci` — **this branch** | 27 failed / 3972 passed |
| `npm run test:ci` — **`origin/main` baseline** | 27 failed / 3955 passed |

Identical failing set on both (21 files, all onboarding-setup / route-contract, none touched here). Net: **+17 passing, 0 new failures.**

### Mutation-checked

Each new test was confirmed to fail when its fix is reverted:

| reverted | test that fails |
|---|---|
| seed back to constant `"1"` | opens the duration editor on what the share actually has left |
| drop the `unchanged` short-circuit | does nothing at all when Save is pressed on an untouched duration |
| always try shorten first | asks the owner for more time without first spending a refused shorten |
| busy flag left set + Save reads it | leaves the row usable after a duration save |

## Not verified

A two-account live grant exercised on a physical device. The tests render the real `OneLocationAgentPage` tree and assert on the rendered combobox text and button disabled state, but the end-to-end owner-approves-recipient path was not walked on hardware.