### PR TITLE
fix(one-setup): keep the blocked finish visible as a control

### DIFF
--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -143,6 +143,9 @@ describe("One setup hub terminal action contract", () => {
       "const isBlockedFilledAction = disabled && !busy && !isQuietSetupAction",
     );
     expect(footer).toContain("disabled:!bg-muted/60");
+    // ...and a visible edge with it. `muted` is the page surface in the light
+    // theme, so the fill alone leaves no control on screen.
+    expect(footer).toContain("disabled:!border-border");
     expect(hub).toContain("disabled:text-muted-foreground");
     expect(hub).not.toContain("disabled:opacity-40");
 

--- a/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
+++ b/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-completion-footer";
@@ -49,6 +49,32 @@ describe("SetupCompletionFooter blocked state", () => {
     expect(button.className).toContain("disabled:!bg-muted/60");
     expect(button.className).toContain("disabled:!text-muted-foreground");
     expect(button.className).toContain("disabled:!opacity-100");
+  });
+
+  it("keeps a visible edge, because the muted fill alone draws nothing in light theme", () => {
+    const { button } = renderFooter({ disabled: true });
+
+    // Measured on the built stylesheet: `muted` over the light page surface is
+    // rgb(242,242,245) on rgb(242,242,247) -- 1:1. Without a border the pill
+    // disappears and leaves a grey label floating on the page, which is a
+    // worse control than the blue one this state replaced. The border is the
+    // only thing keeping it a button, so it is the thing under test.
+    expect(button.className).toContain("disabled:!border-border");
+    expect(button.className).not.toContain("!border-0");
+  });
+
+  it("does not spend geometry to look disabled", () => {
+    const enabled = renderFooter().button.className;
+    cleanup();
+    const blocked = renderFooter({ disabled: true }).button.className;
+
+    // Both states reserve the same 1px. Only the border COLOUR changes, so the
+    // button cannot resize between states -- a zero-drift requirement, and the
+    // reason `!border-0` (which removes the reserved px) does not belong here.
+    for (const state of [enabled, blocked]) {
+      expect(state).toContain("border border-transparent");
+      expect(state).not.toContain("!border-0");
+    }
   });
 
   it("does not absorb a tap while blocked", () => {

--- a/hushh-webapp/components/onboarding/setup/setup-completion-footer.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-completion-footer.tsx
@@ -56,6 +56,14 @@ export function SetupCompletionFooter({
   // light surface -- so a blocked finish looked tappable, absorbed the tap,
   // and explained itself only in the supporting line underneath. A blocked
   // action takes the same neutral container the quiet variant already uses.
+  //
+  // It keeps a border, and the border is the whole reason it stays a control.
+  // In the light theme `muted` and the page surface are the same colour to
+  // within 1:1 contrast (measured: rgb(242,242,245) on rgb(242,242,247)), so
+  // the fill alone draws nothing -- the pill vanished and left a grey label
+  // floating on the page. `border-border` is the same hairline every card on
+  // this surface uses, and the enabled state already reserves 1px for a
+  // transparent one, so making it visible costs no geometry.
   const isBlockedFilledAction = disabled && !busy && !isQuietSetupAction;
 
   return (
@@ -81,7 +89,7 @@ export function SetupCompletionFooter({
               isQuietSetupAction &&
                 "!border-0 !bg-transparent !text-[var(--app-accent)] hover:!bg-[var(--app-accent-tint)] hover:!text-[var(--app-accent)] disabled:!bg-muted/35 disabled:!text-muted-foreground disabled:!opacity-100",
               isBlockedFilledAction &&
-                "!border-0 disabled:!bg-muted/60 disabled:!text-muted-foreground disabled:!opacity-100",
+                "disabled:!border-border disabled:!bg-muted/60 disabled:!text-muted-foreground disabled:!opacity-100",
             )}
             data-testid={testId}
             data-voice-control-id={controlId}


### PR DESCRIPTION
Follow-up to #5304, found by running `apple-visual-qa-gate` against it — a step I skipped the first time.

## The defect

#5304 correctly stopped a blocked "Finish setup" from painting Action Blue. But it also carried `!border-0`, copied from the quiet variant without checking what it does here.

In the light theme `muted` **is** the page surface. The blocked pill composites to `rgb(242,242,245)` on `rgb(242,242,247)` — **1:1 contrast**. With the border removed as well there was nothing left to draw: the control vanished and left a grey label floating on the page.

A button that doesn't look like a button is not an improvement on a button that lies about being tappable. This is live on UAT now.

`!border-0` was also a layout-property edit inside a colour-only change, and an inert one — `border-box` sizing with a fixed `h-12` means both states measure 420×50 either way. Pure diff noise that happened to delete the one thing keeping the control legible.

## The repair

`!border-0` → `disabled:!border-border`. The enabled state already reserves 1px for a transparent border, so only the border *colour* differs between states — no dimension can move — and blocked picks up the same hairline every card on this surface already uses.

Measured on the built stylesheet, both appearances:

| state | fill vs surface | edge vs surface | label vs fill | size |
|---|---|---|---|---|
| light, enabled | 3.6:1 | — | 4.02:1 | 420×50, 1px |
| light, blocked | 1:1 | **1.14:1** | 3.53:1 | 420×50, 1px |
| dark, enabled | 4.92:1 | — | 4.02:1 | 420×50, 1px |
| dark, blocked | 1.11:1 | **1.26:1** | 12.29:1 | 420×50, 1px |

Disabled controls are exempt from WCAG 1.4.3, and the label is deliberately quiet — the point of the measurement is that the *container* is perceivable, which it now is in both themes.

## Why the tests didn't catch it

The tests in #5304 asserted class strings in jsdom, where Tailwind never runs. A class-name assertion is not a colour assertion. Two tests come with this: one pins the border, one pins that neither state spends geometry to look disabled. Neither is sufficient on its own — the colour genuinely needs a browser, which is how this was found.

## Verification

- Full suite **27 failed / 4027 passed**, identical failing set to `origin/main`.
- `tsc --noEmit`, `eslint --max-warnings=0`, `verify:design-system`: clean.
- Rendered on a local build and sampled composited pixels through canvas in light and dark.