### PR TITLE
fix(one-location): make every control in the save sheet tappable, and cut a sentence

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -804,6 +804,49 @@ describe("SaveLocationModal", () => {
     });
   });
 
+  describe("controls stay tappable without moving", () => {
+    const detailProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      mapInitial: { latitude: 28.6139, longitude: 77.209 },
+      onPickExactLocation: vi.fn(),
+      startWithMapPicker: true,
+      collectAddressDetails: true,
+    };
+
+    it("keeps the corner buttons absolutely positioned while growing their hit area", () => {
+      // The hit area is grown with a painted `::after` box, which must NOT
+      // bring `relative` with it: two positioning utilities in one class
+      // string make tailwind-merge keep the last, which drops these out of
+      // absolute positioning and collapsed them from 36px to 18px.
+      render(<SaveLocationModal {...detailProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      for (const name of ["Back to map", "Close"]) {
+        const button = screen.getByRole("button", { name });
+        expect(button.className).toContain("absolute");
+        expect(button.className).not.toMatch(/(^|\s)relative(\s|$)/);
+        expect(button.className).toContain("after:h-11");
+        expect(button.className).toContain("after:w-11");
+        // The painted circle is unchanged.
+        expect(button.className).toContain("h-9");
+        expect(button.className).toContain("w-9");
+      }
+    });
+
+    it("gives each carousel dot a real 44x44 instead of a grown one", () => {
+      // Two dots sit side by side, so faking the region with a `::after` box
+      // would overlap them and send an edge tap to the wrong slide.
+      render(<SaveLocationModal {...detailProps} />);
+
+      for (const dot of screen.getAllByRole("tab")) {
+        expect(dot.className).toContain("h-11");
+        expect(dot.className).toContain("w-11");
+        expect(dot.className).not.toContain("after:");
+      }
+    });
+  });
+
   describe("the sheet reads as a layer, not a patch", () => {
     it("puts its scrim above the full-screen onboarding takeover", () => {
       // Location onboarding is an OPAQUE fixed layer at z-560. The scrim used
@@ -865,9 +908,7 @@ describe("SaveLocationModal", () => {
       fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
       expect(
-        screen.getByText(
-          "Add a house, landmark or PIN so this place can be found.",
-        ),
+        screen.getByText("Add a house, landmark or PIN."),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Save location" }),

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -590,7 +590,12 @@ export function LocationPickerMap({
           type="button"
           onClick={onCancel}
           aria-label="Close map"
-          className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+          className={cn(
+            "press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]",
+            // 32px circle, 44x44 tappable. The `::after` box is painted, not
+            // laid out, so the header row does not move.
+            "relative after:absolute after:left-1/2 after:top-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']",
+          )}
         >
           <X className="h-4 w-4" strokeWidth={2.4} />
         </button>

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -31,8 +31,21 @@ import {
   type SavedLocationAddressDetails,
 } from "@/lib/one-location/saved-location-address";
 
+/**
+ * Grows the tappable region to 44x44 while the visible control keeps its size,
+ * because the `::after` box is painted rather than laid out.
+ *
+ * Deliberately does NOT include `relative`. Adding it to an element that is
+ * already `absolute` puts two positioning utilities in one class string, and
+ * tailwind-merge keeps the last — which drops the element out of absolute
+ * positioning entirely. That collapsed the sheet's corner buttons from 36px
+ * to 18px. Elements that are not already positioned add `relative` themselves.
+ */
+const touchTargetClassName =
+  "after:absolute after:left-1/2 after:top-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']";
+
 const iconButtonClassName =
-  "press-scale absolute flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill-strong)]/80 disabled:opacity-45";
+  `press-scale absolute flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill-strong)]/80 disabled:opacity-45 ${touchTargetClassName}`;
 
 const controlLabelClassName =
   "mb-1.5 block text-[13px] font-semibold leading-[18px] text-muted-foreground";
@@ -74,7 +87,7 @@ function CarouselDots({
 }) {
   return (
     <div
-      className="flex items-center justify-center gap-2 pt-0.5"
+      className="flex items-center justify-center gap-1"
       role="tablist"
       aria-label="Save this place"
     >
@@ -90,7 +103,10 @@ function CarouselDots({
             aria-label={labels[dot]}
             disabled={!reachable}
             onClick={() => onSelect(dot)}
-            className="flex h-6 items-center px-0.5 disabled:cursor-not-allowed"
+            // A real 44x44 each, laid out rather than faked, because two dots
+            // sit side by side and overlapping hit regions would send a tap
+            // near the boundary to the wrong slide.
+            className="flex h-11 w-11 items-center justify-center disabled:cursor-not-allowed"
           >
             <span
               className={cn(
@@ -505,8 +521,10 @@ export function SaveLocationModal({
             !hasOwnAddressAnswer
           ? // The pin is fine; only its address lookup came back empty. Name
             // the way out that is actually open, rather than sending someone
-            // back to a map they already got right.
-            "Add a house, landmark or PIN so this place can be found."
+            // back to a map they already got right. The line above already
+            // shows there is no address, so this only has to carry the action
+            // -- and it matches the shape of its two siblings.
+            "Add a house, landmark or PIN."
           : postalCodeInvalid
             ? // Not the field's own wording. The invalid PIN already says
               // "Enter a valid PIN or postal code." right next to itself, and
@@ -797,7 +815,10 @@ export function SaveLocationModal({
                   type="button"
                   onClick={() => goToSlide(0)}
                   disabled={interactionBusy}
-                  className="press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
+                  className={cn(
+                    "press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45",
+                    "relative after:absolute after:inset-x-0 after:top-1/2 after:h-11 after:-translate-y-1/2 after:content-['']",
+                  )}
                 >
                   Edit pin
                 </button>
@@ -807,7 +828,7 @@ export function SaveLocationModal({
             {/* Ticked, the fields below are filled from that address and keep
                 following the pin. Unticked, they are cleared and left alone.
                 Anything typed by hand survives either way. */}
-            <label className="flex cursor-pointer items-center gap-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
+            <label className="flex min-h-11 cursor-pointer items-center gap-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
               <input
                 type="checkbox"
                 checked={useDetectedAddress}
@@ -1087,7 +1108,10 @@ export function SaveLocationModal({
                     setPlaceSearchError(null);
                   }}
                   disabled={interactionBusy}
-                  className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45"
+                  className={cn(
+                    "press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45",
+                    "relative after:absolute after:inset-x-0 after:top-1/2 after:h-11 after:-translate-y-1/2 after:content-['']",
+                  )}
                   aria-label="Change captured location"
                 >
                   <Pencil className="h-3.5 w-3.5" aria-hidden />


### PR DESCRIPTION
Follow-up to #5303. Running `ui-clarity-layout-guard` and `less-text-karma-ji` over what that PR shipped found three things it missed.

## 1. The carousel dots I added were not tappable

`11–26 × 24px`, measured in Chromium. Two dots sit side by side, so a painted `::after` region would have overlapped them and sent an edge tap to the wrong slide. They get a **real laid-out 44×44** each instead.

## 2. The sheet's other controls were already under 44pt and stayed that way

| Control | Before | Visible box after | Tappable after |
|---|---|---|---|
| Back / Close (corners) | 36×36 | **36×36 (unchanged)** | 44×44 |
| Edit pin | 67×32 | **67×32 (unchanged)** | 54×44 |
| Change captured location | ~32 tall | unchanged | 44 tall |
| Close map (picker) | 32×32 | **32×32 (unchanged)** | 44×44 |
| "Fill from this address" checkbox | 15×15 | unchanged | 44 tall (label) |

Grown with a painted `::after` box, so **every visible box is identical** — 36×36 and 67×32 measured in the browser before and after.

### The first attempt broke the thing it was fixing

Adding `relative` alongside the existing `absolute` put two positioning utilities in one class string. tailwind-merge kept the last, the corner buttons dropped out of absolute positioning, and they collapsed **36px → 18px**. `touchTargetClassName` no longer carries `relative`; elements that need it add it themselves.

Two tests assert this now. Both fail when the fix is reverted — verified by mutation.

## 3. Copy

> `Add a house, landmark or PIN so this place can be found.` → `Add a house, landmark or PIN.`

Eleven words next to two siblings of six and seven. The line above already shows there is no address, so the reason only carries the action.

## Verification

- `tsc --noEmit` clean, `eslint --max-warnings=0` clean on all three files
- Full `vitest run`: **33 failed / 4021 passed**; failing file set **identical** to `origin/main`'s 33 — no new failures
- Unit tests 43 passing (up from 41); the two new ones mutation-checked
- Chromium at **320 / 360 / 390 / 430 / 768** across short (568), normal (844) and tall (932) heights: no horizontal overflow, details footer stays `sticky` with both dots visible, zero bottom overflow
- Tappable regions re-measured with `elementFromPoint` (which sees `::after`, unlike `getBoundingClientRect`)

## Gate status — read this before merging

`responsive-ui-integrity-guard` returns **FAIL**, not PASS, and the reason is infrastructural rather than a defect in this diff:

- This repo runs Playwright **only in `deploy-uat.yml`**, post-deploy. There is no Playwright status check on PRs, so responsive contracts cannot currently gate a merge.
- The skill's definition of done requires a *required CI status check* plus a route manifest with coverage enforcement.
- Creating that means adding a required job to a shared workflow that every other agent's PR flows through. Per `safe-changes` that is your call, not a side effect of this fix.

My responsive evidence here is a real browser at real widths, but it was a local script, not a committed CI gate. That gap is real and I am not claiming otherwise.