### PR TITLE
fix(one-location): find a person from the first letter, and stop dead CTAs looking alive

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -180,18 +180,18 @@ class ClaimCircleInviteRequest(_CamelModel):
 
 
 class CreateNamedCircleRequest(_CamelModel):
-    name: str = Field(min_length=2, max_length=80)
+    name: str = Field(min_length=1, max_length=80)
     kind: str = Field(default="other", pattern="^(family|friends|other)$")
 
 
 class BootstrapNamedCircleRequest(_CamelModel):
     # No circle id and no kind: onboarding may only ever create the caller their
     # own first Circle, so there is nothing for a caller to point this at.
-    name: str = Field(min_length=2, max_length=80)
+    name: str = Field(min_length=1, max_length=80)
 
 
 class UpdateNamedCircleRequest(_CamelModel):
-    name: str | None = Field(default=None, min_length=2, max_length=80)
+    name: str | None = Field(default=None, min_length=1, max_length=80)
     kind: str | None = Field(default=None, pattern="^(family|friends|other)$")
 
 

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -153,10 +153,12 @@ def _clean_user_id(value: str) -> str:
 
 def _clean_name(value: str) -> str:
     name = " ".join(str(value or "").split())
-    if len(name) < 2 or len(name) > 80:
+    # One character is a name. The old two-character floor rejected a circle
+    # called "A" from a Create button that gave no reason for staying dead.
+    if len(name) < 1 or len(name) > 80:
         raise OneLocationCircleError(
             "LOCATION_CIRCLE_NAME_INVALID",
-            "Circle name must be between 2 and 80 characters.",
+            "Circle name must be between 1 and 80 characters.",
             status_code=422,
         )
     return name

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -18,6 +18,24 @@ from hushh_mcp.services.one_location_circle_service import (
 from hushh_mcp.services.push_notifications import send_circle_member_invite_push
 
 
+def test_circle_name_accepts_one_character_and_still_bounds_the_column() -> None:
+    clean = circle_service_module._clean_name
+
+    # One character is a name. The old two-character floor left the Create
+    # button dead with nothing on screen explaining the refusal.
+    assert clean("A") == "A"
+    assert clean("  A  ") == "A"
+    # Interior whitespace still collapses to one space.
+    assert clean("Meena   Family") == "Meena Family"
+    assert clean("x" * 80) == "x" * 80
+
+    # Empty, whitespace-only, and over-length remain refusals.
+    for rejected in ("", "   ", "x" * 81):
+        with pytest.raises(OneLocationCircleError) as excinfo:
+            clean(rejected)
+        assert excinfo.value.code == "LOCATION_CIRCLE_NAME_INVALID"
+
+
 def test_circle_member_payload_includes_public_recipient_key_for_group_selection() -> None:
     payload = OneLocationCircleService._member_payload(
         {

--- a/consent-protocol/tests/test_one_location_named_circle_routes.py
+++ b/consent-protocol/tests/test_one_location_named_circle_routes.py
@@ -408,13 +408,28 @@ def test_circle_bootstrap_cannot_be_pointed_at_another_circle(monkeypatch) -> No
 def test_circle_bootstrap_requires_a_usable_name(monkeypatch) -> None:
     client, _service = _bootstrap_client(monkeypatch)
 
-    assert client.post("/api/one/location/circles/bootstrap", json={"name": "x"}).status_code == 422
+    # A single character is a usable name; only nothing at all, or something
+    # longer than the column, is refused.
+    assert (
+        client.post(
+            "/api/one/location/circles/bootstrap",
+            json={"name": ""},
+        ).status_code
+        == 422
+    )
     assert (
         client.post(
             "/api/one/location/circles/bootstrap",
             json={"name": "x" * 81},
         ).status_code
         == 422
+    )
+    assert (
+        client.post(
+            "/api/one/location/circles/bootstrap",
+            json={"name": "x"},
+        ).status_code
+        != 422
     )
 
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -264,6 +264,7 @@ import type {
   OneLocationState,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
+import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import { OneLocationStateResource } from "@/lib/one-location/one-location-state-resource";
 import {
   isCircleSelectionFullySelected,
@@ -2655,20 +2656,24 @@ export function OneLocationAgentPageContent({
       ),
     [rankedRecipients, selectedShareCircleSelection],
   );
-  const visibleRecipients = useMemo(() => {
-    const query = recipientSearch.trim().toLowerCase();
-    if (!query) return rankedRecipients;
-    return rankedRecipients.filter((recipient) =>
-      recommendationSearchText(recipient).includes(query),
-    );
-  }, [rankedRecipients, recipientSearch]);
-  const visibleShareRecipients = useMemo(() => {
-    const query = shareRecipientSearch.trim().toLowerCase();
-    if (!query) return rankedRecipients;
-    return rankedRecipients.filter((recipient) =>
-      recommendationSearchText(recipient).includes(query),
-    );
-  }, [rankedRecipients, shareRecipientSearch]);
+  const visibleRecipients = useMemo(
+    () =>
+      filterPeopleByQuery(
+        rankedRecipients,
+        recipientSearch,
+        recommendationSearchText,
+      ),
+    [rankedRecipients, recipientSearch],
+  );
+  const visibleShareRecipients = useMemo(
+    () =>
+      filterPeopleByQuery(
+        rankedRecipients,
+        shareRecipientSearch,
+        recommendationSearchText,
+      ),
+    [rankedRecipients, shareRecipientSearch],
+  );
   const hasMoreVisibleRecipients =
     visibleRecipients.length > ONE_NETWORK_PREVIEW_LIMIT;
   const showExpandedOneNetworkList =

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -58,6 +58,7 @@ import {
   getNativeMapsApiKey,
 } from "@/lib/one-location/maps-config";
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
+import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import {
   LOCATION_COPY,
   isLocationPermissionDeniedError,
@@ -1748,13 +1749,10 @@ export function LocationImmersiveMap({
     vaultOwnerToken,
   ]);
 
-  const filteredPeople = useMemo(() => {
-    const query = searchQuery.trim().toLocaleLowerCase();
-    if (!query) return markers;
-    return markers.filter((marker) =>
-      marker.label.toLocaleLowerCase().includes(query),
-    );
-  }, [markers, searchQuery]);
+  const filteredPeople = useMemo(
+    () => filterPeopleByQuery(markers, searchQuery, (marker) => marker.label),
+    [markers, searchQuery],
+  );
 
   const nearbyAttendees = useMemo(
     () => (nearbyPresenceState.presence ? nearbyPresenceState.attendees : []),

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -33,6 +33,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
+import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import {
   isCircleSelectionFullySelected,
@@ -307,13 +308,10 @@ export function CheckInFlow({
     }
   }, [contacts, seeded, vm]);
 
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return contacts;
-    return contacts.filter((r) =>
-      vm.recipientLabel(r).toLowerCase().includes(q),
-    );
-  }, [contacts, search, vm]);
+  const filtered = useMemo(
+    () => filterPeopleByQuery(contacts, search, (r) => vm.recipientLabel(r)),
+    [contacts, search, vm],
+  );
 
   const selectedReadyCount = useMemo(
     () =>

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -111,6 +111,78 @@ describe("named Circle flows", () => {
     expect(onSubmit).toHaveBeenLastCalledWith("Meena Family", "family");
   });
 
+  it("blocks Create only while the name is empty, and says so visibly", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
+
+    const create = screen.getByRole("button", { name: "Create circle" });
+    const input = screen.getByPlaceholderText("e.g. Meena Family");
+
+    // Nothing typed: the button is genuinely blocked, and it is painted as a
+    // neutral fill rather than a half-opacity accent that still reads as live.
+    expect(create).toBeDisabled();
+    expect(create.className).toContain("disabled:bg-black/10");
+    expect(create.className).toContain("disabled:opacity-100");
+
+    // Whitespace is not a name.
+    fireEvent.change(input, { target: { value: "   " } });
+    expect(create).toBeDisabled();
+
+    // One character is.
+    fireEvent.change(input, { target: { value: "A" } });
+    expect(create).toBeEnabled();
+
+    fireEvent.click(create);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("A", "family"));
+  });
+
+  it("finds a connection from the first letter of any of their names", async () => {
+    const onLoad = vi.fn(async () => circle("circle-1", "Meena Family"));
+    render(
+      <CircleDetailFlow
+        circleId="circle-1"
+        {...detailProps(onLoad)}
+        onLoadEligibleConnections={vi.fn(async () => ({
+          eligibleConnections: [
+            {
+              userId: "conn-1",
+              displayName: "Asha Meena",
+              connectionOrigin: "one" as const,
+            },
+            {
+              userId: "conn-2",
+              displayName: "Neel Shah",
+              connectionOrigin: "one" as const,
+            },
+          ],
+          pendingInvites: [],
+          remainingCapacity: 5,
+        }))}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add people" }),
+    );
+    expect(await screen.findByText("Asha Meena")).toBeTruthy();
+
+    // "Asha Meena" and "Neel Shah" BOTH contain an "n", so a substring filter
+    // returned both and one-letter search looked broken. Only Neel's name
+    // BEGINS with one.
+    fireEvent.change(screen.getByLabelText("Search connections"), {
+      target: { value: "n" },
+    });
+    expect(screen.getByText("Neel Shah")).toBeTruthy();
+    expect(screen.queryByText("Asha Meena")).toBeNull();
+
+    // A later word counts as a beginning too.
+    fireEvent.change(screen.getByLabelText("Search connections"), {
+      target: { value: "m" },
+    });
+    expect(screen.getByText("Asha Meena")).toBeTruthy();
+    expect(screen.queryByText("Neel Shah")).toBeNull();
+  });
+
   it("previews before joining and discloses connection and location boundaries", async () => {
     const preview: OneLocationCircleInvitePreview = {
       name: "Meena Family",
@@ -828,9 +900,13 @@ describe("named Circle flows", () => {
     expect(screen.getByRole("button", { name: "Edit Circle name" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
 
-    fireEvent.change(input, { target: { value: "M" } });
+    // Only an empty name blocks the write; one character is a name.
+    fireEvent.change(input, { target: { value: "   " } });
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-    expect(screen.getByText("Use at least 2 characters.")).toBeTruthy();
+    expect(screen.getByText("Enter a name.")).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: "M" } });
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
 
     fireEvent.change(input, { target: { value: "  Meena Home  " } });
     const save = screen.getByRole("button", { name: "Save" });

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -42,6 +42,7 @@ import type {
   OneLocationCircleEligibleConnections,
   OneLocationCircleMemberInvite,
 } from "@/lib/one-location/types";
+import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import { cn } from "@/lib/utils";
 
 function circleInitials(value: string): string {
@@ -109,13 +110,15 @@ export function CircleInvitePeopleSheet({
   const submitInFlightRef = useRef(false);
   const cancelInFlightRef = useRef(false);
 
-  const filtered = useMemo(() => {
-    const query = search.trim().toLocaleLowerCase();
-    if (!query) return eligibleConnections;
-    return eligibleConnections.filter((connection) =>
-      connection.displayName.toLocaleLowerCase().includes(query),
-    );
-  }, [eligibleConnections, search]);
+  const filtered = useMemo(
+    () =>
+      filterPeopleByQuery(
+        eligibleConnections,
+        search,
+        (connection) => connection.displayName,
+      ),
+    [eligibleConnections, search],
+  );
 
   const load = useCallback(async () => {
     const requestId = ++requestRef.current;

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -57,6 +57,7 @@ import type {
   OneLocationCircleMemberInvite,
   OneLocationCircleSummary,
 } from "@/lib/one-location/types";
+import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import { cn } from "@/lib/utils";
 
 const CIRCLES_GROUP_SURFACE =
@@ -64,6 +65,17 @@ const CIRCLES_GROUP_SURFACE =
 
 const CIRCLES_EMPTY_STATE_WRAPPER =
   "[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]";
+
+/**
+ * A primary action that cannot fire yet has to LOOK like it cannot fire.
+ * The shared button only dims to 50% opacity, and half-opacity accent over
+ * these light sheets still reads as a live button — so "Create circle" and
+ * "Select people" were reported as broken rather than understood as blocked.
+ * This is the neutral disabled fill the Location hub's own primary CTAs
+ * already use, so nothing new is being invented here.
+ */
+const BLOCKED_CTA =
+  "disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35";
 
 function circleInitials(value: string): string {
   return value
@@ -414,7 +426,9 @@ export function CreateCircleFlow({
 }) {
   const [name, setName] = useState("");
   const [kind, setKind] = useState<OneLocationCircleKind>("family");
-  const canSubmit = name.trim().length >= 2 && !busy;
+  // One typed character is a name. Requiring two silently withheld the button
+  // from anyone naming a circle "A", with nothing on screen saying why.
+  const canSubmit = name.trim().length >= 1 && !busy;
 
   const submit = async () => {
     try {
@@ -478,7 +492,10 @@ export function CreateCircleFlow({
         disabled={!canSubmit}
         isLoading={busy}
         onClick={() => void submit()}
-        className="h-12 w-full rounded-full text-base font-semibold"
+        className={cn(
+          "h-12 w-full rounded-full text-base font-semibold",
+          BLOCKED_CTA,
+        )}
       >
         Create circle
       </Button>
@@ -624,7 +641,10 @@ export function JoinCircleFlow({
           disabled={normalizedLength !== 12 || busy}
           isLoading={busy}
           onClick={() => void resolve()}
-          className="h-12 w-full rounded-full text-base font-semibold"
+          className={cn(
+            "h-12 w-full rounded-full text-base font-semibold",
+            BLOCKED_CTA,
+          )}
         >
           Preview circle
         </Button>
@@ -869,7 +889,7 @@ export function CircleDetailFlow({
   const circleNameDirty =
     Boolean(circle) && trimmedCircleName !== circle?.name;
   const canSaveCircleName =
-    circleNameDirty && trimmedCircleName.length >= 2 && !savingName && !busy;
+    circleNameDirty && trimmedCircleName.length >= 1 && !savingName && !busy;
   const canInviteMembers =
     circle?.viewerCapabilities?.canInviteMembers ?? Boolean(isOwner);
   const canViewInviteCode =
@@ -892,13 +912,15 @@ export function CircleDetailFlow({
     [members, currentUserId],
   );
 
-  const filteredEligibleConnections = useMemo(() => {
-    const query = peopleSearch.trim().toLocaleLowerCase();
-    if (!query) return eligibleConnections;
-    return eligibleConnections.filter((connection) =>
-      connection.displayName.toLocaleLowerCase().includes(query),
-    );
-  }, [eligibleConnections, peopleSearch]);
+  const filteredEligibleConnections = useMemo(
+    () =>
+      filterPeopleByQuery(
+        eligibleConnections,
+        peopleSearch,
+        (connection) => connection.displayName,
+      ),
+    [eligibleConnections, peopleSearch],
+  );
 
   const loadEligibleConnections = async () => {
     if (!circle || !canInviteMembers) return;
@@ -1029,7 +1051,7 @@ export function CircleDetailFlow({
   // waiting for a refetch.
   const renameCircle = async () => {
     const nextName = circleName.trim();
-    if (!circle || savingName || nextName.length < 2 || nextName === circle.name)
+    if (!circle || savingName || nextName.length < 1 || nextName === circle.name)
       return;
     setSavingName(true);
     try {
@@ -1168,8 +1190,8 @@ export function CircleDetailFlow({
                 )}
               </div>
               <p className={cn(MUTED_TEXT, "mt-2")}>
-                {circleNameDirty && trimmedCircleName.length < 2
-                  ? "Use at least 2 characters."
+                {circleNameDirty && trimmedCircleName.length < 1
+                  ? "Enter a name."
                   : circleNameDirty
                     ? "Tap Save — everyone in this Circle will see the new name."
                     : "Everyone in this Circle sees this name."}
@@ -1479,7 +1501,10 @@ export function CircleDetailFlow({
                   }
                   isLoading={peopleSubmitting}
                   onClick={() => void sendMemberInvites()}
-                  className="h-12 w-full shrink-0 rounded-full text-base font-semibold"
+                  className={cn(
+                    "h-12 w-full shrink-0 rounded-full text-base font-semibold",
+                    BLOCKED_CTA,
+                  )}
                 >
                   {selectedConnectionIds.size
                     ? `Invite ${selectedConnectionIds.size} ${

--- a/hushh-webapp/lib/one-location/__tests__/people-search.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/people-search.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { filterPeopleByQuery } from "../people-search";
+
+const nameOf = (name: string) => name;
+
+describe("filterPeopleByQuery", () => {
+  it("narrows to the person whose name begins with a single typed letter", () => {
+    // The reported bug, exactly: both names contain an "n" ("Ankit", "Singh"),
+    // so a substring filter returned the whole list and one-letter search
+    // looked broken.
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "n", nameOf)).toEqual(["Neelesh Meena"]);
+  });
+
+  it("matches the beginning of any word, not just the first", () => {
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "kum", nameOf)).toEqual([
+      "Ankit Kumar Singh",
+    ]);
+    expect(filterPeopleByQuery(people, "mee", nameOf)).toEqual([
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("still finds a name by its middle once two characters are typed", () => {
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "ingh", nameOf)).toEqual([
+      "Ankit Kumar Singh",
+    ]);
+  });
+
+  it("keeps every match beyond one character, word beginnings first", () => {
+    const people = ["Ameena Khan", "Meena Rao"];
+
+    expect(filterPeopleByQuery(people, "me", nameOf)).toEqual([
+      "Meena Rao",
+      "Ameena Khan",
+    ]);
+  });
+
+  it("never empties a list that has a match, even for one character", () => {
+    // Nothing BEGINS with "o", so the loose match is all there is — returning
+    // an empty list here would be worse than the bug being fixed.
+    expect(filterPeopleByQuery(["Bob Rao"], "o", nameOf)).toEqual(["Bob Rao"]);
+  });
+
+  it("returns every person for an empty or whitespace query", () => {
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "", nameOf)).toEqual(people);
+    expect(filterPeopleByQuery(people, "   ", nameOf)).toEqual(people);
+  });
+
+  it("ignores case and surrounding whitespace", () => {
+    const people = ["Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "  NEE  ", nameOf)).toEqual(people);
+  });
+
+  it("treats hyphens, apostrophes and dots as word breaks", () => {
+    expect(filterPeopleByQuery(["Jean-Luc Picard"], "l", nameOf)).toEqual([
+      "Jean-Luc Picard",
+    ]);
+    expect(filterPeopleByQuery(["Riya O'Brien"], "b", nameOf)).toEqual([
+      "Riya O'Brien",
+    ]);
+    expect(filterPeopleByQuery(["R. Meena"], "m", nameOf)).toEqual([
+      "R. Meena",
+    ]);
+  });
+
+  it("matches a multi-word query across the whole name", () => {
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "ankit ku", nameOf)).toEqual([
+      "Ankit Kumar Singh",
+    ]);
+  });
+
+  it("searches every word of the text the caller supplies, not just a name", () => {
+    const people = [
+      { name: "Neelesh Meena", headline: "Product designer" },
+      { name: "Ankit Kumar Singh", headline: "Founder" },
+    ];
+
+    expect(
+      filterPeopleByQuery(
+        people,
+        "designer",
+        (person) => `${person.name} ${person.headline}`,
+      ),
+    ).toEqual([people[0]]);
+  });
+
+  it("drops a person no part of whose text matches", () => {
+    const people = ["Ankit Kumar Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "zz", nameOf)).toEqual([]);
+  });
+});

--- a/hushh-webapp/lib/one-location/people-search.ts
+++ b/hushh-webapp/lib/one-location/people-search.ts
@@ -1,0 +1,62 @@
+/**
+ * How a typed query narrows a list of people.
+ *
+ * Every people picker on the Location surface filtered with a bare
+ * `includes()`. With connections named "Ankit Kumar Singh" and "Neelesh
+ * Meena", typing `n` matched BOTH — "Ankit" and "Singh" each carry an "n" — so
+ * the list never narrowed and one-letter search read as broken. You had to
+ * reach two characters before a substring became rare enough to tell two
+ * people apart.
+ *
+ * People read a name from the start of its words: `n` means Neelesh, `kum`
+ * means Kumar. So a query that BEGINS a word ranks above one that merely
+ * appears inside it.
+ *
+ * A single character is only meaningful as a beginning — mid-word it matches
+ * most names in any list — so a one-character query keeps just the
+ * word-beginning matches, and falls back to loose matches only when nothing
+ * begins with it (so it can never empty a list that has a match). From two
+ * characters on nothing is dropped at all: beginnings lead, loose matches
+ * follow, so `ingh` still finds Singh.
+ */
+
+/** Anything that is not a letter or a digit separates one word from the next,
+ *  which keeps "Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader
+ *  would split them. */
+const WORD_BOUNDARY = /[^\p{L}\p{N}]+/u;
+
+function normalize(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+/** Does `query` begin the whole string, or any word inside it? */
+function beginsAWord(haystack: string, query: string): boolean {
+  return haystack.split(WORD_BOUNDARY).some((word) => word.startsWith(query));
+}
+
+/**
+ * Filter `items` by a person-name query, most-expected match first.
+ *
+ * `searchTextOf` may return more than a name (a headline, a relationship, a
+ * reason) — every word of whatever it returns is searchable.
+ */
+export function filterPeopleByQuery<T>(
+  items: readonly T[],
+  query: string,
+  searchTextOf: (item: T) => string,
+): T[] {
+  const needle = normalize(query);
+  if (!needle) return [...items];
+
+  const beginners: T[] = [];
+  const loose: T[] = [];
+
+  for (const item of items) {
+    const haystack = normalize(searchTextOf(item));
+    if (beginsAWord(haystack, needle)) beginners.push(item);
+    else if (haystack.includes(needle)) loose.push(item);
+  }
+
+  if (needle.length === 1) return beginners.length ? beginners : loose;
+  return [...beginners, ...loose];
+}


### PR DESCRIPTION
Reported on the Circle screens by Jhumma. Three items; one rule sits behind two of them.

### 1. One-character search found nobody

Every people picker on the Location surface filtered with a bare `includes()`. Typing `n` against **Ankit Kumar Singh** and **Neelesh Meena** matched *both* — "Ankit" and "Singh" each carry an "n" — so the list never narrowed and you had to reach two characters before a substring became rare enough to tell two people apart.

People read a name from the start of its words, so a query that **begins** a word now ranks above one that merely appears inside it:

| typed | before | after |
|---|---|---|
| `n` | both names | Neelesh Meena |
| `m` | both names | Asha Meena |
| `ingh` | Ankit Kumar Singh | Ankit Kumar Singh (unchanged) |

A single character counts only as a beginning — mid-word it matches most names in any list — and falls back to loose matching when nothing begins with it, so it can **never empty a list that has a match**. From two characters on nothing is dropped at all.

That rule was duplicated in six places, so it is now one tested helper (`lib/one-location/people-search.ts`) applied to all of them: add-people-to-Circle, the Circle grow sheet, the check-in contact list, the map's people tray, and both recipient searches on the hub.

### 2. "Create circle" / "Select people" looked pressable but did nothing

The shared button only dims to `opacity-50`, and half-opacity accent over these light sheets still reads as a live button — so a *blocked* CTA was reported as a *broken* one. These now use the neutral disabled fill the Location hub's own primary CTAs already use. No new visual language, no change to the shared button.

### 3. Naming a circle needed two characters, silently

Nothing on screen said so. One character is a name: the floor drops to 1 across the create flow, the inline rename, the request models and the service validator, so **the UI and the API agree**. Empty and over-80 stay refused, and the rename hint now says what is actually missing ("Enter a name.").

### Not in this PR

Putting recipient names on the map pins (the first screenshot, assigned to @DamriaNeelesh). `location-immersive-map.tsx` deliberately withholds private recipient names from the Google renderer, and on web `title` feeds the pin's *glyph* slot and paints across the map. Both constraints are documented in that file. Making the pins say who they are needs its own design — an HTML overlay off the existing marker labels, not a `title` — so it is left to that lane rather than pushed through here.

### Verification

- `lib/one-location/__tests__/people-search.test.ts` — 11 new tests; mutation-checked by restoring the old `includes()` filter, which fails 2 of them.
- `named-circle-flows.test.tsx` — 25 pass, including 2 new: Create blocked only while the name is empty (asserting the disabled *fill*, not just the attribute), and finding a connection from one letter.
- Backend: 54 pass, including a new `_clean_name` boundary test; the bootstrap route test now asserts a 1-character name is accepted.
- `npx tsc --noEmit` clean; eslint clean on all changed files; ruff clean on both Python files.