### PR TITLE
fix(one-location): restore two protected consent words, and cover what shipped untested

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1145,6 +1145,84 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("keeps every counted Now-hub row neutral while its count is zero", async () => {
+    // State beats category. Colour on these three rows means "there is
+    // something here", never "this row exists" — an empty Location screen
+    // reporting 0, 0, 0 in three saturated tiles spends colour on nothing and
+    // leaves none for the rows that do carry state.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [],
+      requests: [],
+    });
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    const toneOf = async (title: string) => {
+      const row = (await screen.findByText(title)).closest(
+        '[data-slot="settings-row"], button, a, div[role="button"]',
+      );
+      return row
+        ?.querySelector('[data-slot="settings-row-icon"]')
+        ?.getAttribute("data-icon-tone");
+    };
+
+    expect(await toneOf("Active shares")).toBe("gray");
+    expect(await toneOf("Shared with me")).toBe("gray");
+    expect(await toneOf("Needs my review")).toBe("gray");
+  });
+
+  it("colours each counted Now-hub row by its own state once it is non-zero", async () => {
+    // Green = sharing is live (same family as the header switch and Check-In),
+    // indigo = other people, orange = something is waiting on you. Each row
+    // reads its OWN count, so one being populated must not colour the others.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      receivedGrants: [
+        {
+          id: "grant_in",
+          ownerUserId: "user_b",
+          recipientUserId: "user_a",
+          ownerDisplayName: "Trusted B",
+          recipientKeyId: "key_a",
+          status: "active",
+          consentScope: "cap.location.live.view",
+          capabilityScopes: ["cap.location.live.view"],
+          durationHours: 1,
+          expiresAt: "2099-05-20T08:00:00.000Z",
+        },
+      ],
+      requests: [
+        {
+          id: "request_1",
+          ownerUserId: "user_a",
+          requesterUserId: "user_b",
+          status: "pending",
+          requestedAt: "2026-05-20T07:30:00.000Z",
+        },
+      ],
+    });
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    const toneOf = async (title: string) => {
+      const row = (await screen.findByText(title)).closest(
+        '[data-slot="settings-row"], button, a, div[role="button"]',
+      );
+      return row
+        ?.querySelector('[data-slot="settings-row-icon"]')
+        ?.getAttribute("data-icon-tone");
+    };
+
+    // locationState() already carries one active ownerGrant.
+    expect(await toneOf("Active shares")).toBe("green");
+    expect(await toneOf("Shared with me")).toBe("indigo");
+    expect(await toneOf("Needs my review")).toBe("orange");
+  });
+
   it("keeps the heading and location toggle inline as the only header action", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),

--- a/hushh-webapp/__tests__/native/one-location-position-resilience.contract.test.ts
+++ b/hushh-webapp/__tests__/native/one-location-position-resilience.contract.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { isLocationPermissionDeniedError } from "@/lib/one-location/location-readiness";
+
 function source(relativePath: string): string {
   return readFileSync(join(process.cwd(), relativePath), "utf8");
 }
@@ -36,5 +38,61 @@ describe("One Location native one-shot position resilience", () => {
     expect(ios).toContain("private func clearPendingLocationCall()");
     expect(ios).toContain("pendingLocationTimeout?.cancel()");
     expect(ios).toContain("if let call = clearPendingLocationCall()");
+  });
+
+  it("tells JS about a revocation that lands while a watch is already running", () => {
+    // locationManagerDidChangeAuthorization answers pendingPermissionCall,
+    // pendingWatchStartCall and pendingLocationCall — and a mid-watch
+    // revocation is none of those, so it used to fall through the final guard
+    // and return. CoreLocation stops delivering, JS is never told, and the
+    // last known point stays on the map with the Location switch still ON for
+    // someone the OS has already cut off.
+    const ios = source("ios/App/App/Plugins/HushhLocationPlugin.swift");
+
+    const denialBranch = ios.slice(
+      ios.indexOf("public func locationManagerDidChangeAuthorization"),
+      ios.indexOf("guard let call = pendingLocationCall else { return }"),
+    );
+    expect(denialBranch).toContain("case .denied, .restricted:");
+    expect(denialBranch).toContain("failWatches(");
+  });
+
+  it("rejects every watch with a message the shared JS denial check recognises", () => {
+    // The cross-language contract. CAPPluginCall.reject takes a `String?`
+    // code and this plugin passes none, so JS cannot switch on a numeric
+    // code — it matches on the MESSAGE via isLocationPermissionDeniedError.
+    // If someone reworded a failWatches() string, a real denial would silently
+    // degrade to a generic error on device and nothing else would catch it.
+    const ios = source("ios/App/App/Plugins/HushhLocationPlugin.swift");
+
+    const messages = [...ios.matchAll(/failWatches\(\s*"([^"]+)"\s*\)/g)].map(
+      (match) => match[1],
+    );
+    expect(messages.length).toBeGreaterThan(0);
+
+    const denials = messages.filter((message) =>
+      isLocationPermissionDeniedError(new Error(message)),
+    );
+    // At least one path must read as a denial: the authorization change.
+    expect(denials).toContain("Location permission was not granted.");
+  });
+
+  it("does not end a live watch on the transient kCLErrorLocationUnknown", () => {
+    // Apple's guidance is to wait that one out — CoreLocation keeps trying.
+    // Treating it as fatal ran failWatches(), which releases every saved call
+    // AND calls stopUpdatingLocation(), so a single blip in a lift or a tunnel
+    // permanently stopped live sharing until the person toggled Location off
+    // and on again.
+    const ios = source("ios/App/App/Plugins/HushhLocationPlugin.swift");
+
+    const didFail = ios.slice(
+      ios.indexOf("didFailWithError error: Error"),
+    );
+    expect(didFail).toContain("as? CLError");
+    expect(didFail).toContain(".locationUnknown");
+    // The early return must come BEFORE the watch teardown, or it does nothing.
+    expect(didFail.indexOf(".locationUnknown")).toBeLessThan(
+      didFail.indexOf("failWatches(message)"),
+    );
   });
 });

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -377,6 +377,10 @@ textarea {
   --system-red: var(--app-destructive);
   --system-orange: var(--app-warning);
   --app-purple: #af52de;
+  /* People, circles, private sharing. Sits beside the other five semantic
+     hues rather than inline in a component, and gives the profile screens'
+     existing [data-icon-tone="indigo"] rules something to reference. */
+  --app-indigo: #5856d6;
   --app-info: var(--app-accent);
   --app-focus-ring: rgba(0, 122, 255, 0.25);
   --app-glass-surface: rgba(255, 255, 255, 0.78);
@@ -944,6 +948,10 @@ textarea {
   --app-success: #30d158;
   --app-warning: #ff9f0a;
   --app-purple: #bf5af2;
+  /* Brightened for dark exactly like --app-warning and --app-destructive are.
+     The raw system value (#5e5ce6) measures 2.77:1 on the 20% tile — the only
+     tone in the map under 3:1 — where every sibling sits above 4.7. */
+  --app-indigo: #7d7aff;
   --app-info: var(--app-accent);
   --app-focus-ring: rgba(10, 132, 255, 0.3);
   --app-glass-surface: rgba(28, 28, 30, 0.78);
@@ -1226,7 +1234,7 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
 [data-profile-stack-screen="panel:account"] [data-icon-tone="indigo"],
 .profile-account-content [data-icon-tone="indigo"],
 .profile-home-content [data-icon-tone="indigo"] {
-  background: #5856d6 !important;
+  background: var(--app-indigo) !important;
 }
 
 [data-profile-stack-screen="account"] [data-icon-tone="purple"],

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -154,10 +154,15 @@ const SETTINGS_ICON_TONE_CLASSNAME = {
   // People, circles and private sharing. Added because the tone vocabulary was
   // smaller than the semantics: `accent`, `blue` and `purple` are byte-identical
   // above, so "these are PEOPLE" had no colour of its own and every row that
-  // meant it rendered as the same action blue as "Share location". iOS system
-  // indigo (#5856D6 light / #5E5CE6 dark), same 12%/20% tile recipe as the rest.
+  // meant it rendered as the same action blue as "Share location".
+  //
+  // Reads --app-indigo rather than carrying its own literals: the value already
+  // existed a second time in globals.css (the profile screens' icon-tone
+  // override), so a hardcoded pair here made one colour live in two files with
+  // nothing binding them. Same 12%/20% tile recipe as the rest, and the token
+  // brightens for dark the way --app-warning and --app-destructive do.
   indigo:
-    "bg-[rgba(88,86,214,0.12)] text-[#5856D6] dark:bg-[rgba(94,92,230,0.20)] dark:text-[#5E5CE6]",
+    "bg-[color-mix(in_srgb,var(--app-indigo)_12%,transparent)] text-[color:var(--app-indigo)] dark:bg-[color-mix(in_srgb,var(--app-indigo)_20%,transparent)] dark:text-[color:var(--app-indigo)]",
   gray:
     "bg-[#E5E5EA] text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#D1D1D6]",
 } as const;

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2341,11 +2341,23 @@ export function LocationImmersiveMap({
             GOOGLE_MAPS_RENDERER_CONSENT_VERSION. All three claims are
             load-bearing and none may be dropped for brevity — private shares
             are opened locally, Google Maps is told the minimum, and Nearby
-            Check-In is a separate opt-in. Only the wording was tightened.
+            Check-In is a separate opt-in.
+
+            Two words in the third claim are protected, and a previous trim of
+            this paragraph lost both:
+            - "only" is the exclusivity guarantee. The other two claims keep
+              theirs ("open only on this device", "gets only what it needs");
+              dropping it here alone said Check-In is separate without saying
+              nothing else can start it.
+            - "Nearby" is the feature's name, and the single word that says
+              this is the surface that shows you to people AROUND you rather
+              than to people you picked. Settings states the same strong form.
+            Shorten the connective tissue if you must; leave those two.
           */}
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
             Private shares open only on this device. Google Maps gets only what
-            it needs to draw them. Check-In is separate — you start it.
+            it needs to draw them. Nearby Check-In is separate — it starts only
+            when you do.
           </p>
           <Button
             className={`mt-4 w-full ${MAP_ACCENT_ACTIVE_CLASSNAME}`}

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -366,12 +366,12 @@ describe("SosPanel", () => {
     fireEvent.change(composer, { target: { value: "a".repeat(140) } });
     expect(screen.getByText("140/140")).toBeInTheDocument();
     expect(hold).toBeEnabled();
-    expect(screen.queryByText("character limit exceed")).toBeNull();
+    expect(screen.queryByText("Message is too long")).toBeNull();
 
     fireEvent.change(composer, { target: { value: "a".repeat(141) } });
     expect(screen.getByText("141/140")).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "character limit exceed",
+      "Message is too long",
     );
     expect(hold).toBeDisabled();
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1531,7 +1531,12 @@ function LocationDetailFlow({
               <SettingsRow
                 key={grant.id}
                 icon={UsersRound}
-                iconTone="purple"
+                // Green, matching the "Active shares" row that opens this
+                // screen. Each row here IS one of those live grants, and
+                // "purple" renders byte-identically to blue in the tone map —
+                // so tapping a green row reporting 3 landed on three blue rows
+                // for the same 3 grants. One object, one colour.
+                iconTone="green"
                 title={vm.grantRecipientLabel(grant)}
                 description={
                   grant.durationMode === "until_stopped"

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -713,7 +713,11 @@ export function SosPanel({
                 role="alert"
                 className="text-[12px] text-[color:var(--app-destructive)]"
               >
-                character limit exceed
+                {/* Same defect the hub copy had: lowercase, verbless, and
+                    read aloud by screen readers via role="alert". This one is
+                    on the emergency surface, where a message that does not
+                    parse is worst. */}
+                Message is too long
               </p>
             ) : (
               <span />

--- a/hushh-webapp/e2e/location-agent-now-ui.spec.ts
+++ b/hushh-webapp/e2e/location-agent-now-ui.spec.ts
@@ -135,3 +135,88 @@ test.describe("Location Agent Now visual contract", () => {
     );
   });
 });
+
+/**
+ * The header switch's responsive contract.
+ *
+ * QA reported the switch had no meaning on an iPhone. The cause was that its
+ * status text carried `hidden … sm:inline`, and `sm` is 640px — so it rendered
+ * in a desktop browser and on no phone at all. A jsdom test could not catch it
+ * (jsdom does not apply media queries, so `getByText` still found the element),
+ * and the fix was originally proven by a manual Playwright session that never
+ * landed in the repo. This is that measurement, committed, so it can fail.
+ *
+ * Two invariants, at every supported width:
+ *  1. The status is visible and has text — a switch never survives alone.
+ *  2. "Location Agent" stays on one line. The full status string is wide
+ *     enough to push a 28px title onto a second line at 320-390px, which is
+ *     why the compact form exists; if someone drops the compact form this
+ *     assertion is what notices.
+ */
+const HEADER_WIDTHS = [320, 360, 375, 390, 430, 639, 640, 768] as const;
+
+test.describe("Location Agent header responsive contract", () => {
+  test.skip(
+    !hasReviewerAuthority(),
+    "Requires REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE.",
+  );
+
+  for (const width of HEADER_WIDTHS) {
+    test(`keeps the location switch's meaning visible at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await openReviewerLocation(page);
+
+      const status = page.getByTestId("one-location-header-status");
+      await expect(status).toBeVisible();
+      expect(((await status.innerText()) ?? "").trim().length).toBeGreaterThan(
+        0,
+      );
+
+      // The status describes the switch, so it must also reach assistive tech.
+      const statusId = await status.getAttribute("id");
+      expect(statusId).toBeTruthy();
+      await expect(
+        page.locator(`[role="switch"][aria-describedby="${statusId}"]`),
+      ).toHaveCount(1);
+
+      // Below 640 the visible word is the compact form; at/above it is the
+      // full string. Neither may be empty, and they must not swap over.
+      const visibleText = (await status.innerText()).trim();
+      if (width < 640) {
+        expect(visibleText).not.toContain("Location ");
+      } else {
+        expect(visibleText).toContain("Location ");
+      }
+
+      // Product-owned title: one line, never clipped.
+      const heading = page.getByRole("heading", { name: "Location Agent" });
+      await expect(heading).toBeVisible();
+      const box = await heading.evaluate((node) => ({
+        clientHeight: node.clientHeight,
+        scrollHeight: node.scrollHeight,
+        scrollWidth: node.scrollWidth,
+        clientWidth: node.clientWidth,
+        lineHeight: parseFloat(getComputedStyle(node).lineHeight),
+      }));
+      expect(box.scrollHeight).toBeLessThanOrEqual(box.clientHeight);
+      expect(box.scrollWidth).toBeLessThanOrEqual(box.clientWidth + 1);
+      // 320px is the one width where a second line is accepted (it wrapped
+      // there before this work too); everywhere else it must stay single.
+      if (width > 320) {
+        expect(box.clientHeight).toBeLessThanOrEqual(
+          Math.ceil(box.lineHeight * 1.5),
+        );
+      }
+
+      // And the page itself must never scroll sideways.
+      const overflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth >
+          document.documentElement.clientWidth,
+      );
+      expect(overflow).toBe(false);
+    });
+  }
+});

--- a/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
@@ -247,4 +247,35 @@ describe("LocationBus.watch", () => {
     expect(LocationBus.getState().status).toBe("denied");
     expect(LocationBus.getState().error).toBe("blocked for this site");
   });
+
+  it("reports a NATIVE mid-watch revocation, which carries no numeric code", async () => {
+    // The case above is browser-shaped: `code: 1` is
+    // GeolocationPositionError.PERMISSION_DENIED. Capacitor's native reject
+    // has no numeric code at all — CAPPluginCall.reject takes `String?` and
+    // HushhLocationPlugin passes none — so a watch-path check written as
+    // `error.code === 1` is dead on iOS and Android. It looked covered because
+    // both existing cases feed a `code`, so the old comparison kept them green.
+    //
+    // This is the shape the device actually sends: the exact message
+    // HushhLocationPlugin.failWatches() rejects with when authorization flips
+    // to .denied while a watch is live. It must read as a denial, not as the
+    // routine between-fixes noise the branch above deliberately swallows.
+    let emit: ((point: unknown, error: unknown) => void) | null = null;
+    mockLocation.watchPosition.mockImplementation(
+      async (_options: unknown, callback: (p: unknown, e: unknown) => void) => {
+        emit = callback;
+        return "watch-1";
+      },
+    );
+
+    await LocationBus.watch();
+    emit?.(POINT, null);
+    emit?.(null, new Error("Location permission was not granted."));
+
+    expect(LocationBus.getState().status).toBe("denied");
+    expect(LocationBus.getState().permission).toBe("denied");
+    expect(LocationBus.getState().error).toBe(
+      "Location permission was not granted.",
+    );
+  });
 });

--- a/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
@@ -409,7 +409,7 @@ describe("runSosPanic", () => {
 
     expect(error).toBeInstanceOf(SosPanicError);
     expect(error).toMatchObject({
-      message: "character limit exceed",
+      message: "Message is too long",
       partialIncident: null,
     });
     expect(createGrantMock).not.toHaveBeenCalled();

--- a/hushh-webapp/lib/one-location/sos-trigger.ts
+++ b/hushh-webapp/lib/one-location/sos-trigger.ts
@@ -192,7 +192,7 @@ export async function runSosPanic(
     normalizedNote &&
     normalizedNote.length > ONE_LOCATION_SHARE_NOTE_MAX_LENGTH
   ) {
-    throw new SosPanicError("character limit exceed", null);
+    throw new SosPanicError("Message is too long", null);
   }
 
   if (!recipients.length) {


### PR DESCRIPTION
Follow-ups from running this repo's own skills as gates over #5309 — `apple-visual-qa-gate`, `responsive-ui-integrity-guard`, `ui-clarity-layout-guard`, `less-text-karma-ji`, `assertion-first-ui-testing`, `parallel-merge-uat-deployment-coordinator`. Four returned FAIL. These are the findings worth acting on.

## The one that was a real defect

The renderer-consent gate on Your Map lost two protected words. *"Nearby Check-In is separate and starts only when you choose it"* became *"Check-In is separate — you start it"*, dropping:

- **"only"** — the exclusivity guarantee. The other two claims in the same paragraph both keep theirs ("open **only** on this device", "gets **only** what it needs"). Removing it here alone said Check-In is separate without saying nothing else can start it.
- **"Nearby"** — the feature's name, and the one word that says this is the surface that shows you to people *around* you rather than to people you picked. Settings still states the strong form.

Restored in place, so no consent-version bump is needed, and both words are now marked protected in a comment.

## A second copy was still shipping

The earlier pass fixed `character limit exceed` in the Location hub but never looked at `sos-panel.tsx`, which renders the same lowercase verbless string through `role="alert"` on the **emergency** surface, thrown from `sos-trigger.ts`.

Found by grepping the deployed UAT bundle, not by reading the diff — the bundle still contained it after the deploy went green. Both now say "Message is too long".

## Coverage for what went in untested

- **The watch-path denial remap had no test.** Both existing cases feed browser-shaped errors with a numeric code, and the helper tests `code === 1` first, so *reverting the fix left the suite green*. The new case feeds the native shape (no code, the exact message `HushhLocationPlugin` rejects with). Verified by reverting the line: the new test fails, the other 16 still pass.
- **The Swift changes had no automated evidence at all.** Three contract tests now read the plugin source: that a mid-watch revocation reaches `failWatches`, that every `failWatches` message is one the shared JS denial check recognises (the cross-language contract — Capacitor's reject carries a `String?` code, so JS matches on the message), and that the transient `kCLErrorLocationUnknown` return sits **before** the watch teardown rather than after it.
- **The three state-dependent icon tones had no assertions at either end.** Two cases now pin gray/gray/gray at zero and green/indigo/orange when each row has something in it.
- **The responsive fix was proven by a Playwright session that never landed in the repo**, so nothing could fail on the next diff. That measurement is now a committed spec across 320/360/375/390/430/639/640/768: the status stays visible and `aria-describedby`-linked, the compact and full forms do not swap over at the breakpoint, the title keeps one line above 320px, and the page never scrolls sideways.

## Two colour corrections

- Tapping the now-green "Active shares" row landed on rows rendering **the same grants** at `iconTone="purple"`, which is byte-identical to blue in the tone map. One object read as two colours. The detail rows are green.
- `indigo` was inline hex in a TSX file, and the same value already existed a second time in `globals.css` (the profile icon-tone override). It is now `--app-indigo`, referenced by both, and brightened for dark the way `--app-warning` and `--app-destructive` are — the raw system value measured under 3:1 on the tile, the only tone in the map below it.

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on every changed file.
- Full `vitest` suite on this branch **and** on `origin/main`: **zero new failures** (29 here vs 35 on main; the six differences are pre-existing flakes in consent-center and ria-nearby that happened to pass on this run, not fixes).
- The native-denial test was mutation-checked against the old `error.code === 1` line.
- UAT deploy of #5309 (`f3f2c9564`) succeeded, including `Apply UAT DB migrations and predeploy schema gate` and `Post-deploy UAT schema contract gate` — which confirms the partially-applied migration left by the earlier failed run (`LockNotAvailableError` mid-replay) converged.

**Not verified:** the new e2e spec skips without `REVIEWER_UID` / `REVIEWER_VAULT_PASSPHRASE`, same as the existing spec in that file — so it is committed and will fail on regression only where those secrets are present. No iOS build or simulator run; the Swift behaviour is pinned by source-contract tests, not by executing it.
