### PR TITLE
fix(one-setup): stop the header action squeezing the title off the screen

### DIFF
--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -256,6 +256,24 @@ describe("One setup hub terminal action contract", () => {
     expect(source).toContain('<div className="hidden sm:block">');
   });
 
+  it("lets the header action drop below the title rather than squeeze it", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // The action cannot wrap its own label and never shrinks, so whatever it
+    // needs it takes. With `min-w-0` the title column surrendered all of it:
+    // at 320px / 200% text the title had 60px to paint 180px of "Finish
+    // setting up One" and ran 96px straight through the action. The floor
+    // plus a wrapping row is what stops that -- and it has to be min-width,
+    // since `flex-1` is `flex: 1 1 0%` and overwrites a basis utility.
+    expect(source).toContain('<div className="flex flex-wrap items-start gap-3">');
+    expect(source).toContain('<div className="min-w-[8rem] flex-1">');
+    expect(source).not.toContain('<div className="min-w-0 flex-1">');
+    expect(source).not.toContain("basis-[8rem]");
+  });
+
   it("requires vault completion after master setup acknowledgement", () => {
     const source = readFileSync(
       join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -399,9 +399,20 @@ export function OneSetupHub() {
             was absolutely positioned over the header before, so the large
             display title ran underneath it and the two overlapped. A flex row
             with a min-w-0 title column and a shrink-0 button keeps real
-            horizontal separation; the title shrinks within its column. */}
-        <div className="flex items-start gap-3">
-          <div className="min-w-0 flex-1">
+            horizontal separation; the title shrinks within its column.
+
+            The row wraps, and the title column holds a floor before it does.
+            `min-w-0` let the title shrink to nothing while a shrink-0 action
+            whose label cannot wrap took what it needed first -- at 320px with
+            200% text that left the title 60px to paint 180px of "Finish
+            setting up One", which overflowed a visible box straight through
+            the action (measured: 96px of overlap, in every hub state). The
+            floor has to be min-width, not flex-basis: `flex-1` is
+            `flex: 1 1 0%`, so a basis utility next to it is simply overwritten
+            and the row never wraps. In rem, so it grows with the text setting
+            that causes the squeeze; above that threshold nothing moves. */}
+        <div className="flex flex-wrap items-start gap-3">
+          <div className="min-w-[8rem] flex-1">
           <PageHeader
             title={
               showVaultInvitation


### PR DESCRIPTION
Found by running `responsive-ui-integrity-guard`'s width matrix over the setup header while auditing #5304. **Pre-existing on `main`** — it reproduces identically in every hub state, so this branch's copy work didn't cause it — but it's the header that work touched, and a verified overlap isn't something to leave listed.

## The defect

The title column carried `min-w-0`, so it could shrink to nothing, while the action beside it is `shrink-0` with a label that can't wrap. The action took whatever width it needed; the title got the remainder.

At 320px with 200% text that remainder was **60px**, and "Finish setting up One" wants **180px**. The box is `overflow: visible`, so the title didn't clip — it painted straight through the action. 96px of the two on top of each other.

| width | 1× | 1.5× | 2× |
|---|---|---|---|
| 320 | 0 → 0 | **3px → 0** | **96px → 0** |
| 360 | 0 → 0 | 0 → 0 | **56px → 0** |
| 375 | 0 → 0 | 0 → 0 | **41px → 0** |
| 390 | 0 → 0 | 0 → 0 | **26px → 0** |
| 430 | 0 → 0 | 0 → 0 | 0 → 0 |
| 768 | action is `sm:hidden` | | |

## The fix

The row wraps and the title column holds a floor, so the action drops to its own line rather than winning the width. Every 1× layout is untouched at every width, 430 @1.5× still fits on one line, and no width introduces horizontal overflow.

**The floor has to be `min-width`, not `flex-basis.`** `flex-1` expands to `flex: 1 1 0%`, so a `basis-[8rem]` utility sitting next to it is simply overwritten and the row never wraps. That was the first attempt — the matrix caught it as unchanged, byte for byte, from the broken version.

## Verification

- Measured in Chromium at 6 widths × 3 text sizes, before and after.
- Full suite **34 failed / 4036 passed** against **49 / 4020** on the base commit — churn in both directions under parallel load. The three that failed only on this branch (profile receipts ×2, consent-centre routing) are in files this change cannot reach and pass **25/25** run alone.
- `tsc --noEmit`, `eslint --max-warnings=0`: clean.
- Contract test pins the wrapping row, the min-width floor, and the fact that `basis-[8rem]` must not come back.