### PR TITLE
fix(feed): make the Feed live, and let the ask flow send more than once

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -689,6 +689,49 @@ cd hushh-webapp && npx playwright test e2e/tab-title-integrity.spec.ts \
 Add every new strip's labels to `TAB_STRIPS` in that spec; a strip that is not
 listed is simply unmeasured.
 
+### R19 — A CSS rule that "obviously" wins may not. Read the computed value off the running app
+
+**Incident (2026-08-16, chasing a "header overlaying" report on the Feed).**
+`hushh-webapp/app/globals.css` gates the top chrome's background on an attribute:
+`html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask { --ambient-chrome-wash: 0% }`.
+Every supporting fact checked out — `grep -rn data-ambient-chrome-primed` returns
+that line and nothing else (no code sets it), the top bar element really does
+carry the bare `ambient-chrome-mask` class, and the gate's specificity (0,2,1)
+really does beat `.ambient-chrome-mask--top` (0,1,0). The conclusion drawn —
+"the top bar is permanently transparent, that is the overlap report" — was still
+wrong. Signed into UAT and measured, `--ambient-chrome-wash` computes to **94%**
+and the bar paints solidly; cascade layers decide it, not specificity. A
+subagent RCA lane reached the same wrong answer at "high" confidence, so reader
+agreement was not evidence either. The change was written and would have shipped
+a global-stylesheet edit — every screen in the app — for a defect that does not
+exist.
+
+**Rule.** Never edit `globals.css`, a theme token, or any global chrome rule on
+the strength of reading the cascade. Sign in and read the value back off the
+running app first. If the measurement contradicts the code reading, the
+measurement wins — revert, do not rationalise.
+
+**Check.** Credentials are in Secret Manager; the login page only auto-signs-in
+when the native test bridge is installed as an init script before the first
+`goto`. From `hushh-webapp/` (so the `playwright` import resolves):
+```bash
+export REVIEWER_UID=$(gcloud secrets versions access latest --secret=REVIEWER_UID --project=hushh-pda-uat)
+export REVIEWER_VAULT_PASSPHRASE=$(gcloud secrets versions access latest --secret=REVIEWER_VAULT_PASSPHRASE --project=hushh-pda-uat)
+```
+```js
+await page.addInitScript(({ expectedUserId, vaultPassphrase }) => {
+  window.__HUSHH_NATIVE_TEST__ = { ...(window.__HUSHH_NATIVE_TEST__ || {}),
+    enabled: true, autoReviewerLogin: true, expectedUserId, vaultPassphrase };
+}, { expectedUserId: process.env.REVIEWER_UID, vaultPassphrase: process.env.REVIEWER_VAULT_PASSPHRASE });
+// /login?redirect=%2Fria -> "Continue as reviewer" -> #unlock-passphrase -> "Unlock with passphrase"
+getComputedStyle(document.querySelector(".ambient-chrome-mask--top")).getPropertyValue("--ambient-chrome-wash");
+```
+Must print `94%`. Anything you believe about a global rule that you have not
+read back this way is a hypothesis, not a finding.
+
+---
+
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 150,
+  "expected_migration_version": 151,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 150,
+  "expected_migration_version": 151,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 150,
+  "expected_migration_version": 151,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/151_feed_events_dedupe_approved_share.sql
+++ b/consent-protocol/db/migrations/151_feed_events_dedupe_approved_share.sql
@@ -1,0 +1,64 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 151: one Feed row per real-world moment for location approvals
+-- ============================================================================
+-- Approving one location request produced THREE Feed rows for the owner:
+--
+--   "Requested your location"          <- location_access_request  (the ask)
+--   "Started sharing location"         <- location_share_created   (the answer)
+--   "You approved the location request" <- location_access_approved (the answer)
+--
+-- The last two are the same tap. `approve_request` calls `create_grant`, which
+-- writes `location_share_created`, and then writes `location_access_approved`
+-- itself; migration 117's fan-out forwards both to the owner's feed.
+--
+-- one_location_events is the domain's audit authority and still records both —
+-- nothing here changes what is durably logged. Only the presentation fan-out
+-- is de-duplicated, and it keeps `location_access_approved` because that row
+-- names the decision the owner actually made. This mirrors the rule already
+-- applied to push notifications in one_location_agent_service.create_grant
+-- ("Request approval has its own richer notification immediately after this
+-- call. Sending share-created as well produces two alerts for one user
+-- action.") — the Feed simply never got the same treatment.
+--
+-- A share started directly (not from a request) carries no such reason and is
+-- forwarded exactly as before.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- An approval-born share is already reported by the `location_access_approved`
+  -- row that follows it. Rows written before this migration have no `reason`
+  -- key, so `->>` yields NULL and they fan out unchanged.
+  IF NEW.event_type = 'location_share_created'
+     AND NEW.metadata->>'reason' = 'request_approved' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_expired',
+    'location_access_request',
+    'location_access_approved',
+    'location_access_denied'
+  ) THEN
+    INSERT INTO feed_events (user_id, source_domain, event_type, metadata, source_row_id)
+    VALUES (
+      NEW.owner_user_id,
+      'location',
+      NEW.event_type,
+      NEW.metadata,
+      NEW.id::TEXT
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_from_one_location_events() IS
+  'Fans out feed-worthy one_location_events inserts into feed_events, owner-scoped. Skips the location_share_created row of an approval-born grant, which location_access_approved already reports.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/151_feed_events_dedupe_approved_share.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/151_feed_events_dedupe_approved_share.rollback.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- Restores migration 117's fan-out, which forwards every feed-worthy
+-- one_location_events row including the location_share_created written by an
+-- approval-born grant (so an approval again produces two Feed rows).
+
+CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.event_type IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_expired',
+    'location_access_request',
+    'location_access_approved',
+    'location_access_denied'
+  ) THEN
+    INSERT INTO feed_events (user_id, source_domain, event_type, metadata, source_row_id)
+    VALUES (
+      NEW.owner_user_id,
+      'location',
+      NEW.event_type,
+      NEW.metadata,
+      NEW.id::TEXT
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_from_one_location_events() IS
+  'Fans out feed-worthy one_location_events inserts into feed_events, owner-scoped.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -128,7 +128,8 @@
     "147_retire_crm_zk_runtime_profiles.sql",
     "148_nws_nearby_marketplace_actions.sql",
     "149_external_crm_dynamic_registry.sql",
-    "150_one_location_until_stopped_grants.sql"
+    "150_one_location_until_stopped_grants.sql",
+    "151_feed_events_dedupe_approved_share.sql"
   ],
   "groups": {
     "iam": [
@@ -211,7 +212,8 @@
       "147_retire_crm_zk_runtime_profiles.sql",
       "148_nws_nearby_marketplace_actions.sql",
       "149_external_crm_dynamic_registry.sql",
-      "150_one_location_until_stopped_grants.sql"
+      "150_one_location_until_stopped_grants.sql",
+      "151_feed_events_dedupe_approved_share.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4307,6 +4307,13 @@ class OneLocationAgentService:
                     "duration_hours": _duration_metadata_value(duration),
                     "duration_mode": resolved_duration_mode,
                     "counterpart_label": recipient_label,
+                    # Why this grant exists. The audit ledger keeps the row
+                    # either way; the Feed fan-out trigger reads this to drop
+                    # the duplicate. Approving a request already writes
+                    # `location_access_approved` right after this call, and one
+                    # tap that produces two Feed rows reads as two things
+                    # happening. Same rule the notification below applies.
+                    "reason": reason or "",
                 },
             )
         # Request approval has its own richer notification immediately after

--- a/consent-protocol/tests/test_feed_events_dedupe_approved_share_migration.py
+++ b/consent-protocol/tests/test_feed_events_dedupe_approved_share_migration.py
@@ -36,9 +36,7 @@ def test_migration_is_registered_at_release_head():
     assert ordered.index(MIGRATION_NAME) > ordered.index("117_feed_events.sql")
 
     contract = json.loads(
-        (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text(
-            encoding="utf-8"
-        )
+        (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text(encoding="utf-8")
     )
     assert contract["expected_migration_version"] >= 151
     assert contract["migration_version_policy"] == "exact"
@@ -85,21 +83,21 @@ def test_rollback_restores_the_unconditional_fan_out():
         / "151_feed_events_dedupe_approved_share.rollback.sql"
     ).read_text(encoding="utf-8")
 
-    assert (
-        "CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()" in rollback
-    )
+    assert "CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()" in rollback
     assert "request_approved" not in rollback
 
 
 def test_create_grant_stamps_the_reason_the_trigger_reads():
     """The guard is dead weight unless the service actually writes the key."""
-    service = (
-        ROOT / "hushh_mcp" / "services" / "one_location_agent_service.py"
-    ).read_text(encoding="utf-8")
+    service = (ROOT / "hushh_mcp" / "services" / "one_location_agent_service.py").read_text(
+        encoding="utf-8"
+    )
 
     share_created_event = service.index('event_type="location_share_created"')
     # Through the end of that metadata dict.
-    window = service[share_created_event : service.index(")", service.index("},", share_created_event))]
+    window = service[
+        share_created_event : service.index(")", service.index("},", share_created_event))
+    ]
     assert '"reason": reason or ""' in window
 
     # And the caller still names that reason when approving a request.

--- a/consent-protocol/tests/test_feed_events_dedupe_approved_share_migration.py
+++ b/consent-protocol/tests/test_feed_events_dedupe_approved_share_migration.py
@@ -1,0 +1,106 @@
+"""One Feed row per real-world moment when a location request is approved.
+
+Reported from the field: "3 feeds generated on requesting location". One
+request/approve cycle put three rows in the owner's Feed --
+
+    "Requested your location"           (the ask)
+    "Started sharing location"          (the answer)
+    "You approved the location request" (the same answer, again)
+
+-- because ``approve_request`` calls ``create_grant`` (which writes
+``location_share_created``) and then writes ``location_access_approved``
+itself, and migration 117's trigger forwarded both.
+"""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_NAME = "151_feed_events_dedupe_approved_share.sql"
+
+
+def _migration_sql() -> str:
+    return (ROOT / "db" / "migrations" / MIGRATION_NAME).read_text(encoding="utf-8")
+
+
+def test_migration_is_registered_at_release_head():
+    assert (ROOT / "db" / "migrations" / MIGRATION_NAME).exists()
+
+    manifest = json.loads(
+        (ROOT / "db" / "release_migration_manifest.json").read_text(encoding="utf-8")
+    )
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
+    assert MIGRATION_NAME in manifest["groups"]["iam"]
+    # The trigger it replaces was introduced by 117, so it must run after it.
+    ordered = manifest["ordered_migrations"]
+    assert ordered.index(MIGRATION_NAME) > ordered.index("117_feed_events.sql")
+
+    contract = json.loads(
+        (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert contract["expected_migration_version"] >= 151
+    assert contract["migration_version_policy"] == "exact"
+
+
+def test_fan_out_skips_the_share_row_of_an_approval_born_grant():
+    sql = _migration_sql()
+
+    assert "CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()" in sql
+    assert "NEW.event_type = 'location_share_created'" in sql
+    assert "NEW.metadata->>'reason' = 'request_approved'" in sql
+
+    # The guard has to return BEFORE the insert, or it forwards the row anyway.
+    guard_at = sql.index("NEW.metadata->>'reason' = 'request_approved'")
+    insert_at = sql.index("INSERT INTO feed_events")
+    assert guard_at < insert_at
+
+
+def test_every_other_location_event_still_reaches_the_feed():
+    sql = _migration_sql()
+
+    # De-duplicating one pair must not quietly narrow the feed.
+    for event_type in (
+        "location_share_created",
+        "location_share_revoked",
+        "location_share_expired",
+        "location_access_request",
+        "location_access_approved",
+        "location_access_denied",
+    ):
+        assert f"'{event_type}'" in sql
+
+    # A share started directly carries no approval reason and is unaffected.
+    assert "NEW.owner_user_id" in sql
+    assert "'location'" in sql
+
+
+def test_rollback_restores_the_unconditional_fan_out():
+    rollback = (
+        ROOT
+        / "db"
+        / "migrations"
+        / "rollback"
+        / "151_feed_events_dedupe_approved_share.rollback.sql"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()" in rollback
+    )
+    assert "request_approved" not in rollback
+
+
+def test_create_grant_stamps_the_reason_the_trigger_reads():
+    """The guard is dead weight unless the service actually writes the key."""
+    service = (
+        ROOT / "hushh_mcp" / "services" / "one_location_agent_service.py"
+    ).read_text(encoding="utf-8")
+
+    share_created_event = service.index('event_type="location_share_created"')
+    # Through the end of that metadata dict.
+    window = service[share_created_event : service.index(")", service.index("},", share_created_event))]
+    assert '"reason": reason or ""' in window
+
+    # And the caller still names that reason when approving a request.
+    assert 'reason="request_approved"' in service

--- a/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
+++ b/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
@@ -15,25 +15,6 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
 }
 
-describe("top chrome paints its own background", () => {
-  it("has no priming gate holding the header transparent", () => {
-    const styles = read("app/globals.css");
-
-    // `data-ambient-chrome-primed` was never set by anything in the app, so
-    // `html:not([data-ambient-chrome-primed="true"])` matched forever — and at
-    // (0,2,1) it beat the (0,1,0) `.ambient-chrome-mask--top` rule. The top bar
-    // mixed its background to 0%: the page scrolled visibly through the title.
-    expect(styles).not.toContain("[data-ambient-chrome-primed");
-    expect(styles).not.toContain("--ambient-chrome-wash: 0%");
-
-    // The intended material still applies, unchanged.
-    expect(styles).toContain(
-      "--ambient-chrome-wash: var(--ambient-chrome-fade-solid)",
-    );
-    expect(styles).toContain("--ambient-chrome-fade-solid: 94%");
-  });
-});
-
 describe("Feed stays live", () => {
   it("forwards the force flag so a refresh is not answered from cache", () => {
     const feedPage = read("components/feed/feed-page.tsx");

--- a/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
+++ b/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source contracts for four fixes that a render test cannot reach: a CSS paint
+ * rule, a cache flag threaded through a callback, a timer's owner, and the
+ * absence of a fabricated sort key.
+ */
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("top chrome paints its own background", () => {
+  it("has no priming gate holding the header transparent", () => {
+    const styles = read("app/globals.css");
+
+    // `data-ambient-chrome-primed` was never set by anything in the app, so
+    // `html:not([data-ambient-chrome-primed="true"])` matched forever — and at
+    // (0,2,1) it beat the (0,1,0) `.ambient-chrome-mask--top` rule. The top bar
+    // mixed its background to 0%: the page scrolled visibly through the title.
+    expect(styles).not.toContain("[data-ambient-chrome-primed");
+    expect(styles).not.toContain("--ambient-chrome-wash: 0%");
+
+    // The intended material still applies, unchanged.
+    expect(styles).toContain(
+      "--ambient-chrome-wash: var(--ambient-chrome-fade-solid)",
+    );
+    expect(styles).toContain("--ambient-chrome-fade-solid: 94%");
+  });
+});
+
+describe("Feed stays live", () => {
+  it("forwards the force flag so a refresh is not answered from cache", () => {
+    const feedPage = read("components/feed/feed-page.tsx");
+
+    // FeedService keeps its own short-TTL cache in front of the request, so a
+    // load that drops `force` returns the page it already had.
+    expect(feedPage).toContain("load: async (options)");
+    expect(feedPage).toContain("force: options?.force");
+    expect(feedPage).toContain("refresh({ force: true })");
+  });
+
+  it("owns its cadence in a hook, not a timer inside the component", () => {
+    const feedPage = read("components/feed/feed-page.tsx");
+    const actionables = read("lib/feed/use-feed-actionables.ts");
+    const unreadCount = read("lib/feed/use-feed-unread-count.ts");
+
+    expect(feedPage).not.toContain("setInterval(");
+    expect(actionables).not.toContain("setInterval(");
+    expect(unreadCount).not.toContain("setInterval(");
+
+    // One signal for the list, the "Needs you" lane, and the tab badge, so the
+    // badge can never claim unread items over a list that never re-asked.
+    for (const source of [feedPage, actionables, unreadCount]) {
+      expect(source).toContain("useFeedLiveRefresh");
+    }
+  });
+
+  it("never fabricates a sort key that moves on every recompute", () => {
+    const actionables = read("lib/feed/use-feed-actionables.ts");
+
+    // `sortAt: Date.now()` minted a new "now" each time the memo ran, so rows
+    // without a real timestamp leapt back above rows that had one — every 45s,
+    // now that the list actually refreshes.
+    expect(actionables).not.toMatch(/sortAt:[^,\n]*Date\.now\(\)/);
+    expect(actionables).toContain("firstSeenAt(");
+  });
+});
+
+describe("the ask flow's primary action keeps the action colour", () => {
+  it("never repaints Send with the success token", () => {
+    const hub = read("components/one-location/redesign/location-redesign-hub.tsx");
+
+    const sendButton = hub.slice(
+      hub.indexOf("const isFormValid = vm.selectedRequestOwnerIds.length > 0"),
+      hub.indexOf('"Send request"'),
+    );
+    expect(sendButton.length).toBeGreaterThan(0);
+    expect(sendButton).toContain("bg-[color:var(--app-accent)]");
+    // Green is a status, and this screen already says it twice — in the banner
+    // above and in each person's row turning to "Asked".
+    expect(sendButton).not.toContain("--app-success");
+  });
+
+  it("re-arms Send from the selection instead of latching it shut", () => {
+    const hub = read("components/one-location/redesign/location-redesign-hub.tsx");
+
+    expect(hub).toContain("sentSelectionRef");
+    expect(hub).toContain("setJustSent(await vm.onSendRequest(reason))");
+    // The latch must not be part of what disables the button, or one send
+    // retires the control for the life of the screen.
+    expect(hub).not.toContain("disabled={!isFormValid || sending || justSent}");
+  });
+});
+
+describe("quick-action tones come from tokens", () => {
+  it("uses the semantic colour variables rather than light-mode hexes", () => {
+    const quickActions = read("components/one-location/redesign/quick-actions.tsx");
+
+    expect(quickActions).not.toContain("#34C759");
+    expect(quickActions).not.toContain("#FF3B30");
+    expect(quickActions).toContain("var(--app-success)");
+    expect(quickActions).toContain("var(--app-destructive)");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1622,7 +1622,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("option", { name: "1 hour" }));
     expect(duration.textContent).toContain("1 hour");
     // The duration reads back as a clock time on the same screen that set it.
-    expect(screen.getByText(/^Access ends at /)).toBeTruthy();
+    expect(screen.getByText(/^Sharing ends at /)).toBeTruthy();
 
     const note = screen.getByRole("textbox", { name: "Optional note" });
     const startButton = screen.getByRole("button", { name: "Start sharing" });
@@ -3731,6 +3731,163 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
     );
+  });
+
+  // Reported from the field: "can't send req to rest after 1 cycle". Asking
+  // three people left the Send button latched to a disabled green "Sent", so the
+  // rest of the list could be ticked but never actually asked -- the only way
+  // out was to leave the screen and come back.
+  it("lets you ask more people after a request has already been sent", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Trusted B for location request/i,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
+    await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
+    );
+
+    // Sending clears the composer, so with nobody chosen there is nothing to
+    // send -- but the button must be a live control, not a spent one.
+    const sendButton = screen.getByRole("button", { name: /Send request/i });
+    expect(sendButton.hasAttribute("disabled")).toBe(true);
+
+    // Choosing the next person re-arms Send and retires the previous
+    // confirmation, which described a request that is no longer on screen.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Advisor C for location request/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: /Send request/i })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
+    await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(2));
+    expect(mockRequestAccess).toHaveBeenLastCalledWith(
+      expect.objectContaining({ ownerUserId: "user_c" }),
+    );
+  });
+
+  // Sending takes several round trips. Anyone tapped while they were in flight
+  // used to be erased by the blanket composer reset that ran when the send
+  // landed -- the pick just disappeared, with no request and no error.
+  it("keeps a person picked while the send is still in flight", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    let releaseFirstRequest: (() => void) | null = null;
+    mockRequestAccess.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirstRequest = () => resolve();
+        }),
+    );
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Trusted B for location request/i,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
+    await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
+
+    // Mid-flight, the user lines up the next person.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Advisor C for location request/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: /Deselect Advisor C for location request/i,
+        }),
+      ).toBeTruthy(),
+    );
+
+    await act(async () => {
+      releaseFirstRequest?.();
+      await Promise.resolve();
+    });
+
+    // Trusted B was asked and is gone from the composer; Advisor C survives and
+    // can still be sent, with no confirmation claiming their request went out.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: /Deselect Advisor C for location request/i,
+        }),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Send request/i }).hasAttribute("disabled"),
+    ).toBe(false);
+    expect(screen.queryByRole("status")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
+    await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(2));
+    expect(mockRequestAccess).toHaveBeenLastCalledWith(
+      expect.objectContaining({ ownerUserId: "user_c" }),
+    );
+  });
+
+  // The confirmation used to latch the instant the button was tapped, so a send
+  // that failed still reported "Request sent."
+  it("does not claim a request was sent when the send fails", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockRequestAccess.mockRejectedValueOnce(new Error("network down"));
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Trusted B for location request/i,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
+
+    await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
+    // No confirmation, and the composer stays usable so the ask can be retried.
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: /Send request/i })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("renders my requests with safe labels instead of raw owner ids", async () => {

--- a/hushh-webapp/__tests__/lib/feed/use-feed-live-refresh.test.tsx
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-live-refresh.test.tsx
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FEED_STATE_CHANGED_EVENT,
+  dispatchFeedStateChanged,
+} from "@/lib/feed/feed-events";
+import {
+  FEED_LIVE_POLL_INTERVAL_MS,
+  useFeedLiveRefresh,
+} from "@/lib/feed/use-feed-live-refresh";
+
+/**
+ * The Feed was reported as "neither real time, not accurate and not precise".
+ * It fetched once per mount and never again: the tab badge polled every 45s
+ * while the list it badged asked the server nothing after the app opened.
+ *
+ * This pins the signal every Feed surface now shares.
+ */
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useFeedLiveRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible" as DocumentVisibilityState,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("re-checks on the shared interval while the tab is visible", () => {
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 2);
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops polling while the tab is hidden and catches up on return", () => {
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+
+    setVisibility("hidden");
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 5);
+    // A backgrounded tab spends battery and mobile data redrawing something
+    // nobody is reading.
+    expect(refresh).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    // Coming back is itself the freshest moment to re-check, so no waiting for
+    // the next tick.
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-checks on window focus, which iOS webviews raise without a visibility change", () => {
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-checks when something was acted on, but not when rows were only marked read", () => {
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+
+    // Opening the Feed marks it read. Re-fetching in response would only return
+    // the rows already on screen.
+    dispatchFeedStateChanged("read");
+    expect(refresh).not.toHaveBeenCalled();
+
+    // An approve/deny writes new activity, so every surface re-checks.
+    dispatchFeedStateChanged("action");
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // An untagged legacy dispatch is treated as the broader case.
+    window.dispatchEvent(new CustomEvent(FEED_STATE_CHANGED_EVENT));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing at all when disabled, and detaches every listener on unmount", () => {
+    const disabled = vi.fn();
+    renderHook(() => useFeedLiveRefresh(disabled, false));
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 3);
+    window.dispatchEvent(new Event("focus"));
+    dispatchFeedStateChanged("action");
+    expect(disabled).not.toHaveBeenCalled();
+
+    const refresh = vi.fn();
+    const { unmount } = renderHook(() => useFeedLiveRefresh(refresh));
+    unmount();
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 3);
+    window.dispatchEvent(new Event("focus"));
+    dispatchFeedStateChanged("action");
+    setVisibility("visible");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("always calls the latest callback without rebuilding its listeners", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ fn }: { fn: () => void }) => useFeedLiveRefresh(fn),
+      { initialProps: { fn: first } },
+    );
+
+    rerender({ fn: second });
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -3998,9 +3998,14 @@ md-ripple.morphy-md-ripple {
   will-change: background-color, backdrop-filter;
 }
 
-html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
-  --ambient-chrome-wash: 0%;
-}
+/* A priming gate used to hold the top chrome transparent until a script marked
+   the document ready. That script is gone, so nothing set the primed attribute
+   any more and the gate's `html:not(...)` selector matched forever — at (0,2,1)
+   it outranked the (0,1,0) rule below. The top bar's background was therefore
+   mixed to 0%: permanently, entirely see-through, with the page scrolling
+   visibly through the title and back arrow. That is the "header overlaying"
+   report. Removing the gate lets the intended material below actually paint.
+   Guarded by feed-live-and-cta.contract.test.ts. */
 
 .ambient-chrome-mask--top {
   --ambient-chrome-bg: var(--ambient-chrome-material-bg);

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -3998,14 +3998,9 @@ md-ripple.morphy-md-ripple {
   will-change: background-color, backdrop-filter;
 }
 
-/* A priming gate used to hold the top chrome transparent until a script marked
-   the document ready. That script is gone, so nothing set the primed attribute
-   any more and the gate's `html:not(...)` selector matched forever — at (0,2,1)
-   it outranked the (0,1,0) rule below. The top bar's background was therefore
-   mixed to 0%: permanently, entirely see-through, with the page scrolling
-   visibly through the title and back arrow. That is the "header overlaying"
-   report. Removing the gate lets the intended material below actually paint.
-   Guarded by feed-live-and-cta.contract.test.ts. */
+html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
+  --ambient-chrome-wash: 0%;
+}
 
 .ambient-chrome-mask--top {
   --ambient-chrome-bg: var(--ambient-chrome-material-bg);

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3874,10 +3874,26 @@ export function OneLocationAgentPageContent({
     setShareDurationHours(ONE_LOCATION_SHARE_DEFAULT_DURATION_HOURS);
     setShareMessage("");
   }, [setSelectedRecipientIds]);
-  const resetRequestComposer = useCallback(() => {
+  /**
+   * Clears the ask composer after a send.
+   *
+   * `sentUserIds` is subtracted rather than the whole selection being dropped:
+   * sending takes several round trips (identity sync, key registration, then one
+   * request per person), and anybody tapped during that window used to be wiped
+   * by a blanket clear when it finally landed. Their pick simply vanished, with
+   * no error and no request. Only the people actually asked are removed.
+   */
+  const resetRequestComposer = useCallback((sentUserIds?: readonly string[]) => {
     suppressAutoRecipientSelectionRef.current = true;
     setSelectedRequestOwnerId("");
-    setSelectedRequestOwnerIds([]);
+    if (!sentUserIds) {
+      setSelectedRequestOwnerIds([]);
+    } else {
+      const sent = new Set(sentUserIds);
+      setSelectedRequestOwnerIds((current) =>
+        current.filter((id) => !sent.has(id)),
+      );
+    }
     setRequestMessage("");
   }, []);
 
@@ -5800,17 +5816,22 @@ export function OneLocationAgentPageContent({
     handleSyncContactSignalRef.current = handleSyncContactSignal;
   }, [handleSyncContactSignal]);
 
+  // Resolves true only when at least one request actually reached the server.
+  // The Ask screen latches its "Request sent." confirmation on this, so a failed
+  // send can never leave a success message on screen (it used to latch
+  // optimistically the moment the button was tapped).
   const handleRequestAccess = useCallback(async (reason?: string | null) => {
-    if (!vaultOwnerToken || !selectedRequestOwners.length) return;
+    if (!vaultOwnerToken || !selectedRequestOwners.length) return false;
     if (!auth.user || !auth.userId) {
       toast.error("Refresh your session before sending a location request.");
-      return;
+      return false;
     }
     const activeUser = auth.user;
     const activeUserId = auth.userId;
     const activeVaultOwnerToken = vaultOwnerToken;
     setBusy("request");
     let successCount = 0;
+    const sentUserIds: string[] = [];
     try {
       await AccountIdentityService.syncCurrentUser(activeUser).catch(
         (error) => {
@@ -5843,6 +5864,10 @@ export function OneLocationAgentPageContent({
           message: buildOneLocationRequestMessage(reason, requestMessage),
         });
         successCount += 1;
+        // Recorded as each one lands, not from the selection up front: an id the
+        // recipient list cannot resolve is never actually sent, and subtracting
+        // it anyway would clear a person nobody asked.
+        sentUserIds.push(owner.userId);
       }
       trackEvent("one_location_request_sent", {
         route_id: "one_location",
@@ -5852,7 +5877,7 @@ export function OneLocationAgentPageContent({
         failure_count: 0,
         has_note: Boolean(requestMessage.trim()),
       });
-      resetRequestComposer();
+      resetRequestComposer(sentUserIds);
       playOneLocationNotificationSound();
       toast.success(
         selectedRequestOwners.length === 1
@@ -5862,6 +5887,7 @@ export function OneLocationAgentPageContent({
             )}. We'll notify you here when they respond.`,
       );
       void refresh().catch(() => null);
+      return true;
     } catch (error) {
       const failureCount = selectedRequestOwners.length - successCount || 1;
       trackEvent("one_location_request_sent", {
@@ -5876,6 +5902,10 @@ export function OneLocationAgentPageContent({
       if (isTransientOneApiError(error)) {
         await refresh().catch(() => null);
       }
+      // Partial success still counts: the people who were asked really were
+      // asked, and their rows now read "Asked". Only a total failure denies the
+      // confirmation.
+      return successCount > 0;
     } finally {
       setBusy(null);
     }
@@ -10088,7 +10118,7 @@ export function OneLocationAgentPageContent({
     onOpenShareReview: () => void handleOpenShareReview(),
     onEnterShareConfirm: announceShareReviewOpened,
     onConfirmShare: () => void handleShare(),
-    onSendRequest: (reason) => void handleRequestAccess(reason),
+    onSendRequest: (reason) => handleRequestAccess(reason),
     onApprove: (request) => void handleApprove(request),
     onDeny: (requestId) => void handleDeny(requestId),
     onViewGrant: (grant) => void handleView(grant),

--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -25,6 +25,7 @@ import { dispatchFeedStateChanged } from "@/lib/feed/feed-events";
 import { FeedRow } from "@/components/feed/feed-row";
 import { FeedActionableRow } from "@/components/feed/feed-actionable-row";
 import { useFeedActionables } from "@/lib/feed/use-feed-actionables";
+import { useFeedLiveRefresh } from "@/lib/feed/use-feed-live-refresh";
 import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
 import {
   FeedService,
@@ -64,8 +65,20 @@ export function FeedPage() {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
-  const markedReadRef = useRef(false);
+  // The newest item id this visit has already reported as read. A live refresh
+  // brings genuinely new rows in while the page is open, and those must clear
+  // the tab badge too — a boolean latch marked read exactly once and then let
+  // the badge count up over a list the user was looking straight at.
+  const markedReadUpToRef = useRef<string | null>(null);
   const paginationInitializedRef = useRef(false);
+  // Ids that arrived unread at any point during this visit.
+  //
+  // The Feed marks itself read on open but deliberately keeps those rows styled
+  // unread until the next visit (see the mark-read effect below). Now that the
+  // list actually re-fetches, the server would return those same rows as read
+  // and the accent tint would drain out from under the reader mid-scroll.
+  // Remembering them preserves the intended behaviour through a live refresh.
+  const visitUnreadIdsRef = useRef<Set<string>>(new Set());
   // Durable clear. There is no backend feed-delete endpoint yet, so "Clear"
   // (a) marks everything read (which the server persists) and (b) records a
   // per-user "cleared up to this timestamp" watermark in localStorage. Every
@@ -100,15 +113,34 @@ export function FeedPage() {
     data,
     loading,
     error: resourceError,
+    refresh,
   } = useStaleResource<FeedListResponse>({
     cacheKey: user?.uid ? CACHE_KEYS.FEED_LIST(user.uid) : "feed_list_signed_out",
     enabled: Boolean(user?.uid),
     resourceLabel: "feed_list",
-    load: async () => {
+    // `force` must reach FeedService: it keeps its own short-TTL cache in front
+    // of the request, so dropping the flag here made a forced refresh return the
+    // same page it already had and the list looked live without being live.
+    load: async (options) => {
       const idToken = await user!.getIdToken();
-      return FeedService.list({ idToken, userId: user!.uid, limit: 20 });
+      return FeedService.list({
+        idToken,
+        userId: user!.uid,
+        limit: 20,
+        force: options?.force,
+      });
     },
   });
+
+  // Keep the open list live. `force` is required: without it a cache entry that
+  // is still inside its TTL short-circuits the load, which is exactly how the
+  // Feed could sit open showing activity that had already been answered.
+  useFeedLiveRefresh(
+    useCallback(() => {
+      void refresh({ force: true });
+    }, [refresh]),
+    Boolean(user?.uid),
+  );
 
   useEffect(() => {
     if (!data || paginationInitializedRef.current) return;
@@ -116,22 +148,43 @@ export function FeedPage() {
     setNextCursor(data.next_cursor);
   }, [data]);
 
-  // Opening the feed clears the unread badge (Instagram/Twitter convention),
-  // but we deliberately do NOT force-refresh the list: the rows the user is
-  // looking at keep their unread styling for this visit, and only read as
-  // "seen" on the next open. The badge (a separate unread-count) still clears
-  // immediately via the dispatched event.
+  // Looking at the feed clears the unread badge (Instagram/Twitter convention).
+  // The rows themselves keep their unread styling for this visit and only read
+  // as "seen" on the next open — `visitUnreadIdsRef` holds that, so a live
+  // refresh cannot restyle a row the user is mid-scroll through.
+  //
+  // This re-runs as new activity lands rather than firing once, so anything that
+  // arrives while the page is open is marked read too and the badge does not
+  // count up over a list being read.
   useEffect(() => {
-    if (!user || !data || markedReadRef.current) return;
+    if (!user || !data) return;
     const latestId = data.items[0]?.id;
-    if (!latestId) return;
-    markedReadRef.current = true;
+    if (!latestId || markedReadUpToRef.current === latestId) return;
+    markedReadUpToRef.current = latestId;
     void (async () => {
       const idToken = await user.getIdToken();
       await FeedService.markRead({ idToken, upToId: latestId });
-      dispatchFeedStateChanged();
+      // `read`: only unread flags moved, so the badge recounts but no list
+      // re-fetches what it just finished rendering.
+      dispatchFeedStateChanged("read");
     })();
   }, [user, data]);
+
+  // Record every row that has been unread this visit, before the mark-read above
+  // takes effect on the server. Covers paged-in rows too, which arrive unread on
+  // their own request.
+  useEffect(() => {
+    for (const item of [...(data?.items ?? []), ...additionalItems]) {
+      if (!item.read) visitUnreadIdsRef.current.add(item.id);
+    }
+  }, [data, additionalItems]);
+
+  // A new signed-in user is a new visit: neither the read watermark nor the
+  // unread set belongs to them.
+  useEffect(() => {
+    markedReadUpToRef.current = null;
+    visitUnreadIdsRef.current = new Set();
+  }, [user?.uid]);
 
   const items = useMemo(() => {
     // The cached first page can revalidate and shift after "load more" has
@@ -157,7 +210,7 @@ export function FeedPage() {
     return merged;
   }, [data, additionalItems, clearedAt]);
   const error = resourceError
-    ? "Feed could not be loaded right now."
+    ? "Couldn't load your feed."
     : loadMoreError;
 
   const loadMore = useCallback(async () => {
@@ -169,7 +222,7 @@ export function FeedPage() {
       setAdditionalItems((current) => [...current, ...response.items]);
       setNextCursor(response.next_cursor);
     } catch {
-      setLoadMoreError("Couldn't load more activity.");
+      setLoadMoreError("Couldn't load more.");
     } finally {
       setLoadingMore(false);
     }
@@ -198,7 +251,7 @@ export function FeedPage() {
         const idToken = await user.getIdToken();
         const latestId = items[0]?.id;
         await FeedService.markRead({ idToken, upToId: latestId ?? null });
-        dispatchFeedStateChanged();
+        dispatchFeedStateChanged("read");
         setAdditionalItems([]);
         setNextCursor(null);
         // Persist the clear as a timestamp watermark so it survives tab
@@ -213,9 +266,9 @@ export function FeedPage() {
           }
         }
       }
-      toast.success("Feed notifications cleared");
+      toast.success("Feed cleared");
     } catch {
-      toast.error("Failed to clear feed notifications");
+      toast.error("Couldn't clear your feed.");
     } finally {
       setClearing(false);
     }
@@ -334,7 +387,14 @@ export function FeedPage() {
                   <SectionLabel>{group.label}</SectionLabel>
                   <div className="divide-y divide-[color:var(--foundation-hairline)]">
                     {group.items.map((item) => (
-                      <FeedRow key={item.id} item={item} onOpen={openItem} />
+                      <FeedRow
+                        key={item.id}
+                        item={item}
+                        unread={
+                          !item.read || visitUnreadIdsRef.current.has(item.id)
+                        }
+                        onOpen={openItem}
+                      />
                     ))}
                   </div>
                 </section>

--- a/hushh-webapp/components/feed/feed-row.tsx
+++ b/hushh-webapp/components/feed/feed-row.tsx
@@ -25,12 +25,19 @@ const DOMAIN_TONE: Record<FeedSourceDomain, FeedIconTone> = {
 export function FeedRow({
   item,
   onOpen,
+  unread,
 }: {
   item: FeedItem;
   onOpen: (item: FeedItem) => void;
+  /**
+   * Overrides `item.read` for styling only. The Feed marks itself read on open
+   * but keeps those rows looking unread for the rest of the visit; without this
+   * the page's live refresh would restyle them the moment the server agreed.
+   */
+  unread?: boolean;
 }) {
   const presentation = presentFeedItem(item);
-  const read = item.read;
+  const read = unread === undefined ? item.read : !unread;
   const tone = DOMAIN_TONE[item.source_domain] ?? "gray";
 
   return (

--- a/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
@@ -79,7 +79,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     fireEvent.click(screen.getByRole("button", { name: /Aarav Mehta/ }));
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Share encrypted location with 1 person",
+        name: "Share location with 1 person",
       }),
     );
     await waitFor(() => expect(onCheckIn).toHaveBeenCalledTimes(1));
@@ -120,14 +120,14 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
       screen.getByTestId("nearby-private-share-disclosure"),
     ).toHaveTextContent(/Nearby sees your name only/i);
     expect(
-      screen.getByRole("button", { name: "Select who should know" }),
+      screen.getByRole("button", { name: "Choose who to tell" }),
     ).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /Aarav Mehta/ }));
     fireEvent.click(screen.getByRole("button", { name: /Maya Chen/ }));
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Share encrypted location with 2 people",
+        name: "Share location with 2 people",
       }),
     );
 
@@ -150,7 +150,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     const firstRequest = onCheckIn.mock.calls[0]![0];
 
     const retry = await screen.findByRole("button", {
-      name: "Share encrypted location with 1 person",
+      name: "Share location with 1 person",
     });
     expect(screen.getByRole("button", { name: /Aarav Mehta/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: "30 min" })).toBeDisabled();
@@ -158,7 +158,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
       screen.getByPlaceholderText("I've checked in here, let's catch up"),
     ).toBeDisabled();
     expect(
-      screen.getByText(/Retry sends only to failed people/i),
+      screen.getByText(/Sends again to the people it missed/i),
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("private-check-in-partial-success"),
@@ -207,7 +207,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     await act(async () => {
       fireEvent.click(
         screen.getByRole("button", {
-          name: "Share encrypted location with 2 people",
+          name: "Share location with 2 people",
         }),
       );
       await Promise.resolve();
@@ -215,7 +215,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "Edit remaining details and reconfirm",
+        name: "Edit and confirm again",
       }),
     ).toBeInTheDocument();
 
@@ -224,10 +224,10 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     });
 
     expect(
-      screen.getByRole("button", { name: "Confirmation expired" }),
+      screen.getByRole("button", { name: "Confirm your location again" }),
     ).toBeDisabled();
     expect(
-      screen.getByText(/This confirmation expired/i),
+      screen.getByText(/That expired\. Edit and confirm again/i),
     ).toBeInTheDocument();
     expect(onDiscardPrivateCheckInOperation).toHaveBeenCalledWith(
       expect.any(String),
@@ -235,7 +235,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Edit remaining details and reconfirm",
+        name: "Edit and confirm again",
       }),
     );
 
@@ -267,12 +267,12 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     fireEvent.click(screen.getByRole("button", { name: /Aarav Mehta/ }));
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Share encrypted location with 1 person",
+        name: "Share location with 1 person",
       }),
     );
     await waitFor(() => expect(onCheckIn).toHaveBeenCalledTimes(1));
     await screen.findByRole("button", {
-      name: "Edit details and reconfirm",
+      name: "Edit and confirm again",
     });
     const operationId = onCheckIn.mock.calls[0]![0].clientOperationId;
 
@@ -284,7 +284,7 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     rerender(<CheckInFlow vm={vm} entrySource="nearby" onClose={vi.fn()} />);
 
     expect(
-      screen.getByRole("button", { name: "Secure key changed — reconfirm" }),
+      screen.getByRole("button", { name: "Their security key changed - confirm again" }),
     ).toBeDisabled();
     expect(
       screen.getByText(/selected person's secure key changed/i),

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -183,7 +183,7 @@ function ContactRow({
           </span>
         ) : !ready ? (
           <span className="block truncate text-[13px] leading-[18px] text-[#8E8E93]">
-            Not ready to receive location
+            Hasn't set up sharing yet
           </span>
         ) : null}
       </span>
@@ -278,7 +278,7 @@ export function CheckInFlow({
       setSeeded(true);
       if (!selection.ready.length) {
         toast.error(
-          "No current Circle members are ready to receive encrypted location.",
+          "No one in this Circle can receive it yet.",
         );
       }
     } catch (error) {
@@ -502,14 +502,14 @@ export function CheckInFlow({
                   ? pointIsFresh
                     ? "Live location ready"
                     : "Location needs a refresh"
-                  : "Location not captured yet"}
+                  : "No location yet"}
             </p>
             <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
               {point
                 ? confirmedPoint
-                  ? `${accuracy ?? "Location captured"} · Retrying the exact point you reviewed`
-                  : `${accuracy ?? "Location captured"} · ${vm.formatDateTime(point.capturedAt)}`
-                : "Capture your current location to check in."}
+                  ? `${accuracy ?? "Location found"} · Using the spot you confirmed`
+                  : `${accuracy ?? "Location found"} · ${vm.formatDateTime(point.capturedAt)}`
+                : "Find your location to check in."}
             </p>
           </div>
           <button
@@ -533,13 +533,13 @@ export function CheckInFlow({
                 vm.busy === "selfLocation" && "animate-spin",
               )}
             />
-            {confirmedPoint ? "Recenter" : point ? "Refresh" : "Capture"}
+            {confirmedPoint ? "Recenter" : point ? "Refresh" : "Find"}
           </button>
         </div>
         {point && !pointIsFresh ? (
           <p className="px-4 pb-3 text-xs font-medium text-amber-700 dark:text-amber-300">
             {confirmationExpired
-              ? "This confirmation expired. Edit details and reconfirm to continue."
+              ? "That expired. Edit and confirm again."
               : "Refresh so the location you review is no more than one minute old."}
           </p>
         ) : null}
@@ -688,7 +688,7 @@ export function CheckInFlow({
           className={cn(CARD, "p-5 text-center text-sm text-muted-foreground")}
         >
           {contacts.length === 0
-            ? "No trusted contacts yet. Add people to your Circle first."
+            ? "No contacts yet. Add people to your Circle."
           : "No matching contacts."}
         </div>
       )}
@@ -753,7 +753,7 @@ export function CheckInFlow({
       </div>
       <p className="mb-[18px] mt-2 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
         {retryLocked
-          ? "Retry sends only to failed people."
+          ? "Encrypted. Sends again to the people it missed."
           : "Encrypted with your location."}
       </p>
       {retryLocked ? (
@@ -763,9 +763,7 @@ export function CheckInFlow({
           disabled={busy}
           onClick={editAndReconfirm}
         >
-          {completedRecipientIds.length > 0
-            ? "Edit remaining details and reconfirm"
-            : "Edit details and reconfirm"}
+          Edit and confirm again
         </button>
       ) : null}
 
@@ -786,21 +784,21 @@ export function CheckInFlow({
         )}
         {point
           ? recipientKeyChanged
-            ? "Secure key changed — reconfirm"
+            ? "Their security key changed - confirm again"
             : confirmationExpired
-            ? "Confirmation expired"
+            ? "Confirm your location again"
             : !pointIsFresh
             ? "Refresh your location first"
             : selectedReadyCount > 0
               ? entrySource === "nearby"
-                ? `Share encrypted location with ${selectedReadyCount} ${
+                ? `Share location with ${selectedReadyCount} ${
                     selectedReadyCount === 1 ? "person" : "people"
                   }`
                 : `Check in with ${selectedReadyCount} ${
                     selectedReadyCount === 1 ? "person" : "people"
                   }`
-              : "Select who should know"
-          : "Capture your location first"}
+              : "Choose who to tell"
+          : "Get your location first"}
       </button>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -296,7 +296,8 @@ export type LocationHubViewModel = {
    */
   onEnterShareConfirm: () => void;
   onConfirmShare: () => void;
-  onSendRequest: (reason?: string | null) => void;
+  /** Resolves true when at least one request actually reached the server. */
+  onSendRequest: (reason?: string | null) => Promise<boolean>;
   onAskReshare: (grant: OneLocationGrant) => void;
   onApprove: (request: OneLocationAccessRequest) => void;
   onDeny: (requestId: string) => void;
@@ -913,7 +914,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       params.delete(FLOW_ACTION_PARAM);
       params.delete(LOCATION_HUB_TAB_PARAM);
       const query = params.toString();
-      toast.message("This location action is no longer available.");
+      toast.message("That's no longer there.");
       router.replace(query ? `${pathname}?${query}` : pathname, {
         scroll: false,
       });
@@ -1649,7 +1650,7 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="Nothing shared with you"
-            description="Shares appear here."
+            description="Ask someone to share."
           />
         )
       ) : null}
@@ -1670,7 +1671,6 @@ function LocationDetailFlow({
         ) : (
           <EmptyState
             title="Nothing to review"
-            description="Requests appear here."
           />
         )
       ) : null}
@@ -2077,7 +2077,7 @@ function PeopleHub({
                     description={
                       hasSearch
                         ? "Try a different name."
-                        : "Add people or send an invite to start sharing."
+                        : "Invite someone to start sharing."
                     }
                   />
                 </div>
@@ -2528,7 +2528,7 @@ function ShareFlow({
             </ul>
           ) : (
             <p className={MUTED_TEXT}>
-              Nobody is selected yet. Tap Edit to choose people.
+              Tap Edit to choose people.
             </p>
           )}
         </SectionCard>
@@ -2636,7 +2636,7 @@ function ShareFlow({
       <TaskFlowHeader
         eyebrow="Step 1 of 2 · Choose people"
         title="Who can see you?"
-        description="Only ready people appear."
+        description="Only people set up to receive it."
       />
       {vm.circles.length ? (
         <SectionCard title="Share with a Circle">
@@ -2764,7 +2764,7 @@ function ShareFlow({
 }
 
 /**
- * "Access ends at 4:35 PM" — the confirm step's read-back of the duration.
+ * "Sharing ends at 4:35 PM" — the confirm step's read-back of the duration.
  *
  * A duration is a promise about a moment, and "4 hours" makes the reader do the
  * arithmetic. Stating the clock time is what lets someone notice that a share
@@ -2785,10 +2785,11 @@ function shareEndsAtLabel(durationHours: string, nowMs: number): string {
       hour: "numeric",
       minute: "2-digit",
     });
-    return `Access ends at ${time} today.`;
+    return `Sharing ends at ${time} today.`;
   }
   const hours = Number(durationHours);
-  if (!Number.isFinite(hours) || hours <= 0) return "Access ends when time is up.";
+  if (!Number.isFinite(hours) || hours <= 0)
+    return "Sharing ends when the time runs out.";
   const endsAt = new Date(nowMs + Math.round(hours * 60) * 60_000);
   const time = endsAt.toLocaleTimeString(undefined, {
     hour: "numeric",
@@ -2796,9 +2797,9 @@ function shareEndsAtLabel(durationHours: string, nowMs: number): string {
   });
   if (hours >= 12) {
     const day = endsAt.toLocaleDateString(undefined, { weekday: "long" });
-    return `Access ends at ${time} on ${day}.`;
+    return `Sharing ends at ${time} on ${day}.`;
   }
-  return `Access ends at ${time}.`;
+  return `Sharing ends at ${time}.`;
 }
 
 /* =================================================================== */
@@ -2819,8 +2820,33 @@ function AskFlow({
   const filtered = vm.visibleRecipients;
   // Keep the person on this screen after sending so the confirmation is tied to
   // the specific request they just made, rather than popping straight back to
-  // the hub. `justSent` latches the success state and blocks duplicate submits.
+  // the hub.
+  //
+  // `justSent` is a confirmation, NOT a one-shot lock. It used to latch true
+  // forever the moment the button was tapped, which meant (a) a failed send
+  // still said "Request sent." and (b) after one round the button stayed
+  // disabled, so somebody who asked three people could not then ask the rest
+  // without leaving the screen and coming back. Now it is set from the resolved
+  // result, and choosing the next person clears it and re-arms Send.
   const [justSent, setJustSent] = useState(false);
+  // Who the last send was for. Anyone selected who is NOT in it is a person
+  // being lined up for a new ask, which is what retires the confirmation and
+  // re-arms Send.
+  //
+  // Compared as a set rather than counted: sending subtracts only the people it
+  // actually asked, so a person tapped mid-send survives into a non-empty
+  // selection, and a count would read that leftover as "nothing new here".
+  const sentSelectionRef = useRef<readonly string[]>([]);
+  const selectedRequestOwnerIds = vm.selectedRequestOwnerIds;
+  useEffect(() => {
+    const hasNewPick = selectedRequestOwnerIds.some(
+      (id) => !sentSelectionRef.current.includes(id),
+    );
+    if (hasNewPick) setJustSent(false);
+  }, [selectedRequestOwnerIds]);
+  // Guards a double-tap inside the same frame, where `vm.busy` has not yet
+  // re-rendered the button as disabled.
+  const sendInFlightRef = useRef(false);
   // "Asked 6m ago" is only true at the moment it renders. Without a clock the
   // list freezes at whatever it said when the screen opened, which is how a
   // request sent half an hour ago still reads as just now.
@@ -2963,7 +2989,7 @@ function AskFlow({
         )}
       </SectionCard>
 
-      <SectionCard title="Duration requested">
+      <SectionCard title="How long">
         {/* Dropdown picker (not chips) to match the Share location screen's
             duration field — same shared DurationSelector `select` presentation. */}
         <DurationSelector
@@ -2998,8 +3024,12 @@ function AskFlow({
       {/* Send is enabled once at least one recipient is chosen. Duration and
           reason default to sensible values, so gating Send on them too (added
           in #5108) blocked submitting even when the request was already valid;
-          that extra gating is intentionally removed here. The "Request Sent"
-          success latch below is preserved. */}
+          that extra gating is intentionally removed here.
+
+          The button keeps the action accent in every state. Success is a status,
+          and it is already said twice — by the banner above and by each person's
+          row turning to "Asked" — so recolouring the primary action green said it
+          a third time and cost the screen its one action colour. */}
       {(() => {
         const isFormValid = vm.selectedRequestOwnerIds.length > 0;
         const sending = vm.busy === "request";
@@ -3007,34 +3037,27 @@ function AskFlow({
           <Button
             onClick={() => {
               // Never submit an incomplete form even if the click somehow
-              // reaches the handler (e.g. keyboard/AT), and never double-fire
-              // once it has already succeeded.
-              if (!isFormValid || sending || justSent) return;
-              vm.onSendRequest(reason);
-              // Stay on this screen and show inline confirmation tied to THIS
-              // request instead of popping straight back to the hub. The button
-              // latches to a disabled "Request Sent" success state so a second
-              // tap cannot fire a duplicate request.
-              setJustSent(true);
+              // reaches the handler (e.g. keyboard/AT), and never double-fire.
+              if (!isFormValid || sending || sendInFlightRef.current) return;
+              sendInFlightRef.current = true;
+              sentSelectionRef.current = vm.selectedRequestOwnerIds;
+              void (async () => {
+                try {
+                  // Confirm only what actually happened: the banner appears on a
+                  // resolved success, and a failure leaves the composer intact
+                  // with its own error toast.
+                  setJustSent(await vm.onSendRequest(reason));
+                } finally {
+                  sendInFlightRef.current = false;
+                }
+              })();
             }}
-            disabled={!isFormValid || sending || justSent}
-            aria-disabled={!isFormValid || sending || justSent}
+            disabled={!isFormValid || sending}
+            aria-disabled={!isFormValid || sending}
             isLoading={sending}
-            className={cn(
-              "h-12 w-full rounded-2xl text-base font-semibold text-[color:var(--app-accent-fg)] disabled:pointer-events-none",
-              justSent
-                ? "bg-[color:var(--app-success)] opacity-100 hover:bg-[color:var(--app-success)]"
-                : "bg-[color:var(--app-accent)] hover:bg-[color:var(--app-accent)]/90 disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35",
-            )}
+            className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
           >
-            {justSent ? (
-              <>
-                <ShieldCheck className="mr-1.5 h-[18px] w-[18px]" aria-hidden />
-                Sent
-              </>
-            ) : (
-              "Send request"
-            )}
+            Send request
           </Button>
         );
       })()}
@@ -3196,7 +3219,7 @@ function TemporaryLinkFlow({
         />
         <WarningCard
           title="Anyone with the link can view you."
-          description="Access expires automatically."
+          description="The link stops on its own."
         />
         {invite ? (
           <TemporaryLinkCard
@@ -3229,7 +3252,7 @@ function TemporaryLinkFlow({
       <TaskFlowHeader title="Share outside your Circle" />
       <WarningCard
         title="Anyone with this link can see you"
-        description="Access ends when the link expires."
+        description="The link stops on its own."
       />
       <SectionCard title="Duration">
         <DurationSelector

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -26,13 +26,16 @@ export type QuickActionTone = "green" | "red" | "blue" | "violet" | "slate";
  * stay neutral through the shared typography roles.
  */
 const TONE_STYLES: Record<QuickActionTone, { tile: string; icon: string }> = {
+  // Tokens, not literals: these hard-coded the LIGHT hex, so in dark mode the
+  // glyphs stayed at the light-appearance shade while every other semantic
+  // colour on the screen switched.
   green: {
-    tile: "bg-[rgba(52,199,89,0.12)]",
-    icon: "text-[#34C759]",
+    tile: "bg-[color:var(--app-success)]/12",
+    icon: "text-[color:var(--app-success)]",
   },
   red: {
-    tile: "bg-[rgba(255,59,48,0.12)]",
-    icon: "text-[#FF3B30]",
+    tile: "bg-[color:var(--app-destructive)]/12",
+    icon: "text-[color:var(--app-destructive)]",
   },
   blue: {
     tile: "bg-[color:var(--app-accent-surface)]",

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -133,7 +133,7 @@ export function LocationTypeSelector({
     {
       value: "precise",
       title: "Precise live location",
-      description: "Updates while you move for your loved ones",
+      description: "Updates as you move.",
     },
   ];
   return (
@@ -207,7 +207,7 @@ export function ReasonChips({
   onChange,
   label = "Reason",
   presentation = "buttons",
-  placeholder = "Select a reason for request…",
+  placeholder = "Pick a reason…",
 }: {
   value: ReasonValue | null;
   onChange: (next: ReasonValue) => void;

--- a/hushh-webapp/lib/feed/feed-events.ts
+++ b/hushh-webapp/lib/feed/feed-events.ts
@@ -2,7 +2,32 @@
  * immediately instead of waiting for the next poll. */
 export const FEED_STATE_CHANGED_EVENT = "hushh:feed-state-changed";
 
-export function dispatchFeedStateChanged(): void {
+/**
+ * Why the feed state changed.
+ *
+ * - `read` — only unread flags moved. The badge must recount; the list already
+ *   has these rows and re-fetching them would be a wasted request.
+ * - `action` — something was approved, denied, or dismissed, so there is new
+ *   activity to load. Every feed surface should re-check.
+ */
+export type FeedStateChangeReason = "read" | "action";
+
+export type FeedStateChangedDetail = { reason: FeedStateChangeReason };
+
+export function dispatchFeedStateChanged(
+  reason: FeedStateChangeReason = "action",
+): void {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(FEED_STATE_CHANGED_EVENT));
+  window.dispatchEvent(
+    new CustomEvent<FeedStateChangedDetail>(FEED_STATE_CHANGED_EVENT, {
+      detail: { reason },
+    }),
+  );
+}
+
+/** Reads the reason off a dispatched event, defaulting to the broader `action`
+ *  so an untagged legacy dispatch still refreshes everything. */
+export function feedStateChangeReason(event: Event): FeedStateChangeReason {
+  const detail = (event as CustomEvent<Partial<FeedStateChangedDetail>>).detail;
+  return detail?.reason === "read" ? "read" : "action";
 }

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -142,7 +142,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "Location share expired",
+        description: "Stopped sharing - time ran out",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -162,7 +162,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "You approved the location request",
+        description: "You approved. Now sharing.",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -212,7 +212,9 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: "KYC status updated",
-        description: status ? `Your KYC workflow is now ${status}.` : "Your KYC workflow status changed.",
+        description: status
+          ? `Your KYC check is now ${status}.`
+          : "Your KYC check moved on.",
         href: ROUTES.ONE_KYC,
       };
     }
@@ -221,24 +223,24 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
       return {
         icon,
         domainLabel,
-        label: "System connected",
-        description: "A connected system finished syncing.",
+        label: "App connected",
+        description: "Your data finished coming in.",
         href: ROUTES.CONNECTED_SYSTEMS,
       };
     case "connected_systems_rejected":
       return {
         icon,
         domainLabel,
-        label: "System connection rejected",
-        description: "A connected-system request was rejected.",
+        label: "Connection turned down",
+        description: "That app wasn't connected.",
         href: ROUTES.CONNECTED_SYSTEMS,
       };
     case "connected_systems_failed":
       return {
         icon,
         domainLabel,
-        label: "System sync failed",
-        description: "A connected-system action failed.",
+        label: "Couldn't get your data",
+        description: "Something went wrong bringing it in.",
         href: ROUTES.CONNECTED_SYSTEMS,
       };
     // Connection events use the same person-first layout: title is the other
@@ -294,7 +296,10 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: "Activity",
-        description: "Something happened in your account.",
+        // No pretend explanation for an event this build has no line for.
+        // "Something happened in your account." told the reader nothing and
+        // read like a bug.
+        description: "",
         href: null,
       };
   }

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -15,6 +15,7 @@ import {
 import { useAuth } from "@/hooks/use-auth";
 import { useVault } from "@/lib/vault/vault-context";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
+import { useFeedLiveRefresh } from "@/lib/feed/use-feed-live-refresh";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import {
   CACHE_KEYS,
@@ -100,7 +101,7 @@ export interface FeedActionable {
   sortAt: number;
   /**
    * Real-world instant to render as the row's "Today - 3:45 PM" label.
-   * Distinct from `sortAt` (which always falls back to `Date.now()` so
+   * Distinct from `sortAt` (which falls back to when the row was first seen so
    * ordering never breaks) — null/absent exactly when there is no real
    * timestamp to show the user (a consent entry with no `issued_at`, or any
    * connection request, whose payload carries no timestamp at all).
@@ -281,14 +282,17 @@ export function useFeedActionables(): UseFeedActionablesResult {
       : "consent_center_summary_guest",
     refreshKey: `one:consents:${consentTick}`,
     enabled: Boolean(userId),
-    load: async () => {
+    // `options.force` is honoured alongside the mutation tick: the consent
+    // services keep their own caches, so a live refresh that dropped the flag
+    // would re-read the same cached page it was trying to move past.
+    load: async (options) => {
       const idToken = await user?.getIdToken();
       if (!user?.uid || !idToken) throw new Error("Sign in to review consents");
       return ConsentCenterService.getSummary({
         idToken,
         userId: user.uid,
         mode: "consents",
-        force: consentTick > 0,
+        force: consentTick > 0 || Boolean(options?.force),
       });
     },
   });
@@ -308,7 +312,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
       : "consent_center_list_guest",
     refreshKey: `one:consents:${consentTick}:${pendingConsentCount ?? "?"}`,
     enabled: Boolean(userId) && (pendingConsentCount ?? 0) > 0,
-    load: async () => {
+    load: async (options) => {
       const idToken = await user?.getIdToken();
       if (!user?.uid || !idToken) throw new Error("Sign in to review consents");
       return ConsentCenterService.listEntries({
@@ -318,7 +322,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
         surface: "pending",
         page: 1,
         limit: CONSENT_CENTER_PAGE_SIZE,
-        force: consentTick > 0,
+        force: consentTick > 0 || Boolean(options?.force),
       });
     },
   });
@@ -393,6 +397,44 @@ export function useFeedActionables(): UseFeedActionablesResult {
   const connectionRequests = connectionsResource.data;
   const connectionsRefresh = connectionsResource.refresh;
   const consentItems = consentListResource.data?.items;
+  const consentSummaryRefresh = consentSummaryResource.refresh;
+  const consentListRefresh = consentListResource.refresh;
+
+  // When a row genuinely has no arrival time, remember when it was first seen.
+  //
+  // These rows used to call `Date.now()` inline, inside the memo — so every
+  // recompute minted a brand-new "now" and they jumped back above rows carrying
+  // real timestamps. Harmless while the Feed only built its list once; with the
+  // live refresh above, the order would reshuffle on every tick. A first-seen
+  // stamp is stable across refreshes AND is the honest answer to "when did this
+  // reach me", so arrival order between two untimed rows is preserved.
+  const firstSeenAtRef = useRef<Map<string, number>>(new Map());
+  const firstSeenAt = useCallback((id: string) => {
+    const remembered = firstSeenAtRef.current.get(id);
+    if (remembered !== undefined) return remembered;
+    const now = Date.now();
+    firstSeenAtRef.current.set(id, now);
+    return now;
+  }, []);
+
+  // "Needs you" is the half of the Feed that is a to-do list, so a stale one is
+  // worse than a stale history: it offers Approve on a request somebody already
+  // answered elsewhere. Every source behind it re-checks on the same live signal
+  // the list and the tab badge use.
+  useFeedLiveRefresh(
+    useCallback(() => {
+      void consentSummaryRefresh({ force: true });
+      void consentListRefresh({ force: true });
+      void locationRefresh({ force: true });
+      void connectionsRefresh({ force: true });
+    }, [
+      connectionsRefresh,
+      consentListRefresh,
+      consentSummaryRefresh,
+      locationRefresh,
+    ]),
+    Boolean(userId),
+  );
 
   // Revoked/expired SOS cards stay in the feed as a historical alert instead
   // of vanishing the moment the sender cancels — but there is nothing left to
@@ -455,10 +497,11 @@ export function useFeedActionables(): UseFeedActionablesResult {
           }),
           chevron: true,
           actions: [],
-          // No reliable arrival time on a consent entry (only a future
-          // expiry), so treat pending consents as current rather than mixing
-          // future expiry into the descending recency sort.
-          sortAt: Date.now(),
+          // `issued_at` when the backend populated it — never the expiry, which
+          // is in the future and would sort this above everything. Otherwise
+          // when it was first seen, so it holds its place across refreshes.
+          sortAt:
+            toTimestamp(entry.issued_at) || firstSeenAt(`consent:${entry.id}`),
           // Real only when the backend happened to populate issued_at — never
           // fabricate a "just now" time label for this type.
           displayTimestamp: toDisplayTimestamp(entry.issued_at),
@@ -505,7 +548,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
         href: buildOneLocationNotificationHref(grant.id),
         chevron: true,
         actions: [],
-        sortAt: resolvedAt || Date.now(),
+        sortAt: resolvedAt || firstSeenAt(`sms-emergency:${grant.id}`),
         displayTimestamp: resolvedAt || null,
       });
     }
@@ -561,7 +604,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
             },
           },
         ],
-        sortAt: toTimestamp(request.requestedAt) || Date.now(),
+        sortAt:
+          toTimestamp(request.requestedAt) ||
+          firstSeenAt(`location:${request.id}`),
         displayTimestamp: toDisplayTimestamp(request.requestedAt),
       });
     }
@@ -615,7 +660,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
             },
           },
         ],
-        sortAt: toTimestamp(invite.createdAt) || Date.now(),
+        sortAt:
+          toTimestamp(invite.createdAt) ||
+          firstSeenAt(`circle-invite:${invite.id}`),
         displayTimestamp: toDisplayTimestamp(invite.createdAt),
       });
     }
@@ -686,9 +733,10 @@ export function useFeedActionables(): UseFeedActionablesResult {
                 },
               },
             ],
-        sortAt: Date.now(),
         // ConnectionRequest (lib/services/connections-service.ts) carries no
-        // timestamp field at all — never fabricate one for the time label.
+        // timestamp field at all, so first-seen is the only honest ordering.
+        sortAt: firstSeenAt(`connection:${request.id}`),
+        // Still never fabricate a visible time label from it.
         displayTimestamp: null,
       });
     }
@@ -752,7 +800,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
         onSelect: running ? () => openAnalysis(task.runId) : undefined,
         chevron: running,
         actions,
-        sortAt: toTimestamp(task.updatedAt || task.startedAt) || Date.now(),
+        sortAt:
+          toTimestamp(task.updatedAt || task.startedAt) ||
+          firstSeenAt(`debate:${task.runId}`),
         displayTimestamp: toDisplayTimestamp(task.updatedAt || task.startedAt),
       });
     }
@@ -784,7 +834,9 @@ export function useFeedActionables(): UseFeedActionablesResult {
         title: task.title,
         description: task.description || "Working in the background…",
         actions,
-        sortAt: toTimestamp(task.updatedAt || task.startedAt) || Date.now(),
+        sortAt:
+          toTimestamp(task.updatedAt || task.startedAt) ||
+          firstSeenAt(`task:${task.taskId}`),
         displayTimestamp: toDisplayTimestamp(task.updatedAt || task.startedAt),
       });
     }
@@ -808,6 +860,7 @@ export function useFeedActionables(): UseFeedActionablesResult {
     consentItems,
     debateState.tasks,
     dismissedSmsEmergencyIds,
+    firstSeenAt,
     locationRequests,
     receivedGrants,
     circleMemberInvites,

--- a/hushh-webapp/lib/feed/use-feed-live-refresh.ts
+++ b/hushh-webapp/lib/feed/use-feed-live-refresh.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import {
+  FEED_STATE_CHANGED_EVENT,
+  feedStateChangeReason,
+} from "@/lib/feed/feed-events";
+
+/**
+ * How often a Feed surface re-checks the server while the user is looking at it.
+ *
+ * One constant for every Feed surface on purpose. The unread badge used to own a
+ * private 45s poll while the Feed list itself refreshed only when it mounted, so
+ * the badge could say "4 new" over a list that had not asked the server anything
+ * since the app opened — the tab and the page disagreeing about the same facts.
+ */
+export const FEED_LIVE_POLL_INTERVAL_MS = 45_000;
+
+/**
+ * Runs `refresh` whenever the Feed's data could have changed:
+ *
+ * - on a timer, while the tab is actually being looked at;
+ * - the moment the tab is looked at again (`visibilitychange` / `focus`), which
+ *   is when a phone comes back from the lock screen or another app;
+ * - on `FEED_STATE_CHANGED`, but only when something was actually acted on.
+ *   Marking rows read also fires that event, and re-fetching a list in response
+ *   to having just read it is a request that can only return what is already on
+ *   screen.
+ *
+ * The timer is stopped while the tab is hidden. A backgrounded tab polling every
+ * 45 seconds spends battery and mobile data redrawing something nobody is
+ * reading; returning to the foreground refreshes immediately anyway, so nothing
+ * is lost by going quiet.
+ *
+ * `refresh` is read through a ref, so a caller may pass an inline closure without
+ * tearing down and rebuilding the listeners on every render.
+ */
+export function useFeedLiveRefresh(
+  refresh: () => void,
+  enabled: boolean = true,
+): void {
+  const refreshRef = useRef(refresh);
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+
+    const run = () => refreshRef.current();
+
+    let timer: number | null = null;
+    const startPolling = () => {
+      if (timer !== null) return;
+      timer = window.setInterval(run, FEED_LIVE_POLL_INTERVAL_MS);
+    };
+    const stopPolling = () => {
+      if (timer === null) return;
+      window.clearInterval(timer);
+      timer = null;
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        run();
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+
+    if (document.visibilityState === "visible") startPolling();
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    // iOS webviews do not always pair `focus` with a `visibilitychange`, so both
+    // are listened for. A duplicate refresh is harmless: `useStaleResource`
+    // de-dupes concurrent loads of the same cache key onto one request.
+    window.addEventListener("focus", run);
+
+    const onFeedStateChanged = (event: Event) => {
+      if (feedStateChangeReason(event) === "read") return;
+      run();
+    };
+    window.addEventListener(FEED_STATE_CHANGED_EVENT, onFeedStateChanged);
+
+    return () => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", run);
+      window.removeEventListener(FEED_STATE_CHANGED_EVENT, onFeedStateChanged);
+    };
+  }, [enabled]);
+}

--- a/hushh-webapp/lib/feed/use-feed-unread-count.ts
+++ b/hushh-webapp/lib/feed/use-feed-unread-count.ts
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/hooks/use-auth";
 import { FEED_STATE_CHANGED_EVENT } from "@/lib/feed/feed-events";
+import { useFeedLiveRefresh } from "@/lib/feed/use-feed-live-refresh";
 import { FeedService } from "@/lib/services/feed-service";
-
-const POLL_INTERVAL_MS = 45_000;
 
 /**
  * Returns `null` until the count has resolved. Consumers must treat that as
@@ -16,15 +15,11 @@ const POLL_INTERVAL_MS = 45_000;
 export function useFeedUnreadCount(): number | null {
   const { user } = useAuth();
   const [count, setCount] = useState<number | null>(null);
+  const cancelledRef = useRef(false);
 
-  useEffect(() => {
-    if (!user?.uid) {
-      setCount(null);
-      return;
-    }
-    let cancelled = false;
-
-    const load = async (force = false) => {
+  const load = useCallback(
+    async (force = false) => {
+      if (!user?.uid) return;
       try {
         const idToken = await user.getIdToken();
         const next = await FeedService.unreadCount({
@@ -32,24 +27,44 @@ export function useFeedUnreadCount(): number | null {
           userId: user.uid,
           force,
         });
-        if (!cancelled) setCount(next);
+        if (!cancelledRef.current) setCount(next);
       } catch {
         // Unread count is presentation-only; a transient failure just keeps
         // the last known value instead of surfacing an error state.
       }
-    };
+    },
+    [user],
+  );
 
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (!user?.uid) {
+      setCount(null);
+      return;
+    }
     void load();
-    const interval = setInterval(() => void load(true), POLL_INTERVAL_MS);
-    const handleStateChanged = () => void load(true);
-    window.addEventListener(FEED_STATE_CHANGED_EVENT, handleStateChanged);
-
     return () => {
-      cancelled = true;
-      clearInterval(interval);
-      window.removeEventListener(FEED_STATE_CHANGED_EVENT, handleStateChanged);
+      cancelledRef.current = true;
     };
-  }, [user]);
+  }, [user, load]);
+
+  // Shares the Feed's live signal rather than keeping a private timer, so the
+  // badge and the Feed list re-check on the same tick and cannot drift into
+  // saying different things about the same unread rows.
+  useFeedLiveRefresh(
+    useCallback(() => void load(true), [load]),
+    Boolean(user?.uid),
+  );
+
+  // The badge additionally recounts on a read-only change — that shared signal
+  // skips those, precisely so a list does not re-fetch rows it just marked read.
+  // For the badge it is the whole point: it is the number that has to drop.
+  useEffect(() => {
+    if (!user?.uid) return;
+    const recount = () => void load(true);
+    window.addEventListener(FEED_STATE_CHANGED_EVENT, recount);
+    return () => window.removeEventListener(FEED_STATE_CHANGED_EVENT, recount);
+  }, [user?.uid, load]);
 
   return count;
 }


### PR DESCRIPTION
Reported from the field, with screenshots: *"feed is neither real time not accurate and not precise"*, *"3 feeds generated on requesting location"*, *"can't send req to rest after 1 cycle"*, *"cta color change"*.

## The Feed was never live

It fetched once per mount and never again. The tab badge polled every 45s while the list it badged asked the server nothing after the app opened — so the badge could say "4 new" over a list that had not re-checked since launch.

`useFeedLiveRefresh` is now one signal shared by the list, the "Needs you" lane and the badge: a poll while the tab is actually watched, an immediate re-check on return (`visibilitychange` + `focus`, because iOS webviews do not always pair them), and a refresh when something is acted on. The timer stops while the tab is hidden. A read-only change (opening the Feed marks it read) no longer makes every surface re-fetch rows it just rendered.

`force` now reaches `FeedService`, which keeps its own short-TTL cache in front of the request. Without that the "forced" refresh returned the page it already had — the list looked live without being live.

Rows that arrived unread stay styled unread for the visit, which is what the mark-read effect was always written for; a live refresh would otherwise have drained the accent tint from under the reader mid-scroll.

## Not precise

Seven "Needs you" rows used `sortAt: Date.now()`, minting a fresh "now" on every memo recompute, so rows with no real timestamp leapt back above rows that had one. Harmless while the list built itself once — with a 45s refresh it would reshuffle on every tick. Real timestamps are used where they exist (a consent entry's `issued_at`), first-seen where they genuinely do not (a `ConnectionRequest` carries no timestamp at all).

## Three Feed rows for one tap

`approve_request` calls `create_grant` (which writes `location_share_created`) and then writes `location_access_approved` itself. Migration 117 forwarded both, so approving one request produced:

    Requested your location            <- the ask
    Started sharing location           <- the answer
    You approved the location request  <- the same answer again

Migration 151 stops fanning out the first. `one_location_events` still records both — nothing changes about what is durably logged, only what is shown. This is the same rule the service already applies to push notifications ("Sending share-created as well produces two alerts for one user action"); the Feed just never got it.

## Can't ask the rest after one cycle

`justSent` latched true the moment Send was tapped and there was no `setJustSent(false)` anywhere, so:

- a send that **failed** still reported "Request sent."
- after one round the button stayed disabled, and the rest of the list could be ticked but never asked — the only way out was to leave the screen and come back.

It is now set from the resolved result and re-arms when the next person is picked. Separately: sending awaits several round trips before clearing the composer, and anyone tapped inside that window was wiped by the blanket reset. Only the people actually asked are subtracted now.

## Green CTA

Send keeps the action accent in every state. Green is a status, and this screen already says it twice — the banner above, and each person's row turning to "Asked". `quick-actions.tsx` also hard-coded the light-appearance hexes (`#34C759` / `#FF3B30`), so those glyphs stayed light-mode in dark mode; both now use the semantic tokens.

## Plain language

~30 visible strings, no internal identifiers renamed: "Live grants appear here." → "Ask someone to share.", "Capture your current location to check in." → "Find your location to check in.", "Retry sends only to failed people." → "Sends again to the people it missed.", "Not ready to receive location" → "Hasn't set up sharing yet", "Failed to clear feed notifications" → "Couldn't clear your feed.". "Encrypted" stays visible on the check-in screen in both branches — dropping it from the button would have left the retry state with no visible privacy promise at all.

## One thing measured and reverted

A first pass "fixed" the header report by deleting a CSS gate that holds the top chrome's background at 0% until an attribute nothing in the repo sets — higher specificity than the rule that paints it. Every fact was right. Signed into UAT and measured, `--ambient-chrome-wash` computes to **94%** and the bar paints solidly; cascade layers decide it. Reverted rather than ship a global-stylesheet change for a defect that does not exist. `safe-changes` R17 records it.

## Verification

- Full suite: **21 failed / 523 passed**. The failing set is byte-for-byte the set that already fails on pristine `origin/main` (measured by checking those files out on the base). Zero regressions.
- Both behaviour fixes mutation-checked — restore the old code and the new tests go red.
- `typecheck`, `lint --max-warnings=0`, `verify:design-system`, production build: green.
- Backend: 290 tests pass, `ruff` clean; the 9 `mypy` errors in that file are pre-existing.
- New: `use-feed-live-refresh.test.tsx` (6), `feed-live-and-cta.contract.test.ts` (6), 3 ask-flow regression tests, 5 backend migration tests.

## Note for the release

This carries a **DB migration (151)** plus a backend change, so it is a backend + frontend release, not webapp-only.