### PR TITLE
test(one-location): measure the ready panel's centring in a real browser

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 
 import { OneLocationOnboardingFlow } from "@/components/one-location/onboarding/one-location-onboarding-flow";
+import { READY_PANEL_CLASSNAME } from "@/components/one-location/onboarding/ready-panel-layout";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -1314,6 +1315,12 @@ describe("OneLocationOnboardingFlow", () => {
       openInviteScreen();
 
       const sheet = screen.getByTestId("one-location-onboarding-ready-panel");
+
+      // The panel must render the shared contract verbatim -- that is what
+      // e2e/one-location-ready-panel.layout.spec.ts measures in a real browser.
+      // JSDOM performs no layout, so this half only proves the classes reach
+      // the DOM; the browser half proves they actually centre the box.
+      expect(sheet.className).toBe(READY_PANEL_CLASSNAME);
 
       // It reads as a dialog over the map, so it belongs in the middle of it.
       // Anchored to the right edge it looked like a panel that had slid off.

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -19,6 +19,11 @@ import {
 } from "lucide-react";
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { OnboardingLiveMap } from "@/components/one-location/onboarding/onboarding-live-map";
+import {
+  READY_MAP_CLASSNAME,
+  READY_PANEL_CLASSNAME,
+  READY_SURFACE_CLASSNAME,
+} from "@/components/one-location/onboarding/ready-panel-layout";
 import { normalizeCircleCode } from "@/lib/one-location/pending-circle-join";
 import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
 import type { ConsentNotificationDeliveryMode } from "@/components/consent/notification-provider";
@@ -1728,7 +1733,7 @@ function ReadyScreen({
 
   return (
     <div
-      className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#14171d] md:bg-[#eef3f8] md:dark:bg-[#070a0f]"
+      className={READY_SURFACE_CLASSNAME}
       data-testid="one-location-onboarding-ready-surface"
     >
       {/* The map gets its own band rather than sitting behind the copy.
@@ -1739,7 +1744,7 @@ function ReadyScreen({
           layout every map product converges on for the same reason. */}
       <OnboardingLiveMap
         point={mapPoint}
-        className="h-[34dvh] max-h-[300px] min-h-[190px] w-full shrink-0 md:absolute md:inset-0 md:h-full md:max-h-none md:min-h-0"
+        className={READY_MAP_CLASSNAME}
       />
 
       {/* Floats over the map: the controls stay reachable without stealing a
@@ -1762,7 +1767,7 @@ function ReadyScreen({
       </header>
 
       <div
-        className="relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-white shadow-[0_-8px_24px_rgba(24,57,91,0.10)] dark:bg-[#14171d] md:absolute md:left-1/2 md:top-1/2 md:mt-0 md:h-auto md:max-h-[calc(100dvh-96px)] md:w-[430px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[30px] md:shadow-[0_24px_80px_rgba(24,57,91,0.22)]"
+        className={READY_PANEL_CLASSNAME}
         data-testid="one-location-onboarding-ready-panel"
       >
         <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4 pt-6 md:px-7 md:pb-5 md:pt-7">

--- a/hushh-webapp/components/one-location/onboarding/ready-panel-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/ready-panel-layout.ts
@@ -1,0 +1,41 @@
+/**
+ * Layout contract for the final onboarding screen ("You're on the map").
+ *
+ * These class strings live here rather than inline so the component and the
+ * layout tests read the same source. The centring below was a real bug: the
+ * panel used to be anchored to the right edge (`md:right-[max(44px,6vw)]`) over
+ * a full-bleed map, which read as a panel that had slid off rather than a
+ * dialog over the map.
+ *
+ * The geometry these classes must produce is asserted two ways, because neither
+ * check alone is sufficient:
+ *
+ *   - `__tests__/components/one-location-onboarding-flow.test.tsx` proves the
+ *     component still renders these classes. It runs in the normal test gate,
+ *     but JSDOM performs no layout, so it cannot prove what they do.
+ *   - `e2e/one-location-ready-panel.layout.spec.ts` renders them in a real
+ *     browser and measures the box. It proves the centring, but needs a browser
+ *     binary, so it is run on demand rather than in the default gate.
+ */
+
+/** Full-bleed surface the map and panel sit in. Owns the positioning context. */
+export const READY_SURFACE_CLASSNAME =
+  "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#14171d] md:bg-[#eef3f8] md:dark:bg-[#070a0f]";
+
+/** A band of its own on phones; the full backdrop from `md:` up. */
+export const READY_MAP_CLASSNAME =
+  "h-[34dvh] max-h-[300px] min-h-[190px] w-full shrink-0 md:absolute md:inset-0 md:h-full md:max-h-none md:min-h-0";
+
+/**
+ * Phones keep the full-width sheet in normal flow -- that is also what the iOS
+ * build renders, so the `md:` rules must never leak into phone widths. From
+ * `md:` up the panel becomes a fixed-width dialog centred on both axes.
+ */
+export const READY_PANEL_CLASSNAME =
+  "relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-white shadow-[0_-8px_24px_rgba(24,57,91,0.10)] dark:bg-[#14171d] md:absolute md:left-1/2 md:top-1/2 md:mt-0 md:h-auto md:max-h-[calc(100dvh-96px)] md:w-[430px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[30px] md:shadow-[0_24px_80px_rgba(24,57,91,0.22)]";
+
+/** Tailwind's `md:` breakpoint -- where the sheet becomes a centred dialog. */
+export const READY_PANEL_DIALOG_MIN_WIDTH_PX = 768;
+
+/** The panel's fixed width once it is a dialog (`md:w-[430px]`). */
+export const READY_PANEL_DIALOG_WIDTH_PX = 430;

--- a/hushh-webapp/e2e/one-location-ready-panel.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-ready-panel.layout.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
+import {
+  READY_MAP_CLASSNAME,
+  READY_PANEL_CLASSNAME,
+  READY_PANEL_DIALOG_MIN_WIDTH_PX,
+  READY_PANEL_DIALOG_WIDTH_PX,
+  READY_SURFACE_CLASSNAME,
+} from "../components/one-location/onboarding/ready-panel-layout";
+
+/**
+ * The invite panel on the final onboarding screen, measured in a real browser.
+ *
+ * The sibling JSDOM test proves the component still renders these classes; it
+ * cannot prove what they do, because JSDOM performs no layout. That gap is not
+ * academic -- the bug this guards against (the panel anchored to the right edge
+ * instead of centred) is invisible to a class assertion and shows up here as a
+ * ~348px offset at desktop width.
+ *
+ * The screen itself only exists for a brand-new account, so reaching it through
+ * the app would need a first-run fixture. Instead this renders the real class
+ * strings, imported from the component's own module, in the real cascade. That
+ * proves the half a class assertion cannot: that these classes centre the box.
+ *
+ * Run with: npm run test:layout-contracts
+ */
+
+const WIDTHS = [320, 360, 375, 390, 430, 767, 768, 769, 1024, 1280] as const;
+
+/** Compile just the utilities this fixture uses, with the real Tailwind. */
+async function buildFixture(): Promise<string> {
+  // Playwright runs from the webapp root (its config lives there).
+  const webappRoot = process.cwd();
+  const { compile } = (await import(
+    path.join(webappRoot, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as { compile: (css: string, opts: unknown) => Promise<{ build: (c: string[]) => string }> };
+
+  const compiler = await compile('@import "tailwindcss";', {
+    base: path.join(webappRoot, "node_modules"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
+          : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  const classes = `${READY_SURFACE_CLASSNAME} ${READY_MAP_CLASSNAME} ${READY_PANEL_CLASSNAME} h-screen flex flex-col`;
+  const css = compiler.build(classes.split(/\s+/).filter(Boolean));
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ready-panel-layout-"));
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css"></head><body style="margin:0">
+<div class="h-screen flex flex-col">
+  <div class="${READY_SURFACE_CLASSNAME}" data-testid="one-location-onboarding-ready-surface">
+    <div class="${READY_MAP_CLASSNAME}" data-testid="onboarding-live-map"></div>
+    <div class="${READY_PANEL_CLASSNAME}" data-testid="one-location-onboarding-ready-panel">
+      <div style="padding:24px">
+        <h1>You&apos;re on the map.</h1><p>Private until you share.</p>
+        <p>SWDX-ENDP-B954</p><button>Copy</button><button>Share</button>
+      </div>
+    </div>
+  </div>
+</div></body></html>`,
+  );
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+test.describe("One Location ready panel layout", () => {
+  for (const width of WIDTHS) {
+    const isDialog = width >= READY_PANEL_DIALOG_MIN_WIDTH_PX;
+
+    test(`is ${isDialog ? "centred as a dialog" : "a full-width sheet"} at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+
+      const panel = page.getByTestId("one-location-onboarding-ready-panel");
+      await expect(panel).toBeVisible();
+
+      const measured = await panel.evaluate((node) => {
+        const box = node.getBoundingClientRect();
+        const root = document.documentElement;
+        return {
+          left: box.left,
+          right: box.right,
+          width: box.width,
+          centerX: box.left + box.width / 2,
+          position: getComputedStyle(node).position,
+          overflow:
+            Math.max(root.scrollWidth, document.body.scrollWidth) - root.clientWidth,
+        };
+      });
+
+      // Nothing may push the page sideways at any width.
+      expect(measured.overflow).toBeLessThanOrEqual(1);
+      expect(measured.left).toBeGreaterThanOrEqual(-1);
+      expect(measured.right).toBeLessThanOrEqual(width + 1);
+
+      if (isDialog) {
+        expect(measured.position).toBe("absolute");
+        expect(Math.abs(measured.width - READY_PANEL_DIALOG_WIDTH_PX)).toBeLessThanOrEqual(1);
+        // The regression this file exists for: right-anchored was ~348px off here.
+        expect(Math.abs(measured.centerX - width / 2)).toBeLessThanOrEqual(1);
+      } else {
+        // Phone widths -- and therefore the iOS build -- keep the sheet in flow.
+        expect(measured.position).not.toBe("absolute");
+        expect(Math.abs(measured.width - width)).toBeLessThanOrEqual(1);
+      }
+    });
+  }
+});

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
+    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts --project=chromium",
     "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check && npm run verify:route-orchestration-index",


### PR DESCRIPTION
Follow-up to #5302, which centred the onboarding invite panel. That fix shipped with only a **class-string assertion** behind it — and JSDOM performs no layout, so it proved the classes reach the DOM and nothing about what they do. The bug it guards against is invisible to that check.

## What this adds

`components/one-location/onboarding/ready-panel-layout.ts` — the three class strings, so the component and both tests read one source instead of three copies.

`e2e/one-location-ready-panel.layout.spec.ts` — compiles those same strings with the real Tailwind, renders them, and **measures the box** at 320/360/375/390/430/767/768/769/1024/1280px, including the `md:` boundary at 767/768/769.

| Width | Asserted |
|---|---|
| ≥ 768px | 430px dialog, centred within 1px, `position: absolute` |
| < 768px | full-width sheet, stays in normal flow (this is what the iOS build renders) |
| every width | no horizontal overflow, panel inside the viewport |

## Why it's trustworthy

Reverting the constant to the old right-anchored class makes the spec fail at every dialog width — **~123px off at 768px, ~348px at 1280px** — and pass again when restored. It was also run in WebKit locally (Safari's engine, what iPhones use): identical, 0.0px offset at all ten widths.

The component test now pins the full class string, so the JSDOM half and the browser half cannot drift apart.

## Why it is not wired into a gate

No workflow currently runs the e2e suite at all — the Chromium install in `deploy-uat.yml` is scoped to the PKM/BYOK verification scripts. Adding a browser install to the PR gate would change a required check for **every PR in this repo**. That is a deliberate infrastructure decision, not something to slip into a test change, so the spec runs on demand:

```
npm run test:layout-contracts
```

Happy to wire it into CI as a follow-up if you want it blocking.

## Verification

- `vitest` component suite: **52 passed**
- `npm run test:layout-contracts`: **10 passed** (Chromium), and 10 passed in WebKit locally
- `tsc --noEmit`: clean
- `eslint --max-warnings=0` on all changed files: clean
- Mutation-checked in both directions

No product behaviour changes — the rendered class strings are byte-identical to what is on `main` today.