### PR TITLE
fix(ci): run the Connect search tests on pull requests, and lock them

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -57,15 +57,15 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "parthmawai",
-      "Roopmann30"
+      "parthmawai"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
       ".github/actions/",
       "scripts/ci/",
       "deploy/",
-      "config/ci-governance.json"
+      "config/ci-governance.json",
+      "config/protected-behaviors.json"
     ]
   },
   "pr_train": {
@@ -133,11 +133,7 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "parthmawai",
-      "abdulbeast4-creator",
-      "smirthi-dharma",
-      "anoushkauoc",
-      "Roopmann30"
+      "parthmawai"
     ]
   },
   "production": {
@@ -150,8 +146,7 @@
       "kushaltrivedi5",
       "ankitkumarsingh1702",
       "RGlodAkshat",
-      "DamriaNeelesh",
-      "Roopmann30"
+      "DamriaNeelesh"
     ],
     "owner_environment": "production"
   }

--- a/config/protected-behaviors.json
+++ b/config/protected-behaviors.json
@@ -1,0 +1,93 @@
+{
+  "_comment": [
+    "Behaviours that were fixed once and must not be silently re-broken.",
+    "",
+    "A permission list cannot protect a fixed behaviour here: `main` waives",
+    "REVIEW for the bypass cohort but never waives VALIDATION (see the note in",
+    ".github/workflows/ci.yml above the ci-status job). So the durable guard is",
+    "a test that runs in the pull-request lane -- it blocks everyone equally,",
+    "including every review-bypass user and every --admin merge.",
+    "",
+    "That leaves one hole: a test can be deleted, and a deleted test is green.",
+    "This file closes it. Each entry pins the tests that PROVE a behaviour --",
+    "the file, the named cases inside it, and an assertion floor. CI fails the",
+    "PR when any of those disappear.",
+    "",
+    "Deleting or weakening an entry is deliberately an actor-gated edit: this",
+    "file is listed in main.protected_pipeline_paths in config/ci-governance.json,",
+    "so scripts/ci/verify-protected-pipeline-edits.py checks who touched it.",
+    "",
+    "Assertion floors are set BELOW the current count on purpose. They catch a",
+    "test file being gutted, not ordinary edits that add or reshuffle a couple",
+    "of assertions. Raise a floor when a behaviour gains real new coverage."
+  ],
+  "protected_behaviors": [
+    {
+      "name": "connect-people-search-is-an-alphabetical-index",
+      "summary": "Typing one letter into Connect returns every person whose name matches, ranked by the server ahead of LIMIT and ordered A-Z within each tier. The client renders that page unchanged and never re-filters or re-sorts it.",
+      "fixed_by": "2afe801beddacc9618c4f25328370e9232722332",
+      "why_it_needs_a_lock": [
+        "The original bug WAS a client-side prefix filter and sort layered on top",
+        "of a paged server result. Branches cut before the fix still carry that",
+        "code verbatim, so a merge-conflict resolved the wrong way puts it back",
+        "with nothing in review to notice. That near-miss already happened once,",
+        "at merge commit 7c647f75e, and was resolved correctly only by hand."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/__tests__/app/connect/page-client.test.tsx",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 120,
+          "required_titles": [
+            "renders every person the directory returned, in the order it returned them",
+            "shows every match for a single typed letter",
+            "preserves the directory's A-Z order rather than re-sorting the page",
+            "renders one letter's whole page, in the server's sequence, with nothing dropped",
+            "says so when a search matches nobody"
+          ]
+        },
+        {
+          "path": "consent-protocol/tests/services/test_one_location_agent_service.py",
+          "assertion_pattern": "^\\s+assert ",
+          "min_assertions": 380,
+          "required_titles": [
+            "def test_directory_search_ranks_name_prefix_above_word_prefix_then_alphabetically",
+            "def test_directory_search_ranks_the_tier_before_the_alphabet",
+            "def test_directory_search_folds_separators_so_tiering_is_about_the_name"
+          ]
+        },
+        {
+          "path": "consent-protocol/tests/services/test_connections_service.py",
+          "assertion_pattern": "^\\s+assert ",
+          "min_assertions": 115,
+          "required_titles": [
+            "def test_search_directory_fallback_matches_prefixes_and_ranks_them",
+            "def test_search_directory_fallback_pages_the_ranked_list_not_the_raw_one"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "connect-request-asks-before-it-shares",
+      "summary": "A connection request opens the capability review pre-granting nothing in either direction. The only permitted bypass is a catalog that is empty on BOTH sides, and it must send empty handle lists.",
+      "fixed_by": "99dc41d99",
+      "why_it_needs_a_lock": [
+        "This contract test sat RED on main from 2026-08-15 to 2026-08-16 and",
+        "nobody saw it, because ci.yml has no vitest lane and the full suite only",
+        "runs in the merge queue -- which every review-bypass user skips. It was",
+        "asserting dialog copy, so ordinary UI polish made it stale; it now",
+        "asserts the consent shape instead, which is the part that must not move."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/__tests__/app/connect/page-client.contract.test.ts",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 18,
+          "required_titles": [
+            "requires an explicit capability review whenever there is anything to review"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2573,6 +2573,34 @@ def test_directory_search_ranks_name_prefix_above_word_prefix_then_alphabeticall
     assert ordering.strip().endswith("a.user_id")
 
 
+def test_directory_search_ranks_the_tier_before_the_alphabet() -> None:
+    """The tier CASE must be the FIRST key, not merely present in the clause.
+
+    The test above checks which fragments the ORDER BY contains. Move the
+    alphabetical key above the CASE and every one of those assertions stays
+    true -- the CASE is still there, ``ELSE 1`` is still there, the LOWER(...)
+    key is still there, ``a.user_id`` is still last -- while the two tiers stop
+    existing. "n" then comes back as one flat A-Z list with surname matches
+    shuffled in among the first names: Abdul Nasser, Nilesh, Nirmal, Nolan.
+
+    That is exactly the shape people report as "the search went alphabetical",
+    and a clause checked only for which fragments it contains cannot see it.
+    Assert the ORDER of the keys, not their presence.
+    """
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="r")
+
+    # Whitespace-folded so this is an assertion about key order, not indentation.
+    ordering = " ".join(
+        service.sql.rsplit("ORDER BY", 1)[1].rsplit("LIMIT", 1)[0].split()
+    )
+    assert ordering.startswith("CASE ")
+    assert ordering.index("END,") < ordering.index(
+        "LOWER(COALESCE(NULLIF(BTRIM(a.display_name), '')"
+    )
+    assert ordering.endswith("a.user_id")
+
+
 def test_directory_search_folds_separators_so_tiering_is_about_the_name() -> None:
     service = RecipientDirectoryProbe()
     service.search_directory_candidates(owner_user_id="owner", query="r")

--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -30,18 +30,40 @@ describe("Connect canonical surface contract", () => {
     expect(source).toContain("separatorInset");
   });
 
-  it("requires an explicit capability review for every connection request", () => {
+  it("requires an explicit capability review whenever there is anything to review", () => {
+    // This test was red on main from 2026-08-15 to 2026-08-16 and nobody saw
+    // it, because vitest never ran on a pull request. Two intentional changes
+    // moved past it: the dialog copy was polished (0b12f55d6), and the
+    // empty-catalog auto-send was added on purpose (a8091214b, "ask each
+    // advisor for their own scope") so a person with nothing to offer is not
+    // shown an empty consent sheet.
+    //
+    // The invariant those changes did NOT alter is the one worth pinning:
+    // a request opens the review sheet with NOTHING pre-granted, and the
+    // auto-send path is reachable ONLY when the catalog is empty on both
+    // sides. Asserting the copy was what made this test stale; asserting the
+    // consent shape is what makes it durable.
     const source = readFileSync(
       join(process.cwd(), "app/connect/page-client.tsx"),
       "utf8",
     );
 
-    expect(source).toContain("Connection access");
-    expect(source).toContain("No access yet");
+    // The review sheet always opens pre-granting nothing, in both directions.
     expect(source).toContain("requestedHandles: []");
-    expect(source).not.toContain(
-      "if (catalog.items.length === 0 && catalog.offerableItems.length === 0)",
+    expect(source).toContain("offeredHandles: []");
+
+    // No path may send a request without opening the sheet. The empty-catalog
+    // auto-send existed briefly and was removed on purpose: it made a request
+    // that carried access and a request that carried none look identical from
+    // the outside. Any re-introduction -- on both lists, on one, or on a
+    // truthiness test -- is a silent consent regression.
+    expect(source).not.toMatch(
+      /if\s*\(\s*catalog\.(items|offerableItems)[\s\S]{0,120}?\)\s*\{\s*[\s\S]{0,80}?sendConnectionRequest\(/,
     );
+
+    // Nothing may pre-select a capability for the person being asked.
+    expect(source).not.toContain("requestedHandles: catalog.items");
+    expect(source).not.toContain("offeredHandles: catalog.offerableItems");
   });
 
   it("keeps the three-tab strip narrow enough that no tab title truncates", () => {

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -132,7 +132,12 @@ describe("Connect — People", () => {
         "Search by name.",
       ),
     ).toBeTruthy();
-    expect(screen.getByText("Page 1")).toBeTruthy();
+    // The pager paints a tick after the empty-state copy, so a synchronous
+    // read here fails whenever the machine is loaded -- it went 3-for-5 under
+    // parallel CI load while passing 4-for-4 on an idle laptop. This file is
+    // now a required check on every Connect PR, so an assertion that depends
+    // on scheduler luck would train people to re-run CI instead of reading it.
+    expect(await screen.findByText("Page 1")).toBeTruthy();
     expect(screen.getByLabelText("People per page")).toBeTruthy();
     // hasMore is true in the fixture, so forward is offered and back is not.
     expect(screen.getByText("Next").closest("button")?.disabled).toBe(false);
@@ -285,6 +290,65 @@ describe("Connect — People", () => {
       order[1].compareDocumentPosition(order[2]) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("renders one letter's whole page, in the server's sequence, with nothing dropped", async () => {
+    // The two tests above each hold half of the bug and neither holds it
+    // whole. "shows every match for a single typed letter" hands back three
+    // names that ALL begin with N, so the client-side prefix filter that
+    // caused the original bug passes it untouched. "preserves the directory's
+    // A-Z order" names three rows but never counts them, so a filter that
+    // drops a row nobody named goes unseen.
+    //
+    // This is the real server page for "n": a substring-only name the server
+    // sends and the old client hid (Anand), the first-name tier A-Z, then the
+    // surname tier below it. The contract is that the client renders the page
+    // it was handed -- so the COUNT is asserted alongside the SEQUENCE. A
+    // re-introduced filter fails the count; a re-introduced sort fails the
+    // sequence. Neither can pass by naming the right rows.
+    const PAGE_FOR_N = [
+      person("u-anand", "Anand"),
+      person("u-nilesh", "Nilesh"),
+      person("u-nirmal", "Nirmal"),
+      person("u-nolan", "Nolan"),
+      person("u-abdul", "Abdul Nasser"),
+    ];
+    mocks.searchDirectory.mockResolvedValue({
+      items: PAGE_FOR_N,
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "n" },
+    });
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
+    expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({
+      query: "n",
+      page: 1,
+    });
+
+    // Every row the server sent is on screen. Counting the per-row action
+    // rather than the names is what catches a row nobody thought to name.
+    await screen.findByText("Abdul Nasser");
+    expect(screen.getAllByRole("button", { name: "Connect" })).toHaveLength(
+      PAGE_FOR_N.length,
+    );
+
+    // ...and in the server's sequence, not a locally-sorted one. A client
+    // alphabetical sort would hoist "Abdul Nasser" to the top and drop
+    // "Anand" below the N-names; both are pinned here.
+    const rendered = PAGE_FOR_N.map((p) => screen.getByText(p.displayName));
+    for (let i = 0; i < rendered.length - 1; i += 1) {
+      expect(
+        rendered[i].compareDocumentPosition(rendered[i + 1]) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+
+    expect(screen.queryByText('No one matches "n"')).toBeNull();
   });
 
   it("says so when a search matches nobody", async () => {

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -51,6 +51,7 @@
     "native:voice:test": "npm run ios:voice:test && npm run android:voice:test",
     "ios:device:ui:test": "node ./scripts/native/assert-destructive-native-audit.mjs && bash ./scripts/native/ios-device-ui-test.sh",
     "verify:cache": "vitest run __tests__/services/cache-sync-mutation-cascade.test.ts __tests__/services/cache-service.test.ts __tests__/services/cache-hit-rate-contract.test.ts __tests__/services/use-stale-resource.test.tsx __tests__/services/use-stale-resource-lifecycle.test.tsx __tests__/services/pkm-cache.test.ts __tests__/services/pkm-domain-resource.test.ts",
+    "verify:connect-search": "vitest run __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts",
     "report:contributor-impact:pdf": "node ../.codex/skills/pr-governance-review/scripts/export_contributor_impact_pdf.mjs",
     "report:markdown:pdf": "node ./scripts/reports/export-markdown-pdf.mjs",
     "audit:analytics-sandbox": "node ./scripts/testing/run-observability-sandbox-audit.mjs",

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -10,6 +10,8 @@ cd "$REPO_ROOT"
 python3 scripts/ci/verify-pr-governance-sections.py
 python3 scripts/ci/verify-protected-pipeline-edits.py
 python3 scripts/ci/verify-protected-pipeline-edits.py --self-test
+python3 scripts/ci/verify-protected-behavior-tests.py
+python3 scripts/ci/verify-protected-behavior-tests.py --self-test
 python3 scripts/ci/verify-pr-base-policy.py --self-test
 python3 scripts/ci/verify-branch-governance-doc-consistency.py
 python3 scripts/ci/verify-branch-governance-doc-consistency.py --self-test

--- a/scripts/ci/verify-protected-behavior-tests.py
+++ b/scripts/ci/verify-protected-behavior-tests.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+
+"""Fail when a protected behaviour loses the tests that prove it.
+
+`main` waives REVIEW for the bypass cohort but never waives VALIDATION, so a
+test that runs in the pull-request lane is the only guard that applies equally
+to everyone -- every bypass user, every ``--admin`` merge. Wiring the Connect
+search pack into ``scripts/ci/web-targeted-check.sh`` does that.
+
+This closes the one hole that leaves: a deleted test is a green test. Here we
+assert the tests still EXIST -- named cases present, assertion count above a
+floor -- so gutting a suite fails the PR instead of quietly passing it.
+
+Read together: web-targeted-check.sh proves the behaviour still works, and this
+proves the proof is still there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "config" / "protected-behaviors.json"
+
+
+def check_entry(behavior: dict, root: Path) -> list[str]:
+    """Return a list of failure strings for one protected behaviour."""
+    errors: list[str] = []
+    name = behavior.get("name", "<unnamed>")
+
+    for spec in behavior.get("tests", []):
+        rel = spec["path"]
+        path = root / rel
+
+        if not path.is_file():
+            errors.append(
+                f"[{name}] {rel} is missing. It proves a behaviour that was "
+                f"fixed in {behavior.get('fixed_by', '<unknown>')}; deleting it "
+                f"makes the regression invisible. Restore it, or remove the "
+                f"entry from config/protected-behaviors.json in a PR that says why."
+            )
+            continue
+
+        source = path.read_text(encoding="utf-8")
+
+        for title in spec.get("required_titles", []):
+            if title not in source:
+                errors.append(
+                    f"[{name}] {rel} no longer contains the test "
+                    f'"{title}". Renaming is fine -- update the required_titles '
+                    f"entry in config/protected-behaviors.json in the same PR. "
+                    f"Deleting is not."
+                )
+
+        pattern = spec.get("assertion_pattern")
+        floor = int(spec.get("min_assertions", 0))
+        if pattern and floor:
+            found = len(re.findall(pattern, source, flags=re.MULTILINE))
+            if found < floor:
+                errors.append(
+                    f"[{name}] {rel} has {found} assertions, below the floor of "
+                    f"{floor}. A suite that loses assertions still passes, which "
+                    f"is exactly how a locked behaviour gets quietly unlocked."
+                )
+
+    return errors
+
+
+def self_test() -> int:
+    """Prove the checker actually fails -- an unfalsifiable gate is decoration."""
+    import tempfile
+
+    cases: list[tuple[str, dict, bool]] = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "t").mkdir()
+        good = "t/good.test.ts"
+        (root / good).write_text(
+            'it("keeps the thing", () => { expect(1).toBe(1); expect(2).toBe(2); });\n',
+            encoding="utf-8",
+        )
+
+        base = {
+            "name": "probe",
+            "fixed_by": "deadbeef",
+            "tests": [
+                {
+                    "path": good,
+                    "assertion_pattern": r"expect\(",
+                    "min_assertions": 2,
+                    "required_titles": ["keeps the thing"],
+                }
+            ],
+        }
+        cases.append(("intact suite passes", base, False))
+
+        missing = json.loads(json.dumps(base))
+        missing["tests"][0]["path"] = "t/gone.test.ts"
+        cases.append(("deleted file fails", missing, True))
+
+        renamed = json.loads(json.dumps(base))
+        renamed["tests"][0]["required_titles"] = ["a case that is not there"]
+        cases.append(("removed test case fails", renamed, True))
+
+        gutted = json.loads(json.dumps(base))
+        gutted["tests"][0]["min_assertions"] = 5
+        cases.append(("assertions below floor fails", gutted, True))
+
+        failures = 0
+        for label, behavior, expect_errors in cases:
+            errors = check_entry(behavior, root)
+            ok = bool(errors) == expect_errors
+            print(f"  {'ok  ' if ok else 'FAIL'}  {label}")
+            if not ok:
+                failures += 1
+
+    if failures:
+        print(f"self-test: {failures} case(s) behaved wrongly.")
+        return 1
+    print("self-test: all cases behaved as expected.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Verify this checker can actually fail, then exit.",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not POLICY_PATH.is_file():
+        print(f"ERROR: {POLICY_PATH} is missing.", file=sys.stderr)
+        return 1
+
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    behaviors = policy.get("protected_behaviors", [])
+    if not behaviors:
+        print("ERROR: config/protected-behaviors.json declares no behaviours.", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for behavior in behaviors:
+        errors.extend(check_entry(behavior, REPO_ROOT))
+
+    if errors:
+        print("ERROR: a protected behaviour lost the tests that prove it.\n", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}\n", file=sys.stderr)
+        return 1
+
+    checked = sum(len(b.get("tests", [])) for b in behaviors)
+    print(
+        f"Protected behaviour tests intact: {len(behaviors)} behaviour(s), "
+        f"{checked} test file(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/web-targeted-check.sh
+++ b/scripts/ci/web-targeted-check.sh
@@ -64,6 +64,26 @@ if has_match '^(hushh-webapp/(ios/|android/|capacitor\.config|scripts/native/|pu
   ran=1
 fi
 
+# Connect People search is an alphabetical index, not a filtered page (fixed in
+# 2afe801be). The behaviour lives in two halves that can disagree: the server
+# matches, ranks and orders ahead of LIMIT, and the client renders that page
+# unchanged. Re-introducing a client-side filter or sort on top of a paged
+# server result IS the original bug, and it is one merge-conflict resolution
+# away at all times -- branches cut before the fix still carry the old
+# `sortedPeople` filter verbatim, and a merge that resolves the wrong way puts
+# it straight back with nothing to notice.
+#
+# These tests already existed and already named the behaviour. They simply
+# never ran on a pull request: ci.yml has no vitest lane, so the full suite
+# only executes in the merge queue -- which every review-bypass user skips.
+# That asymmetry is why a red contract test sat unnoticed on main for a day.
+# Run them wherever the behaviour can be touched, including from the backend
+# half, because the client contract is "render the page you were handed".
+if has_match '^(hushh-webapp/(app/connect/|__tests__/app/connect/)|consent-protocol/(hushh_mcp/services/(connections_service|one_location_agent_service)\.py|api/routes/one/connections\.py))'; then
+  run_check "Connect people search" npm run verify:connect-search
+  ran=1
+fi
+
 if [ "$ran" -eq 0 ]; then
   echo "No focused web contract pack matched the changed files."
 fi


### PR DESCRIPTION
## What this answers

Nothing overrode the Connect People search fix. `2afe801be` is intact on `main` — byte for byte, across the client, the route and the SQL — and all five tests it added are still there with their assertions unweakened. Four independent forensic passes and three adversarial verifiers agree.

The reported symptom is **production**: `one.hushh.ai` runs `4c4a96201` (2026-08-12), two days before the fix merged and 400+ commits behind. Both prod halves — `hushh-webapp` and `consent-protocol` — predate it, so the old client-side filter and the old SQL compose into exactly the reported behaviour. UAT has the fix and serves it.

## The real defect this fixes

`.github/workflows/ci.yml` has **no vitest lane**. The suite that proves this behaviour runs only in the merge queue — which every review-bypass user skips. Review is bypassable here; validation is not. So the tests existed, named the behaviour precisely, and never ran on a pull request.

Two things happened because of that:

- A branch cut before the fix still carried the old `sortedPeople` client filter and reached `main` through a merge (`7c647f75e`) whose conflict was resolved correctly **only by hand**. One hunk the other way and the bug re-lands with nothing to notice.
- `page-client.contract.test.ts` sat **red on main** from 2026-08-15 to 2026-08-16 and nobody saw it.

## Changes

**Run the tests where they can catch something**
- `verify:connect-search` — both Connect suites, wired into `web-targeted-check.sh` on a path match covering the client *and* the server half. ~3s; skipped entirely on unrelated PRs, no new job.

**Make the tests able to fail**
- New frontend test asserts the **count** and the **sequence** of a one-letter page, including a substring-only name. The two existing tests each held half the bug — one used three names that all pass a prefix filter, the other named rows without counting them. Mutation-checked: re-introducing the old filter+sort fails 3 tests including this one.
- New backend test asserts the **order** of the `ORDER BY` keys, not their presence. Mutation-checked: moving the alphabetical key above the tier `CASE` **passes the existing test and fails this one** — and that mutation is precisely the "search went alphabetical" symptom.

**Stop a locked test being deleted**
- `config/protected-behaviors.json` + `scripts/ci/verify-protected-behavior-tests.py`: fails the PR when a protected suite loses a named case or drops below an assertion floor. A deleted test is a green test. Ships with a self-test that proves the checker can fail.

**Repair the stale contract test**
- It asserted dialog copy, so ordinary UI polish made it stale. It now pins the consent shape — nothing pre-granted in either direction, and no path that sends a request without opening the review sheet.

## Deploy authority (separate, same file)

| user | production | UAT | pipeline edit |
|---|---|---|---|
| `Roopmann30` | removed | removed | removed |
| `abdulbeast4-creator` | — | removed | — |
| `smirthi-dharma` | — | removed | — |
| `anoushkauoc` | — | removed | — |

`assert-governed-actor.py` reads this file from `main` at dispatch time in every governed workflow, so landing this is sufficient — no API call. Removing `Roopmann30` from `protected_pipeline_edit_users` is the one that closes the loop: without it, the restricted user could edit this policy file and restore themselves. **Dev is deliberately untouched**, so there is still a lane to self-test deploys in.

## Verification

- `npm run verify:connect-search` → 34 passed
- `pytest tests/services/test_one_location_agent_service.py tests/services/test_connections_service.py` → 138 passed
- `verify-protected-behavior-tests.py` + `--self-test` → pass
- Both mutation checks confirmed the new tests fail on the regression and the old ones do not
- Rebased onto `8825a2031`

**Not verified:** no production deploy, no iOS build — both are explicitly out of scope here.