### PR TITLE
fix(one-location): tighten Location copy, rename the Now tab, drop two dead controls

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -779,7 +779,7 @@ async function openLocationPermissionsStep() {
 }
 
 async function switchLocationTab(
-  name: "Now" | "People" | "Links",
+  name: "Menu" | "People" | "Links",
   expectedHeading: string,
 ) {
   fireEvent.click(screen.getByRole("button", { name }));
@@ -1784,7 +1784,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByPlaceholderText("Search trusted people"),
     ).toHaveValue("Investor");
-    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+    fireEvent.click(screen.getByRole("button", { name: "Menu" }));
     fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
@@ -2836,7 +2836,7 @@ describe("OneLocationAgentPage", () => {
     );
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+    fireEvent.click(screen.getByRole("button", { name: "Menu" }));
     expect(screen.getByRole("button", { name: /Active shares/i })).toBeTruthy();
     await openSharePersonStep();
     fireEvent.change(screen.getByPlaceholderText("Search trusted people"), {

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { TOP_SHELL_TAB_REGISTRY } from "@/lib/navigation/top-shell-tabs";
+import { resolveTopShellBreadcrumb } from "@/lib/navigation/top-shell-breadcrumbs";
+
+const repoFile = (...segments: string[]) =>
+  fs.readFileSync(path.resolve(__dirname, "../..", ...segments), "utf8");
+
+const HUB_SOURCE = repoFile(
+  "components/one-location/redesign/location-redesign-hub.tsx",
+);
+const CONNECT_SOURCE = repoFile("app/connect/page-client.tsx");
+
+/**
+ * The duration ceiling is owned by the consent protocol, not by the web app.
+ * Reading it out of the Python policy rather than hardcoding 24 here is the
+ * point of the test: if someone raises or lowers the server bound, the
+ * assertion below moves with it instead of quietly going stale.
+ */
+const LOCATION_POLICY_SOURCE = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../../consent-protocol/hushh_mcp/operons/location/policy.py",
+  ),
+  "utf8",
+);
+
+function serverMaxShareHours(): number {
+  const match = /^MAX_LOCATION_SHARE_HOURS\s*=\s*([\d.]+)/m.exec(
+    LOCATION_POLICY_SOURCE,
+  );
+  if (!match) {
+    throw new Error(
+      "MAX_LOCATION_SHARE_HOURS not found in the location policy operon — " +
+        "the duration ceiling moved and this contract needs re-pointing.",
+    );
+  }
+  return Number.parseFloat(match[1]);
+}
+
+/** Every `{ value: "…", label: "…" }` duration option authored in the hub. */
+function durationOptionsIn(source: string): { value: string; label: string }[] {
+  return [...source.matchAll(/\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)"\s*\}/g)]
+    .map((m) => ({ value: m[1], label: m[2] }));
+}
+
+describe("One Location — link durations stay inside the server's ceiling", () => {
+  it("offers no invite duration the API would reject", () => {
+    // The invite picker used to offer "7 days" (168h). CreateCircleInviteRequest
+    // bounds durationHours at `le=24` and normalize_duration_hours raises
+    // "between 15 minutes and 24 hours", so picking it returned HTTP 422 —
+    // a control that could only ever fail, with no explanation on screen.
+    const start = HUB_SOURCE.indexOf('<SectionCard title="Invite expires after">');
+    expect(start).toBeGreaterThan(-1);
+    const inviteSection = HUB_SOURCE.slice(start, start + 1200);
+
+    const max = serverMaxShareHours();
+    const numeric = durationOptionsIn(inviteSection)
+      .map((option) => Number.parseFloat(option.value))
+      .filter((hours) => Number.isFinite(hours));
+
+    expect(numeric.length).toBeGreaterThan(0);
+    for (const hours of numeric) {
+      expect(hours).toBeLessThanOrEqual(max);
+    }
+    expect(inviteSection).not.toContain('label: "7 days"');
+  });
+
+  it("states the real ceilings rather than a vague promise", () => {
+    // "Links expire automatically" / "after the time you choose" told the owner
+    // nothing they could plan around.
+    expect(HUB_SOURCE).toContain("up to 1 hour for a location link");
+    expect(HUB_SOURCE).not.toContain("Links expire after the time you choose.");
+  });
+});
+
+describe("One Location — hub tab naming", () => {
+  const locationTabs = TOP_SHELL_TAB_REGISTRY.location;
+
+  it("labels the first tab Menu while keeping its `now` query value", () => {
+    const first = locationTabs.tabs[0];
+    expect(first.label).toBe("Menu");
+    // The value is the deep-link contract (`?view=now`, Kai's
+    // `location.open_now`). Renaming the label must not move it.
+    expect(first.value).toBe("now");
+    expect(locationTabs.defaultValue).toBe("now");
+  });
+});
+
+describe("One Location — the Request location trail agrees with the screen", () => {
+  it("uses one spelling for the crumb, the flow title and the hub row", () => {
+    const params = new URLSearchParams({ action: "ask" });
+    const crumbs = resolveTopShellBreadcrumb("/one/location", params);
+    const last = crumbs?.items.at(-1)?.label;
+
+    expect(last).toBe("Request location");
+    // The header contract: the last crumb IS the screen's title.
+    expect(HUB_SOURCE).toContain(`<TaskFlowHeader title="${last}" />`);
+    // …and the hub row that opens it names the same thing.
+    expect(HUB_SOURCE).toContain(`title="${last}"`);
+    expect(HUB_SOURCE).not.toContain('title="Request Location"');
+  });
+});
+
+describe("Connect — no dead Scopes viewer", () => {
+  it("drops the per-connection Scopes control and its dialog", () => {
+    // It opened a read-only dialog of raw scope handles with every row
+    // disabled: nothing to act on, and mostly the internal handle string.
+    // Match the rendered label expression, not the bare word — the source
+    // still explains in a comment why the control is gone.
+    expect(CONNECT_SOURCE).not.toMatch(/\?\s*"Loading…"\s*:\s*"Scopes"/);
+    expect(CONNECT_SOURCE).not.toMatch(/>\s*Scopes\s*</);
+    expect(CONNECT_SOURCE).not.toContain("viewInformationScopes");
+    expect(CONNECT_SOURCE).not.toContain("informationScopeDraft");
+    expect(CONNECT_SOURCE).not.toContain("ConnectionInformationScopeCatalog");
+  });
+
+  it("keeps Remove, the control that still does something", () => {
+    expect(CONNECT_SOURCE).toContain("pendingRemoveId");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -36,9 +36,9 @@ describe("One Location settings placement", () => {
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
     expect(nowSource).toContain('testId="one-location-request-row"');
-    expect(nowSource).toContain('title="Request Location"');
+    expect(nowSource).toContain('title="Request location"');
 
-    const requestIndex = nowSource.indexOf('title="Request Location"');
+    const requestIndex = nowSource.indexOf('title="Request location"');
     const settingsIndex = nowSource.indexOf('title="Settings"');
     expect(requestIndex).toBeGreaterThan(-1);
     expect(settingsIndex).toBeGreaterThan(requestIndex);
@@ -65,7 +65,7 @@ describe("One Location settings placement", () => {
       return /icon=\{(\w+)\}/.exec(nowSource.slice(rowStart, titleIndex))?.[1];
     };
 
-    const requestIcon = iconFor("Request Location");
+    const requestIcon = iconFor("Request location");
     const shareIcon = iconFor("Share location");
 
     expect(requestIcon).toBeTruthy();

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -549,7 +549,7 @@ describe("top shell breadcrumbs", () => {
       // one flow whose back target is not the hub (it retraces to whoever
       // opened it), so its label and back href are asserted separately below.
       ["share", "Share location"],
-      ["ask", "Ask someone"],
+      ["ask", "Request location"],
       ["invite", "Invite to Circle"],
       ["temp-link", "Public link"],
       ["settings", "Settings"],

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -41,7 +41,6 @@ import { Button } from "@/lib/morphy-ux/button";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import {
   ConnectionsService,
-  type ConnectionInformationScopeCatalog,
   type ConnectionRelationship,
   type ConnectionScopeCatalog,
   type ConnectionSummaryEntry,
@@ -240,11 +239,6 @@ export default function ConnectPageClient() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
-  const [informationScopeDraft, setInformationScopeDraft] = useState<{
-    connection: ConnectionSummaryEntry;
-    catalog: ConnectionInformationScopeCatalog;
-  } | null>(null);
-  const [informationScopeQuery, setInformationScopeQuery] = useState("");
   const [scopeDraft, setScopeDraft] = useState<{
     person: DirectoryPerson;
     catalog: ConnectionScopeCatalog;
@@ -539,38 +533,11 @@ export default function ConnectPageClient() {
     [user],
   );
 
-  const viewInformationScopes = useCallback(
-    async (connection: ConnectionSummaryEntry) => {
-      if (!user) return;
-      try {
-        setBusyId(connection.connectionId);
-        const idToken = await user.getIdToken();
-        const catalog = await ConnectionsService.searchInformationScopes({
-          idToken,
-          counterpartUserId: connection.userId,
-          limit: 50,
-        });
-        setInformationScopeQuery("");
-        setInformationScopeDraft({ connection, catalog });
-      } catch (scopeError) {
-        toast.error(
-          scopeError instanceof Error
-            ? scopeError.message
-            : "Could not load available scopes",
-        );
-      } finally {
-        setBusyId(null);
-      }
-    },
-    [user],
-  );
-
-  const visibleInformationScopes = informationScopeDraft?.catalog.items.filter(
-    (item) => {
-      const query = informationScopeQuery.trim().toLowerCase();
-      return !query || `${item.label ?? ""} ${item.scope}`.toLowerCase().includes(query);
-    },
-  );
+  // The per-connection "Scopes" viewer is deliberately absent. It opened a
+  // read-only dialog of raw scope handles with every row disabled — no action,
+  // no explanation, and mostly the internal handle string itself. Connect
+  // currently carries a single real capability, so the list told people
+  // nothing they could act on. Bring it back with the surface it describes.
 
   const handleConnectMultiple = useCallback(async () => {
     if (!user || !batchConnectDraft || batchConnectDraft.people.length === 0) return;
@@ -1194,17 +1161,6 @@ export default function ConnectPageClient() {
                     density="compact"
                     trailing={
                       <span className="flex shrink-0 items-center justify-end gap-1.5 whitespace-nowrap">
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fade"
-                          size="sm"
-                          className={CONNECT_INLINE_BUTTON_CLASSNAME}
-                          disabled={busyId === connection.connectionId}
-                          onClick={() => void viewInformationScopes(connection)}
-                        >
-                          {busyId === connection.connectionId ? "Loading…" : "Scopes"}
-                        </Button>
                         {pendingRemoveId === connection.connectionId ? (
                           <>
                             <Button
@@ -1816,62 +1772,6 @@ export default function ConnectPageClient() {
       </Dialog>
 
 
-      <Dialog
-        open={informationScopeDraft !== null}
-        onOpenChange={(open) => {
-          if (!open) setInformationScopeDraft(null);
-        }}
-      >
-        <DialogContent className="gap-5">
-          <DialogHeader className="text-left">
-            <DialogTitle>Available details</DialogTitle>
-            <DialogDescription>
-              They choose what appears here.
-            </DialogDescription>
-          </DialogHeader>
-          <Input
-            type="search"
-            value={informationScopeQuery}
-            onChange={(event) => setInformationScopeQuery(event.target.value)}
-            placeholder="Search details"
-            aria-label="Search details"
-          />
-          <div className="max-h-[45vh] overflow-y-auto">
-            {visibleInformationScopes && visibleInformationScopes.length > 0 ? (
-              <SettingsGroup title="Available" separatorInset>
-                {visibleInformationScopes.map((item) => (
-                  <SettingsRow
-                    key={item.scope}
-                    title={item.label || item.scope}
-                    description={item.scope}
-                    density="compact"
-                    disabled
-                  />
-                ))}
-              </SettingsGroup>
-            ) : (
-              <SettingsGroup title="No matches" separatorInset>
-                <SettingsRow
-                  title="Nothing found"
-                  description="Private details stay hidden."
-                  density="compact"
-                  disabled
-                />
-              </SettingsGroup>
-            )}
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="none"
-              effect="fade"
-              onClick={() => setInformationScopeDraft(null)}
-            >
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
       {showLimitBanner && (
         <div className="fixed top-16 left-1/2 -translate-x-1/2 z-[9999] w-[92%] max-w-md rounded-2xl bg-popover/95 backdrop-blur-md p-3.5 shadow-xl border border-border/50 flex items-center justify-between gap-3 animate-in fade-in slide-in-from-top-3 duration-200">
           <span className="text-xs font-medium text-foreground">

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2261,8 +2261,13 @@ function LinksHub({
     <div className="space-y-4">
       <div className="px-[6px]">
         <SectionTitle as="h2">Active links</SectionTitle>
+        {/* This section lists two different things — a live location link and
+            a Circle invite link — and the invite shares no location at all.
+            Copy that described only the first was wrong for half the list,
+            and neither told a new user what a "link" is here. */}
         <RowDescription as="p" className="mt-1">
-          Share your live location outside your Circle.
+          Links you can send to anyone — to show where you are, or to invite
+          them to a Circle.
         </RowDescription>
       </div>
 
@@ -2307,7 +2312,8 @@ function LinksHub({
       <div className="flex items-start gap-2 px-1">
         <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         <p className={MUTED_TEXT}>
-          Links expire after the time you choose.
+          You choose how long — up to 1 hour for a location link, 24 hours for
+          an invite.
         </p>
       </div>
     </div>
@@ -2543,7 +2549,11 @@ function ShareFlow({
                 {shareEndsAtLabel(vm.shareDurationHours, nowMs)}
               </p>
             </div>
-            <div className="space-y-2">
+            {/* space-y-2.5 matches DurationSelector's own label→control gap
+                above. The two label/field pairs sit in the same card, so an
+                8px gap under one and 10px under the other reads as a
+                mistake. */}
+            <div className="space-y-2.5">
               <label
                 htmlFor="one-location-share-note"
                 className="text-sm font-semibold text-foreground"
@@ -3144,10 +3154,15 @@ function InviteFlow({
           value={vm.durationHours}
           onChange={vm.setDurationHours}
           label=""
+          // 24 hours is the ceiling, not a preference. The API rejects
+          // anything above it (`duration_hours … le=24` on
+          // CreateCircleInviteRequest) and `normalize_duration_hours` raises
+          // "between 15 minutes and 24 hours", so the "7 days" option that
+          // used to sit here could only ever return HTTP 422 — an invite the
+          // owner watched fail with no idea why.
           options={[
             { value: "1", label: "1 hour" },
             { value: "24", label: "24 hours" },
-            { value: "168", label: "7 days" },
           ]}
         />
       </SectionCard>

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -55,7 +55,11 @@ function titleizeSegment(segment: string): string {
 function oneLocationActionLabel(action: string): string {
   const labels: Record<string, string> = {
     share: "Share location",
-    ask: "Request Location",
+    // Sentence case, matching every sibling crumb ("Share location", "Active
+    // shares", "Public link") and the screen's own TaskFlowHeader title. The
+    // crumb and the title must read as the same words or the trail and the
+    // screen stop agreeing.
+    ask: "Request location",
     invite: "Invite to Circle",
     "temp-link": "Public link",
     "check-in": "Check-In",

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -85,7 +85,12 @@ export const TOP_SHELL_TAB_REGISTRY = {
     queryParam: "view",
     defaultValue: "now",
     tabs: [
-      { value: "now", label: "Now", href: "/one/location" },
+      // Labelled "Menu", not "Now". Nothing on this tab is time-scoped — it
+      // holds Share location, Your Map, Settings and the rest of the action
+      // list, so "Now" promised live status the tab never showed. The `value`
+      // stays "now" so existing `?view=now` links and Kai's
+      // `location.open_now` action keep resolving.
+      { value: "now", label: "Menu", href: "/one/location" },
       {
         value: "people",
         label: "People",

--- a/hushh-webapp/lib/one-location/kai-circle-ctas.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-ctas.ts
@@ -54,7 +54,7 @@ export function resolveKaiCircleCtas(params: {
   } else {
     ctas.push({
       id: "request_location",
-      label: "Request Location",
+      label: "Request location",
       enabled: viewerCapabilities?.canRequestLocation !== false,
       reason:
         viewerCapabilities?.hasLocationRecipientKey === false


### PR DESCRIPTION
From Ankit's 15 annotated UAT screenshots. **19 of the 26 annotated items were already fixed on `main`** between when the screenshots were taken and now — this PR closes the 7 that were genuinely still open, plus two real bugs found while sourcing the copy.

## Bugs

**The "7 days" invite-link option could only ever fail.** `CreateCircleInviteRequest.duration_hours` is bounded `le=24`, and `normalize_duration_hours` raises "between 15 minutes and 24 hours", so picking 7 days returned HTTP 422 — an invite the owner watched fail with no explanation. Option removed; the new contract test reads `MAX_LOCATION_SHARE_HOURS` out of the policy operon so the picker cannot drift from the server again.

**`main` was red on 3 assertions.** Commit `7220cda7c` renamed the ask crumb but never updated its tests. Fixed, and the spelling unified: crumb, `TaskFlowHeader` title, hub row and Kai CTA now all read **Request location** (sentence case, like every sibling crumb). Previously the crumb said `Request Location` and the title said `Request location` — a mismatch `location-header-system` explicitly forbids.

## Screenshot items closed

| Item | Change |
|---|---|
| Share step 2 | "Optional note" label→field gap 8px → 10px, matching the Duration pair in the same card |
| Hub tabs | "Now" → **"Menu"**. Nothing on that tab is time-scoped — it holds Share location, Your Map, Settings. `value` stays `now`, so `?view=now` and `location.open_now` keep resolving |
| Links tab | Subheading now covers both rows and defines the noun. It previously said "Share your live location outside your Circle" — false for the Circle invite, which shares no location |
| Links tab | Expiry footnote states the real ceilings instead of "after the time you choose" |
| Ask screen | Crumb → "Request location" (see above) |
| Connect | Per-connection **Scopes** button and its dialog removed — it opened a read-only list of raw scope handles with every row `disabled`. Nothing to act on |

## Deliberately not changed

- **"Request with context" as the ask heading.** #5309 renamed it to "Request location", and the header contract requires title == last crumb. Keeping "Request location" satisfies both; "Request with context" would reintroduce the drift.
- **"Ask to refresh".** Already exists — inside the staleness alert, which is where it belongs. A permanently visible button would be noise when the location is fresh.

## Verification

- `tsc --noEmit`: clean
- `verify:design-system` (design system + accent tokens + Apple hierarchy): all pass
- eslint on every changed file, `--max-warnings=0`: clean
- **Baselined against `origin/main`**: main 16 failures → branch 13. **Zero regressions**; the 3 fixed are the stale-rename ones. The other 13 are pre-existing and unrelated (profile stack, page sections, capability intro).
- New contract test mutation-checked: all 5 behaviour-locking assertions fail on reverted source.