### PR TITLE
fix(one-location): make one-letter search work for Indic names, and fix the fourth dead CTA

### DIFF
--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
@@ -11,6 +11,7 @@ import {
   CircleGrowActions,
   CircleInvitePeopleSheet,
 } from "@/components/one-location/redesign/circles/circle-grow-actions";
+import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -92,6 +93,77 @@ describe("CircleGrowActions", () => {
 describe("CircleInvitePeopleSheet", () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("paints its blocked Select people CTA the same as the Circle detail copy", async () => {
+    // This sheet exists twice — here, reached from Check-In, and in the Circle
+    // detail flow. A user meeting the same sheet by a different route must not
+    // see a different button, so both read the one BLOCKED_CTA definition.
+    render(
+      <CircleInvitePeopleSheet
+        open
+        onOpenChange={vi.fn()}
+        circleId="circle-1"
+        circleName="Meena Family"
+        onLoadEligibleConnections={vi.fn().mockResolvedValue({
+          eligibleConnections: [
+            {
+              userId: "conn-1",
+              displayName: "Asha Meena",
+              connectionOrigin: "one" as const,
+            },
+          ],
+          pendingInvites: [],
+          remainingCapacity: 5,
+        })}
+        onInviteConnections={vi.fn().mockResolvedValue(undefined)}
+        onCancelMemberInvite={vi.fn()}
+      />,
+    );
+
+    const cta = await screen.findByRole("button", { name: "Select people" });
+    expect(cta).toBeDisabled();
+    for (const rule of BLOCKED_CTA.split(" ")) {
+      expect(cta.className).toContain(rule);
+    }
+    // The half-opacity accent fill is what made a blocked button read as live.
+    expect(cta.className).not.toContain("disabled:opacity-50");
+  });
+
+  it("finds a connection from the first letter here too", async () => {
+    render(
+      <CircleInvitePeopleSheet
+        open
+        onOpenChange={vi.fn()}
+        circleId="circle-1"
+        circleName="Meena Family"
+        onLoadEligibleConnections={vi.fn().mockResolvedValue({
+          eligibleConnections: [
+            {
+              userId: "conn-1",
+              displayName: "Asha Meena",
+              connectionOrigin: "one" as const,
+            },
+            {
+              userId: "conn-2",
+              displayName: "Neel Shah",
+              connectionOrigin: "one" as const,
+            },
+          ],
+          pendingInvites: [],
+          remainingCapacity: 5,
+        })}
+        onInviteConnections={vi.fn().mockResolvedValue(undefined)}
+        onCancelMemberInvite={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Asha Meena")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Search connections"), {
+      target: { value: "n" },
+    });
+    expect(screen.getByText("Neel Shah")).toBeTruthy();
+    expect(screen.queryByText("Asha Meena")).toBeNull();
   });
 
   it("cancels a pending invitation and reloads eligibility", async () => {

--- a/hushh-webapp/components/one-location/redesign/circles/blocked-cta.ts
+++ b/hushh-webapp/components/one-location/redesign/circles/blocked-cta.ts
@@ -1,0 +1,16 @@
+/**
+ * A primary action that cannot fire yet has to LOOK like it cannot fire.
+ *
+ * The shared button only dims to 50% opacity, and half-opacity accent over
+ * these light sheets still reads as a live button — so "Create circle" and
+ * "Select people" were reported as broken rather than understood as blocked.
+ * This is the neutral disabled fill the Location hub's own primary CTAs
+ * already use; nothing new is invented here.
+ *
+ * It lives in its own module because the add-people sheet exists TWICE — once
+ * in the Circle detail flow and once in the Circle grow actions reached from
+ * Check-In — and the two must not drift into looking different depending on
+ * which entry point the same user took.
+ */
+export const BLOCKED_CTA =
+  "disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35";

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -43,6 +43,7 @@ import type {
   OneLocationCircleMemberInvite,
 } from "@/lib/one-location/types";
 import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { cn } from "@/lib/utils";
 
 function circleInitials(value: string): string {
@@ -383,7 +384,10 @@ export function CircleInvitePeopleSheet({
             }
             isLoading={submitting}
             onClick={() => void sendInvites()}
-            className="h-12 w-full shrink-0 rounded-full text-base font-semibold"
+            className={cn(
+              "h-12 w-full shrink-0 rounded-full text-base font-semibold",
+              BLOCKED_CTA,
+            )}
           >
             {selectedIds.size
               ? `Invite ${selectedIds.size} ${

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -58,6 +58,7 @@ import type {
   OneLocationCircleSummary,
 } from "@/lib/one-location/types";
 import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { cn } from "@/lib/utils";
 
 const CIRCLES_GROUP_SURFACE =
@@ -65,17 +66,6 @@ const CIRCLES_GROUP_SURFACE =
 
 const CIRCLES_EMPTY_STATE_WRAPPER =
   "[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]";
-
-/**
- * A primary action that cannot fire yet has to LOOK like it cannot fire.
- * The shared button only dims to 50% opacity, and half-opacity accent over
- * these light sheets still reads as a live button — so "Create circle" and
- * "Select people" were reported as broken rather than understood as blocked.
- * This is the neutral disabled fill the Location hub's own primary CTAs
- * already use, so nothing new is being invented here.
- */
-const BLOCKED_CTA =
-  "disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35";
 
 function circleInitials(value: string): string {
   return value

--- a/hushh-webapp/lib/one-location/__tests__/people-search.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/people-search.test.ts
@@ -96,6 +96,31 @@ describe("filterPeopleByQuery", () => {
     ).toEqual([people[0]]);
   });
 
+  it("keeps an Indic name whole instead of splitting it at every matra", () => {
+    // A matra is a combining mark, not a letter. Without \p{M} in the word
+    // boundary, "झुम्मा" splits into ["झ","म","म",""] and every syllable reads
+    // as a separate word — so a mid-word letter counts as a beginning and a
+    // genuine match gets dropped.
+    const people = ["सुमन", "कमल"];
+
+    expect(filterPeopleByQuery(people, "म", nameOf)).toEqual(people);
+    expect(filterPeopleByQuery(["झुम्मा", "नीलेश"], "झ", nameOf)).toEqual([
+      "झुम्मा",
+    ]);
+    expect(filterPeopleByQuery(["नीलेश", "सुमन"], "न", nameOf)).toEqual([
+      "नीलेश",
+    ]);
+  });
+
+  it("still finds an Indic name by a syllable inside it", () => {
+    expect(filterPeopleByQuery(["नीलेश मीणा"], "मी", nameOf)).toEqual([
+      "नीलेश मीणा",
+    ]);
+    expect(filterPeopleByQuery(["झुम्मा कुमारी"], "कु", nameOf)).toEqual([
+      "झुम्मा कुमारी",
+    ]);
+  });
+
   it("drops a person no part of whose text matches", () => {
     const people = ["Ankit Kumar Singh", "Neelesh Meena"];
 

--- a/hushh-webapp/lib/one-location/people-search.ts
+++ b/hushh-webapp/lib/one-location/people-search.ts
@@ -20,10 +20,17 @@
  * follow, so `ingh` still finds Singh.
  */
 
-/** Anything that is not a letter or a digit separates one word from the next,
- *  which keeps "Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader
- *  would split them. */
-const WORD_BOUNDARY = /[^\p{L}\p{N}]+/u;
+/** Anything that is not a letter, a digit, or a combining mark separates one
+ *  word from the next, which keeps "Jean-Luc", "O'Brien" and "R. Meena"
+ *  splitting the way a reader would split them.
+ *
+ *  `\p{M}` is what makes this work for Indic names. A matra is a combining
+ *  mark, not a letter, so without it "झुम्मा" splits into ["झ","म","म",""] and
+ *  "नीलेश" into ["न","ल","श"] — every syllable read as a separate word. Word
+ *  beginnings then mean nothing, and a one-letter query can rank a mid-word
+ *  hit as a beginning and drop a real match. With `\p{M}` both stay whole.
+ *  `normalizeSpokenName` in the Location page already treats marks this way. */
+const WORD_BOUNDARY = /[^\p{L}\p{N}\p{M}]+/u;
 
 function normalize(value: string): string {
   return value.trim().toLocaleLowerCase();


### PR DESCRIPTION
Follow-up to #5317. Both of these were found by auditing that change, not by a second bug report.

### 1. One-letter search did not actually work for Indic names

A matra is a combining mark, not a letter, so `\p{L}\p{N}` treated every one as a word separator:

| name | before | after |
|---|---|---|
| `झुम्मा` | `["झ","म","म",""]` | `["झुम्मा"]` |
| `नीलेश` | `["न","ल","श"]` | `["नीलेश"]` |
| `सुमन` | `["स","मन"]` | `["सुमन"]` |

With every syllable read as its own word, "begins a word" meant nothing for these names. A mid-word letter could rank as a beginning, and since a one-character query keeps only beginners, a real match could be dropped — typing `म` over `[सुमन, कमल]` returned `सुमन` alone.

Adding `\p{M}` keeps the name whole. This is the same treatment `normalizeSpokenName` in the Location page already applies to marks, so search now agrees with it.

This never regressed against `main` — the old `includes()` filter was equally mark-blind — but the fix shipped in #5317 did not deliver its promise for a large share of this product's actual users.

### 2. The fourth "Select people" CTA was still dead-looking

The add-people sheet exists **twice**: in the Circle detail flow, and in `CircleGrowActions` reached from Check-In. #5317 applied the neutral disabled fill to three CTAs and missed this one, so the same sheet looked different depending on which route the user took to reach it.

Both now read a single `BLOCKED_CTA` definition — which is why it moved into its own module rather than being copied a third time.

### Verification

- `people-search.test.ts` — 13 tests. The two new Indic cases are mutation-checked: reverting `\p{M}` fails them.
- `circle-grow-actions.test.tsx` — the Check-In copy of the sheet had **no** coverage for either behaviour; it now asserts the blocked CTA carries every `BLOCKED_CTA` rule and no longer carries `disabled:opacity-50`, and that one-letter search filters. That is what stops the two copies drifting again.
- 44 tests pass across the circle + search suites; `tsc --noEmit`, eslint and prettier clean.