### PR TITLE
fix(one-location,feed): let the recipient see the share, and search a name not a blurb

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 151,
+  "expected_migration_version": 152,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 151,
+  "expected_migration_version": 152,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 151,
+  "expected_migration_version": 152,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/152_feed_events_recipient_fanout.sql
+++ b/consent-protocol/db/migrations/152_feed_events_recipient_fanout.sql
@@ -1,0 +1,98 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 152: the person a location is shared WITH gets a Feed row
+-- ============================================================================
+-- Migration 117 fans one_location_events out into feed_events, and writes
+-- every row to NEW.owner_user_id -- the person who shared. The person shared
+-- WITH was never written a row at all.
+--
+-- So: Ankit shares his location with Jamai. Ankit's Feed says "Started
+-- sharing location". Jamai's Feed says nothing, and keeps saying nothing when
+-- the share stops or expires. Jamai's only signal was the push notification,
+-- which is gone the moment it is dismissed. The reported symptom was "the feed
+-- is not real time" -- but for the recipient the row did not exist at any
+-- refresh rate, so no amount of polling was ever going to show it.
+--
+-- The three share-lifecycle events are the ones a recipient is owed, because
+-- each changes what that person can see:
+--   location_share_created  -- someone's location is now visible to you
+--   location_share_revoked  -- it is not any more
+--   location_share_expired  -- it ran out
+--
+-- Requests and approvals are deliberately NOT mirrored: those already notify
+-- the side that has to act, and the owner's row names the decision they made.
+--
+-- WHY A SECOND TRIGGER RATHER THAN EDITING THE FIRST
+-- feed_events_from_one_location_events() is being changed in parallel to
+-- de-duplicate approval-born shares. Two migrations doing CREATE OR REPLACE on
+-- one function means whichever lands second silently reverts the other. This
+-- is an independent concern -- a different audience, not different filtering --
+-- so it gets its own function and its own trigger, and the two compose in
+-- either merge order.
+--
+-- one_location_events remains the domain's audit authority and is untouched.
+-- feed_events stays presentation-only: the row carries a display label and no
+-- ciphertext, no coordinates, no vault-protected content.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION feed_events_recipient_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  owner_label TEXT;
+BEGIN
+  -- A share with no recipient, or one a person made to themselves, has no
+  -- second audience to write to.
+  IF NEW.recipient_user_id IS NULL
+     OR NEW.recipient_user_id = NEW.owner_user_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type NOT IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_expired'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- The event's own `counterpart_label` was resolved for the owner's row, so it
+  -- holds the RECIPIENT's name -- reading it back to the recipient would show
+  -- them their own name. The counterpart from this side is the owner.
+  SELECT NULLIF(BTRIM(COALESCE(display_name, '')), '')
+    INTO owner_label
+    FROM actor_identity_cache
+   WHERE user_id = NEW.owner_user_id;
+
+  INSERT INTO feed_events (
+    user_id, source_domain, event_type, metadata, source_row_id
+  )
+  VALUES (
+    NEW.recipient_user_id,
+    'location',
+    NEW.event_type,
+    COALESCE(NEW.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+           -- Read by the client to pick wording. Without it the recipient's
+           -- revoke row renders the owner's sentence, "You stopped sharing
+           -- location", to the one person who did not.
+           'feed_audience', 'recipient',
+           'counterpart_label', COALESCE(owner_label, 'A trusted person')
+         ),
+    NEW.id::TEXT
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_recipient_from_one_location_events() IS
+  'Fans share-lifecycle one_location_events out to the RECIPIENT feed, with the owner as counterpart. Companion to the owner-scoped feed_events_from_one_location_events().';
+
+DROP TRIGGER IF EXISTS one_location_events_feed_fanout_recipient ON one_location_events;
+CREATE TRIGGER one_location_events_feed_fanout_recipient
+  AFTER INSERT ON one_location_events
+  FOR EACH ROW
+  EXECUTE FUNCTION feed_events_recipient_from_one_location_events();
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/152_feed_events_recipient_fanout.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/152_feed_events_recipient_fanout.rollback.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- Roll back migration 152: stop writing the recipient's copy of a location
+-- share Feed row.
+--
+-- Only the trigger and its function are dropped. Rows already written to
+-- recipients are LEFT IN PLACE: they are a true record of shares those people
+-- really received, and deleting them would silently remove activity from
+-- someone's Feed. They render correctly without the trigger, since the
+-- wording is chosen client-side from the row's own `feed_audience` value.
+--
+-- feed_events_from_one_location_events() (the owner-scoped fan-out) is not
+-- touched here — it is a separate function and predates this migration.
+
+DROP TRIGGER IF EXISTS one_location_events_feed_fanout_recipient ON one_location_events;
+DROP FUNCTION IF EXISTS feed_events_recipient_from_one_location_events();
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -129,7 +129,8 @@
     "148_nws_nearby_marketplace_actions.sql",
     "149_external_crm_dynamic_registry.sql",
     "150_one_location_until_stopped_grants.sql",
-    "151_feed_events_dedupe_approved_share.sql"
+    "151_feed_events_dedupe_approved_share.sql",
+    "152_feed_events_recipient_fanout.sql"
   ],
   "groups": {
     "iam": [
@@ -213,7 +214,8 @@
       "148_nws_nearby_marketplace_actions.sql",
       "149_external_crm_dynamic_registry.sql",
       "150_one_location_until_stopped_grants.sql",
-      "151_feed_events_dedupe_approved_share.sql"
+      "151_feed_events_dedupe_approved_share.sql",
+      "152_feed_events_recipient_fanout.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -450,6 +450,27 @@ def _circle_invite_url(token: str) -> str:
     return f"/one/location/invite/{token}"
 
 
+#: Characters that separate one word of a name from the next, folded to spaces
+#: before a directory search compares anything. Names are not stored tidily --
+#: "Abdul-Rashid", "Abdul R.", "O'Brien" -- and a reader treats all of these as
+#: two words, so the search has to as well.
+#:
+#: Both sides of the comparison MUST use this one list: the stored name is
+#: folded by ``_DIRECTORY_SEPARATOR_SQL`` inside the statement, the typed query
+#: by ``_DIRECTORY_SEPARATOR_FOLD`` in Python. When only one side was folded,
+#: every name carrying punctuation became unsearchable.
+_DIRECTORY_SEPARATORS = "-'._/,"
+_DIRECTORY_SEPARATOR_FOLD = str.maketrans(_DIRECTORY_SEPARATORS, " " * len(_DIRECTORY_SEPARATORS))
+#: The SQL half of the same fold, written out so a test can assert the
+#: statement below still contains exactly this and nothing has drifted.
+_DIRECTORY_SEPARATOR_SQL = (
+    "TRANSLATE(LOWER(BTRIM(COALESCE(a.display_name, ''))), '{}', '{}')".format(
+        _DIRECTORY_SEPARATORS.replace("'", "''"),
+        " " * len(_DIRECTORY_SEPARATORS),
+    )
+)
+
+
 def _identity_display_label(row: dict[str, Any] | None, fallback: str = "A trusted person") -> str:
     if not row:
         return fallback
@@ -3266,7 +3287,23 @@ class OneLocationAgentService:
         # here, so it cannot use this to request an unbounded directory.
         limit = max(1, min(int(limit or 20), 100))
         offset = (page - 1) * limit
-        needle = (query or "").strip().lower()
+        # Fold the typed query exactly the way the stored name is folded.
+        #
+        # Only one side of the comparison used to be folded. The statement
+        # below rewrites a stored name's separators to spaces, so "O'Brien" is
+        # matched as "o brien" -- but the query kept its punctuation, and
+        # "o'brien%" cannot match "o brien". Typing a name the way it is
+        # actually spelled returned nothing, and every apostrophe, hyphen and
+        # initial did it: O'Brien, D'Souza, Jean-Luc, Smith-Jones, "K.R.".
+        # Deleting the punctuation instead ("obrien") failed too, so the search
+        # box looked broken for these names with no way to type around it.
+        #
+        # Fold first, then escape. "_" is on both lists -- a separator here and
+        # a LIKE wildcard below -- and folding settles which one it is: the
+        # stored side has already turned it into a space, so matching it as a
+        # literal could only ever return nothing. Once folded it is a space, so
+        # it reaches LIKE as a space and cannot act as a wildcard either.
+        needle = (query or "").strip().lower().translate(_DIRECTORY_SEPARATOR_FOLD).strip()
         target = (candidate_user_id or "").strip() or None
         # An unrecognised audience widens to "all" rather than narrowing: a typo
         # in a caller must not silently hide people who are really there.
@@ -3275,8 +3312,8 @@ class OneLocationAgentService:
             requested_audience = "all"
         # LIKE metacharacters in a typed name are literal characters, not
         # wildcards. Unescaped, a single "%" typed into Connect matches every
-        # row in the directory and "_" matches any letter, so the escape is
-        # what keeps the pattern describing the name the person actually typed.
+        # row in the directory, so the escape is what keeps the pattern
+        # describing the name the person actually typed.
         #
         # "!" is the escape character rather than the conventional backslash on
         # purpose: a backslash would have to survive both Python's string

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -12,6 +12,9 @@ import hushh_mcp.services.one_location_agent_service as one_location_agent_modul
 import hushh_mcp.services.one_location_agent_service as one_location_service_module
 from hushh_mcp.operons.location.policy import normalize_duration_hours
 from hushh_mcp.services.one_location_agent_service import (
+    _DIRECTORY_SEPARATOR_FOLD,
+    _DIRECTORY_SEPARATOR_SQL,
+    _DIRECTORY_SEPARATORS,
     OneLocationAgentError,
     OneLocationAgentService,
     _contains_plaintext_location_key,
@@ -2619,9 +2622,14 @@ def test_directory_search_folds_separators_so_tiering_is_about_the_name() -> Non
     ("typed", "expected_name_prefix"),
     [
         ("%", "!%%"),
-        ("_", "!_%"),
         ("!", "!!%"),
-        ("50%_off", "50!%!_off%"),
+        # "_" is a separator before it is ever a wildcard: the stored name has
+        # already had it folded to a space, so matching it literally could only
+        # return nothing. Folded and trimmed, a lone "_" carries no letters at
+        # all and reads as an unfilled box -- never as the match-anything
+        # wildcard it would be unescaped.
+        ("_", "%"),
+        ("50%_off", "50!% off%"),
     ],
 )
 def test_directory_search_escapes_like_metacharacters(
@@ -2630,11 +2638,70 @@ def test_directory_search_escapes_like_metacharacters(
     service = RecipientDirectoryProbe()
     service.search_directory_candidates(owner_user_id="owner", query=typed)
 
-    # Unescaped, a typed "%" is a wildcard that matches the entire directory
-    # and "_" matches any single character. They are characters someone typed
-    # into a name box, not query syntax.
+    # Unescaped, a typed "%" is a wildcard that matches the entire directory.
+    # It is a character someone typed into a name box, not query syntax.
     assert service.params["name_prefix"] == expected_name_prefix
     assert service.params["word_prefix"] == f"% {expected_name_prefix}"
+
+
+@pytest.mark.parametrize(
+    ("typed", "expected_needle"),
+    [
+        ("O'Brien", "o brien"),
+        ("Jean-Luc", "jean luc"),
+        ("K.R.", "k r"),
+        ("Smith-Jones", "smith jones"),
+        ("de/la", "de la"),
+        ("Singh, Ankit", "singh  ankit"),
+    ],
+)
+def test_directory_search_folds_the_typed_name_the_same_way_as_the_stored_one(
+    typed: str, expected_needle: str
+) -> None:
+    """Typing a name the way it is spelled has to find it.
+
+    The statement folds a stored name's separators to spaces before matching,
+    so "O'Brien" is compared as "o brien". The query used to keep its
+    punctuation, so the pattern "o'brien%" was tested against "o brien" and
+    could never match -- and deleting the punctuation ("obrien") could not
+    match either. Every name with an apostrophe, a hyphen or an initial was
+    unreachable through the search box.
+    """
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query=typed)
+
+    assert service.params["query"] == expected_needle
+    assert service.params["name_prefix"] == f"{expected_needle}%"
+    assert service.params["word_prefix"] == f"% {expected_needle}%"
+
+
+def test_directory_search_folds_both_sides_with_one_separator_list() -> None:
+    """The Python fold and the SQL fold cannot drift apart.
+
+    They are two halves of one comparison. If either list of separators is
+    edited alone, names carrying the character that was added or removed stop
+    matching, and nothing else in the suite would notice.
+    """
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="n")
+
+    assert service.sql.count(_DIRECTORY_SEPARATOR_SQL) == 3
+    # The Python side folds exactly the characters the SQL side names.
+    for separator in _DIRECTORY_SEPARATORS:
+        assert f"a{separator}b".translate(_DIRECTORY_SEPARATOR_FOLD) == "a b"
+
+
+def test_directory_search_treats_a_query_of_only_separators_as_empty() -> None:
+    """A box holding "-" is a box the reader has not filled in yet.
+
+    Folded, it carries no letters at all. Matching it literally would search
+    for a name beginning with a space and return nothing, which reads as "you
+    have no connections" rather than "keep typing".
+    """
+    service = RecipientDirectoryProbe()
+    service.search_directory_candidates(owner_user_id="owner", query="-.")
+
+    assert service.params["query"] == ""
 
 
 def test_directory_search_preserves_sql_order_against_recommendation_ranking() -> None:

--- a/consent-protocol/tests/test_feed_events_recipient_fanout_migration.py
+++ b/consent-protocol/tests/test_feed_events_recipient_fanout_migration.py
@@ -1,0 +1,159 @@
+"""The person a location is shared WITH gets a Feed row.
+
+Reported from the field: "Ankit have shared me location or Jamai have shared
+me location. The feed should be real time notifying and real time adding."
+
+Migration 117 wrote every location feed row to ``NEW.owner_user_id`` -- the
+person who shared. The recipient was never written a row, so their Feed was
+empty no matter how often it refreshed. Making the Feed poll faster (the
+parallel change) cannot show a row that was never created.
+"""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_NAME = "152_feed_events_recipient_fanout.sql"
+ROLLBACK_NAME = "152_feed_events_recipient_fanout.rollback.sql"
+
+SHARE_LIFECYCLE_EVENTS = (
+    "location_share_created",
+    "location_share_revoked",
+    "location_share_expired",
+)
+
+
+def _migration_sql() -> str:
+    return (ROOT / "db" / "migrations" / MIGRATION_NAME).read_text(encoding="utf-8")
+
+
+def test_migration_is_registered_at_release_head():
+    assert (ROOT / "db" / "migrations" / MIGRATION_NAME).exists()
+    assert (ROOT / "db" / "migrations" / "rollback" / ROLLBACK_NAME).exists()
+
+    manifest = json.loads(
+        (ROOT / "db" / "release_migration_manifest.json").read_text(encoding="utf-8")
+    )
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
+    assert MIGRATION_NAME in manifest["groups"]["iam"]
+
+    # feed_events and one_location_events must both exist before this runs.
+    ordered = manifest["ordered_migrations"]
+    assert ordered.index(MIGRATION_NAME) > ordered.index("117_feed_events.sql")
+
+    for contract_name in (
+        "dev_minimum_schema.json",
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+    ):
+        contract = json.loads(
+            (ROOT / "db" / "contracts" / contract_name).read_text(encoding="utf-8")
+        )
+        assert contract["expected_migration_version"] >= 152, contract_name
+
+
+def test_the_recipient_of_a_share_is_written_a_row():
+    sql = _migration_sql()
+
+    assert "CREATE TRIGGER one_location_events_feed_fanout_recipient" in sql
+    assert "AFTER INSERT ON one_location_events" in sql
+    # The row is addressed to the recipient, which is the entire point.
+    assert "NEW.recipient_user_id," in sql
+    assert "INSERT INTO feed_events" in sql
+
+
+def test_every_share_lifecycle_event_reaches_the_recipient():
+    """Starting, stopping and expiring each change what the recipient can see.
+
+    Dropping any one of them leaves the recipient's Feed telling a story that
+    stops halfway: a share that starts and, as far as the Feed says, never ends.
+    """
+    sql = _migration_sql()
+
+    for event_type in SHARE_LIFECYCLE_EVENTS:
+        assert f"'{event_type}'" in sql, event_type
+
+
+def test_requests_and_approvals_are_not_mirrored_to_the_recipient():
+    """Those already notify the side that has to act.
+
+    Mirroring them would put a second row in the Feed of someone who was
+    already told, which is the duplicate-rows complaint in another form.
+    """
+    sql = _migration_sql()
+
+    for event_type in (
+        "location_access_request",
+        "location_access_approved",
+        "location_access_denied",
+    ):
+        assert f"'{event_type}'" not in sql, event_type
+
+
+def test_a_share_with_no_other_person_writes_nothing():
+    sql = _migration_sql()
+
+    assert "NEW.recipient_user_id IS NULL" in sql
+    assert "NEW.recipient_user_id = NEW.owner_user_id" in sql
+    # Both guards must return before the insert, or a self-share writes a row
+    # telling someone they shared with themselves.
+    guard_at = sql.index("NEW.recipient_user_id IS NULL")
+    insert_at = sql.index("INSERT INTO feed_events")
+    assert guard_at < insert_at
+
+
+def test_the_recipient_row_names_the_owner_not_itself():
+    """`counterpart_label` on the source event was resolved for the owner.
+
+    It holds the RECIPIENT's name. Copied through unchanged, the recipient's
+    Feed would show them their own name as the person who shared with them.
+    """
+    sql = _migration_sql()
+
+    assert "FROM actor_identity_cache" in sql
+    assert "WHERE user_id = NEW.owner_user_id" in sql
+    assert "'counterpart_label'" in sql
+    # The override has to be merged ON TOP of the event metadata, not under it.
+    assert "COALESCE(NEW.metadata, '{}'::jsonb)" in sql
+    assert "||" in sql
+
+
+def test_the_recipient_row_is_marked_so_the_client_can_word_it():
+    """Without this the recipient's revoke row renders the owner's sentence.
+
+    `reason = 'owner_revoke'` is true on BOTH copies of a revoke event, so the
+    client cannot tell the two audiences apart from `reason` alone -- and would
+    tell the recipient "You stopped sharing location".
+    """
+    sql = _migration_sql()
+
+    assert "'feed_audience', 'recipient'" in sql
+
+
+def test_the_owner_fan_out_is_left_alone():
+    """This migration adds an audience; it does not re-filter the existing one.
+
+    A parallel change is doing CREATE OR REPLACE on
+    feed_events_from_one_location_events(). If this migration replaced that
+    function too, whichever landed second would silently revert the other.
+    """
+    sql = _migration_sql()
+
+    assert "CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()" not in sql
+    assert "DROP TRIGGER IF EXISTS one_location_events_feed_fanout ON" not in sql
+    assert "CREATE OR REPLACE FUNCTION feed_events_recipient_from_one_location_events()" in sql
+
+
+def test_rollback_drops_the_trigger_and_keeps_the_rows():
+    """Rows already delivered are real activity someone received.
+
+    Deleting them on rollback would remove shares from a person's Feed that
+    genuinely happened, and they render correctly without the trigger.
+    """
+    rollback = (ROOT / "db" / "migrations" / "rollback" / ROLLBACK_NAME).read_text(encoding="utf-8")
+
+    assert "DROP TRIGGER IF EXISTS one_location_events_feed_fanout_recipient" in rollback
+    assert "DROP FUNCTION IF EXISTS feed_events_recipient_from_one_location_events" in rollback
+    assert "DELETE FROM feed_events" not in rollback
+    # And it must not take the owner's fan-out down with it.
+    assert "DROP FUNCTION IF EXISTS feed_events_from_one_location_events" not in rollback

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2656,22 +2656,30 @@ export function OneLocationAgentPageContent({
       ),
     [rankedRecipients, selectedShareCircleSelection],
   );
+  // A typed search matches the NAME, and nothing else on the row.
+  //
+  // These two boxes used to search `recommendationSearchText`, which appends
+  // every recipient's headline, relationship, category and reason labels to
+  // their name. Those labels are boilerplate — each person carries one of
+  // "Needs action", "Trusted Circle", "One Network", "Contact match",
+  // "Ready for private location sharing" — so most letters begin a word on
+  // EVERY row: "n" hit "Needs", "t" hit "Trusted", "o" hit "One", "r" hit
+  // "Ready", "c" hit "Contact" and "Circle". Typing the first letter of a
+  // person's name returned the entire list, which is exactly the complaint
+  // that word-prefix matching was added to answer. The matcher was already
+  // right; it was being handed a haystack with the same words in every straw.
+  //
+  // Connect settled this rule first: matching on anything other than the name
+  // is how a search returns a person nobody asked for. `recommendationSearchText`
+  // stays for the voice path below, where the input is a whole spoken phrase
+  // rather than one letter and the extra context helps rather than swamps.
   const visibleRecipients = useMemo(
-    () =>
-      filterPeopleByQuery(
-        rankedRecipients,
-        recipientSearch,
-        recommendationSearchText,
-      ),
+    () => filterPeopleByQuery(rankedRecipients, recipientSearch, recipientLabel),
     [rankedRecipients, recipientSearch],
   );
   const visibleShareRecipients = useMemo(
     () =>
-      filterPeopleByQuery(
-        rankedRecipients,
-        shareRecipientSearch,
-        recommendationSearchText,
-      ),
+      filterPeopleByQuery(rankedRecipients, shareRecipientSearch, recipientLabel),
     [rankedRecipients, shareRecipientSearch],
   );
   const hasMoreVisibleRecipients =

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -58,7 +58,10 @@ import {
   getNativeMapsApiKey,
 } from "@/lib/one-location/maps-config";
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
-import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import {
+  filterPeopleByQuery,
+  sortPeopleByName,
+} from "@/lib/one-location/people-search";
 import {
   LOCATION_COPY,
   isLocationPermissionDeniedError,
@@ -1749,8 +1752,17 @@ export function LocationImmersiveMap({
     vaultOwnerToken,
   ]);
 
+  // A–Z before the query, so the tray has somewhere to start looking; the
+  // filter then keeps that order inside each of its relevance groups. Applied
+  // here rather than to `markers` itself, because the pin layer and the
+  // three-avatar preview above read that list positionally.
   const filteredPeople = useMemo(
-    () => filterPeopleByQuery(markers, searchQuery, (marker) => marker.label),
+    () =>
+      filterPeopleByQuery(
+        sortPeopleByName(markers, (marker) => marker.label),
+        searchQuery,
+        (marker) => marker.label,
+      ),
     [markers, searchQuery],
   );
 
@@ -1759,13 +1771,20 @@ export function LocationImmersiveMap({
     [nearbyPresenceState],
   );
 
-  const filteredNearbyAttendees = useMemo(() => {
-    const query = searchQuery.trim().toLocaleLowerCase();
-    if (!query) return nearbyAttendees;
-    return nearbyAttendees.filter((attendee) =>
-      attendee.displayName.toLocaleLowerCase().includes(query),
-    );
-  }, [nearbyAttendees, searchQuery]);
+  // One search box sits above both lists, so both have to narrow the same way.
+  // This one kept a private `includes()` after the pins moved to
+  // `filterPeopleByQuery`, which left a single box behaving as two: typing "n"
+  // narrowed the pins to Neelesh and left every "n"-containing name standing in
+  // Around you.
+  const filteredNearbyAttendees = useMemo(
+    () =>
+      filterPeopleByQuery(
+        sortPeopleByName(nearbyAttendees, (attendee) => attendee.displayName),
+        searchQuery,
+        (attendee) => attendee.displayName,
+      ),
+    [nearbyAttendees, searchQuery],
+  );
 
   const drawerEntryCount = markers.length + nearbyAttendees.length;
 

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -33,7 +33,10 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
-import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import {
+  filterPeopleByQuery,
+  sortPeopleByName,
+} from "@/lib/one-location/people-search";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import {
   isCircleSelectionFullySelected,
@@ -308,8 +311,19 @@ export function CheckInFlow({
     }
   }, [contacts, seeded, vm]);
 
+  // `contacts` is two lists merged (trusted contacts, then whichever Circle is
+  // selected), so its order is "wherever each person happened to come from" —
+  // and it changes the moment a Circle is picked. Ordering the rendered list
+  // A–Z gives it a fixed place to look instead. Only the rendered list is
+  // reordered: seeding, the ready count and every lookup below still read
+  // `contacts`, so which person is pre-ticked does not move.
   const filtered = useMemo(
-    () => filterPeopleByQuery(contacts, search, (r) => vm.recipientLabel(r)),
+    () =>
+      filterPeopleByQuery(
+        sortPeopleByName(contacts, (r) => vm.recipientLabel(r)),
+        search,
+        (r) => vm.recipientLabel(r),
+      ),
     [contacts, search, vm],
   );
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2038,7 +2038,18 @@ function PeopleHub({
                       <PersonRow
                         key={r.userId}
                         name={name}
-                        subtitle={vm.recipientSubtitle(r)}
+                        // Someone sharing their location with you right now
+                        // used to read "Ready for private location sharing" —
+                        // the recommendation line, which describes what COULD
+                        // happen and so says the opposite of what is. The row
+                        // already knew (`receiving`), and spent it on an accent
+                        // colour. Two people with the same name, one sharing
+                        // and one not, were then indistinguishable except by a
+                        // tint, which is the whole reason "is this the same
+                        // person or a different one" is hard to answer here.
+                        subtitle={
+                          receiving ? "Sharing with you" : vm.recipientSubtitle(r)
+                        }
                         active={sharing || receiving}
                         first={i === 0}
                         action={
@@ -2752,6 +2763,11 @@ function ShareFlow({
             );
           })}
         </div>
+      ) : vm.shareRecipientSearch.trim() ? (
+        // A typo used to be reported as "you have no contacts", which sends a
+        // person with twenty of them off to invite people they already have.
+        // The list being empty and the QUERY being empty are different facts.
+        <EmptyState title="No matching people" description="Try a different name." />
       ) : (
         <EmptyState
           title="No trusted people yet"
@@ -2991,10 +3007,17 @@ function AskFlow({
           </div>
         ) : (
           <div className="mt-3">
-            <EmptyState
-              title="No one to request from yet"
-              description="Invite someone first."
-            />
+            {vm.recipientSearch.trim() ? (
+              <EmptyState
+                title="No matching people"
+                description="Try a different name."
+              />
+            ) : (
+              <EmptyState
+                title="No one to request from yet"
+                description="Invite someone first."
+              />
+            )}
           </div>
         )}
       </SectionCard>

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -83,6 +83,13 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
   // "Someone" last). Used to turn vague, subjectless lines like "A live
   // location share was revoked" into explicit subject-action-object sentences.
   const who = resolveCounterpartName(item.metadata);
+  // Whose side of the event this row is. A location share writes one row to
+  // the person sharing and one to the person shared with (migration 152); only
+  // the second carries this marker, and only the second reads as "someone did
+  // this to me" rather than "I did this". Rows written before that migration
+  // have no marker and stay on the owner's wording, which is what they were.
+  const sharedWithMe =
+    metadataString(item.metadata, "feed_audience") === "recipient";
 
   switch (item.event_type) {
     case "consent_requested":
@@ -121,7 +128,9 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: "Started sharing location",
+        description: sharedWithMe
+          ? "Shared their location with you"
+          : "Started sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -132,7 +141,15 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: ownerRevoked ? "You stopped sharing location" : "Stopped sharing location",
+        // `reason` describes what the OWNER did, so on the recipient's row
+        // "owner_revoke" is still true and "You stopped sharing location"
+        // would be shown to the one person who did not stop anything.
+        // Audience decides the sentence; reason only refines the owner's.
+        description: sharedWithMe
+          ? "Stopped sharing their location"
+          : ownerRevoked
+            ? "You stopped sharing location"
+            : "Stopped sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -142,6 +159,8 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
+        // No audience split: this line names no subject, and the row's title is
+        // already the other person, so it reads correctly from both sides.
         description: "Stopped sharing - time ran out",
         href: ROUTES.ONE_LOCATION,
       };

--- a/hushh-webapp/lib/one-location/__tests__/people-order.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/people-order.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import { filterPeopleByQuery, sortPeopleByName } from "../people-search";
+
+const nameOf = (name: string) => name;
+
+describe("sortPeopleByName", () => {
+  it("orders people A to Z", () => {
+    const people = ["Neelesh Meena", "Ankit Kumar Singh", "Meena Rao"];
+
+    expect(sortPeopleByName(people, nameOf)).toEqual([
+      "Ankit Kumar Singh",
+      "Meena Rao",
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("does not let capitalisation decide the order", () => {
+    // The bug this guards: a plain `localeCompare` in some locales, and every
+    // byte-order sort, puts "Zara" ahead of "ankit" because uppercase sorts
+    // first. A reader looking for "ankit" under A would never find it.
+    const people = ["zara", "Ankit", "Bhavya"];
+
+    expect(sortPeopleByName(people, nameOf)).toEqual([
+      "Ankit",
+      "Bhavya",
+      "zara",
+    ]);
+  });
+
+  it("sorts an accented name next to its plain spelling, not after Z", () => {
+    const people = ["Zoe", "Ánkit", "Bhavya"];
+
+    expect(sortPeopleByName(people, nameOf)).toEqual([
+      "Ánkit",
+      "Bhavya",
+      "Zoe",
+    ]);
+  });
+
+  it("leaves the caller's list untouched", () => {
+    const people = ["Neelesh", "Ankit"];
+    sortPeopleByName(people, nameOf);
+
+    expect(people).toEqual(["Neelesh", "Ankit"]);
+  });
+
+  it("ignores surrounding whitespace when deciding where a name goes", () => {
+    // Names are not stored tidily. A leading space used to sort a person above
+    // every letter, at the top of the list, away from their own initial.
+    const people = ["Bhavya", "  Ankit", "Chetan"];
+
+    expect(sortPeopleByName(people, nameOf)).toEqual([
+      "  Ankit",
+      "Bhavya",
+      "Chetan",
+    ]);
+  });
+});
+
+describe("filterPeopleByQuery on a phone keyboard", () => {
+  it("finds an apostrophe name typed with the iOS curly apostrophe", () => {
+    // The reported shape of this bug: an iPhone keyboard inserts U+2019 for an
+    // apostrophe, but the stored name holds the straight U+0027. On the one
+    // device where the user cannot type the other character, the search for a
+    // name they are looking straight at returned nothing.
+    const people = ["Ankit O'Brien", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "o’brien", nameOf)).toEqual([
+      "Ankit O'Brien",
+    ]);
+    expect(filterPeopleByQuery(people, "o'brien", nameOf)).toEqual([
+      "Ankit O'Brien",
+    ]);
+  });
+
+  it("finds a name spelled with an en dash when a hyphen is typed", () => {
+    const people = ["Smith–Jones", "Meena Rao"];
+
+    expect(filterPeopleByQuery(people, "smith-jones", nameOf)).toEqual([
+      "Smith–Jones",
+    ]);
+  });
+
+  it("finds an accented name from the plain letters a keyboard produces", () => {
+    const people = ["Ánkit Singh", "Neelesh Meena"];
+
+    expect(filterPeopleByQuery(people, "ankit", nameOf)).toEqual([
+      "Ánkit Singh",
+    ]);
+  });
+
+  it("leaves an Indic name intact while folding Latin accents", () => {
+    // Accent-stripping must not reach into Devanagari. `\p{Diacritic}` matches
+    // the virama, so it rewrites "झुम्मा" to "झुममा" — a different word, and it
+    // undoes the combining-mark handling that makes one-letter search work for
+    // these names at all. Only the Latin combining block may be stripped.
+    const people = ["झुम्मा", "नीलेश", "अंकित"];
+
+    expect(filterPeopleByQuery(people, "झुम्मा", nameOf)).toEqual(["झुम्मा"]);
+    expect(filterPeopleByQuery(people, "न", nameOf)).toEqual(["नीलेश"]);
+  });
+
+  it("matches the same name whether it is composed or decomposed", () => {
+    // "Á" as one codepoint vs "A" + combining acute. Two different strings for
+    // one name, depending on which keyboard or paste produced it.
+    const composed = "Ánkit";
+    const decomposed = "Ánkit";
+
+    expect(filterPeopleByQuery([composed], decomposed, nameOf)).toEqual([
+      composed,
+    ]);
+    expect(filterPeopleByQuery([decomposed], composed, nameOf)).toEqual([
+      decomposed,
+    ]);
+  });
+});
+
+describe("sortPeopleByName feeding filterPeopleByQuery", () => {
+  it("keeps word-beginning matches first, and orders A-Z inside each group", () => {
+    // This is the whole contract of the pair, and it is why the sort is applied
+    // to the SOURCE list rather than to the filtered result. Sorting afterwards
+    // would put "Ameena" (a mid-word match) above "Meena Rao" (a real word
+    // beginning) purely because A comes before M.
+    const people = [
+      "Meena Rao",
+      "Ameena Khan",
+      "Bhavya Mehta",
+      "Chetan Meenakshi",
+    ];
+
+    const ordered = sortPeopleByName(people, nameOf);
+
+    expect(filterPeopleByQuery(ordered, "mee", nameOf)).toEqual([
+      // begins a word, A-Z
+      "Chetan Meenakshi",
+      "Meena Rao",
+      // merely contains it, A-Z
+      "Ameena Khan",
+    ]);
+  });
+
+  it("shows an alphabetical list before anything is typed", () => {
+    const people = ["Neelesh Meena", "Ankit Kumar Singh"];
+
+    expect(filterPeopleByQuery(sortPeopleByName(people, nameOf), "", nameOf)).toEqual([
+      "Ankit Kumar Singh",
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("still narrows to one person from a single typed letter", () => {
+    // Ordering must not undo the fix that made one-letter search usable:
+    // both names contain an "n", only one begins a word with it.
+    const people = sortPeopleByName(
+      ["Neelesh Meena", "Ankit Kumar Singh"],
+      nameOf,
+    );
+
+    expect(filterPeopleByQuery(people, "n", nameOf)).toEqual(["Neelesh Meena"]);
+  });
+});

--- a/hushh-webapp/lib/one-location/people-search.ts
+++ b/hushh-webapp/lib/one-location/people-search.ts
@@ -32,8 +32,39 @@
  *  `normalizeSpokenName` in the Location page already treats marks this way. */
 const WORD_BOUNDARY = /[^\p{L}\p{N}\p{M}]+/u;
 
+/**
+ * iOS smart punctuation, folded back to what the keyboard shows.
+ *
+ * Typing an apostrophe on an iPhone inserts U+2019, not U+0027 — but a name
+ * stored from a web form holds the straight one. Searching O'Brien from the
+ * app therefore compared "o’brien" against "o'brien" and found nothing, on the
+ * one device where the user cannot type the other character. Curly double
+ * quotes and the en dash get the same treatment for the same reason.
+ */
+const SMART_PUNCTUATION = /[‘’‛]/g;
+const SMART_QUOTES = /[“”]/g;
+const DASHES = /[‐-―]/g;
+
 function normalize(value: string): string {
-  return value.trim().toLocaleLowerCase();
+  return (
+    value
+      .trim()
+      .toLocaleLowerCase()
+      .replace(SMART_PUNCTUATION, "'")
+      .replace(SMART_QUOTES, '"')
+      .replace(DASHES, "-")
+      // Strip accents so "Ánkit" is reachable by typing "ankit", which is what
+      // a phone keyboard produces by default. Composed and decomposed spellings
+      // of the same name also stop being two different strings.
+      //
+      // Deliberately only U+0300–U+036F, the combining marks NFD produces for
+      // Latin, Greek and Cyrillic letters — NOT `\p{Diacritic}`, which also
+      // matches the Devanagari virama and rewrites "झुम्मा" to "झुममा".
+      // Marks in an Indic script are part of the letter, not decoration on it,
+      // and stripping them undoes the word-splitting this file just gained.
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+  );
 }
 
 /** Does `query` begin the whole string, or any word inside it? */
@@ -66,4 +97,35 @@ export function filterPeopleByQuery<T>(
 
   if (needle.length === 1) return beginners.length ? beginners : loose;
   return [...beginners, ...loose];
+}
+
+/**
+ * Order a list of people the way a reader looks one up: A to Z.
+ *
+ * Connect has done this since it shipped, which is why its list is the one
+ * people say works — you can find a name in it before you have typed anything,
+ * because you already know roughly where it will be. The Location pickers were
+ * rendering whichever order the server happened to return, so the same two
+ * connections could swap places between two openings of the same sheet, and a
+ * long list had no place to start looking.
+ *
+ * Sort the SOURCE list, not the filtered result. `filterPeopleByQuery` keeps
+ * input order inside each of its two relevance groups, so an A–Z source comes
+ * out as "names that begin with what you typed, A–Z, then the rest, A–Z" —
+ * relevance first, alphabetical inside it. Re-sorting after the filter would
+ * throw the relevance ranking away and put a mid-word match above the name the
+ * query actually begins.
+ *
+ * `sensitivity: "base"` matches Connect exactly: "ánkit" and "Ankit" sort
+ * together rather than after Z, and case never decides the order.
+ */
+export function sortPeopleByName<T>(
+  items: readonly T[],
+  nameOf: (item: T) => string,
+): T[] {
+  return [...items].sort((a, b) =>
+    normalize(nameOf(a)).localeCompare(normalize(nameOf(b)), undefined, {
+      sensitivity: "base",
+    }),
+  );
 }


### PR DESCRIPTION
Three reported problems. Each had a different cause; none of them was the search matcher.

## 1. Typing the first letter of a name returned everyone

The People tab, Share flow and Ask flow searched `recommendationSearchText`, which appends each person's headline, relationship, category and reason labels to their name. Those labels are boilerplate that **every** row carries — "Needs action", "Trusted Circle", "One Network", "Contact match", "Ready for private location sharing" — so most letters begin a word on every row:

| typed | matched every row via |
|---|---|
| `n` | **N**eeds action |
| `t` | **T**rusted Circle |
| `o` | **O**ne Network |
| `r` | **R**eady for private location sharing |
| `c` | **C**ontact match / **C**ircle |

The word-prefix matcher added in 2f42f907b was correct. It was being handed a haystack with the same words in every straw, which is why the screen still did not narrow after that fix — and why the unit tests passed: they call it with `nameOf = (name) => name`, never the real payload.

These two boxes now match the **name**, the rule Connect settled first ("matching on anything other than the NAME is how a search returns a person nobody asked for"). `recommendationSearchText` stays on the voice path, where the input is a whole spoken phrase rather than one letter.

**The map's "Around you" list** was the one people picker 2f42f907b missed — still a bare `includes()`, so a single search box behaved as two: the pins narrowed, the list directly above them did not.

**Alphabetical order.** Lists now sort A–Z *before* filtering. The SOURCE list is sorted, never the filtered result, so the tiers come out "names that begin with what you typed, A–Z, then the rest, A–Z" — relevance first, alphabetical inside it. Sorting afterwards would rank a mid-word match above a real word beginning. The check-in list needed this most: it is two lists merged, so its order changed the moment a Circle was picked.

**Names with punctuation were unreachable in Connect.** The statement folds a stored name's separators to spaces — `O'Brien` is matched as `o brien` — but the typed query kept its punctuation, so `o'brien%` was tested against `o brien` and could never match. Deleting the punctuation did not match either, so there was no way to type around it. Both sides now fold with one shared constant, asserted against the SQL so they cannot drift.

On iOS the keyboard inserts a curly apostrophe (U+2019) where the stored name has a straight one, so the client folds smart punctuation too — plus Latin accents, using **only** the U+0300–U+036F block and deliberately **not** `\p{Diacritic}`, which matches the Devanagari virama and would rewrite `झुम्मा` to `झुममा`, silently undoing aa7be6ea2. There is a test for exactly that.

**Empty states.** A typo was reported as "No trusted people yet. Invite someone first." — telling someone with twenty contacts they have none, and sending them to invite people they already have.

## 2. The Feed never showed a share to the person it was shared with

Migration 117's fan-out writes every location feed row to `NEW.owner_user_id`. Ankit shares with Jamai: Ankit's Feed says "Started sharing location", **Jamai's Feed says nothing** — and keeps saying nothing when the share stops or expires. Jamai's only signal was the push notification, gone the moment it is dismissed.

Making the Feed poll faster (#5321, merged) cannot show a row that was never created. That change and this one are both needed.

Migration **152 adds a second trigger** rather than editing 117's function, because 151 replaces that same function and two `CREATE OR REPLACE`s mean whichever lands second silently reverts the other. This is a different *audience*, not different filtering, so the two compose in either merge order — with a test asserting this migration never touches the owner-scoped function.

The recipient's copy carries the **owner** as counterpart (the event's own `counterpart_label` was resolved for the owner's row and holds the recipient's own name), and is marked `feed_audience: recipient` so the client can word it. Without that marker a revoke renders "You stopped sharing location" to the one person who did not stop anything.

Rollback drops the trigger and **keeps** delivered rows — they are a true record of shares people really received.

## 3. A live sharer read as a non-sharer

Someone actively sharing their location with you showed the grey recommendation line, identical to a connection who has never shared anything. The row already knew (`receiving`) and spent it on an accent colour.

This is what made "is this the same person or two different ones" hard to answer: two accounts with the same name, one sharing and one not, differing only by a tint.

**Identity itself is sound.** Every list keys on `user_id`; no merge, dedupe or lookup anywhere in Location, Circle or Connect runs on a display name. Two names on screen are two accounts, never one person drawn twice.

## Verification

- Full webapp suite: **29 failing tests, the same 29 as `origin/main`** — failing sets compared and set-identical, zero regressions. (main is currently red for unrelated reasons.)
- consent-protocol: **664 passed**; the 2 `test_one_location_maps_routes` failures also reproduce on `origin/main`.
- `tsc --noEmit` clean; eslint clean on every changed file; ruff check + format clean on changed python.
- Root cause of the duplicate-name report confirmed against real UAT data: "Ankit Kumar Singh" is **four** distinct `user_id`s, and 14 display names are held by more than one account.

## Not in this PR

The Location people list is a fixed 50-row alphabetical window (`list_verified_recipients`, `LIMIT 50`, no query parameter), so client-side search cannot reach person 51. Connect avoids this by searching server-side. Closing it properly means a dedicated search endpoint plus debounced client wiring — a separate change, deliberately not bolted onto this one.