### PR TITLE
fix(one-location): make the people search usable on an iPhone keyboard

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-people-search-keyboard.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-people-search-keyboard.contract.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The Location people-search surfaces on a real iPhone.
+ *
+ * These are all keyboard-and-webview behaviours, so jsdom cannot observe them:
+ * `--kb-height` is set by the native keyboard inset manager, and autocorrect
+ * and `enterKeyHint` are keyboard features with no DOM effect to assert. What
+ * IS assertable, and what actually regressed, is whether the source still says
+ * the thing that makes the phone behave — so these pin the source.
+ */
+
+const read = (relativePath: string) =>
+  readFileSync(join(process.cwd(), relativePath), "utf8");
+
+const PICKER_SHEETS = [
+  "components/one-location/redesign/circles/named-circle-flows.tsx",
+  "components/one-location/redesign/circles/circle-grow-actions.tsx",
+];
+
+describe("Location people-search keyboard contract", () => {
+  it.each(PICKER_SHEETS)(
+    "keeps the keyboard height inside the sheet's max-height (%s)",
+    (path) => {
+      const source = read(path);
+
+      // SheetContent pairs `bottom-[var(--kb-height,0px)]` with a max-height
+      // that subtracts the same value: the sheet lifts above the keyboard and
+      // shrinks by exactly as much. A bare `max-h-[88dvh]` wins the
+      // tailwind-merge and drops only the shrink, so the sheet still lifts and
+      // carries its own title and search field off the top of the screen.
+      expect(source).toContain("max-h-[calc(88dvh-var(--kb-height,0px))]");
+      expect(source).not.toContain("max-h-[88dvh]");
+    },
+  );
+
+  it.each(PICKER_SHEETS)(
+    "does not let a downward swipe over the results close the sheet (%s)",
+    (path) => {
+      // Swiping down through a list is how a phone scrolls it back up. With
+      // drag-dismiss on, that gesture drags the sheet away instead and can
+      // close it, losing the query and every person already ticked.
+      expect(read(path)).toContain("dragDismiss={false}");
+    },
+  );
+});
+
+describe("PersonSearchInput on a phone keyboard", () => {
+  const source = read("components/one-location/redesign/selectors.tsx");
+
+  it("stops iOS rewriting the name as it is typed", () => {
+    // A surname is not a dictionary word. Autocorrect substitutes one mid-search
+    // and the list jumps to the wrong people, or empties, while the person
+    // watches their own typing change under them.
+    expect(source).toContain('autoCorrect="off"');
+    expect(source).toContain('autoCapitalize="none"');
+    expect(source).toContain("spellCheck={false}");
+  });
+
+  it("gives the return key a job, and closes the keyboard with it", () => {
+    // Without this the key reads "return", does nothing at all, and the
+    // keyboard stays parked over the results the person is trying to read.
+    expect(source).toContain('enterKeyHint="search"');
+    expect(source).toContain("event.currentTarget.blur()");
+  });
+
+  it("scrolls itself out from behind the keyboard when tapped", () => {
+    // On a small iPhone the field otherwise sits behind the keyboard and the
+    // person types blind. The delay is what lets the keyboard finish animating,
+    // so the measurement is taken against the shrunken viewport.
+    expect(source).toContain("scrollIntoView(");
+    expect(source).toContain('block: "center"');
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -219,7 +219,11 @@ export function CircleInvitePeopleSheet({
     >
       <SheetContent
         side="bottom"
-        className="mx-auto flex max-h-[88dvh] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
+        // Same pair as the Circle detail sheet: keep the drag gesture off a
+        // scrollable list, and keep the keyboard height inside the max-height
+        // so the search field does not leave the screen when the keyboard opens.
+        dragDismiss={false}
+        className="mx-auto flex max-h-[calc(88dvh-var(--kb-height,0px))] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
       >
         <SheetHeader className="text-left">
           <SheetTitle>Add people to {circleName}</SheetTitle>

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -1312,7 +1312,19 @@ export function CircleDetailFlow({
           >
             <SheetContent
               side="bottom"
-              className="mx-auto flex max-h-[88dvh] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
+              // Swiping down through the results is how a phone scrolls a list
+              // back up. Left on, it drags the sheet away instead and can close
+              // it outright, losing the query and every person already ticked.
+              dragDismiss={false}
+              // The keyboard height MUST stay in this max-height. SheetContent's
+              // default is `max-h-[calc(85dvh-var(--kb-height,0px))]` paired with
+              // `bottom-[var(--kb-height,0px)]`: the sheet lifts above the
+              // keyboard and shrinks by the same amount. A bare dvh max-height
+              // wins the tailwind-merge and drops only the shrink — so the sheet
+              // still lifts, and the title and the search field the person just
+              // tapped slide off the top of the screen. They then type into a
+              // field they cannot see.
+              className="mx-auto flex max-h-[calc(88dvh-var(--kb-height,0px))] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
             >
               <SheetHeader className="text-left">
                 <SheetTitle>Add people to {circle.name}</SheetTitle>

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -295,13 +295,42 @@ export function PersonSearchInput({
     <div className="relative">
       <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <input
-        type="text"
+        type="search"
         aria-label={placeholder}
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder={placeholder}
         data-voice-control-id={voiceControlId}
-        className="h-11 w-full rounded-[14px] border border-border/70 bg-background pl-10 pr-4 text-base text-foreground outline-none transition-shadow placeholder:text-muted-foreground focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+        // A name is not a dictionary word. Left on, iOS autocorrect rewrites an
+        // uncommon surname mid-search and the list jumps to the wrong people or
+        // empties, with the user watching their own typing change under them.
+        // Autocapitalise is off for the same reason a search box is not a name
+        // field: matching is case-insensitive, and a forced capital is one more
+        // thing the keyboard did that the person did not ask for.
+        autoCorrect="off"
+        autoCapitalize="none"
+        spellCheck={false}
+        enterKeyHint="search"
+        onKeyDown={(event) => {
+          // iOS soft-keyboard "return" must dismiss the keyboard; blurring the
+          // field is what actually closes it in the Capacitor webview (there is
+          // no form submit here). Without this the key reads "return", does
+          // nothing, and the keyboard stays over the results being read.
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+        }}
+        onFocus={(event) => {
+          // Tapping this field on a small iPhone otherwise leaves it sitting
+          // behind the keyboard, so the person types blind. The delay lets the
+          // keyboard animate in, so the shrunken viewport is what gets measured.
+          const field = event.currentTarget;
+          window.setTimeout(() => {
+            field.scrollIntoView({ block: "center", behavior: "smooth" });
+          }, 250);
+        }}
+        className="h-11 w-full rounded-[14px] border border-border/70 bg-background pl-10 pr-4 text-base text-foreground outline-none transition-shadow placeholder:text-muted-foreground focus:ring-2 focus:ring-[color:var(--app-accent-ring)] [&::-webkit-search-cancel-button]:appearance-none"
       />
     </div>
   );


### PR DESCRIPTION
Follow-up to #5329. That fixed *what* the Location search matches. This fixes using it on a real device — three problems that only appear once a keyboard opens.

## The sheet carried the search field off the screen

`SheetContent` pairs `bottom-[var(--kb-height,0px)]` with `max-h-[calc(85dvh-var(--kb-height,0px))]` — the sheet lifts above the keyboard and shrinks by exactly as much.

Both Circle people pickers overrode that with a bare `max-h-[88dvh]`. Tailwind-merge keeps the override, so the **shrink is dropped while the lift stays**. The sheet rises by the keyboard height and its own title and search field slide off the top of the screen. You are then typing into a field you cannot see.

The correct pairing already existed two files away, in `nearby-check-in-sheet.tsx:1527`.

## A downward swipe over the results closed the sheet

Swiping down through a list is how a phone scrolls it back up. On these two sheets that gesture dragged the sheet away instead, and could close it outright — losing the typed query and every person already ticked. `dragDismiss={false}`, matching the same precedent.

## The keyboard fought the typing

`PersonSearchInput` (`selectors.tsx`) is the single component behind every Location search box, and it set no input attributes at all:

| | before | after |
|---|---|---|
| autocorrect | on — iOS rewrote surnames mid-search | `off` |
| autocapitalize | on | `none` |
| return key | read "return", did nothing | `enterKeyHint="search"`, blurs to close the keyboard |
| on focus | field sat behind the keyboard | scrolls into view once the keyboard settles |

A surname is not a dictionary word. With autocorrect on, iOS substituted one as the user typed and the list jumped to the wrong people or emptied — with the person watching their own text change under them. This is Connect's treatment (`page-client.tsx:1516-1545`), which is part of why its search is the one that feels right.

## Native / Capacitor

**No native or plugin change is needed.** `--kb-height` is already published by the existing keyboard inset manager, and every fix here is web-layer, so the next iOS build picks them up with no Swift or Capacitor work.

## Verification

- Full webapp suite: failing set **set-identical to `origin/main`** (29 tests, all pre-existing) — zero regressions.
- `tsc --noEmit` and eslint clean.
- These are keyboard-and-webview behaviours with no DOM effect jsdom can observe, so they are pinned by a source contract test (`one-location-people-search-keyboard.contract.test.ts`) rather than a screenshot — including a guard that the bare `max-h-[88dvh]` cannot come back.