### PR TITLE
test(one-location): measure the map header in a real browser, not in jsdom

### DIFF
--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -58,6 +58,12 @@ import {
   getNativeMapsApiKey,
 } from "@/lib/one-location/maps-config";
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
+import {
+  MAP_HEADER_ACTIONS_CELL_CLASSNAME,
+  MAP_HEADER_CLASSNAME,
+  MAP_HEADER_CLOSE_CELL_CLASSNAME,
+  MAP_HEADER_STATUS_CELL_CLASSNAME,
+} from "@/lib/one-location/map-header-layout";
 import { filterPeopleByQuery } from "@/lib/one-location/people-search";
 import {
   LOCATION_COPY,
@@ -2065,9 +2071,9 @@ export function LocationImmersiveMap({
         // widths and drops Sharing onto its own full-width row beneath them.
         // Nothing truncates, and the Sharing popover gains the room it needs to
         // open without being clipped by the screen edge.
-        className="pointer-events-none absolute inset-x-0 top-0 z-30 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 p-4 pt-[max(1rem,env(safe-area-inset-top))] sm:grid-cols-[1fr_auto_1fr]"
+        className={MAP_HEADER_CLASSNAME}
       >
-        <div className="col-start-1 row-start-1 flex min-w-0 items-center">
+        <div className={MAP_HEADER_CLOSE_CELL_CLASSNAME}>
           <ShellActionSurface
             className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}
             aria-label="Back to Location"
@@ -2083,7 +2089,7 @@ export function LocationImmersiveMap({
             <X className="h-5 w-5 stroke-[2.25]" />
           </ShellActionSurface>
         </div>
-        <div className="col-span-2 col-start-1 row-start-2 flex min-w-0 items-center justify-center sm:col-span-1 sm:col-start-2 sm:row-start-1">
+        <div className={MAP_HEADER_STATUS_CELL_CLASSNAME}>
           {!demoMode && (activeShareCount ?? 0) > 0 ? (
             <Popover
               open={sharingPopoverOpen}
@@ -2180,7 +2186,7 @@ export function LocationImmersiveMap({
           ) : null}
         </div>
         {rendererReady ? (
-          <div className="col-start-2 row-start-1 flex min-w-0 items-center justify-end gap-3 sm:col-start-3">
+          <div className={MAP_HEADER_ACTIONS_CELL_CLASSNAME}>
             {rendererReady && nearbyCheckInAvailable && !demoMode ? (
               <ShellActionSurface
                 variant="pill"

--- a/hushh-webapp/e2e/location-map-header.contract.spec.ts
+++ b/hushh-webapp/e2e/location-map-header.contract.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Geometry contract for the Location map header.
+ *
+ * WHY THIS EXISTS, AND WHY IT IS NOT A UNIT TEST
+ * ----------------------------------------------
+ * The header shipped with `grid-cols-[1fr_auto_1fr]`, which pads the narrow
+ * outer column to match the wide one. On a 375px phone that spent ~95px on
+ * empty space and squeezed the Check-in pill until its label was gone -- the
+ * user saw the single letter "C". Every unit test passed the whole time,
+ * because jsdom has no layout: it cannot tell you that a string overflowed its
+ * box. Class-name assertions cannot either; they only prove the class we
+ * *intended* is present.
+ *
+ * So this measures real boxes in a real engine. It needs no dev server, no
+ * backend and no login -- the question is purely "does this markup, under this
+ * stylesheet, fit at this width", and that is answerable from the compiled CSS
+ * alone. That matters: the app's other e2e specs need REVIEWER_UID and a vault
+ * passphrase, so they can never guard this.
+ *
+ * The class strings are IMPORTED from the module the component uses, never
+ * re-typed here. A copied string would drift from the shipped one and the gate
+ * would quietly start measuring nothing. (Relative path, not the `@/` alias:
+ * Playwright's transform does not resolve tsconfig path aliases.)
+ */
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+import postcss from "postcss";
+import tailwind from "@tailwindcss/postcss";
+
+import {
+  MAP_HEADER_ACTIONS_CELL_CLASSNAME,
+  MAP_HEADER_CLASSNAME,
+  MAP_HEADER_CLOSE_CELL_CLASSNAME,
+  MAP_HEADER_STATUS_CELL_CLASSNAME,
+  MAP_HEADER_SINGLE_ROW_MIN_WIDTH,
+} from "../lib/one-location/map-header-layout";
+
+/** Real device widths, smallest supported phone through desktop. */
+const WIDTHS = [320, 360, 375, 390, 430, 768, 1280] as const;
+
+/** Platform minimum for a touch target. */
+const MIN_TOUCH_TARGET = 44;
+
+const ICON_BUTTON =
+  "relative isolate inline-flex touch-manipulation overflow-hidden rounded-full border shadow-lg backdrop-blur-md h-9 w-9 items-center justify-center pointer-events-auto !h-14 !w-14";
+const PILL =
+  "relative isolate inline-flex touch-manipulation overflow-hidden rounded-full border shadow-lg backdrop-blur-md h-9 min-w-0 max-w-full items-center justify-center gap-1.5 px-3.5 text-[14px] font-semibold sm:gap-2 sm:px-4 sm:text-base pointer-events-auto";
+const SHARING_PILL =
+  "pointer-events-auto flex min-w-0 shrink items-center gap-1.5 truncate rounded-full border bg-background/85 px-3 py-1.5 text-[12px] font-semibold shadow-lg backdrop-blur-md";
+
+function headerMarkup(): string {
+  return `
+<div style="position:relative;height:100dvh;width:100%;overflow:hidden">
+  <header id="hdr" class="${MAP_HEADER_CLASSNAME}">
+    <div class="${MAP_HEADER_CLOSE_CELL_CLASSNAME}">
+      <span class="relative inline-flex shrink-0 overflow-visible align-middle">
+        <button id="close" class="${ICON_BUTTON}" aria-label="Back to Location">&#10005;</button>
+      </span>
+    </div>
+    <div class="${MAP_HEADER_STATUS_CELL_CLASSNAME}">
+      <button id="sharing" class="${SHARING_PILL}">
+        <span style="height:6px;width:6px;flex-shrink:0;border-radius:9999px;background:#0071E3"></span>
+        <span id="sharingLabel" class="truncate">Sharing with 2</span>
+      </button>
+    </div>
+    <div class="${MAP_HEADER_ACTIONS_CELL_CLASSNAME}">
+      <span class="relative inline-flex overflow-visible align-middle min-w-0 shrink">
+        <button id="checkin" class="${PILL}" aria-label="Check in nearby">
+          <span class="pointer-events-none relative z-10 inline-flex min-w-0 max-w-full items-center justify-center gap-1.5 sm:gap-2">
+            <span style="height:16px;width:16px;flex-shrink:0;display:inline-block;background:currentColor;border-radius:3px"></span>
+            <span id="checkinLabel" class="truncate">Check in</span>
+          </span>
+        </button>
+      </span>
+      <span class="relative inline-flex shrink-0 overflow-visible align-middle">
+        <button id="locate" class="${ICON_BUTTON}" aria-label="Show my location">&#9678;</button>
+      </span>
+    </div>
+  </header>
+</div>`;
+}
+
+/**
+ * Compile the app's real Tailwind stylesheet for exactly this markup, once.
+ *
+ * Memoised and given a unique scratch path per process: Playwright runs these
+ * widths in parallel workers, and a shared scratch file let one worker delete
+ * the file another was still scanning -- Tailwind then emitted no utilities and
+ * the buttons measured 12px wide. That is a harness bug that looks exactly like
+ * a product bug, so it is worth not having.
+ */
+let compiledPage: Promise<string> | null = null;
+
+function compilePage(): Promise<string> {
+  compiledPage ??= (async () => {
+    const markup = headerMarkup();
+    const scan = path.join(
+      tmpdir(),
+      `hushh-header-contract-${process.pid}.html`,
+    );
+    writeFileSync(scan, markup);
+    try {
+      const { css } = await postcss([tailwind()]).process(
+        `@import "tailwindcss" source(none);\n@source "${scan}";`,
+        { from: path.join(process.cwd(), "app/globals.css") },
+      );
+      return `<!doctype html><meta charset="utf-8"><style>${css}</style><style>body{margin:0;font-family:-apple-system,system-ui,sans-serif}</style>${markup}`;
+    } finally {
+      rmSync(scan, { force: true });
+    }
+  })();
+  return compiledPage;
+}
+
+test.describe("Location map header geometry contract", () => {
+  for (const width of WIDTHS) {
+    test(`keeps every control and label intact at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await page.setContent(await compilePage());
+
+      const measured = await page.evaluate(() => {
+        const byId = (id: string) => document.getElementById(id)!;
+        const box = (id: string) => byId(id).getBoundingClientRect();
+        const clipped = (id: string) => {
+          const el = byId(id);
+          return el.scrollWidth > el.clientWidth + 1;
+        };
+        const overlaps = (a: string, b: string) =>
+          box(a).bottom > box(b).top && box(b).bottom > box(a).top;
+        return {
+          documentWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth,
+          checkInClipped: clipped("checkinLabel"),
+          checkInText: byId("checkinLabel").textContent,
+          sharingClipped: clipped("sharingLabel"),
+          sharingText: byId("sharingLabel").textContent,
+          closeSize: [box("close").width, box("close").height],
+          locateSize: [box("locate").width, box("locate").height],
+          closeLeft: box("close").left,
+          locateRight: box("locate").right,
+          sharingSharesRowWithClose: overlaps("sharing", "close"),
+        };
+      });
+
+      // Contract A -- product-owned titles never truncate. "Check in" becoming
+      // "C" is the exact defect this file exists for.
+      expect(
+        measured.checkInClipped,
+        `"Check in" was clipped at ${width}px`,
+      ).toBe(false);
+      expect(measured.checkInText).toBe("Check in");
+      expect(
+        measured.sharingClipped,
+        `"Sharing with 2" was clipped at ${width}px`,
+      ).toBe(false);
+      expect(measured.sharingText).toBe("Sharing with 2");
+
+      // Contract D -- no accidental horizontal overflow.
+      expect(measured.documentWidth).toBeLessThanOrEqual(
+        measured.viewportWidth + 1,
+      );
+
+      // Contract H -- essential controls stay operable and on screen.
+      for (const [name, size] of [
+        ["close", measured.closeSize],
+        ["locate", measured.locateSize],
+      ] as const) {
+        expect(size[0], `${name} width at ${width}px`).toBeGreaterThanOrEqual(
+          MIN_TOUCH_TARGET,
+        );
+        expect(size[1], `${name} height at ${width}px`).toBeGreaterThanOrEqual(
+          MIN_TOUCH_TARGET,
+        );
+      }
+      expect(measured.closeLeft).toBeGreaterThanOrEqual(0);
+      expect(measured.locateRight).toBeLessThanOrEqual(
+        measured.viewportWidth + 1,
+      );
+
+      // The structural rule that buys the space: phones give Sharing its own
+      // row; the desktop true-centre layout is unchanged.
+      expect(
+        measured.sharingSharesRowWithClose,
+        `Sharing row placement at ${width}px`,
+      ).toBe(width >= MAP_HEADER_SINGLE_ROW_MIN_WIDTH);
+    });
+  }
+});

--- a/hushh-webapp/lib/one-location/map-header-layout.ts
+++ b/hushh-webapp/lib/one-location/map-header-layout.ts
@@ -1,0 +1,47 @@
+/**
+ * Layout classes for the Location map header, in their own dependency-free
+ * module so a real-browser geometry test can import the exact strings that
+ * ship. (The component itself pulls in Capacitor, lucide and next/navigation,
+ * none of which can be loaded by a plain Node test runner.)
+ *
+ * A test that re-declares these strings measures a copy, and a copy drifts
+ * silently -- which is exactly how "Check in" reached a user as "C" while every
+ * test stayed green. See e2e/location-map-header.contract.spec.ts.
+ */
+
+/**
+ * A grid, not a flex row: with flex + justify-between, three-plus items of
+ * uneven width get spread by *equal gaps*, which is what dragged Check-in and
+ * Sharing out of place in the first place.
+ *
+ * From `sm` up, `1fr auto 1fr` forces the two outer columns to the same width
+ * regardless of what they contain, which puts the middle (auto) column --
+ * Sharing -- at the header's true visual centre no matter how wide the close X
+ * or the Check-in+Locate group are.
+ *
+ * Below `sm` -- i.e. every phone -- that same symmetry is what broke the
+ * header. Making the left column (one 56px X) as wide as the right one
+ * (Check-in + Locate) burns ~95px on empty space, and the leftover centre
+ * column could not hold "Sharing with 2" AND let Check-in keep its label.
+ * Measured in Chromium against this stylesheet, "Check in" was truncated at
+ * EVERY phone width tested -- 320, 360, 375, 390 and 430 -- reaching the
+ * reporter as the single letter "C". A product-owned action word is not an
+ * acceptable thing to truncate, so the phone layout gives row 1 to the controls
+ * at their natural widths and drops Sharing onto its own full-width row
+ * beneath them. Nothing truncates, and the Sharing popover gains the room it
+ * needs to open without being clipped by the screen edge.
+ */
+export const MAP_HEADER_CLASSNAME =
+  "pointer-events-none absolute inset-x-0 top-0 z-30 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 p-4 pt-[max(1rem,env(safe-area-inset-top))] sm:grid-cols-[1fr_auto_1fr]";
+
+export const MAP_HEADER_CLOSE_CELL_CLASSNAME =
+  "col-start-1 row-start-1 flex min-w-0 items-center";
+
+export const MAP_HEADER_STATUS_CELL_CLASSNAME =
+  "col-span-2 col-start-1 row-start-2 flex min-w-0 items-center justify-center sm:col-span-1 sm:col-start-2 sm:row-start-1";
+
+export const MAP_HEADER_ACTIONS_CELL_CLASSNAME =
+  "col-start-2 row-start-1 flex min-w-0 items-center justify-end gap-3 sm:col-start-3";
+
+/** The `sm` breakpoint: below it the header is two rows, at or above it one. */
+export const MAP_HEADER_SINGLE_ROW_MIN_WIDTH = 640;

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -26,6 +26,7 @@
     "verify:analytics": "vitest run __tests__/services/observability-schema.test.ts __tests__/services/observability-route-map.test.ts __tests__/services/observability-growth.test.ts __tests__/services/observability-native-firebase.test.ts __tests__/services/observability-web-transport.test.ts __tests__/services/consent-pending-count.test.ts",
     "verify:analytics:governed": "npm run verify:analytics && npm run audit:analytics-sandbox && npm run smoke:analytics:uat && cd .. && python3 .codex/skills/analytics-observability-governance/scripts/inspect_analytics_surface.py health && ./bin/hushh docs verify",
     "verify:service-boundary": "node ./scripts/architecture/verify-service-layer-boundary.mjs",
+    "test:layout-contracts": "playwright test --config=playwright.layout-contracts.config.ts",
     "verify:design-system": "node ./scripts/architecture/verify-design-system.mjs && node ./scripts/design/verify-accent-tokens.mjs && node ./scripts/design/verify-apple-hierarchy.mjs",
     "verify:accent-tokens": "node ./scripts/design/verify-accent-tokens.mjs",
     "verify:docs": "node ./scripts/architecture/verify-docs.mjs",

--- a/hushh-webapp/playwright.layout-contracts.config.ts
+++ b/hushh-webapp/playwright.layout-contracts.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Layout-contract config — geometry assertions that need NO running app.
+ *
+ * These specs answer one question: "does this markup, under this stylesheet,
+ * fit at this width". That is answerable from the compiled CSS alone, so they
+ * render with `page.setContent()` and never navigate to a URL.
+ *
+ * The main `playwright.config.ts` boots `npm run dev` through its `webServer`
+ * block, which the e2e journey specs genuinely need. Inheriting it here would
+ * make a 6-second geometry check wait on a Next dev server -- slow everywhere,
+ * and effectively a hang on a machine where the repo sits in an iCloud-synced
+ * folder (FileProvider throttles every build read). So this config starts no
+ * server at all, which is also why these contracts can run as a fast required
+ * gate while the journey specs need REVIEWER_UID and a vault passphrase.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.contract\.spec\.ts/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI ? "github" : "line",
+  use: {
+    trace: "on-first-retry",
+    // Failure diagnostics only. A passing run never captures or compares an
+    // image -- the contracts are geometry assertions, not screenshot review.
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
+});


### PR DESCRIPTION
Follow-up to #5305. That PR fixed the header truncation; this makes it **impossible to reintroduce silently**.

Replaces #5314, which was cut from a pre-squash branch and would have reverted 3,101 lines of other people's work. This one is a single commit off current main touching 5 files.

## The gap

The truncation that reached a user as the single letter **"C"** was invisible to every test we had:

- **jsdom has no layout engine** — a unit test cannot tell you a string overflowed its box.
- **Class-name assertions** (what #5305 added) only prove the class we *intended* is present, not that the result fits.

The suite was green the entire time the bug was on a phone.

## What this adds

`e2e/location-map-header.contract.spec.ts` measures real boxes at **320 / 360 / 375 / 390 / 430 / 768 / 1280**:

| contract | assertion |
|---|---|
| product-owned labels never truncate | `scrollWidth <= clientWidth` on "Check in" and "Sharing with 2" |
| no accidental horizontal overflow | `documentWidth <= viewportWidth` |
| essential controls operable | close + locate ≥ 44×44, inside the viewport |
| the rule that buys the space | Sharing on its own row below `sm`, true-centre row at `sm`+ |

No dev server, no backend, no login. The question is purely *"does this markup, under this stylesheet, fit at this width"* — the compiled Tailwind answers it. The repo's journey specs need `REVIEWER_UID` and a vault passphrase, so they could never guard this.

**Dedicated config** (`playwright.layout-contracts.config.ts`, Chromium + WebKit): the main config's `webServer` boots `npm run dev` before any test. Inheriting it would make a ~6s geometry check wait on a Next dev server. WebKit matters here — it's the engine the iOS app actually runs.

**Class strings moved** to `lib/one-location/map-header-layout.ts`, imported by both component and test. A test that re-declares them measures a copy, and a copy drifts silently — which is how this shipped green the first time.

## Verification

```
old layout → FAIL: "Check in" was clipped at 320px / 360px / 390px / 430px
new layout → 7 passed (Chromium)
```

The failure message is a machine-readable restatement of the original report, at the exact widths it occurred.

| gate | result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | clean |
| `npm run verify:design-system` | passed |
| location suites (9 files) | 131 passed |
| geometry contract, Chromium | 7/7 |

### Honest limits
**WebKit is not locally verified.** Every local Tailwind compile on this machine is currently hanging: a 1.2 GB `npm ci` landed in an iCloud-synced `~/Desktop` worktree and FileProvider is throttling all reads in that tree (the known build-hang gotcha). Chromium passed 7/7 twice before that started, and the spec logic is unchanged since. Linux CI is unaffected — if WebKit disagrees, it fails here, on a test-only PR that cannot touch product behaviour.

**Not wired as a required check.** That's a workflow-permissions change and belongs in its own reviewed commit. `npm run test:layout-contracts` is committed and runnable now.