### PR TITLE
fix(one-location): open the save sheet on a label, not on a dead button

### DIFF
--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -36,6 +36,16 @@ vi.mock("@/lib/vault/vault-context", () => ({
 
 vi.mock("@/lib/one-location/saved-locations", () => ({
   DuplicateSavedLocationError: class DuplicateSavedLocationError extends Error {},
+  // Real behaviour, not a stub: the modal opens on whatever this returns, and
+  // a stub would hide a label being pre-selected over a saved place.
+  defaultSavedLocationCategory: (
+    existing: ReadonlyArray<{ category: string }> = [],
+  ) => {
+    const taken = new Set(existing.map((location) => location.category));
+    if (!taken.has("home")) return "home";
+    if (!taken.has("work")) return "work";
+    return "other";
+  },
   duplicateSavedLocationMessage: (location: {
     category: string;
     label: string;

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -104,6 +104,88 @@ describe("SaveLocationModal", () => {
     mapPickerMockState.canConfirm = true;
   });
 
+  it("opens on Home so the primary button is live without a tap", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText("Pick Home, Work or Other first."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not pre-select a label that would overwrite a saved place", () => {
+    // Home and Work are singletons, so opening on Home for someone who already
+    // has one would replace their Home the moment they pressed Save.
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        existingLocations={[{ category: "home" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Work" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+  });
+
+  it("still opens live when both singletons are taken", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        existingLocations={[{ category: "home" }, { category: "work" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Other" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps the place's own label when editing", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        initialCategory="work"
+        existingLocations={[{ category: "home" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Work" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   it("shows address lookup progress without exposing coordinates", () => {
     render(<SaveLocationModal {...baseProps} address={null} loadingAddress />);
 
@@ -264,9 +346,12 @@ describe("SaveLocationModal", () => {
     ).toBeInTheDocument();
 
     const saveButton = screen.getByRole("button", { name: "Save location" });
-    // Still off, but now for the one reason that remains, and it says so.
-    expect(saveButton).toBeDisabled();
-    expect(screen.getByText("Pick Home, Work or Other first.")).toBeInTheDocument();
+    // Live on arrival: nothing is saved yet, so it opens on Home and the one
+    // remaining reason to be off no longer applies.
+    expect(saveButton).toBeEnabled();
+    expect(
+      screen.queryByText("Pick Home, Work or Other first."),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: " Flat 4B, Tower 2 " },
@@ -427,14 +512,12 @@ describe("SaveLocationModal", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Pick Home, Work or Other first."),
-    ).toBeInTheDocument();
+    // Home is already selected, so the only way to a dead button now is
+    // something the person actually typed.
     expect(
       screen.getByRole("button", { name: "Save location" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Home" }));
     fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
       target: { value: "!" },
     });
@@ -880,13 +963,23 @@ describe("SaveLocationModal", () => {
         />,
       );
 
+      // It now opens live, so block it the only way left -- something the
+      // person typed -- and check the styling follows the state.
+      const save = screen.getByRole("button", { name: "Save location" });
+      expect(save).toBeEnabled();
+      expect(save.className).toContain("var(--app-accent)");
+
       // A dimmed blue still reads as the live primary action and earns a dead
       // tap, so a blocked CTA must not be blue at all.
-      const save = screen.getByRole("button", { name: "Save location" });
+      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+        target: { value: "!" },
+      });
       expect(save).toBeDisabled();
       expect(save.className).not.toContain("var(--app-accent)");
 
-      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+        target: { value: "110001" },
+      });
       expect(save).toBeEnabled();
       expect(save.className).toContain("var(--app-accent)");
     });

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -21,7 +21,11 @@ import {
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
 import { cn } from "@/lib/utils";
-import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
+import {
+  defaultSavedLocationCategory,
+  type SavedLocation,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
 import {
   EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
   inferSavedLocationAddressDetails,
@@ -178,6 +182,12 @@ export type SaveLocationModalProps = {
   collectAddressDetails?: boolean;
   /** Pre-select a category when editing an existing saved place. */
   initialCategory?: SavedLocationCategory | null;
+  /**
+   * Places already saved. Only their categories are read, to pre-select a label
+   * that is still free -- Home and Work are singletons, so pre-selecting an
+   * occupied one would overwrite that place on save.
+   */
+  existingLocations?: readonly Pick<SavedLocation, "category">[];
   /** Pre-fill the custom label (for an "Other" place) when editing. */
   initialCustomLabel?: string | null;
   /** Pre-fill the structured address detail fields when editing. */
@@ -304,6 +314,7 @@ export function SaveLocationModal({
   startWithMapPicker = false,
   collectAddressDetails = false,
   initialCategory = null,
+  existingLocations = [],
   initialCustomLabel = null,
   initialDetails = null,
   saveLabel = "Save location",
@@ -370,7 +381,12 @@ export function SaveLocationModal({
       houseOrFlatEditedRef.current = Boolean(
         initialDetails && initialDetails.houseOrFlat,
       );
-      setCategory(initialCategory ?? null);
+      // Editing keeps the place's own label; a new place opens on the first
+      // label still free, so the primary button is live on arrival instead of
+      // waiting behind "Pick Home, Work or Other first."
+      setCategory(
+        initialCategory ?? defaultSavedLocationCategory(existingLocations),
+      );
       setCustomLabel(initialCustomLabel ?? "");
       setEditingPlace(false);
       setPickedAddress(null);

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -774,6 +774,12 @@ export function SavedLocationsSection() {
         collectAddressDetails
         startWithMapPicker
         initialCategory={editingLocation?.category ?? null}
+        // Excluding the place being edited: its own label is still free to it.
+        existingLocations={
+          editingLocation
+            ? locations.filter((location) => location.id !== editingLocation.id)
+            : locations
+        }
 
         initialCustomLabel={
           editingLocation?.category === "other" ? editingLocation.label : null

--- a/hushh-webapp/lib/one-location/__tests__/default-saved-location-category.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/default-saved-location-category.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultSavedLocationCategory,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
+
+const at = (...categories: SavedLocationCategory[]) =>
+  categories.map((category) => ({ category }));
+
+describe("defaultSavedLocationCategory", () => {
+  it("opens on Home for a first save, so nothing has to be picked", () => {
+    // The whole point: the primary button is live on arrival instead of dead
+    // behind "Pick Home, Work or Other first."
+    expect(defaultSavedLocationCategory([])).toBe("home");
+    expect(defaultSavedLocationCategory()).toBe("home");
+  });
+
+  it("does not pre-select a label that would overwrite a saved place", () => {
+    // Home and Work take fixed ids from `generateId`, so they hold one place
+    // each. Pre-selecting an occupied one would replace it on save.
+    expect(defaultSavedLocationCategory(at("home"))).toBe("work");
+    expect(defaultSavedLocationCategory(at("home", "work"))).toBe("other");
+  });
+
+  it("still answers when both singletons are taken", () => {
+    // "Other" holds many places, so there is always a free label and the
+    // button is never dead.
+    expect(defaultSavedLocationCategory(at("home", "work", "other"))).toBe(
+      "other",
+    );
+    expect(defaultSavedLocationCategory(at("other", "other"))).toBe("home");
+  });
+
+  it("fills the earlier gap rather than appending", () => {
+    // Someone who saved only Work should be offered Home, not Other.
+    expect(defaultSavedLocationCategory(at("work"))).toBe("home");
+    expect(defaultSavedLocationCategory(at("work", "other"))).toBe("home");
+    expect(defaultSavedLocationCategory(at("other"))).toBe("home");
+  });
+
+  it("ignores order and duplicates", () => {
+    expect(defaultSavedLocationCategory(at("work", "home"))).toBe("other");
+    expect(defaultSavedLocationCategory(at("home", "home"))).toBe("work");
+  });
+});

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -28,6 +28,29 @@ const SAVED_LOCATION_CATEGORY_PRIORITY: Record<SavedLocationCategory, number> = 
   other: 2,
 };
 
+/**
+ * Which label to pre-select when someone saves a place.
+ *
+ * The picker used to open with nothing chosen, so the primary button sat dead
+ * behind "Pick Home, Work or Other first." -- an extra tap demanded before the
+ * screen would do the one thing it exists for. On the first save the answer is
+ * almost always Home, so ask for nothing and pre-select it.
+ *
+ * It cannot simply always be Home: `generateId` gives Home and Work fixed ids,
+ * so they are singletons, and pre-selecting an occupied one would quietly
+ * overwrite a place already saved when the person pressed Save. So this walks
+ * Home -> Work -> Other and returns the first that is still free. "Other" holds
+ * many places, so there is always an answer and the button is never dead.
+ */
+export function defaultSavedLocationCategory(
+  existing: readonly Pick<SavedLocation, "category">[] = [],
+): SavedLocationCategory {
+  const taken = new Set(existing.map((location) => location.category));
+  if (!taken.has("home")) return "home";
+  if (!taken.has("work")) return "work";
+  return "other";
+}
+
 export type SavedLocation = {
   id: string;
   category: SavedLocationCategory;


### PR DESCRIPTION
From Ankit's simulator screenshots: **"Save location" is greyed out on arrival**, blocked behind *"Pick Home, Work or Other first."* — a tap demanded before the screen will do the one thing it exists for.

On a first save the answer is almost always Home. So ask for nothing and pre-select it.

## Why it isn't just "always default to Home"

`generateId()` returns the literal string `"home"` / `"work"`, so **those two are singletons**. Opening on an occupied label would quietly overwrite that place the moment Save was pressed — someone saving a café would lose their Home, with no warning.

`defaultSavedLocationCategory()` walks **Home → Work → Other** and returns the first still free. `Other` holds many places, so there is always an answer and the button is never dead.

| Already saved | Opens on |
|---|---|
| nothing (onboarding — the screenshots) | Home |
| Home | Work |
| Home + Work | Other |
| Work only | Home |

Editing is unchanged — an explicit `initialCategory` still wins, and the saved-places list excludes the place being edited, since its own label is still free to it.

## Verification

- 54 tests pass across the picker, the modal, and the saved-places section
- `tsc --noEmit` clean, `eslint --max-warnings=0` clean on all changed files
- **Mutation-checked twice.** Reverting the default → 6 tests fail. Making it unconditionally `"home"` → the 3 tests guarding the overwrite fail. That second one matters: it is the difference between a friction fix and silent data loss.

Three existing tests asserted the old blocking behaviour; they are updated rather than deleted, and the one guarding "a blocked CTA must not look blue" now blocks the button via an invalid PIN instead, so that rule is still enforced.

## Not in this PR

Ankit also reported the map not rendering on the Confirm-pin step, and excessive vertical gaps in both sheets. Both need the simulator to diagnose honestly rather than guess at — the map in particular has a known two-key failure mode where it silently degrades with no console error. Running that next.