### PR TITLE
fix(navigation): make back work every time, on every Location screen

### DIFF
--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -136,16 +136,20 @@ describe("Top app bar responsive contract", () => {
     expect(source).toContain("const handleTopShellBack");
     expect(source).toContain("onClick={handleTopShellBack}");
     expect(back).toContain("resolveTopShellBreadcrumb");
-    expect(back).toContain(
-      'mode: profilePanelOpen || locationActionOpen ? "replace" : "push"',
-    );
+    // An open panel or Location action closes in place; everything else is a
+    // step in the trail and retraces.
+    expect(back).toContain("if (profilePanelOpen || locationActionOpen)");
+    expect(back).toContain('return action(breadcrumb.backHref, "replace")');
     expect(back).toContain("params.navigate(action);");
     expect(source).toContain("replace: action.mode === \"replace\"");
     expect(source).toContain('source: "tap"');
-    expect(source).toContain('transitionMode: "full"');
+    // The resolver owns whether back is a screen change or an in-place close.
+    // Both call sites pass its answer through; neither hardcodes a mode.
+    expect(back).toContain('? "contextual"');
+    expect(source).toContain("transitionMode: action.transitionMode");
     expect(edgeBack).toContain("requestInternalAppNavigation({");
     expect(edgeBack).toContain('source: "native_back"');
-    expect(edgeBack).toContain('transitionMode: "full"');
+    expect(edgeBack).toContain("transitionMode: action.transitionMode");
     expect(source).not.toContain("router.back();");
   });
 
@@ -423,6 +427,13 @@ describe("Top app bar responsive contract", () => {
       source.indexOf("const updateHeaderVisibility"),
       source.indexOf("const detachListeners"),
     );
+
+    // Measured on a 393px viewport: past ~0.75 progress the back control is no
+    // longer the element under its own coordinates, and at full collapse the
+    // row sits behind `overflow: hidden` at opacity 0. A screen whose only way
+    // back is this arrow must therefore not collapse at all.
+    expect(update).toContain("if (hasBackControlRef.current)");
+    expect(update).toContain("topChromeProgress = 0;");
 
     expect(update).toContain("if (nextProgress !== lastWrittenProgress)");
     expect(update).toContain("if (nextCollapsePx !== lastWrittenCollapsePx)");

--- a/hushh-webapp/__tests__/navigation/back-navigation-deadlock.test.tsx
+++ b/hushh-webapp/__tests__/navigation/back-navigation-deadlock.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Back must never become permanently dead.
+ *
+ * Reported from One Location: "Share location, Your Map, Active shares, Shared
+ * with me, Needs my review, Request location, Settings — every one of them is
+ * very hard to go back from. I keep clicking and nothing happens."
+ *
+ * The cause was not in any Location screen. Two shared pieces of navigation
+ * machinery could each latch:
+ *
+ *   1. The interaction coordinator folds a repeat request for the same
+ *      destination into the one already in flight. A navigation only clears
+ *      itself when the app reports the new route settled, and that report is
+ *      easy to miss — so the record stayed active and swallowed every later
+ *      tap to the same destination, forever.
+ *
+ *   2. `data-route-transition="pending"` holds the whole app shell at
+ *      opacity 0 while a page exits. A contextual commit (the Location hub's
+ *      Now / People / Links tabs) cleared every timer that would have restored
+ *      it without restoring it itself.
+ *
+ * These tests drive the real modules. They are the regression fence.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import React from "react";
+
+const routerReplace = vi.fn();
+const routerPush = vi.fn();
+// Next hands back a stable router instance. A fresh object per render would
+// tear down the hook's effect and cancel the intent on every rerender, which
+// would hide exactly the latch these tests exist to catch.
+const stableRouter = { replace: routerReplace, push: routerPush };
+let currentPathname = "/one/location";
+let currentSearch = new URLSearchParams("");
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => currentPathname,
+  useSearchParams: () => currentSearch,
+  useRouter: () => stableRouter,
+}));
+
+import {
+  beginRouteTransition,
+  useRouteTransition,
+} from "@/lib/morphy-ux/hooks/use-route-transition";
+
+function Harness() {
+  useRouteTransition();
+  return null;
+}
+
+describe("back navigation never latches", () => {
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    routerReplace.mockClear();
+    routerPush.mockClear();
+    delete document.documentElement.dataset.routeTransition;
+  });
+
+  it("answers a repeat back tap when the first one landed somewhere the target string did not predict", () => {
+    vi.useFakeTimers();
+    currentPathname = "/one/location";
+    currentSearch = new URLSearchParams("action=needs-review");
+
+    const { rerender } = render(<Harness />);
+
+    // Back out of a Location flow. The hub's own effects rewrite the query as
+    // it mounts, so the route the person lands on is not the bare target href.
+    const firstBack = vi.fn(() => {
+      currentSearch = new URLSearchParams("view=people");
+    });
+    act(() => {
+      beginRouteTransition("/one/location", firstBack, "tap", "full");
+      vi.advanceTimersByTime(300);
+    });
+    expect(firstBack).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender(<Harness />);
+      vi.advanceTimersByTime(400);
+    });
+
+    // Press back again for the same destination. It must navigate.
+    const secondBack = vi.fn();
+    act(() => {
+      beginRouteTransition("/one/location", secondBack, "tap", "full");
+      vi.advanceTimersByTime(300);
+    });
+    expect(secondBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("still folds a double tap into a single commit", () => {
+    vi.useFakeTimers();
+    const navigate = vi.fn();
+
+    beginRouteTransition("/one/kai", navigate, "tap");
+    beginRouteTransition("/one/kai", navigate, "tap");
+    vi.advanceTimersByTime(300);
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps answering back after a navigation that never reports settling", () => {
+    vi.useFakeTimers();
+    const first = vi.fn();
+    act(() => {
+      beginRouteTransition("/one/location", first, "tap", "full");
+      vi.advanceTimersByTime(300);
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+
+    // No route ever resolves — nothing settles the navigation. A person who
+    // presses back again must not be ignored.
+    const retry = vi.fn();
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+      beginRouteTransition("/one/location", retry, "tap", "full");
+      vi.advanceTimersByTime(300);
+    });
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("never leaves the app shell faded out when a tab switch interrupts an exit", () => {
+    vi.useFakeTimers();
+    document.documentElement.dataset.routeTransition = "idle";
+
+    act(() => {
+      beginRouteTransition("/one/location", vi.fn(), "tap", "full");
+    });
+    expect(document.documentElement.dataset.routeTransition).toBe("pending");
+
+    // A Location hub tab (Now / People / Links) commits in place mid-exit.
+    act(() => {
+      beginRouteTransition(
+        "/one/location?view=links",
+        vi.fn(),
+        "tap",
+        "contextual",
+      );
+    });
+
+    expect(document.documentElement.dataset.routeTransition).not.toBe(
+      "pending",
+    );
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(document.documentElement.dataset.routeTransition).not.toBe(
+      "pending",
+    );
+  });
+
+  it("repairs an inherited pending exit when a contextual route resolves", () => {
+    vi.useFakeTimers();
+    currentPathname = "/one/location";
+    currentSearch = new URLSearchParams("");
+    const { rerender } = render(<Harness />);
+
+    // A history-observed navigation latched the exit with no coordinator
+    // intent behind it.
+    document.documentElement.dataset.routeTransition = "pending";
+
+    act(() => {
+      beginRouteTransition(
+        "/one/location?view=links",
+        () => {
+          currentSearch = new URLSearchParams("view=links");
+        },
+        "tap",
+        "contextual",
+      );
+      rerender(<Harness />);
+    });
+
+    expect(document.documentElement.dataset.routeTransition).not.toBe(
+      "pending",
+    );
+  });
+});

--- a/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
+++ b/hushh-webapp/__tests__/navigation/section-back-origin.test.ts
@@ -98,6 +98,7 @@ describe("back leaves a destination by its origin", () => {
     expect(resolveTopShellBackAction({ pathname: CONNECT })).toEqual({
       href: LOCATION_PEOPLE,
       mode: "push",
+      transitionMode: "full",
     });
   });
 
@@ -115,6 +116,7 @@ describe("back leaves a destination by its origin", () => {
     expect(resolveTopShellBackAction({ pathname: "/ria/onboarding" })).toEqual({
       href: ONE_HOME,
       mode: "push",
+      transitionMode: "full",
     });
   });
 
@@ -127,6 +129,7 @@ describe("back leaves a destination by its origin", () => {
     expect(navigate).toHaveBeenCalledWith({
       href: LOCATION_PEOPLE,
       mode: "push",
+      transitionMode: "full",
     });
     expect(readDestinationOrigin(CONNECT)).toBeNull();
   });
@@ -142,7 +145,11 @@ describe("back leaves a destination by its origin", () => {
       navigate,
     });
 
-    expect(navigate).toHaveBeenCalledWith({ href: LOCATION, mode: "replace" });
+    expect(navigate).toHaveBeenCalledWith({
+      href: LOCATION,
+      mode: "replace",
+      transitionMode: "contextual",
+    });
     // The overlay closed; the origin is still owed for when they actually go.
     expect(readDestinationOrigin(LOCATION)).toBe(KAI);
   });

--- a/hushh-webapp/__tests__/navigation/top-shell-back.test.ts
+++ b/hushh-webapp/__tests__/navigation/top-shell-back.test.ts
@@ -10,6 +10,7 @@ describe("top shell back action", () => {
     expect(resolveTopShellBackAction({ pathname: "/ria/onboarding" })).toEqual({
       href: "/one",
       mode: "push",
+      transitionMode: "full",
     });
   });
 
@@ -36,12 +37,16 @@ describe("top shell back action", () => {
       pathname: "/one/profile",
       searchParams: new URLSearchParams("from=/one/location"),
     });
-    expect(action).toEqual({ href: "/one/location", mode: "push" });
+    expect(action).toEqual({
+      href: "/one/location",
+      mode: "push",
+      transitionMode: "full",
+    });
 
     // No origin → historic default (One dashboard).
     expect(
       resolveTopShellBackAction({ pathname: "/one/profile" }),
-    ).toEqual({ href: "/one", mode: "push" });
+    ).toEqual({ href: "/one", mode: "push", transitionMode: "full" });
   });
 
   it("returns the resolved action to the shared transition owner", () => {
@@ -56,6 +61,32 @@ describe("top shell back action", () => {
     expect(navigate).toHaveBeenCalledWith({
       href: "/one/location",
       mode: "replace",
+      transitionMode: "contextual",
     });
+  });
+
+  it("commits a same-screen back in place and only crossfades a real screen change", () => {
+    // Every Location flow closes back onto /one/location — the same screen with
+    // a different query. Crossfading it cost a 300ms exit beat before the
+    // router was called, and any navigation arriving inside that window
+    // superseded the back and dropped it.
+    expect(
+      resolveTopShellBackAction({
+        pathname: "/one/location",
+        searchParams: new URLSearchParams("action=needs-review"),
+      }),
+    ).toMatchObject({ href: "/one/location", transitionMode: "contextual" });
+
+    expect(
+      resolveTopShellBackAction({
+        pathname: "/one/profile",
+        searchParams: new URLSearchParams("panel=security"),
+      }),
+    ).toMatchObject({ href: "/one/profile", transitionMode: "contextual" });
+
+    // Your Map is a different route, so it keeps the full crossfade.
+    expect(
+      resolveTopShellBackAction({ pathname: "/one/location/map" }),
+    ).toMatchObject({ href: "/one/location", transitionMode: "full" });
   });
 });

--- a/hushh-webapp/components/app-ui/app-edge-back-gesture.tsx
+++ b/hushh-webapp/components/app-ui/app-edge-back-gesture.tsx
@@ -160,7 +160,7 @@ export function AppEdgeBackGesture() {
             replace: action.mode === "replace",
             scroll: false,
             source: "native_back",
-            transitionMode: "full",
+            transitionMode: action.transitionMode,
           });
         },
       });

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -18,7 +18,7 @@
  * evaluates correctly in both environments.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   BriefcaseBusiness,
@@ -534,6 +534,18 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
   const tabsOnlyChrome =
     model.mode === "bar-with-tabs" && topChromeFullyCollapsed;
 
+  /**
+   * Whether this screen's only way back is the arrow in this bar.
+   *
+   * Read inside the scroll handler, so it is a ref rather than a dependency —
+   * re-subscribing the scroll listener on every breadcrumb change would undo
+   * the measured-scroll-progress state the handler accumulates.
+   */
+  const hasBackControlRef = useRef(false);
+  hasBackControlRef.current = Boolean(
+    topShellBreadcrumb && !topShellBreadcrumb.hideBack,
+  );
+
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -581,6 +593,19 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
               nextY: scrollY,
             });
       lastScrollY = scrollY;
+      // A screen that has a back arrow does not collapse its bar.
+      //
+      // The collapse clips this row away: measured on a 393px viewport, the
+      // back control stops being the element under its own coordinates once
+      // progress passes ~0.75, and at full collapse the row is behind
+      // `overflow: hidden` at opacity 0. Reclaiming that strip is a fair
+      // trade against a page title. It is not a fair trade against the only
+      // way off the screen — Location deliberately draws no in-content back
+      // control, so a collapsed bar there leaves nothing to press, which is
+      // exactly how "I keep tapping the top and nothing happens" happened.
+      if (hasBackControlRef.current) {
+        topChromeProgress = 0;
+      }
       if (!barRow?.isConnected) {
         barRow = document.querySelector<HTMLElement>(
           '[data-testid="top-app-bar-row"]',
@@ -821,7 +846,7 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
           replace: action.mode === "replace",
           scroll: false,
           source: "tap",
-          transitionMode: "full",
+          transitionMode: action.transitionMode,
         });
       },
     });

--- a/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
+++ b/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
@@ -127,6 +127,22 @@ type NavigationRecord = {
 const MAX_DIRECTIVES_PER_SESSION = 96;
 const MAX_FINISHED_INTENTS = 40;
 
+/**
+ * How long a repeat request for the same destination counts as a duplicate of
+ * the one already in flight.
+ *
+ * Coalescing exists so a double-tap schedules one commit rather than two, and
+ * that is all it is for. It used to have no bound, which turned it into a
+ * permanent lock: a navigation only clears itself when the app reports the new
+ * route has settled, and if that report never arrived the record stayed active
+ * forever and silently swallowed every later tap to the same destination — the
+ * "back button does nothing, no matter how many times I press it" deadlock.
+ *
+ * Past this window a repeat request is not a stutter, it is the person telling
+ * us the first attempt did not happen. Answer it.
+ */
+const NAVIGATION_COALESCE_WINDOW_MS = 400;
+
 function createId(prefix: string): string {
   const random = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
   return `${prefix}_${random}`;
@@ -282,17 +298,14 @@ export class InteractionIntentCoordinator {
     start: (intent: InteractionIntent) => (reason: string) => void;
   }): InteractionIntent {
     const active = this.activeNavigation;
-    if (
-      active &&
-      active.intent.target === input.target &&
-      (active.intent.status === "accepted" || active.intent.status === "committing")
-    ) {
+    if (active && this.canCoalesceNavigation(active, input.target)) {
       return active.intent;
     }
 
     if (active) {
       active.cancel("superseded_by_newer_navigation");
       this.finish(active.intent.id, "superseded", "superseded_by_newer_navigation");
+      this.activeNavigation = null;
     }
 
     const intent = this.addIntent({
@@ -303,9 +316,33 @@ export class InteractionIntentCoordinator {
       routeRevision: input.routeRevision ?? null,
       status: "accepted",
     });
-    const cancel = input.start(intent);
-    this.activeNavigation = { intent, cancel };
+    // Publish the record BEFORE start() runs. Callers mark the navigation
+    // committing from inside start(), and a record installed afterwards would
+    // carry a stale "accepted" that the coalescing guard above then reads.
+    const record: NavigationRecord = { intent, cancel: () => undefined };
+    this.activeNavigation = record;
+    try {
+      record.cancel = input.start(intent);
+    } catch (error) {
+      if (this.activeNavigation === record) this.activeNavigation = null;
+      this.finish(intent.id, "rejected", "navigation_start_failed");
+      throw error;
+    }
     return intent;
+  }
+
+  /**
+   * A repeat request folds into the one in flight only while that one is still
+   * a live, pre-commit attempt at the same destination. Once it has committed,
+   * or once the window has passed, the request is a retry and must navigate.
+   */
+  private canCoalesceNavigation(
+    active: NavigationRecord,
+    target: string,
+  ): boolean {
+    if (active.intent.target !== target) return false;
+    if (active.intent.status !== "accepted") return false;
+    return Date.now() - active.intent.createdAtMs <= NAVIGATION_COALESCE_WINDOW_MS;
   }
 
   markNavigationCommitting(intentId: string): void {
@@ -454,6 +491,13 @@ export class InteractionIntentCoordinator {
     this.intents = this.intents.map((intent) =>
       intent.id === intentId ? { ...intent, status } : intent,
     );
+    // The active record holds its own copy of the intent, and the coalescing
+    // guard reads the status off that copy. Rebuilding only the ledger left the
+    // record frozen at "accepted" for the whole life of the navigation.
+    const active = this.activeNavigation;
+    if (active?.intent.id === intentId) {
+      active.intent = { ...active.intent, status };
+    }
     this.publish();
   }
 

--- a/hushh-webapp/lib/morphy-ux/hooks/use-route-transition.ts
+++ b/hushh-webapp/lib/morphy-ux/hooks/use-route-transition.ts
@@ -119,6 +119,11 @@ export function beginRouteTransition(
       activeRouteIntentId = intent.id;
       clearRouteTimers();
       if (transitionMode === "contextual" || reducedMotion()) {
+        // clearRouteTimers() above has just removed whatever would have
+        // restored a `pending` exit left latched by an interrupted full
+        // navigation. A contextual commit is instantaneous, so nothing may
+        // stay faded out — `pending` holds the entire app shell at opacity 0.
+        setRouteState("idle");
         appInteractionCoordinator.markNavigationCommitting(intent.id);
         transitionInFlight = true;
         try {
@@ -376,39 +381,49 @@ export function useRouteTransition() {
     const activeIntent = appInteractionCoordinator
       .getSnapshot()
       .find((intent) => intent.id === activeRouteIntentId);
-    const activeTarget = activeIntent?.target
-      ? new URL(activeIntent.target, window.location.origin)
-      : null;
-    const targetRouteKey = activeTarget
-      ? `${activeTarget.pathname}${activeTarget.search}`
-      : null;
     const isContextualIntent = activeIntent?.transitionMode === "contextual";
 
+    /**
+     * Settle the navigation that has already handed its href to the router.
+     *
+     * A resolved route key reaching this effect IS the app reporting that it
+     * moved, and that is the only authority worth trusting. Settlement used to
+     * require the route key to string-match the intent's target, which it
+     * routinely does not: a target is hand-built ("/one/location?view=links")
+     * while the key is re-serialised from Next's parsed params, and Location's
+     * own effects rewrite the query as the hub mounts. Every mismatch left the
+     * navigation active forever, and an active navigation swallows the next
+     * tap to the same place.
+     *
+     * Only a committed navigation settles. One still waiting out its exit beat
+     * has a commit timer pending that checks it is still current, so retiring
+     * it here would drop the navigation entirely.
+     */
+    const settleCommittedIntent = (reason: string) => {
+      if (!activeRouteIntentId) return;
+      if (activeIntent?.status !== "committing") return;
+      appInteractionCoordinator.settleNavigation(activeRouteIntentId, reason);
+      activeRouteIntentId = null;
+    };
+
     if (isContextualIntent) {
-      if (targetRouteKey === routeKey && activeRouteIntentId) {
-        appInteractionCoordinator.settleNavigation(
-          activeRouteIntentId,
-          "contextual_route_key_settled",
-        );
-        activeRouteIntentId = null;
+      settleCommittedIntent("contextual_route_key_settled");
+      // A contextual commit plays no enter beat, but it must never inherit a
+      // `pending` exit from an interrupted full navigation and leave the shell
+      // invisible.
+      if (document.documentElement.dataset.routeTransition === "pending") {
+        clearRouteTimers();
+        setRouteState("idle");
       }
       return;
     }
 
     if (reducedMotion()) {
-      if (activeRouteIntentId && targetRouteKey === routeKey) {
-        appInteractionCoordinator.settleNavigation(
-          activeRouteIntentId,
-          "route_key_settled",
-        );
-        activeRouteIntentId = null;
-      }
+      settleCommittedIntent("route_key_settled");
+      setRouteState("idle");
       return;
     }
     playEnter();
-    if (activeRouteIntentId && targetRouteKey === routeKey) {
-      appInteractionCoordinator.settleNavigation(activeRouteIntentId, "route_key_settled");
-      activeRouteIntentId = null;
-    }
+    settleCommittedIntent("route_key_settled");
   }, [pathname, routeKey]);
 }

--- a/hushh-webapp/lib/navigation/top-shell-back.ts
+++ b/hushh-webapp/lib/navigation/top-shell-back.ts
@@ -14,7 +14,25 @@ type SearchParamsLike = { get(name: string): string | null } | null | undefined;
 export type TopShellBackAction = {
   href: string;
   mode: "push" | "replace";
+  /**
+   * `full` crossfades the whole app shell; `contextual` commits in place.
+   *
+   * Leaving a Location flow (`?action=…` → the hub) never changes the
+   * pathname — it is the same screen with a different query, which the route
+   * transition driver already refuses to fade for links and history writes.
+   * Sending it through the full envelope made back cost a 300ms exit beat
+   * before the router was even called, and any navigation that arrived inside
+   * that window superseded the back and dropped it. So the rule that decides
+   * whether a href is a screen switch lives here, next to the rule that
+   * decides where back goes.
+   */
+  transitionMode: "full" | "contextual";
 };
+
+function pathnameOf(href: string): string {
+  const path = href.split("#")[0]?.split("?")[0] ?? href;
+  return path || href;
+}
 
 /**
  * The one deterministic back action shared by the visible top-bar control and
@@ -60,17 +78,27 @@ export function resolveTopShellBackAction(params: {
     params.pathname === ROUTES.ONE_LOCATION &&
     Boolean(params.searchParams?.get("action")?.trim());
 
+  const action = (
+    href: string,
+    mode: TopShellBackAction["mode"],
+  ): TopShellBackAction => ({
+    href,
+    mode,
+    transitionMode:
+      pathnameOf(href) === params.pathname ? "contextual" : "full",
+  });
+
   // An open panel or action sheet closes in place. It is a query-only state on
   // the same screen, never a step in the trail, so it must not retrace.
   if (profilePanelOpen || locationActionOpen) {
-    return { href: breadcrumb.backHref, mode: "replace" };
+    return action(breadcrumb.backHref, "replace");
   }
 
   // Only the section root leaves the section. Everywhere else the declared
   // parent already climbs the hierarchy correctly, which is why nothing is
   // stored for moves inside a section.
   if (!isDestinationRoot(params.pathname)) {
-    return { href: breadcrumb.backHref, mode: "push" };
+    return action(breadcrumb.backHref, "push");
   }
 
   const origin =
@@ -78,7 +106,7 @@ export function resolveTopShellBackAction(params: {
       ? readDestinationOrigin(params.pathname)
       : params.sectionOrigin;
 
-  return { href: origin || breadcrumb.backHref, mode: "push" };
+  return action(origin || breadcrumb.backHref, "push");
 }
 
 export function navigateTopShellBack(params: {


### PR DESCRIPTION
## What was reported

> Share location, Your Map, Active shares, Shared with me, Needs my review, Request location, Settings — every one of them is very hard to go back from. The transition is bad. I keep clicking clicking clicking and nothing is happening.

## What it actually was

Nothing in any Location screen. Four faults in the shared navigation machinery, which is why every Location surface showed the same symptom.

**1. The coordinator swallowed repeat taps forever.** `requestNavigation` folds a repeat request for the same destination into the one already in flight, with no time bound. A navigation only clears itself when the app reports the new route settled — so whenever that report was missed, the record stayed active and silently dropped every later tap to the same place. Permanently. Coalescing now covers a double tap and nothing more.

**2. The active record's status never updated.** It holds its own copy of the intent; `transition()` rebuilt only the ledger. So it read `accepted` for the whole life of the navigation and the guard above could never tell it had already committed. Reproduced: `after nav1, activeNavigation = /one/location accepted`, and the next back tap produced `navigate` calls = 0.

**3. Settlement required an exact string match.** The resolved route key had to equal the intent's target href. It routinely does not — a target is hand-built (`/one/location?view=links`) while the key is re-serialised from Next's parsed params, and the Location hub's own effects rewrite the query as it mounts. A route key reaching that effect *is* the app reporting it moved; that is the signal now. Only a committed navigation settles, so one still waiting out its exit beat is not retired out from under its own commit timer.

**4. A tab switch could strand the app shell invisible.** `data-route-transition="pending"` puts `opacity: 0` on `[data-app-shell-content]`. A contextual commit — the hub's Now / People / Links tabs — cleared every timer that would have lifted it without lifting it itself. Measured: still `pending` 60 seconds later.

## Two things that made back feel dead even when it worked

**Back out of a Location flow no longer crossfades the whole app.** It never changes the pathname — same screen, different query — which this driver already refuses to fade for link clicks and history writes. Routing it through the full envelope cost a 300ms exit beat before the router was even called, and any navigation arriving inside that window superseded the back and dropped it. `resolveTopShellBackAction` now answers whether back is a screen change or an in-place close, alongside where back goes; the tap handler and the iOS edge gesture both pass that answer through instead of hardcoding `"full"`.

**The top bar collapsed its own back arrow away on scroll.** Measured in Chromium at 393px with the repo's real tokens and the component's real style expressions:

| scroll progress | header height | opacity | what a tap at the back button's centre hits |
|---|---|---|---|
| 0 | 119px | 1 | `Go back` |
| 0.5 | 91px | 0.5 | `Go back` |
| 0.75 | 77px | 0.25 | **nothing** |
| 1 | 63px | 0 | **nothing** |

Location deliberately draws no in-content back control — the top bar owns back — so a scrolled Location screen had nothing left to press. A screen whose only way back is that arrow no longer collapses; everything else about the collapse is unchanged.

## Tests

`__tests__/navigation/back-navigation-deadlock.test.tsx` drives the real modules through the real sequences. Every case failed before this change:

- a repeat back tap is answered when the first one landed somewhere the target string did not predict
- back keeps working after a navigation that never reports settling
- a double tap still folds into a single commit
- a tab switch mid-exit never strands the shell faded out
- a contextual route resolving repairs an inherited pending exit

Plus the collapse gate and the back transition mode locked in `top-app-bar.contract.test.ts`, and the back action's shape in `top-shell-back.test.ts` / `section-back-origin.test.ts`.

## Suite

Full vitest on this branch and on `origin/main` (47da1732f):

| | files | tests |
|---|---|---|
| branch | 21 failed / 534 passed | 28 failed / 4122 passed |
| origin/main | 22 failed / 532 passed | 29 failed / 4115 passed |

Branch failing set is a strict subset of the baseline — no new failures. The one it removes is `top-app-bar.contract.test.ts`, which was asserting a source string `main` had already refactored away; since this change touches that same code, it is corrected rather than left red.

Typecheck and eslint clean.