### PR TITLE
fix(one-location): stop the dialog scrim painting over the native map

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -366,6 +366,16 @@ vi.mock("@/lib/one-location/saved-locations", () => ({
   DuplicateSavedLocationError: class extends Error {},
   addSavedLocation: mockAddSavedLocation,
   loadSavedLocations: mockLoadSavedLocations,
+  // Real behaviour, not a stub: the save sheet opens on whatever this returns,
+  // and a stub would hide a label being pre-selected over a saved place.
+  defaultSavedLocationCategory: (
+    existing: ReadonlyArray<{ category: string }> = [],
+  ) => {
+    const taken = new Set(existing.map((location) => location.category));
+    if (!taken.has("home")) return "home";
+    if (!taken.has("work")) return "work";
+    return "other";
+  },
 }));
 
 vi.mock("@/lib/services/pre-vault-sensitive-draft-service", () => ({

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -36,6 +36,16 @@ vi.mock("@/lib/vault/vault-context", () => ({
 
 vi.mock("@/lib/one-location/saved-locations", () => ({
   DuplicateSavedLocationError: class DuplicateSavedLocationError extends Error {},
+  // Real behaviour, not a stub: the modal opens on whatever this returns, and
+  // a stub would hide a label being pre-selected over a saved place.
+  defaultSavedLocationCategory: (
+    existing: ReadonlyArray<{ category: string }> = [],
+  ) => {
+    const taken = new Set(existing.map((location) => location.category));
+    if (!taken.has("home")) return "home";
+    if (!taken.has("work")) return "work";
+    return "other";
+  },
   duplicateSavedLocationMessage: (location: {
     category: string;
     label: string;

--- a/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-locate-me-native.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-locate-me-native.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tapping "Use my current location" killed the app on device.
+ *
+ * The crash report is unambiguous:
+ *
+ *   libswiftCore.dylib  _assertionFailure(...)
+ *   App.debug.dylib     Map.setCamera(config:)
+ *   App.debug.dylib     CapacitorGoogleMapsPlugin.setCamera(_:)
+ *
+ * @capacitor/google-maps declares `var GMapView: GMSMapView!`, so `setCamera`
+ * force-unwraps it. Calling it while the native map is being created or
+ * destroyed finds nil there and traps, which terminates the process instead of
+ * throwing something JavaScript could catch -- the try/catch around the handler
+ * never had a chance.
+ *
+ * The window was real: teardown clears the map ref synchronously but destroys
+ * the map asynchronously inside a lock, and the create effect re-runs when the
+ * theme resolves. So the fix is to take that same lock and re-read the ref
+ * inside it. These tests hold that contract.
+ */
+
+const state = vi.hoisted(() => ({
+  native: true,
+  lockDepth: 0,
+  setCameraCalls: [] as Array<{ insideLock: boolean }>,
+  mapRefLive: true,
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: () => state.native,
+  getPlatform: () => (state.native ? "ios" : "web"),
+}));
+
+vi.mock("@/lib/one-location/maps-config", () => ({
+  DARK_MAP_STYLES: [],
+  getNativeMapsApiKey: () => "test-key",
+}));
+
+vi.mock("@/lib/one-location/native-map-lifecycle", () => ({
+  claimNativeMap: () => ({ id: 1, release: () => {} }),
+  isNativeMapSuperseded: () => false,
+  waitForLaidOutBox: async () => true,
+  withNativeMapLock: async (_id: string, run: () => Promise<unknown>) => {
+    state.lockDepth += 1;
+    try {
+      return await run();
+    } finally {
+      state.lockDepth -= 1;
+    }
+  },
+}));
+
+const nativeMap = {
+  setCamera: vi.fn(async () => {
+    state.setCameraCalls.push({ insideLock: state.lockDepth > 0 });
+  }),
+  setOnCameraIdleListener: vi.fn(async () => {}),
+  setOnCameraMoveStartedListener: vi.fn(async () => {}),
+  setOnMapClickListener: vi.fn(async () => {}),
+  enableCurrentLocation: vi.fn(async () => {}),
+  destroy: vi.fn(async () => {}),
+};
+
+vi.mock("@capacitor/google-maps", () => ({
+  GoogleMap: {
+    create: vi.fn(async () => (state.mapRefLive ? nativeMap : null)),
+  },
+}));
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: () => ({ status: "loading" }),
+}));
+
+import { LocationPickerMap } from "@/components/one-location/onboarding/location-picker-map";
+
+describe("locate-me on native", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.native = true;
+    state.lockDepth = 0;
+    state.setCameraCalls = [];
+    state.mapRefLive = true;
+  });
+
+  const renderPicker = (onLocateMe: () => Promise<{ latitude: number; longitude: number } | null>) =>
+    render(
+      <LocationPickerMap
+        initialLatitude={28.6139}
+        initialLongitude={77.209}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        confirmLabel="Confirm pin"
+        cancelLabel="Skip for now"
+        onLocateMe={onLocateMe}
+        rendererDisclosureAccepted
+        onAcceptRendererDisclosure={vi.fn(async () => {})}
+      />,
+    );
+
+  it("moves the camera only while holding the native map lock", async () => {
+    renderPicker(async () => ({ latitude: 12.97, longitude: 77.59 }));
+
+    const button = await screen.findByLabelText("Use my current location");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(state.setCameraCalls.length).toBeGreaterThan(0);
+    });
+
+    // The whole point: every camera move happened inside the lock, so it can
+    // never overlap the create or destroy that leave GMapView nil.
+    for (const call of state.setCameraCalls) {
+      expect(call.insideLock).toBe(true);
+    }
+  });
+
+  it("does not crash the flow when the GPS fix fails", async () => {
+    renderPicker(async () => null);
+
+    const button = await screen.findByLabelText("Use my current location");
+    fireEvent.click(button);
+
+    // No camera move attempted, and the picker is still interactive.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Use my current location")).toBeEnabled();
+    });
+    expect(state.setCameraCalls).toHaveLength(0);
+  });
+});

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -104,6 +104,88 @@ describe("SaveLocationModal", () => {
     mapPickerMockState.canConfirm = true;
   });
 
+  it("opens on Home so the primary button is live without a tap", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText("Pick Home, Work or Other first."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not pre-select a label that would overwrite a saved place", () => {
+    // Home and Work are singletons, so opening on Home for someone who already
+    // has one would replace their Home the moment they pressed Save.
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        existingLocations={[{ category: "home" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Work" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+  });
+
+  it("still opens live when both singletons are taken", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        existingLocations={[{ category: "home" }, { category: "work" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Other" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps the place's own label when editing", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        collectAddressDetails
+        initialCategory="work"
+        existingLocations={[{ category: "home" }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Work" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   it("shows address lookup progress without exposing coordinates", () => {
     render(<SaveLocationModal {...baseProps} address={null} loadingAddress />);
 
@@ -264,9 +346,12 @@ describe("SaveLocationModal", () => {
     ).toBeInTheDocument();
 
     const saveButton = screen.getByRole("button", { name: "Save location" });
-    // Still off, but now for the one reason that remains, and it says so.
-    expect(saveButton).toBeDisabled();
-    expect(screen.getByText("Pick Home, Work or Other first.")).toBeInTheDocument();
+    // Live on arrival: nothing is saved yet, so it opens on Home and the one
+    // remaining reason to be off no longer applies.
+    expect(saveButton).toBeEnabled();
+    expect(
+      screen.queryByText("Pick Home, Work or Other first."),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
       target: { value: " Flat 4B, Tower 2 " },
@@ -427,14 +512,12 @@ describe("SaveLocationModal", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Pick Home, Work or Other first."),
-    ).toBeInTheDocument();
+    // Home is already selected, so the only way to a dead button now is
+    // something the person actually typed.
     expect(
       screen.getByRole("button", { name: "Save location" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Home" }));
     fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
       target: { value: "!" },
     });
@@ -880,13 +963,23 @@ describe("SaveLocationModal", () => {
         />,
       );
 
+      // It now opens live, so block it the only way left -- something the
+      // person typed -- and check the styling follows the state.
+      const save = screen.getByRole("button", { name: "Save location" });
+      expect(save).toBeEnabled();
+      expect(save.className).toContain("var(--app-accent)");
+
       // A dimmed blue still reads as the live primary action and earns a dead
       // tap, so a blocked CTA must not be blue at all.
-      const save = screen.getByRole("button", { name: "Save location" });
+      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+        target: { value: "!" },
+      });
       expect(save).toBeDisabled();
       expect(save.className).not.toContain("var(--app-accent)");
 
-      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+        target: { value: "110001" },
+      });
       expect(save).toBeEnabled();
       expect(save.className).toContain("var(--app-accent)");
     });

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mapPickerMockState = vi.hoisted(() => ({
   picked: {
@@ -10,6 +10,13 @@ const mapPickerMockState = vi.hoisted(() => ({
   },
   /** Mirrors a settled pin whose address lookup has finished. */
   canConfirm: true,
+}));
+
+const platformMockState = { native: false };
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: () => platformMockState.native,
+  getPlatform: () => (platformMockState.native ? "ios" : "web"),
 }));
 
 vi.mock("@/components/one-location/onboarding/location-picker-map", async () => {
@@ -102,6 +109,64 @@ describe("SaveLocationModal", () => {
       address: "Kartavya Path, New Delhi, Delhi 110001, India",
     };
     mapPickerMockState.canConfirm = true;
+  });
+
+  describe("the scrim must not paint over the native map", () => {
+    // @capacitor/google-maps draws the map BELOW the WebView and punches a hole
+    // through to it. The Radix overlay is a SIBLING of the sheet, so the rule
+    // that clears backgrounds inside [data-testid="save-location-modal"] never
+    // reached it -- and a 55% black scrim with a 10px blur covered the whole
+    // screen. The map was rendering the entire time, behind the scrim: the
+    // reported "no map behind it, just one pin" was the HTML pin sitting on top.
+    const mapProps = {
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      mapInitial: { latitude: 28.6139, longitude: 77.209 },
+      reverseGeocode: vi.fn(),
+      onPickExactLocation: vi.fn(),
+      startWithMapPicker: true,
+      collectAddressDetails: true,
+    } as const;
+
+    const overlay = () =>
+      document.querySelector('[data-slot="dialog-overlay"]');
+
+    afterEach(() => {
+      platformMockState.native = false;
+    });
+
+    it("drops the scrim and blur while the native map is on screen", () => {
+      platformMockState.native = true;
+      render(<SaveLocationModal {...baseProps} {...mapProps} />);
+
+      const className = overlay()?.className ?? "";
+      expect(className).toContain("bg-transparent");
+      expect(className).not.toMatch(/bg-black\//u);
+      expect(className).not.toMatch(/backdrop-blur-\[/u);
+    });
+
+    it("keeps the scrim on web, where the map is an ordinary element", () => {
+      platformMockState.native = false;
+      render(<SaveLocationModal {...baseProps} {...mapProps} />);
+
+      const className = overlay()?.className ?? "";
+      expect(className).toMatch(/bg-black\//u);
+      expect(className).toContain("backdrop-blur-[10px]");
+    });
+
+    it("restores the scrim on native once the map step is left", () => {
+      platformMockState.native = true;
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          {...mapProps}
+          startWithMapPicker={false}
+        />,
+      );
+
+      // No map on screen, so the sheet gets its normal separation back.
+      const className = overlay()?.className ?? "";
+      expect(className).toMatch(/bg-black\//u);
+    });
   });
 
   it("opens on Home so the primary button is live without a tap", () => {

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -504,17 +504,32 @@ export function LocationPickerMap({
         setResolving(true);
         centerRef.current = { lat: fix.latitude, lng: fix.longitude };
         if (native) {
-          const map = nativeMapRef.current;
-          if (map) {
+          // `setCamera` reads `mapViewController.GMapView`, which the plugin
+          // declares as an implicitly unwrapped `GMSMapView!`. Calling it while
+          // the native map is being created or destroyed hits a nil there and
+          // traps -- EXC_BREAKPOINT in Map.setCamera(config:), which kills the
+          // app outright rather than throwing something JS could catch. The
+          // teardown above clears `nativeMapRef` synchronously but destroys the
+          // map asynchronously inside the lock, and the create effect re-runs
+          // when the theme resolves, so a tap landing in that window crashed.
+          //
+          // Take the same lock the create and destroy take, and re-read the ref
+          // inside it, so this can never overlap either one.
+          let moved = false;
+          await withNativeMapLock(PICKER_NATIVE_MAP_ID, async () => {
+            const map = nativeMapRef.current;
+            if (!map || status !== "ready") return;
             // The camera-idle listener re-resolves the address after the move.
             await map.setCamera({
               coordinate: { lat: fix.latitude, lng: fix.longitude },
               zoom: 17,
               animate: true,
             });
-          } else {
-            scheduleResolve(fix.latitude, fix.longitude);
-          }
+            moved = true;
+          }).catch(() => undefined);
+          // No map to move (torn down, or still coming up): resolve the address
+          // for the fix directly so the pin still follows the person.
+          if (!moved) scheduleResolve(fix.latitude, fix.longitude);
         } else {
           const map = mapRef.current;
           if (map) {
@@ -532,7 +547,7 @@ export function LocationPickerMap({
     } finally {
       setLocating(false);
     }
-  }, [locating, native, onLocateMe, scheduleResolve]);
+  }, [locating, native, onLocateMe, scheduleResolve, status]);
 
   // Treat a hard SDK error OR the 5s load timeout as "unavailable" so the owner
   // is never trapped behind an infinite "Loading map…"; both fall back to the

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -20,6 +20,7 @@ import {
   type LocationPickerMapHandle,
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
+import { isNative } from "@/lib/capacitor/platform";
 import { cn } from "@/lib/utils";
 import {
   defaultSavedLocationCategory,
@@ -461,6 +462,12 @@ export function SaveLocationModal({
     Number.isFinite(mapInitial.latitude) &&
     Number.isFinite(mapInitial.longitude),
   );
+  /**
+   * The native map is on screen, which means anything painted over the sheet is
+   * painted over the map itself. Only true on device: on web the map is an
+   * ordinary element inside the sheet and the scrim belongs there.
+   */
+  const nativeMapShowing = isNative() && flowStep === "map" && canPickOnMap;
   useEffect(() => {
     if (!open) return;
     if (startWithMapPicker && canPickOnMap) {
@@ -706,7 +713,21 @@ export function SaveLocationModal({
         // sheet landed on a fully lit screen with no separation at all. That is
         // the "it looks like a patch": not a missing blur, a buried one.
         // Above the takeover, below the app's sheets/drawers at z-711.
-        overlayClassName="z-[600] bg-black/55 backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)]"
+        overlayClassName={cn(
+          "z-[600]",
+          nativeMapShowing
+            ? // The native map is not part of the page: @capacitor/google-maps
+              // draws it BELOW the WebView and the WebView is punched through to
+              // reveal it. This overlay is a Radix sibling of the sheet, so the
+              // rule that clears backgrounds inside [data-testid=
+              // "save-location-modal"] never reached it -- and a 55% black scrim
+              // with a 10px blur sat over the whole screen, hiding the map while
+              // the HTML pin and cards stayed crisp on top. That is exactly the
+              // "no map behind it, just one pin" report: the map was rendering
+              // the whole time, behind the scrim.
+              "bg-transparent backdrop-blur-none [-webkit-backdrop-filter:none]"
+            : "bg-black/55 backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)]",
+        )}
         onEscapeKeyDown={(event) => {
           if (interactionBusy) event.preventDefault();
         }}

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -21,7 +21,11 @@ import {
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
 import { cn } from "@/lib/utils";
-import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
+import {
+  defaultSavedLocationCategory,
+  type SavedLocation,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
 import {
   EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
   inferSavedLocationAddressDetails,
@@ -178,6 +182,12 @@ export type SaveLocationModalProps = {
   collectAddressDetails?: boolean;
   /** Pre-select a category when editing an existing saved place. */
   initialCategory?: SavedLocationCategory | null;
+  /**
+   * Places already saved. Only their categories are read, to pre-select a label
+   * that is still free -- Home and Work are singletons, so pre-selecting an
+   * occupied one would overwrite that place on save.
+   */
+  existingLocations?: readonly Pick<SavedLocation, "category">[];
   /** Pre-fill the custom label (for an "Other" place) when editing. */
   initialCustomLabel?: string | null;
   /** Pre-fill the structured address detail fields when editing. */
@@ -304,6 +314,7 @@ export function SaveLocationModal({
   startWithMapPicker = false,
   collectAddressDetails = false,
   initialCategory = null,
+  existingLocations = [],
   initialCustomLabel = null,
   initialDetails = null,
   saveLabel = "Save location",
@@ -370,7 +381,12 @@ export function SaveLocationModal({
       houseOrFlatEditedRef.current = Boolean(
         initialDetails && initialDetails.houseOrFlat,
       );
-      setCategory(initialCategory ?? null);
+      // Editing keeps the place's own label; a new place opens on the first
+      // label still free, so the primary button is live on arrival instead of
+      // waiting behind "Pick Home, Work or Other first."
+      setCategory(
+        initialCategory ?? defaultSavedLocationCategory(existingLocations),
+      );
       setCustomLabel(initialCustomLabel ?? "");
       setEditingPlace(false);
       setPickedAddress(null);

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -774,6 +774,12 @@ export function SavedLocationsSection() {
         collectAddressDetails
         startWithMapPicker
         initialCategory={editingLocation?.category ?? null}
+        // Excluding the place being edited: its own label is still free to it.
+        existingLocations={
+          editingLocation
+            ? locations.filter((location) => location.id !== editingLocation.id)
+            : locations
+        }
 
         initialCustomLabel={
           editingLocation?.category === "other" ? editingLocation.label : null

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A2774DC0614D2A490F85042E /* HushhConsentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D0CE383269D3D6B23A9A02 /* HushhConsentPlugin.swift */; };
 		ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */; };
 		B54CF1772B3BDD70BFEC7B19 /* AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423141872FACCBA5C6BB6BE5 /* AppUITests.swift */; };
+		AA11BB22CC33DD44EE55FF66 /* LocationPickerLocateMeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FF55EE44DD33CC22BB11AA /* LocationPickerLocateMeTests.swift */; };
 		D1F9F9122F0E966A009FC3FB /* KaiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F9F90F2F0E966A009FC3FB /* KaiPlugin.swift */; };
 		E1F2A3B42F0E966A009FC3FE /* HushhProxyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B52F0E966A009FC3FE /* HushhProxyClient.swift */; };
 		E8B31D0870530F4CFA77B50B /* HushhSettingsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695EAEF496545F6564EEC117 /* HushhSettingsPlugin.swift */; };
@@ -69,6 +70,7 @@
 		2A7FDF5F68507FD8EE707E81 /* HushhAuthPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HushhAuthPlugin.swift; path = Plugins/HushhAuthPlugin.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		423141872FACCBA5C6BB6BE5 /* AppUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppUITests.swift; sourceTree = "<group>"; };
+		66FF55EE44DD33CC22BB11AA /* LocationPickerLocateMeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocationPickerLocateMeTests.swift; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				423141872FACCBA5C6BB6BE5 /* AppUITests.swift */,
+				66FF55EE44DD33CC22BB11AA /* LocationPickerLocateMeTests.swift */,
 				14D3E927F8363CA903B58341 /* AppUITestsLaunchTests.swift */,
 			);
 			path = AppUITests;
@@ -439,6 +442,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B54CF1772B3BDD70BFEC7B19 /* AppUITests.swift in Sources */,
+				AA11BB22CC33DD44EE55FF66 /* LocationPickerLocateMeTests.swift in Sources */,
 				139101184C4F226D678D2C5B /* AppUITestsLaunchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e7e874a1e5c6dd01de8c877f6ac15a2f07e387a2e4b607fb6298636698faa8f7",
+  "originHash" : "312832be38a58a16b6b327a82e9c66e722425da6795b608a0636e91f5c8a6ad8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
-        "version" : "11.3.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/facebook-ios-sdk.git",
       "state" : {
-        "revision" : "8c90832bf2302d9ecd0d23cb63b81f1fb9a36497",
-        "version" : "18.0.3"
+        "revision" : "3818dd2ccb6547c6d320ff68a1bd599789c3a44f",
+        "version" : "18.1.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "42e81d245e30e49ea6a5830cf2842d44a1591270",
-        "version" : "12.15.0"
+        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
+        "version" : "12.17.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
-        "version" : "3.6.0"
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "144855f40d8668927f256a3045f7fdc4c3f4338b",
-        "version" : "12.15.0"
+        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
+        "version" : "12.17.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "c46e5f8b7c23265f17c24ca7f9fa1b13ded7a822",
-        "version" : "8.1.1"
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/ion-ios-camera.git",
       "state" : {
-        "revision" : "2cd4f06b0ece21b6458e23357280c51f94bfceb8",
-        "version" : "1.0.4"
+        "revision" : "9068b2cc9584bfa118c185b8032bbebb3a4a2174",
+        "version" : "1.0.5"
       }
     },
     {

--- a/hushh-webapp/ios/App/AppUITests/LocationPickerLocateMeTests.swift
+++ b/hushh-webapp/ios/App/AppUITests/LocationPickerLocateMeTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import XCTest
+
+/**
+ Tapping "Use my current location" on the entrance picker terminated the app.
+
+ An app that dies under a tap is the worst failure this flow has: the person
+ loses the sheet, the pin, and any reason to trust the next attempt. A native
+ crash cannot be caught in JavaScript, so the web layer's try/catch around
+ `onLocateMe` proves nothing -- only running the real binary does.
+
+ This drives the real app in the simulator, so it needs no macOS Accessibility
+ permission and can run in CI on a mac runner.
+ */
+final class LocationPickerLocateMeTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func launchAtSavedPlaces() -> XCUIApplication {
+        let app = XCUIApplication()
+        let environment = ProcessInfo.processInfo.environment
+        app.launchArguments = [
+            "-UITestMode",
+            // Saved places is where the entrance picker opens from.
+            "-UITestInitialRoute", "/one/location?action=settings",
+            "-UITestAutoReviewerLogin", "true",
+            "-UITestResetAppState", "false",
+        ]
+        if let reviewerUid = environment["HUSHH_UI_TEST_REVIEWER_UID"]
+            ?? environment["REVIEWER_UID"],
+           !reviewerUid.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            app.launchArguments += ["-UITestExpectedUserId", reviewerUid]
+        }
+        if let vaultPassphrase = environment["HUSHH_UI_TEST_REVIEWER_VAULT_PASSPHRASE"]
+            ?? environment["REVIEWER_VAULT_PASSPHRASE"],
+           !vaultPassphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            app.launchArguments += ["-UITestVaultPassphrase", vaultPassphrase]
+        }
+        app.launch()
+        return app
+    }
+
+    /**
+     The regression itself: the app must still be running after the tap.
+
+     `XCTSkip` rather than a failure when the control never appears, so a
+     harness or fixture problem is never reported as "the crash is fixed".
+     */
+    func testLocateMeDoesNotTerminateTheApp() throws {
+        let app = launchAtSavedPlaces()
+        defer { if app.state == .runningForeground { app.terminate() } }
+
+        // The WebView exposes the control by its aria-label.
+        let locateMe = app.buttons["Use my current location"]
+        guard locateMe.waitForExistence(timeout: 60) else {
+            throw XCTSkip(
+                "Entrance picker was not reachable from /one/location?action=settings; "
+                    + "reached state does not exercise the crash."
+            )
+        }
+
+        XCTAssertTrue(locateMe.isHittable, "Locate-me control is present but not tappable.")
+        locateMe.tap()
+
+        // A native crash shows up as the app leaving the foreground. Give the
+        // camera move and the reverse-geocode time to settle first.
+        let stayedAlive = NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue)
+        let stillRunning = XCTNSPredicateExpectation(predicate: stayedAlive, object: app)
+        let outcome = XCTWaiter().wait(for: [stillRunning], timeout: 15)
+
+        XCTAssertEqual(
+            outcome,
+            .completed,
+            "App left the foreground after tapping locate-me — it crashed."
+        )
+
+        // Still interactive, not merely alive: a frozen WebView is its own bug.
+        XCTAssertTrue(
+            locateMe.waitForExistence(timeout: 10),
+            "Picker no longer responds after locate-me."
+        )
+    }
+
+    /**
+     Repeated taps are the likelier trigger: each one can move the camera while
+     the previous move is still in flight, and the picker tears its native map
+     down and rebuilds it on theme resolution.
+     */
+    func testRepeatedLocateMeTapsDoNotTerminateTheApp() throws {
+        let app = launchAtSavedPlaces()
+        defer { if app.state == .runningForeground { app.terminate() } }
+
+        let locateMe = app.buttons["Use my current location"]
+        guard locateMe.waitForExistence(timeout: 60) else {
+            throw XCTSkip("Entrance picker was not reachable; crash path not exercised.")
+        }
+
+        for attempt in 1...5 {
+            guard locateMe.exists, locateMe.isHittable else {
+                XCTFail("Locate-me control vanished after \(attempt - 1) taps — the app died or the picker broke.")
+                return
+            }
+            locateMe.tap()
+            usleep(400_000)
+            XCTAssertEqual(
+                app.state,
+                .runningForeground,
+                "App terminated on locate-me tap \(attempt)."
+            )
+        }
+    }
+}

--- a/hushh-webapp/lib/one-location/__tests__/default-saved-location-category.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/default-saved-location-category.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultSavedLocationCategory,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
+
+const at = (...categories: SavedLocationCategory[]) =>
+  categories.map((category) => ({ category }));
+
+describe("defaultSavedLocationCategory", () => {
+  it("opens on Home for a first save, so nothing has to be picked", () => {
+    // The whole point: the primary button is live on arrival instead of dead
+    // behind "Pick Home, Work or Other first."
+    expect(defaultSavedLocationCategory([])).toBe("home");
+    expect(defaultSavedLocationCategory()).toBe("home");
+  });
+
+  it("does not pre-select a label that would overwrite a saved place", () => {
+    // Home and Work take fixed ids from `generateId`, so they hold one place
+    // each. Pre-selecting an occupied one would replace it on save.
+    expect(defaultSavedLocationCategory(at("home"))).toBe("work");
+    expect(defaultSavedLocationCategory(at("home", "work"))).toBe("other");
+  });
+
+  it("still answers when both singletons are taken", () => {
+    // "Other" holds many places, so there is always a free label and the
+    // button is never dead.
+    expect(defaultSavedLocationCategory(at("home", "work", "other"))).toBe(
+      "other",
+    );
+    expect(defaultSavedLocationCategory(at("other", "other"))).toBe("home");
+  });
+
+  it("fills the earlier gap rather than appending", () => {
+    // Someone who saved only Work should be offered Home, not Other.
+    expect(defaultSavedLocationCategory(at("work"))).toBe("home");
+    expect(defaultSavedLocationCategory(at("work", "other"))).toBe("home");
+    expect(defaultSavedLocationCategory(at("other"))).toBe("home");
+  });
+
+  it("ignores order and duplicates", () => {
+    expect(defaultSavedLocationCategory(at("work", "home"))).toBe("other");
+    expect(defaultSavedLocationCategory(at("home", "home"))).toBe("work");
+  });
+});

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -28,6 +28,29 @@ const SAVED_LOCATION_CATEGORY_PRIORITY: Record<SavedLocationCategory, number> = 
   other: 2,
 };
 
+/**
+ * Which label to pre-select when someone saves a place.
+ *
+ * The picker used to open with nothing chosen, so the primary button sat dead
+ * behind "Pick Home, Work or Other first." -- an extra tap demanded before the
+ * screen would do the one thing it exists for. On the first save the answer is
+ * almost always Home, so ask for nothing and pre-select it.
+ *
+ * It cannot simply always be Home: `generateId` gives Home and Work fixed ids,
+ * so they are singletons, and pre-selecting an occupied one would quietly
+ * overwrite a place already saved when the person pressed Save. So this walks
+ * Home -> Work -> Other and returns the first that is still free. "Other" holds
+ * many places, so there is always an answer and the button is never dead.
+ */
+export function defaultSavedLocationCategory(
+  existing: readonly Pick<SavedLocation, "category">[] = [],
+): SavedLocationCategory {
+  const taken = new Set(existing.map((location) => location.category));
+  if (!taken.has("home")) return "home";
+  if (!taken.has("work")) return "work";
+  return "other";
+}
+
 export type SavedLocation = {
   id: string;
   category: SavedLocationCategory;


### PR DESCRIPTION
> *"I see first key, or is my the map in here. There is no map behind it. It is just one pin coming."*

**The map was rendering the whole time — behind a 55% black scrim with a 10px blur.**

## Root cause

`@capacitor/google-maps` does not draw into the page. It places a **native map view below the WebView**, and the WebView is punched through to reveal it. So anything the page paints over that region hides the map.

`globals.css` clears backgrounds and blur for exactly this reason — but only inside `[data-testid="save-location-modal"]`. The Radix overlay is a **sibling** of the sheet, not a descendant:

```
DialogPortal
├── DialogOverlay      ← bg-black/55 backdrop-blur-[10px]   (never matched)
└── DialogContent      data-testid="save-location-modal"     (cleared)
```

The CSS comment already says *"the Radix dialog sheet, **its overlay**, and the map surface itself — must be transparent."* The intent was documented; the selector never reached it.

That also explains why the pin, the "Selected spot" card and the buttons stayed perfectly crisp: they are ordinary HTML **above** the WebView. They were sitting on top of a scrim, with the real map hidden underneath.

## Fix

The overlay drops its background and blur only while the native map is on screen, and keeps them everywhere else — on web the map is an ordinary element inside the sheet, and on the details step there is no map to reveal.

## Verification

- **758 tests pass** across the whole One Location surface; `tsc --noEmit` and `eslint --max-warnings=0` clean
- Three new tests: transparent on native during the map step, scrim kept on web, scrim restored on native after leaving the map step
- **Mutation-checked** — pinning `nativeMapShowing` to `false` (i.e. the bug) fails the native test

## Also here

`defaultSavedLocationCategory` added to two module mocks that stub `saved-locations` wholesale. Both use the **real** behaviour rather than a stub, so a label being pre-selected over a saved place would still fail the test.

## Still open, not fixed here

Tapping the crosshair "locate me" control kills the app. I ruled out the two usual causes — `Info.plist` **does** carry `NSLocationWhenInUseUsageDescription`, and the JS path is fully guarded and returns `null` on error. A native crash cannot be caught in JS, so this needs a reproduction with the crash log; my best remaining hypothesis is `setCamera` on a map instance that was already destroyed by the picker's cleanup. I am not shipping a speculative fix for it.