### PR TITLE
fix(onboarding): plain-language setup copy and two fewer screens

### DIFF
--- a/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
+++ b/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
@@ -17063,9 +17063,11 @@
     {
       "action_id": "setup.open_connections",
       "surface_id": "one_setup_hub",
-      "label": "Set up AI access",
+      "label": "Choose your AI",
       "aliases": [
+        "choose my ai",
         "set up AI access",
+        "ai access",
         "choose gemini",
         "configure one",
         "use my gemini key"
@@ -17077,7 +17079,7 @@
         "key",
         "setup"
       ],
-      "meaning": "Opens AI access setup so the person can choose Hussh managed Gemini or validate and protect their own Gemini access.",
+      "meaning": "Opens the AI access choice so the person can use Hussh's Gemini or add their own Gemini key.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -17141,7 +17143,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connections",
-            "label": "Set up AI access",
+            "label": "Choose your AI",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connections",
@@ -17493,8 +17495,10 @@
     {
       "action_id": "setup.open_email",
       "surface_id": "one_setup_hub",
-      "label": "KYC",
+      "label": "Identity checks",
       "aliases": [
+        "identity checks",
+        "kyc",
         "set up kyc",
         "open kyc setup",
         "let one draft for me",
@@ -17571,7 +17575,7 @@
           {
             "type": "action",
             "action_id": "setup.open_email",
-            "label": "KYC",
+            "label": "Identity checks",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/email",
@@ -17602,9 +17606,10 @@
     {
       "action_id": "setup.open_finance",
       "surface_id": "one_setup_hub",
-      "label": "Set up your finances",
+      "label": "Set up your money",
       "aliases": [
         "set up finance",
+        "set up my money",
         "open finance setup",
         "set up investing"
       ],
@@ -17678,7 +17683,7 @@
           {
             "type": "action",
             "action_id": "setup.open_finance",
-            "label": "Set up your finances",
+            "label": "Set up your money",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/finance",
@@ -17709,7 +17714,7 @@
     {
       "action_id": "setup.open_ria",
       "surface_id": "one_setup_hub",
-      "label": "Set up RIA",
+      "label": "Set up your advisor profile",
       "aliases": [
         "set up ria",
         "set up my advisor profile",
@@ -17786,7 +17791,7 @@
           {
             "type": "action",
             "action_id": "setup.open_ria",
-            "label": "Set up RIA",
+            "label": "Set up your advisor profile",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/ria",
@@ -17817,14 +17822,15 @@
     {
       "action_id": "setup.open_connected_systems",
       "surface_id": "one_setup_hub",
-      "label": "CRM",
+      "label": "Connect your CRM",
       "aliases": [
         "link my record to external systems",
         "link my record",
         "link my tools",
         "set up connected systems",
         "show crm systems",
-        "connect crm"
+        "connect crm",
+        "connect my crm"
       ],
       "search_keywords": [
         "link tools",
@@ -17897,7 +17903,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connected_systems",
-            "label": "CRM",
+            "label": "Connect your CRM",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connected-systems",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4851,7 +4851,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "f58cda76e5a7f088a0582ce137d62f298be2d524301f832cffec9b23f80a6a3b",
+    "action_gateway": "4e2fe49364c8d317bd3d97d3a0a68713a56ba6c7cf94f0a3321683aa33cea6ea",
     "agent_registry": "8f9c669153e52a57c68ca44db8b8419c1ecc8bb489ceee21a6286ca2eba3c207",
     "cache_manifest": "44fe96be2ef540812f726e064570c67b28e41f134a24839b66b10c72a7a63737",
     "data_plane": "314c1b4e33e47c02b2438aade82b0b92d09f21404e7dbff62b45463b2f51d70c",

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -17063,9 +17063,11 @@
     {
       "action_id": "setup.open_connections",
       "surface_id": "one_setup_hub",
-      "label": "Set up AI access",
+      "label": "Choose your AI",
       "aliases": [
+        "choose my ai",
         "set up AI access",
+        "ai access",
         "choose gemini",
         "configure one",
         "use my gemini key"
@@ -17077,7 +17079,7 @@
         "key",
         "setup"
       ],
-      "meaning": "Opens AI access setup so the person can choose Hussh managed Gemini or validate and protect their own Gemini access.",
+      "meaning": "Opens the AI access choice so the person can use Hussh's Gemini or add their own Gemini key.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -17141,7 +17143,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connections",
-            "label": "Set up AI access",
+            "label": "Choose your AI",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connections",
@@ -17493,8 +17495,10 @@
     {
       "action_id": "setup.open_email",
       "surface_id": "one_setup_hub",
-      "label": "KYC",
+      "label": "Identity checks",
       "aliases": [
+        "identity checks",
+        "kyc",
         "set up kyc",
         "open kyc setup",
         "let one draft for me",
@@ -17571,7 +17575,7 @@
           {
             "type": "action",
             "action_id": "setup.open_email",
-            "label": "KYC",
+            "label": "Identity checks",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/email",
@@ -17602,9 +17606,10 @@
     {
       "action_id": "setup.open_finance",
       "surface_id": "one_setup_hub",
-      "label": "Set up your finances",
+      "label": "Set up your money",
       "aliases": [
         "set up finance",
+        "set up my money",
         "open finance setup",
         "set up investing"
       ],
@@ -17678,7 +17683,7 @@
           {
             "type": "action",
             "action_id": "setup.open_finance",
-            "label": "Set up your finances",
+            "label": "Set up your money",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/finance",
@@ -17709,7 +17714,7 @@
     {
       "action_id": "setup.open_ria",
       "surface_id": "one_setup_hub",
-      "label": "Set up RIA",
+      "label": "Set up your advisor profile",
       "aliases": [
         "set up ria",
         "set up my advisor profile",
@@ -17786,7 +17791,7 @@
           {
             "type": "action",
             "action_id": "setup.open_ria",
-            "label": "Set up RIA",
+            "label": "Set up your advisor profile",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/ria",
@@ -17817,14 +17822,15 @@
     {
       "action_id": "setup.open_connected_systems",
       "surface_id": "one_setup_hub",
-      "label": "CRM",
+      "label": "Connect your CRM",
       "aliases": [
         "link my record to external systems",
         "link my record",
         "link my tools",
         "set up connected systems",
         "show crm systems",
-        "connect crm"
+        "connect crm",
+        "connect my crm"
       ],
       "search_keywords": [
         "link tools",
@@ -17897,7 +17903,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connected_systems",
-            "label": "CRM",
+            "label": "Connect your CRM",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connected-systems",

--- a/hushh-webapp/__tests__/app/one/setup/calendar/calendar-onboarding-setup-client.test.tsx
+++ b/hushh-webapp/__tests__/app/one/setup/calendar/calendar-onboarding-setup-client.test.tsx
@@ -35,7 +35,7 @@ describe("CalendarOnboardingSetupClient", () => {
     expect(
       screen.getByRole("heading", { name: "Understand your schedule." }),
     ).toBeTruthy();
-    expect(screen.getByText("A clear view of what is ahead, with time for what matters.")).toBeTruthy();
+    expect(screen.getByText("See what's ahead, and make time for what matters.")).toBeTruthy();
     expect(screen.getByText("Find time")).toBeTruthy();
     expect(screen.getByText("Schedule with control")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();

--- a/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
@@ -24,7 +24,7 @@ describe("CapabilityCinematicIntroGate", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "A clearer way to understand your money.",
+        name: "See your money clearly.",
       }),
     ).toBeTruthy();
     expect(screen.queryByText("Finance preferences")).toBeNull();
@@ -98,33 +98,29 @@ describe("CapabilityCinematicIntroGate", () => {
     expect(screen.getByText("Finance preferences")).toBeTruthy();
   });
 
-  it("uses the shared prologue for AI access without promoting it to a capability", () => {
-    render(
-      <CapabilityCinematicIntroGate capabilityId="connections">
-        <p>Connections settings</p>
-      </CapabilityCinematicIntroGate>,
+  it("does not gate AI access behind the prologue", () => {
+    // AI access is the mandatory step that blocks finishing setup, so it opens
+    // its real two-option choice directly. The gate does not know about it at
+    // all -- neither as a copy fallback nor as a provider-mark special case.
+    const gateSource = fs.readFileSync(
+      path.resolve(
+        process.cwd(),
+        "components/onboarding/setup/capability-cinematic-intro.tsx",
+      ),
+      "utf8",
+    );
+    const aiAccessPage = fs.readFileSync(
+      path.resolve(
+        process.cwd(),
+        "components/connections/gemini-runtime-configuration-page.tsx",
+      ),
+      "utf8",
     );
 
-    expect(
-      screen.getByRole("heading", {
-        name: "Choose the intelligence behind your private agent.",
-      }),
-    ).toBeTruthy();
-    const providerLane = screen.getByRole("list", { name: "AI providers" });
-    expect(providerLane).toBeTruthy();
-    for (const provider of ["Google Gemini", "OpenAI", "Claude", "Grok", "Meta Muse Spark"]) {
-      expect(screen.getByLabelText(provider)).toBeTruthy();
-    }
-    expect(screen.queryByText("Connections settings")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-
-    expect(screen.getByText("Connections settings")).toBeTruthy();
-    expect(
-      window.sessionStorage.getItem(
-        capabilityCinematicIntroSessionKey("connections"),
-      ),
-    ).toBe("1");
+    expect(gateSource).not.toContain('"connections"');
+    expect(gateSource).not.toContain("Choose the intelligence behind");
+    expect(gateSource).not.toContain("RUNTIME_PROVIDER_CATALOG");
+    expect(aiAccessPage).not.toContain("CapabilityCinematicIntroGate");
   });
 
   it("keeps the Continue action centered and full-width on compact viewports", () => {
@@ -178,18 +174,20 @@ describe("CapabilityCinematicIntroGate", () => {
   });
 
   it("uses transparent, fixed provider mark cells rather than filled brand tiles", () => {
-    const gateSource = fs.readFileSync(
+    // The provider lane moved onto the AI access screen itself when its
+    // prologue was removed; the treatment contract travelled with it.
+    const source = fs.readFileSync(
       path.resolve(
         process.cwd(),
-        "components/onboarding/setup/capability-cinematic-intro.tsx",
+        "components/connections/gemini-runtime-configuration-page.tsx",
       ),
       "utf8",
     );
 
-    expect(gateSource).toContain("data-runtime-provider-lane");
-    expect(gateSource).toContain('className="inline-flex h-12 w-12 items-center justify-center"');
-    expect(gateSource).not.toContain("bg-[color:var(--app-card-surface-compact)]");
-    expect(gateSource).not.toContain("shadow-[var(--shadow-xs)]");
+    expect(source).toContain("data-runtime-provider-lane");
+    expect(source).toContain('className="inline-flex h-9 w-9 items-center justify-center"');
+    expect(source).not.toContain("bg-[color:var(--app-card-surface-compact)]");
+    expect(source).not.toContain("shadow-[var(--shadow-xs)]");
   });
 
   it("keeps every authored setup journey on the shared, non-durable gate", () => {
@@ -201,18 +199,13 @@ describe("CapabilityCinematicIntroGate", () => {
         "app/one/setup/connected-systems/connected-systems-onboarding-setup-client.tsx",
         "connected-systems",
       ],
-      [
-        "app/one/setup/location/location-onboarding-setup-client.tsx",
-        "location",
-      ],
+      // Location deliberately dropped the prologue (see the comment in
+      // location-onboarding-setup-client.tsx: "five taps; it is now three"),
+      // so it is not on this list. AI access dropped it for the same reason.
       ["app/one/setup/gmail/gmail-onboarding-setup-client.tsx", "gmail"],
       [
         "app/one/setup/calendar/calendar-onboarding-setup-client.tsx",
         "calendar",
-      ],
-      [
-        "components/connections/gemini-runtime-configuration-page.tsx",
-        "connections",
       ],
     ] as const;
 

--- a/hushh-webapp/__tests__/components/gemini-runtime-settings-card.test.tsx
+++ b/hushh-webapp/__tests__/components/gemini-runtime-settings-card.test.tsx
@@ -87,7 +87,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       />,
     );
 
-    expect(screen.getByText("Hussh managed Gemini")).toBeTruthy();
+    expect(screen.getByText("Use Hussh's AI")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Gemini" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Coming soon" })).toBeTruthy();
     for (const provider of [
@@ -122,7 +122,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Hussh managed Gemini/i }),
+      screen.getByRole("button", { name: /Use Hussh's AI/i }),
     );
 
     await waitFor(() => expect(onSelectionReadyChange).toHaveBeenCalledTimes(1));
@@ -147,7 +147,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Use my Gemini access/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Use my own key/i }));
 
     expect(onSelectionReadyChange).not.toHaveBeenCalled();
     expect(onRequestVaultCreation).not.toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Use my Gemini access/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Use my own key/i }));
     fireEvent.change(screen.getByLabelText("Gemini API key"), {
       target: { value: "test-gemini-key" },
     });
@@ -217,11 +217,11 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /Use my Gemini access/i }),
+        screen.getByRole("button", { name: /Use my own key/i }),
       ).toHaveAttribute("aria-pressed", "true"),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: /Hussh managed Gemini/i }),
+      screen.getByRole("button", { name: /Use Hussh's AI/i }),
     );
 
     await waitFor(() =>
@@ -230,7 +230,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       ),
     );
     expect(
-      screen.getByRole("button", { name: /Use my Gemini access/i }),
+      screen.getByRole("button", { name: /Use my own key/i }),
     ).toHaveAttribute("aria-pressed", "true");
   });
 
@@ -251,7 +251,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Use my Gemini access/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Use my own key/i }));
     const keyInput = screen.getByLabelText("Gemini API key");
     fireEvent.change(keyInput, { target: { value: "test-gemini-key" } });
 
@@ -288,7 +288,7 @@ describe("GeminiRuntimeSettingsCard setup choice", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Use my Gemini access/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Use my own key/i }));
     const keyInput = screen.getByLabelText("Gemini API key");
     fireEvent.change(keyInput, { target: { value: "first-key" } });
     fireEvent.click(screen.getByRole("button", { name: "Validate key" }));

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -75,13 +75,36 @@ describe("One setup hub terminal action contract", () => {
     );
 
     expect(source).toContain('title="Remaining"');
-    expect(source).toContain('title="AI access"');
+    expect(source).toContain('title="Choose your AI"');
     expect(source).toContain("<SetupNavigationTile");
     expect(source).toContain('voiceControlId="one_setup_tile_connections"');
     expect(source).not.toContain("Private configuration");
-    expect(source.indexOf('title="AI access"')).toBeLessThan(
+    expect(source.indexOf('title="Choose your AI"')).toBeLessThan(
       source.indexOf("remainingItems.map"),
     );
+  });
+
+  it("marks the one mandatory row as required rather than leaving it a quiet grey status", () => {
+    const hub = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+    const tile = readFileSync(
+      join(
+        process.cwd(),
+        "components/onboarding/setup/capability-setup-tile.tsx",
+      ),
+      "utf8",
+    );
+
+    // "Required" in the same muted grey as every other trailing label reads as
+    // one more optional status. The blocking row takes the accent pill and the
+    // current-step role so it is legible as the thing to do first.
+    expect(hub).toContain('statusLabel="Required"');
+    expect(hub).toContain('statusTone="required"');
+    expect(tile).toContain('statusTone === "required"');
+    expect(tile).toContain("bg-[var(--app-accent-tint)]");
+    expect(tile).toContain('aria-current={isCurrent ? "step" : undefined}');
   });
 
   it("counts the mandatory AI access choice in the same progress projection as capability rows", () => {
@@ -115,7 +138,7 @@ describe("One setup hub terminal action contract", () => {
     expect(source).toContain("isLoading || isEnriching");
     expect(source).toContain("<SetupHubLoadingState />");
     expect(source).not.toContain("<Skeleton");
-    expect(source).toContain("Checking your setup choices");
+    expect(source).toContain("Checking your setup…");
     expect(source).toMatch(/actions:\s*hubStateLoading\s*\?\s*\[\]\s*:/);
     expect(stateHook).toContain("useState(enrichVault)");
     expect(stateHook).toContain("useState(enrichOauth)");
@@ -153,12 +176,9 @@ describe("One setup hub terminal action contract", () => {
     // has a supporting line under the button; the phone header action has
     // nothing but a `title` tooltip, which a touch device never shows -- so the
     // header summary both layouts render has to name it too.
-    expect(hub).toContain('"Choose AI access to finish."');
-    expect(hub).toContain(
-      "${done} of ${total} ready. Choose AI access to finish.",
-    );
+    expect(hub).toContain('"Choose your AI first."');
     expect(
-      hub.match(/Choose AI access to finish\./g)?.length,
+      hub.match(/Choose your AI first\./g)?.length,
     ).toBeGreaterThanOrEqual(3);
   });
 
@@ -188,7 +208,6 @@ describe("One setup hub terminal action contract", () => {
 
     expect(hub).toContain("Only you can open what you save.");
     expect(hub).toContain("Not even we can read it.");
-    expect(hub).toContain('"One step left."');
     expect(hub).toContain('"Add the rest any time."');
   });
 
@@ -284,7 +303,6 @@ describe("One setup hub terminal action contract", () => {
     expect(source).toContain("const completeSetupAfterVault = useCallback(async ()");
     const masterHandler = source.slice(source.indexOf("const handleMasterAck"));
     expect(masterHandler).not.toContain("acknowledgeOneSetupExit");
-    expect(source).toContain('data-testid="one-setup-vault-invitation"');
     expect(source).toContain("Set a lock");
     expect(source).not.toContain("I’ll do this later");
     expect(source).not.toContain("one-setup-vault-invitation-later");
@@ -293,6 +311,87 @@ describe("One setup hub terminal action contract", () => {
     expect(source).toContain("PreVaultSensitiveDraftService.finalizeForVault");
     expect(source).toContain("PostUnlockSyncService.run");
     expect(source).toContain("onSuccess={() => undefined}");
+  });
+
+  it("opens the last step straight from Finish setup, with no screen in between", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // The hub used to replace its whole body with an invitation screen whose
+    // only control opened this dialog -- a full screen and an extra tap in
+    // front of the last step. Finish setup now opens the lock step itself.
+    const masterAckStart = source.indexOf("const handleMasterAck");
+    const masterHandler = source.slice(
+      masterAckStart,
+      source.indexOf("useLocalOnboardingActionHandler", masterAckStart),
+    );
+    expect(masterHandler).toContain("setVaultDialogOpen(true);");
+    expect(source).not.toContain("showVaultInvitation");
+    expect(source).not.toContain('data-testid="one-setup-vault-invitation"');
+    expect(source).not.toContain("A private place for what matters");
+    expect(source).not.toContain('data-testid="one-setup-vault-invitation-open"');
+
+    // ...and the promise that screen carried moves onto the step that needs it.
+    const vaultFlow = readFileSync(
+      join(process.cwd(), "components/vault/vault-flow.tsx"),
+      "utf8",
+    );
+    expect(vaultFlow).toContain('description="Only you can open what you save."');
+  });
+
+  it("keeps AI access one tap from the hub instead of behind a prologue", () => {
+    const page = readFileSync(
+      join(
+        process.cwd(),
+        "components/connections/gemini-runtime-configuration-page.tsx",
+      ),
+      "utf8",
+    );
+    const gate = readFileSync(
+      join(
+        process.cwd(),
+        "components/onboarding/setup/capability-cinematic-intro.tsx",
+      ),
+      "utf8",
+    );
+
+    // AI access is the one step that blocks finishing setup. A prologue with
+    // its own Continue button in front of a two-option choice is pure friction.
+    expect(page).not.toContain("CapabilityCinematicIntroGate");
+    expect(gate).not.toContain('"connections"');
+    // The provider marks the prologue used to carry now render inline on the
+    // real screen, so no context is lost with the screen.
+    expect(page).toContain("data-runtime-provider-lane");
+    expect(page).toContain("RUNTIME_PROVIDER_CATALOG");
+    expect(gate).not.toContain("data-runtime-provider-lane");
+
+    // Taking the recommended option is the entire decision, so it finishes the
+    // step. Bring-your-own-key still continues through the footer, because it
+    // has a form left to fill.
+    expect(page).toContain('if (choice === "hushh_managed_vertex") {');
+    expect(page).toContain("returnToSetupHub();");
+  });
+
+  it("names the recommended AI option so the default is not worked out by elimination", () => {
+    const card = readFileSync(
+      join(
+        process.cwd(),
+        "components/connections/gemini-runtime-settings-card.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(card).toContain('<Badge variant="outline">Recommended</Badge>');
+    expect(card).toContain('title="Use Hussh\'s AI"');
+    expect(card).toContain('title="Use my own key"');
+    // System nouns and vendor plumbing stay out of the two rows a person reads.
+    expect(card).not.toContain("Hussh managed Gemini");
+    expect(card).not.toContain("Use my Gemini access");
+    expect(card).not.toContain(
+      "It stays only in this session until your private vault is ready.",
+    );
   });
 
   it("does not allow a setup route to create a first vault before Finish setup", () => {

--- a/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
+++ b/hushh-webapp/__tests__/components/setup-completion-footer-blocked-state.test.tsx
@@ -88,12 +88,12 @@ describe("SetupCompletionFooter blocked state", () => {
   it("states what is still needed next to the blocked action", () => {
     renderFooter({
       disabled: true,
-      supportingText: "Choose AI access to finish.",
+      supportingText: "Choose your AI first.",
     });
 
     // Colour is never the only signal: the reason is readable text, so it
     // survives a screen reader and a person who cannot separate the two greys.
-    expect(screen.getByText("Choose AI access to finish.")).toBeTruthy();
+    expect(screen.getByText("Choose your AI first.")).toBeTruthy();
   });
 
   it("keeps the accent while a real completion is in flight", () => {

--- a/hushh-webapp/__tests__/lib/capability-setup-copy.test.ts
+++ b/hushh-webapp/__tests__/lib/capability-setup-copy.test.ts
@@ -11,31 +11,52 @@ describe("onboarding capability copy", () => {
     });
   });
 
-  it("frames location as a trusted-person sharing choice", () => {
+  it("frames location as a sharing choice the person controls", () => {
     const location = getCapabilitySetupCopy("location");
 
     expect(location?.setupTitle).toBe("Set up location");
-    expect(location?.setupBlurb).toContain("trusted people you choose");
+    expect(location?.setupBlurb).toBe("Share where you are, when you want.");
   });
 
-  it("frames KYC as a simple drafting toggle", () => {
+  it("names the identity-check step in words, not an abbreviation", () => {
     const email = getCapabilitySetupCopy("email");
 
+    // "KYC" survives as the capability id, the route, and the agent lane. It
+    // does not survive as the first thing a person reads.
     expect(email).toMatchObject({
-      setupTitle: "KYC",
+      setupTitle: "Identity checks",
       actionLabel: "Set up KYC",
       resumeActionLabel: "Finish KYC",
     });
-    expect(email?.setupBlurb).toContain("one@hushh.ai");
+    expect(email?.setupBlurb).toBe("One drafts the replies. You approve.");
   });
 
-  it("uses the canonical CRM name for record setup", () => {
+  it("frames CRM setup as a connection the person approves", () => {
     const connectedSystems = getCapabilitySetupCopy("connected-systems");
 
     expect(connectedSystems).toMatchObject({
-      setupTitle: "CRM",
+      setupTitle: "Connect your CRM",
       actionLabel: "Set up CRM",
     });
-    expect(connectedSystems?.setupBlurb).toContain("verified identity");
+    expect(connectedSystems?.setupBlurb).toBe("One finds your record. You approve.");
+  });
+
+  it("keeps every setup row short enough to read at a glance", () => {
+    // Long value-first sentences were what made this list feel like work.
+    // Nothing a person scans on the hub runs past a single short line.
+    for (const id of [
+      "gmail",
+      "calendar",
+      "location",
+      "email",
+      "finance",
+      "ria",
+      "connected-systems",
+    ]) {
+      const copy = getCapabilitySetupCopy(id);
+      expect(copy, id).toBeDefined();
+      expect(copy!.setupTitle.split(" ").length, `${id} title`).toBeLessThanOrEqual(5);
+      expect(copy!.setupBlurb.split(" ").length, `${id} blurb`).toBeLessThanOrEqual(8);
+    }
   });
 });

--- a/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
+++ b/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
@@ -37,17 +37,17 @@ describe("setup catalog voice parity", () => {
       "Connect Gmail",
       "Connect your calendar",
       "Set up location",
-      "KYC",
-      "Set up your finances",
-      "Set up RIA",
-      "CRM",
+      "Identity checks",
+      "Set up your money",
+      "Set up your advisor profile",
+      "Connect your CRM",
     ]);
     expect(
       hubContract.actions
         .filter((action) => action.action_id.startsWith("setup.open_"))
         .map((action) => action.label),
     ).toEqual([
-      "Set up AI access",
+      "Choose your AI",
       ...CAPABILITY_SETUP_COPY.map((capability) => capability.setupTitle),
     ]);
     expect(actions.get("setup.open_connections")?.execution_target).toMatchObject({

--- a/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
@@ -98,7 +98,7 @@ export function EmailOnboardingSetupClient() {
     } catch {
       setEnabled(false);
       setLoadState("error");
-      toast.error("KYC preference could not be loaded. Please try again.");
+      toast.error("Couldn't load this setting. Try again.");
     }
   }, [user]);
 
@@ -122,7 +122,7 @@ export function EmailOnboardingSetupClient() {
         if (!cancelled) {
           setEnabled(false);
           setLoadState("error");
-          toast.error("KYC preference could not be loaded. Please try again.");
+          toast.error("Couldn't load this setting. Try again.");
         }
       }
     })();
@@ -177,8 +177,8 @@ export function EmailOnboardingSetupClient() {
       setEnabled(previous);
       toast.error(
         error instanceof Error && error.message.includes("non-relay")
-          ? "Verify a non-relay sending address before enabling KYC."
-          : "KYC preference could not be saved. Please try again.",
+          ? "Verify a non-relay sending address first."
+          : "Couldn't save this setting. Try again.",
       );
     } finally {
       setSaving(false);
@@ -194,14 +194,14 @@ export function EmailOnboardingSetupClient() {
   );
 
   if (!user || checkingIdentity) {
-    return <SetupCapabilityLoading label="Preparing KYC setup…" />;
+    return <SetupCapabilityLoading label="One moment…" />;
   }
 
   if (!identityPrefaceComplete) {
     return <KycIdentityPreface onComplete={() => setIdentityPrefaceComplete(true)} />;
   }
 
-  if (!coordinator.isReady) return <SetupCapabilityLoading label="Preparing KYC setup…" />;
+  if (!coordinator.isReady) return <SetupCapabilityLoading label="One moment…" />;
 
   return (
     <AppPageShell
@@ -211,7 +211,9 @@ export function EmailOnboardingSetupClient() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          title="KYC"
+          // Matches the setup row. "KYC" is an abbreviation nobody meets for
+          // the first time and understands; it stays in the code and the id.
+          title="Identity checks"
           description={`Requests must come from ${user?.email || "your verified email"}.`}
           accent="neutral"
         />
@@ -238,7 +240,7 @@ export function EmailOnboardingSetupClient() {
                 checked={enabled}
                 onCheckedChange={handleToggle}
                 disabled={saving || loadState !== "ready"}
-                aria-label="Prepare KYC responses automatically"
+                aria-label="Prepare replies automatically"
                 data-voice-control-id="one-setup-email-drafting-toggle"
               />
             }

--- a/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/app-ui/app-page-shell";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import { GeminiRuntimeSettingsCard } from "@/components/connections/gemini-runtime-settings-card";
-import { CapabilityCinematicIntroGate } from "@/components/onboarding/setup/capability-cinematic-intro";
+import { RuntimeProviderMark } from "@/components/brand/runtime-provider-mark";
+import { RUNTIME_PROVIDER_CATALOG } from "@/lib/connections/runtime-provider-catalog";
 import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-completion-footer";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { useAuth } from "@/hooks/use-auth";
@@ -113,19 +114,7 @@ export function GeminiRuntimeConfigurationPage({
   const needsUnlock = !setupMode && Boolean(
     user && !isVaultUnlocked && hasVault === true,
   );
-  const finishConnections = useCallback(async () => {
-    if (!hasRuntimeChoice) {
-      return {
-        status: "blocked" as const,
-        summary: "Choose AI access before finishing setup.",
-      };
-    }
-    if (finishing) {
-      return {
-        status: "blocked" as const,
-        summary: "AI access setup is already being finished.",
-      };
-    }
+  const returnToSetupHub = useCallback(() => {
     setFinishing(true);
     const requested = requestInternalAppNavigation({
       href: ROUTES.ONE_SETUP,
@@ -135,13 +124,29 @@ export function GeminiRuntimeConfigurationPage({
       transitionMode: "full",
     });
     if (!requested) router.replace(ROUTES.ONE_SETUP);
+  }, [router]);
+
+  const finishConnections = useCallback(async () => {
+    if (!hasRuntimeChoice) {
+      return {
+        status: "blocked" as const,
+        summary: "Choose your AI first.",
+      };
+    }
+    if (finishing) {
+      return {
+        status: "blocked" as const,
+        summary: "AI access setup is already being finished.",
+      };
+    }
+    returnToSetupHub();
     return {
       status: "started" as const,
       summary: "AI access setup is complete. Returning to setup.",
       routeAfter: ROUTES.ONE_SETUP,
       screenAfter: "one_setup",
     };
-  }, [finishing, hasRuntimeChoice, router]);
+  }, [finishing, hasRuntimeChoice, returnToSetupHub]);
 
   useLocalOnboardingActionHandler(
     "setup.finish_connections",
@@ -186,11 +191,45 @@ export function GeminiRuntimeConfigurationPage({
       }}
     >
       <AppPageHeaderRegion>
+        {/* The provider marks used to live on a full-screen prologue with its
+            own Continue button — one extra screen and one extra tap in front of
+            a two-option choice. They carry the same "these are the models"
+            context here, inline, at zero cost. */}
+        {setupMode ? (
+          <ul
+            className="mb-4 flex flex-wrap items-center gap-2"
+            aria-label="AI providers"
+            data-runtime-provider-lane
+          >
+            {RUNTIME_PROVIDER_CATALOG.map((provider) => (
+              <li key={provider.id} className="relative">
+                <span
+                  className="inline-flex h-9 w-9 items-center justify-center"
+                  title={
+                    provider.availability === "available"
+                      ? `${provider.name} is available now`
+                      : `${provider.name} is coming soon`
+                  }
+                >
+                  <RuntimeProviderMark
+                    provider={provider}
+                    className={provider.id === "gemini" ? "h-9 w-9" : undefined}
+                  />
+                </span>
+                <span className="sr-only">
+                  {provider.availability === "available"
+                    ? `${provider.name} is available now.`
+                    : `${provider.name} is coming soon.`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
         <PageHeader
-          title={setupMode ? "AI access" : "Gemini settings"}
+          title={setupMode ? "Choose your AI" : "Gemini settings"}
           description={
             setupMode
-              ? "Choose Hussh managed Gemini or set up your own Gemini access. Your credential stays in this session until you finish setup."
+              ? "Use ours, or bring your own key."
               : "Choose how your private agent reaches Gemini."
           }
           accent="neutral"
@@ -220,6 +259,14 @@ export function GeminiRuntimeConfigurationPage({
                   );
                   setSetupChoice(state.oneRuntimeSetupChoice);
                   setHasRuntimeChoice(true);
+                  // Taking the recommended option IS the whole decision —
+                  // there is nothing further to enter — so it finishes this
+                  // step instead of parking the person on a Continue button
+                  // they have to find. Bringing your own key still continues
+                  // below, because that path has a form left to fill.
+                  if (choice === "hushh_managed_vertex") {
+                    returnToSetupHub();
+                  }
                 }
               : undefined
           }
@@ -237,14 +284,14 @@ export function GeminiRuntimeConfigurationPage({
       </AppPageContentRegion>
       {setupMode ? (
         <SetupCompletionFooter
-          label="Finish AI access setup"
+          label="Continue"
           onComplete={() => void finishConnections()}
           busy={finishing}
           disabled={!hasRuntimeChoice || finishing}
           controlId="one-setup-connections-terminal"
           actionId="setup.finish_connections"
           purpose="Record the selected Gemini runtime and return to setup."
-          supportingText="Choose one Gemini option before continuing."
+          supportingText="Pick one to continue."
         />
       ) : null}
       {!setupMode && user ? (
@@ -264,14 +311,9 @@ export function GeminiRuntimeConfigurationPage({
     </AppPageShell>
   );
 
-  // AI access is a root prerequisite rather than an agent capability. Its
-  // shared intro stays presentational-only and never enters the capability
-  // catalog or generated action registry.
-  return setupMode ? (
-    <CapabilityCinematicIntroGate capabilityId="connections">
-      {content}
-    </CapabilityCinematicIntroGate>
-  ) : (
-    content
-  );
+  // AI access is a root prerequisite rather than an agent capability, and it is
+  // the ONE step that blocks finishing setup. It deliberately does not sit
+  // behind the shared cinematic prologue: a mandatory two-option choice must be
+  // one tap from the hub, not a screen, a Continue, and then the choice.
+  return content;
 }

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -226,7 +226,7 @@ export function GeminiRuntimeSettingsCard({
       setMode("hushh_managed_vertex");
       setHasExplicitSelection(true);
       notifyGeminiRuntimeConfigurationChanged();
-      toast.success("Hussh managed Gemini is selected.");
+      toast.success("Using Hussh's AI.");
     } catch (error) {
       setMode(previousMode);
       setHasExplicitSelection(previousSelection);
@@ -498,12 +498,17 @@ export function GeminiRuntimeSettingsCard({
         <SettingsRow
         asChild
         leading={<GeminiLogo className="h-8 w-8" />}
-        title="Hussh managed Gemini"
-        description="Ready now with Hussh-managed Gemini. No personal key is needed."
+        title="Use Hussh's AI"
+        description="No key needed."
+        // The default we want people to take. Until it is chosen the row says
+        // so out loud, so the fast path is the obvious one rather than the one
+        // you work out by elimination.
         trailing={
           mode === "hushh_managed_vertex" && hasExplicitSelection ? (
             <Badge variant="secondary">Selected</Badge>
-          ) : null
+          ) : (
+            <Badge variant="outline">Recommended</Badge>
+          )
         }
         testId="profile-managed-runtime"
       >
@@ -517,11 +522,11 @@ export function GeminiRuntimeSettingsCard({
         <SettingsRow
         asChild
         leading={<GeminiLogo className="h-8 w-8" />}
-        title="Use my Gemini access"
+        title="Use my own key"
         description={
           requiresExplicitSelection && !vaultReady
-            ? "Add a Gemini key now. It stays only in this session until your private vault is ready."
-            : "Use a Google AI Studio key encrypted only in your private vault."
+            ? "Add your own Gemini key."
+            : "Your key stays locked to you."
         }
         trailing={
           mode === "byok" && hasExplicitSelection ? (
@@ -659,7 +664,6 @@ export function GeminiRuntimeSettingsCard({
 
       <SettingsGroup
         title="Coming soon"
-        description="More model choices will appear here when they are ready."
         testId="profile-coming-soon-runtime"
         separatorInset
       >

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1134,19 +1134,19 @@ export function AuthStep({
                   className="text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]"
                 />
                 <span className="type-footnote text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]">
-                  Consent-first. Nothing moves without your yes.
+                  You choose what One can see.
                 </span>
               </div>
 
               <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/45">
-                By continuing, you agree to the{" "}
+                By continuing you agree to our{" "}
                 <button
                   type="button"
                   onClick={() => void openLegalDoc("terms")}
                   data-voice-control-id="auth_terms"
                   className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
                 >
-                  Terms of Service
+                  Terms
                 </button>
                 <span aria-hidden="true"> and </span>
                 <button

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -134,10 +134,13 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
             ))}
           </div>
 
+          {/* Plain words only. "Encrypted" and "consent" are the mechanism and
+              the legal term; "locked" and "your yes" are what a person actually
+              pictures. "Vault" is a code noun and never appears in copy. */}
           <p className={styles.description}>
-            Everything stays encrypted in your vault.
+            Everything you save stays locked.
             <br />
-            Nothing moves without your consent.
+            Nothing moves without your yes.
           </p>
         </div>
 

--- a/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-cinematic-intro.tsx
@@ -2,8 +2,6 @@
 
 import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
-import { RuntimeProviderMark } from "@/components/brand/runtime-provider-mark";
-import { RUNTIME_PROVIDER_CATALOG } from "@/lib/connections/runtime-provider-catalog";
 import { Button } from "@/lib/morphy-ux/button";
 import {
   getCapabilitySetupCopy,
@@ -14,11 +12,11 @@ import { type OneSetupCapabilityId } from "@/lib/onboarding/setup-capability-ids
 const INTRO_SESSION_KEY_PREFIX = "one_capability_intro_seen_v1";
 
 /**
- * AI access is a root setup prerequisite, not an agent capability. It uses
- * the same presentational prologue without entering the capability catalog or
- * generated action registry.
+ * AI access is deliberately NOT in this union. It is the one mandatory step
+ * that blocks finishing setup, so it opens its real choice directly from the
+ * hub instead of a prologue with its own Continue button in front of it.
  */
-export type CapabilityCinematicIntroId = OneSetupCapabilityId | "connections";
+export type CapabilityCinematicIntroId = OneSetupCapabilityId;
 
 export function capabilityCinematicIntroSessionKey(
   capabilityId: CapabilityCinematicIntroId,
@@ -57,20 +55,6 @@ function markCapabilityIntroSeen(capabilityId: CapabilityCinematicIntroId) {
 function fallbackCopy(
   capabilityId: CapabilityCinematicIntroId,
 ): CapabilitySetupCopy {
-  if (capabilityId === "connections") {
-    return {
-      id: capabilityId,
-      title: "AI access",
-      setupTitle: "Choose how One reaches Gemini",
-      setupBlurb: "Start with Gemini today. More models are on the way.",
-      actionLabel: "Continue",
-      resumeActionLabel: "Continue",
-      href: "/one/setup/connections",
-      introPremise: "Choose the intelligence behind your private agent.",
-      introPromise: "Gemini is ready today. More models are coming soon.",
-    };
-  }
-
   return {
     id: capabilityId,
     title: capabilityId,
@@ -194,36 +178,6 @@ export function CapabilityCinematicIntroGate({
       aria-labelledby={`capability-intro-${capabilityId}`}
       data-capability-cinematic-intro={capabilityId}
     >
-      {capabilityId === "connections" ? (
-        <ul
-          className="mb-5 flex flex-wrap items-center gap-2"
-          aria-label="AI providers"
-          data-runtime-provider-lane
-        >
-          {RUNTIME_PROVIDER_CATALOG.map((provider) => (
-            <li key={provider.id} className="relative">
-              <span
-                className="inline-flex h-12 w-12 items-center justify-center"
-                title={
-                  provider.availability === "available"
-                    ? `${provider.name} is available now`
-                    : `${provider.name} is coming soon`
-                }
-              >
-                <RuntimeProviderMark
-                  provider={provider}
-                  className={provider.id === "gemini" ? "h-12 w-12" : undefined}
-                />
-              </span>
-              <span className="sr-only">
-                {provider.availability === "available"
-                  ? `${provider.name} is available now.`
-                  : `${provider.name} is coming soon.`}
-              </span>
-            </li>
-          ))}
-        </ul>
-      ) : null}
       {/* Eyebrow was `text-muted-foreground`, which reads as heavily faded /
           low-contrast on the light onboarding background. Use the primary
           foreground token at reduced weight so it stays legible in both themes

--- a/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
@@ -71,7 +71,15 @@ export interface SetupNavigationTileProps {
   icon: OneCapabilityIcon;
   tone: OneCapabilityTone;
   statusLabel?: string;
+  /**
+   * How the trailing label reads. `required` is the mandatory step that blocks
+   * the exit: it takes the accent pill so it cannot be mistaken for the same
+   * quiet grey status every other row carries.
+   */
+  statusTone?: "muted" | "required";
   isComplete?: boolean;
+  /** Mark the row as the current step in a guided sequence. */
+  isCurrent?: boolean;
   className?: string;
 }
 
@@ -84,7 +92,9 @@ export function SetupNavigationTile({
   icon,
   tone,
   statusLabel,
+  statusTone = "muted",
   isComplete = false,
+  isCurrent = false,
   className,
 }: SetupNavigationTileProps) {
   const router = useRouter();
@@ -123,9 +133,14 @@ export function SetupNavigationTile({
       trailing={
         statusLabel ? (
           <span
+            data-setup-status-tone={statusTone}
             className={cn(
-              "text-xs font-medium",
-              isComplete ? "text-[var(--tone-green)]" : "text-muted-foreground",
+              "shrink-0 text-xs font-medium",
+              isComplete
+                ? "text-[var(--tone-green)]"
+                : statusTone === "required"
+                  ? "rounded-full bg-[var(--app-accent-tint)] px-2 py-0.5 font-semibold text-[var(--app-accent-deep)]"
+                  : "text-muted-foreground",
             )}
           >
             {statusLabel}
@@ -141,7 +156,10 @@ export function SetupNavigationTile({
         onPointerEnter={prefetchRoute}
         onFocus={prefetchRoute}
         onTouchStart={prefetchRoute}
-        aria-label={title}
+        aria-label={
+          statusLabel ? `${title}: ${statusLabel}` : title
+        }
+        aria-current={isCurrent ? "step" : undefined}
         data-href={href}
         data-voice-control-id={voiceControlId}
         className={cn(

--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -92,7 +92,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
               onClick={handleSkip}
               className="w-16 justify-end text-[14px] font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground rounded-full px-3 py-1.5 h-auto transition-colors"
               showRipple={false}
-              aria-label="Skip KYC setup"
+              aria-label="Skip identity checks"
             >
               Skip
             </Button>

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { LockKeyhole, PlugZap } from "lucide-react";
+import { PlugZap } from "lucide-react";
 
 import {
   AppPageContentRegion,
@@ -340,12 +340,17 @@ export function OneSetupHub() {
       if (!runtimeChoiceConfirmed) {
         return {
           status: "blocked" as const,
-          summary: "Choose AI access before continuing.",
+          summary: "Choose your AI first.",
         };
       }
 
       if (!isVaultUnlocked) {
+        // No screen in between. Finish setup opens the lock step itself; the
+        // reassurance the old invitation screen carried ("only you can open
+        // what you save") now lives on the lock step's own first screen, so
+        // nothing is lost and a whole tap disappears.
         setVaultInvitationOpen(true);
+        setVaultDialogOpen(true);
         return {
           status: "succeeded" as const,
           summary: "One step left: set a lock.",
@@ -372,15 +377,17 @@ export function OneSetupHub() {
   // under it, so the one mandatory step has to be named somewhere they can read
   // it before they tap. The header description is the only copy both layouts
   // share, so the blocker rides there rather than only in the desktop footer.
+  //
+  // It carries ONLY that. The segmented progress bar below already renders
+  // "done of total"; repeating the count in words was two facts competing for
+  // the one line people actually read.
   const summary = hubStateLoading
-    ? "Checking what's set up…"
+    ? "One moment…"
     : allReady
-      ? "Everything's set up. You're good to go."
+      ? "Add more any time."
       : !runtimeChoiceComplete
-        ? `${done} of ${total} ready. Choose AI access to finish.`
-        : `${done} of ${total} ready, ${remaining} left to set up.`;
-  const showVaultInvitation =
-    vaultInvitationOpen && Boolean(user) && !isVaultUnlocked;
+        ? "Choose your AI first."
+        : `${remaining} left.`;
 
   return (
     <AppPageShell
@@ -415,13 +422,9 @@ export function OneSetupHub() {
           <div className="min-w-[8rem] flex-1">
           <PageHeader
             title={
-              showVaultInvitation
-                ? "A private place for what matters"
-                : !hubStateLoading && allReady
-                  ? "You're all set"
-                  : "Finish setting up One"
+              !hubStateLoading && allReady ? "You're all set" : "Set up One"
             }
-            description={showVaultInvitation ? "One step left." : summary}
+            description={summary}
             accent="neutral"
             className={styles.setupHeader}
           />
@@ -429,13 +432,13 @@ export function OneSetupHub() {
           {/* Mobile surfaces the master Skip/Finish action top-right in the
               header so it is always reachable and never hides behind the fixed
               "Talk to One" agent bar. Desktop keeps the in-flow footer below. */}
-          {!hubStateLoading && !showVaultInvitation ? (
+          {!hubStateLoading ? (
             <button
               type="button"
               onClick={() => void handleMasterAck()}
               disabled={dismissing || !runtimeChoiceComplete}
               title={
-                !runtimeChoiceComplete ? "Choose AI access to finish." : undefined
+                !runtimeChoiceComplete ? "Choose your AI first." : undefined
               }
               data-testid="one-setup-master-ack-mobile"
               // Same rule as the desktop footer: the accent is reserved for a
@@ -450,43 +453,7 @@ export function OneSetupHub() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
-        {showVaultInvitation ? (
-          <section
-            className="motion-step-enter mx-auto flex min-h-[18rem] w-full max-w-[30rem] flex-col items-center justify-center text-center"
-            aria-labelledby="one-setup-vault-invitation-title"
-            data-testid="one-setup-vault-invitation"
-          >
-            <div
-              className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--app-accent-tint)] text-[var(--app-accent-deep)]"
-              aria-hidden="true"
-            >
-              <LockKeyhole className="h-6 w-6" />
-            </div>
-            <h2
-              id="one-setup-vault-invitation-title"
-              className="mt-5 text-balance type-title2 text-foreground"
-            >
-              Only you can open what you save.
-            </h2>
-            <p className="mt-3 max-w-[28rem] text-pretty type-subhead text-muted-foreground">
-              Not even we can read it.
-            </p>
-            <div className="mt-8 flex w-full max-w-[24rem] flex-col gap-3">
-              <Button
-                type="button"
-                variant="blue-gradient"
-                effect="fill"
-                size="lg"
-                fullWidth
-                className="min-h-14 justify-center text-center"
-                onClick={() => setVaultDialogOpen(true)}
-                data-testid="one-setup-vault-invitation-open"
-              >
-                Set a lock
-              </Button>
-            </div>
-          </section>
-        ) : hubStateLoading ? (
+        {hubStateLoading ? (
           <SetupHubLoadingState />
         ) : (
           <>
@@ -516,13 +483,18 @@ export function OneSetupHub() {
                 {!runtimeChoiceComplete ? (
                   <SetupNavigationTile
                     id="connections"
-                    title="AI access"
-                    description="Choose Hussh managed Gemini or your own Gemini access."
+                    title="Choose your AI"
+                    description="Use ours, or bring your own."
                     href={ROUTES.ONE_SETUP_CONNECTIONS}
                     voiceControlId="one_setup_tile_connections"
                     icon={lucideCapabilityIcon(PlugZap)}
                     tone="connected"
                     statusLabel="Required"
+                    // The one row that blocks the exit. A muted grey "Required"
+                    // reads like every other trailing label, so it gets the
+                    // accent pill and the current-step role instead.
+                    statusTone="required"
+                    isCurrent
                   />
                 ) : null}
                 {remainingItems.map((item) => (
@@ -552,8 +524,8 @@ export function OneSetupHub() {
                   {runtimeChoiceComplete ? (
                     <SetupNavigationTile
                       id="connections"
-                      title="AI access"
-                      description="Change how One reaches Gemini."
+                      title="Choose your AI"
+                      description="Change this any time."
                       href={ROUTES.ONE_SETUP_CONNECTIONS}
                       voiceControlId="one_setup_tile_connections"
                       icon={lucideCapabilityIcon(PlugZap)}
@@ -599,7 +571,7 @@ export function OneSetupHub() {
                 }
                 supportingText={
                   !runtimeChoiceComplete
-                    ? "Choose AI access to finish."
+                    ? "Choose your AI first."
                     : "Add the rest any time."
                 }
                 variant="blue-gradient"
@@ -633,7 +605,7 @@ export function OneSetupHub() {
           dismissible={false}
           enableGeneratedDefault
           title="Set a lock"
-          description="Create a private place for the details you choose to save."
+          description="Only you can open what you save. Not even we can read it."
           onSuccess={() => undefined}
         />
       ) : null}
@@ -649,7 +621,7 @@ function SetupHubLoadingState() {
       aria-busy="true"
       aria-label="Checking setup progress"
     >
-      Checking your setup choices…
+      Checking your setup…
     </div>
   );
 }

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
@@ -16,10 +16,12 @@
   "actions": [
     {
       "action_id": "setup.open_connections",
-      "label": "Set up AI access",
-      "meaning": "Opens AI access setup so the person can choose Hussh managed Gemini or validate and protect their own Gemini access.",
+      "label": "Choose your AI",
+      "meaning": "Opens the AI access choice so the person can use Hussh's Gemini or add their own Gemini key.",
       "aliases": [
+        "choose my ai",
         "set up AI access",
+        "ai access",
         "choose gemini",
         "configure one",
         "use my gemini key"
@@ -121,9 +123,11 @@
     },
     {
       "action_id": "setup.open_email",
-      "label": "KYC",
+      "label": "Identity checks",
       "meaning": "Opens KYC setup so you can choose whether One prepares responses for approval.",
       "aliases": [
+        "identity checks",
+        "kyc",
         "set up kyc",
         "open kyc setup",
         "let one draft for me",
@@ -151,9 +155,9 @@
     },
     {
       "action_id": "setup.open_finance",
-      "label": "Set up your finances",
+      "label": "Set up your money",
       "meaning": "Opens the Finance capability setup step from the setup hub.",
-      "aliases": ["set up finance", "open finance setup", "set up investing"],
+      "aliases": ["set up finance", "set up my money", "open finance setup", "set up investing"],
       "search_keywords": ["finance", "setup", "investing", "kai"],
       "reachability": {
         "routes": ["/one/setup"],
@@ -175,7 +179,7 @@
     },
     {
       "action_id": "setup.open_ria",
-      "label": "Set up RIA",
+      "label": "Set up your advisor profile",
       "meaning": "Opens the RIA advisor-profile setup step from the setup hub.",
       "aliases": ["set up ria", "set up my advisor profile", "open ria setup"],
       "search_keywords": ["ria", "advisor", "profile", "verification", "setup"],
@@ -199,7 +203,7 @@
     },
     {
       "action_id": "setup.open_connected_systems",
-      "label": "CRM",
+      "label": "Connect your CRM",
       "meaning": "Opens CRM setup so the person can find an existing record or review creating one.",
       "aliases": [
         "link my record to external systems",
@@ -207,7 +211,8 @@
         "link my tools",
         "set up connected systems",
         "show crm systems",
-        "connect crm"
+        "connect crm",
+        "connect my crm"
       ],
       "search_keywords": [
         "link tools",

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1037,7 +1037,9 @@ export function VaultFlow({
               <VaultFlowHeader
                 icon={Lock}
                 title="Create your passphrase"
-                description="This is what opens your private place."
+                // Carries the promise the removed "private place" invitation
+                // screen used to make, on the step that actually needs it.
+                description="Only you can open what you save."
               />
               <div className="space-y-1.5">
                 <Label htmlFor="passphrase" className="type-footnote font-medium text-muted-foreground">

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -17063,9 +17063,11 @@
     {
       "action_id": "setup.open_connections",
       "surface_id": "one_setup_hub",
-      "label": "Set up AI access",
+      "label": "Choose your AI",
       "aliases": [
+        "choose my ai",
         "set up AI access",
+        "ai access",
         "choose gemini",
         "configure one",
         "use my gemini key"
@@ -17077,7 +17079,7 @@
         "key",
         "setup"
       ],
-      "meaning": "Opens AI access setup so the person can choose Hussh managed Gemini or validate and protect their own Gemini access.",
+      "meaning": "Opens the AI access choice so the person can use Hussh's Gemini or add their own Gemini key.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -17141,7 +17143,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connections",
-            "label": "Set up AI access",
+            "label": "Choose your AI",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connections",
@@ -17493,8 +17495,10 @@
     {
       "action_id": "setup.open_email",
       "surface_id": "one_setup_hub",
-      "label": "KYC",
+      "label": "Identity checks",
       "aliases": [
+        "identity checks",
+        "kyc",
         "set up kyc",
         "open kyc setup",
         "let one draft for me",
@@ -17571,7 +17575,7 @@
           {
             "type": "action",
             "action_id": "setup.open_email",
-            "label": "KYC",
+            "label": "Identity checks",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/email",
@@ -17602,9 +17606,10 @@
     {
       "action_id": "setup.open_finance",
       "surface_id": "one_setup_hub",
-      "label": "Set up your finances",
+      "label": "Set up your money",
       "aliases": [
         "set up finance",
+        "set up my money",
         "open finance setup",
         "set up investing"
       ],
@@ -17678,7 +17683,7 @@
           {
             "type": "action",
             "action_id": "setup.open_finance",
-            "label": "Set up your finances",
+            "label": "Set up your money",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/finance",
@@ -17709,7 +17714,7 @@
     {
       "action_id": "setup.open_ria",
       "surface_id": "one_setup_hub",
-      "label": "Set up RIA",
+      "label": "Set up your advisor profile",
       "aliases": [
         "set up ria",
         "set up my advisor profile",
@@ -17786,7 +17791,7 @@
           {
             "type": "action",
             "action_id": "setup.open_ria",
-            "label": "Set up RIA",
+            "label": "Set up your advisor profile",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/ria",
@@ -17817,14 +17822,15 @@
     {
       "action_id": "setup.open_connected_systems",
       "surface_id": "one_setup_hub",
-      "label": "CRM",
+      "label": "Connect your CRM",
       "aliases": [
         "link my record to external systems",
         "link my record",
         "link my tools",
         "set up connected systems",
         "show crm systems",
-        "connect crm"
+        "connect crm",
+        "connect my crm"
       ],
       "search_keywords": [
         "link tools",
@@ -17897,7 +17903,7 @@
           {
             "type": "action",
             "action_id": "setup.open_connected_systems",
-            "label": "CRM",
+            "label": "Connect your CRM",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/connected-systems",

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -262,7 +262,9 @@ function resolveTopShellBreadcrumbInner(
       align: "center",
       items: [
         { label: "Set up", href: ROUTES.ONE_SETUP },
-        { label: "AI access" },
+        // Matches the on-screen title; a crumb that disagrees with the heading
+        // reads as two different screens.
+        { label: "Choose your AI" },
       ],
     };
   }

--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -76,133 +76,118 @@ const SETUP_COPY_BY_ID: Record<
   }
 > = {
   finance: {
-    setupTitle: "Set up your finances",
-    setupBlurb:
-      "Tell One how you like to invest so it can read your portfolio and surface analysis that fits you.",
+    setupTitle: "Set up your money",
+    setupBlurb: "See how your money is doing.",
     actionLabel: "Set up Finance",
     resumeActionLabel: "Finish Finance",
-    introPremise: "A clearer way to understand your money.",
-    introPromise:
-      "One only uses the accounts and preferences you choose to share.",
+    introPremise: "See your money clearly.",
+    introPromise: "Only the accounts you share. Nothing else.",
     setupBullets: [
-      "Share how you like to invest in a few quick taps.",
-      "One reads your portfolio and tailors the analysis to you.",
-      "Hand off to a real advisor whenever you want.",
+      "Tell One how you like to invest.",
+      "One reads your portfolio and tailors what it shows you.",
+      "Hand off to a real advisor any time.",
     ],
   },
   gmail: {
     setupTitle: "Connect Gmail",
-    setupBlurb:
-      "Connect Gmail so One can understand the brands you care about and build a private memory of recent interactions.",
+    setupBlurb: "One learns what you care about.",
     actionLabel: "Connect Gmail",
     resumeActionLabel: "Finish Gmail",
-    introPremise: "Let the details you choose become more useful.",
-    introPromise:
-      "Gmail is connected only with your approval, and you stay in control of what One remembers.",
+    introPremise: "Your mail, made useful.",
+    introPromise: "Connected only with your yes.",
     setupBullets: [
-      "Connect Gmail once, with your approval.",
-      "One learns your brand affinities from the interactions you approve.",
-      "Keep a private memory of recent interactions, ready when you need it.",
+      "Connect Gmail once, with your yes.",
+      "One learns the brands you care about.",
+      "What it remembers stays private to you.",
     ],
   },
   calendar: {
     setupTitle: "Connect your calendar",
-    setupBlurb:
-      "Connect Google Calendar so One can summarize your schedule, find time, and prepare meeting changes for your approval.",
+    setupBlurb: "One keeps track of your day.",
     actionLabel: "Connect Calendar",
     resumeActionLabel: "Finish Calendar",
     introPremise: "Understand your schedule.",
-    introPromise:
-      "A clear view of what is ahead, with time for what matters.",
+    introPromise: "See what's ahead, and make time for what matters.",
     setupBullets: [
       "Connect Google Calendar with the access you choose.",
-      "Ask One for schedule summaries and availability.",
-      "Review every meeting change before it happens.",
+      "Ask One what's on today.",
+      "Approve every meeting change before it happens.",
     ],
   },
   email: {
-    setupTitle: "KYC",
-    setupBlurb:
-      "Choose whether requests you send to one@hushh.ai may prepare responses for your approval.",
+    // "KYC" is an abbreviation nobody meets for the first time and understands.
+    // The row now says what actually happens; the destination keeps the name.
+    setupTitle: "Identity checks",
+    setupBlurb: "One drafts the replies. You approve.",
     actionLabel: "Set up KYC",
     resumeActionLabel: "Finish KYC",
-    introPremise: "An identity that moves at your pace.",
-    introPromise:
-      "You decide which details to save and when One may use them to help you.",
+    introPremise: "Replies, ready when you are.",
+    introPromise: "You approve every reply.",
     setupBullets: [
       "Turn drafting on or off any time.",
-      "Every draft stays yours to review before it sends.",
+      "Every draft is yours to review before it sends.",
     ],
   },
   location: {
     setupTitle: "Set up location",
-    setupBlurb:
-      "Set up location so you can share it with the trusted people you choose, whenever you want.",
+    setupBlurb: "Share where you are, when you want.",
     actionLabel: "Choose location",
     resumeActionLabel: "Finish location",
     introPremise: "Be easier to reach when it matters.",
-    introPromise:
-      "Your location stays private until you choose the people and moment to share it.",
+    introPromise: "Private until you choose to share.",
     setupBullets: [
-      "Choose the trusted people who can receive a location share.",
-      "Start and stop sharing whenever you want.",
-      "Your location stays private unless you choose to share it.",
+      "Pick the people who can see where you are.",
+      "Start and stop sharing any time.",
+      "Private unless you choose to share.",
     ],
   },
   ria: {
-    setupTitle: "Set up RIA",
-    setupBlurb:
-      "Create and verify your advisor profile so One can open the right professional workspace for you.",
+    setupTitle: "Set up your advisor profile",
+    setupBlurb: "Verify once. Get your advisor workspace.",
     actionLabel: "Verify RIA",
     resumeActionLabel: "Finish RIA",
-    introPremise: "A professional workspace shaped around your practice.",
-    introPromise:
-      "You review every detail before it becomes part of your advisor profile.",
+    introPremise: "A workspace built for your practice.",
+    introPromise: "You review every detail first.",
     setupBullets: [
       "Verify your advisor or firm credentials.",
-      "Choose the services you offer and review your profile.",
-      "Submit only when the profile is accurate.",
+      "Choose the services you offer.",
+      "Submit only when the profile is right.",
     ],
   },
   pkm: {
     setupTitle: "Save what matters",
-    setupBlurb:
-      "Keep notes and personal details in one private place that only you and One can open.",
+    setupBlurb: "Notes only you can open.",
     actionLabel: "Save what matters",
     resumeActionLabel: "Finish saving",
     setupBullets: [
-      "Save notes and personal details in one place.",
-      "Only you and One can ever open it.",
-      "One recalls what matters exactly when you need it.",
+      "Save notes and details in one place.",
+      "Only you and One can open it.",
+      "One recalls them when you need them.",
     ],
   },
   consent: {
     setupTitle: "Review who has access",
-    setupBlurb:
-      "See every request to use your personal information, approve what you trust, and pull access back any time.",
+    setupBlurb: "Approve or pull back access.",
     actionLabel: "Review access",
     resumeActionLabel: "Review access",
     exploreTitle: "Here's your access center",
-    exploreBlurb:
-      "Nothing to set up. This is where you see and control who can use your personal information.",
+    exploreBlurb: "Nothing to set up. See and control who can use your data.",
     exploreBullets: [
-      "Every request to use your personal information shows up here.",
+      "Every request to use your data shows up here.",
       "Approve what you trust, decline the rest.",
-      "Pull access back at any time, instantly.",
+      "Pull access back any time, instantly.",
     ],
   },
   "connected-systems": {
-    setupTitle: "CRM",
-    setupBlurb:
-      "Find your CRM record or approve creating one from your verified identity.",
+    setupTitle: "Connect your CRM",
+    setupBlurb: "One finds your record. You approve.",
     actionLabel: "Set up CRM",
     resumeActionLabel: "Finish CRM",
-    introPremise: "Start with the record that already knows you.",
-    introPromise:
-      "One looks for your record before creating anything, and you approve every change.",
+    introPremise: "Start with the record you already have.",
+    introPromise: "Nothing changes without your yes.",
     setupBullets: [
       "One looks for your record first, then creates one if needed.",
-      "Nothing happens without your approval.",
+      "Nothing happens without your yes.",
     ],
   },
 };


### PR DESCRIPTION
Everything a new person reads between Welcome and home, in plain words — and two screens that existed only to hold a Continue button, removed.

## Copy

| Screen | Before | After |
|---|---|---|
| Welcome | "Everything stays encrypted in your vault. Nothing moves without your consent." | "Everything you save stays locked. Nothing moves without your yes." |
| Sign-in | "Consent-first. Nothing moves without your yes." | "You choose what One can see." |
| Sign-in | "By continuing, you agree to the Terms of Service and Privacy Policy." | "By continuing you agree to our Terms and Privacy Policy." |
| Setup hub | "Finish setting up One" / "0 of 8 ready. Choose AI access to finish." | "Set up One" / "Choose your AI first." |
| Setup row | "AI access" — "Choose Hussh managed Gemini or your own Gemini access." | "Choose your AI" — "Use ours, or bring your own." |
| Setup row | "Connect Gmail" — 18 words | "Connect Gmail" — "One learns what you care about." |
| Setup row | "Connect your calendar" — 17 words | "Connect your calendar" — "One keeps track of your day." |
| Setup row | "Set up location" — 16 words | "Set up location" — "Share where you are, when you want." |
| Setup row | "KYC" — 13 words | "Identity checks" — "One drafts the replies. You approve." |
| Setup row | "Set up your finances" — 18 words | "Set up your money" — "See how your money is doing." |
| Setup row | "Set up RIA" — 15 words | "Set up your advisor profile" — "Verify once. Get your advisor workspace." |
| Setup row | "CRM" — 11 words | "Connect your CRM" — "One finds your record. You approve." |
| AI access | "AI access" / "Choose Hussh managed Gemini or set up your own Gemini access. Your credential stays in this session until you finish setup." | "Choose your AI" / "Use ours, or bring your own key." |
| AI access | "Hussh managed Gemini" — "Ready now with Hussh-managed Gemini. No personal key is needed." | "Use Hussh's AI" — "No key needed." + **Recommended** |
| AI access | "Use my Gemini access" — 16 words | "Use my own key" — "Add your own Gemini key." |

`vault`, `encrypted`, `consent`, `KYC`, `RIA`, `CRM`, `managed`, `credential` and `runtime` all leave the surfaces a person reads. Every identifier — ids, routes, agent lanes, test ids — is unchanged.

`__tests__/lib/capability-setup-copy.test.ts` now enforces a ceiling: every setup row title is ≤5 words and every blurb ≤8, so the sentences cannot creep back.

## Friction

**AI access loses its cinematic prologue.** It is the one step that blocks finishing setup, so a full screen with its own Continue in front of a two-option choice was pure cost. The five provider marks that screen carried now render inline on the real screen, so no context is lost with it.

**Taking the recommended option finishes the step** and returns to the hub. It is the whole decision — there is nothing further to enter. Bring-your-own-key still continues through the footer, because that path has a form left to fill.

**"Finish setup" opens the lock step directly.** The "A private place for what matters / One step left" screen in between existed only to hold a button that opened the lock dialog. Its promise ("Only you can open what you save") moves onto the lock step's own first screen.

Net for someone taking the default path: **4 taps become 2**, and two full screens disappear.

## Making the mandatory step legible

"Required" rendered in the same muted grey as every other trailing label, so it read as one more optional status. It now takes an accent pill and `aria-current="step"`. The recommended AI option says **Recommended** rather than leaving people to work out the default by elimination.

## Verification

- `tsc --noEmit` clean, `eslint --max-warnings=0` clean on every changed file.
- Voice action contracts regenerated; `verify:voice-gateway`, `verify:route-orchestration-index` and `verify:surface-map` all report current.
- Full `vitest run` compared against `origin/main`: no new failures. The pre-existing red set is unchanged.
- New contract tests pin each friction removal so it cannot silently return: no prologue in front of AI access, no screen between Finish setup and the lock step, the required pill, and the word ceilings.