### PR TITLE
fix(one-location): add an editable Address line to the save sheet

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -1026,6 +1026,99 @@ describe("SaveLocationModal", () => {
         null,
       );
     });
+
+    it("unblocks the save once the person types an address line themselves", () => {
+      render(<SaveLocationModal {...strandedProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeDisabled();
+
+      fireEvent.change(screen.getByLabelText(/Address line/), {
+        target: { value: "12 MG Road, Bengaluru" },
+      });
+
+      const save = screen.getByRole("button", { name: "Save location" });
+      expect(save).toBeEnabled();
+      fireEvent.click(save);
+
+      expect(baseProps.onSave).toHaveBeenCalledWith(
+        "home",
+        "",
+        expect.anything(),
+        "12 MG Road, Bengaluru",
+      );
+    });
+  });
+
+  describe("the Address line box", () => {
+    const HOUSE_NUMBER_ADDRESS =
+      "B-284/3, Rd Number 1, Chhatarpur Enclave Phase 2, New Delhi, Delhi 110074, India";
+
+    it("auto-populates from the detected address", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address={HOUSE_NUMBER_ADDRESS}
+          collectAddressDetails
+        />,
+      );
+
+      expect(screen.getByLabelText(/Address line/)).toHaveValue(
+        HOUSE_NUMBER_ADDRESS,
+      );
+    });
+
+    it("keeps what the person typed instead of the address that arrives later", () => {
+      const { rerender } = render(
+        <SaveLocationModal
+          {...baseProps}
+          address={HOUSE_NUMBER_ADDRESS}
+          collectAddressDetails
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText(/Address line/), {
+        target: { value: "My corrected street address" },
+      });
+
+      // A later reverse-geocode (or a repicked pin) must not take it back.
+      rerender(
+        <SaveLocationModal
+          {...baseProps}
+          address="C-11/2, Somewhere Else, Delhi 110088, India"
+          collectAddressDetails
+        />,
+      );
+
+      expect(screen.getByLabelText(/Address line/)).toHaveValue(
+        "My corrected street address",
+      );
+    });
+
+    it("saves the typed address line, not the raw detected address", () => {
+      render(
+        <SaveLocationModal
+          {...baseProps}
+          address={HOUSE_NUMBER_ADDRESS}
+          collectAddressDetails
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText(/Address line/), {
+        target: { value: "My corrected street address" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.click(screen.getByRole("button", { name: "Save location" }));
+
+      expect(baseProps.onSave).toHaveBeenCalledWith(
+        "home",
+        "",
+        expect.anything(),
+        "My corrected street address",
+      );
+    });
   });
 
   it("shows a plus-code address without the plus code", () => {

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -367,6 +367,11 @@ export function SaveLocationModal({
   // gave -- a prefill that fights the typing is worse than no prefill.
   const postalCodeEditedRef = useRef(false);
   const houseOrFlatEditedRef = useRef(false);
+  // The address line itself, editable and separate from the entrance-detail
+  // fields below it -- it IS the detected address, not something inferred
+  // from it, so it is not governed by the "fill the fields below" checkbox.
+  const addressLineEditedRef = useRef(false);
+  const [addressLineValue, setAddressLineValue] = useState("");
 
   // Reset internal selection each time the modal (re)opens. When editing an
   // existing saved place, seed the category/label/detail fields from the
@@ -381,6 +386,8 @@ export function SaveLocationModal({
       houseOrFlatEditedRef.current = Boolean(
         initialDetails && initialDetails.houseOrFlat,
       );
+      addressLineEditedRef.current = false;
+      setAddressLineValue("");
       // Editing keeps the place's own label; a new place opens on the first
       // label still free, so the primary button is live on arrival instead of
       // waiting behind "Pick Home, Work or Other first."
@@ -503,6 +510,14 @@ export function SaveLocationModal({
   const detectedAddress =
     stripPlusCodeSegment(pickedAddress) || resolvedAddress || "";
   /**
+   * The Address line box tracks the detected address until the person types
+   * over it -- the same "typed wins" rule as House/flat and PIN, just for the
+   * line those fields are extracted from rather than for one piece of it.
+   */
+  const effectiveAddressLine = addressLineEditedRef.current
+    ? addressLineValue
+    : detectedAddress;
+  /**
    * Something the person put in themselves. This matters because a pinned
    * point does not always come back with an address: on the native build
    * before the vault exists there is no server reverse-geocode and no browser
@@ -533,7 +548,7 @@ export function SaveLocationModal({
       : category === null
         ? "Pick Home, Work or Other first."
         : collectAddressDetails &&
-            detectedAddress.length === 0 &&
+            effectiveAddressLine.length === 0 &&
             !hasOwnAddressAnswer
           ? // The pin is fine; only its address lookup came back empty. Name
             // the way out that is actually open, rather than sending someone
@@ -667,7 +682,7 @@ export function SaveLocationModal({
         category,
         label ?? "",
         normalizedAddressDetails,
-        detectedAddress || null,
+        effectiveAddressLine.trim() || null,
       );
       return;
     }
@@ -839,6 +854,33 @@ export function SaveLocationModal({
                   Edit pin
                 </button>
               ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="saved-location-address-line"
+                className={controlLabelClassName}
+              >
+                Address line
+              </label>
+              <input
+                id="saved-location-address-line"
+                type="text"
+                value={effectiveAddressLine}
+                onChange={(event) => {
+                  addressLineEditedRef.current = true;
+                  setAddressLineValue(event.target.value);
+                }}
+                disabled={interactionBusy}
+                maxLength={300}
+                autoComplete={deferredUntilVault ? "off" : "street-address"}
+                placeholder={
+                  loadingAddress
+                    ? "Finding your address…"
+                    : "e.g. 12 MG Road, Bengaluru"
+                }
+                className={controlInputClassName}
+              />
             </div>
 
             {/* Ticked, the fields below are filled from that address and keep


### PR DESCRIPTION
The onboarding "save a place" sheet showed the detected address as a read-only line and only let a person correct pieces of it (house/flat, PIN, landmark) -- never the address itself. A slightly-off geocode had no way to be fixed by hand.

Address line is a new field that auto-fills from the detected address and, like House-flat and PIN, keeps following the pin until someone types over it -- typed wins, permanently, the same rule already used for the other two fields. It also becomes the line actually saved (replacing the raw detected address at save time), and a pin whose lookup came back empty can now be saved on a typed address line alone, not only via a house number/landmark/PIN workaround.

Branched from latest `main`, which already carries #5303's fix for the address-not-populating regression.

## Verification

| | |
|---|---|
| `vitest run` on the modal's own test file | 44 passed (40 existing + 4 new) |
| `tsc --noEmit` | clean on the changed file |
| `eslint --max-warnings=0` | clean on both changed files |