### PR TITLE
fix(one-location): make the address sheet a real iOS sheet

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2306,7 +2306,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockReverseGeocode).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2396,7 +2396,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Second user's home" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2576,7 +2576,7 @@ describe("OneLocationAgentPage", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -2774,13 +2774,13 @@ describe("OneLocationAgentPage", () => {
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Tower 2, Floor 4" },
     });
     fireEvent.change(screen.getByLabelText(/Building colour/), {
       target: { value: "White gate" },
     });
-    fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+    fireEvent.change(screen.getByLabelText(/Landmark/), {
       target: { value: "India Gate" },
     });
 

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -325,10 +325,10 @@ describe("SavedLocationsSection", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
     expect(
-      await screen.findByRole("heading", { name: "Add your address details" }),
+      await screen.findByRole("heading", { name: "Address details" }),
     ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B, Tower 2" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -376,9 +376,9 @@ describe("SavedLocationsSection", () => {
       }),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    await screen.findByRole("heading", { name: "Add your address details" });
+    await screen.findByRole("heading", { name: "Address details" });
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
@@ -389,7 +389,7 @@ describe("SavedLocationsSection", () => {
       "This place is already saved as Home. Choose a different place or remove it first.",
     );
     expect(
-      screen.getByRole("dialog", { name: "Add your address details" }),
+      screen.getByRole("dialog", { name: "Address details" }),
     ).toBeInTheDocument();
   });
 
@@ -408,9 +408,9 @@ describe("SavedLocationsSection", () => {
       name: /pin your entrance|before google maps opens/i,
     });
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    await screen.findByRole("heading", { name: "Add your address details" });
+    await screen.findByRole("heading", { name: "Address details" });
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
@@ -422,7 +422,7 @@ describe("SavedLocationsSection", () => {
       ),
     );
     expect(
-      screen.getByRole("dialog", { name: "Add your address details" }),
+      screen.getByRole("dialog", { name: "Address details" }),
     ).toBeInTheDocument();
   });
 

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -284,7 +284,7 @@ describe("SaveLocationModal", () => {
       screen.getByText(/Tag where you are/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/stays encrypted in your vault/i),
+      screen.getByText(/stays private to you/i),
     ).toBeInTheDocument();
   });
 
@@ -316,7 +316,7 @@ describe("SaveLocationModal", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Other" }));
-    fireEvent.change(screen.getByLabelText(/give it a name/i), {
+    fireEvent.change(screen.getByLabelText(/name it/i), {
       target: { value: "Gym" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save location/i }));
@@ -394,14 +394,14 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
     expect(
-      screen.getByRole("dialog", { name: "Add your address details" }),
+      screen.getByRole("dialog", { name: "Address details" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Add your address details" }),
+      screen.getByRole("heading", { name: "Address details" }),
     ).toHaveFocus();
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110001");
     expect(
-      screen.getByText(/Saved after your vault is ready/i),
+      screen.getByText(/Saves once your lock is set/i),
     ).toBeInTheDocument();
     // The detected address is shown, and the fields below were filled from
     // it -- here only the PIN, since "Kartavya Path" is a street rather than
@@ -418,17 +418,17 @@ describe("SaveLocationModal", () => {
       screen.queryByText("Pick Home, Work or Other first."),
     ).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: " Flat 4B, Tower 2 " },
     });
     fireEvent.change(screen.getByLabelText(/Building colour/), {
       target: { value: "Blue gate" },
     });
-    fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+    fireEvent.change(screen.getByLabelText(/Landmark/), {
       target: { value: "Opposite City Mall" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Other" }));
-    fireEvent.change(screen.getByLabelText(/Give it a name/i), {
+    fireEvent.change(screen.getByLabelText(/Name it/i), {
       target: { value: " Parents' home " },
     });
 
@@ -496,14 +496,14 @@ describe("SaveLocationModal", () => {
       <SaveLocationModal {...props} rendererDisclosureAccepted={false} />,
     );
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "Flat 4B" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
     rerender(<SaveLocationModal {...props} rendererDisclosureAccepted />);
 
-    expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+    expect(screen.getByLabelText(/House or flat/)).toHaveValue(
       "Flat 4B",
     );
     expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
@@ -521,15 +521,15 @@ describe("SaveLocationModal", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+    fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: "12A" },
     });
-    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
       target: { value: "!" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveAttribute(
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveAttribute(
       "aria-invalid",
       "true",
     );
@@ -583,7 +583,7 @@ describe("SaveLocationModal", () => {
       screen.getByRole("button", { name: "Save location" }),
     ).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
       target: { value: "!" },
     });
 
@@ -591,7 +591,7 @@ describe("SaveLocationModal", () => {
     // PIN or postal code." right beside the input. Two places worth looking,
     // not the same sentence twice.
     expect(
-      screen.getByText("Check the PIN or postal code above."),
+      screen.getByText("Check the PIN or postcode above."),
     ).toBeInTheDocument();
   });
 
@@ -611,10 +611,10 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+      expect(screen.getByLabelText(/House or flat/)).toHaveValue(
         "B-284/3",
       );
-      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110074");
+      expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110074");
       // And the address itself is still shown, as it was before.
       expect(screen.getByText(HOUSE_NUMBER_ADDRESS)).toBeInTheDocument();
     });
@@ -631,10 +631,10 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+      expect(screen.getByLabelText(/House or flat/)).toHaveValue(
         "",
       );
-      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("560001");
+      expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("560001");
     });
 
     it("never overwrites a field the person typed in", () => {
@@ -646,7 +646,7 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      fireEvent.change(screen.getByLabelText(/House, flat, floor or block/), {
+      fireEvent.change(screen.getByLabelText(/House or flat/), {
         target: { value: "Flat 9, Rear block" },
       });
 
@@ -659,11 +659,11 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+      expect(screen.getByLabelText(/House or flat/)).toHaveValue(
         "Flat 9, Rear block",
       );
       // The untouched field still follows the pin.
-      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110088");
+      expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110088");
     });
 
     it("clears the filled fields when unticked, and refills them when ticked again", () => {
@@ -676,21 +676,21 @@ describe("SaveLocationModal", () => {
       );
 
       const checkbox = screen.getByRole("checkbox", {
-        name: /fill the fields below/i,
+        name: /fill from this address/i,
       });
       expect(checkbox).toBeChecked();
 
       fireEvent.click(checkbox);
-      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+      expect(screen.getByLabelText(/House or flat/)).toHaveValue(
         "",
       );
-      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("");
+      expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("");
 
       fireEvent.click(checkbox);
-      expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue(
+      expect(screen.getByLabelText(/House or flat/)).toHaveValue(
         "B-284/3",
       );
-      expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110074");
+      expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110074");
     });
 
     it("does not save the house number twice when it came from the address", () => {
@@ -730,7 +730,7 @@ describe("SaveLocationModal", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110001");
 
     mapPickerMockState.picked = {
       latitude: 12.9716,
@@ -740,7 +740,7 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("560001");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("560001");
   });
 
   it("preserves a manually corrected postal code when the pin moves", () => {
@@ -756,7 +756,7 @@ describe("SaveLocationModal", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
-    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
       target: { value: "110002" },
     });
 
@@ -768,7 +768,7 @@ describe("SaveLocationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110002");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110002");
   });
 
   it("restores the inferred postal code when the same modal reopens", () => {
@@ -779,13 +779,13 @@ describe("SaveLocationModal", () => {
     };
     const { rerender } = render(<SaveLocationModal {...props} />);
 
-    fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+    fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
       target: { value: "110002" },
     });
     rerender(<SaveLocationModal {...props} open={false} />);
     rerender(<SaveLocationModal {...props} open />);
 
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("110001");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("110001");
   });
 
   it("maps Escape to the same safe skip action on the map step", () => {
@@ -880,7 +880,7 @@ describe("SaveLocationModal", () => {
 
       swipe(sheet, -120);
       expect(
-        screen.getByRole("dialog", { name: "Add your address details" }),
+        screen.getByRole("dialog", { name: "Address details" }),
       ).toBeInTheDocument();
 
       swipe(sheet, 120);
@@ -933,7 +933,7 @@ describe("SaveLocationModal", () => {
 
       expect(onPickExactLocation).toHaveBeenCalledTimes(1);
       expect(
-        screen.getByRole("dialog", { name: "Add your address details" }),
+        screen.getByRole("dialog", { name: "Address details" }),
       ).toBeInTheDocument();
     });
 
@@ -962,29 +962,37 @@ describe("SaveLocationModal", () => {
       collectAddressDetails: true,
     };
 
-    it("keeps the corner buttons absolutely positioned while growing their hit area", () => {
-      // The hit area is grown with a painted `::after` box, which must NOT
-      // bring `relative` with it: two positioning utilities in one class
-      // string make tailwind-merge keep the last, which drops these out of
-      // absolute positioning and collapsed them from 36px to 18px.
+    it("lays the details header's controls out beside the title instead of over it", () => {
+      // These used to be `absolute left-4/right-4 top-4` over a header padded
+      // to `px-9`. A 36px button starting at 16px ends at 52px, so it covered
+      // the title -- and because the sheet itself was the scroller, the two
+      // drifted apart the moment anyone scrolled. A flex row cannot overlap
+      // itself. `e2e/save-location-sheet.layout.spec.ts` measures it.
       render(<SaveLocationModal {...detailProps} />);
       fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
 
+      const header = screen
+        .getByRole("heading", { name: "Address details" })
+        .closest("header");
+      expect(header).not.toBeNull();
+
       for (const name of ["Back to map", "Close"]) {
         const button = screen.getByRole("button", { name });
-        expect(button.className).toContain("absolute");
-        expect(button.className).not.toMatch(/(^|\s)relative(\s|$)/);
+        expect(header!.contains(button)).toBe(true);
+        expect(button.className).not.toMatch(/(^|\s)absolute(\s|$)/);
+        // The hit area is still grown with a painted `::after` box, and the
+        // painted circle is unchanged.
         expect(button.className).toContain("after:h-11");
         expect(button.className).toContain("after:w-11");
-        // The painted circle is unchanged.
         expect(button.className).toContain("h-9");
         expect(button.className).toContain("w-9");
       }
     });
 
     it("gives each carousel dot a real 44x44 instead of a grown one", () => {
-      // Two dots sit side by side, so faking the region with a `::after` box
-      // would overlap them and send an edge tap to the wrong slide.
+      // Two dots sit side by side, so faking the horizontal region with a
+      // `::after` box would overlap them and send an edge tap to the wrong
+      // slide. Width therefore stays laid out on both variants.
       render(<SaveLocationModal {...detailProps} />);
 
       for (const dot of screen.getAllByRole("tab")) {
@@ -992,6 +1000,72 @@ describe("SaveLocationModal", () => {
         expect(dot.className).toContain("w-11");
         expect(dot.className).not.toContain("after:");
       }
+    });
+
+    it("shrinks the dots into the sheet grabber on the details slide", () => {
+      // In the pinned header they take the grabber's place rather than adding
+      // a third stacked row to the footer, so the height comes back through
+      // the painted box while the 44px of horizontal separation stays real.
+      render(<SaveLocationModal {...detailProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      for (const dot of screen.getAllByRole("tab")) {
+        expect(dot.className).toContain("w-11");
+        expect(dot.className).toContain("h-[18px]");
+        expect(dot.className).toContain("after:h-11");
+        expect(dot.className).toContain("after:w-11");
+      }
+    });
+  });
+
+  describe("the details sheet is a frame, not one long scroll box", () => {
+    const detailProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      mapInitial: { latitude: 28.6139, longitude: 77.209 },
+      onPickExactLocation: vi.fn(),
+      startWithMapPicker: true,
+      collectAddressDetails: true,
+    };
+
+    it("scrolls the body only, so the pinned rows cannot be scrolled past", () => {
+      render(<SaveLocationModal {...detailProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      const sheet = screen.getByTestId("save-location-modal");
+      // `overflow-y-hidden`, not `overflow-hidden`: tailwind-merge files those
+      // under different keys, so the primitive's own `overflow-y-auto` would
+      // survive and the whole sheet would keep scrolling behind the header.
+      expect(sheet.className).toContain("overflow-y-hidden");
+      expect(sheet.className).not.toContain("overflow-y-auto");
+
+      const save = screen.getByRole("button", { name: /Save location/ });
+      const footer = save.parentElement!;
+      const scroller = footer.previousElementSibling as HTMLElement;
+      expect(scroller.className).toContain("overflow-y-auto");
+      expect(scroller.className).toContain("flex-1");
+      expect(scroller.className).toContain("min-h-0");
+
+      // The last field belongs to the scroller, and the primary action does
+      // not -- which is what stops content bleeding under the button.
+      expect(scroller.contains(screen.getByLabelText(/Landmark/))).toBe(true);
+      expect(scroller.contains(save)).toBe(false);
+    });
+
+    it("puts the pinned footer on a solid surface", () => {
+      // It used to be `sticky bottom-0` on a `/95` background, so the field
+      // underneath showed through the button.
+      render(<SaveLocationModal {...detailProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      const footer = screen.getByRole("button", { name: /Save location/ })
+        .parentElement!;
+      expect(footer.className).toContain(
+        "bg-[color:var(--app-card-surface-default-solid)]",
+      );
+      expect(footer.className).not.toContain("/95");
+      expect(footer.className).not.toContain("sticky");
+      expect(footer.className).toContain("shrink-0");
     });
   });
 
@@ -1036,13 +1110,13 @@ describe("SaveLocationModal", () => {
 
       // A dimmed blue still reads as the live primary action and earns a dead
       // tap, so a blocked CTA must not be blue at all.
-      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+      fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
         target: { value: "!" },
       });
       expect(save).toBeDisabled();
       expect(save.className).not.toContain("var(--app-accent)");
 
-      fireEvent.change(screen.getByLabelText(/PIN \/ postal code/), {
+      fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
         target: { value: "110001" },
       });
       expect(save).toBeEnabled();
@@ -1076,7 +1150,7 @@ describe("SaveLocationModal", () => {
     it("saves once the person supplies it themselves", () => {
       render(<SaveLocationModal {...strandedProps} />);
       fireEvent.click(screen.getByRole("button", { name: "Home" }));
-      fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+      fireEvent.change(screen.getByLabelText(/Landmark/), {
         target: { value: "Opposite City Mall" },
       });
 
@@ -1100,7 +1174,7 @@ describe("SaveLocationModal", () => {
         screen.getByRole("button", { name: "Save location" }),
       ).toBeDisabled();
 
-      fireEvent.change(screen.getByLabelText(/Address line/), {
+      fireEvent.change(screen.getByLabelText(/^Address$/), {
         target: { value: "12 MG Road, Bengaluru" },
       });
 
@@ -1117,7 +1191,7 @@ describe("SaveLocationModal", () => {
     });
   });
 
-  describe("the Address line box", () => {
+  describe("the Address box", () => {
     const HOUSE_NUMBER_ADDRESS =
       "B-284/3, Rd Number 1, Chhatarpur Enclave Phase 2, New Delhi, Delhi 110074, India";
 
@@ -1130,7 +1204,7 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/Address line/)).toHaveValue(
+      expect(screen.getByLabelText(/^Address$/)).toHaveValue(
         HOUSE_NUMBER_ADDRESS,
       );
     });
@@ -1144,7 +1218,7 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      fireEvent.change(screen.getByLabelText(/Address line/), {
+      fireEvent.change(screen.getByLabelText(/^Address$/), {
         target: { value: "My corrected street address" },
       });
 
@@ -1157,7 +1231,7 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/Address line/)).toHaveValue(
+      expect(screen.getByLabelText(/^Address$/)).toHaveValue(
         "My corrected street address",
       );
     });
@@ -1171,7 +1245,7 @@ describe("SaveLocationModal", () => {
         />,
       );
 
-      fireEvent.change(screen.getByLabelText(/Address line/), {
+      fireEvent.change(screen.getByLabelText(/^Address$/), {
         target: { value: "My corrected street address" },
       });
       fireEvent.click(screen.getByRole("button", { name: "Home" }));
@@ -1199,7 +1273,7 @@ describe("SaveLocationModal", () => {
       screen.getByText("Teliarganj, Prayagraj, Uttar Pradesh 211004, India"),
     ).toBeInTheDocument();
     // And it is not offered as a house number.
-    expect(screen.getByLabelText(/House, flat, floor or block/)).toHaveValue("");
-    expect(screen.getByLabelText(/PIN \/ postal code/)).toHaveValue("211004");
+    expect(screen.getByLabelText(/House or flat/)).toHaveValue("");
+    expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("211004");
   });
 });

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -20,6 +20,12 @@ import {
   type LocationPickerMapHandle,
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
+import {
+  SHEET_BODY_CLASSNAME,
+  SHEET_DETAILS_SHELL_CLASSNAME,
+  SHEET_FOOTER_CLASSNAME,
+  SHEET_HEADER_CLASSNAME,
+} from "@/components/one-location/onboarding/save-location-sheet-layout";
 import { isNative } from "@/lib/capacitor/platform";
 import { cn } from "@/lib/utils";
 import {
@@ -52,6 +58,16 @@ const touchTargetClassName =
 const iconButtonClassName =
   `press-scale absolute flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill-strong)]/80 disabled:opacity-45 ${touchTargetClassName}`;
 
+/**
+ * The same control, laid out instead of absolutely positioned. Written as its
+ * own string rather than merged from the one above, because dropping
+ * `absolute` through tailwind-merge needs a competing utility from the same
+ * key and `relative` is the only one -- which is exactly the trap documented
+ * on `touchTargetClassName`.
+ */
+const inlineIconButtonClassName =
+  `press-scale relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill-strong)]/80 disabled:opacity-45 ${touchTargetClassName}`;
+
 const controlLabelClassName =
   "mb-1.5 block text-[13px] font-semibold leading-[18px] text-muted-foreground";
 
@@ -83,12 +99,20 @@ function CarouselDots({
   labels,
   onSelect,
   canAdvance,
+  compact = false,
 }: {
   index: number;
   count: number;
   labels: string[];
   onSelect: (next: number) => void;
   canAdvance: boolean;
+  /**
+   * Sits where an iOS sheet's grabber sits, doing both jobs at once. Half the
+   * height, so the pinned header stays a header -- the touch target is given
+   * back vertically by the painted `::after` box, and the 44px of horizontal
+   * separation that keeps a tap off the wrong dot is untouched.
+   */
+  compact?: boolean;
 }) {
   return (
     <div
@@ -111,19 +135,33 @@ function CarouselDots({
             // A real 44x44 each, laid out rather than faked, because two dots
             // sit side by side and overlapping hit regions would send a tap
             // near the boundary to the wrong slide.
-            className="flex h-11 w-11 items-center justify-center disabled:cursor-not-allowed"
+            className={cn(
+              "flex w-11 items-center justify-center disabled:cursor-not-allowed",
+              compact
+                ? `relative h-[18px] after:h-11 after:w-11 ${touchTargetClassName}`
+                : "h-11",
+            )}
           >
             <span
               className={cn(
-                "block h-[7px] rounded-full transition-all duration-200",
+                "block h-[5px] rounded-full transition-all duration-200",
                 active
-                  ? "w-[22px] bg-[color:var(--app-accent)]"
+                  ? "w-[24px] bg-[color:var(--app-accent)]"
                   : "w-[7px] bg-[color:var(--app-neutral-fill-strong)]",
               )}
             />
           </button>
         );
       })}
+    </div>
+  );
+}
+
+/** The plain iOS grabber, for a sheet with only one slide to be on. */
+function SheetGrabber() {
+  return (
+    <div className="flex h-[18px] items-center justify-center" aria-hidden>
+      <span className="block h-[5px] w-9 rounded-full bg-[color:var(--app-neutral-fill-strong)]" />
     </div>
   );
 }
@@ -263,9 +301,7 @@ function SavedLocationCategoryPicker({
 }) {
   return (
     <div role="group" aria-label="Saved location category">
-      <p className={controlLabelClassName}>
-        What kind of place is this?
-      </p>
+      <p className={controlLabelClassName}>Kind of place</p>
       <div className="grid grid-cols-3 gap-2.5">
         {CATEGORY_OPTIONS.map(({ category, label, Icon }) => {
           const selected = value === category;
@@ -565,10 +601,10 @@ export function SaveLocationModal({
             "Add a house, landmark or PIN."
           : postalCodeInvalid
             ? // Not the field's own wording. The invalid PIN already says
-              // "Enter a valid PIN or postal code." right next to itself, and
+              // "Enter a valid PIN or postcode." right next to itself, and
               // the same sentence twice on one screen reads as a stutter
               // rather than as two places worth looking.
-              "Check the PIN or postal code above."
+              "Check the PIN or postcode above."
             : null;
   const canSave =
     category !== null &&
@@ -599,6 +635,13 @@ export function SaveLocationModal({
   };
   const carouselIndex = flowStep === "details" ? 1 : 0;
   const carouselLabels = ["Pin your entrance", "Address details"];
+  /**
+   * The details pane owns its own scrolling, so the sheet around it stops
+   * being a scroll box and becomes a frame: pinned header, one scroller,
+   * pinned footer. Scoped to this pane so the map and summary panes keep the
+   * plain scrolling sheet they were built against.
+   */
+  const detailsPaneActive = flowStep === "details" && collectAddressDetails;
 
   const goToSlide = (next: number) => {
     if (interactionBusy || next === carouselIndex) return;
@@ -750,11 +793,14 @@ export function SaveLocationModal({
           if (interactionBusy || flowStep === "map") event.preventDefault();
         }}
         className={cn(
-          "z-[601] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
+          "z-[601] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0",
           "rounded-b-none rounded-t-[24px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[20px]",
           // A real edge and a real lift, so the sheet reads as a layer above
           // the screen rather than a rectangle pasted onto it.
-          "border border-black/[0.06] bg-[color:var(--app-card-surface-default-solid)] p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] dark:border-white/[0.08] sm:p-6 sm:pb-6",
+          "border border-black/[0.06] bg-[color:var(--app-card-surface-default-solid)] dark:border-white/[0.08]",
+          detailsPaneActive
+            ? SHEET_DETAILS_SHELL_CLASSNAME
+            : "gap-5 overflow-y-auto p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] sm:p-6 sm:pb-6",
           // `!` because the sheet's arbitrary shadow does not merge away the
           // dialog primitive's own `shadow-[var(--app-card-shadow-feature)]`:
           // tailwind-merge leaves both classes on the element and the base one
@@ -808,284 +854,312 @@ export function SaveLocationModal({
             ) : null}
           </div>
         ) : flowStep === "details" && collectAddressDetails ? (
-          <div {...paneProps}>
-            <button
-              type="button"
-              onClick={() =>
-                canPickOnMap ? goToSlide(0) : setFlowStep("summary")
-              }
-              disabled={interactionBusy}
-              aria-label={canPickOnMap ? "Back to map" : "Back"}
-              className={cn(iconButtonClassName, "left-4 top-4")}
-            >
-              <ArrowLeft className="h-4.5 w-4.5" strokeWidth={2.4} />
-            </button>
-            <button
-              type="button"
-              onClick={onSkip}
-              disabled={interactionBusy}
-              aria-label="Close"
-              className={cn(iconButtonClassName, "right-4 top-4")}
-            >
-              <X className="h-4.5 w-4.5" strokeWidth={2.4} />
-            </button>
-
-            <header className="px-9 text-center">
-              <DialogTitle
-                ref={detailsTitleRef}
-                tabIndex={-1}
-                className="text-[28px] font-bold leading-[1.12] tracking-normal text-foreground outline-none"
-              >
-                Add your address details
-              </DialogTitle>
-              <p
-                id={descriptionId}
-                className="mt-2 text-[15px] leading-5 text-muted-foreground"
-              >
-                Only the address is needed. The rest helps at the door.
+          <div
+            {...paneProps}
+            className={cn(paneProps.className, "flex-1 gap-0")}
+          >
+            {/* Pinned. The controls are laid out beside the title rather than
+                floated over it, which is what let a 36px button starting at
+                16px cover a header padded to 36px. */}
+            <header className={SHEET_HEADER_CLASSNAME}>
+              {carouselMode ? (
+                <CarouselDots
+                  compact
+                  index={1}
+                  count={2}
+                  labels={carouselLabels}
+                  canAdvance
+                  onSelect={goToSlide}
+                />
+              ) : (
+                <SheetGrabber />
+              )}
+              <div className="mt-1 flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    canPickOnMap ? goToSlide(0) : setFlowStep("summary")
+                  }
+                  disabled={interactionBusy}
+                  aria-label={canPickOnMap ? "Back to map" : "Back"}
+                  className={inlineIconButtonClassName}
+                >
+                  <ArrowLeft className="h-4.5 w-4.5" strokeWidth={2.4} />
+                </button>
+                <DialogTitle
+                  ref={detailsTitleRef}
+                  tabIndex={-1}
+                  className="min-w-0 flex-1 truncate text-center text-[17px] font-semibold leading-[22px] tracking-normal text-foreground outline-none"
+                >
+                  Address details
+                </DialogTitle>
+                <button
+                  type="button"
+                  onClick={onSkip}
+                  disabled={interactionBusy}
+                  aria-label="Close"
+                  className={inlineIconButtonClassName}
+                >
+                  <X className="h-4.5 w-4.5" strokeWidth={2.4} />
+                </button>
+              </div>
+              {/* The sentence that used to sit under the title. The card below
+                  shows the address and the group label below that says the
+                  fields are optional, so on screen it only repeated them. */}
+              <p id={descriptionId} className="sr-only">
+                Optional details that help someone reach your door.
               </p>
             </header>
 
-            {/* The detected address, shown as the thing the fields below were
-                filled from. */}
-            <div className="flex items-start gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
-              <span className="mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
-                <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
-              </span>
-              <div className="min-w-0 flex-1">
-                <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
-                  Pinned location
-                </p>
-                <p className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-5 text-foreground">
-                  {loadingAddress
-                    ? "Finding your address…"
-                    : detectedAddress || "Your selected map point"}
-                </p>
+            <div className={SHEET_BODY_CLASSNAME}>
+              {/* The detected address, shown as the thing the fields below were
+                  filled from. */}
+              <div className="flex items-start gap-2.5 rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3">
+                <span className="mt-0.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent)]/12 text-[color:var(--app-accent)]">
+                  <MapPin className="h-[17px] w-[17px]" strokeWidth={1.9} aria-hidden />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-normal leading-[18px] tracking-normal text-muted-foreground">
+                    Pinned
+                  </p>
+                  <p className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-5 text-foreground">
+                    {loadingAddress
+                      ? "Finding address…"
+                      : detectedAddress || "No address found"}
+                  </p>
+                </div>
+                {canPickOnMap ? (
+                  <button
+                    type="button"
+                    onClick={() => goToSlide(0)}
+                    disabled={interactionBusy}
+                    // One visible word; the pin is what the icon and the line
+                    // above it already say. The accessible name keeps the phrase.
+                    aria-label="Edit pin"
+                    className={cn(
+                      "press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45",
+                      "relative after:absolute after:inset-x-0 after:top-1/2 after:h-11 after:-translate-y-1/2 after:content-['']",
+                    )}
+                  >
+                    Edit
+                  </button>
+                ) : null}
               </div>
-              {canPickOnMap ? (
-                <button
-                  type="button"
-                  onClick={() => goToSlide(0)}
-                  disabled={interactionBusy}
-                  className={cn(
-                    "press-scale shrink-0 rounded-full bg-[color:var(--app-accent)]/12 px-2.5 py-1.5 text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-45",
-                    "relative after:absolute after:inset-x-0 after:top-1/2 after:h-11 after:-translate-y-1/2 after:content-['']",
-                  )}
-                >
-                  Edit pin
-                </button>
-              ) : null}
-            </div>
 
-            <div>
-              <label
-                htmlFor="saved-location-address-line"
-                className={controlLabelClassName}
-              >
-                Address line
-              </label>
-              <input
-                id="saved-location-address-line"
-                type="text"
-                value={effectiveAddressLine}
-                onChange={(event) => {
-                  addressLineEditedRef.current = true;
-                  setAddressLineValue(event.target.value);
-                }}
-                disabled={interactionBusy}
-                maxLength={300}
-                autoComplete={deferredUntilVault ? "off" : "street-address"}
-                placeholder={
-                  loadingAddress
-                    ? "Finding your address…"
-                    : "e.g. 12 MG Road, Bengaluru"
-                }
-                className={controlInputClassName}
-              />
-            </div>
-
-            {/* Ticked, the fields below are filled from that address and keep
-                following the pin. Unticked, they are cleared and left alone.
-                Anything typed by hand survives either way. */}
-            <label className="flex min-h-11 cursor-pointer items-center gap-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={useDetectedAddress}
-                onChange={(event) => {
-                  const next = event.target.checked;
-                  setUseDetectedAddress(next);
-                  // Both directions act now rather than at the next pin move,
-                  // so the box never reads as on while the fields disagree
-                  // with it. Unticking forgets that anything was typed, which
-                  // is what makes re-ticking a clean redo.
-                  houseOrFlatEditedRef.current = false;
-                  postalCodeEditedRef.current = false;
-                  setAddressDetails((current) =>
-                    detectedAddressDetails(current, next ? detectedAddress : null, {
-                      houseOrFlat: false,
-                      postalCode: false,
-                    }),
-                  );
-                }}
-                disabled={interactionBusy}
-                className="h-[15px] w-[15px] shrink-0 accent-[color:var(--app-accent)] disabled:opacity-45"
-              />
-              Fill the fields below from this address
-            </label>
-
-            <div className="space-y-3.5">
+              {/* Added on main while this sheet was being rebuilt: the
+                  address itself is editable, because a pin that resolves to
+                  the wrong line left no way to correct it. */}
               <div>
                 <label
-                  htmlFor="saved-location-house-or-flat"
+                  htmlFor="saved-location-address-line"
                   className={controlLabelClassName}
                 >
-                  House, flat, floor or block{" "}
-                  <span className="font-normal">(optional)</span>
+                  Address
                 </label>
                 <input
-                  id="saved-location-house-or-flat"
+                  id="saved-location-address-line"
                   type="text"
-                  value={addressDetails.houseOrFlat}
-                  onChange={(event) =>
-                    updateAddressDetail("houseOrFlat", event.target.value)
-                  }
+                  value={effectiveAddressLine}
+                  onChange={(event) => {
+                    addressLineEditedRef.current = true;
+                    setAddressLineValue(event.target.value);
+                  }}
                   disabled={interactionBusy}
-                  maxLength={80}
-                  autoComplete={deferredUntilVault ? "off" : "address-line1"}
-                  placeholder="e.g. Flat 4B, Tower 2"
+                  maxLength={300}
+                  autoComplete={deferredUntilVault ? "off" : "street-address"}
+                  placeholder={
+                    loadingAddress ? "Finding address…" : "12 MG Road, Bengaluru"
+                  }
                   className={controlInputClassName}
                 />
               </div>
 
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {/* Ticked, the fields below are filled from that address and keep
+                  following the pin. Unticked, they are cleared and left alone.
+                  Anything typed by hand survives either way. */}
+              <label className="flex min-h-11 cursor-pointer items-center gap-2 px-1 text-[13px] leading-[18px] text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={useDetectedAddress}
+                  onChange={(event) => {
+                    const next = event.target.checked;
+                    setUseDetectedAddress(next);
+                    // Both directions act now rather than at the next pin move,
+                    // so the box never reads as on while the fields disagree
+                    // with it. Unticking forgets that anything was typed, which
+                    // is what makes re-ticking a clean redo.
+                    houseOrFlatEditedRef.current = false;
+                    postalCodeEditedRef.current = false;
+                    setAddressDetails((current) =>
+                      detectedAddressDetails(current, next ? detectedAddress : null, {
+                        houseOrFlat: false,
+                        postalCode: false,
+                      }),
+                    );
+                  }}
+                  disabled={interactionBusy}
+                  className="h-[15px] w-[15px] shrink-0 accent-[color:var(--app-accent)] disabled:opacity-45"
+                />
+                Fill from this address
+              </label>
+
+              <div className="space-y-3.5">
+                {/* Said once, for the group, instead of an "(optional)" tag
+                    hanging off all four labels. */}
+                <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
+                  Optional — helps at the door.
+                </p>
                 <div>
                   <label
-                    htmlFor="saved-location-building-color"
+                    htmlFor="saved-location-house-or-flat"
                     className={controlLabelClassName}
                   >
-                    Building colour{" "}
-                    <span className="font-normal">(optional)</span>
+                    House or flat
                   </label>
                   <input
-                    id="saved-location-building-color"
+                    id="saved-location-house-or-flat"
                     type="text"
-                    value={addressDetails.buildingColor}
+                    value={addressDetails.houseOrFlat}
                     onChange={(event) =>
-                      updateAddressDetail("buildingColor", event.target.value)
+                      updateAddressDetail("houseOrFlat", event.target.value)
                     }
                     disabled={interactionBusy}
-                    maxLength={40}
-                    autoComplete="off"
-                    placeholder="e.g. Blue gate"
+                    maxLength={80}
+                    autoComplete={deferredUntilVault ? "off" : "address-line1"}
+                    placeholder="Flat 4B, Tower 2"
                     className={controlInputClassName}
                   />
                 </div>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="saved-location-building-color"
+                      className={controlLabelClassName}
+                    >
+                      Building colour
+                    </label>
+                    <input
+                      id="saved-location-building-color"
+                      type="text"
+                      value={addressDetails.buildingColor}
+                      onChange={(event) =>
+                        updateAddressDetail("buildingColor", event.target.value)
+                      }
+                      disabled={interactionBusy}
+                      maxLength={40}
+                      autoComplete="off"
+                      placeholder="Blue gate"
+                      className={controlInputClassName}
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="saved-location-postal-code"
+                      className={controlLabelClassName}
+                    >
+                      PIN / postcode
+                    </label>
+                    <input
+                      id="saved-location-postal-code"
+                      type="text"
+                      value={addressDetails.postalCode}
+                      onChange={(event) =>
+                        updateAddressDetail("postalCode", event.target.value)
+                      }
+                      disabled={interactionBusy}
+                      maxLength={12}
+                      inputMode="text"
+                      autoComplete={deferredUntilVault ? "off" : "postal-code"}
+                      aria-describedby={
+                        addressDetails.postalCode.length > 0 &&
+                        !isValidPostalCode(addressDetails.postalCode)
+                          ? postalCodeErrorId
+                          : undefined
+                      }
+                      aria-invalid={
+                        addressDetails.postalCode.length > 0 &&
+                        !isValidPostalCode(addressDetails.postalCode)
+                      }
+                      placeholder="560001"
+                      className={cn(
+                        controlInputClassName,
+                        "aria-[invalid=true]:border-[color:var(--app-destructive)]",
+                      )}
+                    />
+                    {addressDetails.postalCode.length > 0 &&
+                    !isValidPostalCode(addressDetails.postalCode) ? (
+                      <p
+                        id={postalCodeErrorId}
+                        role="alert"
+                        className="mt-1.5 text-[13px] leading-[18px] text-[color:var(--app-destructive)]"
+                      >
+                        Enter a valid PIN or postcode.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+
                 <div>
                   <label
-                    htmlFor="saved-location-postal-code"
+                    htmlFor="saved-location-landmark"
                     className={controlLabelClassName}
                   >
-                    PIN / postal code{" "}
-                    <span className="font-normal">(optional)</span>
+                    Landmark
                   </label>
                   <input
-                    id="saved-location-postal-code"
+                    id="saved-location-landmark"
                     type="text"
-                    value={addressDetails.postalCode}
+                    value={addressDetails.landmark}
                     onChange={(event) =>
-                      updateAddressDetail("postalCode", event.target.value)
+                      updateAddressDetail("landmark", event.target.value)
                     }
                     disabled={interactionBusy}
-                    maxLength={12}
-                    inputMode="text"
-                    autoComplete={deferredUntilVault ? "off" : "postal-code"}
-                    aria-describedby={
-                      addressDetails.postalCode.length > 0 &&
-                      !isValidPostalCode(addressDetails.postalCode)
-                        ? postalCodeErrorId
-                        : undefined
-                    }
-                    aria-invalid={
-                      addressDetails.postalCode.length > 0 &&
-                      !isValidPostalCode(addressDetails.postalCode)
-                    }
-                    placeholder="e.g. 560001"
-                    className={cn(
-                      controlInputClassName,
-                      "aria-[invalid=true]:border-[color:var(--app-destructive)]",
-                    )}
+                    maxLength={100}
+                    autoComplete={deferredUntilVault ? "off" : "address-line2"}
+                    placeholder="Opposite City Mall"
+                    className={controlInputClassName}
                   />
-                  {addressDetails.postalCode.length > 0 &&
-                  !isValidPostalCode(addressDetails.postalCode) ? (
-                    <p
-                      id={postalCodeErrorId}
-                      role="alert"
-                      className="mt-1.5 text-[13px] leading-[18px] text-[color:var(--app-destructive)]"
-                    >
-                      Enter a valid PIN or postal code.
-                    </p>
-                  ) : null}
                 </div>
               </div>
 
-              <div>
-                <label
-                  htmlFor="saved-location-landmark"
-                  className={controlLabelClassName}
-                >
-                  Nearby landmark{" "}
-                  <span className="font-normal">(optional)</span>
-                </label>
-                <input
-                  id="saved-location-landmark"
-                  type="text"
-                  value={addressDetails.landmark}
-                  onChange={(event) =>
-                    updateAddressDetail("landmark", event.target.value)
-                  }
-                  disabled={interactionBusy}
-                  maxLength={100}
-                  autoComplete={deferredUntilVault ? "off" : "address-line2"}
-                  placeholder="e.g. Opposite City Mall"
-                  className={controlInputClassName}
-                />
-              </div>
+              <SavedLocationCategoryPicker
+                value={category}
+                disabled={interactionBusy}
+                onChange={setCategory}
+              />
+
+              {category === "other" ? (
+                <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
+                  <label
+                    htmlFor="saved-location-details-custom-label"
+                    className={controlLabelClassName}
+                  >
+                    Name it
+                  </label>
+                  <input
+                    id="saved-location-details-custom-label"
+                    type="text"
+                    value={customLabel}
+                    onChange={(event) => setCustomLabel(event.target.value)}
+                    disabled={interactionBusy}
+                    maxLength={40}
+                    placeholder="Gym, parents' house"
+                    className={controlInputClassName}
+                  />
+                </div>
+              ) : null}
+
+              {/* A caption, not a card. It reassures; it is not a control, and
+                  the panel it used to sit in gave it a control's weight. */}
+              <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
+                {deferredUntilVault
+                  ? "Saves once your lock is set."
+                  : "Private to you."}
+              </p>
             </div>
 
-            <SavedLocationCategoryPicker
-              value={category}
-              disabled={interactionBusy}
-              onChange={setCategory}
-            />
-
-            {category === "other" ? (
-              <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
-                <label
-                  htmlFor="saved-location-details-custom-label"
-                  className={controlLabelClassName}
-                >
-                  Give it a name <span className="font-normal">(optional)</span>
-                </label>
-                <input
-                  id="saved-location-details-custom-label"
-                  type="text"
-                  value={customLabel}
-                  onChange={(event) => setCustomLabel(event.target.value)}
-                  disabled={interactionBusy}
-                  maxLength={40}
-                  placeholder="e.g. Gym, parents' house"
-                  className={controlInputClassName}
-                />
-              </div>
-            ) : null}
-
-            <p className="rounded-[14px] bg-[color:var(--app-card-surface-compact)] px-3.5 py-3 text-[13px] leading-[18px] text-muted-foreground">
-              {deferredUntilVault
-                ? "Saved after your vault is ready."
-                : "Saved in your private vault."}
-            </p>
-
-            <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-[18px] border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)]/95 px-3 pb-1 pt-3 backdrop-blur">
+            <div className={SHEET_FOOTER_CLASSNAME}>
               {/* A disabled primary button with no explanation is the whole of
                   "saving is not working" from the outside. When it is off, say
                   which single thing turns it on. */}
@@ -1119,15 +1193,6 @@ export function SaveLocationModal({
               >
                 Skip for now
               </button>
-              {carouselMode ? (
-                <CarouselDots
-                  index={1}
-                  count={2}
-                  labels={carouselLabels}
-                  canAdvance
-                  onSelect={goToSlide}
-                />
-              ) : null}
             </div>
           </div>
         ) : (
@@ -1154,7 +1219,7 @@ export function SaveLocationModal({
                 id={descriptionId}
                 className="mt-2 text-[15px] leading-5 text-muted-foreground"
               >
-                Tag where you are. It stays encrypted in your vault.
+                Tag where you are. It stays private to you.
               </p>
             </header>
 
@@ -1212,10 +1277,10 @@ export function SaveLocationModal({
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="block text-[15px] font-semibold leading-5 text-[color:var(--app-accent)]">
-                    Pin your entrance on the map
+                    Pin your entrance
                   </span>
                   <span className="block text-[13px] leading-[18px] text-muted-foreground">
-                    GPS can be off by a few meters — drag the pin to your door.
+                    GPS lands near, not at, your door.
                   </span>
                 </span>
               </button>
@@ -1314,7 +1379,7 @@ export function SaveLocationModal({
                   htmlFor="saved-location-custom-label"
                   className={controlLabelClassName}
                 >
-                  Give it a name <span className="font-normal">(optional)</span>
+                  Name it
                 </label>
                 <input
                   id="saved-location-custom-label"
@@ -1323,7 +1388,7 @@ export function SaveLocationModal({
                   onChange={(event) => setCustomLabel(event.target.value)}
                   disabled={interactionBusy}
                   maxLength={40}
-                  placeholder="e.g. Gym, Mom's house, Cafe"
+                  placeholder="Gym, Mom's house"
                   className={controlInputClassName}
                 />
               </div>

--- a/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
@@ -1,0 +1,51 @@
+/**
+ * The three-row shell for the address-details sheet: a pinned header, one
+ * scroller, a pinned footer.
+ *
+ * Exported as plain strings so `e2e/save-location-sheet.layout.spec.ts` can
+ * compile and measure the REAL classes in a real browser. A JSDOM test can
+ * only prove these strings are on the elements; it performs no layout, so it
+ * cannot prove the two things that were actually broken:
+ *
+ *  1. The header's corner buttons used to be `absolute left-4/right-4 top-4`
+ *     inside the sheet's own scroll box, over a header padded to `px-9` (36px).
+ *     A 36px button starting at 16px ends at 52px, so it sat ON the title --
+ *     and because the sheet itself was the scroller, both drifted apart as
+ *     soon as anyone scrolled. They are laid-out flex items now: a row cannot
+ *     overlap itself.
+ *  2. The footer was `sticky bottom-0` on a `/95` translucent background, so
+ *     the last field showed THROUGH the primary button. It is a real flex row
+ *     outside the scroller now, on a solid surface.
+ */
+
+/**
+ * Sheet shell while the details pane is on screen. Turns the dialog from "one
+ * long scroll box with padding" into a fixed frame whose middle row scrolls.
+ *
+ * `overflow-y-hidden`, not `overflow-hidden`: tailwind-merge files the two
+ * under different keys, so `overflow-hidden` would leave the primitive's
+ * `overflow-y-auto` standing and the whole sheet would keep scrolling behind
+ * the pinned rows. Same failure mode as the `relative`/`absolute` note in
+ * save-location-modal.tsx.
+ */
+export const SHEET_DETAILS_SHELL_CLASSNAME =
+  "gap-0 overflow-y-hidden p-0 sm:p-0";
+
+/** Pinned top row. `shrink-0` so a long title never steals the body's height. */
+export const SHEET_HEADER_CLASSNAME =
+  "relative z-10 shrink-0 border-b border-[color:var(--app-separator)] px-3 pb-2.5 pt-2.5";
+
+/** The only scrolling element in the sheet. */
+export const SHEET_BODY_CLASSNAME =
+  "flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch] px-5 pb-5 pt-4";
+
+/**
+ * Pinned bottom row. Solid background, not the old `/95` -- a translucent
+ * pinned bar reads as a patch stuck over the form rather than as the floor of
+ * the sheet, and it is what let the last input show through the button.
+ */
+export const SHEET_FOOTER_CLASSNAME =
+  "relative z-10 flex shrink-0 flex-col gap-2 border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)] px-5 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+12px)]";
+
+/** Widths the sheet has to hold its shape at, smallest phone upward. */
+export const SHEET_LAYOUT_WIDTHS = [320, 360, 375, 390, 430, 768] as const;

--- a/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
+++ b/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
@@ -1,0 +1,240 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
+import {
+  SHEET_BODY_CLASSNAME,
+  SHEET_DETAILS_SHELL_CLASSNAME,
+  SHEET_FOOTER_CLASSNAME,
+  SHEET_HEADER_CLASSNAME,
+  SHEET_LAYOUT_WIDTHS,
+} from "../components/one-location/onboarding/save-location-sheet-layout";
+
+/**
+ * The address-details sheet, measured in a real browser.
+ *
+ * The sibling JSDOM test proves the component still renders these classes; it
+ * cannot prove what they do, because JSDOM performs no layout. Both bugs this
+ * guards against are invisible to a class assertion:
+ *
+ *  1. The title sat UNDER the corner buttons. They were `absolute left-4/
+ *     right-4 top-4` -- 36px wide starting at 16px, so ending at 52px -- over
+ *     a header padded to `px-9` (36px). 16px of overlap on each side, and the
+ *     sheet being its own scroller meant the two drifted apart on any scroll.
+ *  2. The last field showed THROUGH the primary button, because the footer was
+ *     `sticky bottom-0` on a `/95` translucent background.
+ *
+ * Reproducing the real sheet would need the whole onboarding flow, a map key
+ * and a signed-in fixture. Instead this renders the real class strings,
+ * imported from the component's own module, in the real Tailwind cascade --
+ * which is exactly the half a class assertion cannot reach: that these classes
+ * produce three non-overlapping rows at every phone width.
+ *
+ * Run with: npm run test:layout-contracts
+ */
+
+/** Compile just the utilities this fixture uses, with the real Tailwind. */
+async function buildFixture(): Promise<string> {
+  // Playwright runs from the webapp root (its config lives there).
+  const webappRoot = process.cwd();
+  const { compile } = (await import(
+    path.join(webappRoot, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as {
+    compile: (
+      css: string,
+      opts: unknown,
+    ) => Promise<{ build: (c: string[]) => string }>;
+  };
+
+  const compiler = await compile('@import "tailwindcss";', {
+    base: path.join(webappRoot, "node_modules"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
+          : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  const shell =
+    "fixed left-1/2 bottom-0 w-full max-w-[420px] -translate-x-1/2 flex min-h-0 flex-col max-h-[min(92dvh,760px)] rounded-t-[24px] border";
+  const row = "flex items-center gap-2";
+  const button = "relative flex h-9 w-9 shrink-0 items-center justify-center";
+  const title =
+    "min-w-0 flex-1 truncate text-center text-[17px] font-semibold leading-[22px]";
+  const field = "h-12 w-full rounded-[14px] border";
+  const primary =
+    "flex h-[52px] w-full items-center justify-center rounded-full";
+  const secondary = "h-11 w-full rounded-full";
+
+  const classes = [
+    shell,
+    SHEET_DETAILS_SHELL_CLASSNAME,
+    SHEET_HEADER_CLASSNAME,
+    SHEET_BODY_CLASSNAME,
+    SHEET_FOOTER_CLASSNAME,
+    row,
+    button,
+    title,
+    field,
+    primary,
+    secondary,
+    "mt-1 space-y-3.5 mb-1.5 block",
+  ].join(" ");
+  const css = compiler.build(classes.split(/\s+/).filter(Boolean));
+
+  // Enough fields to overflow every width under test, so the body genuinely
+  // has to scroll -- a footer only bleeds when there is something behind it.
+  const fields = Array.from(
+    { length: 8 },
+    (_, i) =>
+      `<div><label class="mb-1.5 block">Field ${i + 1}</label>` +
+      `<input class="${field}" data-testid="sheet-field" value="Value ${i + 1}"></div>`,
+  ).join("");
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "save-location-sheet-"));
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css">
+<style>:root{--app-separator:#e5e5ea;--app-card-surface-default-solid:#fff}</style>
+</head><body style="margin:0;background:#111">
+<div class="${shell} ${SHEET_DETAILS_SHELL_CLASSNAME}" data-testid="save-location-modal">
+  <header class="${SHEET_HEADER_CLASSNAME}" data-testid="sheet-header">
+    <div class="${row} mt-1">
+      <button class="${button}" data-testid="sheet-back">&#8592;</button>
+      <h2 class="${title}" data-testid="sheet-title">Address details</h2>
+      <button class="${button}" data-testid="sheet-close">&#10005;</button>
+    </div>
+  </header>
+  <div class="${SHEET_BODY_CLASSNAME}" data-testid="sheet-body">
+    <div class="space-y-3.5">${fields}</div>
+  </div>
+  <div class="${SHEET_FOOTER_CLASSNAME}" data-testid="sheet-footer">
+    <button class="${primary}" data-testid="sheet-save">Save location</button>
+    <button class="${secondary}" data-testid="sheet-skip">Skip for now</button>
+  </div>
+</div></body></html>`,
+  );
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+type Box = { x: number; y: number; width: number; height: number };
+
+async function boxOf(
+  page: import("@playwright/test").Page,
+  testId: string,
+): Promise<Box> {
+  const box = await page.getByTestId(testId).boundingBox();
+  expect(box, `${testId} should be laid out`).not.toBeNull();
+  return box!;
+}
+
+test.describe("Save-location address sheet layout", () => {
+  for (const width of SHEET_LAYOUT_WIDTHS) {
+    test(`keeps header, body and footer apart at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+
+      const header = await boxOf(page, "sheet-header");
+      const body = await boxOf(page, "sheet-body");
+      const footer = await boxOf(page, "sheet-footer");
+
+      // Three stacked rows, in order, touching but never overlapping.
+      expect(Math.round(body.y)).toBeGreaterThanOrEqual(
+        Math.round(header.y + header.height) - 1,
+      );
+      expect(Math.round(body.y + body.height)).toBeLessThanOrEqual(
+        Math.round(footer.y) + 1,
+      );
+      expect(footer.height).toBeGreaterThan(0);
+    });
+
+    test(`never lets the corner buttons touch the title at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+
+      const back = await boxOf(page, "sheet-back");
+      const title = await boxOf(page, "sheet-title");
+      const close = await boxOf(page, "sheet-close");
+
+      expect(back.x + back.width).toBeLessThanOrEqual(title.x);
+      expect(title.x + title.width).toBeLessThanOrEqual(close.x);
+      // And the title still has room to be a title.
+      expect(title.width).toBeGreaterThan(80);
+    });
+
+    test(`scrolls the body without moving the pinned rows at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+
+      const headerBefore = await boxOf(page, "sheet-header");
+      const footerBefore = await boxOf(page, "sheet-footer");
+
+      const scrolled = await page.getByTestId("sheet-body").evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+        return {
+          top: el.scrollTop,
+          overflow: el.scrollHeight - el.clientHeight,
+        };
+      });
+      // The fixture must genuinely overflow, or this proves nothing.
+      expect(scrolled.overflow).toBeGreaterThan(0);
+      expect(scrolled.top).toBeGreaterThan(0);
+
+      const headerAfter = await boxOf(page, "sheet-header");
+      const footerAfter = await boxOf(page, "sheet-footer");
+      expect(Math.round(headerAfter.y)).toBe(Math.round(headerBefore.y));
+      expect(Math.round(footerAfter.y)).toBe(Math.round(footerBefore.y));
+
+      // Scrolled to the bottom, the last field is still clear of the footer --
+      // the old translucent sticky bar let it show through the button.
+      const fields = page.getByTestId("sheet-field");
+      const last = await fields.nth((await fields.count()) - 1).boundingBox();
+      expect(last).not.toBeNull();
+      expect(Math.round(last!.y + last!.height)).toBeLessThanOrEqual(
+        Math.round(footerAfter.y) + 1,
+      );
+    });
+  }
+
+  test("paints the footer on a fully opaque surface", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(await buildFixture());
+
+    // Measured through a canvas rather than pattern-matched on the computed
+    // string. Tailwind resolves `bg-…/95` to `oklab(… / 0.95)`, not to an
+    // `rgba(…)` -- a regex looking for `rgba` passes that happily, which is
+    // how the first version of this test failed to notice the very background
+    // it was written to reject.
+    const alpha = await page.getByTestId("sheet-footer").evaluate((el) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = canvas.height = 1;
+      const ctx = canvas.getContext("2d")!;
+      ctx.clearRect(0, 0, 1, 1);
+      // Seed with fully transparent, so a colour the canvas cannot parse
+      // leaves alpha at 0 and fails rather than silently reading as opaque.
+      ctx.fillStyle = "rgba(0, 0, 0, 0)";
+      ctx.fillStyle = getComputedStyle(el).backgroundColor;
+      ctx.fillRect(0, 0, 1, 1);
+      return ctx.getImageData(0, 0, 1, 1).data[3];
+    });
+    // Anything under 255 and the field behind it shows through the button.
+    expect(alpha).toBe(255);
+  });
+});

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
-    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts --project=chromium",
+    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts --project=chromium",
     "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check && npm run verify:route-orchestration-index",


### PR DESCRIPTION
## What was wrong

Two structural defects, both from the sheet being **one long scroll box** with things stuck onto it.

**The title sat under the corner buttons.** They were `absolute left-4/right-4 top-4` — 36px wide starting at 16px, so ending at 52px — over a header padded to `px-9` (36px). 16px of overlap on each side. Because the sheet was also its own scroller, the two drifted apart the moment anyone scrolled.

**The last field showed through the primary button.** The footer was `sticky bottom-0` on a `/95` translucent background.

## What changed

The sheet is a frame now: **pinned header → one scroller → pinned footer.**

- The back/close controls are laid-out flex items beside the title. A row cannot overlap itself.
- The footer is a real row outside the scroller, on a fully opaque surface.
- The carousel dots take the sheet grabber's place in the header instead of adding a third stacked row to the footer — one element doing both jobs, and ~50px of pinned footer back.
- `overflow-y-hidden`, not `overflow-hidden`: tailwind-merge files those under different keys, so `overflow-hidden` would leave the primitive's own `overflow-y-auto` standing.
- Scoped to the details pane via `detailsPaneActive`, so the map and summary panes keep the plain scrolling sheet they were built against.

## Copy

| before | after |
|---|---|
| Add your address details | Address details |
| Only the address is needed. The rest helps at the door. | *dropped from view; kept as the `sr-only` description* |
| Pinned location | Pinned |
| Your selected map point | No address found |
| Edit pin | Edit *(accessible name unchanged)* |
| Fill the fields below from this address | Fill from this address |
| House, flat, floor or block (optional) | House or flat |
| PIN / postal code (optional) | PIN / postcode |
| Nearby landmark (optional) | Landmark |
| Give it a name (optional) | Name it |
| What kind of place is this? | Kind of place |
| Saved in your private vault. | Private to you. |
| Saved after your vault is ready. | Saves once your lock is set. |
| Pin your entrance on the map / GPS can be off by a few meters — drag the pin to your door. | Pin your entrance / GPS lands near, not at, your door. |

Four `(optional)` tags collapse into one **"Optional — helps at the door."** above the group. `e.g. ` comes off every placeholder. `vault` leaves the visible copy on both panes.

## Coverage

`e2e/save-location-sheet.layout.spec.ts` compiles the component's own exported class strings with the real Tailwind and measures them in Chromium at 320/360/375/390/430/768:

- three rows that never overlap
- corner buttons that never reach the title, at any width
- pinned rows that do not move when the body scrolls, and the last field still clear of the footer at the bottom of the scroll
- footer background alpha is exactly 255, read through a canvas rather than pattern-matched — Tailwind resolves `bg-…/95` to `oklab(… / 0.95)`, which an `rgba` regex passes happily

**Mutation-checked** against all three original defects: restoring the translucent sticky footer, the absolute-over-`px-9` header, and the non-scrolling body each fail the suite. Wired into `npm run test:layout-contracts` (29 passing).

JSDOM covers what a class assertion can reach: the controls live inside the header, the scroller owns the last field and not the Save button, the footer is solid and not sticky.

## Verification

- `npm run typecheck` — clean
- `npx eslint components/one-location e2e/save-location-sheet.layout.spec.ts --max-warnings=0` — clean
- `npm run test:layout-contracts` — 29 passed
- `vitest` across `components/one-location`, `lib/one-location`, `__tests__/lib/one-location` — **80 of 81 files pass, 789 tests**
- `verify:design-system`, `verify:surface-map`, `verify:service-boundary`, `audit:ui-surfaces` — all pass

The one failing file, `__tests__/components/one-location-agent-page.test.tsx`, fails **identically on this branch and on merged main** (69 failed / 19 passed on both) — pre-existing, unrelated to this change.