### PR TITLE
fix(voice): give the action-id screen segment its own, wider cap

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  ACTION_ID_SCREEN_SEGMENT_CAP,
   ARRAY_DIMENSION_CAP_ERROR,
   INVALID_ARRAY_TYPE_ERROR,
   STRUCTURED_CONTEXT_ARRAY_CAP,
@@ -1154,12 +1155,76 @@ describe("a surface that declares more controls than the context can carry", () 
     expect(snapshot.available_action_ids).toContain("location.pause_updates");
     // Still bounded -- this fixes an ordering bug, it does not lift the cap.
     expect(snapshot.available_action_ids.length).toBeLessThanOrEqual(
-      STRUCTURED_CONTEXT_ARRAY_CAP,
+      ACTION_ID_SCREEN_SEGMENT_CAP,
     );
     // And the openers are what yields, since navigation is admitted from any
     // screen whether or not this surface submitted it.
     expect(snapshot.available_action_ids).not.toContain(
       "location.open_join_circle",
+    );
+  });
+
+  it("fits every one of Location's real local handlers, not just three of them", () => {
+    // The scenario above used 3 local handlers as a stand-in. Location's
+    // actual published contract has grown to 12 (add_to_circle and
+    // remove_from_circle are the newest), which is more than the generic
+    // STRUCTURED_CONTEXT_ARRAY_CAP (10) even after ranking puts every local
+    // handler ahead of every route opener. Two of the twelve fell off the
+    // end and came back `action_unavailable` -- indistinguishable from a
+    // broken feature -- for as long as the segment cap stayed at 10.
+    window.history.pushState({}, "", "/one/location");
+    const openers = [
+      "location.open_now",
+      "location.open_people",
+      "location.open_links",
+      "location.open_share",
+      "location.open_ask",
+      "location.open_invite",
+      "location.open_create_circle",
+      "location.open_join_circle",
+      "location.open_temporary_link",
+      "location.open_check_in",
+      "location.open_sos",
+      "location.open_sms_contacts",
+      "location.open_settings",
+      "location.open_active_shares",
+      "location.open_shared_with_me",
+      "location.open_needs_review",
+      "location.add_connections",
+      "location.open_map",
+    ];
+    const localHandlers = [
+      "location.refresh",
+      "location.pause_updates",
+      "location.select_share_recipient",
+      "location.share_selected",
+      "location.stop_sos",
+      "location.set_auto_share",
+      "location.add_emergency_contact",
+      "location.remove_emergency_contact",
+      "location.resume_updates",
+      "location.create_circle",
+      "location.add_to_circle",
+      "location.remove_from_circle",
+    ];
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "one_location",
+      controls: [...openers, ...localHandlers].map((actionId) => ({
+        id: actionId,
+        actionId,
+        label: actionId,
+      })),
+    });
+
+    const snapshot = buildOneVoiceContextSnapshot({
+      appRuntimeState: makeRuntimeState("/one/location", "one_location"),
+    });
+
+    for (const actionId of localHandlers) {
+      expect(snapshot.available_action_ids).toContain(actionId);
+    }
+    expect(snapshot.available_action_ids.length).toBeLessThanOrEqual(
+      ACTION_ID_SCREEN_SEGMENT_CAP,
     );
   });
 });

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -25,8 +25,27 @@ import type {
 } from "@/lib/voice/voice-ui-state-machine";
 
 export const STRUCTURED_CONTEXT_ARRAY_CAP = 10;
+/**
+ * The screen-owned segment of available_action_ids specifically, separate
+ * from STRUCTURED_CONTEXT_ARRAY_CAP because that constant is also the default
+ * bound for arrays with their own, independent backend limit (visible_modules
+ * and visible_control_ids are both truncated server-side at 10 regardless of
+ * what this file sends) -- widening it there would not add capacity, only
+ * hide where the real truncation happens.
+ *
+ * This has been wrong twice before at the generic 10: Location outgrew it at
+ * 19 published controls, then again as its own actions grew past 21 to 30 --
+ * both times as new local handlers (`add_to_circle`, `remove_from_circle`,
+ * ...) fell off the end of a list already full of route openers, and every
+ * one of them returned action_unavailable, indistinguishable from a broken
+ * feature. 14 covers Location's current 12 screen-owned local handlers with
+ * two spares, while AVAILABLE_ACTION_IDS_CAP (18) still bounds the total, so
+ * a crowded screen trades a few of the 8 GLOBAL_NAV_ACTION_IDS slots for
+ * commands that actually do something on it.
+ */
+export const ACTION_ID_SCREEN_SEGMENT_CAP = 14;
 // A surface's own declared inventory before ranking. Deliberately far above
-// what any surface declares today (Location, the largest, publishes 21), so it
+// what any surface declares today (Location, the largest, publishes 30), so it
 // bounds a runaway publisher without ever deciding which actions the model is
 // allowed to see. That decision belongs to prioritizeAvailableActionIds and the
 // two caps applied after it.
@@ -438,8 +457,13 @@ function sanitizeRouteQuery(pathname: string): string {
   return pairs.sort().join("&");
 }
 
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? uniqueStrings(value) : [];
+function readStringArray(
+  value: unknown,
+  maximumDimensionCap = STRUCTURED_CONTEXT_ARRAY_CAP,
+): string[] {
+  return Array.isArray(value)
+    ? uniqueStrings(value, maximumDimensionCap)
+    : [];
 }
 
 /**
@@ -504,7 +528,7 @@ function prioritizeAvailableActionIds(
     .sort((left, right) => left.rank - right.rank || left.index - right.index)
     .map((entry) => entry.actionId);
   if (
-    ranked.length > STRUCTURED_CONTEXT_ARRAY_CAP &&
+    ranked.length > ACTION_ID_SCREEN_SEGMENT_CAP &&
     process.env.NODE_ENV !== "production"
   ) {
     // Loud, and it names what was lost. This was a console.debug, and the
@@ -517,18 +541,22 @@ function prioritizeAvailableActionIds(
     // admits navigation from any screen whether or not it was submitted here.
     // So the ids that genuinely go missing are the local handlers, which is
     // what naming them makes obvious.
-    const dropped = ranked.slice(STRUCTURED_CONTEXT_ARRAY_CAP);
+    const dropped = ranked.slice(ACTION_ID_SCREEN_SEGMENT_CAP);
     console.warn(
       `[VOICE_CONTEXT] ${screen || "unknown screen"} declared ${ranked.length} ` +
-        `action ids but only ${STRUCTURED_CONTEXT_ARRAY_CAP} fit. ` +
+        `action ids but only ${ACTION_ID_SCREEN_SEGMENT_CAP} fit. ` +
         `Dropped: ${dropped.join(", ")}`,
     );
   }
-  // Screen-ranked segment first (original cap), then the reserved global
+  // Screen-ranked segment first (own cap, wider than the generic array
+  // default -- see ACTION_ID_SCREEN_SEGMENT_CAP), then the reserved global
   // navigation segment so cross-agent navigation is always proposable. The
   // combined list stays within AVAILABLE_ACTION_IDS_CAP, which the backend
   // accepts (Pydantic max_length is kept in sync).
-  const screenSegment = enforceArrayDimensionCap(ranked).items;
+  const screenSegment = enforceArrayDimensionCap(
+    ranked,
+    ACTION_ID_SCREEN_SEGMENT_CAP,
+  ).items;
   if (!includeGlobalNavigation) return screenSegment;
   const combined = [...screenSegment];
   for (const navId of GLOBAL_NAV_ACTION_IDS) {
@@ -905,8 +933,16 @@ export function buildOneVoiceContextSnapshot(args: {
       surfaceMetadata: publishedSurface,
     });
   const app = args.appRuntimeState;
+  // available_action_ids already comes out of buildStructuredScreenContext
+  // ranked and bounded at AVAILABLE_ACTION_IDS_CAP (18), not the generic
+  // 10-item default -- re-reading it through the default here silently
+  // re-truncated an already-correct 14-item screen segment back down to 10,
+  // in plain Set-insertion order rather than by rank, and cost the two
+  // lowest-index local handlers (add_to_circle, remove_from_circle) their
+  // slot a second time even after the ranking-side cap was fixed.
   const publishedAvailableActionIds = readStringArray(
     structured.screen_metadata.available_action_ids,
+    AVAILABLE_ACTION_IDS_CAP,
   );
   const vaultReady = Boolean(
     structured.vault.unlocked &&


### PR DESCRIPTION
Reported as "voice agent used to work decently good, but few of the cmds are now broken." Root cause: Location's own local-handler commands (`add_to_circle`, `remove_from_circle`, ...) grew to 12, past the generic 10-item cap the ranking logic truncates the screen segment to. A dropped local handler comes back from the relay as `action_unavailable`, which reads as a broken command, not as a full context array.

This is the third time this exact class of bug has shipped on this file -- both prior instances are already documented in comments here (`PUBLISHED_ACTION_IDS_CAP` widened once, ranking-by-priority added once). Both times, a cap was fixed in one place while a sibling truncation elsewhere undid it.

## The fix, two parts

1. `ACTION_ID_SCREEN_SEGMENT_CAP` (14) replaces the shared default specifically for the screen-owned segment of `available_action_ids`. `STRUCTURED_CONTEXT_ARRAY_CAP` itself is untouched -- it's still the correct bound for the other arrays that reuse it as their default (`visible_modules`, control/concept voice aliases, ...), which the backend independently truncates at 10 regardless of what the client sends.
2. `buildOneVoiceContextSnapshot` was re-reading `available_action_ids` back out through `readStringArray`'s plain default cap after `buildStructuredScreenContext` had already built and ranked it -- silently re-truncating an already-correct 14-item list down to 10, in plain insertion order rather than by rank. This is what actually caused the two lowest-priority local handlers to keep failing even with the ranking cap raised. Fixed by passing `AVAILABLE_ACTION_IDS_CAP` explicitly at that one call site.

## Verification

| | |
|---|---|
| `vitest run` on the file's own test suite | 35 passed (34 existing + 1 new) |
| New test | reproduces Location's real, current 12-local-handler contract; proves all 12 survive, not just the 3 used in the existing fixture |
| `tsc --noEmit` | clean on both changed files |
| `eslint --max-warnings=0` | clean on both changed files |
| Full `vitest run __tests__/voice` | 3 pre-existing failures confirmed unrelated (route-orchestration-index / route-playbook-contract / navigation-journey -- generated-artifact staleness on calendar/check-in routes), reproduced identically on `main` without this change |