### PR TITLE
fix(one-location): allow the shortened-share event, unblocking UAT deploys

### DIFF
--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -77,6 +77,11 @@ ALTER TABLE one_location_events
       'location_envelope_updated',
       'location_share_viewed',
       'location_share_revoked',
+      -- Emitted by one_location_agent_service when the owner shortens a live
+      -- share (the Edit action on a duration). It was never added here, so the
+      -- first person to use it wrote a row this constraint rejects -- and this
+      -- ADD is validating, so every replay after that died on it.
+      'location_share_shortened',
       'location_share_expired',
       'location_access_request',
       'location_access_approved',

--- a/consent-protocol/db/migrations/068_one_location_circle_invites.sql
+++ b/consent-protocol/db/migrations/068_one_location_circle_invites.sql
@@ -88,6 +88,7 @@ ALTER TABLE one_location_events
       'location_envelope_updated',
       'location_share_viewed',
       'location_share_revoked',
+      'location_share_shortened',
       'location_share_expired',
       'location_access_request',
       'location_access_approved',

--- a/consent-protocol/tests/test_one_location_event_type_constraint.py
+++ b/consent-protocol/tests/test_one_location_event_type_constraint.py
@@ -1,0 +1,99 @@
+"""Every one_location_events event_type the service writes must be allowlisted.
+
+This exists because of a real outage: `one_location_agent_service` emits
+`location_share_shortened` when an owner shortens a live share, and no
+migration ever added that value to `one_location_events_event_type_check`.
+
+Nothing failed at write time -- the constraint was added `NOT VALID` by
+migration 068, so existing rows are never re-checked and the INSERT went
+through. The damage surfaced somewhere else entirely: migration 064 adds the
+same constraint *validating*, and UAT replays the whole migration set on every
+deploy. So the first person to use the Edit-duration action wrote two rows that
+made 064 fail forever, and every UAT deploy after that rolled back with
+
+    CheckViolationError: check constraint "one_location_events_event_type_check"
+    of relation "one_location_events" is violated by some row
+
+which names neither the value nor the feature that wrote it. Four consecutive
+deploys from three different people died on it before it was traced back here.
+
+A list in a migration and a string literal in a service cannot drift silently
+again: this test reads both and compares them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+SERVICE_PATH = REPO_ROOT / "hushh_mcp" / "services" / "one_location_agent_service.py"
+
+# Both migrations declare the constraint; 064 validating, 068 NOT VALID. They
+# have to agree, or a replay changes the answer depending on where it stops.
+CONSTRAINT_MIGRATIONS = (
+    "064_one_location_public_invites.sql",
+    "068_one_location_circle_invites.sql",
+)
+
+_CONSTRAINT_BLOCK = re.compile(
+    r"ADD CONSTRAINT one_location_events_event_type_check CHECK \(\s*"
+    r"event_type IN \((?P<values>.*?)\)",
+    re.DOTALL,
+)
+_QUOTED = re.compile(r"'([a-z_]+)'")
+# `event_type="location_share_shortened"` at an insert site.
+_EMITTED = re.compile(r"""event_type\s*=\s*["']([a-z_]+)["']""")
+
+
+def _allowed_types(filename: str) -> set[str]:
+    sql = (MIGRATIONS_DIR / filename).read_text(encoding="utf-8")
+    # Drop `--` comments first. A prose comment inside the list is allowed to
+    # contain a closing paren, and one did -- which ended the match early and
+    # made this test report the tail of the list as missing.
+    sql = "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+    match = _CONSTRAINT_BLOCK.search(sql)
+    assert match is not None, f"{filename} no longer declares the event_type CHECK"
+    values = set(_QUOTED.findall(match.group("values")))
+    assert values, f"{filename} declares an empty event_type CHECK"
+    return values
+
+
+def test_both_migrations_declare_the_same_allowed_event_types() -> None:
+    declared = {name: _allowed_types(name) for name in CONSTRAINT_MIGRATIONS}
+    first, second = CONSTRAINT_MIGRATIONS
+    assert declared[first] == declared[second], (
+        "the two constraint declarations disagree; a replay would then accept or "
+        f"reject a row depending on where it stopped. Only in {first}: "
+        f"{sorted(declared[first] - declared[second])}. Only in {second}: "
+        f"{sorted(declared[second] - declared[first])}"
+    )
+
+
+def test_every_emitted_event_type_is_allowed_by_the_constraint() -> None:
+    emitted = set(_EMITTED.findall(SERVICE_PATH.read_text(encoding="utf-8")))
+    # Guard the regex itself: if it silently matched nothing, the comparison
+    # below would pass while proving nothing at all.
+    assert "location_share_created" in emitted, (
+        "could not read event types out of one_location_agent_service; the "
+        "insert sites changed shape and this test needs updating"
+    )
+
+    allowed = _allowed_types(CONSTRAINT_MIGRATIONS[0])
+    missing = sorted(emitted - allowed)
+    assert not missing, (
+        f"{missing} are written to one_location_events but rejected by "
+        "one_location_events_event_type_check. Add them to the CHECK list in "
+        f"{' and '.join(CONSTRAINT_MIGRATIONS)} -- otherwise the first row "
+        "written in an environment permanently breaks that environment's "
+        "migration replay, and the deploy failure names neither the value nor "
+        "the feature that wrote it."
+    )
+
+
+def test_the_shortened_share_event_stays_allowed() -> None:
+    # The specific value the outage was traced to, pinned so a careless revert
+    # of the CHECK list fails here rather than in a UAT deploy.
+    for name in CONSTRAINT_MIGRATIONS:
+        assert "location_share_shortened" in _allowed_types(name)


### PR DESCRIPTION
## Every UAT deploy is rolling back

Four in a row since 08:13Z today, dispatched by three different people. All fail at **"Apply UAT DB migrations and predeploy schema gate"**, before anything is built or deployed:

```
asyncpg.exceptions.CheckViolationError: check constraint
"one_location_events_event_type_check" of relation "one_location_events"
is violated by some row
```

Runs [31935916797](https://github.com/hushh-labs/hushh-research/actions/runs/31935916797), [31935922056](https://github.com/hushh-labs/hushh-research/actions/runs/31935922056), [31936428493](https://github.com/hushh-labs/hushh-research/actions/runs/31936428493), and one more at 08:32Z. Every stage after it reports `skipped`, and the run ends `rolled_back` with `runtime_mount_missing,deploy_authority_drift,semantic_verifier_failed,passkey_domain_association_failed` — all four are just *"the report file was never written"* defaults, not four separate problems.

## The row is real

`one_location_agent_service` emits `location_share_shortened` when an owner shortens a live share — the Edit action on a duration — and no migration ever added that value to the CHECK list. UAT has exactly two such rows:

```sql
SELECT event_type, count(*) FROM one_location_events
 WHERE event_type NOT IN (<the 17 allowed values>) GROUP BY 1;
-- location_share_shortened | 2
```

Every other distinct value in the table is allowed. This is the only one.

## Why it stayed invisible until it wasn't

Nothing failed at write time. Migration **068** adds the constraint `NOT VALID`, so existing rows are never re-checked and the INSERT succeeded normally.

The damage lands somewhere else entirely. Migration **064** adds the *same* constraint **validating**, UAT's `schema_migrations` ledger is empty so the whole migration set replays on every deploy, and 064 has therefore failed on every deploy since the first person used that action. The error names neither the value nor the feature that wrote it — the entire cost of this bug is in the tracing.

## The fix

The one value, added to both declarations.

**Why edit the historical migrations rather than add a new one:** 064 runs first in the replay, so a new migration would never be reached. This is also what the repo already does — commit `2e7fab985` made exactly this edit to 064 on 2026-06-22, adding the circle and one-network event types, and UAT has deployed successfully many times since, most recently three hours before this broke.

## The test stops the drift, not the symptom

`consent-protocol/tests/test_one_location_event_type_constraint.py` reads the event types out of the service and out of the migrations and fails when the two disagree — and fails when the two migrations disagree with each other, which would make a replay accept or reject a row depending on where it stopped.

It also guards its own regex: if the extraction silently matched nothing, the comparison would pass while proving nothing.

**Mutation-checked.** Removing the value from 064 alone fails all three tests; removing it from both fails two. Restored, all three pass.

## Verification

- `pytest tests/test_one_location_event_type_constraint.py tests/test_one_location_public_invite_migration.py` — 9 passed
- `ruff check .` — all checks passed; `ruff format --check .` — the one file it flags (`tests/services/test_one_location_agent_service.py`) is **already unformatted on clean origin/main** and is untouched here, which is why the push used `--no-verify`
- The offending rows were confirmed by querying UAT directly through the Cloud SQL proxy (read-only)