### PR TITLE
fix(one-location): duration wheel reaches a full day, gets a clean :00 minute mark

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx
@@ -1,13 +1,12 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { DurationWheelPicker } from "@/components/one-location/redesign/duration-wheel-picker";
 
 describe("DurationWheelPicker", () => {
   it("shows the parsed hours/minutes for the incoming value", () => {
-    // "1" (60 min) has no exact grid point now that :00 isn't selectable --
-    // it sits exactly between 0h45m and 1h15m, and rounds up to 1h15m rather
-    // than silently shrinking the requested duration.
+    // "1" (60 min) now has an exact grid point -- :00 is selectable once
+    // Hours is above zero -- so it resolves exactly, no rounding.
     render(<DurationWheelPicker value="1" onChange={vi.fn()} />);
 
     expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
@@ -16,10 +15,10 @@ describe("DurationWheelPicker", () => {
     );
     expect(
       screen.getByRole("spinbutton", { name: "Minutes" }),
-    ).toHaveAttribute("aria-valuetext", "15 min");
+    ).toHaveAttribute("aria-valuetext", "0 min");
   });
 
-  it("floors every duration at 15 minutes — :00 is not a selectable minute value", () => {
+  it("floors every duration at 15 minutes when hours would be 0 — 0h0m is not a selectable combination", () => {
     render(<DurationWheelPicker value="0" onChange={vi.fn()} />);
 
     expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
@@ -56,10 +55,9 @@ describe("DurationWheelPicker", () => {
     onChange.mockClear();
     fireEvent.click(toggle);
 
-    // Restores the wheel's own snapped position (1h15m), not the raw "1"
-    // that was passed in and immediately rounded up to the nearest grid
-    // point on mount.
-    expect(onChange).toHaveBeenCalledWith("1.25");
+    // Restores the wheel's own snapped position (1h00m, an exact grid
+    // point now that :00 is selectable) -- same as the raw "1" passed in.
+    expect(onChange).toHaveBeenCalledWith("1");
     expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
       "aria-disabled",
       "false",
@@ -90,16 +88,67 @@ describe("DurationWheelPicker", () => {
   it("labels both columns visibly, not just for screen readers", () => {
     render(<DurationWheelPicker value="1" onChange={vi.fn()} />);
 
-    expect(screen.getByText("Hours")).toBeInTheDocument();
-    expect(screen.getByText("Minutes")).toBeInTheDocument();
+    // Visible unit labels sit inline beside each column (iOS Timer style),
+    // not in a header row above the wheel -- the accessible name ("Hours" /
+    // "Minutes") stays on each spinbutton's aria-label regardless.
+    expect(screen.getByText("hours")).toBeInTheDocument();
+    expect(screen.getByText("min")).toBeInTheDocument();
   });
 
-  it("never offers :00 as a minute value — the floor is 15 minutes", () => {
-    render(<DurationWheelPicker value="1" onChange={vi.fn()} />);
+  it("offers :00 as a minute value once Hours is above zero, shown unpadded like Hours", () => {
+    render(<DurationWheelPicker value="2" onChange={vi.fn()} />);
 
     const minutesWheel = screen.getByRole("spinbutton", { name: "Minutes" });
     expect(minutesWheel).toHaveAttribute("aria-valuemin", "0");
-    expect(minutesWheel).toHaveAttribute("aria-valuemax", "2");
-    expect(screen.queryByText("00")).not.toBeInTheDocument();
+    expect(minutesWheel).toHaveAttribute("aria-valuemax", "3");
+    expect(minutesWheel).toHaveAttribute("aria-valuetext", "0 min");
+    // "0", not "00" -- matches the Hours column's own plain digit style.
+    // Scoped to the Minutes wheel: with Hours on 2, its own "0" row (hours
+    // 0, still visible a couple rows out) would otherwise collide.
+    expect(within(minutesWheel).getByText("0")).toBeInTheDocument();
+  });
+
+  it("keeps 0 hours 0 minutes unreachable, snapping Minutes to 15 the instant Hours reaches 0", () => {
+    const onChange = vi.fn();
+    // "1" resolves exactly to 1h 0m (Minutes starts on "0").
+    render(<DurationWheelPicker value="1" onChange={onChange} />);
+    expect(
+      screen.getByRole("spinbutton", { name: "Minutes" }),
+    ).toHaveAttribute("aria-valuetext", "0 min");
+
+    // Scroll Hours down from 1 to 0 while Minutes is still sitting on "0"
+    // -- the forbidden 0h0m combination is reachable this way even though
+    // neither wheel alone ever "chose" it.
+    fireEvent.keyDown(screen.getByRole("spinbutton", { name: "Hours" }), {
+      key: "ArrowUp",
+    });
+
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
+      "aria-valuetext",
+      "0 hr",
+    );
+    expect(
+      screen.getByRole("spinbutton", { name: "Minutes" }),
+    ).toHaveAttribute("aria-valuetext", "15 min");
+    expect(onChange).not.toHaveBeenCalledWith("0");
+  });
+
+  it("reaches 0 minutes smoothly via keyboard when Hours is above zero (no guard interference)", () => {
+    // Regression check: the 0h0m guard must only apply when Hours is
+    // exactly 0 -- it must never block Minutes from reaching "0" while
+    // Hours is 1 or more.
+    render(<DurationWheelPicker value="2.75" onChange={vi.fn()} />);
+    const minutesWheel = screen.getByRole("spinbutton", { name: "Minutes" });
+    // 2.75h = 2h45m -> Minutes starts on "45", the last item.
+    expect(minutesWheel).toHaveAttribute("aria-valuetext", "45 min");
+
+    fireEvent.keyDown(minutesWheel, { key: "ArrowUp" }); // 45 -> 30
+    fireEvent.keyDown(minutesWheel, { key: "ArrowUp" }); // 30 -> 15
+    fireEvent.keyDown(minutesWheel, { key: "ArrowUp" }); // 15 -> 0
+    expect(minutesWheel).toHaveAttribute("aria-valuetext", "0 min");
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
+      "aria-valuetext",
+      "2 hr",
+    );
   });
 });

--- a/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
@@ -9,12 +9,21 @@ import { cn } from "@/lib/utils";
 /** Mirrors check-in-flow.tsx's UNTIL_STOP_VALUE — the max accepted grant window. */
 export const DURATION_WHEEL_UNTIL_STOP_VALUE = "24";
 
-const HOURS_VALUES = Array.from({ length: 11 }, (_, i) => i); // 0..10
-// No "00" — the floor of the grid is 15 minutes, not a soft guard against it.
-const MINUTE_VALUES = [15, 30, 45];
+const HOURS_VALUES = Array.from({ length: 24 }, (_, i) => i); // 0..23
+// A literal 24 is deliberately excluded: the backend caps duration at
+// `le=24` (consent-protocol/api/routes/one/location.py), and any nonzero
+// minute past a 24th hour (e.g. 24h15m) would fail that check. 23h45m is
+// the real ceiling.
+//
+// "00" is now on the grid -- exact hours (1h, 2h, ...) are representable --
+// but 0h0m never is: it's filtered out of ALL_GRID_MINUTES below, and
+// DurationWheelPicker separately guards against reaching it by direct
+// interaction (the two wheels scroll independently, so 0h + 00min is
+// otherwise reachable by scrolling either one).
+const MINUTE_VALUES = [0, 15, 30, 45];
 const ALL_GRID_MINUTES = HOURS_VALUES.flatMap((h) =>
-  MINUTE_VALUES.map((m) => h * 60 + m),
-); // 15..645 in 15-minute steps, 0h0m is not a representable state
+  MINUTE_VALUES.filter((m) => h > 0 || m > 0).map((m) => h * 60 + m),
+); // 15..1425 in 15-minute steps (plus every exact hour); 0h0m excluded
 
 const ITEM_HEIGHT = 40;
 const VISIBLE_ROWS = 5;
@@ -263,13 +272,11 @@ function WheelColumn({
       aria-valuetext={`${formatLabel(items[selectedIndex] ?? 0)} ${unitSuffix}`}
       aria-disabled={disabled}
       onKeyDown={onKeyDown}
-      className="w-14 shrink-0 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
+      className="w-16 shrink-0 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
       style={{
-        // Fixed, not flex-stretched: this column sits inside a `flex
-        // flex-col` header wrapper (label above it), and flex's default
-        // `align-items: stretch` only fills the CROSS axis of a
-        // column-direction parent (width), not its height. Without an
-        // explicit height here, this box takes its content's natural
+        // Fixed, not left to its content: this column sits inside a `flex
+        // items-center` row wrapper (its unit label beside it), and without
+        // an explicit height here it would take its content's natural
         // height instead of the fixed viewport.
         height: VIEWPORT_HEIGHT,
         WebkitMaskImage:
@@ -331,10 +338,10 @@ function WheelColumn({
 }
 
 /**
- * Apple-style two-column duration wheel (hours 0-10, minutes 15/30/45) plus
- * an "Until I stop" toggle. Keeps the same `value`/`onChange` decimal-hours
- * string contract as the DurationSelector it replaces, so callers need no
- * other changes.
+ * Apple-style two-column duration wheel (hours 0-23, minutes 00/15/30/45)
+ * plus an "Until I stop" toggle. Keeps the same `value`/`onChange`
+ * decimal-hours string contract as the DurationSelector it replaces, so
+ * callers need no other changes.
  */
 export function DurationWheelPicker({
   value,
@@ -363,12 +370,33 @@ export function DurationWheelPicker({
   const hoursApiRef = useRef<EmblaCarouselType | null>(null);
   const minutesApiRef = useRef<EmblaCarouselType | null>(null);
 
+  // The two wheels scroll independently, so 0h + 00min is reachable by
+  // direct interaction (scrolling Hours to 0 while Minutes sits on 00, or
+  // the reverse) even though 0h0m isn't a real duration. `minutesIndex`
+  // itself is corrected below (with a resync so the wheel visually catches
+  // up), but `effectiveMinutesIndex` is what's actually emitted and
+  // rendered as selected -- computed fresh every render, so the invalid
+  // combination is never emitted even for the one render before the
+  // correction effect runs.
+  const effectiveMinutesIndex =
+    hoursIndex === 0 && MINUTE_VALUES[minutesIndex] === 0
+      ? MINUTE_VALUES.indexOf(15)
+      : minutesIndex;
+
   useEffect(() => {
-    const next = untilStop ? untilStopValue : formatDurationHours(hoursIndex, minutesIndex);
+    if (effectiveMinutesIndex === minutesIndex) return;
+    setMinutesIndex(effectiveMinutesIndex);
+    setResyncToken((token) => token + 1);
+  }, [effectiveMinutesIndex, minutesIndex]);
+
+  useEffect(() => {
+    const next = untilStop
+      ? untilStopValue
+      : formatDurationHours(hoursIndex, effectiveMinutesIndex);
     if (next === lastEmittedRef.current) return;
     lastEmittedRef.current = next;
     onChange(next);
-  }, [untilStop, hoursIndex, minutesIndex, untilStopValue, onChange]);
+  }, [untilStop, hoursIndex, effectiveMinutesIndex, untilStopValue, onChange]);
 
   useEffect(() => {
     if (value === lastEmittedRef.current) return;
@@ -381,26 +409,10 @@ export function DurationWheelPicker({
   }, [value, untilStopValue]);
 
   return (
-    <div className="mx-auto max-w-[200px] space-y-3">
-      {/* Labels live in their OWN row, above the wheel row entirely -- not
-          stacked inside it. Mixing a label into each column's own flex-col
-          wrapper pushed that column down by the label's height, so the
-          selection highlight bar (centered against this whole block) no
-          longer lined up with either column's actual centered row. Keeping
-          the wheel row's only children the two fixed-height columns (plus
-          the highlight bar) means `top-1/2` here is guaranteed to be each
-          column's true center. */}
-      <div className="flex justify-center gap-6">
-        <span className="w-14 shrink-0 text-center text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Hours
-        </span>
-        <span className="w-14 shrink-0 text-center text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Minutes
-        </span>
-      </div>
+    <div className="mx-auto max-w-[260px] space-y-3">
       <div
         className={cn(
-          "relative mx-auto flex justify-center gap-6",
+          "relative mx-auto flex items-center justify-center gap-6",
           untilStop && "pointer-events-none opacity-40",
         )}
         style={{ height: VIEWPORT_HEIGHT }}
@@ -410,28 +422,48 @@ export function DurationWheelPicker({
           className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-[12px] border-y border-border/70 bg-muted/40"
           style={{ height: ITEM_HEIGHT }}
         />
-        <WheelColumn
-          items={HOURS_VALUES}
-          formatLabel={(h) => String(h)}
-          selectedIndex={hoursIndex}
-          onSettledIndex={setHoursIndex}
-          apiRef={hoursApiRef}
-          disabled={untilStop}
-          ariaLabel="Hours"
-          unitSuffix="hr"
-          resyncToken={resyncToken}
-        />
-        <WheelColumn
-          items={MINUTE_VALUES}
-          formatLabel={(m) => String(m).padStart(2, "0")}
-          selectedIndex={minutesIndex}
-          onSettledIndex={setMinutesIndex}
-          apiRef={minutesApiRef}
-          disabled={untilStop}
-          ariaLabel="Minutes"
-          unitSuffix="min"
-          resyncToken={resyncToken}
-        />
+        {/* Unit label sits INLINE, to the right of its column, not in a
+            header row above the wheel -- matches iOS's own Timer picker,
+            and gives the extra width this wheel gained (widened to close
+            up the empty gutters either side of it on a real device)
+            somewhere useful to go instead of just a bigger empty box.
+            Static/non-scrolling, and deliberately muted rather than styled
+            as part of the highlighted selection -- iOS keeps its unit
+            labels neutral too, even though the highlight bar (absolutely
+            positioned edge-to-edge on the row below) technically extends
+            behind them. */}
+        <div className="flex items-center gap-2">
+          <WheelColumn
+            items={HOURS_VALUES}
+            formatLabel={(h) => String(h)}
+            selectedIndex={hoursIndex}
+            onSettledIndex={setHoursIndex}
+            apiRef={hoursApiRef}
+            disabled={untilStop}
+            ariaLabel="Hours"
+            unitSuffix="hr"
+            resyncToken={resyncToken}
+          />
+          <span className="text-sm font-medium text-muted-foreground">
+            hours
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <WheelColumn
+            items={MINUTE_VALUES}
+            formatLabel={(m) => String(m)}
+            selectedIndex={effectiveMinutesIndex}
+            onSettledIndex={setMinutesIndex}
+            apiRef={minutesApiRef}
+            disabled={untilStop}
+            ariaLabel="Minutes"
+            unitSuffix="min"
+            resyncToken={resyncToken}
+          />
+          <span className="text-sm font-medium text-muted-foreground">
+            min
+          </span>
+        </div>
         {untilStop ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <span className="rounded-full bg-background/90 px-3 py-1 text-sm font-semibold text-foreground shadow-sm">
@@ -458,7 +490,7 @@ export function DurationWheelPicker({
       <p className="sr-only" aria-live="polite">
         {untilStop
           ? "Duration: until you stop"
-          : `Duration: ${hoursIndex} hours ${MINUTE_VALUES[minutesIndex]} minutes`}
+          : `Duration: ${hoursIndex} hours ${MINUTE_VALUES[effectiveMinutesIndex]} minutes`}
       </p>
     </div>
   );


### PR DESCRIPTION
# Description

Follow-up to #5332 (merged), from live testing on `uat.one.hushh.ai`. Three
fixes, all isolated to `duration-wheel-picker.tsx` (+ its own test file) —
no other file touched, so this can't affect anyone else's in-flight work.

1. **Hours: 0-10 → 0-23** (not a literal 24). Backend caps duration at
   `le=24`; 24h + any nonzero minute would fail that check, so 23h45m is the
   real, always-valid ceiling.
2. **Minutes gains a `:00` mark**, shown unpadded (`"0"`) to match the Hours
   column's own style — not zero-padded (`"00"`). Exact hours (1h, 2h, ...)
   are now representable instead of always rounding up to `:15`. **`0 hours
   + 0 minutes` is guarded as unreachable** — the two wheels scroll
   independently, so driving either one to 0 while the other already sits
   on 0 was otherwise reachable. `DurationWheelPicker` derives an
   `effectiveMinutesIndex` and snaps Minutes to 15 the instant that
   combination would occur, reusing the `resyncToken` mechanism already
   built in #5332 rather than adding a new one.
3. **Empty side gutters fixed**: labels move from a header row above the
   wheel to inline text beside each column (iOS Timer style), and the wheel
   widens to use that reclaimed space — done entirely inside the component,
   nothing else needed to change.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (no route files changed; `/one/location` UI only)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — web-only presentational component, no native Capacitor
    plugin surface.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable — presentational-only change, same-file revert path.
- UI browser or Playwright proof:
  - [x] Route/spec listed below: `/one/location?action=share`. Verified
    live in a real `next dev` browser session (not just jsdom): Hours
    reaches 23 with the align:"start" fix from #5332 still holding (bar,
    bold number, and real scroll position agree at every point); Minutes
    reaches "0" smoothly via keyboard when Hours is 1+; driving Hours to 0
    while Minutes sits on "0" snaps Minutes to "15" without ever emitting a
    0-duration value.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0`
  - [x] `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx __tests__/components/one-location-agent-page.test.tsx` (102/102 passing)
  - [ ] `npm run build` — not run (large monorepo build; typecheck+lint+full
    targeted test suite covered correctness for this presentational change,
    same approach as #5332)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR
  does not duplicate — it's a direct follow-up to the merged #5332.
- [x] This PR changes a current reachable app surface
  (`/one/location?action=share`).
- [x] Reachable production attach point: same `DurationWheelPicker` wired
  into `location-redesign-hub.tsx`'s `ShareFlow` from #5332 — untouched
  here, only the component's own internals changed.
- [x] New tests import and exercise production code
  (`DurationWheelPicker` directly, plus the full Share-flow suite).
- [x] Production surface proved: `duration-wheel-picker.test.tsx` (10
  tests, including 2 new ones for the 0h0m guard and the no-guard-
  interference regression check).
- [x] Required checks are current on this head, commit is signed off
  (`git commit -s`), branch is built directly off latest `main` (which
  already includes #5332).
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx`
- [ ] **iOS**: Not applicable — no native Capacitor plugin surface.
- [ ] **Android**: Not applicable, same reason as iOS.

## 🧪 Testing

- [x] Tested on Web (Chrome, via a real `next dev` session — not just jsdom)
- [ ] Tested on iOS Simulator/Device — not applicable (web-only component)
- [ ] Tested on Android Emulator/Device — not applicable
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Route: `/one/location?action=share`. Live-verified via keyboard-driven
Playwright checks (Hours to `aria-valuemax=23`, Minutes `:00` reachable and
guarded, bar/bold/scroll agreement holds at the new range) plus a manual
pass in a real browser session.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — presentational duration input
  only, same `value`/`onChange` string contract, unchanged from #5332.
- [x] Sensitive surface touched: none
- [x] Error path / rollback: same-file revert

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new third-party dependencies added