### PR TITLE
fix(connect,circles): the four phone-width defects QA photographed

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -656,7 +656,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Bulk person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select multiple" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
 
     expect(
       screen.getByText("Pick up to 8, across pages."),
@@ -715,7 +715,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select multiple" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
     fireEvent.click(screen.getByLabelText("Select Person 0"));
     expect(screen.getByText("Review 1 of 8")).toBeTruthy();
 
@@ -768,7 +768,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Connected Carl")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select multiple" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
 
     // Eligible: a real, enabled checkbox.
     expect(
@@ -848,7 +848,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Ada Advisor")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select multiple" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
     fireEvent.click(screen.getByLabelText("Select Ada Advisor"));
     fireEvent.click(screen.getByLabelText("Select Ben Advisor"));
     fireEvent.click(screen.getByRole("button", { name: "Review 2 of 8" }));
@@ -974,5 +974,109 @@ describe("Connect — removing a connection", () => {
     const card = parseVoiceCard(result.data);
     expect(card?.kind).toBe("choice");
     expect(parseVoiceConfirm(result.data)).toBeNull();
+  });
+});
+
+describe("Connect — the phone-width geometry QA reported", () => {
+  // What a class assertion can and cannot do is the whole point of this block.
+  // JSDOM applies no CSS, so none of these prove a pixel. They prove the
+  // component still hands the browser the geometry that
+  // `e2e/connect-circle-cta.layout.spec.ts` measured and found correct. Neither
+  // half is sufficient on its own; that spec is the other half.
+
+  it("keeps a connection's Remove beside the name, not under it", async () => {
+    // `stackTrailingOnMobile` puts the trailing control on its own line below
+    // `sm:` -- which is 640px, so on every iPhone. It was set here for a single
+    // 72px "Remove", and QA read the result as a broken row: "remove neeche aa
+    // rha". The People list on the same screen has never stacked.
+    mocks.listConnections.mockResolvedValue([
+      {
+        connectionId: "c-1",
+        userId: "u-rashid",
+        displayName: "Abdul Rashid",
+        maskedEmail: "r***d@gmail.com",
+      },
+    ]);
+    render(<ConnectPageClient />);
+
+    const remove = await screen.findByRole("button", {
+      name: "Remove connection with Abdul Rashid",
+    });
+    const trailing = remove.closest("div");
+    expect(trailing).toBeTruthy();
+
+    // Whole class tokens, not substrings: this wrapper already carries
+    // `max-w-full`, which contains "w-full" and would make a `toContain` check
+    // pass or fail for the wrong reason.
+    const classes = new Set(trailing!.className.split(/\s+/));
+
+    // The classes SettingsRow adds only when it is stacking.
+    expect(classes.has("justify-between")).toBe(false);
+    expect(classes.has("pt-1")).toBe(false);
+    expect(classes.has("w-full")).toBe(false);
+    // And the one it keeps when it is not.
+    expect(classes.has("justify-end")).toBe(true);
+  });
+
+  it("asks for the search field in two words", async () => {
+    render(<ConnectPageClient />);
+    expect(await screen.findByPlaceholderText("Search people")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("Search people by name")).toBeNull();
+  });
+
+  it("reserves the clear-button gutter only once there is something to clear", async () => {
+    // 44px of right padding held back from a field whose only content is its
+    // placeholder is 44px the placeholder does not get.
+    render(<ConnectPageClient />);
+    const field = (await screen.findByPlaceholderText(
+      "Search people",
+    )) as HTMLInputElement;
+
+    expect(field.className).toContain("pr-3.5");
+    expect(field.className).not.toContain("pr-11");
+
+    fireEvent.change(field, { target: { value: "ada" } });
+    expect(field.className).toContain("pr-11");
+  });
+
+  it("spends one word on cancelling a request, and says whose in the label", async () => {
+    // "Cancel request" under a 100px floor sized for "Cancelling…" made the
+    // least common row state the widest control on the screen. The visible word
+    // is short; the accessible name still carries the whole meaning, and names
+    // the person -- which the old fixed label never did.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [
+        {
+          ...person("u1", "Smirthika Dharmalingam"),
+          relationship: "pending_outgoing" as const,
+        },
+      ],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+
+    const cancel = await screen.findByRole("button", {
+      name: "Cancel your request to Smirthika Dharmalingam",
+    });
+    expect(cancel.textContent).toBe("Cancel");
+    expect(screen.queryByText("Cancel request")).toBeNull();
+
+    // WCAG 2.5.3: the accessible name has to contain the visible label, or
+    // "tap Cancel" is an instruction voice control cannot follow.
+    expect(
+      cancel.getAttribute("aria-label")!.includes(cancel.textContent!),
+    ).toBe(true);
+  });
+
+  it("keeps the selection toggle to one word, without hiding what it does", async () => {
+    render(<ConnectPageClient />);
+    const toggle = await screen.findByRole("button", {
+      name: "Select several people",
+    });
+    expect(toggle.textContent).toBe("Select");
+    expect(toggle.getAttribute("aria-label")!.startsWith(toggle.textContent!)).toBe(
+      true,
+    );
   });
 });

--- a/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
@@ -19,15 +19,30 @@ describe("Connect page layout contract", () => {
     expect(source).not.toContain('eyebrow="One"');
   });
 
-  it("stacks connection actions below labels on narrow screens", () => {
+  it("keeps a connection's action beside its name, not stacked below it", () => {
+    // This assertion used to require the opposite, and shipped the defect QA
+    // reported as "remove neeche aa rha". `stackTrailingOnMobile` moves the
+    // trailing control onto its own line below `sm:` -- which is 640px, so on
+    // every iPhone -- and it was doing that for a single 72px "Remove" that had
+    // room to sit inline the whole time. A connection read as two rows, and the
+    // People list directly beneath it on the same screen never stacked, so the
+    // two halves of Connect disagreed about their own geometry.
+    //
+    // Measured, not asserted from a class name:
+    // `e2e/connect-circle-cta.layout.spec.ts` renders both SettingsRow
+    // geometries in a real browser and confirms the stacking one really does
+    // push the action below the name at 320-430px.
     const source = fs.readFileSync(
       path.join(WEBAPP_ROOT, "app/connect/page-client.tsx"),
       "utf8",
     );
 
-    expect(source).toMatch(
-      /sortedConnections\.map[\s\S]*?<SettingsRow[\s\S]*?stackTrailingOnMobile[\s\S]*?title=\{connection\.displayName \|\| connection\.userId\}/,
-    );
+    const connectionRow = source.match(
+      /sortedConnections\.map[\s\S]*?<SettingsRow[\s\S]*?\/>/,
+    )?.[0];
+    expect(connectionRow, "the connections list still renders a SettingsRow").toBeTruthy();
+    expect(connectionRow).not.toMatch(/^\s*stackTrailingOnMobile\s*$/m);
+    expect(connectionRow).toContain("trailing=");
   });
 
   it("hard-gates Connect and the private agent on live in-memory vault state", () => {

--- a/hushh-webapp/app/connect/connect-search-layout.ts
+++ b/hushh-webapp/app/connect/connect-search-layout.ts
@@ -1,0 +1,42 @@
+/**
+ * Geometry for Connect's search row, in one place both the screen and the
+ * browser layout contract read from.
+ *
+ * The row is a search field and a selection toggle sharing one line. QA found
+ * it clipped on a phone: the placeholder rendered as "Search people by nam".
+ * Three separate things were spending the row's width, and only one of them
+ * was the label:
+ *
+ *  1. The placeholder was five words where two carry the meaning.
+ *  2. The toggle said "Select multiple" -- ~55px explaining a mode whose own
+ *     section description already explains it.
+ *  3. The field reserved `pr-11` (44px) for the clear button at all times,
+ *     including while empty -- i.e. at exactly the moment the placeholder is
+ *     the only thing in the field and the button does not exist.
+ *
+ * Values live here rather than inline so `e2e/connect-circle-cta.layout.spec.ts`
+ * can measure the real strings. A fixture that hand-copies them stops proving
+ * anything the first time one changes.
+ */
+
+/** Two words. The narrowest supported phone has to be able to read all of it. */
+export const CONNECT_SEARCH_PLACEHOLDER = "Search people";
+
+/** Left inset clears the search glyph; the right one is conditional. */
+export const CONNECT_SEARCH_INPUT_CLASSNAME = "h-10 pl-11";
+
+/** Added only while the clear button is actually in the gutter. */
+export const CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME = "pr-11";
+
+/** Used while the gutter is empty, so the placeholder gets the space back. */
+export const CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME = "pr-3.5";
+
+/**
+ * The selection toggle, at a fixed width so switching between "Select" and
+ * "Cancel" cannot resize the search field beside it.
+ */
+export const CONNECT_SELECT_TOGGLE_CLASSNAME =
+  "h-10 min-h-10 w-[84px] shrink-0 rounded-full px-0 text-[15px] font-semibold leading-5";
+
+/** Gap between the field and the toggle (`gap-2`). */
+export const CONNECT_SEARCH_ROW_GAP_PX = 8;

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { BadgeCheck, Lock, Search as SearchIcon, UserRound, Users, X } from "lucide-react";
+import { BadgeCheck, Loader2, Lock, Search as SearchIcon, UserRound, Users, X } from "lucide-react";
 
 import {
   AppPageContentRegion,
@@ -54,6 +54,13 @@ import {
 } from "@/lib/voice/voice-action-card";
 import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
 import { getDirectoryPersonDescription } from "./directory-person-label";
+import {
+  CONNECT_SEARCH_INPUT_CLASSNAME,
+  CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
+  CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
+  CONNECT_SEARCH_PLACEHOLDER,
+  CONNECT_SELECT_TOGGLE_CLASSNAME,
+} from "./connect-search-layout";
 import { cn } from "@/lib/utils";
 
 type ConnectTab = "people" | "advisors" | "nearby";
@@ -1441,8 +1448,23 @@ export default function ConnectPageClient() {
                     key={connection.connectionId}
                     icon={Users}
                     iconTone="blue"
-                    stackTrailingOnMobile
-                    title={connection.displayName || connection.userId}
+                    // Deliberately NOT stackTrailingOnMobile. That prop drops
+                    // the trailing control onto its own line below the name on
+                    // every phone (`sm:` is 640px, so "mobile" here is every
+                    // iPhone), and it was doing so for a single 72px "Remove"
+                    // that had room to sit inline all along -- a connection
+                    // read as two rows, and the list lost its right-hand
+                    // column. The People list below has never stacked; these
+                    // two lists sit on the same screen and now agree.
+                    title={
+                      <span className="block min-w-0 truncate">
+                        {connection.displayName || connection.userId}
+                      </span>
+                    }
+                    // SettingsRow derives `data-voice-label` from a string
+                    // title, and this one is now an element so it can truncate.
+                    // Passing the name keeps the attribute the row already had.
+                    voiceLabel={connection.displayName || connection.userId}
                     density="compact"
                     trailing={
                       <span className="flex shrink-0 items-center justify-end gap-1.5 whitespace-nowrap">
@@ -1509,10 +1531,15 @@ export default function ConnectPageClient() {
                     type="text"
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
-                    placeholder="Search people by name"
+                    placeholder={CONNECT_SEARCH_PLACEHOLDER}
                     aria-label="Search people"
                     data-voice-control-id="one-connect-search"
-                    className="h-10 pl-11 pr-11"
+                    className={cn(
+                      CONNECT_SEARCH_INPUT_CLASSNAME,
+                      query
+                        ? CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
+                        : CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
+                    )}
                     enterKeyHint="search"
                     onKeyDown={(event) => {
                       // iOS soft-keyboard "return" must dismiss the keyboard;
@@ -1571,15 +1598,20 @@ export default function ConnectPageClient() {
                   variant="none"
                   effect="fill"
                   size="sm"
-                  className="h-10 min-h-10 shrink-0 rounded-full px-4 text-[15px] font-semibold leading-5"
+                  className={CONNECT_SELECT_TOGGLE_CLASSNAME}
                   disabled={loading || people.length === 0}
+                  aria-label={
+                    isSelectionMode
+                      ? "Cancel selecting people"
+                      : "Select several people"
+                  }
                   onClick={() => {
                     setIsSelectionMode((current) => !current);
                     setSelectedPeople(new Map());
                     setShowLimitBanner(false);
                   }}
                 >
-                  {isSelectionMode ? "Cancel" : "Select multiple"}
+                  {isSelectionMode ? "Cancel" : "Select"}
                 </Button>
               </div>
               <SettingsGroup
@@ -1736,16 +1768,31 @@ export default function ConnectPageClient() {
                               variant="none"
                               effect="fill"
                               size="sm"
+                              // One word at the width of every other action in
+                              // this column. "Cancel request" plus a 100px
+                              // floor sized for "Cancelling…" made the widest
+                              // control on the screen the one belonging to the
+                              // least common row state -- 116px of a 375px row,
+                              // against 72px for Connect directly above it. The
+                              // in-flight state is a spinner in the same box
+                              // rather than a longer word, so the row never
+                              // reflows mid-tap. `loading` also sets aria-busy.
                               className={cn(
                                 CONNECT_ROW_ACTION_CLASSNAME,
-                                "min-w-[100px]"
+                                "w-[72px] px-0"
                               )}
-                              disabled={busyId === person.userId}
+                              loading={busyId === person.userId}
+                              aria-label={`Cancel your request to ${title}`}
                               onClick={() => void cancelConnectionRequest(person)}
                             >
-                              {busyId === person.userId
-                                ? "Cancelling…"
-                                : "Cancel request"}
+                              {busyId === person.userId ? (
+                                <Loader2
+                                  className="h-4 w-4 animate-spin"
+                                  aria-hidden="true"
+                                />
+                              ) : (
+                                "Cancel"
+                              )}
                             </Button>
                           ) : (
                             <Button

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -16,6 +16,7 @@ import {
   CreateCircleFlow,
   JoinCircleFlow,
 } from "@/components/one-location/redesign/circles/named-circle-flows";
+import { CIRCLE_NAME_ACTION_CLASSNAME } from "@/components/one-location/redesign/circles/circle-name-row-layout";
 import type {
   OneLocationCircleDetail,
   OneLocationCircleInvitePreview,
@@ -925,6 +926,43 @@ describe("named Circle flows", () => {
       expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
     );
     expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives Save and Edit one box, so the field never resizes mid-edit", async () => {
+    // QA: "Save CTA, not looking good". The cause was measurable. Save took
+    // `Button`'s `default` size, whose `min-h-[50px]` outlives an `h-11` --
+    // `h-` and `min-h-` are separate tailwind-merge groups -- so it rendered
+    // 50px against a 44px field. And because Save is wider than a pencil
+    // glyph, swapping one for the other resized the input on the first
+    // keystroke.
+    //
+    // JSDOM cannot see either of those; it applies no CSS. What it can prove is
+    // that both states are handed the one shared class string that
+    // `e2e/connect-circle-cta.layout.spec.ts` measured at 44px and a fixed
+    // width, on Chromium and on WebKit.
+    const onLoad = vi.fn(async () => circle("circle-1", "Meena Family"));
+    render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
+
+    const input = (await screen.findByLabelText(
+      "Circle name",
+    )) as HTMLInputElement;
+
+    const edit = screen.getByRole("button", { name: "Edit Circle name" });
+    expect(edit.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
+
+    fireEvent.change(input, { target: { value: "Meena Home" } });
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
+
+    // The height override is only load-bearing with its `min-h` partner.
+    const tokens = new Set(CIRCLE_NAME_ACTION_CLASSNAME.split(/\s+/));
+    expect(tokens.has("h-11")).toBe(true);
+    expect(tokens.has("min-h-11")).toBe(true);
+
+    // A word alone. The check mark beside "Save" said the same thing twice and
+    // pulled the button's padding in through `has-[>svg]`.
+    expect(save.querySelector("svg")).toBeNull();
+    expect(save.textContent).toBe("Save");
   });
 
   it("saves the Circle name on Enter and reverts it on Escape", async () => {

--- a/hushh-webapp/components/one-location/redesign/circles/circle-name-row-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-name-row-layout.ts
@@ -1,0 +1,29 @@
+/**
+ * Geometry for the Circle name field and the control beside it.
+ *
+ * QA's note was "Save CTA, not looking good". The cause was measurable rather
+ * than a matter of taste: the Save button took `Button`'s `default` size, whose
+ * `min-h-[50px]` outlives the `h-11` the caller set, because `h-` and `min-h-`
+ * are separate tailwind-merge groups and the override never landed. Save
+ * rendered 50px tall against a 44px field -- 6px proud of it on both edges.
+ *
+ * The second half was movement. Save is wider than a pencil glyph, so sizing
+ * each state to its own content resized the input on the first keystroke and
+ * again on save. Both states now share one width.
+ *
+ * Values live here rather than inline so `e2e/connect-circle-cta.layout.spec.ts`
+ * can measure the real strings in the real cascade.
+ */
+
+/** The field's height, and therefore the control's. */
+export const CIRCLE_NAME_ROW_HEIGHT_PX = 44;
+
+/** Shared by both trailing states, so neither can drift from the other. */
+export const CIRCLE_NAME_ACTION_CLASSNAME =
+  "h-11 min-h-11 w-[72px] shrink-0 rounded-xl px-0 text-[15px] font-semibold";
+
+export const CIRCLE_NAME_INPUT_CLASSNAME =
+  "h-11 min-w-0 flex-1 rounded-xl border border-border bg-background px-3 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]";
+
+/** The field and its control sit on one line (`flex items-center gap-2`). */
+export const CIRCLE_NAME_ROW_CLASSNAME = "mt-2 flex items-center gap-2";

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -46,6 +46,11 @@ import {
   TrustNoteCard,
 } from "@/components/one-location/redesign/primitives";
 import { MUTED_TEXT } from "@/components/one-location/redesign/tokens";
+import {
+  CIRCLE_NAME_ACTION_CLASSNAME,
+  CIRCLE_NAME_INPUT_CLASSNAME,
+  CIRCLE_NAME_ROW_CLASSNAME,
+} from "@/components/one-location/redesign/circles/circle-name-row-layout";
 import type {
   OneLocationCircleDetail,
   OneLocationCircleEligibleConnection,
@@ -1135,7 +1140,7 @@ export function CircleDetailFlow({
               >
                 Circle name
               </label>
-              <div className="mt-2 flex gap-2">
+              <div className={CIRCLE_NAME_ROW_CLASSNAME}>
                 <input
                   id={CIRCLE_NAME_INPUT_ID}
                   ref={nameInputRef}
@@ -1152,28 +1157,28 @@ export function CircleDetailFlow({
                   }}
                   maxLength={80}
                   autoComplete="off"
-                  className="h-11 min-w-0 flex-1 rounded-xl border border-border bg-background px-3 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+                  className={CIRCLE_NAME_INPUT_CLASSNAME}
                 />
                 {circleNameDirty ? (
                   <Button
                     type="button"
+                    size="sm"
                     disabled={!canSaveCircleName}
                     isLoading={savingName}
                     onClick={() => void renameCircle()}
-                    className="h-11 shrink-0 rounded-xl px-4 font-semibold"
+                    className={CIRCLE_NAME_ACTION_CLASSNAME}
                     data-testid="one-location-circle-name-save"
                   >
-                    <Check className="mr-1.5 h-4 w-4" />
                     Save
                   </Button>
                 ) : (
                   <Button
                     type="button"
+                    size="sm"
                     variant="outline"
-                    size="icon"
                     aria-label="Edit Circle name"
                     onClick={() => nameInputRef.current?.focus()}
-                    className="h-11 w-11 shrink-0 rounded-xl"
+                    className={CIRCLE_NAME_ACTION_CLASSNAME}
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
@@ -1183,8 +1188,8 @@ export function CircleDetailFlow({
                 {circleNameDirty && trimmedCircleName.length < 1
                   ? "Enter a name."
                   : circleNameDirty
-                    ? "Tap Save — everyone in this Circle will see the new name."
-                    : "Everyone in this Circle sees this name."}
+                    ? "Tap Save to rename."
+                    : "Circle members see this."}
               </p>
             </div>
           ) : null}

--- a/hushh-webapp/components/ui/input.tsx
+++ b/hushh-webapp/components/ui/input.tsx
@@ -2,6 +2,20 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * The field's own classes, before any caller's overrides.
+ *
+ * Exported so a real-browser layout contract can measure this input without
+ * rebuilding (and then silently drifting from) the string that gives it its
+ * height, padding and 17px value type. A fixture that hand-copies these stops
+ * proving anything the first time one of them changes here.
+ */
+const INPUT_CLASSNAME = cn(
+  "ui-text-input-value file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-11 w-full min-w-0 rounded-[var(--app-radius-md)] border border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] px-3.5 py-2 shadow-none transition-[background-color,border-color,color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-semibold disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+  "focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px]",
+  "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+)
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
@@ -10,15 +24,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       autoCapitalize={type === "email" ? "none" : props.autoCapitalize}
       autoCorrect={type === "email" ? "off" : props.autoCorrect}
       spellCheck={type === "email" ? false : props.spellCheck}
-      className={cn(
-        "ui-text-input-value file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-11 w-full min-w-0 rounded-[var(--app-radius-md)] border border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] px-3.5 py-2 shadow-none transition-[background-color,border-color,color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-semibold disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        "focus-visible:border-[color:var(--app-accent)] focus-visible:ring-[color:var(--app-focus-ring)] focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
-      )}
+      className={cn(INPUT_CLASSNAME, className)}
       {...props}
     />
   )
 }
 
-export { Input }
+export { Input, INPUT_CLASSNAME }

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -1,0 +1,636 @@
+import { expect, test, type Page } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
+import {
+  CONNECT_SEARCH_INPUT_CLASSNAME,
+  CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
+  CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
+  CONNECT_SEARCH_PLACEHOLDER,
+  CONNECT_SEARCH_ROW_GAP_PX,
+  CONNECT_SELECT_TOGGLE_CLASSNAME,
+} from "../app/connect/connect-search-layout";
+import {
+  CIRCLE_NAME_ACTION_CLASSNAME,
+  CIRCLE_NAME_INPUT_CLASSNAME,
+  CIRCLE_NAME_ROW_CLASSNAME,
+  CIRCLE_NAME_ROW_HEIGHT_PX,
+} from "../components/one-location/redesign/circles/circle-name-row-layout";
+import { INPUT_CLASSNAME } from "../components/ui/input";
+import { buttonVariants } from "../components/ui/button";
+import { cn } from "../lib/utils";
+
+/**
+ * Three QA reports from one round of phone testing, measured in a real browser.
+ *
+ *   1. "Save CTA, not looking good" -- the Circle rename button.
+ *   2. "remove neeche aa rha" -- the trailing control on a connection row
+ *      dropping onto its own line.
+ *   3. "text is long currently inside search bar" -- the Connect placeholder
+ *      clipping to "Search people by nam", and the request button beside it
+ *      reading oversized.
+ *
+ * Every one of them is invisible to the JSDOM suite, which applies no CSS and
+ * measures every element as 0x0. A `className.toContain(...)` assertion would
+ * have passed on all three the entire time they were broken. So the sibling
+ * JSDOM tests prove the components still render these class strings, and this
+ * file proves what the strings do -- in the real Tailwind cascade, at the real
+ * type, across the phone widths the product ships on.
+ *
+ * Both routes are behind sign-in, so reaching them would need a reviewer
+ * fixture and a live backend. Instead this renders the real class strings,
+ * imported from the modules the screens themselves import, exactly as the
+ * ready-panel and save-location-sheet contracts already do.
+ *
+ * Run with: npm run test:layout-contracts
+ */
+
+/** Every common iPhone width, plus one tablet reference. `sm:` is 640px, so
+ *  everything below that is what actually ships to the App Store. */
+const PHONE_WIDTHS = [320, 360, 375, 390, 430] as const;
+const WIDTHS = [...PHONE_WIDTHS, 768] as const;
+
+/** The app's horizontal page padding at phone widths, as a conservative floor.
+ *  Assuming LESS room than the screen really has can only make these stricter. */
+const PAGE_PADDING_PX = 16;
+
+/** Tailwind `sm:`. Below it, `stackTrailingOnMobile` is in force. */
+const SM_BREAKPOINT_PX = 640;
+
+/**
+ * The real stylesheet, compiled once per worker.
+ *
+ * `globals.css` is used rather than a bare `@import "tailwindcss"` because the
+ * type this measures is defined there, not in Tailwind: `ui-text-input-value`
+ * sets the search field to 17px/22px Inter via `--type-input-value-*`. Compiling
+ * without it would measure a 16px system font and quietly prove nothing about
+ * the field that shipped.
+ *
+ * `@source` directives are stripped: they exist to widen the scanner across the
+ * component tree for the real build, and here the candidate list is explicit.
+ * Leaving them in would scan thousands of files for utilities already listed.
+ */
+async function buildStylesheet(candidates: string[]): Promise<string> {
+  // Playwright runs from the webapp root (its config lives there).
+  const webappRoot = process.cwd();
+  const { compile } = (await import(
+    path.join(webappRoot, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as {
+    compile: (
+      css: string,
+      opts: unknown,
+    ) => Promise<{ build: (c: string[]) => string }>;
+  };
+
+  const globals = fs
+    .readFileSync(path.join(webappRoot, "app/globals.css"), "utf8")
+    .replace(/^@source\s+[^;]+;\s*$/gm, "");
+
+  const compiler = await compile(globals, {
+    base: path.join(webappRoot, "app"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
+          : id === "tw-animate-css"
+            ? path.join(webappRoot, "node_modules/tw-animate-css/dist/tw-animate.css")
+            : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  return compiler.build(candidates);
+}
+
+/**
+ * Write a fixture directory and return its `file://` URL.
+ *
+ * The real Inter face is copied in and the stylesheet's absolute `/fonts/...`
+ * URLs rewritten to point at it. Without that step the page silently falls back
+ * to a system font, and every width measured here would be a measurement of the
+ * wrong typeface -- which is the only thing the placeholder assertions are
+ * actually about.
+ */
+async function buildFixture(name: string, body: string, candidates: string[]) {
+  const webappRoot = process.cwd();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+
+  let css = await buildStylesheet(candidates);
+
+  const fontSource = path.join(webappRoot, "public/fonts/Inter");
+  if (fs.existsSync(fontSource)) {
+    fs.cpSync(fontSource, path.join(dir, "fonts/Inter"), { recursive: true });
+    css = css.replace(/url\(["']?\/fonts\//g, 'url("./fonts/');
+  }
+
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css"></head>
+<body style="margin:0"><div style="padding:0 ${PAGE_PADDING_PX}px">${body}</div></body></html>`,
+  );
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+/** Box geometry, as a human reads it off a screenshot. */
+interface Box {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+}
+
+/** The selector is passed as an argument, never captured: `page.evaluate`
+ *  ships the function's source to the browser, where a closure variable from
+ *  this file would arrive undefined. */
+function boxOf(page: Page, selector: string): Promise<Box> {
+  return page.evaluate((sel) => {
+    const node = document.querySelector(sel);
+    if (!node) throw new Error(`missing ${sel}`);
+    const r = node.getBoundingClientRect();
+    return {
+      top: r.top,
+      bottom: r.bottom,
+      left: r.left,
+      right: r.right,
+      width: r.width,
+      height: r.height,
+    };
+  }, selector);
+}
+
+/** `document.fonts.ready` resolves to a FontFaceSet, which cannot cross the
+ *  bridge -- await it and return nothing. */
+const fontsReady = (page: Page) =>
+  page.evaluate(() => document.fonts.ready.then(() => undefined));
+
+// ---------------------------------------------------------------------------
+// 1. The Circle name field and the control beside it
+// ---------------------------------------------------------------------------
+
+/**
+ * The class attribute the button really carries.
+ *
+ * Composed through the component's own `buttonVariants` and `cn`, not by
+ * concatenating strings, because tailwind-merge is the entire subject here. It
+ * is what decides that `h-11` erases `h-[50px]` while leaving `min-h-[50px]`
+ * standing -- and a fixture that skipped it would be measuring a class list the
+ * app never renders, in whatever order Tailwind happened to emit.
+ */
+const circleActionClass = (className: string, size: "sm" | "default") =>
+  cn(buttonVariants({ variant: "default", size, className }));
+
+/** The Save button exactly as it shipped: `Button`'s `default` size under an
+ *  `h-11` that could never reach its `min-h-[50px]`. */
+const CIRCLE_ACTION_BEFORE = "h-11 shrink-0 rounded-xl px-4 font-semibold";
+
+const CIRCLE_CANDIDATES = [
+  ...circleActionClass(CIRCLE_NAME_ACTION_CLASSNAME, "sm").split(/\s+/),
+  ...circleActionClass(CIRCLE_ACTION_BEFORE, "default").split(/\s+/),
+  ...CIRCLE_NAME_INPUT_CLASSNAME.split(/\s+/),
+  ...CIRCLE_NAME_ROW_CLASSNAME.split(/\s+/),
+];
+
+function circleRowBody(
+  state: "save" | "edit",
+  className: string = CIRCLE_NAME_ACTION_CLASSNAME,
+  size: "sm" | "default" = "sm",
+): string {
+  const cls = circleActionClass(className, size);
+  const action =
+    state === "save"
+      ? `<button data-testid="circle-name-action" class="${cls}">Save</button>`
+      : `<button data-testid="circle-name-action" aria-label="Edit Circle name" class="${cls}">&#9998;</button>`;
+  return `<div class="${CIRCLE_NAME_ROW_CLASSNAME}">
+  <input data-testid="circle-name-input" class="${CIRCLE_NAME_INPUT_CLASSNAME}" value="Family" />
+  ${action}
+</div>`;
+}
+
+test.describe("Circle name row", () => {
+  for (const width of WIDTHS) {
+    test(`field and control are the same 44px box at ${width}px`, async ({
+      page,
+    }) => {
+      const measured: Record<string, { input: Box; action: Box }> = {};
+
+      for (const state of ["save", "edit"] as const) {
+        await page.setViewportSize({ width, height: 844 });
+        await page.goto(
+          await buildFixture(
+            "circle-name-row",
+            circleRowBody(state),
+            CIRCLE_CANDIDATES,
+          ),
+        );
+        await fontsReady(page);
+
+        measured[state] = {
+          input: await boxOf(page, '[data-testid="circle-name-input"]'),
+          action: await boxOf(page, '[data-testid="circle-name-action"]'),
+        };
+      }
+
+      for (const state of ["save", "edit"] as const) {
+        const { input, action } = measured[state];
+
+        // The reported defect: Save took `Button`'s default size, whose
+        // `min-h-[50px]` survives an `h-11` override, so it rendered 50px
+        // against a 44px field and stood 3px proud on each edge.
+        expect(
+          Math.abs(action.height - CIRCLE_NAME_ROW_HEIGHT_PX),
+          `${state}: control height`,
+        ).toBeLessThanOrEqual(0.5);
+        expect(
+          Math.abs(input.height - CIRCLE_NAME_ROW_HEIGHT_PX),
+          `${state}: field height`,
+        ).toBeLessThanOrEqual(0.5);
+
+        // Same box, same line, flush on both edges.
+        expect(Math.abs(action.top - input.top), `${state}: top`).toBeLessThanOrEqual(0.5);
+        expect(
+          Math.abs(action.bottom - input.bottom),
+          `${state}: bottom`,
+        ).toBeLessThanOrEqual(0.5);
+
+        // Nothing may push the page sideways.
+        expect(action.right, `${state}: right edge`).toBeLessThanOrEqual(
+          width - PAGE_PADDING_PX + 1,
+        );
+        expect(input.left, `${state}: left edge`).toBeGreaterThanOrEqual(
+          PAGE_PADDING_PX - 1,
+        );
+      }
+
+      // Typing the first character must not resize the field. Save is wider
+      // than a pencil glyph, so before the shared width the input jumped by the
+      // difference the moment the row became dirty, and back again on save.
+      expect(
+        Math.abs(measured.save.action.width - measured.edit.action.width),
+        "control width is identical in both states",
+      ).toBeLessThanOrEqual(0.5);
+      expect(
+        Math.abs(measured.save.input.width - measured.edit.input.width),
+        "field width is identical in both states",
+      ).toBeLessThanOrEqual(0.5);
+    });
+  }
+
+  test("the version QA photographed really was 6px too tall", async ({ page }) => {
+    // Mutation check. Without this, the assertions above could be passing on a
+    // rule that was never capable of failing.
+    //
+    // `h-11` on `Button`'s `default` size erases `h-[50px]` and leaves
+    // `min-h-[50px]` untouched -- `h-` and `min-h-` are separate tailwind-merge
+    // groups -- so the button resolved to a 50px minimum against a 44px field.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(
+      await buildFixture(
+        "circle-name-row-before",
+        circleRowBody("save", CIRCLE_ACTION_BEFORE, "default"),
+        CIRCLE_CANDIDATES,
+      ),
+    );
+    await fontsReady(page);
+
+    const input = await boxOf(page, '[data-testid="circle-name-input"]');
+    const action = await boxOf(page, '[data-testid="circle-name-action"]');
+
+    expect(Math.abs(input.height - CIRCLE_NAME_ROW_HEIGHT_PX)).toBeLessThanOrEqual(0.5);
+    expect(action.height, "the shipped Save button measured 50px").toBeGreaterThan(
+      input.height + 4,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The Connect search row
+// ---------------------------------------------------------------------------
+
+const SEARCH_CANDIDATES = [
+  ...INPUT_CLASSNAME.split(/\s+/),
+  ...CONNECT_SEARCH_INPUT_CLASSNAME.split(/\s+/),
+  ...CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME.split(/\s+/),
+  ...CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME.split(/\s+/),
+  ...CONNECT_SELECT_TOGGLE_CLASSNAME.split(/\s+/),
+  "flex",
+  "w-full",
+  "items-center",
+  "gap-2",
+  "relative",
+  "flex-1",
+  "inline-flex",
+  "justify-center",
+  "whitespace-nowrap",
+  "min-h-9",
+  "h-9",
+  // The before-geometry the mutation check reproduces.
+  "px-4",
+  "rounded-full",
+  "text-[15px]",
+  "font-semibold",
+  "leading-5",
+  "h-10",
+  "min-h-10",
+  "shrink-0",
+];
+
+/**
+ * The row as it shipped, and as QA photographed it.
+ *
+ * Kept here rather than in the app module because these are dead values: a
+ * five-word placeholder, a content-sized toggle spelling out "Select multiple",
+ * and a right gutter reserved for a clear button that is not in an empty field.
+ * A fit assertion that never rejects anything is not a fit assertion, so the
+ * contract measures the real before-geometry rather than trusting that the
+ * after-geometry is roomy.
+ */
+const BEFORE = {
+  placeholder: "Search people by name",
+  inputClassName: "h-10 pl-11 pr-11",
+  toggleClassName:
+    "h-10 min-h-10 shrink-0 rounded-full px-4 text-[15px] font-semibold leading-5",
+  toggleLabel: "Select multiple",
+} as const;
+
+const BUTTON_BASE = "inline-flex items-center justify-center whitespace-nowrap";
+
+/** The row exactly as Connect builds it: field, `gap-2`, fixed-width toggle. */
+const searchRowBody = (empty: boolean) => `<div class="flex w-full items-center gap-2">
+  <div class="relative flex-1">
+    <input data-testid="connect-search" placeholder="${CONNECT_SEARCH_PLACEHOLDER}"
+      class="${INPUT_CLASSNAME} ${CONNECT_SEARCH_INPUT_CLASSNAME} ${
+        empty
+          ? CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME
+          : CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
+      }" />
+  </div>
+  <button data-testid="connect-select-toggle"
+    class="${BUTTON_BASE} min-h-9 h-9 ${CONNECT_SELECT_TOGGLE_CLASSNAME}">Select</button>
+</div>`;
+
+/** The same row before this change, for the mutation check. */
+const searchRowBodyBefore = () => `<div class="flex w-full items-center gap-2">
+  <div class="relative flex-1">
+    <input data-testid="connect-search" placeholder="${BEFORE.placeholder}"
+      class="${INPUT_CLASSNAME} ${BEFORE.inputClassName}" />
+  </div>
+  <button data-testid="connect-select-toggle"
+    class="${BUTTON_BASE} min-h-9 h-9 ${BEFORE.toggleClassName}">${BEFORE.toggleLabel}</button>
+</div>`;
+
+/**
+ * How much room the placeholder actually has, and how much it needs.
+ *
+ * Width is measured by laying the string out in the field's own computed font
+ * rather than estimated from a character count -- Inter is proportional, and a
+ * per-character average is wrong by enough to make a fit assertion meaningless.
+ */
+function probePlaceholder(text: string) {
+  const node = document.querySelector(
+    '[data-testid="connect-search"]',
+  ) as HTMLInputElement | null;
+  if (!node) throw new Error("missing search field");
+
+  const style = getComputedStyle(node);
+  const available =
+    node.clientWidth -
+    parseFloat(style.paddingLeft) -
+    parseFloat(style.paddingRight);
+
+  const ruler = document.createElement("span");
+  ruler.textContent = text;
+  ruler.style.cssText = `position:absolute;visibility:hidden;white-space:pre;font:${style.font};letter-spacing:${style.letterSpacing}`;
+  document.body.appendChild(ruler);
+  const needed = ruler.getBoundingClientRect().width;
+  ruler.remove();
+
+  return { available, needed, fontSize: style.fontSize };
+}
+
+test.describe("Connect search row", () => {
+  for (const width of PHONE_WIDTHS) {
+    test(`placeholder is fully readable at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(
+        await buildFixture("connect-search", searchRowBody(true), SEARCH_CANDIDATES),
+      );
+      await fontsReady(page);
+
+      // The fixture must be measuring the real 17px field type. If globals.css
+      // ever stops reaching this page, every assertion below would pass against
+      // a smaller fallback font and prove nothing.
+      const current = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
+      expect(current.fontSize, "field is at the app's real input type").toBe("17px");
+
+      expect(
+        current.needed,
+        `"${CONNECT_SEARCH_PLACEHOLDER}" needs ${current.needed.toFixed(1)}px of ${current.available.toFixed(1)}px`,
+      ).toBeLessThanOrEqual(current.available);
+
+      // Mutation check, against the row as it actually shipped -- the long
+      // placeholder in a field that also reserved its clear gutter, beside a
+      // toggle that spelled out "Select multiple". If this passed, the
+      // assertion above would have passed while QA was photographing the bug,
+      // and it would be guarding nothing.
+      await page.goto(
+        await buildFixture(
+          "connect-search-before",
+          searchRowBodyBefore(),
+          SEARCH_CANDIDATES,
+        ),
+      );
+      await fontsReady(page);
+      const before = await page.evaluate(probePlaceholder, BEFORE.placeholder);
+      expect(
+        before.needed,
+        `"${BEFORE.placeholder}" needed ${before.needed.toFixed(1)}px of ${before.available.toFixed(1)}px and clipped`,
+      ).toBeGreaterThan(before.available);
+    });
+  }
+
+  test("the clear-button gutter is only reserved once there is a query", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 844 });
+
+    await page.goto(
+      await buildFixture("connect-search-empty", searchRowBody(true), SEARCH_CANDIDATES),
+    );
+    const empty = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
+
+    await page.goto(
+      await buildFixture("connect-search-typed", searchRowBody(false), SEARCH_CANDIDATES),
+    );
+    const typed = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
+
+    // An empty field has no clear button in it, so it should not be holding
+    // 44px back from the only thing it is showing.
+    expect(empty.available).toBeGreaterThan(typed.available);
+  });
+
+  test("the selection toggle is a fixed width, so the field never resizes", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 844 });
+    await page.goto(
+      await buildFixture("connect-toggle", searchRowBody(true), SEARCH_CANDIDATES),
+    );
+
+    const toggle = await boxOf(page, '[data-testid="connect-select-toggle"]');
+    const field = await boxOf(page, '[data-testid="connect-search"]');
+
+    // "Select" and "Cancel" are different lengths; a content-sized toggle would
+    // hand the difference to the search field and move it on every tap.
+    expect(Math.abs(toggle.width - 84)).toBeLessThanOrEqual(0.5);
+    expect(Math.abs(toggle.left - field.right - CONNECT_SEARCH_ROW_GAP_PX)).toBeLessThanOrEqual(0.5);
+    expect(toggle.right).toBeLessThanOrEqual(375 - PAGE_PADDING_PX + 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The settings-row grid, and what `stackTrailingOnMobile` really does
+// ---------------------------------------------------------------------------
+
+const ROW_CANDIDATES = [
+  "grid",
+  "w-full",
+  "grid-cols-1",
+  "grid-cols-[minmax(0,1fr)_auto]",
+  "sm:grid-cols-[minmax(0,1fr)_auto]",
+  "items-center",
+  "sm:items-center",
+  "gap-x-3",
+  "sm:gap-x-3",
+  "gap-y-1",
+  "sm:gap-y-0",
+  "min-h-[56px]",
+  "px-4",
+  "py-2.5",
+  "min-w-0",
+  "flex-1",
+  "truncate",
+  "block",
+  "flex",
+  "justify-end",
+  "justify-between",
+  "w-full",
+  "sm:w-auto",
+  "sm:justify-end",
+  "pt-1",
+  "sm:pt-0",
+  "shrink-0",
+  "h-8",
+  "min-h-8",
+  "rounded-2xl",
+  "px-2.5",
+  "px-0",
+  "w-[72px]",
+  "min-w-[72px]",
+  "min-w-[100px]",
+  "text-[14px]",
+  "font-semibold",
+  "leading-[18px]",
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "whitespace-nowrap",
+];
+
+/**
+ * `SettingsRow`'s two geometries, side by side.
+ *
+ * These mirror the grid and trailing classes in `components/app-ui/settings-ui.tsx`
+ * for `shouldStackTrailing` true and false. The point is not to re-test that
+ * component -- it is to establish, in a real browser, that the prop Connect's
+ * connection list was passing genuinely puts the action on a second line at
+ * phone widths. The sibling JSDOM test then proves Connect no longer passes it.
+ */
+const rowsBody = `
+<div data-testid="stacked" class="grid w-full grid-cols-1 gap-y-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-x-3 sm:gap-y-0 min-h-[56px] px-4 py-2.5">
+  <div class="min-w-0 flex-1"><span data-testid="stacked-title" class="block min-w-0 truncate">Abdul Rashid</span></div>
+  <div class="flex w-full min-w-0 justify-between pt-1 sm:w-auto sm:justify-end sm:pt-0">
+    <button data-testid="stacked-action" class="inline-flex items-center justify-center whitespace-nowrap h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px] shrink-0">Remove</button>
+  </div>
+</div>
+<div data-testid="inline" class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 min-h-[56px] px-4 py-2.5">
+  <div class="min-w-0 flex-1"><span data-testid="inline-title" class="block min-w-0 truncate">Abdul Rashid</span></div>
+  <div class="flex shrink-0 items-center justify-end">
+    <button data-testid="inline-action" class="inline-flex items-center justify-center whitespace-nowrap h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px] shrink-0">Remove</button>
+  </div>
+</div>
+<div data-testid="cancel-row" class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 min-h-[56px] px-4 py-2.5">
+  <div class="min-w-0 flex-1"><span class="block min-w-0 truncate">Smirthika Dharmalingam</span></div>
+  <div class="flex shrink-0 items-center justify-end">
+    <button data-testid="cancel-action" class="inline-flex items-center justify-center whitespace-nowrap h-8 min-h-8 rounded-2xl text-[14px] font-semibold leading-[18px] shrink-0 w-[72px] px-0">Cancel</button>
+  </div>
+</div>
+<div data-testid="connect-row" class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 min-h-[56px] px-4 py-2.5">
+  <div class="min-w-0 flex-1"><span class="block min-w-0 truncate">Smirthi</span></div>
+  <div class="flex shrink-0 items-center justify-end">
+    <button data-testid="connect-action" class="inline-flex items-center justify-center whitespace-nowrap h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px] shrink-0 min-w-[72px]">Connect</button>
+  </div>
+</div>`;
+
+test.describe("Connect list rows", () => {
+  for (const width of PHONE_WIDTHS) {
+    test(`a connection keeps its action on one line at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES));
+      await fontsReady(page);
+
+      expect(width, "this width is below sm: and therefore a phone").toBeLessThan(
+        SM_BREAKPOINT_PX,
+      );
+
+      const stackedTitle = await boxOf(page, '[data-testid="stacked-title"]');
+      const stackedAction = await boxOf(page, '[data-testid="stacked-action"]');
+      const inlineTitle = await boxOf(page, '[data-testid="inline-title"]');
+      const inlineAction = await boxOf(page, '[data-testid="inline-action"]');
+
+      // The bug, reproduced: with `stackTrailingOnMobile` the action starts
+      // below the name's baseline -- a second line, on every iPhone.
+      expect(
+        stackedAction.top,
+        "stackTrailingOnMobile genuinely stacks below sm:",
+      ).toBeGreaterThanOrEqual(stackedTitle.bottom);
+
+      // The geometry the list uses now: one line, action pinned right.
+      expect(
+        inlineAction.top,
+        "the shipped row keeps the action beside the name",
+      ).toBeLessThan(inlineTitle.bottom);
+      expect(inlineAction.right).toBeGreaterThan(inlineTitle.right);
+      expect(inlineAction.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
+    });
+  }
+
+  test("the request action is no wider than the Connect beside it", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 844 });
+    await page.goto(await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES));
+    await fontsReady(page);
+
+    const cancel = await boxOf(page, '[data-testid="cancel-action"]');
+    const connect = await boxOf(page, '[data-testid="connect-action"]');
+
+    // "Cancel request" under a 100px floor made the least common row state the
+    // widest control on the screen -- 116px against Connect's 72px.
+    expect(Math.abs(cancel.width - 72)).toBeLessThanOrEqual(0.5);
+    expect(cancel.width).toBeLessThanOrEqual(connect.width + 0.5);
+    expect(cancel.height).toBeLessThanOrEqual(32.5);
+  });
+});

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
-    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts --project=chromium",
+    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts e2e/connect-circle-cta.layout.spec.ts --project=chromium && CI=1 playwright test e2e/connect-circle-cta.layout.spec.ts --project=webkit",
     "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check && npm run verify:route-orchestration-index",

--- a/hushh-webapp/playwright.config.ts
+++ b/hushh-webapp/playwright.config.ts
@@ -47,7 +47,8 @@ export default defineConfig({
       // Opt specs in as they are made WebKit-clean.
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
-      testMatch: /circle-join-responsive-contract\.spec\.ts/,
+      testMatch:
+        /(circle-join-responsive-contract|connect-circle-cta\.layout)\.spec\.ts/,
     },
     {
       name: "firefox",


### PR DESCRIPTION
Four things from one round of phone testing, on two screens. All four were geometry, and all four were invisible to the JSDOM suite — it applies no CSS and measures every element as 0×0, so a `className.toContain(...)` assertion passed on all of them the entire time they were broken.

### Circle detail — "Save CTA, not looking good"

Save took `Button`'s `default` size, whose `min-h-[50px]` outlives an `h-11`. `h-` and `min-h-` are separate tailwind-merge groups, so the override never landed:

```
h-11 on size="default"  →  … min-h-[50px] py-3 … h-11 shrink-0 rounded-xl px-4
                               ^^^^^^^^^^^^ survives; h-[50px] was stripped
```

A 50px button against a 44px field, standing 3px proud on each edge. Save was also wider than the pencil it replaced, so the input resized on the first keystroke and again on save. Both states now share one 44×72 box. The check mark is gone — it said the same thing as the word, and pulled the padding in through `has-[>svg]`.

### Connect — "remove neeche aa rha"

`stackTrailingOnMobile` drops the trailing control onto its own line below `sm:`, which is 640px — so on every iPhone. It was set for a single 72px "Remove" that had room to sit inline all along. The People list on the same screen has never stacked; the two halves of Connect now agree.

### Connect — "text is long currently inside search bar"

Three things were spending the row's width and only one of them was the label:

| | before | after |
|---|---|---|
| placeholder | "Search people by name" | "Search people" |
| toggle | "Select multiple" | "Select" |
| right gutter | `pr-11` always | `pr-11` only when the clear button is there |

The gutter is the one worth calling out: 44px reserved for a clear button that does not exist while the field is empty — i.e. at exactly the moment the placeholder is the only thing in it.

### Connect — "cancel req CTA over sized toh nahi lag rha?"

"Cancel request" under a `min-w-[100px]` floor sized for "Cancelling…" made the least common row state the widest control on the screen: 116px of a 375px row, against 72px for Connect directly above it. Now one word at 72px. The in-flight state is a spinner in the same box rather than a longer word, so the row never reflows mid-tap, and the accessible name names the person — which the old fixed label never did.

---

## Testing

`e2e/connect-circle-cta.layout.spec.ts` measures all of this in a real browser at 320/360/375/390/430/768, on **Chromium and WebKit** — WebKit being the engine the iOS build actually runs. It composes classes through the components' own `cn` and `buttonVariants` rather than concatenating strings, because tailwind-merge is the entire subject.

Two mutation checks reproduce the shipped geometry and prove it failed:

- the old Save button measures more than 4px taller than its field
- the old placeholder overflows the old row at every phone width

Sibling JSDOM tests pin what the browser measured. Each was confirmed to fail on the reverted code before being kept.

A contract test asserting connection actions **should** stack is flipped, with the reason recorded — it was pinning the defect.

```
vitest (affected)      68 passed
layout contracts       49 passed (chromium)   20 passed (webkit)
typecheck / lint       clean
```

Full suite: **21 failed / 4274 passed** on this branch against **21 failed / 4268 passed** on `origin/main`. The failing sets are byte-identical — no regressions; the 6 extra passes are these tests.