### PR TITLE
fix(one-location): add a literal 24-hour mark to the duration wheel, locked to 0 minutes

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx
@@ -36,7 +36,7 @@ describe("DurationWheelPicker", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Until I stop" }));
 
-    expect(onChange).toHaveBeenCalledWith("24");
+    expect(onChange).toHaveBeenCalledWith("until_stopped");
     expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
       "aria-disabled",
       "true",
@@ -78,11 +78,28 @@ describe("DurationWheelPicker", () => {
   });
 
   it("treats the until-stop alias value as already-toggled-on when passed in externally", () => {
-    render(<DurationWheelPicker value="24" onChange={vi.fn()} />);
+    render(<DurationWheelPicker value="until_stopped" onChange={vi.fn()} />);
 
     expect(
       screen.getByRole("button", { name: "Until I stop" }),
     ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("treats a literal 24 as an ordinary 24-hour duration, not the until-stop alias", () => {
+    // "24" used to BE the sentinel; now that a literal 24h0m is reachable
+    // on the wheel, it has to resolve as a real duration instead.
+    render(<DurationWheelPicker value="24" onChange={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Until I stop" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
+      "aria-valuetext",
+      "24 hr",
+    );
+    expect(
+      screen.getByRole("spinbutton", { name: "Minutes" }),
+    ).toHaveAttribute("aria-valuetext", "0 min");
   });
 
   it("labels both columns visibly, not just for screen readers", () => {
@@ -131,6 +148,51 @@ describe("DurationWheelPicker", () => {
       screen.getByRole("spinbutton", { name: "Minutes" }),
     ).toHaveAttribute("aria-valuetext", "15 min");
     expect(onChange).not.toHaveBeenCalledWith("0");
+  });
+
+  it("keeps 24h45m unreachable, snapping Minutes to 0 the instant Hours reaches 24", () => {
+    const onChange = vi.fn();
+    render(<DurationWheelPicker value="23.75" onChange={onChange} />);
+    // 23.75h = 23h45m -> Minutes starts on "45".
+    expect(
+      screen.getByRole("spinbutton", { name: "Minutes" }),
+    ).toHaveAttribute("aria-valuetext", "45 min");
+
+    // Scroll Hours up from 23 to 24 while Minutes is still sitting on "45"
+    // -- the forbidden 24h45m combination is reachable this way even though
+    // neither wheel alone ever "chose" it.
+    fireEvent.keyDown(screen.getByRole("spinbutton", { name: "Hours" }), {
+      key: "ArrowDown",
+    });
+
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
+      "aria-valuetext",
+      "24 hr",
+    );
+    expect(
+      screen.getByRole("spinbutton", { name: "Minutes" }),
+    ).toHaveAttribute("aria-valuetext", "0 min");
+    expect(onChange).not.toHaveBeenCalledWith("24.75");
+    expect(onChange).not.toHaveBeenCalledWith("24.25");
+    expect(onChange).not.toHaveBeenCalledWith("24.5");
+  });
+
+  it("locks Minutes to 0 while Hours sits at the 24 ceiling", () => {
+    render(<DurationWheelPicker value="24" onChange={vi.fn()} />);
+    expect(
+      screen.getByRole("spinbutton", { name: "Hours" }),
+    ).toHaveAttribute("aria-valuemax", "24");
+    const minutesWheel = screen.getByRole("spinbutton", { name: "Minutes" });
+    expect(minutesWheel).toHaveAttribute("aria-valuetext", "0 min");
+
+    // Any attempt to move Minutes off 0 while Hours is still 24 snaps
+    // straight back -- mirrors Minutes refusing to sit on 0 while Hours is 0.
+    fireEvent.keyDown(minutesWheel, { key: "ArrowDown" });
+    expect(minutesWheel).toHaveAttribute("aria-valuetext", "0 min");
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toHaveAttribute(
+      "aria-valuetext",
+      "24 hr",
+    );
   });
 
   it("reaches 0 minutes smoothly via keyboard when Hours is above zero (no guard interference)", () => {

--- a/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
@@ -6,24 +6,40 @@ import type { EmblaCarouselType, EmblaOptionsType } from "embla-carousel";
 
 import { cn } from "@/lib/utils";
 
-/** Mirrors check-in-flow.tsx's UNTIL_STOP_VALUE — the max accepted grant window. */
-export const DURATION_WHEEL_UNTIL_STOP_VALUE = "24";
+// Not "24" -- once a literal 24 hours became reachable on the wheel (see
+// MAX_HOURS_INDEX below), the wheel could legitimately emit the string
+// "24" itself (24h + 0min), which would collide with this sentinel on a
+// fresh mount and get misread as "Until I stop" instead of a real 24-hour
+// selection. Confirmed unused anywhere else in the codebase, so changing
+// it is fully self-contained to this file.
+export const DURATION_WHEEL_UNTIL_STOP_VALUE = "until_stopped";
 
-const HOURS_VALUES = Array.from({ length: 24 }, (_, i) => i); // 0..23
-// A literal 24 is deliberately excluded: the backend caps duration at
-// `le=24` (consent-protocol/api/routes/one/location.py), and any nonzero
-// minute past a 24th hour (e.g. 24h15m) would fail that check. 23h45m is
-// the real ceiling.
+const HOURS_VALUES = Array.from({ length: 25 }, (_, i) => i); // 0..24
+// 24 is only ever valid paired with 0 minutes: the backend caps duration at
+// `le=24` (consent-protocol/api/routes/one/location.py), and 24h + any
+// nonzero minute (e.g. 24h15m = 24.25h) would fail that check. 24h0m = 24.0
+// exactly satisfies it, so it's the real ceiling -- both ALL_GRID_MINUTES
+// below and DurationWheelPicker's own live guard enforce that minutes locks
+// to 0 once hours reaches this index, mirroring the 0h0m guard at the other
+// end (see MAX_HOURS_INDEX usages).
+const MAX_HOURS_INDEX = HOURS_VALUES.length - 1; // 24
 //
 // "00" is now on the grid -- exact hours (1h, 2h, ...) are representable --
 // but 0h0m never is: it's filtered out of ALL_GRID_MINUTES below, and
 // DurationWheelPicker separately guards against reaching it by direct
 // interaction (the two wheels scroll independently, so 0h + 00min is
-// otherwise reachable by scrolling either one).
+// otherwise reachable by scrolling either one). Same treatment applies at
+// the top end: MAX_HOURS_INDEX (24h) is only ever valid paired with 0.
 const MINUTE_VALUES = [0, 15, 30, 45];
-const ALL_GRID_MINUTES = HOURS_VALUES.flatMap((h) =>
-  MINUTE_VALUES.filter((m) => h > 0 || m > 0).map((m) => h * 60 + m),
-); // 15..1425 in 15-minute steps (plus every exact hour); 0h0m excluded
+const ALL_GRID_MINUTES = HOURS_VALUES.flatMap((h) => {
+  const validMinutesForHour =
+    h === 0
+      ? MINUTE_VALUES.filter((m) => m > 0)
+      : h === MAX_HOURS_INDEX
+        ? MINUTE_VALUES.filter((m) => m === 0)
+        : MINUTE_VALUES;
+  return validMinutesForHour.map((m) => h * 60 + m);
+}); // 15..1440 in 15-minute steps (plus every exact hour); 0h0m excluded, 24h capped at :00
 
 const ITEM_HEIGHT = 40;
 const VISIBLE_ROWS = 5;
@@ -338,7 +354,7 @@ function WheelColumn({
 }
 
 /**
- * Apple-style two-column duration wheel (hours 0-23, minutes 00/15/30/45)
+ * Apple-style two-column duration wheel (hours 0-24, minutes 00/15/30/45)
  * plus an "Until I stop" toggle. Keeps the same `value`/`onChange`
  * decimal-hours string contract as the DurationSelector it replaces, so
  * callers need no other changes.
@@ -370,18 +386,22 @@ export function DurationWheelPicker({
   const hoursApiRef = useRef<EmblaCarouselType | null>(null);
   const minutesApiRef = useRef<EmblaCarouselType | null>(null);
 
-  // The two wheels scroll independently, so 0h + 00min is reachable by
-  // direct interaction (scrolling Hours to 0 while Minutes sits on 00, or
-  // the reverse) even though 0h0m isn't a real duration. `minutesIndex`
-  // itself is corrected below (with a resync so the wheel visually catches
-  // up), but `effectiveMinutesIndex` is what's actually emitted and
-  // rendered as selected -- computed fresh every render, so the invalid
-  // combination is never emitted even for the one render before the
-  // correction effect runs.
+  // The two wheels scroll independently, so both ends of the range are
+  // reachable by direct interaction even though they aren't real durations:
+  // 0h + 00min (scrolling Hours to 0 while Minutes sits on 00, or the
+  // reverse), and MAX_HOURS_INDEX (24h) + any nonzero minute (24h15m would
+  // exceed the backend's 24h cap). `minutesIndex` itself is corrected below
+  // (with a resync so the wheel visually catches up), but
+  // `effectiveMinutesIndex` is what's actually emitted and rendered as
+  // selected -- computed fresh every render, so neither invalid combination
+  // is ever emitted, even for the one render before the correction effect
+  // runs.
   const effectiveMinutesIndex =
     hoursIndex === 0 && MINUTE_VALUES[minutesIndex] === 0
       ? MINUTE_VALUES.indexOf(15)
-      : minutesIndex;
+      : hoursIndex === MAX_HOURS_INDEX && MINUTE_VALUES[minutesIndex] !== 0
+        ? MINUTE_VALUES.indexOf(0)
+        : minutesIndex;
 
   useEffect(() => {
     if (effectiveMinutesIndex === minutesIndex) return;


### PR DESCRIPTION
# Description

Follow-up to #5332 and #5354 (both merged). Hours stopped at 23, on
purpose: 24h + any nonzero minute exceeds the backend's `le=24` cap. But
`24h + 0min = 24.0` satisfies it exactly, so this extends Hours to 0–24 and
**locks Minutes to 0 the instant Hours reaches 24** — `24h45m` stays
unreachable, mirroring the existing `0h0m` guard from #5354 (reuses the
same `effectiveMinutesIndex` + `resyncToken` mechanism, just at the other
boundary). All changes isolated to `duration-wheel-picker.tsx` + its own
test file — no other file touched.

**A real collision this surfaces, fixed alongside it**: the wheel's
`DURATION_WHEEL_UNTIL_STOP_VALUE` sentinel (meaning "Until I stop") was the
string `"24"` — chosen because 24 used to be unreachable by scrolling. Once
literal `24h0m` becomes scrollable, the wheel would legitimately emit `"24"`
for it, identical to the sentinel — a real 24-hour selection round-tripping
back in as `value` on a fresh mount would've misread as "Until I stop".
Changed the default sentinel to `"until_stopped"` (matching what the Share
flow's wheel already passes explicitly). Confirmed via a full trace before
making the change: the exported constant has no other consumer anywhere in
the codebase, and `check-in-flow.tsx`'s own same-named `"24"` constant is a
fully independent, unexported local — so this is self-contained to this one
file.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (no route files changed; `/one/location` UI only)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — web-only presentational component, no native Capacitor
    plugin surface.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable — presentational-only change, same-file revert path.
- UI browser or Playwright proof:
  - [x] Route/spec listed below: `/one/location?action=share` and the Ask
    flow's "How long" card. Verified live in a real `next dev` browser
    session (not just jsdom): Hours reaches 24 (`aria-valuemax="24"`) with
    the align:"start" fix from #5332 still holding (bar, bold number, and
    real scroll position agree); Minutes auto-locks to "0" the instant
    Hours hits 24; attempting to scroll Minutes off 0 while Hours=24 snaps
    straight back; going back down to Hours=0 still correctly re-locks
    Minutes to 15 (no regression to the #5354 guard).
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0`
  - [x] `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx __tests__/components/one-location-agent-page.test.tsx` (105/105 passing)
  - [ ] `npm run build` — not run (large monorepo build; typecheck+lint+full
    targeted test suite covered correctness, same approach as #5332/#5354)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR
  does not duplicate — it's a direct follow-up to the merged #5332/#5354.
- [x] This PR changes a current reachable app surface
  (`/one/location?action=share`, Ask flow's "How long" card).
- [x] Reachable production attach point: same `DurationWheelPicker` wired
  into `location-redesign-hub.tsx` from #5332/#5354 — untouched here, only
  the component's own internals changed.
- [x] New tests import and exercise production code (`DurationWheelPicker`
  directly, plus the full Share-flow suite).
- [x] Production surface proved: `duration-wheel-picker.test.tsx` (13
  tests, including 4 new ones for the 24h boundary guard and the sentinel
  fix).
- [x] Required checks are current on this head, commit is signed off
  (`git commit -s`), branch is built directly off latest `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx`
- [ ] **iOS**: Not applicable — no native Capacitor plugin surface.
- [ ] **Android**: Not applicable, same reason as iOS.

## 🧪 Testing

- [x] Tested on Web (Chrome, via a real `next dev` session — not just jsdom)
- [ ] Tested on iOS Simulator/Device — not applicable (web-only component)
- [ ] Tested on Android Emulator/Device — not applicable
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Route: `/one/location?action=share` and the Ask flow's "How long" card.
Live-verified: scrolling Hours to its new max shows `24` bold/blue with
`0` for Minutes, both inside the highlight bar; scrolling Minutes away from
0 at that point snaps right back.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — presentational duration
  input only, same `value`/`onChange` string contract, unchanged from
  #5332/#5354.
- [x] Sensitive surface touched: none
- [x] Error path / rollback: same-file revert

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new third-party dependencies added