### PR TITLE
feat(one-location): name every pin on Your Map

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -9,6 +9,15 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mapHarness = vi.hoisted(() => {
+  type CameraListener = (data: unknown) => void;
+  // The renderer is the only thing that knows what the camera is showing, and
+  // the HTML name pills are positioned from it. Holding the callbacks lets a
+  // case drive a real camera report instead of faking the layer's own maths.
+  const listeners: {
+    boundsChanged?: CameraListener;
+    cameraIdle?: CameraListener;
+    cameraMoveStarted?: CameraListener;
+  } = {};
   const map = {
     addCircles: vi.fn(async (_circles: unknown[]) => ["circle-0"]),
     addMarkers: vi.fn(async (markers: unknown[]) =>
@@ -26,10 +35,32 @@ const mapHarness = vi.hoisted(() => {
     removeCircles: vi.fn(async () => undefined),
     setCamera: vi.fn(async () => undefined),
     setOnMarkerClickListener: vi.fn(async () => undefined),
+    setOnBoundsChangedListener: vi.fn(async (_callback: CameraListener) => {}),
+    setOnCameraIdleListener: vi.fn(async (_callback: CameraListener) => {}),
+    setOnCameraMoveStartedListener: vi.fn(
+      async (_callback: CameraListener) => {},
+    ),
     setPadding: vi.fn(async () => undefined),
+  };
+  // Re-installed per case: afterEach clears every implementation on this map.
+  const resetCameraListeners = () => {
+    listeners.boundsChanged = undefined;
+    listeners.cameraIdle = undefined;
+    listeners.cameraMoveStarted = undefined;
+    map.setOnBoundsChangedListener.mockImplementation(async (callback) => {
+      listeners.boundsChanged = callback;
+    });
+    map.setOnCameraIdleListener.mockImplementation(async (callback) => {
+      listeners.cameraIdle = callback;
+    });
+    map.setOnCameraMoveStartedListener.mockImplementation(async (callback) => {
+      listeners.cameraMoveStarted = callback;
+    });
   };
   return {
     map,
+    listeners,
+    resetCameraListeners,
     create: vi.fn(async () => map),
   };
 });
@@ -330,6 +361,7 @@ beforeEach(() => {
   platformHarness.native = false;
   trayHeaderHeightStub = 72;
   trayContentHeightStub = 260;
+  mapHarness.resetCameraListeners();
   // Lanes are module state: without this a superseded claim or a queued
   // teardown from an earlier case leaks into the next one.
   __resetNativeMapLifecycleForTests();
@@ -2046,5 +2078,178 @@ describe("LocationImmersiveMap reported map defects", () => {
     expect(toast.message).not.toHaveBeenCalledWith(
       "No one is sharing a live location with you yet.",
     );
+  });
+
+  /**
+   * jsdom lays nothing out, so every rect is 0x0 and a layer positioned in the
+   * map box's own pixels would have no box to be positioned in. These are the
+   * measurements a phone actually reports: a full-bleed map, a one-row header,
+   * and the collapsed people tray sitting above the home indicator.
+   */
+  function stubPhoneGeometry() {
+    const box = (x: number, y: number, width: number, height: number) =>
+      ({
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        if (this.tagName === "CAPACITOR-GOOGLE-MAP") return box(0, 0, 390, 844);
+        if (this.tagName === "HEADER") return box(0, 0, 390, 72);
+        if (this.tagName === "SECTION") return box(167, 772, 56, 56);
+        return box(0, 0, 0, 0);
+      },
+    );
+  }
+
+  /** One camera report, coalesced into state on the next animation frame. */
+  async function reportCamera(overrides: Record<string, unknown> = {}) {
+    await act(async () => {
+      mapHarness.listeners.cameraIdle?.({
+        mapId: "one-location-private-map",
+        bounds: {
+          northeast: { lat: 25.47, lng: 81.87 },
+          southwest: { lat: 25.42, lng: 81.8 },
+          center: { lat: 25.445, lng: 81.835 },
+        },
+        latitude: 25.445,
+        longitude: 81.835,
+        zoom: 12,
+        bearing: 0,
+        tilt: 0,
+        ...overrides,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    });
+  }
+
+  it("names each pin by first name, and your own pin My location", async () => {
+    // The reported gap: two pins and no way to tell who is who without opening
+    // the tray. "Ankit Kumar Singh" is what the tray says; a pill over a pin
+    // gets the one word he is called.
+    stubPhoneGeometry();
+    serviceHarness.captureCurrentPosition.mockResolvedValue({
+      latitude: 25.46,
+      longitude: 81.85,
+      accuracyM: 12,
+      capturedAt: "2026-07-23T00:00:00.000Z",
+      sourcePlatform: "ios",
+    });
+    serviceHarness.getMapState.mockResolvedValue({
+      markers: [
+        incomingMarker(ANKIT, 25.4358, 81.8463),
+        incomingMarker(ABDUL, 25.4501, 81.8201),
+      ],
+      preferences: { presenceMode: "ghost" },
+    });
+
+    await renderReadyMap();
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-marker-count",
+        "2",
+      );
+    });
+
+    // Nothing is drawn until the renderer says what it is showing: the pills
+    // are positioned from the camera, never guessed.
+    expect(screen.getByTestId("one-location-map-name-labels")).toHaveAttribute(
+      "data-label-count",
+      "0",
+    );
+
+    await reportCamera();
+
+    const labels = screen.getAllByTestId("one-location-map-name-label");
+    expect(labels.map((label) => label.textContent)).toEqual([
+      "My location",
+      "Ankit",
+      "Abdul",
+    ]);
+    expect(labels[0]).toHaveAttribute("data-kind", "self");
+    expect(labels[1]).toHaveAttribute("data-kind", "person");
+
+    // The boundary the pills are allowed to exist on top of: names are HTML in
+    // the WebView, and the renderer is still told nothing but coordinates.
+    const markerPayload = JSON.stringify(mapHarness.map.addMarkers.mock.calls);
+    expect(markerPayload).not.toContain("Ankit");
+    expect(markerPayload).not.toContain("Abdul");
+  });
+
+  it("draws no name over a rotated map, and none for a pin off screen", async () => {
+    stubPhoneGeometry();
+    serviceHarness.getMapState.mockResolvedValue({
+      markers: [incomingMarker(ANKIT, 25.4358, 81.8463)],
+      preferences: { presenceMode: "ghost" },
+    });
+
+    await renderReadyMap();
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-marker-count",
+        "1",
+      );
+    });
+
+    await reportCamera();
+    expect(screen.getAllByTestId("one-location-map-name-label")).toHaveLength(1);
+
+    // The projection is flat, so under a bearing every name would slide off
+    // its own pin. A name over the wrong pin is worse than no name.
+    await reportCamera({ bearing: 42 });
+    expect(screen.queryAllByTestId("one-location-map-name-label")).toHaveLength(
+      0,
+    );
+
+    // Panned away: the pin is not on screen, so neither is what it is called.
+    await reportCamera({
+      bounds: {
+        northeast: { lat: 45, lng: 10 },
+        southwest: { lat: 44, lng: 9 },
+        center: { lat: 44.5, lng: 9.5 },
+      },
+    });
+    expect(screen.queryAllByTestId("one-location-map-name-label")).toHaveLength(
+      0,
+    );
+  });
+
+  it("fades the names out while a native camera is mid-gesture", async () => {
+    // iOS and Android report the camera only once it settles. Holding the old
+    // positions through a drag would walk every name away from its pin, so the
+    // layer says nothing until it knows something again.
+    platformHarness.native = true;
+    stubPhoneGeometry();
+    serviceHarness.getMapState.mockResolvedValue({
+      markers: [incomingMarker(ANKIT, 25.4358, 81.8463)],
+      preferences: { presenceMode: "ghost" },
+    });
+
+    await renderReadyMap();
+    await reportCamera();
+
+    const layer = screen.getByTestId("one-location-map-name-labels");
+    expect(layer).toHaveClass("opacity-100");
+
+    await act(async () => {
+      mapHarness.listeners.cameraMoveStarted?.({
+        mapId: "one-location-private-map",
+        isGesture: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(layer).toHaveClass("opacity-0");
+
+    // The camera settling is what ends the blackout.
+    await reportCamera();
+    expect(layer).toHaveClass("opacity-100");
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location/map-name-labels.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/map-name-labels.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateMapNameLabelWidthPx,
+  firstNameFromLabel,
+  layoutMapNameLabels,
+  projectToMapBox,
+  MAP_NAME_LABEL_GAP_PX,
+  MAP_NAME_LABEL_HEIGHT_PX,
+  MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX,
+  MAP_NAME_LABEL_PIN_OFFSET_PX,
+  type MapNameLabelCamera,
+  type MapNameLabelCandidate,
+  type PlacedMapNameLabel,
+} from "@/lib/one-location/map-name-labels";
+
+/** A north-up camera over one degree of the world in each direction. */
+function camera(overrides: Partial<MapNameLabelCamera> = {}): MapNameLabelCamera {
+  return {
+    north: 1,
+    south: -1,
+    east: 1,
+    west: -1,
+    zoom: 12,
+    bearing: 0,
+    tilt: 0,
+    ...overrides,
+  };
+}
+
+const VIEWPORT = { width: 400, height: 400 };
+
+function person(
+  key: string,
+  latitude: number,
+  longitude: number,
+  text = key,
+): MapNameLabelCandidate {
+  return { key, text, kind: "person", point: { latitude, longitude } };
+}
+
+function boxOf(label: PlacedMapNameLabel) {
+  const halfWidth = estimateMapNameLabelWidthPx(label.text) / 2;
+  const bottom = label.y - MAP_NAME_LABEL_PIN_OFFSET_PX;
+  return {
+    left: label.x - halfWidth,
+    right: label.x + halfWidth,
+    top: bottom - MAP_NAME_LABEL_HEIGHT_PX,
+    bottom,
+  };
+}
+
+describe("firstNameFromLabel", () => {
+  it("keeps only the name a person is called", () => {
+    expect(firstNameFromLabel("Ankit Kumar Singh")).toBe("Ankit");
+    expect(firstNameFromLabel("Neelesh")).toBe("Neelesh");
+    expect(firstNameFromLabel("  Maya   Chen  ")).toBe("Maya");
+  });
+
+  it("survives the shapes a display name actually arrives in", () => {
+    // A trailing comma from a "Surname, Given" entry must not reach the pill.
+    expect(firstNameFromLabel("Rivera, Sam")).toBe("Rivera");
+    // A login used as a display name is not a name; the local part is the
+    // only human-sized piece of it.
+    expect(firstNameFromLabel("ankit@example.com")).toBe("ankit");
+    expect(firstNameFromLabel("‘Zoe’ Clarke")).toBe("Zoe");
+  });
+
+  it("returns nothing rather than a stray initial when there is no name", () => {
+    // The caller picks its own fallback. Splitting "A trusted person" here
+    // would put the single letter "A" over somebody's pin.
+    expect(firstNameFromLabel("")).toBe("");
+    expect(firstNameFromLabel("   ")).toBe("");
+  });
+});
+
+describe("projectToMapBox", () => {
+  it("puts the camera's centre in the middle of the map box", () => {
+    const centre = projectToMapBox(
+      { latitude: 0, longitude: 0 },
+      camera(),
+      VIEWPORT,
+    );
+    expect(centre?.x).toBeCloseTo(200, 6);
+    expect(centre?.y).toBeCloseTo(200, 6);
+  });
+
+  it("grows y downward, because screens do", () => {
+    const north = projectToMapBox(
+      { latitude: 0.5, longitude: 0 },
+      camera(),
+      VIEWPORT,
+    );
+    expect(north?.y).toBeLessThan(200);
+  });
+
+  it("reads a camera straddling the antimeridian as the 20 degrees on screen", () => {
+    // west=170, east=-170. A plain `east - west` is -340 here, which would put
+    // every pin in the Pacific somewhere off the left edge.
+    const straddling = camera({ west: 170, east: -170 });
+    expect(
+      projectToMapBox({ latitude: 0, longitude: 175 }, straddling, VIEWPORT)?.x,
+    ).toBeCloseTo(100, 5);
+    expect(
+      projectToMapBox({ latitude: 0, longitude: -175 }, straddling, VIEWPORT)?.x,
+    ).toBeCloseTo(300, 5);
+  });
+
+  it("treats a whole-world camera as 360 degrees, not zero", () => {
+    const world = camera({ west: -180, east: 180, north: 60, south: -60 });
+    expect(
+      projectToMapBox({ latitude: 0, longitude: 0 }, world, VIEWPORT)?.x,
+    ).toBeCloseTo(200, 5);
+  });
+
+  it("refuses a map box with no size", () => {
+    expect(
+      projectToMapBox({ latitude: 0, longitude: 0 }, camera(), {
+        width: 0,
+        height: 0,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("layoutMapNameLabels", () => {
+  it("draws nothing over a rotated or tilted map", () => {
+    // The projection is flat. Under a bearing every name would sit over
+    // somebody else's pin, and a wrong name is worse than no name.
+    const labels = [person("maya", 0, 0)];
+    expect(
+      layoutMapNameLabels({
+        labels,
+        camera: camera({ bearing: 42 }),
+        viewport: VIEWPORT,
+      }),
+    ).toEqual([]);
+    expect(
+      layoutMapNameLabels({
+        labels,
+        camera: camera({ tilt: 30 }),
+        viewport: VIEWPORT,
+      }),
+    ).toEqual([]);
+  });
+
+  it("names every pin that has room of its own", () => {
+    const placed = layoutMapNameLabels({
+      labels: [person("maya", 0.5, -0.5), person("jordan", -0.5, 0.5)],
+      camera: camera(),
+      viewport: VIEWPORT,
+    });
+    expect(placed.map((label) => label.key)).toEqual(["maya", "jordan"]);
+  });
+
+  it("keeps you when your pill and somebody else's cannot both fit", () => {
+    const placed = layoutMapNameLabels({
+      labels: [
+        person("maya", 0, 0.001),
+        {
+          key: "self",
+          text: "My location",
+          kind: "self",
+          point: { latitude: 0, longitude: 0 },
+        },
+      ],
+      camera: camera(),
+      viewport: VIEWPORT,
+    });
+    // Input order put the other person first; priority, not order, decides.
+    expect(placed.map((label) => label.key)).toEqual(["self"]);
+  });
+
+  it("drops a pin hidden under the top controls or the people tray", () => {
+    const placed = layoutMapNameLabels({
+      labels: [person("under-header", 0.9, 0), person("under-tray", -0.9, 0)],
+      camera: camera(),
+      viewport: { ...VIEWPORT, insetTop: 120, insetBottom: 120 },
+    });
+    expect(placed).toEqual([]);
+  });
+
+  it("drops a pill an edge would clip rather than drawing half of it", () => {
+    const placed = layoutMapNameLabels({
+      labels: [person("edge", 0, 0.999, "Maya")],
+      camera: camera(),
+      viewport: VIEWPORT,
+    });
+    expect(placed).toEqual([]);
+  });
+
+  it("keeps clear of the desktop check-in panel down the right edge", () => {
+    // The panel is real UI over the map, not map. A name behind it is the same
+    // as a name behind the header, and gets the same answer.
+    const labels = [person("right-edge", 0, 0.7, "Maya")];
+    expect(
+      layoutMapNameLabels({ labels, camera: camera(), viewport: VIEWPORT }),
+    ).toHaveLength(1);
+    expect(
+      layoutMapNameLabels({
+        labels,
+        camera: camera(),
+        viewport: { ...VIEWPORT, insetRight: 160 },
+      }),
+    ).toEqual([]);
+  });
+
+  it("stays legible when the whole world is on screen", () => {
+    // Fifty shares spread across a world view is the zoomed-out case: without
+    // a rule, every name lands within a few hundred pixels of the others.
+    const crowd = Array.from({ length: 50 }, (_, index) =>
+      person(
+        `p${index}`,
+        ((index % 7) - 3) * 4,
+        (Math.floor(index / 7) - 3) * 6,
+        `Person${index}`,
+      ),
+    );
+    const placed = layoutMapNameLabels({
+      labels: crowd,
+      camera: camera({ north: 60, south: -60, east: 60, west: -60 }),
+      viewport: { width: 390, height: 844, insetTop: 96, insetBottom: 88 },
+    });
+
+    expect(placed.length).toBeGreaterThan(0);
+    expect(placed.length).toBeLessThan(crowd.length);
+
+    for (let i = 0; i < placed.length; i += 1) {
+      for (let j = i + 1; j < placed.length; j += 1) {
+        const a = placed[i]!;
+        const b = placed[j]!;
+        const boxA = boxOf(a);
+        const boxB = boxOf(b);
+        const separated =
+          boxA.right + MAP_NAME_LABEL_GAP_PX <= boxB.left ||
+          boxB.right + MAP_NAME_LABEL_GAP_PX <= boxA.left ||
+          boxA.bottom + MAP_NAME_LABEL_GAP_PX <= boxB.top ||
+          boxB.bottom + MAP_NAME_LABEL_GAP_PX <= boxA.top;
+        expect(separated).toBe(true);
+        expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThanOrEqual(
+          MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX,
+        );
+      }
+    }
+  });
+
+  it("spreads names further apart while the renderer is clustering", () => {
+    // A clustered pin is not drawn at its own coordinate, so a name placed
+    // there would label a bubble that stands for four people.
+    const pair = [person("maya", 0, 0, "Maya"), person("jordan", -0.28, 0, "Jordan")];
+    const options = { labels: pair, camera: camera(), viewport: VIEWPORT };
+    expect(layoutMapNameLabels(options)).toHaveLength(2);
+    expect(
+      layoutMapNameLabels({ ...options, minAnchorDistancePx: 96 }),
+    ).toHaveLength(1);
+  });
+
+  it("ignores a marker with nothing to say", () => {
+    expect(
+      layoutMapNameLabels({
+        labels: [person("blank", 0, 0, "   ")],
+        camera: camera(),
+        viewport: VIEWPORT,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -31,6 +31,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+import { MapNameLabels } from "@/components/one-location/map-name-labels";
 import {
   NearbyCheckInSheet,
   type NearbyCheckInPlaceFocus,
@@ -53,6 +54,14 @@ import {
   writeLocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
 import { updateOneLocationControlState } from "@/lib/one-location/location-control-state";
+import {
+  firstNameFromLabel,
+  layoutMapNameLabels,
+  MAP_NAME_LABEL_CLUSTERED_ANCHOR_DISTANCE_PX,
+  MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX,
+  type MapNameLabelCamera,
+  type PlacedMapNameLabel,
+} from "@/lib/one-location/map-name-labels";
 import {
   getBrowserMapsApiKey,
   getNativeMapsApiKey,
@@ -119,6 +128,13 @@ const TRAY_COLLAPSED_HEIGHT_PX = 56; // 3.5rem, the collapsed pill.
 // measured DOM element, so it stays a literal constant -- everything else
 // below is read from the real, rendered header and body instead of guessed.
 const TRAY_BORDER_HEIGHT_PX = 2;
+/**
+ * The check-in panel's footprint from `md` up, where it docks down the right
+ * side instead of rising from the bottom. Read by both the camera padding and
+ * the name-pill layer, because a strip of map one of them thinks is visible and
+ * the other does not is exactly how a name ends up behind the panel.
+ */
+const DESKTOP_CHECK_IN_PANEL_WIDTH_PX = 436;
 const MAP_ACCENT_CONTROL_CLASSNAME =
   "!border-[var(--app-accent-border)] !bg-[var(--app-accent-surface)] !text-[var(--app-accent-deep)] hover:!bg-[var(--app-accent-surface-strong)] dark:!text-[var(--app-accent-bright)]";
 const MAP_ACCENT_ACTIVE_CLASSNAME =
@@ -137,10 +153,39 @@ function activeShareLabels(grants: OneLocationGrant[]): string[] {
     );
 }
 
+/**
+ * The camera payload `onCameraIdle` and `onBoundsChanged` both deliver.
+ *
+ * Declared here rather than imported: @capacitor/google-maps keeps its callback
+ * data types in `./definitions` and its package root re-exports only the map
+ * primitives, so `CameraIdleCallbackData` is not importable at all. Naming just
+ * the fields this layer reads is also the narrower contract -- the pills need a
+ * viewport and an orientation, not a mapId or a centre.
+ */
+type MapCameraEvent = {
+  bounds?: {
+    northeast: { lat: number; lng: number };
+    southwest: { lat: number; lng: number };
+  };
+  zoom?: number;
+  bearing?: number;
+  tilt?: number;
+};
+
 type RenderMarker = {
   key: string;
   point: PlainLocationPoint;
   label: string;
+  /**
+   * What the pill above this pin says, which is never the whole of `label`:
+   * "Ankit Kumar Singh" is a form-field answer, and three words stacked over a
+   * pin is how a map with four people on it stops being readable. A first name
+   * for a person, "My location" for this device, the venue for a check-in.
+   *
+   * It stays in the WebView. The renderer is still handed the generic titles
+   * below -- this is the label layer's own copy, not a relaxation of that line.
+   */
+  shortLabel: string;
   /**
    * `place` is the venue the owner is checking in to. It is deliberately
    * distinct from `self`: the two are frequently a street apart, and collapsing
@@ -221,6 +266,17 @@ function isStaleAt(
 function displayLabel(marker: OneLocationMapMarker): string {
   return marker.grant.ownerDisplayName?.trim() || "A trusted person";
 }
+
+/** What this person's pin is called on the map itself. */
+function displayShortLabel(marker: OneLocationMapMarker): string {
+  const full = marker.grant.ownerDisplayName?.trim();
+  // The unnamed case never goes through the first-name split: "A trusted
+  // person" would come back as the single letter "A".
+  return (full ? firstNameFromLabel(full) : "") || "Trusted person";
+}
+
+/** The pill over this device's own pin. */
+const SELF_SHORT_LABEL = "My location";
 
 function personInitials(label: string): string {
   return label
@@ -474,6 +530,34 @@ export function LocationImmersiveMap({
     return () => window.clearInterval(timer);
   }, []);
   const [selfMarker, setSelfMarker] = useState<RenderMarker | null>(null);
+  /**
+   * What the renderer is currently showing, so the HTML name pills can be put
+   * over the right pins. Null until the first camera report lands, which is
+   * also why the layer simply does not exist on a renderer too old to send one.
+   */
+  const [mapCamera, setMapCamera] = useState<MapNameLabelCamera | null>(null);
+  /**
+   * iOS and Android report the camera only once it SETTLES, so between the
+   * gesture starting and it stopping the coordinates above describe where the
+   * map used to be. The pills fade out for that window rather than slide across
+   * the screen away from their pins. Web reports every frame and never sets it.
+   */
+  const [cameraMoving, setCameraMoving] = useState(false);
+  const [mapBox, setMapBox] = useState({
+    width: 0,
+    height: 0,
+    insetTop: 0,
+    insetBottom: 0,
+    insetLeft: 0,
+    insetRight: 0,
+  });
+  /**
+   * Web fires a bounds report per animation frame of a pan. Coalescing them
+   * into one state update per frame is what keeps a drag at 60fps with a
+   * screenful of names on it.
+   */
+  const cameraFrameRef = useRef<number | null>(null);
+  const pendingCameraRef = useRef<MapNameLabelCamera | null>(null);
   // Count of the account's own ACTIVE outgoing shares (people it is sharing
   // its location WITH). Sourced from the full getState (map-state only carries
   // incoming markers), so it's fetched on a lighter cadence than the 5s marker
@@ -782,6 +866,7 @@ export function LocationImmersiveMap({
         key: "current-device-location",
         kind: "self",
         label: "You",
+        shortLabel: SELF_SHORT_LABEL,
         point,
         tint: SELF_TINT,
       };
@@ -811,6 +896,7 @@ export function LocationImmersiveMap({
       key: "current-device-location",
       kind: "self",
       label: "You",
+      shortLabel: SELF_SHORT_LABEL,
       point,
       tint: SELF_TINT,
     });
@@ -834,6 +920,7 @@ export function LocationImmersiveMap({
         const demoMarkers = locationMapDemoPeople().map((person) => ({
           ...person,
           kind: "person" as const,
+          shortLabel: firstNameFromLabel(person.label) || person.label,
         }));
         markerSignatureRef.current = markerSignature(demoMarkers);
         setMarkers(demoMarkers);
@@ -854,6 +941,7 @@ export function LocationImmersiveMap({
                 `${marker.grant.id}:${marker.envelope.capturedAt}`,
               point,
               label: displayLabel(marker),
+              shortLabel: displayShortLabel(marker),
               kind: "person",
               grantId: marker.grant.id,
               capturedAt: marker.envelope.capturedAt ?? null,
@@ -1105,6 +1193,47 @@ export function LocationImmersiveMap({
         return;
       }
       mapRef.current = map;
+      // The name pills are HTML above the map, so they need to know what the
+      // renderer is showing. Both platforms emit `onBoundsChanged` beside
+      // `onCameraIdle`, but only web emits it DURING a gesture -- native sends
+      // both once the camera settles, which is what `onCameraMoveStarted`
+      // compensates for by fading the layer out for the length of a drag.
+      //
+      // Wrapped, and tried before `setMapReady`, because a renderer without
+      // camera listeners must still produce a working map: the only thing it
+      // loses is the names floating over its pins.
+      try {
+        const publishCamera = (data: MapCameraEvent | null) => {
+          const bounds = data?.bounds;
+          if (!bounds) return;
+          pendingCameraRef.current = {
+            north: bounds.northeast.lat,
+            south: bounds.southwest.lat,
+            east: bounds.northeast.lng,
+            west: bounds.southwest.lng,
+            zoom: Number(data.zoom) || 0,
+            bearing: Number(data.bearing) || 0,
+            tilt: Number(data.tilt) || 0,
+          };
+          if (cameraFrameRef.current !== null) return;
+          cameraFrameRef.current = window.requestAnimationFrame(() => {
+            cameraFrameRef.current = null;
+            const next = pendingCameraRef.current;
+            if (!next) return;
+            setMapCamera(next);
+            // A fresh camera IS the end of the stale window, whether it
+            // arrived from an idle event or from web's per-frame reports.
+            setCameraMoving(false);
+          });
+        };
+        await map.setOnBoundsChangedListener(publishCamera);
+        await map.setOnCameraIdleListener(publishCamera);
+        if (isNative()) {
+          await map.setOnCameraMoveStartedListener(() => setCameraMoving(true));
+        }
+      } catch {
+        // No camera reports, so no name pills. Everything else still works.
+      }
       await map.setOnMarkerClickListener((event) => {
         const marker = markerByMapIdRef.current.get(event.markerId);
         if (!marker) return;
@@ -1127,6 +1256,12 @@ export function LocationImmersiveMap({
     return () => {
       cancelled = true;
       setMapReady(false);
+      if (cameraFrameRef.current !== null) {
+        window.cancelAnimationFrame(cameraFrameRef.current);
+        cameraFrameRef.current = null;
+      }
+      pendingCameraRef.current = null;
+      setMapCamera(null);
       // Destroy the native map instance and drop the ref on teardown. Without
       // this, closing Your Map left the @capacitor/google-maps instance
       // (registered under MAP_ID) alive; re-opening then raced a fresh create()
@@ -1237,6 +1372,9 @@ export function LocationImmersiveMap({
       key: `nearby-place:${nearbyPlaceFocus.placeId || "active"}`,
       kind: "place",
       label: nearbyPlaceFocus.label,
+      // A venue is a public place the owner picked, so the pill may name it in
+      // full -- unlike a person, whose full name stays in the tray.
+      shortLabel: nearbyPlaceFocus.label,
       point: {
         latitude: nearbyPlaceFocus.latitude,
         longitude: nearbyPlaceFocus.longitude,
@@ -1259,6 +1397,53 @@ export function LocationImmersiveMap({
     if (nearbyPlaceMarker) next.push(nearbyPlaceMarker);
     return next;
   }, [isCheckInSurface, markers, nearbyPlaceMarker, selfMarker]);
+
+  /**
+   * Past this many pins the renderer merges neighbours into cluster bubbles, so
+   * a pin is no longer drawn at its own coordinate. Shared with the pill layer,
+   * which has to spread its names further apart while that is true or it would
+   * label bubbles that stand for four people with the name of one.
+   */
+  const clusteringActive = visibleMarkers.length > 8;
+
+  /**
+   * The names floating over the pins.
+   *
+   * Order and overlap are decided in `layoutMapNameLabels`, which is where the
+   * zoomed-out case is actually handled: at world zoom fifty shares fall within
+   * a few hundred pixels of each other, and the answer is a handful of readable
+   * names rather than fifty pills in a heap.
+   */
+  const nameLabels = useMemo<PlacedMapNameLabel[]>(() => {
+    if (!mapCamera || !rendererReady || status === "unavailable") return [];
+    return layoutMapNameLabels({
+      labels: visibleMarkers.map((marker) => ({
+        key: marker.key,
+        text: marker.shortLabel,
+        kind: marker.kind,
+        point: {
+          latitude: marker.point.latitude,
+          longitude: marker.point.longitude,
+        },
+        stale: isStaleAt(marker.capturedAt, freshnessSeconds, staleClockMs),
+        tintCss: marker.tint ? tintCss(marker.tint) : undefined,
+      })),
+      camera: mapCamera,
+      viewport: mapBox,
+      minAnchorDistancePx: clusteringActive
+        ? MAP_NAME_LABEL_CLUSTERED_ANCHOR_DISTANCE_PX
+        : MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX,
+    });
+  }, [
+    clusteringActive,
+    freshnessSeconds,
+    mapBox,
+    mapCamera,
+    rendererReady,
+    staleClockMs,
+    status,
+    visibleMarkers,
+  ]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -1290,7 +1475,7 @@ export function LocationImmersiveMap({
         : 0;
       const padding = {
         top: Math.ceil(top + 12),
-        right: desktopCheckInOpen ? 436 : 20,
+        right: desktopCheckInOpen ? DESKTOP_CHECK_IN_PANEL_WIDTH_PX : 20,
         bottom: Math.ceil(
           Math.max(
             trayBottomInset + COLLAPSED_TRAY_HEIGHT + 12,
@@ -1348,6 +1533,85 @@ export function LocationImmersiveMap({
       window.removeEventListener("resize", schedulePadding);
     };
   }, [mapReady, nearbyCheckInOpen]);
+
+  // The pill layer is positioned in the map box's own pixels, so it needs that
+  // box's size and the room the floating chrome takes out of it. Measured from
+  // the real elements rather than assumed: the top controls are one row on a
+  // desktop and two on a phone, and that ~60px difference decides where the
+  // highest name on the map is allowed to sit.
+  useEffect(() => {
+    const element = mapElement.current;
+    if (!element || !mapReady) return;
+    let frame: number | null = null;
+    const measure = () => {
+      frame = null;
+      const rect = element.getBoundingClientRect();
+      const controlsBottom =
+        topControlsRef.current?.getBoundingClientRect().bottom ?? rect.top;
+      const trayRect = peopleTrayRef.current?.getBoundingClientRect();
+      // The tray's COLLAPSED footprint, not its live height -- opening the
+      // people list must not wipe every name out of the lower half of the map.
+      const trayInset = trayRect
+        ? Math.max(0, rect.bottom - trayRect.bottom) + TRAY_COLLAPSED_HEIGHT_PX
+        : TRAY_COLLAPSED_HEIGHT_PX;
+      // Check-in docks to the right from `md` up and rises from the bottom
+      // below it, so the room it takes is a different edge on each.
+      const checkInSheet = nearbyCheckInOpen
+        ? document.querySelector<HTMLElement>(
+            "[data-one-location-nearby-check-in-sheet]",
+          )
+        : null;
+      const desktopCheckInOpen =
+        nearbyCheckInOpen &&
+        window.matchMedia("(min-width: 768px)").matches;
+      const mobileSheetInset =
+        checkInSheet && !desktopCheckInOpen
+          ? Math.max(0, rect.bottom - checkInSheet.getBoundingClientRect().top)
+          : 0;
+      const next = {
+        width: rect.width,
+        height: rect.height,
+        insetTop: Math.max(0, controlsBottom - rect.top) + 8,
+        insetBottom: Math.max(trayInset, mobileSheetInset) + 8,
+        insetLeft: 8,
+        insetRight:
+          (desktopCheckInOpen ? DESKTOP_CHECK_IN_PANEL_WIDTH_PX : 0) + 8,
+      };
+      setMapBox((current) =>
+        current.width === next.width &&
+        current.height === next.height &&
+        current.insetTop === next.insetTop &&
+        current.insetBottom === next.insetBottom &&
+        current.insetLeft === next.insetLeft &&
+        current.insetRight === next.insetRight
+          ? current
+          : next,
+      );
+    };
+    const scheduleMeasure = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(measure);
+    };
+    measure();
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(element);
+    if (topControlsRef.current) observer.observe(topControlsRef.current);
+    const checkInSheet = document.querySelector<HTMLElement>(
+      "[data-one-location-nearby-check-in-sheet]",
+    );
+    if (nearbyCheckInOpen && checkInSheet) observer.observe(checkInSheet);
+    window.addEventListener("resize", scheduleMeasure);
+    window.addEventListener("orientationchange", scheduleMeasure);
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener("resize", scheduleMeasure);
+      window.removeEventListener("orientationchange", scheduleMeasure);
+    };
+    // rendererReady and isCheckInSurface decide whether the top controls and
+    // the people tray are mounted at all, and the check-in panel changes which
+    // edge of the map is spoken for, so all three have to re-run the measure.
+  }, [isCheckInSurface, mapReady, nearbyCheckInOpen, rendererReady]);
 
   // The tray body's rendered box is height-clamped by its scroll container,
   // so its own size never reflects how tall its content actually is. Track
@@ -1596,7 +1860,7 @@ export function LocationImmersiveMap({
           return marker ? [[id, marker] as const] : [];
         }),
       );
-      if (visibleMarkers.length > 8) {
+      if (clusteringActive) {
         await map.enableClustering(4);
       } else {
         await map.disableClustering();
@@ -1621,6 +1885,7 @@ export function LocationImmersiveMap({
     // keeps a live-coloured pin until some unrelated refresh happens to redraw
     // it.
   }, [
+    clusteringActive,
     entryLocationSettled,
     mapReady,
     visibleMarkers,
@@ -2083,6 +2348,16 @@ export function LocationImmersiveMap({
           closing ? "pointer-events-none" : ""
         }`}
       />
+      {/*
+        Who each pin is. A coloured pin says somebody is here; on a map with
+        two people on it that is not the question being asked. The names live
+        in the WebView above the map -- never handed to the renderer, which
+        keeps the private-share boundary exactly where the marker effect above
+        put it -- and are inert, so they cannot swallow a pan or a tap.
+      */}
+      {rendererReady && mapReady && status !== "unavailable" && !closing ? (
+        <MapNameLabels labels={nameLabels} stalePositions={cameraMoving} />
+      ) : null}
       <header
         ref={topControlsRef}
         aria-label={

--- a/hushh-webapp/components/one-location/map-name-labels.tsx
+++ b/hushh-webapp/components/one-location/map-name-labels.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { memo } from "react";
+
+import {
+  MAP_NAME_LABEL_MAX_WIDTH_PX,
+  MAP_NAME_LABEL_PIN_OFFSET_PX,
+  type PlacedMapNameLabel,
+} from "@/lib/one-location/map-name-labels";
+
+export interface MapNameLabelsProps {
+  labels: PlacedMapNameLabel[];
+  /**
+   * The camera is moving and the coordinates below describe where it WAS. Only
+   * iOS and Android ever set this: those renderers report the camera once it
+   * settles, so the honest thing to do mid-gesture is fade out rather than drag
+   * a name across the map away from the pin it belongs to.
+   */
+  stalePositions?: boolean;
+}
+
+/**
+ * The name that floats above each pin on Your Map.
+ *
+ * Deliberately inert: `pointer-events-none` all the way down, so a pill can
+ * never swallow a pan, a pinch, or a tap meant for the pin underneath -- the
+ * renderer's own marker-click listener stays the only thing that answers a tap
+ * on a person. It is also `aria-hidden`, because it says nothing the people
+ * tray below does not already say in a list a screen reader can move through.
+ */
+function MapNameLabelsImpl({ labels, stalePositions }: MapNameLabelsProps) {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="one-location-map-name-labels"
+      data-label-count={labels.length}
+      // z-10 keeps the pills above the map surface and below every control:
+      // the top chrome (z-30) and the people tray (z-20) are things you press,
+      // and a name is not allowed to sit over one of them.
+      className={`pointer-events-none absolute inset-0 z-10 overflow-hidden transition-opacity duration-200 ease-out motion-reduce:transition-none ${
+        stalePositions ? "opacity-0" : "opacity-100"
+      }`}
+    >
+      {labels.map((label) => {
+        const isSelf = label.kind === "self";
+        return (
+          <span
+            key={label.key}
+            data-testid="one-location-map-name-label"
+            data-kind={label.kind}
+            data-stale={label.stale ? "true" : undefined}
+            className={`absolute left-0 top-0 flex select-none items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold leading-4 tracking-[-0.01em] shadow-[0_6px_20px_color-mix(in_oklab,var(--foreground)_22%,transparent)] backdrop-blur-md sm:text-[12px] ${
+              isSelf
+                ? "border-[color-mix(in_oklab,var(--app-accent-fg)_35%,transparent)] bg-[var(--app-accent)] text-[var(--app-accent-fg)]"
+                : label.stale
+                  ? "border-border/70 bg-background/85 text-muted-foreground"
+                  : "border-[var(--app-accent-border)] bg-background/90 text-foreground"
+            }`}
+            style={{
+              // Positioned with a transform rather than left/top: on web the
+              // camera reports every frame of a pan, and a compositor-only
+              // property is what keeps fifty of these tracking their pins
+              // without a layout pass each time.
+              transform: `translate3d(${label.x}px, ${
+                label.y - MAP_NAME_LABEL_PIN_OFFSET_PX
+              }px, 0) translate(-50%, -100%)`,
+              maxWidth: MAP_NAME_LABEL_MAX_WIDTH_PX,
+            }}
+          >
+            <span
+              // Your own dot breathes, the way the "Sharing with N" status
+              // does: this one is a live reading from the device in your hand,
+              // not a position somebody else last published.
+              className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                isSelf
+                  ? "bg-[var(--app-accent-fg)] motion-safe:animate-pulse"
+                  : ""
+              }`}
+              style={
+                isSelf
+                  ? undefined
+                  : {
+                      // The pin's own colour. Reading it from the same tint the
+                      // renderer was given is what stops a grey "gone quiet"
+                      // pin from wearing a live-coloured dot.
+                      backgroundColor: label.stale
+                        ? "var(--app-tertiary-label)"
+                        : (label.tintCss ?? "var(--app-accent)"),
+                    }
+              }
+            />
+            <span className="min-w-0 truncate">{label.text}</span>
+            {/* The tail. Without it, a name sitting between two nearby pins is
+                a guess about which one it belongs to. */}
+            <span
+              className={`absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-[5px] rotate-45 rounded-[2px] border-b border-r ${
+                isSelf
+                  ? "border-[color-mix(in_oklab,var(--app-accent-fg)_35%,transparent)] bg-[var(--app-accent)]"
+                  : label.stale
+                    ? "border-border/70 bg-background/85"
+                    : "border-[var(--app-accent-border)] bg-background/90"
+              }`}
+            />
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export const MapNameLabels = memo(MapNameLabelsImpl);

--- a/hushh-webapp/lib/one-location/map-name-labels.ts
+++ b/hushh-webapp/lib/one-location/map-name-labels.ts
@@ -1,0 +1,333 @@
+/**
+ * Name pills that float above the pins on Your Map.
+ *
+ * A coloured pin answers "somebody is here". It does not answer "who", and on a
+ * map with more than one person that is the only question being asked. The pill
+ * layer is HTML drawn ON TOP of the map surface, never data handed to the
+ * renderer: the private-share boundary in `location-immersive-map.tsx` says the
+ * Google renderer receives coordinates and a generic title, never a recipient's
+ * name, and putting names in the WebView is what lets the map say who is who
+ * without moving that line.
+ *
+ * Everything here is pure geometry so it can be reasoned about (and tested)
+ * without a map instance: project a coordinate into the map box, drop what is
+ * not comfortably on screen, and refuse to draw two pills on top of each other.
+ * That last rule is what keeps a zoomed-out world view legible instead of a
+ * pile of overlapping names.
+ */
+
+export type MapNameLabelKind = "person" | "self" | "place";
+
+export interface MapNameLabelPoint {
+  latitude: number;
+  longitude: number;
+}
+
+export interface MapNameLabelCandidate {
+  key: string;
+  /** Already shortened for display -- a first name, not a full name. */
+  text: string;
+  kind: MapNameLabelKind;
+  point: MapNameLabelPoint;
+  /** Their last position is older than live, so the pill greys out with the pin. */
+  stale?: boolean;
+  /** The pin's own colour, so the pill's dot cannot drift from the pin it names. */
+  tintCss?: string;
+}
+
+/**
+ * What the renderer is currently showing. Both platforms report this through
+ * `onCameraIdle`/`onBoundsChanged`; on web those fire continuously through a
+ * gesture, on iOS and Android only once the camera settles.
+ */
+export interface MapNameLabelCamera {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+  zoom: number;
+  bearing: number;
+  tilt: number;
+}
+
+/** The map box in CSS pixels, minus the chrome floating over it. */
+export interface MapNameLabelViewport {
+  width: number;
+  height: number;
+  /** Room taken by the top controls; a pill hidden under them helps nobody. */
+  insetTop?: number;
+  /** Room taken by the people tray at the bottom edge. */
+  insetBottom?: number;
+  insetLeft?: number;
+  /** Room taken by the desktop check-in panel down the right-hand side. */
+  insetRight?: number;
+}
+
+export interface PlacedMapNameLabel extends MapNameLabelCandidate {
+  /** Pixels from the map box's left edge, at the pin's own longitude. */
+  x: number;
+  /** Pixels from the map box's top edge, at the pin's own latitude. */
+  y: number;
+}
+
+/**
+ * How far above the coordinate the pill's bottom edge sits.
+ *
+ * A Google pin is drawn ~40px tall with its TIP on the coordinate, and the
+ * pill's tail reaches ~5px below its own bottom edge. 48 leaves the tail
+ * pointing at the pin's head with a few pixels of daylight, rather than
+ * merging into it.
+ */
+export const MAP_NAME_LABEL_PIN_OFFSET_PX = 48;
+/** The pill's own height, including its border. Mirrors the rendered pill. */
+export const MAP_NAME_LABEL_HEIGHT_PX = 26;
+/** Breathing room between two pills before they count as touching. */
+export const MAP_NAME_LABEL_GAP_PX = 8;
+export const MAP_NAME_LABEL_MAX_WIDTH_PX = 156;
+export const MAP_NAME_LABEL_MIN_WIDTH_PX = 52;
+/**
+ * Two pins closer together than this share one story, and two pills that close
+ * cannot say which name belongs to which pin even when the boxes miss each
+ * other. Raised while the renderer is clustering, because a clustered pin is
+ * not drawn where its coordinate is.
+ */
+export const MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX = 44;
+export const MAP_NAME_LABEL_CLUSTERED_ANCHOR_DISTANCE_PX = 96;
+
+/** Semibold 12px, measured against the rendered pill rather than guessed. */
+const GLYPH_WIDTH_PX = 6.9;
+/** Dot + gap + horizontal padding + both borders. */
+const PILL_CHROME_WIDTH_PX = 34;
+
+/** Web Mercator stops at the poles; past this the projection has no y. */
+const MAX_MERCATOR_LATITUDE = 85.05112878;
+
+function mercatorY(latitude: number): number {
+  const clamped = Math.min(
+    MAX_MERCATOR_LATITUDE,
+    Math.max(-MAX_MERCATOR_LATITUDE, latitude),
+  );
+  return Math.log(Math.tan(Math.PI / 4 + (clamped * Math.PI) / 360));
+}
+
+/**
+ * Degrees travelled going EAST from `from` to `to`, always in [0, 360).
+ *
+ * Longitude is a circle, so a plain subtraction is wrong exactly where it
+ * matters most: a map straddling the antimeridian reports west=170, east=-170,
+ * and `east - west` is -340 rather than the 20 degrees actually on screen.
+ */
+function eastwardDegrees(from: number, to: number): number {
+  const delta = (to - from) % 360;
+  return delta < 0 ? delta + 360 : delta;
+}
+
+/**
+ * Where a coordinate lands inside the map box, in CSS pixels.
+ *
+ * Flat Mercator: correct for a north-up, untilted camera, which is the only
+ * camera this layer ever draws for (see `layoutMapNameLabels`). Returns null
+ * when the camera cannot describe a projection at all.
+ */
+export function projectToMapBox(
+  point: MapNameLabelPoint,
+  camera: MapNameLabelCamera,
+  viewport: MapNameLabelViewport,
+): { x: number; y: number } | null {
+  if (!(viewport.width > 0) || !(viewport.height > 0)) return null;
+  if (!Number.isFinite(point.latitude) || !Number.isFinite(point.longitude)) {
+    return null;
+  }
+
+  const top = mercatorY(camera.north);
+  const bottom = mercatorY(camera.south);
+  const latitudeSpan = top - bottom;
+  if (!(latitudeSpan > 0)) return null;
+
+  // A camera showing the whole world reports west === east; that is 360
+  // degrees of longitude, not zero.
+  const longitudeSpan = eastwardDegrees(camera.west, camera.east) || 360;
+
+  const x =
+    (eastwardDegrees(camera.west, point.longitude) / longitudeSpan) *
+    viewport.width;
+  const y = ((top - mercatorY(point.latitude)) / latitudeSpan) * viewport.height;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x, y };
+}
+
+/**
+ * The pill's width before it is rendered, so collisions can be resolved in one
+ * pass instead of by measuring the DOM. An estimate is enough: it decides
+ * whether two names may share the screen, never what either one says.
+ */
+export function estimateMapNameLabelWidthPx(text: string): number {
+  const glyphs = text.trim().length;
+  return Math.min(
+    MAP_NAME_LABEL_MAX_WIDTH_PX,
+    Math.max(
+      MAP_NAME_LABEL_MIN_WIDTH_PX,
+      PILL_CHROME_WIDTH_PX + glyphs * GLYPH_WIDTH_PX,
+    ),
+  );
+}
+
+/**
+ * The one word a person is called.
+ *
+ * "Ankit Kumar Singh" is a form-field answer; on a pill above a pin it is three
+ * words of somebody else's screen. Handles the shapes a display name actually
+ * arrives in -- extra whitespace, a trailing comma, an address used as a name
+ * -- and returns "" when there is no name in there at all, so the caller can
+ * choose its own fallback rather than print a stray initial.
+ */
+export function firstNameFromLabel(label: string): string {
+  const collapsed = label.replace(/\s+/g, " ").trim();
+  if (!collapsed) return "";
+
+  const [first = ""] = collapsed.split(" ");
+  // "ankit@example.com" is a login, not a name, and its first token is the
+  // whole address. The local part is the only human-sized piece of it.
+  const withoutAddress = first.includes("@")
+    ? (first.split("@")[0] ?? first)
+    : first;
+  const trimmed = withoutAddress.replace(
+    /^[.,;:!?'"“”‘’()[\]{}<>|/\\-]+|[.,;:!?'"“”‘’()[\]{}<>|/\\-]+$/g,
+    "",
+  );
+  return trimmed || withoutAddress;
+}
+
+interface LabelBox {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function pillBox(
+  anchor: { x: number; y: number },
+  text: string,
+  pinOffsetPx: number,
+  labelHeightPx: number,
+): LabelBox {
+  const halfWidth = estimateMapNameLabelWidthPx(text) / 2;
+  const bottom = anchor.y - pinOffsetPx;
+  return {
+    left: anchor.x - halfWidth,
+    right: anchor.x + halfWidth,
+    top: bottom - labelHeightPx,
+    bottom,
+  };
+}
+
+function overlaps(a: LabelBox, b: LabelBox, gapPx: number): boolean {
+  return (
+    a.left - gapPx < b.right &&
+    a.right + gapPx > b.left &&
+    a.top - gapPx < b.bottom &&
+    a.bottom + gapPx > b.top
+  );
+}
+
+/** self first, then the check-in place, then people in the order given. */
+const KIND_PRIORITY: Record<MapNameLabelKind, number> = {
+  self: 0,
+  place: 1,
+  person: 2,
+};
+
+export interface MapNameLabelLayoutOptions {
+  labels: MapNameLabelCandidate[];
+  camera: MapNameLabelCamera;
+  viewport: MapNameLabelViewport;
+  /** Raise while the renderer is clustering. */
+  minAnchorDistancePx?: number;
+  pinOffsetPx?: number;
+  labelHeightPx?: number;
+  gapPx?: number;
+}
+
+/**
+ * Decide which names may be drawn, and where.
+ *
+ * The rules, in the order they are applied:
+ *  1. A rotated or tilted camera gets no pills at all. The projection above is
+ *     flat, so a bearing would slide every name off its own pin -- a wrong
+ *     name over a pin is worse than no name.
+ *  2. Whoever matters most is placed first: you, then the place you are
+ *     checking in to, then everyone else. Priority decides who KEEPS their
+ *     pill when two of them cannot both have one.
+ *  3. A pin under the top controls, the people tray or the desktop check-in
+ *     panel is not on screen in any sense that matters, and neither is one
+ *     whose pill an edge would cut in half. Both are dropped rather than
+ *     half-drawn.
+ *  4. Nothing may overlap anything already placed -- not the boxes, and not
+ *     the pins themselves. This is the rule that makes a zoomed-out map read
+ *     as a handful of legible names instead of a stack of pills.
+ */
+export function layoutMapNameLabels(
+  options: MapNameLabelLayoutOptions,
+): PlacedMapNameLabel[] {
+  const {
+    labels,
+    camera,
+    viewport,
+    minAnchorDistancePx = MAP_NAME_LABEL_MIN_ANCHOR_DISTANCE_PX,
+    pinOffsetPx = MAP_NAME_LABEL_PIN_OFFSET_PX,
+    labelHeightPx = MAP_NAME_LABEL_HEIGHT_PX,
+    gapPx = MAP_NAME_LABEL_GAP_PX,
+  } = options;
+
+  if (labels.length === 0) return [];
+
+  const bearing = ((camera.bearing % 360) + 360) % 360;
+  const rotated = bearing > 0.5 && bearing < 359.5;
+  if (rotated || Math.abs(camera.tilt) > 0.5) return [];
+
+  const insetTop = Math.max(0, viewport.insetTop ?? 0);
+  const insetBottom = Math.max(0, viewport.insetBottom ?? 0);
+  const insetLeft = Math.max(0, viewport.insetLeft ?? 0);
+  const insetRight = Math.max(0, viewport.insetRight ?? 0);
+  const rightEdge = viewport.width - insetRight;
+
+  const ordered = labels
+    .map((label, index) => ({ label, index }))
+    .sort(
+      (a, b) =>
+        KIND_PRIORITY[a.label.kind] - KIND_PRIORITY[b.label.kind] ||
+        a.index - b.index,
+    );
+
+  const placed: PlacedMapNameLabel[] = [];
+  const boxes: LabelBox[] = [];
+
+  for (const { label } of ordered) {
+    if (!label.text.trim()) continue;
+    const anchor = projectToMapBox(label.point, camera, viewport);
+    if (!anchor) continue;
+
+    // The pin itself has to be somewhere a person can actually look.
+    if (anchor.x < insetLeft || anchor.x > rightEdge) continue;
+    if (anchor.y < insetTop || anchor.y > viewport.height - insetBottom) {
+      continue;
+    }
+
+    const box = pillBox(anchor, label.text, pinOffsetPx, labelHeightPx);
+    if (box.left < insetLeft || box.right > rightEdge) continue;
+    if (box.top < insetTop) continue;
+
+    const crowded = placed.some(
+      (other) =>
+        Math.hypot(other.x - anchor.x, other.y - anchor.y) <
+        minAnchorDistancePx,
+    );
+    if (crowded) continue;
+    if (boxes.some((other) => overlaps(other, box, gapPx))) continue;
+
+    boxes.push(box);
+    placed.push({ ...label, x: anchor.x, y: anchor.y });
+  }
+
+  return placed;
+}


### PR DESCRIPTION
# Description

A coloured pin says *somebody* is here. On Your Map with two people on it, that is not the question being asked — and the only way to answer it was to open the people tray and match a row to a dot by eye.

Each pin now carries a name pill above it: **the first name** for a person, **"My location"** for this device, **the venue** for a check-in. Snapchat-shaped, and it holds up zoomed all the way out.

**How it works, and why it is built this way**

- **The pills are HTML in the WebView, positioned over the map — never data handed to the renderer.** The private-share boundary in `location-immersive-map.tsx` is unchanged: Google still receives coordinates and a generic title (`"Private location"`), and a recipient's name still never leaves the device. A test asserts the `addMarkers` payload contains neither name.
- **Inert by design.** `pointer-events-none` all the way down, so a pill cannot swallow a pan, a pinch, or a tap meant for the pin underneath — the renderer's own marker-click listener stays the only thing that answers a tap on a person. Also `aria-hidden`, because the pills say nothing the people tray does not already say in a list a screen reader can move through.
- **Positions come from the renderer's own camera reports.** Web emits `onBoundsChanged` every frame of a gesture, so names track their pins live (coalesced to one state update per animation frame). iOS and Android report only once the camera settles, so the layer fades out for the length of a drag rather than sliding names away from the pins they belong to. A rotated or tilted camera gets no pills at all — the projection is flat, and a name over the wrong pin is worse than no name.
- **Overlap is resolved before anything is drawn**: you first, then the check-in place, then everyone else. Nothing may collide with a pill already placed, sit closer than one pin-width to another pin, hide under the top controls / people tray / desktop check-in panel, or get clipped by an edge. That is what keeps a zoomed-out world view a handful of legible names instead of fifty pills in a heap. The minimum spacing widens while the renderer is clustering, because a clustered pin is not drawn at its own coordinate.
- **Responsive by measurement, not assumption.** The map box, the top controls (one row on desktop, two on a phone), the collapsed tray footprint and the check-in panel are all measured from the real elements and re-measured on resize / orientation change.
- `"Ankit Kumar Singh"` is what the tray says; the pill gets `"Ankit"`. A display name with no name in it falls back to `"Trusted person"` rather than printing the stray initial a naive split would produce.

**Files**

| File | What it is |
| --- | --- |
| `hushh-webapp/lib/one-location/map-name-labels.ts` | New. Pure geometry: Mercator projection into the map box, first-name extraction, culling and collision rules. |
| `hushh-webapp/components/one-location/map-name-labels.tsx` | New. The presentational pill layer. |
| `hushh-webapp/components/one-location/location-immersive-map.tsx` | Camera listeners, viewport measurement, `shortLabel` on every marker, renders the layer. |
| `hushh-webapp/__tests__/lib/one-location/map-name-labels.test.ts` | New. 17 cases over the geometry. |
| `hushh-webapp/__tests__/components/location-immersive-map.test.tsx` | 3 new cases + a camera-listener harness. |

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location/map` (and the check-in surface rendered by the same component). No route added, removed, or renamed.

- API / schema / type changes:
  - [x] Listed below: `RenderMarker` (component-local) gains a required `shortLabel`. No wire format, no service type, no backend contract touched.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: the same layer on web, iOS and Android. The one deliberate difference is behavioural, not structural — native renderers report the camera only at idle, so the layer fades during a gesture there and tracks continuously on web. Both paths go through the same `layoutMapNameLabels`.

- Docs updated (exact files):
  - [x] None. No documented contract changed; the module and component carry their own rationale in-file.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below: this sits directly on the private-share boundary and deliberately does **not** move it. Names are rendered in the WebView from already-decrypted, already-in-memory state; the Google renderer's payload is unchanged. See Privacy & Consent below.

- Caller / proxy / backend pairing:
  - [x] Not applicable — client-only.

- Rollback or safe-failure behavior:
  - [x] Listed below: the camera-listener registration is wrapped, so a renderer that cannot report its camera still produces a fully working map — it just has no name pills. A zero-size map box, a missing camera, a rotated camera, or an off-screen pin each resolve to "draw nothing", never to a wrong name.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: no Playwright spec added. Positioning depends on real camera reports from the Google renderer, which the layout-contract lane does not drive; the geometry is covered by unit tests instead, and the component tests drive real `onCameraIdle` / `onCameraMoveStarted` payloads through the production component. Device screenshots still to be attached — see Testing.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test` — ran the affected suites instead (see Testing); the full suite has pre-existing failures on `main` unrelated to this diff.
  - [x] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (intentional fixture reset only)
  - [ ] `python scripts/ops/kai-system-audit.py ...`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run verify:one-location`
  - [x] `cd hushh-webapp && npx eslint <changed files> --max-warnings=0`
  - [x] `python scripts/ci/verify-protected-behavior-tests.py`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: the check-in legend (which names *colours*, not pins) or the people tray (which names people in a list, not on the map).
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: `LocationImmersiveMap`, rendered by `app/one/location/map/page.tsx`.
- [x] New tests import and exercise production code, not only mocks: the component cases render `LocationImmersiveMap` and drive the real camera callbacks it registers.
- [x] New helpers/components are wired to an existing route.
- [x] Production surface proved: `npm run build` green; the pill layer renders under `data-testid="one-location-map-name-labels"` in the component tests.
- [x] Required checks are current on this head, commits are signed off, and the branch is cut from current `origin/main`.
- [x] Maintainer edits are enabled.
- [x] Not part of a stack.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js / React implementation. No new `app/api/...` route — this is presentation over existing client state.
- [x] **iOS**: no Swift plugin change needed. Uses the `@capacitor/google-maps` camera listeners already present in the plugin (`onCameraIdle`, `onBoundsChanged`, `onCameraMoveStarted`); the pills are WebView HTML composited over the native map view.
- [x] **Android**: same — existing plugin listeners, no Kotlin change.

## 🧪 Testing

- [x] `npx vitest run __tests__/lib/one-location/map-name-labels.test.ts __tests__/components/location-immersive-map.test.tsx` → **58 passed**
- [x] `npm run verify:one-location` → **134 passed**
- [x] `npx vitest run __tests__/components/location-map-chrome.contract.test.tsx __tests__/components/one-location-map-owner-boundary.contract.test.ts __tests__/navigation/location-map-route-layout.test.ts __tests__/lib/one-location/native-map-lifecycle.test.ts __tests__/components/one-location-copy-pass.contract.test.ts` → **27 passed**
- [x] `npm run typecheck`, `npm run build`, `npm run verify:design-system` → green
- [ ] Tested on Web (Chrome/Safari) — not yet run by hand against a live map
- [ ] Tested on iOS Simulator/Device — the native fade path is covered by a component test, not yet by a device run
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

New coverage worth calling out:

- `firstNameFromLabel` over the shapes a display name actually arrives in — extra whitespace, `"Rivera, Sam"`, an address used as a name, an empty name.
- The antimeridian camera (`west=170, east=-170`), where a plain `east - west` would push every Pacific pin off the left edge.
- The whole-world camera, where `west === east` means 360°, not 0°.
- 50 pins on one world view: asserts every drawn pill is separated from every other, both by box and by pin distance.
- A rotated camera, a tilted camera, a pin under the chrome, a pill an edge would clip, and the desktop check-in panel's right-hand inset.

## 📸 Screenshots / Video

Not attached yet — a capture of `/one/location/map` with two shares live will be added before merge.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It renders data the component had already decrypted into foreground memory for the people tray. It reads nothing new and fetches nothing new.
- [x] `checkConsentToken()`: not applicable — no new read path. Markers still arrive only through the existing recipient-scoped, consent-gated map state.
- [x] Sensitive surface touched: **consent / vault (location shares)** — and deliberately unchanged. The rule that the Google renderer gets coordinates and a generic title, never a private recipient's name, is preserved and now has a test naming it.
- [x] Error path / safe-failure proved: no camera, no listeners, a zero-size box, a rotated camera or an off-screen pin all resolve to drawing nothing.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies added or changed
