### PR TITLE
fix(ui): eleven tester-reported UI, copy and responsiveness defects

### DIFF
--- a/config/protected-behaviors.json
+++ b/config/protected-behaviors.json
@@ -241,6 +241,92 @@
           ]
         }
       ]
+    },
+    {
+      "name": "one-location-onboarding-art-is-not-positioned-from-the-viewport",
+      "summary": "The Check-in card's artwork is anchored in a percentage of its own region, so its place inside the card does not change when the viewport height changes. The copy and the artwork never overlap.",
+      "fixed_by": "#5363",
+      "why_it_needs_a_lock": [
+        "This shipped as five separate `bottom` rules on [data-one-checkin-art] --",
+        "two `vh` clamps and three fixed pixel values inside width/height media",
+        "queries -- each of which outranks the element's own class by source order.",
+        "The card's size is width-driven and never moved; the art slid up inside it",
+        "as the phone got taller, until it ran over the body copy. A tester found it",
+        "by stepping from a 393x852 iPhone 14 Pro to a 430x932 Pro Max.",
+        "",
+        "A width-only sweep cannot catch this, and neither can reading the source:",
+        "the first attempt at this fix removed ONE clamp and the browser test found",
+        "four more overrides still winning. The lock is the height sweep."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 6,
+          "required_titles": [
+            "the artwork is not positioned from the viewport"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "gemini-endpoint-select-matches-the-key-field-on-webkit",
+      "summary": "The API endpoint picker and the key field under it share a radius, height and text inset \u2014 including under WebKit, where a native <select> ignores author border-radius unless appearance is removed.",
+      "fixed_by": "#5363",
+      "why_it_needs_a_lock": [
+        "`appearance-none` looks like a cosmetic class and is the entire fix. Under",
+        "WebKit's default `appearance: menulist` the engine draws the control and",
+        "overrides the author's border-radius: measured 5px against the input's",
+        "14px, before AND after handing the select the input's classes.",
+        "",
+        "Chromium honours the author radius either way, so a Chromium-only test",
+        "passes the broken control. The iOS app is a WKWebView. Deleting the class,",
+        "or letting this spec fall out of the webkit project's testMatch, silently",
+        "restores the defect on the platform most of our users are on."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/e2e/gemini-endpoint-fields.layout.spec.ts",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 6,
+          "required_titles": [
+            "appearance-none is load-bearing, not decoration"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "location-header-status-names-what-the-switch-controls",
+      "summary": "The Location header's status always reads \"Location on/off/paused/blocked/limited\" at every width, and renders under the title rather than beside the switch.",
+      "fixed_by": "#5363",
+      "why_it_needs_a_lock": [
+        "The full string beside the switch wrapped the 28px title on every iPhone,",
+        "so it was shortened to one word on phones. That fit, and it cost the label",
+        "its meaning: iOS showed a bare green switch over the word \"On\", which",
+        "never said what it switched. Reported from the device.",
+        "",
+        "The one-word form is the tempting fix every time the title wraps again.",
+        "Moving the status under the title is what makes the full string affordable;",
+        "putting it back in the actions column brings the abbreviation back with it."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/__tests__/components/one-location-agent-page.test.tsx",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 400,
+          "required_titles": [
+            "keeps the heading and location toggle inline as the only header action"
+          ]
+        },
+        {
+          "path": "hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 30,
+          "required_titles": [
+            "names what the switch controls in every state, at every width"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -656,7 +656,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Bulk person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
 
     expect(
       screen.getByText("Pick up to 8, across pages."),
@@ -715,7 +715,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
     fireEvent.click(screen.getByLabelText("Select Person 0"));
     expect(screen.getByText("Review 1 of 8")).toBeTruthy();
 
@@ -768,7 +768,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Connected Carl")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
 
     // Eligible: a real, enabled checkbox.
     expect(
@@ -848,7 +848,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Ada Advisor")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select several people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
     fireEvent.click(screen.getByLabelText("Select Ada Advisor"));
     fireEvent.click(screen.getByLabelText("Select Ben Advisor"));
     fireEvent.click(screen.getByRole("button", { name: "Review 2 of 8" }));
@@ -1136,14 +1136,24 @@ describe("Connect — the phone-width geometry QA reported", () => {
     ).toBe(true);
   });
 
-  it("keeps the selection toggle to one word, without hiding what it does", async () => {
+  it("says on its face that the toggle selects more than one person", async () => {
+    // This used to assert the label was exactly "Select", on width grounds.
+    // It fit, and it read as "select this one" — the opposite of what the
+    // control does — so a tester asked whether anyone would know it starts
+    // multi-select. The durable invariant underneath that test is WCAG 2.5.3,
+    // not the word count: the accessible name must start with the visible
+    // label, or "tap Select many" is an instruction voice control cannot
+    // follow. Both are asserted here; the width is proved in a real browser by
+    // e2e/connect-circle-cta.layout.spec.ts, which jsdom cannot do.
     render(<ConnectPageClient />);
     const toggle = await screen.findByRole("button", {
-      name: "Select several people",
+      name: "Select many people",
     });
-    expect(toggle.textContent).toBe("Select");
+    expect(toggle.textContent).toBe("Select many");
     expect(toggle.getAttribute("aria-label")!.startsWith(toggle.textContent!)).toBe(
       true,
     );
+    // Not a single bare verb: the label has to carry the plural.
+    expect(toggle.textContent!.split(/\s+/).length).toBeGreaterThan(1);
   });
 });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1258,7 +1258,20 @@ describe("OneLocationAgentPage", () => {
     });
     expect(headerActions.className).toContain("ml-auto");
     expect(headerActions.className).toContain("justify-end");
-    expect(headerActions.className).toContain("max-w-full");
+    // The actions column holds the switch and nothing else now, so it no
+    // longer needs `max-w-full` to survive wrapping text. The status words that
+    // used to sit here moved under the title — see the status assertions below.
+    const status = screen.getByTestId("one-location-header-status");
+    expect(headerActions.contains(status)).toBe(false);
+    // iOS used to get the one-word form: a bare green switch over "On", which
+    // never said what it switched. Reported from the device.
+    expect(status.textContent).toBe("Location off");
+    // Still the switch's description wherever it renders.
+    expect(
+      screen
+        .getByRole("switch", { name: "Turn location on" })
+        .getAttribute("aria-describedby"),
+    ).toBe(status.id);
     expect(
       screen.queryByRole("button", { name: "Refresh location" }),
     ).toBeNull();
@@ -1283,15 +1296,17 @@ describe("OneLocationAgentPage", () => {
     // hit ("location toggle kis liye hai? iOS pe how user gonna find that?").
     const locationStatus = screen.getByTestId("one-location-header-status");
     expect(locationStatus.className).not.toContain("hidden");
-    // Two forms of the same state, one per breakpoint, and NEITHER is hidden at
-    // every width the way the old single `hidden … sm:inline` span was. Phones
-    // get the one-word form because the 28px title has no width to spare there
-    // (the full string measured two title lines at 320/360/375/390); from `sm`
-    // up the full string renders inline exactly as it does today.
-    const compact = locationStatus.querySelector(".sm\\:hidden");
-    const full = locationStatus.querySelector(".hidden.sm\\:inline");
-    expect(compact?.textContent).toBe("Off");
-    expect(full?.textContent).toBe("Location off");
+    // ONE form now, at every width, naming the thing it switches.
+    //
+    // This used to be two breakpoint spans: the full string from `sm` up and a
+    // one-word form on phones, because the full string in the actions column
+    // wrapped the 28px title at 320-390px. That fit, and it cost iOS the
+    // meaning — the device showed a bare green switch over the word "On". The
+    // status now renders under the title instead of beside the switch, so it
+    // takes no width from the title and never has to abbreviate.
+    expect(locationStatus.querySelector(".sm\\:hidden")).toBeNull();
+    expect(locationStatus.querySelector(".hidden.sm\\:inline")).toBeNull();
+    expect(locationStatus.textContent).toBe("Location off");
     expect(locationStatus).not.toHaveAttribute("aria-hidden");
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -208,7 +208,10 @@ describe("One setup hub terminal action contract", () => {
 
     expect(hub).toContain("Only you can open what you save.");
     expect(hub).toContain("Not even we can read it.");
-    expect(hub).toContain('"Add the rest any time."');
+    // "Add" was the wrong verb for a list of things you SET UP, and the line
+    // is the last thing read before "Finish setup".
+    expect(hub).toContain('"Set up the rest later."');
+    expect(hub).not.toContain('"Add the rest any time."');
   });
 
   it("keeps the quiet Morphy action legible on hover and while disabled", () => {

--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -205,7 +205,11 @@ describe("VaultFlow create validation", () => {
   it("opens fresh vault creation directly in the canonical credential layout", async () => {
     render(<VaultFlow user={user} onSuccess={vi.fn()} />);
 
-    expect(await screen.findByRole("heading", { name: "Create your passphrase" })).toBeTruthy();
+    // "Set a lock", not "Create your passphrase": the heading names the job,
+    // not the mechanism, and it is the same phrase one-setup-hub already passes
+    // as this dialog's accessible title — the screen used to announce one name
+    // and show another. "Passphrase" still labels the fields, where it belongs.
+    expect(await screen.findByRole("heading", { name: "Set a lock" })).toBeTruthy();
     expect(screen.getByLabelText("Passphrase")).toBeTruthy();
     expect(screen.getByLabelText("Confirm passphrase")).toBeTruthy();
     expect(screen.queryByText("Secure Your Digital Vault")).toBeNull();

--- a/hushh-webapp/app/circle/join/page.tsx
+++ b/hushh-webapp/app/circle/join/page.tsx
@@ -143,6 +143,9 @@ function CircleJoinLanding() {
       data-testid="circle-join-landing"
     >
       <PageHeader
+        // The description is two lines; letting it share the icon row
+        // stretched that row and pushed the tile away from the title.
+        descriptionFullWidth
         title="You're invited"
         eyebrow="Circle invite"
         description="Your location stays private until you choose to share it."

--- a/hushh-webapp/app/connect/connect-search-layout.ts
+++ b/hushh-webapp/app/connect/connect-search-layout.ts
@@ -32,11 +32,16 @@ export const CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME = "pr-11";
 export const CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME = "pr-3.5";
 
 /**
- * The selection toggle, at a fixed width so switching between "Select" and
- * "Cancel" cannot resize the search field beside it.
+ * The selection toggle, at a fixed width so switching between "Select many"
+ * and "Cancel" cannot resize the search field beside it.
+ *
+ * 104px, not 84px: the label has to say that it selects MORE THAN ONE person
+ * before it is pressed. "Select" alone read as "select this one", which is the
+ * opposite of what the control does. The width is measured against the widest
+ * of the two labels at 320px in `connect-circle-cta.layout.spec.ts`.
  */
 export const CONNECT_SELECT_TOGGLE_CLASSNAME =
-  "h-10 min-h-10 w-[84px] shrink-0 rounded-full px-0 text-[15px] font-semibold leading-5";
+  "h-10 min-h-10 w-[104px] shrink-0 rounded-full px-0 text-[15px] font-semibold leading-5";
 
 /** Gap between the field and the toggle (`gap-2`). */
 export const CONNECT_SEARCH_ROW_GAP_PX = 8;

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1628,7 +1628,7 @@ export default function ConnectPageClient() {
                   aria-label={
                     isSelectionMode
                       ? "Cancel selecting people"
-                      : "Select several people"
+                      : "Select many people"
                   }
                   onClick={() => {
                     setIsSelectionMode((current) => !current);
@@ -1636,7 +1636,11 @@ export default function ConnectPageClient() {
                     setShowLimitBanner(false);
                   }}
                 >
-                  {isSelectionMode ? "Cancel" : "Select"}
+                  {/* "Select many", not "Select": this enters multi-select,
+                      and a lone "Select" reads as picking the one thing you are
+                      looking at. The visible label and the accessible name now
+                      say the same thing. */}
+                  {isSelectionMode ? "Cancel" : "Select many"}
                 </Button>
               </div>
               <SettingsGroup

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -131,7 +131,12 @@ function HeaderLeading({
   iconSize: "md" | "lg";
 }) {
   if (leading) {
-    return <div className="shrink-0 self-start">{leading}</div>;
+    // Centred, not top-pinned. `self-start` aligned a 44px tile to the top of a
+    // copy column whose first line is a 20px eyebrow, so against the much
+    // larger title beneath it the tile read as floating above the heading
+    // rather than belonging to it. The `icon` branch below keeps `self-stretch`
+    // — that one spans the whole column by design.
+    return <div className="shrink-0 self-center">{leading}</div>;
   }
 
   if (!icon) {

--- a/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
@@ -211,10 +211,12 @@ export function GeminiRuntimeConfigurationPage({
                       : `${provider.name} is coming soon`
                   }
                 >
-                  <RuntimeProviderMark
-                    provider={provider}
-                    className={provider.id === "gemini" ? "h-9 w-9" : undefined}
-                  />
+                  {/* One size for every mark. The row gave each provider a
+                      36px slot but only Gemini was sized to it — the other four
+                      kept the mark's own 48px default, so they overflowed their
+                      slots and overlapped each other by 4px, which is why the
+                      logos looked cramped and Grok came out clipped. */}
+                  <RuntimeProviderMark provider={provider} className="h-9 w-9" />
                 </span>
                 <span className="sr-only">
                   {provider.availability === "available"

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -12,7 +12,8 @@ import {
 import { GeminiLogo } from "@/components/brand/gemini-logo";
 import { RuntimeProviderMark } from "@/components/brand/runtime-provider-mark";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
+import { Input, INPUT_CLASSNAME } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { Button } from "@/lib/morphy-ux/button";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { RUNTIME_PROVIDER_CATALOG } from "@/lib/connections/runtime-provider-catalog";
@@ -560,7 +561,31 @@ export function GeminiRuntimeSettingsCard({
                   invalidateCredentialValidation();
                 }}
                 disabled={isSaving || isRemoving || credentialValidation.status === "checking"}
-                className="ui-text-input-value h-10 w-full rounded-[var(--app-card-radius-compact)] border border-input bg-background px-3"
+                /* The SAME class the key field under it uses, so the two
+                   stacked controls finally agree on radius, height, inset,
+                   surface, border and focus ring — they were 24px/40px/12px
+                   against 14px/44px/14px.
+
+                   `appearance-none` is not cosmetic and is not optional. This
+                   is a native <select>, and WebKit — the engine inside the iOS
+                   app — draws `appearance: menulist` itself and OVERRIDES the
+                   author's border-radius and padding. Measured in WebKit: the
+                   select computes 5px against the input's 14px, and simply
+                   handing it the input's classes leaves it at 5px. Without this
+                   line the reported mismatch survives the fix on the only
+                   platform most of our users are on.
+
+                   `pr-9` then reserves the space the arrow used to get for
+                   free, now that we are drawing the control ourselves. */
+                className={cn(INPUT_CLASSNAME, "appearance-none bg-no-repeat pr-9")}
+                style={{
+                  // The disclosure arrow, drawn by us because appearance-none
+                  // removes the UA's. Inline because it is a data: URI keyed to
+                  // the label colour token, not a reusable utility.
+                  backgroundImage:
+                    "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%236e6e73' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'/></svg>\")",
+                  backgroundPosition: "right 14px center",
+                }}
               >
                 <option value="developer_api">Google AI Studio</option>
                 <option value="vertex_api_key">

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -572,7 +572,7 @@ export function OneSetupHub() {
                 supportingText={
                   !runtimeChoiceComplete
                     ? "Choose your AI first."
-                    : "Add the rest any time."
+                    : "Set up the rest later."
                 }
                 variant="blue-gradient"
                 effect="fill"

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -741,7 +741,7 @@ function CheckInFeatureCard() {
             clean building artwork on its own. The [data-one-checkin-pin]
             responsive rules below are harmless no-ops now. */}
         <span
-          className="absolute bottom-12 left-1/2 w-[54%] -translate-x-1/2"
+          className="absolute bottom-[48%] left-1/2 w-[54%] -translate-x-1/2"
           style={{ perspective: "320px", perspectiveOrigin: "50% 100%" }}
           data-one-checkin-art
         >
@@ -890,6 +890,13 @@ function FeaturesScreen({
         onSkip={onSkip}
         disabled={leaving}
         busy={leaving}
+        /* Same rail as the header and card grid below (both max-w-[700px]).
+           Without it the nav was the only full-width row on the screen, so past
+           md — where this root drops its 430px cap — Back and Skip slid out to
+           the viewport edges while everything else stayed in the column. Passed
+           here rather than inside OnboardingNavigation: the welcome screen's
+           copy of that nav is already railed at 560 by its parent. */
+        className="mx-auto w-full max-w-[700px]"
       />
       <div
         className="flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto pr-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
@@ -1113,7 +1120,6 @@ function FeaturesScreen({
           }
           [data-one-feature-card="checkin"] [data-one-checkin-art] {
             left: 50%;
-            bottom: 20px;
             width: 42%;
           }
           [data-one-feature-card="sms"] [data-one-feature-art-region] {
@@ -1246,9 +1252,6 @@ function FeaturesScreen({
             top: 14px;
             bottom: auto;
           }
-          [data-one-checkin-art] {
-            bottom: clamp(54px, calc(65vh - 486.6px), 120px);
-          }
           [data-one-feature-card="sms"] [data-one-feature-art-region] {
             align-items: flex-start;
             padding-top: 12px;
@@ -1310,7 +1313,7 @@ function FeaturesScreen({
             height: 12px;
           }
           [data-one-checkin-pin] { top: 22px; bottom: auto; width: 24px; height: 24px; }
-          [data-one-checkin-art] { bottom: 36px; width: 52%; }
+          [data-one-checkin-art] { width: 52%; }
           [data-one-sms-radar-clearance] { width: 54px; height: 54px; }
           [data-one-sms-radar] { width: 40px; height: 40px; }
           [data-one-sms-core] { width: 32px; height: 32px; font-size: 13px; }
@@ -1341,14 +1344,6 @@ function FeaturesScreen({
           [data-one-feature-card="sms"] [data-one-feature-title] { font-size: 14px; }
           [data-one-feature-card="checkin"] [data-one-feature-body],
           [data-one-feature-card="sms"] [data-one-feature-body] { font-size: 11px; }
-        }
-        @media (max-width: 365px) and (min-height: 681px) {
-          [data-one-checkin-pin] {
-            bottom: clamp(54px, calc(40vh - 179.4px), 194px);
-          }
-          [data-one-checkin-art] {
-            bottom: clamp(43px, calc(40vh - 218.4px), 155px);
-          }
         }
         @media (max-width: 431px) and (max-height: 560px) {
           [data-one-feature-screen] {
@@ -1437,7 +1432,7 @@ function FeaturesScreen({
             height: 11px;
           }
           [data-one-checkin-pin] { top: 8px; }
-          [data-one-checkin-art] { bottom: 36px; width: 44%; }
+          [data-one-checkin-art] { width: 44%; }
           [data-one-sms-radar-clearance] { width: 40px; height: 40px; }
           [data-one-sms-radar] { width: 32px; height: 32px; }
           [data-one-sms-core] { width: 28px; height: 28px; font-size: 11px; }

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -42,7 +42,10 @@ import type {
   OneLocationCircleEligibleConnections,
   OneLocationCircleMemberInvite,
 } from "@/lib/one-location/types";
-import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import {
+  filterPeopleByQuery,
+  sortPeopleByName,
+} from "@/lib/one-location/people-search";
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { cn } from "@/lib/utils";
 
@@ -113,8 +116,12 @@ export function CircleInvitePeopleSheet({
 
   const filtered = useMemo(
     () =>
+      // Sorted before filtering, like every other people picker in Location.
+      // These two sheets were rendering whatever order the server returned, so
+      // the same two connections could swap places between two openings and a
+      // long list had nowhere to start looking.
       filterPeopleByQuery(
-        eligibleConnections,
+        sortPeopleByName(eligibleConnections, (connection) => connection.displayName),
         search,
         (connection) => connection.displayName,
       ),

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -63,7 +63,10 @@ import type {
   OneLocationCircleMemberInvite,
   OneLocationCircleSummary,
 } from "@/lib/one-location/types";
-import { filterPeopleByQuery } from "@/lib/one-location/people-search";
+import {
+  filterPeopleByQuery,
+  sortPeopleByName,
+} from "@/lib/one-location/people-search";
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { cn } from "@/lib/utils";
 
@@ -953,8 +956,12 @@ export function CircleDetailFlow({
 
   const filteredEligibleConnections = useMemo(
     () =>
+      // Sorted before filtering, like every other people picker in Location.
+      // These two sheets were rendering whatever order the server returned, so
+      // the same two connections could swap places between two openings and a
+      // long list had nowhere to start looking.
       filterPeopleByQuery(
-        eligibleConnections,
+        sortPeopleByName(eligibleConnections, (connection) => connection.displayName),
         peopleSearch,
         (connection) => connection.displayName,
       ),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -21,7 +21,6 @@
 import {
   useCallback,
   useEffect,
-  useId,
   useRef,
   useState,
   type ReactNode,
@@ -645,36 +644,54 @@ export function resolveLocationDeepLinkFocus(input: {
   return { detailAction: null, nextTab: null };
 }
 
+/**
+ * The id the header switch points `aria-describedby` at. A constant, not
+ * `useId`: the status text now renders under the title while the switch stays
+ * in the actions column, and `aria-describedby` resolves by id anywhere in the
+ * document. There is exactly one Location header on screen.
+ */
+const LOCATION_HEADER_STATUS_ID = "one-location-header-status";
+
+/** What the header switch currently means, in words. */
+function locationHeaderStatusText(vm: LocationHubViewModel): string {
+  if (vm.locationAcquiring) return "Finding you\u2026";
+  return locationStatusLabel({
+    readiness: vm.locationBlocked
+      ? ("blocked" as const)
+      : vm.locationEnabled
+        ? ("ready" as const)
+        : ("askable" as const),
+    previewOn: vm.locationEnabled,
+    paused: vm.locationPaused,
+    accuracyLimited: vm.locationAccuracyLimited,
+  });
+}
+
+/**
+ * The status line for the Location header, rendered UNDER the title.
+ *
+ * It used to sit in the actions column beside the switch, and the full string
+ * made that column wide enough to wrap the 28px "Location Agent" title at every
+ * iPhone width. The fix for THAT was to shorten it to one word on phones — so
+ * iOS, the platform this control was designed for, showed a bare green switch
+ * over the single word "On", which never said what it switched. Under the title
+ * the line costs the title no width at all, so it can say the whole thing.
+ */
+function LocationHeaderStatus({ vm }: { vm: LocationHubViewModel }) {
+  return (
+    <span
+      id={LOCATION_HEADER_STATUS_ID}
+      data-testid="one-location-header-status"
+      className="ui-text-helper-text text-[color:var(--app-secondary-label)]"
+    >
+      {locationHeaderStatusText(vm)}
+    </span>
+  );
+}
+
 function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
-  const statusId = useId();
   const locationOn = vm.locationEnabled;
   const acquiring = vm.locationAcquiring;
-  const statusReadiness = vm.locationBlocked
-    ? ("blocked" as const)
-    : locationOn
-      ? ("ready" as const)
-      : ("askable" as const);
-  const statusLabel = acquiring
-    ? "Finding you…"
-    : locationStatusLabel({
-        readiness: statusReadiness,
-        previewOn: locationOn,
-        paused: vm.locationPaused,
-        accuracyLimited: vm.locationAccuracyLimited,
-      });
-  // One word on phones. Measured, not guessed: with the full "Location blocked"
-  // in this column the 28px "Location Agent" title wraps to two lines at every
-  // iPhone width (320/360/375/390); with the compact word the column stays the
-  // width of the switch and the title keeps its single line, exactly as today.
-  const compactStatusLabel = acquiring
-    ? "Finding…"
-    : locationStatusLabel({
-        readiness: statusReadiness,
-        previewOn: locationOn,
-        paused: vm.locationPaused,
-        accuracyLimited: vm.locationAccuracyLimited,
-        compact: true,
-      });
 
   const handleLocationChange = (checked: boolean) => {
     if (checked === locationOn) return;
@@ -689,13 +706,10 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
     <div
       role="group"
       aria-label="Location"
-      // Column on phones, row from `sm` up. The status text is the only thing
-      // that says what this switch is FOR, so it has to survive the compact
-      // layout; there is not enough width on a 320px screen to keep it beside
-      // the switch without wrapping the "Location Agent" title, so it moves
-      // underneath instead. From `sm` the order props restore the original
-      // single-row arrangement exactly: status, then switch.
-      className="ml-auto flex max-w-full shrink-0 flex-col items-end justify-center gap-1 sm:flex-row sm:items-center sm:justify-end sm:gap-0"
+      // Just the switch now. The status words moved under the title, which is
+      // what lets them be the full "Location on / off / paused / blocked" at
+      // every width instead of the single word "On" that iOS used to get.
+      className="ml-auto flex shrink-0 items-center justify-end"
       data-testid="one-location-header-actions"
     >
       <Switch
@@ -711,30 +725,15 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
         // The status text is the switch's description, not decoration. It used
         // to be aria-hidden, so a VoiceOver user got "Turn location on" and no
         // way to hear whether it was blocked, paused, or still finding them.
-        aria-describedby={statusId}
+        aria-describedby={LOCATION_HEADER_STATUS_ID}
         // The same pair of contract actions the Settings toggle carries.
         // Both are the same control in two places, so voice can offer
         // pause/resume from the Now tab without opening Settings first.
         data-voice-control-id="one-location-updates-toggle"
         // No colour override: the shared Switch already carries the iOS
         // system green, so this toggle reads the same as every other one.
-        className={cn(acquiring && "animate-pulse", "sm:order-2")}
+        className={cn(acquiring && "animate-pulse")}
       />
-      {/*
-        Visible at every width. It used to be `hidden … sm:inline`, which meant
-        the one label explaining the switch rendered on desktop and never on a
-        phone — the exact screen the switch was designed for. What was left on
-        iOS was a bare green switch under a title that names the agent, not the
-        control, so "what is this toggle for?" had no answer on the device.
-      */}
-      <span
-        id={statusId}
-        data-testid="one-location-header-status"
-        className="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)] sm:order-1 sm:pr-2"
-      >
-        <span className="sm:hidden">{compactStatusLabel}</span>
-        <span className="hidden sm:inline">{statusLabel}</span>
-      </span>
     </div>
   );
 }
@@ -1221,6 +1220,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         icon={MapPin}
         accent="location"
         titleRole="agent"
+        description={<LocationHeaderStatus vm={vm} />}
         actionsInlineMobile
         actions={<LocationHeaderActions vm={vm} />}
       />

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1036,7 +1036,15 @@ export function VaultFlow({
             >
               <VaultFlowHeader
                 icon={Lock}
-                title="Create your passphrase"
+                /* "Set a lock" — the phrase this product already uses for
+                   this exact dialog. one-setup-hub.tsx:607 passes it as the
+                   dialog's accessible title while the visible heading said
+                   something else, so the screen announced one name and showed
+                   another. It also stops naming the mechanism: what the person
+                   is doing is locking their private place, and the passphrase
+                   is merely how. The fields below still say "Passphrase",
+                   which is where that word belongs. */
+                title="Set a lock"
                 // Carries the promise the removed "private place" invitation
                 // screen used to make, on the step that actually needs it.
                 description="Only you can open what you save."

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -376,7 +376,7 @@ const searchRowBody = (empty: boolean) => `<div class="flex w-full items-center 
       }" />
   </div>
   <button data-testid="connect-select-toggle"
-    class="${BUTTON_BASE} min-h-9 h-9 ${CONNECT_SELECT_TOGGLE_CLASSNAME}">Select</button>
+    class="${BUTTON_BASE} min-h-9 h-9 ${CONNECT_SELECT_TOGGLE_CLASSNAME}">Select many</button>
 </div>`;
 
 /** The same row before this change, for the mutation check. */
@@ -479,23 +479,58 @@ test.describe("Connect search row", () => {
     expect(empty.available).toBeGreaterThan(typed.available);
   });
 
-  test("the selection toggle is a fixed width, so the field never resizes", async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 375, height: 844 });
-    await page.goto(
-      await buildFixture("connect-toggle", searchRowBody(true), SEARCH_CANDIDATES),
-    );
+  // Every compact width the product supports, not just 375. The label grew from
+  // "Select" to "Select many" so the control says on its face that it selects
+  // more than one person, and the whole risk of that change is the narrowest
+  // phone — which is the one width the old single-viewport test never ran.
+  for (const width of [320, 360, 375, 390, 430] as const) {
+    test(`the selection toggle holds its label and its width at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(
+        await buildFixture("connect-toggle", searchRowBody(true), SEARCH_CANDIDATES),
+      );
 
-    const toggle = await boxOf(page, '[data-testid="connect-select-toggle"]');
-    const field = await boxOf(page, '[data-testid="connect-search"]');
+      const toggle = await boxOf(page, '[data-testid="connect-select-toggle"]');
+      const field = await boxOf(page, '[data-testid="connect-search"]');
 
-    // "Select" and "Cancel" are different lengths; a content-sized toggle would
-    // hand the difference to the search field and move it on every tap.
-    expect(Math.abs(toggle.width - 84)).toBeLessThanOrEqual(0.5);
-    expect(Math.abs(toggle.left - field.right - CONNECT_SEARCH_ROW_GAP_PX)).toBeLessThanOrEqual(0.5);
-    expect(toggle.right).toBeLessThanOrEqual(375 - PAGE_PADDING_PX + 1);
-  });
+      // Fixed width: "Select many" and "Cancel" are different lengths, and a
+      // content-sized toggle would hand the difference to the search field and
+      // move it on every tap. The number is read off the shipped token rather
+      // than written down twice.
+      const tokenWidth = Number(
+        /w-\[(\d+)px\]/.exec(CONNECT_SELECT_TOGGLE_CLASSNAME)?.[1],
+      );
+      expect(Number.isFinite(tokenWidth)).toBe(true);
+      expect(Math.abs(toggle.width - tokenWidth)).toBeLessThanOrEqual(0.5);
+
+      // The label FITS. This is the assertion the width number cannot make on
+      // its own: a wider label inside an unchanged box would still measure the
+      // box correctly and ship clipped text.
+      const label = await page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="connect-select-toggle"]',
+        ) as HTMLElement;
+        return {
+          text: el.textContent ?? "",
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          lines: el.getClientRects().length,
+        };
+      });
+      expect(label.text).toBe("Select many");
+      expect(label.scrollWidth).toBeLessThanOrEqual(label.clientWidth + 1);
+      expect(label.lines).toBe(1);
+
+      // The field still owns the rest of the row, and nothing leaves the page.
+      expect(
+        Math.abs(toggle.left - field.right - CONNECT_SEARCH_ROW_GAP_PX),
+      ).toBeLessThanOrEqual(0.5);
+      expect(toggle.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
+      expect(field.width).toBeGreaterThan(120);
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/hushh-webapp/e2e/gemini-endpoint-fields.layout.spec.ts
+++ b/hushh-webapp/e2e/gemini-endpoint-fields.layout.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
+import { INPUT_CLASSNAME } from "../components/ui/input";
+
+/**
+ * The two stacked controls under "API endpoint" on Choose your AI, measured in
+ * a real browser — and specifically in WebKit, because WebKit is the whole
+ * reason this file exists.
+ *
+ * Reported: the transport picker and the key field under it do not share a
+ * corner radius. The obvious fix is to hand the <select> the same classes the
+ * <input> already uses. That fix is not enough, and a Chromium-only test would
+ * have said it was.
+ *
+ * A native <select> defaults to `appearance: menulist`, and under that value
+ * WebKit draws the control itself and IGNORES the author's border-radius and
+ * padding. Measured here: with the input's classes but no `appearance-none`,
+ * WebKit still computes ~5px against the input's 14px — the reported mismatch
+ * survives, on the engine inside the iOS app, where most of our users are.
+ * Chromium honours the author radius either way, so it reports the fix as
+ * working. This spec pins the property that actually makes the two agree.
+ *
+ * The class strings are imported from the shipped module rather than copied, so
+ * this cannot pass against a stale copy of them.
+ *
+ * Run: npx playwright test e2e/gemini-endpoint-fields.layout.spec.ts
+ */
+
+/** The exact classes the select carries in gemini-runtime-settings-card.tsx. */
+const SELECT_CLASSNAME = `${INPUT_CLASSNAME} appearance-none bg-no-repeat pr-9`;
+
+/** The same control WITHOUT appearance-none — the fix that looks right and is not. */
+const SELECT_WITHOUT_APPEARANCE = `${INPUT_CLASSNAME} pr-9`;
+
+const WIDTHS = [320, 360, 375, 390, 430] as const;
+
+async function buildFixture(): Promise<string> {
+  const webappRoot = process.cwd();
+  const { compile } = (await import(
+    path.join(webappRoot, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as {
+    compile: (css: string, opts: unknown) => Promise<{ build: (c: string[]) => string }>;
+  };
+
+  const compiler = await compile('@import "tailwindcss";', {
+    base: path.join(webappRoot, "node_modules"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
+          : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  const markup = `
+    <label class="block space-y-1">API endpoint
+      <select data-testid="endpoint-select" class="${SELECT_CLASSNAME}">
+        <option>Google AI Studio</option>
+        <option>Google Cloud Vertex API key</option>
+      </select>
+    </label>
+    <input data-testid="key-input" class="${INPUT_CLASSNAME}"
+           placeholder="Paste a Google AI Studio Gemini key" />
+    <select data-testid="regression-select" class="${SELECT_WITHOUT_APPEARANCE}">
+      <option>Google AI Studio</option>
+    </select>`;
+
+  const used = new Set<string>();
+  for (const match of markup.matchAll(/class="([^"]*)"/g)) {
+    for (const token of match[1].split(/\s+/)) if (token) used.add(token);
+  }
+  const css = compiler.build([...used]);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-endpoint-"));
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css">
+<style>
+  /* The app shell's own tokens, which this fixture has no shell to inherit. */
+  :root {
+    --app-radius-md: 14px;
+    --app-separator: rgba(60,60,67,.12);
+    --app-secondary-surface: #f9f9fb;
+    --app-accent: #087ff5;
+    --app-focus-ring: rgba(8,127,245,.35);
+  }
+  body { margin: 0; font-family: -apple-system, system-ui, sans-serif; }
+  .stack { display: grid; gap: 8px; padding: 0 16px; }
+</style></head><body><div class="stack">${markup}</div></body></html>`,
+  );
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+type Probe = {
+  radius: string;
+  height: number;
+  paddingLeft: string;
+  appearance: string;
+  right: number;
+  left: number;
+};
+
+async function probe(page: import("@playwright/test").Page, testId: string): Promise<Probe> {
+  return page.evaluate((id) => {
+    const el = document.querySelector(`[data-testid="${id}"]`) as HTMLElement;
+    const cs = getComputedStyle(el);
+    const box = el.getBoundingClientRect();
+    return {
+      radius: cs.borderTopLeftRadius,
+      height: box.height,
+      paddingLeft: cs.paddingLeft,
+      appearance: cs.appearance,
+      right: box.right,
+      left: box.left,
+    };
+  }, testId);
+}
+
+test.describe("Choose your AI — API endpoint fields", () => {
+  for (const width of WIDTHS) {
+    test(`the picker and the key field agree at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+
+      const select = await probe(page, "endpoint-select");
+      const input = await probe(page, "key-input");
+
+      // The reported defect, in one line: the two stacked controls under one
+      // label must share a corner.
+      expect(select.radius).toBe(input.radius);
+      expect(parseFloat(select.radius)).toBeGreaterThan(8);
+
+      // And the rest of the pairing, which was also off: 40px vs 44px tall,
+      // and text inset 12px vs 14px.
+      expect(Math.abs(select.height - input.height)).toBeLessThanOrEqual(0.5);
+      expect(select.paddingLeft).toBe(input.paddingLeft);
+
+      // Both stay on the page.
+      expect(select.left).toBeGreaterThanOrEqual(-0.5);
+      expect(select.right).toBeLessThanOrEqual(width + 0.5);
+    });
+  }
+
+  test("appearance-none is load-bearing, not decoration", async ({
+    page,
+    browserName,
+  }) => {
+    // The mutation check, run as a test rather than by hand: the same control
+    // without `appearance-none`. On WebKit it must NOT match the input, which
+    // is what proves the property is doing the work. Chromium honours the
+    // author radius regardless, so it can only be asserted as a no-worse case
+    // there — recording exactly why a Chromium-only run cannot gate this.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(await buildFixture());
+
+    const input = await probe(page, "key-input");
+    const withoutAppearance = await probe(page, "regression-select");
+    const fixed = await probe(page, "endpoint-select");
+
+    expect(fixed.radius).toBe(input.radius);
+
+    if (browserName === "webkit") {
+      expect(withoutAppearance.appearance).not.toBe("none");
+      expect(withoutAppearance.radius).not.toBe(input.radius);
+      expect(parseFloat(withoutAppearance.radius)).toBeLessThan(
+        parseFloat(input.radius),
+      );
+    }
+  });
+});

--- a/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
@@ -1,0 +1,257 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * The onboarding Check-in card, measured across viewport HEIGHTS.
+ *
+ * Reported from UAT: "iphone 14 pro ka baad responsiveness break ho rha, text
+ * overlapping on img" — past iPhone 14 Pro the body line "Check in anywhere.
+ * Your Circle knows you arrived." ran straight over the building artwork.
+ *
+ * The name of the bug is misleading and that is exactly why this file measures
+ * what it measures. It is not a WIDTH bug. The card sizes itself from its own
+ * width (`aspect-[0.68/1]`), but the artwork inside it was positioned by two
+ * rules keyed to the VIEWPORT:
+ *
+ *   [data-one-checkin-art] { bottom: clamp(54px, calc(65vh - 486.6px), 120px); }
+ *   @media (max-width: 365px) and (min-height: 681px) { ...a second clamp... }
+ *
+ * So the card's own geometry stayed constant while the art slid up inside it as
+ * the viewport got taller, until it reached the copy. The reporter met it by
+ * stepping from a 393x852 iPhone 14 Pro to a 430x932 14 Pro Max — taller, not
+ * just wider — which is why a width-only sweep never caught it.
+ *
+ * The fix anchors the art in a percentage of its OWN region (`bottom-[48%]` of
+ * `data-one-use-case-art`, itself `h-[47%]` of the card), which makes the
+ * position independent of the viewport. This spec is the guard: it sweeps
+ * heights, not just widths, and fails if the copy and the artwork ever touch.
+ *
+ * The card's `<style>` rules are READ OUT OF THE SOURCE FILE at test time
+ * rather than copied here, so a reintroduced viewport clamp is caught rather
+ * than shadowed by a stale duplicate.
+ *
+ * Run: npx playwright test e2e/one-location-checkin-card.layout.spec.ts
+ */
+
+const FLOW_SOURCE_PATH = path.join(
+  process.cwd(),
+  "components/one-location/onboarding/one-location-onboarding-flow.tsx",
+);
+
+/**
+ * Every size the product supports, paired so that HEIGHT varies independently
+ * of width. The 393->430 step and the 852->932 step are the reporter's own.
+ */
+const VIEWPORTS = [
+  { w: 320, h: 568 },
+  { w: 320, h: 900 },
+  { w: 360, h: 780 },
+  { w: 375, h: 812 },
+  { w: 390, h: 844 },
+  { w: 393, h: 852 },
+  { w: 393, h: 932 },
+  { w: 430, h: 932 },
+  { w: 430, h: 1180 },
+] as const;
+
+/**
+ * The card is rendered at a FIXED width on purpose.
+ *
+ * Its own geometry is width-driven and self-consistent (`aspect-[0.68/1]` plus
+ * container-query typography), so re-deriving a width from each viewport would
+ * only re-measure that. The defect is the other axis: the artwork was placed
+ * from the VIEWPORT, so it slid up inside a card whose size had not changed.
+ * Holding the card still and sweeping the viewport isolates exactly that.
+ * 187px is the real card width on a 430px phone: (430 - 40 padding - 16 gap)/2.
+ */
+const CARD_WIDTH_PX = 187;
+
+/** The card markup, mirroring CheckInFeatureCard's structure and classes. */
+const CARD = `
+<article class="relative flex aspect-[0.68/1] w-full flex-col overflow-hidden rounded-[26px] bg-[#f4f6f8] [container-type:inline-size]"
+         data-testid="location-use-case-checkin" data-one-use-case-card data-one-feature-card="checkin">
+  <div class="relative z-20 px-4 pt-4" data-one-feature-copy>
+    <span class="inline-flex rounded-full bg-[#dff4e7] px-3 py-1 text-[11px] font-bold text-[#27884f]" data-one-use-case-tag>Check in</span>
+    <p class="text-[19px] font-bold leading-[1.15]" data-one-feature-title>At the venue, but<br />can&rsquo;t find each other?</p>
+    <p class="text-[14px] leading-[1.4] text-[#747b86]" data-one-feature-body>Check in anywhere. Your Circle knows you arrived.</p>
+  </div>
+  <div class="absolute inset-x-0 bottom-0 h-[47%]" data-one-use-case-art aria-hidden="true">
+    <span class="absolute bottom-[48%] left-1/2 w-[54%] -translate-x-1/2" data-one-checkin-art>
+      <img data-one-checkin-hotel alt="" class="block w-full origin-bottom object-contain"
+           src="/one-location/onboarding/feature-checkin-house-transparent.webp" />
+    </span>
+  </div>
+</article>`;
+
+/** The component's own <style> block, read from source so it cannot drift. */
+function cardStyleFromSource(): string {
+  const source = fs.readFileSync(FLOW_SOURCE_PATH, "utf8");
+  const rules = [...source.matchAll(/\[data-one-checkin-[a-z]+\][^{}]*\{[^{}]*\}/g)].map(
+    (m) => m[0],
+  );
+  return rules.join("\n");
+}
+
+async function buildFixture(): Promise<string> {
+  const webappRoot = process.cwd();
+  const { compile } = (await import(
+    path.join(webappRoot, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as {
+    compile: (css: string, opts: unknown) => Promise<{ build: (c: string[]) => string }>;
+  };
+
+  const compiler = await compile('@import "tailwindcss";', {
+    base: path.join(webappRoot, "node_modules"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
+          : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  const used = new Set<string>();
+  for (const match of CARD.matchAll(/class="([^"]*)"/g)) {
+    for (const token of match[1].split(/\s+/)) if (token) used.add(token);
+  }
+  const css = compiler.build([...used]);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checkin-card-"));
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.copyFileSync(
+    path.join(webappRoot, "public/one-location/onboarding/feature-checkin-house-transparent.webp"),
+    path.join(dir, "feature-checkin-house-transparent.webp"),
+  );
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css">
+<style>
+  body { margin: 0; font-family: -apple-system, system-ui, sans-serif; }
+  /* Half the feature grid's width, which is what a card gets on this screen. */
+  .grid { display: grid; grid-template-columns: ${CARD_WIDTH_PX}px; gap: 16px; padding: 16px; }
+  ${cardStyleFromSource()}
+</style></head><body><div class="grid">${CARD}<div></div></div></body></html>`,
+  );
+  // The image path in CARD is absolute; rewrite it to sit beside the fixture.
+  const html = fs
+    .readFileSync(path.join(dir, "fixture.html"), "utf8")
+    .replace(
+      "/one-location/onboarding/feature-checkin-house-transparent.webp",
+      "feature-checkin-house-transparent.webp",
+    );
+  fs.writeFileSync(path.join(dir, "fixture.html"), html);
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+test.describe("One Location onboarding — check-in card", () => {
+  for (const { w, h } of VIEWPORTS) {
+    test(`copy never touches the artwork at ${w}x${h}`, async ({ page }) => {
+      await page.setViewportSize({ width: w, height: h });
+      await page.goto(await buildFixture());
+      await page.waitForFunction(() => {
+        const img = document.querySelector("[data-one-checkin-hotel]") as HTMLImageElement | null;
+        return Boolean(img?.complete && img.naturalWidth > 0);
+      });
+
+      const measured = await page.evaluate(() => {
+        const q = (sel: string) => document.querySelector(sel) as HTMLElement;
+        const body = q("[data-one-feature-body]").getBoundingClientRect();
+        const art = q("[data-one-checkin-hotel]").getBoundingClientRect();
+        const card = q("[data-one-use-case-card]").getBoundingClientRect();
+        const region = q("[data-one-use-case-art]").getBoundingClientRect();
+        return {
+          gap: art.top - body.bottom,
+          artBottom: art.bottom,
+          artTop: art.top,
+          regionTop: region.top,
+          regionBottom: region.bottom,
+          cardBottom: card.bottom,
+          cardTop: card.top,
+        };
+      });
+
+      // THE REPORTED DEFECT: the body copy and the artwork must not overlap.
+      //
+      // -1px, not 0: this fixture hardcodes the card's type sizes, while the
+      // real card shrinks them with container queries, so its copy block ends a
+      // fraction lower here than it does in the app. The tolerance covers that
+      // difference and nothing else — the defect being guarded was tens of
+      // pixels of overlap, not a rounding edge.
+      expect(measured.gap).toBeGreaterThan(-1);
+
+      // The artwork stays inside its own region, so it can never climb into the
+      // copy no matter how tall the viewport gets.
+      expect(measured.artTop).toBeGreaterThanOrEqual(measured.regionTop - 0.5);
+      expect(measured.artBottom).toBeLessThanOrEqual(measured.regionBottom + 0.5);
+
+      // And inside the card, so nothing spills past the rounded corners.
+      expect(measured.artBottom).toBeLessThanOrEqual(measured.cardBottom + 0.5);
+      expect(measured.artTop).toBeGreaterThan(measured.cardTop);
+    });
+  }
+
+  // The sharpest form of this test, and the one that does not depend on the
+  // fixture reproducing the app's typography at all: hold the card still, change
+  // ONLY the viewport height, and require the artwork not to move inside its own
+  // region. That is precisely what the two `vh` clamps broke, and precisely what
+  // anchoring the art in a percentage of its own region restores.
+  for (const width of [320, 375, 430] as const) {
+    test(`the artwork holds its place inside the card as the viewport grows at ${width}px`, async ({
+      page,
+    }) => {
+      const url = await buildFixture();
+      const offsets: number[] = [];
+
+      for (const height of [560, 740, 932, 1180]) {
+        await page.setViewportSize({ width, height });
+        await page.goto(url);
+        await page.waitForFunction(() => {
+          const img = document.querySelector(
+            "[data-one-checkin-hotel]",
+          ) as HTMLImageElement | null;
+          return Boolean(img?.complete && img.naturalWidth > 0);
+        });
+        offsets.push(
+          await page.evaluate(() => {
+            const art = document
+              .querySelector("[data-one-checkin-hotel]")!
+              .getBoundingClientRect();
+            const region = document
+              .querySelector("[data-one-use-case-art]")!
+              .getBoundingClientRect();
+            // How far the art sits above the bottom of its own region.
+            return Math.round((region.bottom - art.bottom) * 100) / 100;
+          }),
+        );
+      }
+
+      // Every height must produce the same offset. Before the fix these were
+      // four different numbers, and the largest of them is what pushed the art
+      // into the copy on the reporter's taller phone.
+      expect(new Set(offsets).size).toBe(1);
+    });
+  }
+
+  test("the artwork is not positioned from the viewport", async () => {
+    // The mechanism, asserted directly. Both clamps read `vh`/`min-height`, so
+    // the art moved when the viewport grew while the card did not. Anything
+    // viewport-keyed on these selectors is the bug coming back, and a height
+    // sweep alone would only catch it once someone picked the wrong height.
+    const rules = cardStyleFromSource();
+    expect(rules).not.toMatch(/vh\b/);
+    expect(rules).not.toMatch(/min-height/);
+
+    const source = fs.readFileSync(FLOW_SOURCE_PATH, "utf8");
+    expect(source).not.toContain("clamp(54px, calc(65vh - 486.6px), 120px)");
+    expect(source).not.toContain("@media (max-width: 365px) and (min-height: 681px)");
+  });
+});

--- a/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
+++ b/hushh-webapp/lib/morphy-ux/tokens/surfaces.ts
@@ -57,6 +57,24 @@ export const PILL_NEUTRAL =
 /** Shared readable section label. */
 export const EYEBROW = "ui-text-section-label";
 
+/**
+ * The eyebrow above a screen title. Deliberately NOT `EYEBROW`.
+ *
+ * `EYEBROW` and `SECTION_HEADING` are the same string, and that string resolves
+ * to 15px/500 in the same grey as `.ui-text-page-subtitle` (`--app-section-label`
+ * and `--app-secondary-label` are the identical hex in both themes). So above a
+ * title the eyebrow and the description underneath differed by font-weight
+ * alone, and the eyebrow read as a stray first line of body copy rather than a
+ * label — which is exactly how it was reported.
+ *
+ * 12px/600 with a little tracking against a 28px/700 title and a 15px/400
+ * description gives three unmistakable levels. Sentence case, not uppercase:
+ * `scripts/design/verify-apple-hierarchy.mjs` fails this file for shouting, and
+ * several of these eyebrows are phrases ("Copy, share or revoke"), not labels.
+ */
+export const SCREEN_EYEBROW =
+  "text-[12px] font-semibold leading-4 tracking-[0.04em] text-[color:var(--app-section-label)]";
+
 /** Warning / caution banner surface. */
 export const WARNING_SURFACE =
   "rounded-[var(--app-card-radius-compact,16px)] border border-amber-500/30 bg-amber-500/10 text-amber-800 dark:text-amber-200";

--- a/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/surface-primitives.tsx
@@ -23,7 +23,7 @@ import {
   ACCENT_ICON_BUBBLE,
   AVATAR_BUBBLE,
   CARD_SURFACE,
-  EYEBROW,
+  SCREEN_EYEBROW,
   MUTED_TEXT,
   PILL_LIVE,
   PILL_NEUTRAL,
@@ -66,7 +66,7 @@ export function TaskFlowHeader({
               <ChevronRight className="h-5 w-5 rotate-180" />
             </button>
           ) : null}
-          {eyebrow ? <p className={EYEBROW}>{eyebrow}</p> : null}
+          {eyebrow ? <p className={SCREEN_EYEBROW}>{eyebrow}</p> : null}
         </div>
       ) : null}
       <h1 className={SCREEN_TITLE}>{title}</h1>

--- a/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-readiness.test.ts
@@ -186,26 +186,26 @@ describe("status label", () => {
     ).toBe("Location on");
   });
 
-  it("drops the repeated 'Location' for the phone header without changing which state wins", () => {
+  it("names what the switch controls in every state, at every width", () => {
     // The compact form exists because the phone header puts this text under a
     // 28px title that already says Location: the long string measured two title
     // lines at 320/360/375/390. It must agree with the full form on every
     // state, or the same switch would report differently on a phone and a
     // laptop.
     const cases = [
-      [{ readiness: "askable", previewOn: false, paused: false, accuracyLimited: false }, "Location off", "Off"],
-      [{ readiness: "blocked", previewOn: false, paused: false, accuracyLimited: false }, "Location blocked", "Blocked"],
-      [{ readiness: "blocked", previewOn: true, paused: true, accuracyLimited: true }, "Location paused", "Paused"],
-      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: true }, "Location limited", "Limited"],
-      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: false }, "Location on", "On"],
+      [{ readiness: "askable", previewOn: false, paused: false, accuracyLimited: false }, "Location off"],
+      [{ readiness: "blocked", previewOn: false, paused: false, accuracyLimited: false }, "Location blocked"],
+      [{ readiness: "blocked", previewOn: true, paused: true, accuracyLimited: true }, "Location paused"],
+      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: true }, "Location limited"],
+      [{ readiness: "ready", previewOn: true, paused: false, accuracyLimited: false }, "Location on"],
     ] as const;
 
-    for (const [params, full, compact] of cases) {
+    for (const [params, full] of cases) {
       expect(locationStatusLabel(params)).toBe(full);
-      expect(locationStatusLabel({ ...params, compact: true })).toBe(compact);
-      // Same state, same word — the compact form is the full one minus the
-      // repeated noun, never a different verdict.
-      expect(full.toLowerCase().endsWith(compact.toLowerCase())).toBe(true);
+      // Every state names the thing being switched. The one-word form this
+      // used to also return is gone: it fit beside the switch and told an iOS
+      // user nothing, which is how the header ended up reading just "On".
+      expect(full.startsWith("Location ")).toBe(true);
     }
   });
 });

--- a/hushh-webapp/lib/one-location/location-readiness.ts
+++ b/hushh-webapp/lib/one-location/location-readiness.ts
@@ -144,30 +144,26 @@ export function locationReadiness(params: {
 }
 
 /**
- * Short status text for the Location header.
+ * Status text for the Location header.
  *
- * `compact` drops the leading "Location", for the phone layout where the switch
- * sits under a 28px title that already says Location. Two reasons, both
- * measured rather than assumed: the word is pure repetition of the screen
- * title, and at 320-390px the longer string is wide enough to push "Location
- * Agent" onto a second line. The precedence lives here once so the two forms
- * can never disagree about which state wins.
+ * There used to be a `compact` form that dropped the leading "Location" so the
+ * string would fit beside the switch without wrapping the 28px title. It fit,
+ * and it cost the label its meaning: on iOS the header showed a bare green
+ * switch over the single word "On", which never said what it switched. The
+ * status now renders under the title instead of beside the switch, so it costs
+ * the title no width and can always say the whole thing.
  */
 export function locationStatusLabel(params: {
   readiness: LocationReadiness;
   previewOn: boolean;
   paused: boolean;
   accuracyLimited: boolean;
-  compact?: boolean;
 }): string {
-  const prefix = params.compact ? "" : "Location ";
-  const word = (compact: string, full: string) =>
-    params.compact ? compact : `${prefix}${full}`;
-  if (params.paused) return word("Paused", "paused");
-  if (params.readiness === "blocked") return word("Blocked", "blocked");
-  if (!params.previewOn) return word("Off", "off");
-  if (params.accuracyLimited) return word("Limited", "limited");
-  return word("On", "on");
+  if (params.paused) return "Location paused";
+  if (params.readiness === "blocked") return "Location blocked";
+  if (!params.previewOn) return "Location off";
+  if (params.accuracyLimited) return "Location limited";
+  return "Location on";
 }
 
 /**

--- a/hushh-webapp/lib/one-location/people-search.ts
+++ b/hushh-webapp/lib/one-location/people-search.ts
@@ -86,16 +86,33 @@ export function filterPeopleByQuery<T>(
   const needle = normalize(query);
   if (!needle) return [...items];
 
+  // `leading` is split out of `beginners` for ONE character only: a person
+  // typing a single letter is almost always reaching for someone whose name
+  // STARTS with it, and without this tier "r" put Abdul Rashid above Roopmann
+  // — both correct word-beginning matches, but the wrong one first. Reported
+  // as "search is not effective at one character".
+  //
+  // This changes the ORDER, never the SET. Which people a query returns is a
+  // protected behaviour (config/protected-behaviors.json,
+  // "location-people-search-finds-a-person-from-one-letter"); requiring two
+  // characters, as the report suggested, would delete it. Two-or-more stays
+  // byte-identical so the documented "A-Z inside each group" still holds.
+  const leading: T[] = [];
   const beginners: T[] = [];
   const loose: T[] = [];
 
   for (const item of items) {
     const haystack = normalize(searchTextOf(item));
-    if (beginsAWord(haystack, needle)) beginners.push(item);
-    else if (haystack.includes(needle)) loose.push(item);
+    if (beginsAWord(haystack, needle)) {
+      if (needle.length === 1 && haystack.startsWith(needle)) leading.push(item);
+      else beginners.push(item);
+    } else if (haystack.includes(needle)) loose.push(item);
   }
 
-  if (needle.length === 1) return beginners.length ? beginners : loose;
+  if (needle.length === 1) {
+    const begins = [...leading, ...beginners];
+    return begins.length ? begins : loose;
+  }
   return [...beginners, ...loose];
 }
 

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
-    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts e2e/connect-circle-cta.layout.spec.ts e2e/one-location-live-share.layout.spec.ts e2e/one-location-duration-ladder.layout.spec.ts --project=chromium && CI=1 playwright test e2e/connect-circle-cta.layout.spec.ts --project=webkit",
+    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts e2e/connect-circle-cta.layout.spec.ts e2e/one-location-live-share.layout.spec.ts e2e/one-location-duration-ladder.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts e2e/one-location-checkin-card.layout.spec.ts --project=chromium && CI=1 playwright test e2e/connect-circle-cta.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts --project=webkit",
     "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check && npm run verify:route-orchestration-index",

--- a/hushh-webapp/playwright.config.ts
+++ b/hushh-webapp/playwright.config.ts
@@ -47,8 +47,13 @@ export default defineConfig({
       // Opt specs in as they are made WebKit-clean.
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      // `gemini-endpoint-fields.layout` is opted in deliberately and is the
+      // reason this project matters: a native <select> under WebKit's
+      // `appearance: menulist` ignores the author's border-radius, so the
+      // radius defect it covers is INVISIBLE in Chromium. A Chromium-only run
+      // passes the broken control.
       testMatch:
-        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout)\.spec\.ts/,
+        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout)\.spec\.ts/,
     },
     {
       name: "firefox",


### PR DESCRIPTION
Eleven defects reported from UAT with screenshots. All eleven confirmed still present on `3c945a2b0` before being touched.

## Responsiveness

**Check-in card copy ran over the artwork past iPhone 14 Pro.** Not a width bug — which is why a width sweep never caught it. The card is width-driven and never moved; the artwork was placed by **five** `bottom` rules keyed to the viewport (two `vh` clamps, three fixed pixels inside width/height media queries), each outranking the element's own class by source order. So the art slid up inside a card whose size was constant. The reporter met it stepping from 393×852 to 430×932 — **taller**, not just wider.

> The first pass at this removed *one* clamp. The browser test then found four more still winning. That is why the guard is a height sweep and not a source read.

**API endpoint picker vs key field.** `appearance-none` is the load-bearing part, and it is **invisible in Chromium**: under WebKit's `appearance: menulist` the engine draws a native `<select>` itself and overrides the author radius — measured **5px against the input's 14px**, both before *and* after handing the select the input's classes. The iOS app is a WKWebView.

**Provider logo row.** The row gave each mark a 36px slot but only Gemini was sized to it; the other four kept their 48px default and overlapped by 4px — which is what covered part of "Grok". The shared brand assets are untouched (the inventory forbids editing them).

**Features-screen nav.** The only full-width row on a screen railed at 700px, so past `md` Back and Skip slid to the viewport edges. Railed at the call site — the welcome screen's copy of that nav is already railed at 560.

## Labels and alignment

| | |
|---|---|
| **Location eyebrow** | Used the settings-group-heading token: 15px/500 in the *same grey* as the description under it. They differed by font-weight alone, so "People" read as a stray line of body copy. Now 12px/600, sentence case — `verify-apple-hierarchy` fails this file for shouting. |
| **Circle invite icon** | A 44px tile `self-start` against a column whose first line is a 20px eyebrow, so it floated above the title. |
| **Location header status** | The full string wrapped the 28px title on every iPhone, so it had been cut to one word — and iOS got a bare green switch over "On", which never said what it switched. Moved under the title, where it costs the title no width. The one-word form is deleted. |
| **Connect toggle** | "Select" reads as "select this one". Now "Select many", **measured** to fit at 320px in both engines. |

## Copy

- `Create your passphrase` → **`Set a lock`**. The heading named the mechanism, and `one-setup-hub` already passes "Set a lock" as this dialog's accessible title — the screen announced one name and showed another. "Passphrase" still labels the fields.
- `Add the rest any time.` → **`Set up the rest later.`**

## Search

The report asked for a two-character minimum. That would **delete a protected behaviour** (one letter must still find a person), so the fix changes the **order**, never the **set**: at one character a name that *starts* with the letter now ranks above a later word that does. `"r"` still returns both Roopmann and Abdul Rashid — Roopmann is now first. Both sheets also gain the A–Z source sort the other four pickers already had.

## Coverage

Two new browser specs, both enumerated in `test:layout-contracts`, and `gemini-endpoint-fields` opted into the **WebKit** project specifically — the radius defect cannot be seen in Chromium.

The check-in spec's sharpest assertion is fixture-independent: hold the card still, change only the viewport height, require the artwork not to move. **Mutation-checked** by reintroducing a `vh` clamp — 9 of 13 go red.

The connect layout spec now runs at 320/360/375/390/430 instead of 375 alone, and asserts the label **fits** (scrollWidth, one line) rather than only measuring the box — a wider label in an unchanged box would have measured fine and shipped clipped.

Three behaviours registered in `config/protected-behaviors.json`.

**One test renamed, not kept:** "keeps the selection toggle to one word" asserted a width decision. The durable invariant under it is WCAG 2.5.3 — the accessible name must contain the visible label — and that still holds.

## Verification

- typecheck, lint, `verify:design-system` clean
- **117 Playwright contracts** pass in Chromium and WebKit
- full vitest: **27 failed / 4368 passed** on this branch vs **27 failed / 4368 passed** on `origin/main` — byte-identical failing sets, zero regression

**Not verified:** the Circle-invite icon alignment and the features-screen rail are asserted structurally, not measured in a browser — both screens sit behind sign-in and neither has an existing fixture.