### PR TITLE
fix(feed): mark notifications seen on navigation away and sync badge count in real time

### DIFF
--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -20,7 +20,7 @@ import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography"
 import { Button } from "@/lib/morphy-ux/button";
 import { useAuth } from "@/hooks/use-auth";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
-import { CACHE_KEYS } from "@/lib/services/cache-service";
+import { CACHE_KEYS, CACHE_TTL, CacheService } from "@/lib/services/cache-service";
 import { dispatchFeedStateChanged } from "@/lib/feed/feed-events";
 import { FeedRow } from "@/components/feed/feed-row";
 import { FeedActionableRow } from "@/components/feed/feed-actionable-row";
@@ -148,27 +148,65 @@ export function FeedPage() {
     setNextCursor(data.next_cursor);
   }, [data]);
 
-  // Looking at the feed clears the unread badge (Instagram/Twitter convention).
-  // The rows themselves keep their unread styling for this visit and only read
-  // as "seen" on the next open — `visitUnreadIdsRef` holds that, so a live
-  // refresh cannot restyle a row the user is mid-scroll through.
-  //
-  // This re-runs as new activity lands rather than firing once, so anything that
-  // arrives while the page is open is marked read too and the badge does not
-  // count up over a list being read.
+  const latestIdRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!user || !data) return;
-    const latestId = data.items[0]?.id;
-    if (!latestId || markedReadUpToRef.current === latestId) return;
-    markedReadUpToRef.current = latestId;
-    void (async () => {
-      const idToken = await user.getIdToken();
-      await FeedService.markRead({ idToken, upToId: latestId });
-      // `read`: only unread flags moved, so the badge recounts but no list
-      // re-fetches what it just finished rendering.
+    if (data?.items[0]?.id) {
+      latestIdRef.current = data.items[0].id;
+    }
+  }, [data]);
+
+  // Bulk mark unread notifications read when navigating away from the feed page
+  // (unmount or tab visibility hidden), invalidating the feed list cache so the
+  // next visit displays them as seen, and dispatching feed state change to
+  // immediately refresh the tab badge count.
+  useEffect(() => {
+    const markSeen = () => {
+      const latestId = latestIdRef.current;
+      if (!user?.uid || !latestId || markedReadUpToRef.current === latestId) return;
+      markedReadUpToRef.current = latestId;
+
+      // Optimistic instant update (0ms): set cached unread count to 0 & update UI state immediately
+      CacheService.getInstance().set(
+        CACHE_KEYS.FEED_UNREAD_COUNT(user.uid),
+        0,
+        CACHE_TTL.SHORT,
+      );
+      CacheService.getInstance().invalidate(CACHE_KEYS.FEED_LIST(user.uid));
       dispatchFeedStateChanged("read");
-    })();
-  }, [user, data]);
+
+      // Fire backend markRead call asynchronously in background
+      void (async () => {
+        try {
+          const idToken = await user.getIdToken();
+          await FeedService.markRead({
+            idToken,
+            upToId: latestId,
+            userId: user.uid,
+          });
+        } catch (error) {
+          markedReadUpToRef.current = null;
+          console.warn(
+            "[FeedPage] Failed to mark notifications read on navigate away:",
+            error,
+          );
+        }
+      })();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        markSeen();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      markSeen();
+    };
+  }, [user]);
 
   // Record every row that has been unread this visit, before the mark-read above
   // takes effect on the server. Covers paged-in rows too, which arrive unread on

--- a/hushh-webapp/lib/feed/use-feed-unread-count.ts
+++ b/hushh-webapp/lib/feed/use-feed-unread-count.ts
@@ -3,8 +3,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/hooks/use-auth";
-import { FEED_STATE_CHANGED_EVENT } from "@/lib/feed/feed-events";
+import {
+  FEED_STATE_CHANGED_EVENT,
+  feedStateChangeReason,
+} from "@/lib/feed/feed-events";
 import { useFeedLiveRefresh } from "@/lib/feed/use-feed-live-refresh";
+import { CACHE_KEYS, CacheService } from "@/lib/services/cache-service";
 import { FeedService } from "@/lib/services/feed-service";
 
 /**
@@ -61,7 +65,19 @@ export function useFeedUnreadCount(): number | null {
   // For the badge it is the whole point: it is the number that has to drop.
   useEffect(() => {
     if (!user?.uid) return;
-    const recount = () => void load(true);
+    const recount = (event: Event) => {
+      const reason = feedStateChangeReason(event);
+      if (reason === "read") {
+        const cached = CacheService.getInstance().get<number>(
+          CACHE_KEYS.FEED_UNREAD_COUNT(user.uid),
+        );
+        if (cached != null) {
+          setCount(cached);
+          return;
+        }
+      }
+      void load(true);
+    };
     window.addEventListener(FEED_STATE_CHANGED_EVENT, recount);
     return () => window.removeEventListener(FEED_STATE_CHANGED_EVENT, recount);
   }, [user?.uid, load]);

--- a/hushh-webapp/lib/services/feed-service.ts
+++ b/hushh-webapp/lib/services/feed-service.ts
@@ -124,7 +124,7 @@ export class FeedService {
     return count;
   }
 
-  static async markRead(options: { idToken: string; upToId?: string | null }): Promise<void> {
+  static async markRead(options: { idToken: string; upToId?: string | null; userId?: string }): Promise<void> {
     const response = await ApiService.apiFetch("/api/one/feed/read", {
       method: "POST",
       headers: {
@@ -138,6 +138,10 @@ export class FeedService {
     if (!response.ok) {
       const payload = (await response.json().catch(() => ({}))) as ErrorPayload;
       throw new Error(payload.detail || payload.error || `Request failed: ${response.status}`);
+    }
+    if (options.userId) {
+      CacheService.getInstance().invalidate(CACHE_KEYS.FEED_LIST(options.userId));
+      CacheService.getInstance().invalidate(CACHE_KEYS.FEED_UNREAD_COUNT(options.userId));
     }
   }
 }


### PR DESCRIPTION
When you leave/switch away from the Feed page or switch browser tabs, all loaded notifications are automatically marked as seen in the database, and the cache is cleared so they show as seen when you return. 

The red unread-count badge at the top updates immediately (< 1 second) as soon as notifications are marked seen, without waiting for the 45-second polling timer.