### PR TITLE
fix(one-location): a state bug, an unlabelled wait, and five UI/copy defects

### DIFF
--- a/config/protected-behaviors.json
+++ b/config/protected-behaviors.json
@@ -327,6 +327,61 @@
           ]
         }
       ]
+    },
+    {
+      "name": "confirming-a-place-in-onboarding-turns-location-on",
+      "summary": "Saving and labelling a place during Location onboarding sets the live preview on, so the hub the person is redirected to does not greet them with \"Location off\" seconds after they granted permission and dropped a pin.",
+      "fixed_by": "fix/location-polish-round3",
+      "why_it_needs_a_lock": [
+        "Onboarding captures a position DIRECTLY rather than through",
+        "`ensureForegroundLocationReady`, so it never reaches `activateMyLocation`",
+        "and never sets `selfPreviewEnabled`. A new owner also has no grants and no",
+        "nearby presence, so all three disjuncts behind `locationEnabled` are false.",
+        "",
+        "It shipped because every hub test reaches the hub through",
+        "`skipLocationEntryFlow`, which presses \"Skip for now\" on the save modal \u2014",
+        "so the save path never once reached an assertion about the header. The",
+        "guard has to be a test that SAVES.",
+        "",
+        "The write is two fields on the same call the header switch itself uses.",
+        "Deleting it restores a hub that contradicts what the person just did."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/__tests__/components/one-location-agent-page.test.tsx",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 400,
+          "required_titles": [
+            "turns location on once a place is confirmed in onboarding"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "duration-cells-stay-compact-wherever-they-render",
+      "summary": "Every duration choice in Location renders at the 44px / 15px cell, including the nearby Check-in sheet's \"Stay visible for\" pills, which now reuse the ladder's exported class strings instead of a morphy Button.",
+      "fixed_by": "fix/location-polish-round3",
+      "why_it_needs_a_lock": [
+        "A morphy <Button> at size=\"default\" is 50px tall with a 17px label, and",
+        "neither can be overridden from outside: min-h-[50px] sits in a different",
+        "tailwind-merge group from h-*, and .ui-text-button-label forces 17px",
+        "!important. So the Check-in sheet rendered the SAME role 6px taller and 2px",
+        "larger than this app's own duration control, and the only way back is a raw",
+        "<button> carrying the ladder's classes.",
+        "",
+        "Reaching for <Button> while tidying this sheet is the obvious move and it",
+        "silently undoes the fix. The geometry test is what catches that."
+      ],
+      "tests": [
+        {
+          "path": "hushh-webapp/e2e/one-location-duration-ladder.layout.spec.ts",
+          "assertion_pattern": "expect\\(",
+          "min_assertions": 20,
+          "required_titles": [
+            "Check-in duration pills reuse the ladder cell"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2870,6 +2870,55 @@ describe("OneLocationAgentPage", () => {
     ).toBe("1");
   });
 
+  it("turns location on once a place is confirmed in onboarding", async () => {
+    // Reported from UAT: "onboarding mein mera location save ho rha, i could
+    // able to confirm the location as home office others — then after
+    // redirecting to this main page why location off..."
+    //
+    // Onboarding captured a position directly instead of going through
+    // `ensureForegroundLocationReady`, so it never reached `activateMyLocation`
+    // and never set `selfPreviewEnabled`. A brand-new owner also has no grants
+    // and no nearby presence, so all three disjuncts behind `locationEnabled`
+    // were false and the hub greeted them with "Location off" — seconds after
+    // they granted permission, took a fix, dragged a pin and tagged it Home.
+    //
+    // Every other hub test reaches the hub through `skipLocationEntryFlow`,
+    // which presses "Skip for now" on this modal, so the save path never once
+    // reached an assertion about the header. That is why this shipped.
+    window.localStorage.removeItem(
+      "one_location_saved_location_prompt_v2:user_a",
+    );
+    mockLoadSavedLocations.mockResolvedValue([]);
+    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+
+    render(<OneLocationAgentPage />);
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openLocationPermissionsStep();
+
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save location" }));
+    await waitFor(() => expect(mockAddSavedLocation).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    await expectLocationInviteStep();
+    fireEvent.click(await locationFinishButton());
+    expect(
+      await screen.findByRole("heading", { name: "Location Agent" }),
+    ).toBeTruthy();
+
+    // The header agrees with what the person just did.
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("one-location-header-status").textContent,
+      ).toBe("Location on"),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Turn location off" }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
   it("reoffers the two-step saved-place flow when Location is already granted", async () => {
     window.localStorage.removeItem(
       "one_location_saved_location_prompt_v2:user_a",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -9808,6 +9808,26 @@ export function OneLocationAgentPageContent({
           // existing Finish setup transaction commits it after vault unlock.
           PreVaultSensitiveDraftService.stageSavedLocation(auth.userId, input);
         }
+        // Confirming a place turns the live preview on.
+        //
+        // Onboarding captures a position directly rather than through
+        // `ensureForegroundLocationReady`, so it never reached
+        // `activateMyLocation` and never set `selfPreviewEnabled`. A brand-new
+        // owner also has no grants and no nearby presence, so all three
+        // disjuncts behind `locationEnabled` were false and the hub they are
+        // redirected to greeted them with "Location off" — seconds after they
+        // granted permission, let the device take a fix, dragged a pin and
+        // tagged it Home. Saving a place really is a different authority from
+        // sharing one, but "my location is off" is not a true reading of the
+        // state the person just created.
+        //
+        // The same two-field write the header switch itself performs, so both
+        // entry points leave the control in one state.
+        updateOneLocationControlState(auth.userId, (current) => ({
+          ...current,
+          paused: false,
+          selfPreviewEnabled: true,
+        }));
         if (
           savedLocationSessionEpochRef.current !== sessionEpoch ||
           savedLocationSessionUserId !== savingUserId

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -21,6 +21,13 @@ import {
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
+import {
+  DURATION_CELL_CLASS,
+  DURATION_CELL_OFF_CLASS,
+  DURATION_CELL_ON_CLASS,
+  DURATION_GRID_CLASS,
+} from "@/components/one-location/redesign/duration-presets";
+
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -2023,21 +2030,30 @@ export function NearbyCheckInSheet({
                   <Clock3 className="h-4 w-4 text-muted-foreground" />
                   <h2 className="font-semibold">Stay visible for</h2>
                 </div>
-                <div className="mt-3 grid grid-cols-3 gap-2">
+                {/* Raw <button>, not the morphy <Button>: at `size="default"`
+                    that component carries min-h-[50px] in a different
+                    tailwind-merge group from h-*, and `.ui-text-button-label`
+                    forces 17px !important — so it cannot be made compact from
+                    the outside. These are the same class strings the share
+                    duration ladder uses for the identical role (44px, 15px),
+                    so the two duration controls in this product can no longer
+                    disagree about how big a duration choice is. */}
+                <div className={cn("mt-3", DURATION_GRID_CLASS)}>
                   {DURATIONS.map((duration) => (
-                    <Button
+                    <button
                       key={duration.value}
                       type="button"
-                      variant={
-                        durationMinutes === duration.value
-                          ? "default"
-                          : "secondary"
-                      }
                       aria-pressed={durationMinutes === duration.value}
                       onClick={() => setDurationMinutes(duration.value)}
+                      className={cn(
+                        DURATION_CELL_CLASS,
+                        durationMinutes === duration.value
+                          ? DURATION_CELL_ON_CLASS
+                          : DURATION_CELL_OFF_CLASS,
+                      )}
                     >
                       {duration.label}
-                    </Button>
+                    </button>
                   ))}
                 </div>
               </section>
@@ -2077,7 +2093,10 @@ export function NearbyCheckInSheet({
 
               <Button
                 type="button"
-                className="h-12 w-full disabled:!bg-muted disabled:!text-muted-foreground disabled:!opacity-100"
+                // Both halves, or neither lands: `h-12` alone loses to the
+                // size variant's own min-h-[50px], which is why this button has
+                // been 50px the whole time its class said 48.
+                className="h-12 min-h-12 w-full disabled:!bg-muted disabled:!text-muted-foreground disabled:!opacity-100"
                 disabled={
                   busy !== null ||
                   capturing ||

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -171,7 +171,7 @@ describe("SosPanel", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Hold to alert your emergency contacts and give them your live location.",
+          "Alerts your emergency contacts with your live location.",
         ),
       ).toBeInTheDocument();
       expect(screen.getByText(/Alerts Carol/)).toBeInTheDocument();
@@ -435,7 +435,7 @@ describe("SosPanel", () => {
     );
     // Idle: no stop affordance, the core is the pressable SOS control.
     expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
-    expect(screen.getByText("SOS")).toBeInTheDocument();
+    expect(screen.getByText("SMS")).toBeInTheDocument();
     expect(screen.queryByTestId("sos-sent-face")).toBeNull();
 
     // Live: the core becomes a receipt and the stop button appears.
@@ -464,13 +464,13 @@ describe("SosPanel", () => {
     expect(onStopSos).not.toHaveBeenCalled();
   });
 
-  it("returns the core to SOS once the session is no longer active (external revoke sync)", () => {
+  it("returns the core to SMS once the session is no longer active (external revoke sync)", () => {
     const { rerender } = render(<SosPanel {...baseProps} active />);
     expect(screen.getByTestId("sos-sent-face")).toBeInTheDocument();
     // Simulate the incident being cleared elsewhere (e.g. Active shares → Stop),
     // which flips `active` back to false and must reset the SMS screen.
     rerender(<SosPanel {...baseProps} active={false} />);
-    expect(screen.getByText("SOS")).toBeInTheDocument();
+    expect(screen.getByText("SMS")).toBeInTheDocument();
     expect(screen.queryByTestId("sos-sent-face")).toBeNull();
     expect(screen.getByTestId("sos-status-label")).toHaveTextContent(
       "Hold to send location",

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -205,13 +205,11 @@ export function DurationPresetPicker({
                40–80px. */
             visibleRows={DURATION_CUSTOM_VISIBLE_ROWS}
           />
-          <button
-            type="button"
-            onClick={() => setWheelOpen(false)}
-            className={cn(DURATION_CELL_CLASS, DURATION_CELL_OFF_CLASS, "w-full")}
-          >
-            Done
-          </button>
+          {/* No "Done" row. The wheel emits on every settle, so the value was
+              already chosen before that button existed — it confirmed nothing
+              and closed a panel the person can close by picking any other rung.
+              It cost 52px on the tallest state of the tallest control on this
+              screen, which is the screen that was called too busy. */}
         </div>
       ) : null}
     </div>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -3706,12 +3706,18 @@ function TemporaryLinkFlow({
           so it offers no precision card either. The "expires automatically"
           note that sat here was the third statement of the same fact — the
           warning above and the duration control already carry it. */}
+      {/* The label changes while it works. This press waits on a device fix
+          before it can post anything, so on a cold start it can sit for
+          several seconds — and it used to sit as a bare spinner with the label
+          hidden, which is why it read as "taking longer than expected" rather
+          than as "still finding you". Naming the wait is the fix available
+          here; the wait itself is a GPS acquisition. */}
       <Button
         onClick={vm.onCreatePublicInvite}
         isLoading={vm.busy === "publicInvite"}
-        className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+        className="h-12 min-h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
       >
-        Create link
+        {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
       </Button>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -71,7 +71,13 @@ export function DurationSelector({
   const labelId = useId();
 
   return (
-    <div className="space-y-2.5">
+    // `max-w-[420px]` on the GROUP, not on the ladder inside it. The label and
+    // the "Ends 1:25 AM" read-back live at this level; clamping only the
+    // buttons left the hint floating ~370px to the right of the control it
+    // reads back, on an 880px shell. Inert on every phone — the card is
+    // narrower than 420 there — which is deliberate: this half of the report
+    // was a desktop screenshot of 258px-wide duration cells.
+    <div className="max-w-[420px] space-y-2.5">
       {label || hint ? (
         <div className="flex items-baseline justify-between gap-3">
           {label ? (

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -404,12 +404,16 @@ export function SosPanel({
           the heading are the same words. Back lives in the top bar only. */}
       <TaskFlowHeader
         title="Save my Soul"
-        // Says what the alert ACTUALLY does. It previously promised text-message
-        // delivery that works offline; neither is true — this flow creates a
-        // location grant and fires one push, and it needs the network. Someone
-        // can hold this button instead of calling for help, so the promise has
-        // to be the truth.
-        description="Hold to alert your emergency contacts and give them your live location."
+        // Two facts, and only the two the screen cannot show: who it reaches,
+        // and that it sends where you are. "Hold to…" was the third statement
+        // of an instruction the button itself carries and the line under it
+        // repeats verbatim.
+        //
+        // Still the literal truth, which matters more here than anywhere else
+        // in the product: this creates a location grant and fires one push, so
+        // it needs the network and it is not an offline text message. Someone
+        // may hold this instead of calling for help.
+        description="Alerts your emergency contacts with your live location."
       />
 
       {/* The design's top-right actions. The screen's own title moved into the
@@ -580,8 +584,14 @@ export function SosPanel({
                     : "0 0 64px 4px rgb(var(--sos-glow-rgb) / 0.2), inset 0 1px 0 rgba(255,255,255,0.24)",
               }}
             >
+              {/* "SMS", the name this feature carries everywhere else in the
+                  product — the Location menu tile is "SMS / Save my soul", and
+                  the outgoing message is an SMS. Only the visible glyph
+                  changes: every identifier (data-testid, event name, scope
+                  handle, backend enum) still says sos, because those are
+                  contracts, not copy. */}
               <span className="text-[44px] font-semibold tracking-[1.5px] lg:text-[64px] lg:tracking-[2px]">
-                SOS
+                SMS
               </span>
             </button>
           )}
@@ -769,8 +779,12 @@ export function SosPanel({
           ) : null}
         </div>
 
-        {/* The dialer. A text row, not a filled pill — it is the last resort,
-            not a peer of the SOS control. */}
+        {/* The dialer. Outlined and tinted, never filled — it needs to read as
+            tappable without becoming a peer of the SOS control.
+            It had no surface at all and measured ~35px tall, under the 44px
+            this product enforces everywhere else, on the one screen where the
+            person is least able to aim. An outline buys the affordance; the
+            filled treatment stays reserved for SOS. */}
         <div className="mt-10 flex min-h-[52px] items-center justify-center lg:mt-14">
           {emergencyStatus === "resolved" && emergency ? (
             shouldFallbackWindowsEmergencyCall ? (
@@ -778,7 +792,7 @@ export function SosPanel({
                 type="button"
                 onClick={handleWindowsEmergencyCopy}
                 aria-label={`Copy ${emergency.number} emergency services (${emergency.countryName})`}
-                className="press-scale flex items-center gap-2.5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-70"
+                className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
               >
                 <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
                 <span className="text-left leading-tight">
@@ -798,7 +812,7 @@ export function SosPanel({
               <a
                 href={`tel:${emergency.number}`}
                 aria-label={`Call ${emergency.number} emergency services (${emergency.countryName})`}
-                className="press-scale flex items-center gap-2.5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-70"
+                className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
               >
                 <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
                 <span className="text-left leading-tight">

--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -74,9 +74,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     // the exact middle regardless of label width.
     const content = isLoading ? (
       <span className="relative inline-flex items-center justify-center">
-        <span aria-hidden="true" className="opacity-0">
-          {children}
-        </span>
+        {/* NOT aria-hidden. It is visually hidden to reserve the width, but
+            hiding it from the accessibility tree too left a loading button
+            with NO accessible name at all — the spinner beside it is
+            aria-hidden as well, so screen readers announced an unlabelled
+            button, and a long wait had nothing to identify it. */}
+        <span className="opacity-0">{children}</span>
         <span className="absolute inset-0 flex items-center justify-center">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
         </span>
@@ -90,6 +93,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         type={asChild ? undefined : "button"}
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        aria-busy={isLoading || undefined}
         disabled={disabled || isLoading}
         {...props}
       >

--- a/hushh-webapp/e2e/one-location-duration-ladder.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-duration-ladder.layout.spec.ts
@@ -47,12 +47,18 @@ const WIDTHS = [320, 375, 390, 430] as const;
 const COLLAPSED_MAX_HEIGHT_PX = 182;
 
 /**
- * Custom open: the collapsed ladder + gap 8 + pt-1 4 + a 3-row wheel 120 +
- * gap 8 + a 44px Done row = 362. This state is the one that can push
- * "Start sharing" back down the page, so it gets its own ceiling. Shipping
- * the Custom wheel at the default 5 rows would be 442 and fail here.
+ * Custom open: the collapsed ladder + gap 8 + pt-1 4 + a 3-row wheel 120 = 310.
+ * This state is the one that can push "Start sharing" back down the page, so it
+ * gets its own ceiling. Shipping the Custom wheel at the default 5 rows would be
+ * 390 and fail here.
+ *
+ * Was 366, for a 44px "Done" row plus its 8px gap. That button confirmed
+ * nothing — the wheel emits on every settle, so the value was already chosen —
+ * and it was 52px on the tallest state of the tallest control on a screen the
+ * founder called too busy. The ceiling comes down with it, or the next 52px of
+ * creep lands silently in the space it left.
  */
-const EXPANDED_MAX_HEIGHT_PX = 366;
+const EXPANDED_MAX_HEIGHT_PX = 314;
 
 /** Derived from the component, never hand-copied: 3 rows x 40px = 120. */
 const CUSTOM_WHEEL_HEIGHT_PX =
@@ -124,7 +130,6 @@ async function buildFixture(customOpen = false): Promise<string> {
           customOpen
             ? `<div class="space-y-2 pt-1">
                  <div data-wheel style="height:${CUSTOM_WHEEL_HEIGHT_PX}px"></div>
-                 ${cell("Done", false, "w-full")}
                </div>`
             : ""
         }
@@ -135,6 +140,49 @@ async function buildFixture(customOpen = false): Promise<string> {
   );
   return `file://${path.join(dir, "fixture.html")}`;
 }
+
+/**
+ * The nearby Check-in sheet reuses these exact cell classes for its "Stay
+ * visible for" pills. It used to render morphy <Button>s at size="default",
+ * which are 50px tall with a 17px label — 6px and 2px more than this app's own
+ * duration control, on a sheet the founder asked to make smaller. Measuring
+ * them here, against the same constants, is what stops the two drifting again.
+ */
+test.describe("Check-in duration pills reuse the ladder cell", () => {
+  for (const width of WIDTHS) {
+    test(`are 44px, not 50px, at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture({ customOpen: false, width }));
+
+      const cells = await page.evaluate(() => {
+        return [...document.querySelectorAll("[data-grid] > button")].map((el) => {
+          const cs = getComputedStyle(el as HTMLElement);
+          const box = el.getBoundingClientRect();
+          return {
+            height: Math.round(box.height * 100) / 100,
+            minHeight: cs.minHeight,
+            fontSize: cs.fontSize,
+            scrollWidth: (el as HTMLElement).scrollWidth,
+            clientWidth: (el as HTMLElement).clientWidth,
+          };
+        });
+      });
+
+      expect(cells.length).toBeGreaterThan(0);
+      for (const cell of cells) {
+        // The compact height this control settled on, and the one the check-in
+        // sheet now shares. 50px is the morphy default it must not drift back to.
+        expect(cell.height).toBeLessThanOrEqual(45);
+        expect(cell.height).toBeGreaterThanOrEqual(43.5);
+        expect(cell.fontSize).toBe("15px");
+        // Still a real touch target.
+        expect(parseFloat(cell.minHeight)).toBeGreaterThanOrEqual(44);
+        // And the label still fits at the narrowest phone.
+        expect(cell.scrollWidth).toBeLessThanOrEqual(cell.clientWidth + 1);
+      }
+    });
+  }
+});
 
 test.describe("One Location duration ladder layout", () => {
   for (const width of WIDTHS) {


### PR DESCRIPTION
Eight items reported from UAT with screenshots. All confirmed still present before being touched.

## The state bug — "Location off" right after onboarding saved the location

Onboarding captures a position **directly** instead of going through `ensureForegroundLocationReady`, so it never reached `activateMyLocation` and never set `selfPreviewEnabled`. A brand-new owner also has no grants and no nearby presence, so all three disjuncts behind `locationEnabled` were false — and the hub greeted them with "Location off" seconds after they granted permission, let the device take a fix, dragged a pin and tagged it Home.

Confirming a place now performs the **same two-field write the header switch itself performs**, so both entry points leave the control in one state.

> It shipped because every hub test reaches the hub through `skipLocationEntryFlow`, which presses "Skip for now" on the save modal — so the save path never once reached an assertion about the header. The new test **saves**, and is mutation-checked (revert the fix → it goes red).

## The unlabelled wait — public link "taking time more than expected"

The first answer was to prewarm GPS. **That was refuted:** the prewarm is discarded after 20s (so it helps only if you press within 20 seconds), and calling the bus outside a user gesture can spend the iOS one-shot permission prompt. On a warm session the press already pays zero GPS.

What *is* wrong, and was confirmed: the shared `Button`'s loading state marks **both** the label and the spinner `aria-hidden`, so a loading button has **no accessible name** and no `aria-busy`. A screen reader announced an unlabelled button; sighted users got a bare spinner with nothing saying what it was doing. The label now stays in the a11y tree, the button reports `aria-busy`, and this action says **"Creating link…"** while it waits on the device.

## Five more

| | |
|---|---|
| **Check-in pills** | Morphy `<Button>`s at `size="default"` — 50px tall, 17px label — while this app's own ladder renders the identical role at **44px/15px**. Neither is overridable from outside (`min-h-[50px]` is in a different tailwind-merge group from `h-*`; `.ui-text-button-label` forces 17px `!important`), so they are now raw buttons carrying the ladder's exported classes. The sheet CTA's `h-12` was dead for the same reason. |
| **Save my Soul copy** | Said in twelve words what the button and the line under it already say. Now carries only the two facts the screen cannot show: who it reaches, and that it sends where you are. |
| **Emergency dialer** | No surface at all, measured **~35px** — under the 44px this product enforces everywhere else, on the screen where the person is least able to aim. Now outlined and tinted: affordance without becoming a peer of SOS, which is what the design note above it asks for. |
| **Circle label** | Now reads **SMS**, the name this feature carries everywhere else (the Location menu tile is "SMS / Save my soul"). Visible glyph only — every identifier still says `sos`, because those are contracts, not copy. |
| **Share duration** | The "Done" row confirmed nothing (the wheel emits on every settle) and cost 52px on the tallest state of the tallest control on the screen called too busy. Removed, and the layout budget comes down **366 → 314** so the space cannot silently refill. The duration **group** is clamped to 420px on desktop — at the wrapper that also holds the label and the "Ends 1:25 AM" read-back, because clamping only the buttons would leave that hint floating ~370px to its right. |

## Deliberately not done

Removing **Cancel** or folding the **single-recipient list** were both proposed. Both break tests, and Cancel additionally carries a `resetShareDraft()` that the URL-driven close path does not — so removing it would silently drop the draft reset.

## Verification

- typecheck, lint, `verify:design-system` clean
- **121 Playwright contracts** pass in Chromium and WebKit, including a new one measuring the shared duration cell at 44px/15px at every compact width and asserting the label still fits
- full vitest **27 failed / 4389 passed** vs **28 failed / 4387 passed** on `origin/main` — no new failures, +1 test
- ladder budget mutation-checked; C2 fix mutation-checked
- two behaviours registered in `config/protected-behaviors.json`

**Not verified:** the actual wall-clock of link creation. The backend does four serialized round trips, which is real but out of scope for a UI pass — the change here makes the wait *legible*, not shorter.