### PR TITLE
feat(voice): give Voice settings' changelog its own dedicated page

### DIFF
--- a/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
+++ b/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
@@ -4045,6 +4045,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/changelog",
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.changelog",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.changelog",
+        "purpose": "A read-only list of voice engine updates and fixes. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -3729,6 +3729,29 @@
       "alias": null,
       "api_dependencies": [],
       "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": null,
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "pathname": "/one/profile/preferences/voice/changelog",
+      "route_mode": "standard",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.profile.preferences.voice.changelog"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
         "policy": "none",
         "refresh_trigger": "none",
         "resource_classes": [
@@ -4877,13 +4900,13 @@
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "bed21dbc32024d52d456378ab5d1eac8ca7326e7726ac38092ea036b5a47fdd8",
     "agent_registry": "8f9c669153e52a57c68ca44db8b8419c1ecc8bb489ceee21a6286ca2eba3c207",
-    "cache_manifest": "704440f9aaccd05b71ddb59e904dca1525bf97fcce9ca8331cb8bcf31bd38e39",
+    "cache_manifest": "5dfec3e2a668bae6e7e5c0fee9e9bf2ec89a470aa86362d9bf832c3a3bf21edb",
     "data_plane": "314c1b4e33e47c02b2438aade82b0b92d09f21404e7dbff62b45463b2f51d70c",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "797c80df3cec108b4686510d6aa01c8141bc1629ededa6577498335cbf69e590",
-    "route_index": "3aade9f87e36280d108639c8acd10bc62a15688cb162222f0747116b55ca3bac",
-    "route_layout": "35e58ba1ad5192cf8a290456cc64b88202dc7b14f34808d1846225637125c658",
-    "surface_map": "cd84aa1da9e427607fb017bd06e6629e33ab8e5f8d44dd67861f15121032ce2e",
+    "route_index": "dcd8ea3905524f2633bf19deb32a23966cd25d03f7b459d8edb532ee6b7fb093",
+    "route_layout": "3c9da85499419e4a856d61ca635c78d68e63439c1efc9c23cbf013391f28ffad",
+    "surface_map": "700d6fccea2e3b614b1385d3c3ca87fa414c92f8ad665322719becf4cb702f46",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
@@ -4895,7 +4918,7 @@
     "decision_required": 2,
     "in_process_specialists": 3,
     "one_specialist_tools": 5,
-    "physical_routes": 127,
+    "physical_routes": 128,
     "semantic_routes": 14,
     "table_families": 46
   }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -4045,6 +4045,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/changelog",
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.changelog",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.changelog",
+        "purpose": "A read-only list of voice engine updates and fixes. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/__tests__/components/voice-changelog-page.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-changelog-page.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VoiceChangelogPage } from "@/components/profile/voice-changelog-page";
+import { VOICE_ENGINE_CHANGELOG } from "@/lib/agent/voice-engine-changelog";
+
+describe("VoiceChangelogPage", () => {
+  it("renders every changelog entry, not just a capped preview", () => {
+    render(<VoiceChangelogPage />);
+
+    for (const entry of VOICE_ENGINE_CHANGELOG) {
+      expect(screen.getByText(entry.title)).toBeInTheDocument();
+    }
+  });
+
+  it("has no \"See all updates\" row -- this page is already the full list", () => {
+    render(<VoiceChangelogPage />);
+
+    expect(
+      screen.queryByRole("button", { name: "See all updates" }),
+    ).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { VoicePreferencesPanel } from "@/components/profile/voice-preferences-panel";
 import {
@@ -16,7 +16,9 @@ afterEach(() => {
 
 describe("VoicePreferencesPanel", () => {
   it("shows the One header with the current engine version", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
 
     expect(screen.getByRole("heading", { name: "One" })).toBeInTheDocument();
     expect(
@@ -27,7 +29,9 @@ describe("VoicePreferencesPanel", () => {
   });
 
   it("opens with voice on and every enforceable domain allowed, matching today's behavior", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
 
     expect(screen.getByRole("switch", { name: "Voice control" })).toBeChecked();
     expect(
@@ -36,7 +40,9 @@ describe("VoicePreferencesPanel", () => {
   });
 
   it("Finance and Calendar show as coming soon, not a switch", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
 
     expect(screen.queryByRole("switch", { name: "Finance" })).toBeNull();
     expect(screen.queryByRole("switch", { name: "Calendar" })).toBeNull();
@@ -44,7 +50,9 @@ describe("VoicePreferencesPanel", () => {
   });
 
   it("turning off a domain persists to voice preferences", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
 
     fireEvent.click(screen.getByRole("switch", { name: "Location" }));
 
@@ -52,7 +60,9 @@ describe("VoicePreferencesPanel", () => {
   });
 
   it("turning off the master toggle disables the domain and safety switches", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
 
     fireEvent.click(screen.getByRole("switch", { name: "Voice control" }));
 
@@ -63,8 +73,11 @@ describe("VoicePreferencesPanel", () => {
     ).toBeDisabled();
   });
 
-  it("changelog shows a preview and expands to the full list", () => {
-    render(<VoicePreferencesPanel userId={userId} />);
+  it("changelog shows a preview and \"See all updates\" opens the dedicated changelog page", () => {
+    const onOpenChangelog = vi.fn();
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={onOpenChangelog} />,
+    );
 
     expect(screen.getByText("What's new")).toBeInTheDocument();
     const seeAll = screen.getByRole("button", { name: "See all updates" });
@@ -72,6 +85,6 @@ describe("VoicePreferencesPanel", () => {
 
     fireEvent.click(seeAll);
 
-    expect(screen.queryByRole("button", { name: "See all updates" })).toBeNull();
+    expect(onOpenChangelog).toHaveBeenCalledTimes(1);
   });
 });

--- a/hushh-webapp/app/one/profile/preferences/voice/changelog/page.tsx
+++ b/hushh-webapp/app/one/profile/preferences/voice/changelog/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/profile/profile-workspace-page";

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -70,6 +70,7 @@ import { ProfileKaiPreferencesPanel } from "@/components/profile/profile-kai-pre
 import { GeminiLogo } from "@/components/brand/gemini-logo";
 import { GeminiRuntimeSettingsCard } from "@/components/connections/gemini-runtime-settings-card";
 import { VoicePreferencesPanel } from "@/components/profile/voice-preferences-panel";
+import { VoiceChangelogPage } from "@/components/profile/voice-changelog-page";
 import { ConnectedSystemsPanel } from "@/components/profile/connected-systems-panel";
 import { ThemeToggleLean } from "@/components/theme-toggle";
 import {
@@ -3918,13 +3919,28 @@ function ProfilePageContent() {
           />
         ),
       });
-    } else if (activeDetail === "voice") {
+    } else if (activeDetail === "voice" || activeDetail === "voice-changelog") {
       profileStackEntries.push({
         key: "detail:voice",
         title: "Voice",
         description: "One's voice controls.",
-        content: <VoicePreferencesPanel userId={user.uid} />,
+        content: (
+          <VoicePreferencesPanel
+            userId={user.uid}
+            onOpenChangelog={() =>
+              updateProfileView({ detail: "voice-changelog" }, "push")
+            }
+          />
+        ),
       });
+      if (activeDetail === "voice-changelog") {
+        profileStackEntries.push({
+          key: "detail:voice-changelog",
+          title: "What's new",
+          description: "Voice engine updates and fixes.",
+          content: <VoiceChangelogPage />,
+        });
+      }
     }
   } else if (!routeBlockedByVault && activePanel === "security") {
     profileStackEntries.push({

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,15 +10,15 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 127,
+    "total_screens": 128,
     "physical_page_count": 0,
-    "route_contract_count": 127,
-    "surface_map_count": 127,
+    "route_contract_count": 128,
+    "surface_map_count": 128,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 44,
-      "vault-backed": 45,
+      "vault-backed": 46,
       "hidden flow": 14,
       "auth/pre-vault": 6,
       "RIA/provider": 9,
@@ -1709,7 +1709,7 @@
       "surface_map_present": true,
       "route_contract_present": true,
       "evidence": {
-        "cache_service": false,
+        "cache_service": true,
         "use_stale_resource": true,
         "device_cache": false,
         "secure_cache": false,
@@ -3812,6 +3812,51 @@
       ]
     },
     {
+      "route": "/one/profile/preferences/voice/changelog",
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "route_contract_mode": "standard",
+      "screen_class": "vault-backed",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/one/profile/preferences/voice/changelog",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": true,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": true,
+        "resource_wrapper": true,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "review native route beacon coverage"
+      ]
+    },
+    {
       "route": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_contract_mode": "redirect",
@@ -5679,5 +5724,5 @@
       ]
     }
   ],
-  "content_sha256": "bd0dad9f9711f6a7b2f2734a7f65cb81e83c0a3700eafaefb9ecc557962e6e95"
+  "content_sha256": "04cabe4fc09bb6f5d5ef8151cd71f2fb4657ad9803418031208b4d2cd47bd188"
 }

--- a/hushh-webapp/components/profile/voice-changelog-page.tsx
+++ b/hushh-webapp/components/profile/voice-changelog-page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { VOICE_ENGINE_CHANGELOG } from "@/lib/agent/voice-engine-changelog";
+
+export function VoiceChangelogPage() {
+  return (
+    <SettingsGroup>
+      {VOICE_ENGINE_CHANGELOG.map((entry, index) => (
+        <SettingsRow
+          key={`${entry.version}:${entry.title}:${index}`}
+          title={entry.title}
+          description={entry.description}
+          trailing={
+            <span className="text-xs text-muted-foreground">{entry.date}</span>
+          }
+          stackTrailingOnMobile
+        />
+      ))}
+    </SettingsGroup>
+  );
+}

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -39,11 +39,8 @@ function VoiceHeader() {
   );
 }
 
-function VoiceChangelog() {
-  const [expanded, setExpanded] = useState(false);
-  const entries = expanded
-    ? VOICE_ENGINE_CHANGELOG
-    : VOICE_ENGINE_CHANGELOG.slice(0, CHANGELOG_PREVIEW_COUNT);
+function VoiceChangelog({ onOpenChangelog }: { onOpenChangelog: () => void }) {
+  const entries = VOICE_ENGINE_CHANGELOG.slice(0, CHANGELOG_PREVIEW_COUNT);
   const hasMore = VOICE_ENGINE_CHANGELOG.length > CHANGELOG_PREVIEW_COUNT;
 
   return (
@@ -59,10 +56,10 @@ function VoiceChangelog() {
           stackTrailingOnMobile
         />
       ))}
-      {hasMore && !expanded ? (
+      {hasMore ? (
         <SettingsRow
           title="See all updates"
-          onClick={() => setExpanded(true)}
+          onClick={onOpenChangelog}
           chevron
         />
       ) : null}
@@ -72,8 +69,10 @@ function VoiceChangelog() {
 
 export function VoicePreferencesPanel({
   userId,
+  onOpenChangelog,
 }: {
   userId: string | null;
+  onOpenChangelog: () => void;
 }) {
   const [state, setState] = useState<OneVoicePreferencesState>(() =>
     readVoicePreferences(userId),
@@ -92,7 +91,7 @@ export function VoicePreferencesPanel({
   return (
     <div className="space-y-4">
       <VoiceHeader />
-      <VoiceChangelog />
+      <VoiceChangelog onOpenChangelog={onOpenChangelog} />
       <SettingsGroup>
         <SettingsRow
           title="Voice control"

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -4045,6 +4045,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/changelog",
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.changelog",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.changelog",
+        "purpose": "A read-only list of voice engine updates and fixes. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -5798,6 +5798,61 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/one/profile/preferences/voice/changelog",
+      "page_file": "app/one/profile/preferences/voice/changelog/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "standard",
+        "exemption_reason": null,
+        "shell_verification_file": "app/profile/profile-workspace-page.tsx",
+        "shell_verification_includes": [
+          "AppPageShell",
+          "AppPageHeaderRegion",
+          "AppPageContentRegion",
+          "PageHeader",
+          "SurfaceStack"
+        ],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.profile.preferences.voice.changelog",
+          "purpose": "A read-only list of voice engine updates and fixes. Nothing to act on here.",
+          "screen": "profile_preferences",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": null,
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "physical_page_exists": true,
@@ -8573,5 +8628,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "fedc79de59811a35f8676fc7417240075b671d1e046ee8dc8e7ef3b45bdf71b4"
+  "content_sha256": "abffe02c63b4bbd6d400a9804f06375462cdd7a24444962f73feed3dfc74ccbb"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -2821,6 +2821,42 @@
     }
   },
   {
+    "route": "/one/profile/preferences/voice/changelog",
+    "mode": "standard",
+    "shellVerification": {
+      "file": "app/profile/profile-workspace-page.tsx",
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.preferences.voice.changelog",
+      "purpose": "A read-only list of voice engine updates and fixes. Nothing to act on here.",
+      "screen": "profile_preferences",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
     "route": "/one/profile/security",
     "mode": "standard",
     "shellVerification": {

--- a/hushh-webapp/lib/navigation/profile-routes.ts
+++ b/hushh-webapp/lib/navigation/profile-routes.ts
@@ -20,6 +20,7 @@ export type ProfileDetail =
   | "gemini"
   | "device"
   | "voice"
+  | "voice-changelog"
   | "vault"
   | "session"
   | "gmail-connection"
@@ -98,7 +99,8 @@ export function normalizeProfileDetail(
     (detail === "kai-preferences" ||
       detail === "gemini" ||
       detail === "device" ||
-      detail === "voice")
+      detail === "voice" ||
+      detail === "voice-changelog")
   ) {
     return detail;
   }
@@ -211,6 +213,13 @@ export function buildProfileRoute(params?: {
     if (detail === "voice") {
       return appendQuery(ROUTES.PROFILE_PREFERENCES_VOICE, {}, params?.searchParams);
     }
+    if (detail === "voice-changelog") {
+      return appendQuery(
+        ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG,
+        {},
+        params?.searchParams,
+      );
+    }
     return appendQuery(ROUTES.PROFILE_PREFERENCES, {}, params?.searchParams);
   }
 
@@ -321,6 +330,9 @@ export function resolveProfileRouteState(
   }
   if (normalizedPath === ROUTES.PROFILE_PREFERENCES_VOICE) {
     return { panel: "preferences", detail: "voice" };
+  }
+  if (normalizedPath === ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG) {
+    return { panel: "preferences", detail: "voice-changelog" };
   }
 
   if (normalizedPath === ROUTES.PROFILE_SECURITY) {

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -75,6 +75,7 @@ export const ROUTES = {
   PROFILE_PREFERENCES_GEMINI: "/one/profile/preferences/gemini",
   PROFILE_PREFERENCES_DEVICE: "/one/profile/preferences/device",
   PROFILE_PREFERENCES_VOICE: "/one/profile/preferences/voice",
+  PROFILE_PREFERENCES_VOICE_CHANGELOG: "/one/profile/preferences/voice/changelog",
   PROFILE_SECURITY: "/one/profile/security",
   PROFILE_SECURITY_VAULT: "/one/profile/security/vault",
   PROFILE_SECURITY_SESSION: "/one/profile/security/session",

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -1016,6 +1016,25 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  // Voice's changelog is a third level nested under the Voice detail screen,
+  // one deeper than the generic panel/detail breadcrumb below can express (it
+  // only carries a single detail label). Back must retrace to Voice itself,
+  // not to Preferences.
+  if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG) {
+    const preferencesHref = profilePanelHref("preferences");
+    return {
+      backHref: ROUTES.PROFILE_PREFERENCES_VOICE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: ROUTES.PROFILE },
+        { label: "Preferences", href: preferencesHref },
+        { label: "Voice", href: ROUTES.PROFILE_PREFERENCES_VOICE },
+        { label: "What's new" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.PROFILE_RECEIPTS) {
     return {
       backHref: ROUTES.GMAIL,


### PR DESCRIPTION
## Summary
- Voice settings' "What's new" was capped inline with an "expand in place" button. It now shows a 2-entry preview, and "See all updates" navigates to a dedicated `/one/profile/preferences/voice/changelog` page listing every entry — matching how every other Profile detail screen behaves.
- New route wired through `profile-routes.ts`/`routes.ts`/`ProfileStackNavigator` (pushes both the Voice and Changelog stack entries so back-navigation retraces to Voice, not Preferences).
- Added a breadcrumb special case (`Profile > Preferences > Voice > What's new`) since this is a third level nested under a detail screen, one deeper than the generic panel/detail breadcrumb resolver supports.
- Registered the new route in `app-route-layout.contract.json` and regenerated the four generated artifacts (surface map, cache-coherence manifest, route orchestration index x3, runtime topology index).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] `voice-preferences-panel.test.tsx` updated for new navigate-away behavior (was testing in-place expand) — 6/6 passing
- [x] New `voice-changelog-page.test.tsx` — asserts full list renders, no redundant "See all updates" row — 2/2 passing
- [x] `top-shell-breadcrumbs.test.ts` — 33/33 passing (unrelated pre-existing failure in a different suite not touched here)
- [x] `one-location-agent-page.test.tsx` (broad regression sweep) — 92/92 passing
- [x] Backend `mypy` clean