### PR TITLE
fix(voice): enforce the master Voice control toggle, not just per-domain ones

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -29,6 +29,7 @@ from google.adk.tools.tool_context import ToolContext
 
 from hushh_mcp.one_adk.voice_domain_policy import (
     is_voice_domain_disabled,
+    is_voice_entirely_disabled,
     resolve_voice_domain,
     voice_domain_label,
 )
@@ -415,6 +416,15 @@ async def run_app_action(
         }
 
     voice_settings = _voice_settings(tool_context)
+    if is_voice_entirely_disabled(voice_settings):
+        logger.info("one_adk_action_decision action=%s status=domain_disabled domain=all", clean_id)
+        return {
+            "status": "domain_disabled",
+            "message": (
+                "Voice control is turned off in your settings. Turn it back on "
+                "in Profile, Preferences, Voice, or do this by tap instead."
+            ),
+        }
     voice_domain = resolve_voice_domain(clean_id)
     if is_voice_domain_disabled(voice_domain, voice_settings.get("disabled_domains")):
         logger.info(
@@ -954,10 +964,18 @@ async def start_app_goal(
     # navigation journey only reaches it (via the non-journey fallthrough)
     # after parking its own navigation directive first. One check here covers
     # both; the plain run_app_action call further down repeats it harmlessly.
+    goal_voice_settings = _voice_settings(tool_context)
+    if is_voice_entirely_disabled(goal_voice_settings):
+        logger.info("one_adk_goal_decision action=%s status=domain_disabled domain=all", clean_id)
+        return {
+            "status": "domain_disabled",
+            "message": (
+                "Voice control is turned off in your settings. Turn it back on "
+                "in Profile, Preferences, Voice, or do this by tap instead."
+            ),
+        }
     voice_domain = resolve_voice_domain(clean_id)
-    if is_voice_domain_disabled(
-        voice_domain, _voice_settings(tool_context).get("disabled_domains")
-    ):
+    if is_voice_domain_disabled(voice_domain, goal_voice_settings.get("disabled_domains")):
         logger.info(
             "one_adk_goal_decision action=%s status=domain_disabled domain=%s",
             clean_id,

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -517,6 +517,27 @@ def _one_runtime_instruction(context: Any) -> str:
     if not isinstance(voice_context, dict):
         return ONE_IDENTITY_INSTRUCTION + pkm_instruction
 
+    # Gate 1/Gate 2 already refuse every actual tool call while voice is off,
+    # but a plain "what can you do" question never reaches a tool -- it is
+    # answered straight from this instruction, so the off state has to be
+    # stated here too or the model just describes capabilities as if voice
+    # were still on.
+    voice_settings = voice_context.get("voice_settings")
+    voice_settings = voice_settings if isinstance(voice_settings, dict) else {}
+    voice_disabled_instruction = ""
+    if voice_settings.get("voice_enabled") is False:
+        voice_disabled_instruction = (
+            "\n\nVOICE CONTROL IS OFF: the person has turned off voice control "
+            "in their own settings (Profile, Preferences, Voice). Every app "
+            "action and specialist delegation will be refused while this is "
+            "off. Do not describe, offer, or attempt any action, and do not "
+            "list what you can do as if voice were on. If asked what you can "
+            "do, say plainly that voice control is off and tell them to turn "
+            "it back on in Profile, Preferences, Voice, or to do things by tap "
+            "instead. You may still answer general questions that need no app "
+            "action."
+        )
+
     available_action_ids = voice_context.get("available_action_ids")
     verified_action_ids = (
         [
@@ -643,7 +664,13 @@ def _one_runtime_instruction(context: Any) -> str:
 
     playbook = voice_context.get("route_playbook")
     if not isinstance(playbook, dict):
-        return ONE_IDENTITY_INSTRUCTION + layer_instruction + action_inventory + pkm_instruction
+        return (
+            ONE_IDENTITY_INSTRUCTION
+            + layer_instruction
+            + action_inventory
+            + pkm_instruction
+            + voice_disabled_instruction
+        )
 
     purpose = bounded(playbook.get("purpose"), 480)
     entry_cue = bounded(playbook.get("entry_cue"), 240)
@@ -663,6 +690,7 @@ def _one_runtime_instruction(context: Any) -> str:
         + "remain the only execution authority."
         + action_inventory
         + pkm_instruction
+        + voice_disabled_instruction
     )
 
 
@@ -841,15 +869,23 @@ async def _specialist_turn(
             ),
         }
     if availability.state == "domain_disabled":
+        message = (
+            (
+                "Voice control is turned off in your settings. Turn it back on "
+                "in Profile, Preferences, Voice, or do this by tap instead."
+            )
+            if availability.reason_code == "voice_disabled_by_user"
+            else (
+                f"Voice control is turned off for {specialist_label(agent_id)} "
+                "in your settings. Turn it back on in Profile, Preferences, "
+                "Voice, or do this by tap instead."
+            )
+        )
         return {
             "status": availability.state,
             "reason": availability.reason_code,
             "availability": availability_payload,
-            "message": (
-                f"Voice control is turned off for {specialist_label(agent_id)} "
-                "in your settings. Turn it back on in Profile, Preferences, "
-                "Voice, or do this by tap instead."
-            ),
+            "message": message,
         }
     if availability.state in {"needs_auth", "vault_locked"}:
         return {

--- a/consent-protocol/hushh_mcp/one_adk/specialist_availability.py
+++ b/consent-protocol/hushh_mcp/one_adk/specialist_availability.py
@@ -14,6 +14,7 @@ from typing import Any, Literal
 from hushh_mcp.adk_bridge.dispatch import is_wired_specialist
 from hushh_mcp.one_adk.voice_domain_policy import (
     is_voice_domain_disabled,
+    is_voice_entirely_disabled,
     resolve_voice_domain_for_specialist,
 )
 from hushh_mcp.services.route_orchestration_index import is_one_delegate_admitted
@@ -108,6 +109,8 @@ def resolve_specialist_availability(
     # actual reason is that the person turned Email off themselves.
     voice_settings = context.get("voice_settings")
     voice_settings = voice_settings if isinstance(voice_settings, dict) else {}
+    if is_voice_entirely_disabled(voice_settings):
+        return result("domain_disabled", "voice_disabled_by_user")
     voice_domain = resolve_voice_domain_for_specialist(agent_id)
     if is_voice_domain_disabled(voice_domain, voice_settings.get("disabled_domains")):
         return result("domain_disabled", "voice_domain_disabled_by_user")

--- a/consent-protocol/hushh_mcp/one_adk/voice_domain_policy.py
+++ b/consent-protocol/hushh_mcp/one_adk/voice_domain_policy.py
@@ -109,3 +109,17 @@ def is_voice_domain_disabled(domain: str | None, disabled_domains: object) -> bo
     if not domain or not isinstance(disabled_domains, (list, tuple, set, frozenset)):
         return False
     return domain in disabled_domains
+
+
+def is_voice_entirely_disabled(voice_settings: object) -> bool:
+    """Whether the person has turned the whole voice agent off (the master
+    Voice control switch), independent of any per-domain toggle.
+
+    Fails open (False) for anything not a dict -- absent context (non-live
+    callers, tests, an older cached snapshot) must never block an
+    already-authorized action, matching sanitize_voice_settings' own
+    fail-open default and every other read of this dict.
+    """
+    if not isinstance(voice_settings, dict):
+        return False
+    return voice_settings.get("voice_enabled") is False

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -214,6 +214,39 @@ class TestAgentTreeShape:
         assert "Do not call open_screen" in instruction
         assert "First assess meaning semantically" in instruction
 
+    def test_runtime_instruction_warns_when_voice_control_is_off(self):
+        # Gate 1/Gate 2 refuse every actual tool call while voice is off, but
+        # a plain "what can you do" question never reaches a tool -- it is
+        # answered straight from this instruction, so the off state must be
+        # stated here or the model narrates capabilities as if nothing changed.
+        instruction = _one_runtime_instruction(
+            SimpleNamespace(
+                state={
+                    STATE_VOICE_CONTEXT: {
+                        "available_action_ids": ["location.pause_updates"],
+                        "voice_settings": {"voice_enabled": False},
+                    }
+                }
+            )
+        )
+
+        assert "VOICE CONTROL IS OFF" in instruction
+        assert "Do not describe, offer, or attempt any action" in instruction
+
+    def test_runtime_instruction_has_no_voice_off_warning_when_voice_is_on(self):
+        instruction = _one_runtime_instruction(
+            SimpleNamespace(
+                state={
+                    STATE_VOICE_CONTEXT: {
+                        "available_action_ids": ["location.pause_updates"],
+                        "voice_settings": {"voice_enabled": True},
+                    }
+                }
+            )
+        )
+
+        assert "VOICE CONTROL IS OFF" not in instruction
+
     def test_runtime_instruction_prioritizes_top_modal_layer(self):
         instruction = _one_runtime_instruction(
             SimpleNamespace(
@@ -360,6 +393,29 @@ class TestSpecialistTurn:
         assert result["status"] == "domain_disabled"
         assert result["reason"] == "voice_domain_disabled_by_user"
         assert "Location" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_refuses_every_specialist_when_the_master_toggle_is_off(self):
+        # The master Voice control switch, distinct from any per-domain
+        # toggle: turning it off must refuse specialist delegation the same
+        # way a domain-specific disable does, not just influence the model's
+        # own conversational judgment.
+        result = await _specialist_turn(
+            "agent_location",
+            "share my location with Sarah",
+            _tool_context(
+                {
+                    STATE_USER_ID: "u1",
+                    STATE_CONSENT_TOKEN: "t1",
+                    STATE_VOICE_CONTEXT: {
+                        "voice_settings": {"voice_enabled": False},
+                    },
+                }
+            ),
+        )
+        assert result["status"] == "domain_disabled"
+        assert result["reason"] == "voice_disabled_by_user"
+        assert "Location" not in result["message"]
 
     @pytest.mark.asyncio
     async def test_domain_disabled_takes_priority_over_missing_auth(self):
@@ -762,6 +818,19 @@ class TestRunAppAction:
         assert not any(k.startswith(f"{_STATE_PENDING_DIRECTIVE}:") for k in state)
 
     @pytest.mark.asyncio
+    async def test_run_app_action_refuses_when_voice_entirely_disabled(self):
+        state = {
+            "hussh:voice_context": {
+                "available_action_ids": ["location.pause_updates"],
+                "voice_settings": {"voice_enabled": False},
+            }
+        }
+        result = await run_app_action("location.pause_updates", {}, _tool_context(state))
+        assert result["status"] == "domain_disabled"
+        assert "Location" not in result["message"]
+        assert not any(k.startswith(f"{_STATE_PENDING_DIRECTIVE}:") for k in state)
+
+    @pytest.mark.asyncio
     async def test_run_app_action_allows_when_domain_not_disabled(self):
         state = {
             "hussh:voice_context": {
@@ -788,6 +857,21 @@ class TestRunAppAction:
             "hussh:voice_context": {
                 "available_action_ids": ["location.select_share_recipient"],
                 "voice_settings": {"disabled_domains": ["location"]},
+            }
+        }
+        result = await start_app_goal(
+            "location.select_share_recipient", {"person": "Sarah"}, _tool_context(state)
+        )
+        assert result["status"] == "domain_disabled"
+        assert not any(k.startswith(f"{_STATE_PENDING_DIRECTIVE}:") for k in state)
+        assert _STATE_GOAL_RUN not in state
+
+    @pytest.mark.asyncio
+    async def test_start_app_goal_refuses_when_voice_entirely_disabled(self):
+        state = {
+            "hussh:voice_context": {
+                "available_action_ids": ["location.select_share_recipient"],
+                "voice_settings": {"voice_enabled": False},
             }
         }
         result = await start_app_goal(

--- a/consent-protocol/tests/test_specialist_availability.py
+++ b/consent-protocol/tests/test_specialist_availability.py
@@ -24,6 +24,16 @@ class TestDomainDisabled:
         assert availability.state == "domain_disabled"
         assert availability.reason_code == "voice_domain_disabled_by_user"
 
+    def test_refuses_every_specialist_when_the_master_toggle_is_off(self):
+        # The master Voice control switch is distinct from every per-domain
+        # toggle: turning it off must refuse regardless of disabled_domains.
+        availability = _resolve(
+            "agent_location",
+            {"voice_settings": {"voice_enabled": False, "disabled_domains": []}},
+        )
+        assert availability.state == "domain_disabled"
+        assert availability.reason_code == "voice_disabled_by_user"
+
     def test_allows_a_specialist_whose_domain_is_not_restricted(self):
         availability = _resolve(
             "agent_location",

--- a/consent-protocol/tests/test_voice_domain_policy.py
+++ b/consent-protocol/tests/test_voice_domain_policy.py
@@ -2,6 +2,7 @@ from hushh_mcp.one_adk.voice_domain_policy import (
     VOICE_DOMAIN_ACTION_PREFIXES,
     VOICE_DOMAIN_SPECIALIST_IDS,
     is_voice_domain_disabled,
+    is_voice_entirely_disabled,
     resolve_voice_domain,
     resolve_voice_domain_for_specialist,
     voice_domain_label,
@@ -64,6 +65,30 @@ class TestIsVoiceDomainDisabled:
     def test_true_with_a_set_or_tuple_too(self):
         assert is_voice_domain_disabled("location", {"location"}) is True
         assert is_voice_domain_disabled("location", ("location",)) is True
+
+
+class TestIsVoiceEntirelyDisabled:
+    def test_true_only_when_voice_enabled_is_explicitly_false(self):
+        assert is_voice_entirely_disabled({"voice_enabled": False}) is True
+
+    def test_false_when_voice_enabled_is_true(self):
+        assert is_voice_entirely_disabled({"voice_enabled": True}) is False
+
+    def test_fails_open_when_the_key_is_absent(self):
+        # sanitize_voice_settings always stamps this key, but a non-live
+        # caller or an older cached snapshot may not -- absence must never
+        # read as "disabled".
+        assert is_voice_entirely_disabled({}) is False
+
+    def test_fails_open_when_voice_settings_is_malformed(self):
+        assert is_voice_entirely_disabled(None) is False
+        assert is_voice_entirely_disabled("voice_enabled") is False
+        assert is_voice_entirely_disabled(False) is False
+
+    def test_ignores_disabled_domains_entirely(self):
+        # The master toggle is orthogonal to the per-domain list -- an empty
+        # or absent disabled_domains must not affect this check either way.
+        assert is_voice_entirely_disabled({"voice_enabled": False, "disabled_domains": []}) is True
 
 
 class TestVoiceDomainLabel:

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4903,7 +4903,7 @@
     "cache_manifest": "5dfec3e2a668bae6e7e5c0fee9e9bf2ec89a470aa86362d9bf832c3a3bf21edb",
     "data_plane": "314c1b4e33e47c02b2438aade82b0b92d09f21404e7dbff62b45463b2f51d70c",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "797c80df3cec108b4686510d6aa01c8141bc1629ededa6577498335cbf69e590",
+    "one_specialist_tools": "e6e3e5388d1f1660d0f72c295fceb091116bbf66944f00b85454fa7d2c76d768",
     "route_index": "dcd8ea3905524f2633bf19deb32a23966cd25d03f7b459d8edb532ee6b7fb093",
     "route_layout": "3c9da85499419e4a856d61ca635c78d68e63439c1efc9c23cbf013391f28ffad",
     "surface_map": "700d6fccea2e3b614b1385d3c3ca87fa414c92f8ad665322719becf4cb702f46",


### PR DESCRIPTION
## Summary

Reported: turning off "Voice control" in Voice settings did nothing —
the agent kept working and, when asked what it can do, described
everything as if the switch were still on.

Root cause: only `disabled_domains` and `require_tap_confirmation` were
ever wired into Gate 1 (`run_app_action`, `start_app_goal`) and Gate 2
(specialist delegation). The master `voice_enabled` field flowed all the
way into the live context sent to the model, but nothing ever read it —
turning it off only disabled the *other* switches in the settings panel
itself, cosmetically.

- Gate 1 and Gate 2 now refuse every action/specialist delegation (not
  just a specific domain) when `voice_enabled` is `false`, with a
  distinct message that says voice control is off rather than naming
  one domain.
- The refusal only fires on an actual tool call, so a plain "what can
  you do" question never reaches it. Added a system-instruction note so
  the model states the off condition directly instead of narrating
  capabilities as if voice were still on.
- New `is_voice_entirely_disabled()` in `voice_domain_policy.py`, fails
  open (matches every other read of `voice_settings`).

## Test plan
- [x] New unit tests for `is_voice_entirely_disabled` (5 cases)
- [x] New `run_app_action`/`start_app_goal` refusal tests
- [x] New specialist-delegation refusal test
- [x] New system-instruction tests (warning present when off, absent when on)
- [x] Full existing suite (`test_voice_domain_policy.py`,
      `test_specialist_availability.py`, `test_one_adk_agent_tree.py`) —
      128/128 passing
- [x] `mypy`, `ruff`, `bandit` clean
- [x] Regenerated `runtime-topology-index.v1.json` (content hash changed)