### PR TITLE
fix(one-location): group the actions together, and let the tab strip share the cards' edges

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1244,6 +1244,38 @@ describe("OneLocationAgentPage", () => {
     expect(await toneOf("Needs my review")).toBe("orange");
   });
 
+  it("groups the two things you do apart from the things that are happening", async () => {
+    // Reported: "share location / request location ek sath hona chahiye kyuki
+    // yeh user ke action items hain" — sharing your location and asking for
+    // someone else's are the same kind of decision pointed in opposite
+    // directions, and they sat two groups apart: one alone at the top, the
+    // other buried under three status rows.
+    //
+    // Everything else on this tab is either what is already happening (active
+    // shares, shared with me, needs my review) or where to look at it (Your
+    // Map) or how to change it (Settings). Two groups, not three.
+    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    const actions = await screen.findByTestId("one-location-now-share");
+    expect(within(actions).getByText("Share location")).toBeTruthy();
+    expect(within(actions).getByText("Request location")).toBeTruthy();
+
+    const rest = screen.getByTestId("one-location-now-status");
+    expect(within(rest).getByText("Your Map")).toBeTruthy();
+    expect(within(rest).getByText("Active shares")).toBeTruthy();
+    expect(within(rest).getByText("Settings")).toBeTruthy();
+
+    // The two must not drift back apart.
+    expect(within(rest).queryByText("Share location")).toBeNull();
+    expect(within(rest).queryByText("Request location")).toBeNull();
+    // And the standalone map group is gone, so the tab is two groups.
+    expect(screen.queryByTestId("one-location-now-primary")).toBeNull();
+  });
+
   it("keeps the heading and location toggle inline as the only header action", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -150,7 +150,22 @@ export function TopShellTabs({
         className={cn(
           "relative flex",
           isLocationTabs
-            ? "mx-5 h-9 w-[calc(100%-40px)] max-w-[720px] rounded-[10px] bg-[color:var(--app-neutral-fill)] p-0.5"
+            ? // Same edges as the cards under it, at every width.
+              //
+              // This carried `mx-5` on top of the frame's own
+              // `px-[var(--page-inline-gutter-standard)]`, so it paid the page
+              // gutter twice and sat 40px narrower than the grouped cards on
+              // EVERY phone — 36px from the edge against their 16px. And it
+              // capped at 720px, a number belonging to nothing else here, while
+              // the Location column is 880px: 104-112px short on desktop.
+              //
+              // The cap is now the page column's own content width, so the two
+              // cannot drift apart again. Both tokens already exist. Scoped to
+              // Location by the `isLocationTabs` branch above — the other four
+              // tab sets take the underline arm and do not move. Do NOT
+              // generalise this: the RIA workspace runs a 96rem shell, and an
+              // 880px cap would leave its strip ~600px short per side.
+              "h-9 w-full max-w-[calc(var(--app-shell-agent)-2*var(--page-inline-gutter-standard))] rounded-[10px] bg-[color:var(--app-neutral-fill)] p-0.5"
             : "h-full w-full",
         )}
         role="tablist"

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1406,6 +1406,11 @@ function NowHub({
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
           rather than only the screen it lives on. */}
+      {/* The two things a person DOES on this screen, together. Sharing your
+          location and asking for someone else's are the same kind of decision
+          pointed in opposite directions, and they were two groups apart — one
+          alone at the top, the other buried under three status rows. Everything
+          below is what is already happening, or where to look at it. */}
       <SettingsGroup
         separatorInset
         testId="one-location-now-share"
@@ -1422,10 +1427,32 @@ function NowHub({
           voiceControlId="one-location-action-share"
           voiceActionId="location.open_share"
         />
+        {/* Asking someone to share was reachable only from the People tab, so
+            the Now tab listed every way to give a location out and none to ask
+            for one. Same flow and same voice control id as that entry -- this
+            is an additional way in, not a second implementation. */}
+        {/* Not `Send`: that is the same paper-plane silhouette as `Navigation`
+            on "Share location" two rows up, so at row size the two entries read
+            as the same icon -- and they are opposites. A speech bubble asking a
+            question is distinct at a glance and matches what the flow does:
+            "Requests should explain why. The other person chooses whether to
+            share." Radar and Crosshair were rejected for implying tracking on a
+            surface built around consent. */}
+        <SettingsRow
+          icon={MessageCircleQuestionMark}
+          iconTone="blue"
+          title="Request location"
+          density="compact"
+          chevron
+          onClick={onRequestLocation}
+          testId="one-location-request-row"
+          voiceControlId="one-location-action-ask"
+          voiceActionId="location.open_ask"
+        />
       </SettingsGroup>
       <SettingsGroup
         separatorInset
-        testId="one-location-now-primary"
+        testId="one-location-now-status"
         shellClassName={groupedShellClassName}
       >
         <SettingsRow
@@ -1439,13 +1466,6 @@ function NowHub({
           voiceControlId="one-location-open-map"
           voiceActionId="location.open_map"
         />
-      </SettingsGroup>
-
-      <SettingsGroup
-        separatorInset
-        testId="one-location-now-status"
-        shellClassName={groupedShellClassName}
-      >
         <SettingsRow
           icon={UsersRound}
           iconTone={activeSharesIconTone}
@@ -1478,28 +1498,6 @@ function NowHub({
           onClick={onOpenNeedsReview}
           voiceControlId="one-location-action-needs-review"
           voiceActionId="location.open_needs_review"
-        />
-        {/* Asking someone to share was reachable only from the People tab, so
-            the Now tab listed every way to give a location out and none to ask
-            for one. Same flow and same voice control id as that entry -- this
-            is an additional way in, not a second implementation. */}
-        {/* Not `Send`: that is the same paper-plane silhouette as `Navigation`
-            on "Share location" two rows up, so at row size the two entries read
-            as the same icon -- and they are opposites. A speech bubble asking a
-            question is distinct at a glance and matches what the flow does:
-            "Requests should explain why. The other person chooses whether to
-            share." Radar and Crosshair were rejected for implying tracking on a
-            surface built around consent. */}
-        <SettingsRow
-          icon={MessageCircleQuestionMark}
-          iconTone="blue"
-          title="Request location"
-          density="compact"
-          chevron
-          onClick={onRequestLocation}
-          testId="one-location-request-row"
-          voiceControlId="one-location-action-ask"
-          voiceActionId="location.open_ask"
         />
         <SettingsRow
           icon={Lock}

--- a/hushh-webapp/e2e/one-location-tab-strip.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-tab-strip.layout.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * The Location hub's Menu / People / Links strip, measured against the cards
+ * under it.
+ *
+ * Reported: the strip should span the content width "jaisa apple mein hota
+ * hain". It did not, for two stacked reasons, and neither was visible without
+ * measuring:
+ *
+ *   1. The tablist carried `mx-5` INSIDE a frame that already applies
+ *      `px-[var(--page-inline-gutter-standard)]`, so it paid the page gutter
+ *      twice — left edge 36px against the cards' 16px, 40px narrower on EVERY
+ *      phone. This is not a desktop-only defect.
+ *   2. It capped at `max-w-[720px]`, a number belonging to nothing else on the
+ *      screen, while the Location column is 880px. 112px short at 1024, 104px
+ *      at 1280 and 1440.
+ *
+ * THE ASSERTION IS DELIBERATELY RELATIVE. It compares the tablist's edges to
+ * the MEASURED card's edges, never to 880 or 824. Asserting literals would lock
+ * in the coupling to `AppPageShell width="agent"` rather than guard it: change
+ * that prop and a literal test keeps passing while the strip silently
+ * mismatches again.
+ *
+ * The strip lives in the FIXED top bar and the cards live in the page, so they
+ * are siblings, not ancestor and descendant — two independently measured
+ * frames that have to agree. That is exactly why this needs a browser.
+ *
+ * Run: npx playwright test e2e/one-location-tab-strip.layout.spec.ts
+ */
+
+const WEBAPP_ROOT = process.cwd();
+
+/** Every compact width the product supports, plus the desktop steps. */
+const WIDTHS = [320, 360, 375, 390, 430, 768, 1024, 1280, 1440] as const;
+
+/**
+ * The Location tablist's class string, read out of the component.
+ *
+ * Anchored on the `isLocationTabs` branch rather than on the class text itself.
+ * Anchoring on the text means any edit to it makes this throw "marker not
+ * found" instead of reporting the geometry that actually broke — the spec would
+ * fail, but for the wrong reason, and would say nothing useful.
+ */
+function locationTablistClass(): string {
+  const source = fs.readFileSync(
+    path.join(WEBAPP_ROOT, "components/app-ui/top-shell-tabs.tsx"),
+    "utf8",
+  );
+  // Anchored on the pill's own fill token, which is what makes this element the
+  // Location segmented control and appears nowhere else in the file. Anchoring
+  // on the width classes instead would make any edit to them throw "not found"
+  // rather than report the geometry that broke.
+  const anchor = source.indexOf("bg-[color:var(--app-neutral-fill)]");
+  if (anchor < 0) throw new Error("Location tablist fill token not found");
+  const open = source.lastIndexOf('"', anchor);
+  const close = source.indexOf('"', anchor);
+  if (open < 0 || close < 0) throw new Error("tablist class string not found");
+  return source.slice(open + 1, close);
+}
+
+const TABLIST_CLASS = locationTablistClass();
+
+/** The top bar's frame and the page shell's frame — the two that must agree. */
+const FRAME_CLASS = "mx-auto w-full px-[var(--page-inline-gutter-standard)]";
+
+
+/**
+ * The shell width and the gutter ladder, lifted from app/globals.css.
+ *
+ * Read, not copied: the whole point of this contract is that the strip and the
+ * page column share one measure, so the fixture must use the shipping values.
+ */
+function tokenCss(): string {
+  const css = fs.readFileSync(path.join(WEBAPP_ROOT, "app/globals.css"), "utf8");
+  const agent = /--app-shell-agent:\s*([^;]+);/.exec(css);
+  if (!agent) throw new Error("--app-shell-agent not found in globals.css");
+
+  // Every declaration of the gutter, in source order, with the min-width it
+  // sits under (the base one has none).
+  const gutters: { min: number; value: string }[] = [];
+  for (const m of css.matchAll(/--page-inline-gutter-standard:\s*([^;]+);/g)) {
+    const before = css.slice(0, m.index ?? 0);
+    const media = [...before.matchAll(/@media[^{]*\(min-width:\s*(\d+)px\)/g)].pop();
+    const openBraces = (before.match(/\{/g) ?? []).length;
+    const closeBraces = (before.match(/\}/g) ?? []).length;
+    const insideMedia = openBraces - closeBraces > 1;
+    gutters.push({
+      min: insideMedia && media ? Number(media[1]) : 0,
+      value: m[1].trim(),
+    });
+  }
+  if (!gutters.length) throw new Error("gutter token not found in globals.css");
+
+  const base = gutters.filter((g) => g.min === 0).pop()!;
+  const steps = [...new Map(gutters.filter((g) => g.min > 0).map((g) => [g.min, g])).values()]
+    .sort((a, b) => a.min - b.min);
+
+  return [
+    `:root{--app-shell-agent:${agent[1].trim()};--page-inline-gutter-standard:${base.value}}`,
+    ...steps.map(
+      (g) =>
+        `@media (min-width:${g.min}px){:root{--page-inline-gutter-standard:${g.value}}}`,
+    ),
+    ".app-page-shell[data-app-shell-width=\"agent\"]{max-width:var(--app-shell-agent)}",
+  ].join("\n");
+}
+
+async function buildFixture(): Promise<string> {
+  const { compile } = (await import(
+    path.join(WEBAPP_ROOT, "node_modules/tailwindcss/dist/lib.mjs")
+  )) as {
+    compile: (css: string, opts: unknown) => Promise<{ build: (c: string[]) => string }>;
+  };
+
+  const compiler = await compile('@import "tailwindcss";', {
+    base: path.join(WEBAPP_ROOT, "node_modules"),
+    onDependency: () => {},
+    loadStylesheet: async (id: string, base: string) => {
+      const file =
+        id === "tailwindcss"
+          ? path.join(WEBAPP_ROOT, "node_modules/tailwindcss/index.css")
+          : path.resolve(base, id);
+      return {
+        path: file,
+        base: path.dirname(file),
+        content: fs.readFileSync(file, "utf8"),
+      };
+    },
+  });
+
+  const markup = `
+<div data-app-top-bar style="position:fixed;inset-inline:0;top:0">
+  <div style="position:relative;width:100%">
+    <div class="${FRAME_CLASS} flex flex-col" style="max-width:80rem">
+      <div style="position:relative;width:100%;flex-shrink:0">
+        <div class="flex h-14 w-full items-center justify-center">
+          <div data-testid="tablist" role="tablist" class="${TABLIST_CLASS}">
+            <button class="flex h-full flex-1 items-center justify-center px-3">Menu</button>
+            <button class="flex h-full flex-1 items-center justify-center px-3">People</button>
+            <button class="flex h-full flex-1 items-center justify-center px-3">Links</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<main class="app-page-shell ${FRAME_CLASS} max-w-[880px]" data-app-shell-width="agent" style="padding-top:56px">
+  <div class="w-full min-w-0 space-y-4">
+    <div data-testid="card" data-ui-role="grouped-card" style="height:60px;background:#eee;border-radius:24px"></div>
+  </div>
+</main>`;
+
+  const used = new Set<string>();
+  for (const match of markup.matchAll(/class="([^"]*)"/g)) {
+    for (const token of match[1].split(/\s+/)) if (token) used.add(token);
+  }
+  const css = compiler.build([...used]);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tab-strip-"));
+  fs.writeFileSync(path.join(dir, "fixture.css"), css);
+  fs.writeFileSync(
+    path.join(dir, "fixture.html"),
+    `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="fixture.css">
+<style>
+  /* The two tokens this contract turns on, READ OUT OF app/globals.css at test
+     time rather than hand-copied — if the shell width or the gutter ladder is
+     retuned, this fixture moves with it instead of quietly certifying the old
+     numbers. globals.css itself cannot be compiled standalone here (its imports
+     do not resolve outside Next), which is why the working specs in this folder
+     all inject the tokens the same way. */
+  ${tokenCss()}
+  body{margin:0;font-family:-apple-system,system-ui,sans-serif}
+</style>
+</head><body>${markup}</body></html>`,
+  );
+  return `file://${path.join(dir, "fixture.html")}`;
+}
+
+test.describe("One Location tab strip", () => {
+  for (const width of WIDTHS) {
+    test(`shares its edges with the cards below at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(await buildFixture());
+
+      const measured = await page.evaluate(() => {
+        const tablist = document
+          .querySelector('[data-testid="tablist"]')!
+          .getBoundingClientRect();
+        const card = document
+          .querySelector('[data-testid="card"]')!
+          .getBoundingClientRect();
+        return {
+          tabLeft: Math.round(tablist.left * 100) / 100,
+          tabRight: Math.round(tablist.right * 100) / 100,
+          tabWidth: Math.round(tablist.width * 100) / 100,
+          cardLeft: Math.round(card.left * 100) / 100,
+          cardRight: Math.round(card.right * 100) / 100,
+          cardWidth: Math.round(card.width * 100) / 100,
+        };
+      });
+
+      // THE CONTRACT: the strip and the cards are one column.
+      expect(
+        Math.abs(measured.tabLeft - measured.cardLeft),
+        `left edges differ: strip ${measured.tabLeft} vs card ${measured.cardLeft}`,
+      ).toBeLessThanOrEqual(0.5);
+      expect(
+        Math.abs(measured.tabRight - measured.cardRight),
+        `right edges differ: strip ${measured.tabRight} vs card ${measured.cardRight}`,
+      ).toBeLessThanOrEqual(0.5);
+      expect(
+        Math.abs(measured.tabWidth - measured.cardWidth),
+        `widths differ: strip ${measured.tabWidth} vs card ${measured.cardWidth}`,
+      ).toBeLessThanOrEqual(0.5);
+
+      // And neither leaves the viewport.
+      expect(measured.tabLeft).toBeGreaterThanOrEqual(-0.5);
+      expect(measured.tabRight).toBeLessThanOrEqual(width + 0.5);
+    });
+  }
+
+  test("caps to the page column rather than an unrelated number", async () => {
+    // The cap has to be derived from the shell the page actually uses, or the
+    // two drift apart again the next time either is retuned. Reading it here
+    // stops a literal creeping back in.
+    expect(TABLIST_CLASS).toContain("var(--app-shell-agent)");
+    expect(TABLIST_CLASS).toContain("var(--page-inline-gutter-standard)");
+    expect(TABLIST_CLASS).not.toContain("max-w-[720px]");
+    // `mx-5` was the second inset that made it 40px narrower on every phone.
+    expect(TABLIST_CLASS).not.toContain("mx-5");
+  });
+});

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
-    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts e2e/connect-circle-cta.layout.spec.ts e2e/one-location-live-share.layout.spec.ts e2e/one-location-duration-ladder.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts e2e/one-location-checkin-card.layout.spec.ts e2e/feed-needs-you-row.layout.spec.ts --project=chromium && CI=1 playwright test e2e/connect-circle-cta.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts e2e/feed-needs-you-row.layout.spec.ts --project=webkit",
+    "test:layout-contracts": "CI=1 playwright test e2e/one-location-ready-panel.layout.spec.ts e2e/save-location-sheet.layout.spec.ts e2e/connect-circle-cta.layout.spec.ts e2e/one-location-live-share.layout.spec.ts e2e/one-location-duration-ladder.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts e2e/one-location-checkin-card.layout.spec.ts e2e/feed-needs-you-row.layout.spec.ts e2e/one-location-tab-strip.layout.spec.ts --project=chromium && CI=1 playwright test e2e/connect-circle-cta.layout.spec.ts e2e/gemini-endpoint-fields.layout.spec.ts e2e/feed-needs-you-row.layout.spec.ts e2e/one-location-tab-strip.layout.spec.ts --project=webkit",
     "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check && npm run verify:route-orchestration-index",

--- a/hushh-webapp/playwright.config.ts
+++ b/hushh-webapp/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       // radius defect it covers is INVISIBLE in Chromium. A Chromium-only run
       // passes the broken control.
       testMatch:
-        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout)\.spec\.ts/,
+        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout|one-location-tab-strip\.layout)\.spec\.ts/,
     },
     {
       name: "firefox",


### PR DESCRIPTION
## 1. Share location and Request location now sit together

> "share location / request location ek sath hona chahiye kyuki yeh user ke action items hain"

They were two groups apart — Share alone at the top, Request buried under three status rows. They're the same kind of decision pointed in opposite directions (give my location / ask for yours), and the only two things on this tab a person **does**. Everything else is what's already happening (active shares, shared with me, needs my review), where to look at it (Your Map), or how to change it (Settings).

**Three groups become two**, which also takes a card off a screen that's been called busy.

## 2. The Menu / People / Links strip now shares the cards' edges

> "menu people links, ki width expand karna chahiye jaisa apple mein hota hain"

Two stacked causes, both measured in Chromium against the real tokens:

| | |
|---|---|
| **Double inset** | The tablist carried `mx-5` *inside* a frame that already applies `px-[var(--page-inline-gutter-standard)]` — it paid the page gutter twice. Left edge **36px against the cards' 16px: 40px narrower on every phone.** Never a desktop-only defect. |
| **Wrong cap** | `max-w-[720px]`, a number belonging to nothing else on screen, while the Location column is 880px. **112px short at 1024, 104px at 1280/1440.** |

The cap is now the page column's own content width, derived from the tokens that already define it, so the two can't drift apart again. **Measured 0.0px edge error at 320/360/375/390/430/768/1024/1280/1440.**

Scoped to Location by the `isLocationTabs` branch the component already had — the other four tab sets take the underline arm and don't move. **Deliberately not generalised:** the RIA workspace runs a 96rem shell, where an 880px cap would leave its strip ~600px short per side.

## Coverage

A new browser spec measures the strip against the **measured card** at all nine widths, in Chromium and WebKit, enumerated in `test:layout-contracts` and opted into the webkit project. It asserts against the card's real rect rather than against `880`/`824` on purpose — literals would lock in the coupling to `AppPageShell width="agent"` instead of guarding it.

**Mutation-checked twice.** The first version anchored its class lookup on the width classes themselves, so reverting the fix made it throw *"not found"* instead of reporting geometry — failing for the wrong reason and saying nothing useful. It now anchors on the pill's fill token, and the mutation produces the real message: `left edges differ: strip 36 vs card 16`.

The regrouping has its own test, also mutation-checked.

## Not bundled

Renaming the **"Menu"** tab. It is the only UI-furniture noun in the whole registry (Finance is Market/Portfolio/Analysis; Consent is Requests/Active/History/Connections) — but `value: "now"` is the `?view=now` deep link and Kai's `location.open_now` contract, so that's a copy change with its own risk surface and doesn't belong inside a width fix.

## Verification

- typecheck, lint, `verify:design-system` clean
- **151 Playwright contracts** pass in Chromium and WebKit
- full vitest **28 failed / 4395 passed** vs **27 failed / 4395 passed** on `origin/main`

The one delta is `pkm-natural-panel.test.tsx` — unrelated to Location, passes **3/3 in isolation on both trees**, and flaked on the baseline side in an earlier round. A full-suite ordering flake, not this change.