### PR TITLE
fix(app-shell): clear the header's fade for anchor jumps and the section rail

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -816,6 +816,36 @@ The first fails closed for any `flow` route that does not name the file owning
 its clearance. The second measures the pixels at eight widths in Chromium and in
 WebKit — WebKit being the engine the iOS app actually runs.
 
+### R22 — A fixture that inherits `:root` is measuring a different app than the one that ships
+
+**Incident (2026-08-17, extending the R21 contract to the sticky section rail.)**
+The new browser test passed with the bug deliberately reintroduced. The fixture
+built the shell from `resolveSignedInShellContentOffset` and let everything else
+inherit from `app/globals.css`, which looked faithful and was not: CSS
+substitutes a custom property using the values present where it is **declared**,
+so `:root`'s `--top-shell-mask-visible-height` bakes in `:root`'s own
+`--top-fade-active` (8px) and keeps that computed value as it inherits. The real
+route shell re-declares the whole derived block, resolving the same token
+against 22px. The fixture's header was therefore **14px shorter** than the
+shipped one — and a rail pinned 6px too high cleared it comfortably.
+
+A passing new test is not evidence. Only the mutation is.
+
+**Rule.** When a test reproduces a runtime surface outside the app, it must
+build it from the **same exported function** the app uses, never from a
+hand-picked subset of tokens. If a value is re-declared at a scope below
+`:root`, inheriting it instead of re-declaring it silently changes the number.
+And every new contract test gets mutation-checked against the bug it claims to
+catch, before it is committed — reintroduce the defect, watch it go red, restore.
+
+**Check.**
+```bash
+cd ~/Desktop/husshresearch/hushh-webapp
+# The fixture and the shell must read one source; this returns two call sites.
+grep -rn "resolveTopShellGeometryStyle" app components e2e
+```
+One call site means something is hand-copying the geometry again.
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
+++ b/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { resolveTopShellGeometryStyle } from "@/components/app-ui/signed-in-shell-content-offset";
+
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
@@ -30,19 +32,36 @@ describe("tabbed ambient chrome contract", () => {
       "--ambient-chrome-wash: var(--ambient-chrome-fade-solid)",
     );
     expect(styles).toContain("var(--top-fade-active)");
-    expect(providers).toContain(
-      '"--top-fade-active": topShellMetrics.hasTabs ? "20px" : "22px"',
-    );
     expect(providers).toContain('"--top-ambient-tab-tail-midpoint": "8px"');
     expect(styles).not.toContain(
       "calc(var(--top-shell-reserved-height) + 50px)",
     );
-    expect(providers).toContain('"--top-shell-reserved-height":');
-    expect(providers).toContain('"--top-shell-visual-height":');
-    expect(providers).toContain('"--top-shell-live-height":');
-    expect(providers).toContain('"--top-shell-mask-tabs-gap":');
-    expect(providers).toContain('"--top-shell-mask-visible-height":');
-    expect(providers).toContain('"--top-tabs-total",');
+
+    // The derived geometry moved out of this file into one exported function
+    // so the layout contract can build the same shell (safe-changes R22).
+    // Assert the resolved values rather than the source text: a grep for a
+    // literal line breaks on any refactor while proving nothing about output.
+    expect(providers).toContain("resolveTopShellGeometryStyle({");
+
+    const plain = resolveTopShellGeometryStyle({ hasTabs: false });
+    const tabbed = resolveTopShellGeometryStyle({ hasTabs: true });
+
+    expect(plain["--top-fade-active"]).toBe("22px");
+    expect(tabbed["--top-fade-active"]).toBe("20px");
+    expect(plain["--top-tabs-total"]).toBe("0px");
+    expect(tabbed["--top-tabs-total"]).toBe(
+      "calc(var(--top-tabs-h) + var(--top-tabs-gap))",
+    );
+    for (const token of [
+      "--top-shell-reserved-height",
+      "--top-shell-visual-height",
+      "--top-shell-live-height",
+      "--top-shell-mask-tabs-gap",
+      "--top-shell-mask-visible-height",
+    ]) {
+      expect(plain[token], `${token} must be declared at route-shell scope`)
+        .toBeTruthy();
+    }
   });
 
   it("keeps the Consent bounded manager clear of the tab-mask tail", () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2219,11 +2219,15 @@ html.kb-open .ambient-chrome-mask--bottom {
   ) !important;
 }
 
-/* Anchor clearance: hash-targeted elements must clear the fixed top shell */
+/* Anchor clearance: hash-targeted elements must clear the fixed top shell.
+   Against the VISIBLE height, not the reserved one -- the mask is solid to
+   --top-shell-reserved-height and then dissolves over --top-fade-active, so
+   reserving only the solid part landed every jumped-to heading inside the
+   dissolve. See safe-changes R21. */
 [id]:target,
 [data-page-primary][id],
 [data-section-header][id] {
-  scroll-margin-top: var(--top-shell-reserved-height, 60px);
+  scroll-margin-top: var(--top-shell-mask-visible-height, 82px);
 }
 
 .fullscreen-flow-shell {

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -60,7 +60,10 @@ import {
 import { useAuth } from "@/hooks/use-auth";
 import { LocationBus } from "@/lib/one-location/location-bus";
 import { PersonaProvider } from "@/lib/persona/persona-context";
-import { resolveSignedInShellContentOffset } from "@/components/app-ui/signed-in-shell-content-offset";
+import {
+  resolveSignedInShellContentOffset,
+  resolveTopShellGeometryStyle,
+} from "@/components/app-ui/signed-in-shell-content-offset";
 import { NativeTestRouter } from "@/components/app-ui/native-test-router";
 import { RiaSurfaceScopeSync } from "@/components/ria/ria-surface-scope-sync";
 import { NativeTestBootstrap } from "@/components/app-ui/native-test-bootstrap";
@@ -203,39 +206,14 @@ function AppShellFrame({ children }: ProvidersProps) {
         "--page-top-local-offset": topShellMetrics.hasTabs
           ? routeLayout.pageTopLocalOffset || "0px"
           : routeLayout.pageTopLocalOffset || "0px",
-        "--top-tabs-gap": "var(--kai-route-tabs-content-gap)",
-        "--top-tabs-total": topShellMetrics.hasTabs
-          ? "calc(var(--top-tabs-h) + var(--top-tabs-gap))"
-          : "0px",
-        "--top-subnav-total": "0px",
-        "--top-systembar-row-gap": "4px",
-        // These derived values must be declared at the route-shell scope.
-        // CSS custom-property substitution happens before inheritance, so a
-        // root-only definition would keep resolving the root's `0px` tabs.
-        "--top-shell-reserved-height":
-          "calc(var(--top-inset) + var(--top-systembar-row-gap) + var(--top-bar-h) + var(--top-tabs-total))",
-        "--top-shell-visual-height":
-          "calc(var(--top-shell-reserved-height) + var(--top-fade-active))",
-        "--top-shell-live-height":
-          "calc(var(--top-shell-visual-height) - var(--top-chrome-collapse-px, 0px))",
-        // The route-body tab gap is deliberate reading space, not a chrome
-        // extension. Keep it out of the mask so dark mode cannot form a band
-        // beneath the tab underline.
-        "--top-shell-mask-tabs-gap": "0px",
-        "--top-shell-mask-solid-height":
-          "calc(var(--top-shell-reserved-height) - var(--top-shell-mask-tabs-gap) - var(--top-chrome-collapse-px, 0px))",
-        "--top-shell-mask-visible-height":
-          "calc(var(--top-shell-mask-solid-height) + var(--top-fade-active))",
-        "--top-shell-h": "var(--top-shell-reserved-height)",
-        "--top-glass-h": "var(--top-shell-visual-height)",
-        // The mask owns the entire resolved shell plus a short,
-        // context-sensitive tail. Tabs stay fully solid through their
-        // underline, but the dissolve must finish before the first bounded
-        // route surface so its text remains readable.
-        "--top-fade-active": topShellMetrics.hasTabs ? "20px" : "22px",
+        // Derived top-shell geometry, declared at route-shell scope. It lives
+        // in one exported function because CSS substitutes a custom property
+        // with the values present where it is DECLARED -- so a root-only
+        // definition bakes in the root's `0px` tabs and 8px fade and keeps
+        // them. Anything reproducing the shell (the layout contract) reads the
+        // same function rather than copying a subset.
+        ...resolveTopShellGeometryStyle({ hasTabs: topShellMetrics.hasTabs }),
         "--top-ambient-tab-tail-midpoint": "8px",
-        "--top-content-pad":
-          "calc(var(--top-shell-visual-height) + var(--top-subnav-total, 0px) + var(--top-content-safe-gap))",
         "--kai-route-content-gap": topShellMetrics.hasTabs ? "28px" : "20px",
         "--kai-route-content-gap-sm": topShellMetrics.hasTabs ? "32px" : "24px",
         "--app-top-shell-visible": topShellMetrics.shellVisible ? "1" : "0",

--- a/hushh-webapp/components/app-ui/section-toc.tsx
+++ b/hushh-webapp/components/app-ui/section-toc.tsx
@@ -62,6 +62,19 @@ function SectionTocRows({
   );
 }
 
+/**
+ * Where the desktop rail pins itself.
+ *
+ * Measured against `--top-shell-mask-visible-height`, not
+ * `--top-shell-reserved-height`: the shell is solid to the reserved height and
+ * then dissolves over `--top-fade-active`, so pinning to the reserved height
+ * plus 1rem parked the rail's first row inside that dissolve, under the header.
+ * Exported so `e2e/app-shell-top-clearance.layout.spec.ts` measures the string
+ * that actually ships. See safe-changes R21.
+ */
+export const SECTION_TOC_RAIL_CLASSNAME =
+  "hidden lg:sticky lg:top-[calc(var(--top-shell-mask-visible-height)+1rem)] lg:block lg:self-start";
+
 /** Desktop-only sticky rail, hidden below the lg breakpoint. */
 export function SectionTocRail({
   entries,
@@ -75,7 +88,7 @@ export function SectionTocRail({
   description?: string;
 }) {
   return (
-    <aside className="hidden lg:sticky lg:top-[calc(var(--top-shell-reserved-height)+1rem)] lg:block lg:self-start">
+    <aside className={SECTION_TOC_RAIL_CLASSNAME}>
       <nav
         aria-label={title}
         className="overflow-hidden border-y border-border/60 bg-background/45"
@@ -84,7 +97,7 @@ export function SectionTocRail({
           <p className="text-sm font-semibold text-foreground">{title}</p>
           <RowDescription>{description}</RowDescription>
         </header>
-        <ScrollArea className="max-h-[calc(100dvh-var(--top-shell-reserved-height)-9rem)] border-t border-border/60">
+        <ScrollArea className="max-h-[calc(100dvh-var(--top-shell-mask-visible-height)-9rem)] border-t border-border/60">
           <div className="divide-y divide-border/60">
             <SectionTocRows
               entries={entries}

--- a/hushh-webapp/components/app-ui/signed-in-shell-content-offset.ts
+++ b/hushh-webapp/components/app-ui/signed-in-shell-content-offset.ts
@@ -35,6 +35,64 @@ const STANDARD_PAGE_TOP_START = "32px";
  */
 const FULLSCREEN_FLOW_PAGE_TOP_START = "var(--top-fade-active)";
 
+/**
+ * How far the top mask dissolves past its solid edge, published by the route
+ * shell in `app/providers.tsx`.
+ *
+ * The `:root` fallback in `globals.css` is a much smaller 8px, so anything that
+ * reproduces the shell outside the app -- notably
+ * `e2e/app-shell-top-clearance.layout.spec.ts` -- must use these values or it
+ * measures a header 14px shorter than the one that ships, and clearance bugs
+ * pass. Exported from here so the shell and its contract read one source.
+ */
+export const TOP_SHELL_FADE_ACTIVE_PX = {
+  withTabs: "20px",
+  withoutTabs: "22px",
+} as const;
+
+/**
+ * The top shell's derived geometry, declared at ROUTE-SHELL scope.
+ *
+ * These cannot live only in `:root`. CSS substitutes a custom property using
+ * the values present where it is DECLARED, so a `:root` definition of
+ * `--top-shell-mask-visible-height` bakes in `:root`'s own `--top-fade-active`
+ * (8px) and keeps that computed value as it inherits down, no matter what the
+ * shell sets below it. Re-declaring here is what makes the mask 82px instead of
+ * 68px on a real route -- and re-declaring is also the reason anything
+ * reproducing the shell outside the app must use this function rather than
+ * hand-copying a subset.
+ */
+export function resolveTopShellGeometryStyle(params: {
+  hasTabs: boolean;
+}): CSSProperties {
+  return {
+    "--top-tabs-gap": "var(--kai-route-tabs-content-gap)",
+    "--top-tabs-total": params.hasTabs
+      ? "calc(var(--top-tabs-h) + var(--top-tabs-gap))"
+      : "0px",
+    "--top-subnav-total": "0px",
+    "--top-systembar-row-gap": "4px",
+    "--top-shell-reserved-height":
+      "calc(var(--top-inset) + var(--top-systembar-row-gap) + var(--top-bar-h) + var(--top-tabs-total))",
+    "--top-shell-visual-height":
+      "calc(var(--top-shell-reserved-height) + var(--top-fade-active))",
+    "--top-shell-live-height":
+      "calc(var(--top-shell-visual-height) - var(--top-chrome-collapse-px, 0px))",
+    "--top-shell-mask-tabs-gap": "0px",
+    "--top-shell-mask-solid-height":
+      "calc(var(--top-shell-reserved-height) - var(--top-shell-mask-tabs-gap) - var(--top-chrome-collapse-px, 0px))",
+    "--top-shell-mask-visible-height":
+      "calc(var(--top-shell-mask-solid-height) + var(--top-fade-active))",
+    "--top-shell-h": "var(--top-shell-reserved-height)",
+    "--top-glass-h": "var(--top-shell-visual-height)",
+    "--top-fade-active": params.hasTabs
+      ? TOP_SHELL_FADE_ACTIVE_PX.withTabs
+      : TOP_SHELL_FADE_ACTIVE_PX.withoutTabs,
+    "--top-content-pad":
+      "calc(var(--top-shell-visual-height) + var(--top-subnav-total, 0px) + var(--top-content-safe-gap))",
+  } as CSSProperties;
+}
+
 export function resolveSignedInShellContentOffset(params: {
   shellVisible: boolean;
   routeLayoutMode: AppRouteLayoutMode;

--- a/hushh-webapp/e2e/app-shell-top-clearance.layout.spec.ts
+++ b/hushh-webapp/e2e/app-shell-top-clearance.layout.spec.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
-import { resolveSignedInShellContentOffset } from "../components/app-ui/signed-in-shell-content-offset";
+import {
+  resolveSignedInShellContentOffset,
+  resolveTopShellGeometryStyle,
+} from "../components/app-ui/signed-in-shell-content-offset";
+import { SECTION_TOC_RAIL_CLASSNAME } from "../components/app-ui/section-toc";
 
 /**
  * Nothing a route paints may sit under the fixed top shell.
@@ -107,7 +111,17 @@ function shellMarkup(mode: Mode): string {
            <p data-route-body>First line of the page</p>
          </main>`;
 
-  return `<div data-app-shell-root="true" style="${inlineStyle(offset.style)}">
+  // The derived geometry has to be re-declared here exactly as the route shell
+  // declares it. Inheriting the `:root` definitions instead resolves the mask
+  // against root's 8px fade rather than the shell's 22px, shortening the header
+  // by 14px -- enough for a real clearance bug to pass. Flow routes never carry
+  // contextual tabs.
+  const shellStyle = inlineStyle({
+    ...offset.style,
+    ...resolveTopShellGeometryStyle({ hasTabs: false }),
+  });
+
+  return `<div data-app-shell-root="true" style="${shellStyle}">
       <div data-app-top-bar style="position: fixed; inset-inline: 0; top: 0; z-index: 50;">
         <div
           data-top-mask
@@ -115,11 +129,19 @@ function shellMarkup(mode: Mode): string {
           style="height: var(--top-shell-mask-visible-height);"
         ></div>
       </div>
-      <div data-app-scroll-root="true">${body}</div>
+      <div data-app-scroll-root="true">
+        ${body}
+        <h2 data-section-header id="anchored-section">A jumped-to heading</h2>
+        <aside class="${SECTION_TOC_RAIL_CLASSNAME}" data-toc-rail>Sections</aside>
+      </div>
     </div>`;
 }
 
-const CANDIDATES = ["app-page-shell", "fullscreen-flow-shell"];
+const CANDIDATES = [
+  "app-page-shell",
+  "fullscreen-flow-shell",
+  ...SECTION_TOC_RAIL_CLASSNAME.split(/\s+/),
+];
 
 /**
  * One shell per document, deliberately. Rendering both in one page put the
@@ -205,5 +227,70 @@ test.describe("app shell top clearance", () => {
     expect(measured.visible).toBe(measured.reserved + measured.fade);
     expect(measured.padTop).toBeGreaterThan(measured.reserved);
     expect(measured.padTop).toBeGreaterThanOrEqual(measured.visible);
+  });
+
+  test("a jumped-to heading lands below the header, not inside its fade", async ({
+    page,
+  }) => {
+    // scroll-margin-top decides where the browser parks a hash target. Reserving
+    // only the solid part of the mask put every anchored heading 22px under the
+    // header on every route that has anchors.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(await writeFixture("standard"));
+
+    const measured = await page.evaluate(() => {
+      const px = (name: string) => {
+        const probe = document.createElement("div");
+        probe.style.cssText = `position:absolute;visibility:hidden;height:var(${name});`;
+        document.querySelector("[data-app-shell-root]")!.appendChild(probe);
+        const height = +probe.getBoundingClientRect().height.toFixed(2);
+        probe.remove();
+        return height;
+      };
+      const heading = document.querySelector("[data-section-header]")!;
+      return {
+        visible: px("--top-shell-mask-visible-height"),
+        reserved: px("--top-shell-reserved-height"),
+        scrollMargin: parseFloat(
+          getComputedStyle(heading).scrollMarginTop,
+        ),
+      };
+    });
+
+    expect(measured.scrollMargin).toBeGreaterThan(measured.reserved);
+    expect(measured.scrollMargin).toBeGreaterThanOrEqual(measured.visible);
+  });
+
+  test("the desktop section rail pins below the header", async ({ page }) => {
+    // lg: only -- the rail is display:none below 1024.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(await writeFixture("standard"));
+
+    const measured = await page.evaluate(() => {
+      const px = (name: string) => {
+        const probe = document.createElement("div");
+        probe.style.cssText = `position:absolute;visibility:hidden;height:var(${name});`;
+        document.querySelector("[data-app-shell-root]")!.appendChild(probe);
+        const height = +probe.getBoundingClientRect().height.toFixed(2);
+        probe.remove();
+        return height;
+      };
+      const rail = document.querySelector("[data-toc-rail]")!;
+      const style = getComputedStyle(rail);
+      return {
+        visible: px("--top-shell-mask-visible-height"),
+        reserved: px("--top-shell-reserved-height"),
+        display: style.display,
+        position: style.position,
+        top: parseFloat(style.top),
+      };
+    });
+
+    // If the rail stopped being a sticky lg: element this test would pass
+    // vacuously, so assert the posture it is measuring.
+    expect(measured.display).not.toBe("none");
+    expect(measured.position).toBe("sticky");
+    expect(measured.top).toBeGreaterThan(measured.reserved);
+    expect(measured.top).toBeGreaterThanOrEqual(measured.visible);
   });
 });


### PR DESCRIPTION
Follow-up to #5375, same defect class (safe-changes R21), two more surfaces.

Both measured clearance against `--top-shell-reserved-height` — the height the
top mask is **solid** to — rather than `--top-shell-mask-visible-height`, the
height it actually **paints** to.

| Surface | Cleared | Header paints to | |
|---|---|---|---|
| `scroll-margin-top` for `[id]:target` / `[data-page-primary]` / `[data-section-header]` | 60px | 82px | **22px under** |
| Desktop section rail (sticky) | 76px | 82px | **6px under** |

The anchor one is app-wide: every jump to a heading, on every route with
anchors, parked the heading inside the header. Its own comment read *"Anchor
clearance: hash-targeted elements must clear the fixed top shell"*.

## The test I nearly shipped that could not fail

The first version of the rail check **passed with the bug reintroduced**.

The fixture built the shell from `resolveSignedInShellContentOffset` and let
everything else inherit from `app/globals.css`. That looks faithful and isn't:
CSS substitutes a custom property using the values present where it is
**declared**, so `:root`'s `--top-shell-mask-visible-height` bakes in `:root`'s
own `--top-fade-active` (8px) and carries that computed value down, whatever the
shell sets below. The real route shell re-declares the whole derived block, so it
resolves against 22px.

The fixture was measuring a header **14px shorter** than the shipped one — and a
rail pinned 6px too high cleared it comfortably.

Fixed at the cause: the derived geometry is now one exported function,
`resolveTopShellGeometryStyle`, which `app/providers.tsx` spreads and the layout
contract builds its fixture from. Neither can drift without failing.

## Test changes

`ambient-chrome-tabs.contract.test.ts` asserted that block as **literal source
text** inside `providers.tsx`, so moving it broke the test. The greps are
replaced with assertions on the resolved values — those survive a refactor and
prove more than a string match ever did.

## Verification

- Both new browser cases mutation-checked: restore the old values, both go red.
- `npm run test:layout-contracts` — 125 chromium + 64 webkit passed.
- `npx tsc --noEmit`, `eslint` on every changed file — clean.
- `npm run test:ci` — 27 failures across 17 files, **every one also failing on
  untouched origin/main** (the suite is flaky by ±2 files; three baseline runs
  gave 17/27, 18/31, 17/27).
- All four generated indexes verified current — no artifact churn.

Adds R22. No user-facing copy changes.