### PR TITLE
fix(one-location): resync countdown clock on new grant/request data

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -3235,6 +3235,14 @@ function AskFlow({
     const timer = window.setInterval(() => setStatusNowMs(Date.now()), 30_000);
     return () => window.clearInterval(timer);
   }, []);
+  // A grant accepted between ticks would otherwise be measured against a
+  // `statusNowMs` from before it existed, inflating "Sharing with you, X
+  // more" by up to a tick's worth of staleness -- enough to round a whole
+  // hour up to "1h 1m more". Resyncing the instant new data lands keeps the
+  // remaining-time math honest from the very first render of a fresh grant.
+  useEffect(() => {
+    setStatusNowMs(Date.now());
+  }, [vm.receivedGrants, vm.requestedByMe]);
   return (
     <div className="space-y-5">
       <TaskFlowHeader


### PR DESCRIPTION
# Description

The "Request location" screen's "Sharing with you, {duration} more" row could show one extra minute over the requested duration right after a request was accepted (e.g. "1h 1m more" for a 1 hour request, "4h 1m more" for 4 hours). Backend grant/expiry math is exact (`now + timedelta(hours=duration)`, verified no buffer anywhere in the create/approve path); the bug was purely on the display side.

`AskFlow`'s `statusNowMs` clock (`location-redesign-hub.tsx`) only updates on a 30s `setInterval`, never resynced when new grant/request data arrives. If a grant was accepted between ticks, the row briefly rendered against a `nowMs` up to 30s stale -- old enough for `formatLocationRemaining`'s intentional ceil-to-minute rounding to round the (inflated) remaining time up into an extra whole minute. Fix: resync `statusNowMs` to `Date.now()` immediately whenever `receivedGrants`/`requestedByMe` change, in addition to the existing 30s tick.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` (Request location / Ask flow row status)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None (shared web component, no native surface)

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable (client-side display-only fix, reverting the effect addition is a no-op revert)

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `/one/location?action=ask` -- no live browser/Playwright run performed for this PR; relying on existing unit coverage (`hushh-webapp/lib/one-location/__tests__/duration-copy.test.ts`, `hushh-webapp/__tests__/components/request-recipient-status.test.ts`, 31 tests, unchanged, passing) plus code-level trace of the fix. A reviewer should do a live accept-cycle check before merge.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` (targeted: duration-copy + request-recipient-status suites; full suite has pre-existing unrelated flaky failures on this Windows sandbox -- worker-spawn timeouts and unrelated feature tests, none touching one-location)
  - [x] `cd hushh-webapp && npm run build`
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Reachable production attach point: `AskFlow` in `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx`, rendered from `/one/location?action=ask`.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (client component, shared by web and the mobile webview)
- [ ] **iOS**: Not applicable -- shared web component rendered inside the Capacitor webview, no native plugin code touched.
- [ ] **Android**: Not applicable -- same as iOS.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) -- not done live; see UI browser proof note above
- [ ] Tested on iOS Simulator/Device -- not applicable, no native code touched
- [ ] Tested on Android Emulator/Device -- not applicable, no native code touched
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

Not attached -- fix is a timing/clock-sync change with no visual/layout difference; existing screenshot in the linked bug report shows the "1h 1m more" defect this PR resolves.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? No -- it only changes which `Date.now()` snapshot is used to render an already-fetched grant's remaining time.
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: no new error paths; reverting the added `useEffect` fully restores prior behavior.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed -- not applicable, no dependency changes
