### PR TITLE
feat(voice): wire latency telemetry and fix native-unsafe backgrounding

### DIFF
--- a/hushh-webapp/__tests__/services/gemini-live-client.test.ts
+++ b/hushh-webapp/__tests__/services/gemini-live-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { GeminiLiveClient } from "@/lib/services/gemini-live-client";
+import * as voiceTelemetry from "@/lib/voice/voice-telemetry";
 
 describe("GeminiLiveClient action confirmation", () => {
   it("returns a typed disconnected result instead of throwing from an absent socket", async () => {
@@ -57,6 +58,35 @@ describe("GeminiLiveClient action confirmation", () => {
       await timeoutResult;
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+describe("GeminiLiveClient voice latency telemetry", () => {
+  it("logs session-ready latency the moment the handshake completes", async () => {
+    const logSpy = vi
+      .spyOn(voiceTelemetry, "logVoiceMetric")
+      .mockImplementation(() => undefined);
+    try {
+      const transport = new GeminiLiveClient();
+      const connection = transport as unknown as {
+        handleSocketMessage: (data: string) => Promise<void>;
+        sessionStartRequestedAt: number;
+      };
+      connection.sessionStartRequestedAt = performance.now() - 250;
+
+      await connection.handleSocketMessage(JSON.stringify({ setupComplete: {} }));
+
+      const call = logSpy.mock.calls.find(
+        ([payload]) => payload.metric === "voice_session_ready_ms",
+      );
+      expect(call).toBeDefined();
+      // >= the artificial 250ms head start, not an exact value -- this only
+      // needs to prove the clock actually started at start(), not at whatever
+      // instant the message happened to arrive.
+      expect(call?.[0].value).toBeGreaterThanOrEqual(250);
+    } finally {
+      logSpy.mockRestore();
     }
   });
 });

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -55,6 +55,7 @@ import { usePersonaState } from "@/lib/persona/persona-context";
 import {
   appInteractionCoordinator,
   useActiveActionRun,
+  useAppLifecycle,
   type DirectiveSettlement,
   type VoiceSessionLease,
 } from "@/lib/interaction/interaction-intent-coordinator";
@@ -1514,20 +1515,26 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     };
   }, [conversationActive, runtime?.oneVoiceContextSnapshot, runtime?.tier]);
 
+  // Not a raw `visibilitychange` listener: that event alone is known to be
+  // unreliable inside the native iOS/Android WebView shell, which is exactly
+  // where a leaked-open mic matters most. `appInteractionCoordinator`
+  // already merges DOM visibility with Capacitor's native `appStateChange`
+  // into one verdict -- this is the one place in the app that must react to
+  // real backgrounding, so it reads that verdict instead of duplicating half
+  // of it.
+  const appLifecycle = useAppLifecycle();
   useEffect(() => {
-    if (typeof document === "undefined") return;
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") return;
-      prewarmedRelayRef.current = null;
-      if (liveClientRef.current || conversationActive) {
-        stopConversation();
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [conversationActive, stopConversation]);
+    if (appLifecycle.state !== "background") return;
+    prewarmedRelayRef.current = null;
+    if (liveClientRef.current || conversationActive) {
+      stopConversation();
+    }
+  }, [
+    appLifecycle.state,
+    appLifecycle.revision,
+    conversationActive,
+    stopConversation,
+  ]);
 
   // Tear down the live session if the bar unmounts (route change, sign-out).
   // Also clear the shared voice store so a stale status (e.g. "error",

--- a/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
+++ b/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
@@ -537,6 +537,21 @@ export function useActionRuns(): readonly ActionRun[] {
   );
 }
 
+/**
+ * The app's own "active" / "background" verdict -- fed by both DOM
+ * `visibilitychange` AND Capacitor's native `appStateChange`, because
+ * visibility events alone are known to be unreliable inside the native
+ * iOS/Android WebView shell. Prefer this over a raw `visibilitychange`
+ * listener for anything that must reliably react to backgrounding on native.
+ */
+export function useAppLifecycle(): Readonly<AppLifecycleSnapshot> {
+  return useSyncExternalStore(
+    appInteractionCoordinator.subscribeLifecycle,
+    appInteractionCoordinator.getLifecycleSnapshot,
+    appInteractionCoordinator.getLifecycleSnapshot,
+  );
+}
+
 export function useActiveActionRun(): ActionRun | null {
   const runs = useActionRuns();
   for (let index = runs.length - 1; index >= 0; index -= 1) {

--- a/hushh-webapp/lib/services/gemini-live-client.ts
+++ b/hushh-webapp/lib/services/gemini-live-client.ts
@@ -13,6 +13,7 @@ import type {
   RealtimeVoiceTransport,
 } from "@/lib/voice/one-voice-transport";
 import { mapAgentVoiceStatusToOneVoiceState } from "@/lib/voice/voice-ui-state-machine";
+import { createVoiceTurnId, logVoiceMetric } from "@/lib/voice/voice-telemetry";
 
 /**
  * Browser client for Gemini Live full-duplex voice.
@@ -262,6 +263,10 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
   private visitorActivitySent = false;
   /** Real-time pacing guard for outbound audio; see sendRealtimeAudio. */
   private lastRealtimeAudioSentAt = 0;
+  /** `performance.now()` at the top of `start()`, for session-ready latency. */
+  private sessionStartRequestedAt = 0;
+  /** `Date.now()` of the first audio chunk of the currently open model turn, for turn-duration latency. */
+  private turnStartedAt: number | null = null;
   /** Frames discarded as backlog. Non-zero means the main thread stalled. */
   private droppedBacklogFrames = 0;
   private consecutiveSpeechFrames = 0;
@@ -335,6 +340,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
 
   async start(options?: OneVoiceTransportStartOptions): Promise<void> {
     if (this.ws) return;
+    this.sessionStartRequestedAt = performance.now();
     this.sessionId = createGeminiLiveSessionId();
     this.sourceSeq = 0;
     this.visitorActivitySent = false;
@@ -665,6 +671,12 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     if ("setupComplete" in message) {
       this.setupComplete = true;
       this.clearSetupTimeout();
+      logVoiceMetric({
+        metric: "voice_session_ready_ms",
+        value: performance.now() - this.sessionStartRequestedAt,
+        turnId: this.sessionId ?? createVoiceTurnId(),
+        tags: { provider: this.provider },
+      });
       // Push the initial app context (screen + governed consent token) now
       // that the session is live; the relay never accepts these in the URL.
       // Do not expose a listening mic until the relay acknowledges it. The
@@ -825,6 +837,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
 
     if (serverContent.interrupted) {
       this.modelTurnOpen = false;
+      // Cut short by the person, not a real "how long did the model take"
+      // sample -- drop it rather than let it skew voice_turn_duration_ms.
+      this.turnStartedAt = null;
       this.stopPlayback();
       this.setState("listening");
       return;
@@ -836,6 +851,15 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       // When audio is still queued, the last node's onended settles instead.
       this.modelTurnOpen = false;
       this.suppressModelAudio = false;
+      if (this.turnStartedAt !== null) {
+        logVoiceMetric({
+          metric: "voice_turn_duration_ms",
+          value: Date.now() - this.turnStartedAt,
+          turnId: this.sessionId ?? createVoiceTurnId(),
+          tags: { provider: this.provider },
+        });
+        this.turnStartedAt = null;
+      }
       if (
         this.activeSources.size === 0 &&
         !this.closed &&
@@ -1279,6 +1303,12 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     node.start(startAt);
     this.playheadTime = startAt + buffer.duration;
     this.lastAudioEnqueueAt = Date.now();
+    if (!this.modelTurnOpen) {
+      // First chunk of a NEW model turn (the prior one closed with
+      // turnComplete/interrupted, or this is the first turn of the
+      // session) -- the reference point turnComplete measures duration from.
+      this.turnStartedAt = Date.now();
+    }
     this.modelTurnOpen = true;
     this.setState("speaking");
     this.activeSources.add(node);
@@ -1358,6 +1388,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     if (this.closed) return;
     this.closed = true;
     this.setupComplete = false;
+    // A turn left open by a mid-turn stop must not leak into the next
+    // session's first voice_turn_duration_ms sample.
+    this.turnStartedAt = null;
     this.clearSetupTimeout();
     this.initialContextReady = false;
     this.initialContextInFlight = false;


### PR DESCRIPTION
## Summary
Part of #5377 (voice polish epic). Audited all four of the epic's scope areas against current code before touching anything -- most of it turned out to already be mature, deliberately-engineered code (barge-in, the waveform, the 17-state voice UI state machine, mic-denied fallback, clipping mitigation via output scheduling/resume fade). Only two real gaps:

1. **Latency telemetry was dead code.** `voice-telemetry.ts` defines `logVoiceMetric`/`createVoiceTurnId` but had zero call sites anywhere in the app -- there was no way to actually measure whether voice latency is "minimized" (the epic's own acceptance criterion). Wires two measurements into `GeminiLiveClient`:
   - `voice_session_ready_ms` -- mic + socket + setup handshake time, from `start()` to `setupComplete`.
   - `voice_turn_duration_ms` -- first response audio chunk to `turnComplete`. Deliberately excludes interrupted turns from the sample: a barge-in is the person cutting the model off, not a real "how long did it take" reading, and mixing the two would skew the metric toward looking faster than it is.

2. **Backgrounding used the wrong signal.** `agent-bar.tsx` tore down the live voice session on a raw DOM `visibilitychange` listener only. The app already has a purpose-built lifecycle coordinator, `appInteractionCoordinator`, that merges DOM visibility with Capacitor's native `appStateChange` -- specifically because visibility events alone are known to be unreliable inside the native iOS/Android WebView shell. `agent-bar.tsx` never subscribed to it, so a mic left open on native backgrounding may not have reliably torn down. Adds a `useAppLifecycle()` hook (matching the file's existing `useInteractionIntents`/`useActionRuns` pattern) and switches the teardown effect to read it instead.

Cross-platform verification (the epic's fourth scope item) is deliberately left open -- it requires real iOS/Android device testing, which isn't something this PR (or an agent) can close out.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] 275/275 relevant tests passing, including a new test proving `voice_session_ready_ms` is measured from the real session-start clock, not logged with a garbage value
- [x] `voice_turn_duration_ms` is not covered by an automated test -- exercising it fully would require mocking the WebAudio pipeline (AudioContext/GainNode/AudioBufferSourceNode), which doesn't exist in this test suite yet; verified by direct code review of the guarded `turnStartedAt` state instead (set only on a genuine first-chunk-of-turn transition, reset on `interrupted` and `stop()` so nothing leaks across turns/sessions)