### PR TITLE
fix(one-location): let a duration edit regrow within its original ceiling without re-asking

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1479,10 +1479,12 @@ def shorten_location_grant(
     payload: ShortenGrantRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    """Bring a grant's expiry earlier. Either party may call this; the
-    service rejects any attempt to move the expiry later -- extending
-    access is the owner's consent to give again, via request_access, not a
-    duration either side can hand themselves through this route."""
+    """Move a grant's expiry anywhere the owner already authorized. Either
+    party may call this; the service rejects any candidate past the grant's
+    ceiling (the furthest expiry the owner has ever explicitly authorized) --
+    growing past that ceiling is the owner's consent to give again, via
+    request_access, not a duration either side can hand themselves through
+    this route."""
     try:
         return {
             "grant": _service().shorten_grant(
@@ -1504,9 +1506,11 @@ def set_location_grant_duration(
     """Set a new end time on a share you own, in either direction.
 
     Owner only, and the service enforces that by matching on `owner_user_id`
-    alone. A recipient still has just `/shorten`: giving time back needs no
-    permission, taking more is the owner's to give -- and here the owner is the
-    caller, so lengthening their own share is that consent, not a bypass of it."""
+    alone. A recipient still has just `/shorten`, bounded by the grant's
+    ceiling: moving within it needs no permission, going past it is the
+    owner's to give -- and here the owner is the caller, so setting any new
+    end time on their own share (which also becomes the new ceiling) is that
+    consent, not a bypass of it."""
     try:
         return {
             "grant": _service().set_grant_duration(

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 154,
+  "expected_migration_version": 156,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -791,6 +791,7 @@
       "capability_scopes",
       "duration_hours",
       "expires_at",
+      "ceiling_expires_at",
       "duration_mode",
       "created_at",
       "updated_at",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 154,
+  "expected_migration_version": 156,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 154,
+  "expected_migration_version": 156,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -791,6 +791,7 @@
       "capability_scopes",
       "duration_hours",
       "expires_at",
+      "ceiling_expires_at",
       "duration_mode",
       "created_at",
       "updated_at",

--- a/consent-protocol/db/migrations/155_one_location_grant_ceiling.sql
+++ b/consent-protocol/db/migrations/155_one_location_grant_ceiling.sql
@@ -1,0 +1,62 @@
+-- One Location: remember how far the owner actually authorized a grant to
+-- run, separately from where its expiry currently sits.
+--
+-- `expires_at` is mutated in place by every duration edit -- `shorten_grant`
+-- moves it earlier, `set_grant_duration` moves it either way. Once the
+-- recipient shortens a 1-hour grant to 15 minutes, the fact that the owner
+-- once agreed to a full hour is gone: nothing on the row remembers it. So
+-- asking to go back up to 30 minutes -- still well inside what was already
+-- approved -- reads as a brand new ask for more time, and gets sent to the
+-- owner exactly like a request for 4 hours would. Shrink-then-regrow inside
+-- an already-approved window and shrink-then-request-beyond-it become the
+-- same code path, which is the bug: growing back toward what was already
+-- granted should need nobody's permission a second time.
+--
+-- `ceiling_expires_at` is that missing memory: the furthest-out expiry the
+-- owner has ever explicitly authorized for this grant. It moves only on an
+-- owner-authorized write (grant creation, an approved request, the owner's
+-- own duration edit) and never on the self-serve shrink/regrow a recipient
+-- (or either party, via `shorten_grant`) can do without asking. A duration
+-- edit that stays at or under the ceiling applies immediately, whichever
+-- direction it moves the live expiry; only a candidate past the ceiling
+-- still needs a fresh request_access the owner approves -- and approving it
+-- is itself an owner-authorized write, so it becomes the new ceiling.
+--
+-- NULL means "no ceiling known": an until_stopped grant (no expiry to bound
+-- in the first place) and any row written before this migration. Both fall
+-- back to comparing against the live `expires_at`, which is exactly today's
+-- behavior -- this column can only ever unlock a self-serve regrow that
+-- was previously blocked, never permit something that was allowed before.
+
+BEGIN;
+
+ALTER TABLE one_location_share_grants
+  ADD COLUMN IF NOT EXISTS ceiling_expires_at TIMESTAMPTZ;
+
+-- Backfill only what is still live. An expired or revoked grant's ceiling
+-- can never be read again by a duration edit, so there is nothing to gain by
+-- filling it in for rows that are already inert.
+UPDATE one_location_share_grants
+SET ceiling_expires_at = expires_at
+WHERE status = 'active'
+  AND ceiling_expires_at IS NULL;
+
+-- Documents the invariant rather than enforcing anything new: every writer
+-- of expires_at that also knows about ceiling_expires_at already keeps this
+-- true by construction (see one_location_agent_service.py). NOT VALID, like
+-- 154's own additions, so this does not pay for a full-table scan today.
+ALTER TABLE one_location_share_grants
+  DROP CONSTRAINT IF EXISTS one_location_share_grants_ceiling_bounds;
+
+ALTER TABLE one_location_share_grants
+  ADD CONSTRAINT one_location_share_grants_ceiling_bounds
+    CHECK (
+      ceiling_expires_at IS NULL
+      OR expires_at IS NULL
+      OR expires_at <= ceiling_expires_at
+    ) NOT VALID;
+
+COMMENT ON COLUMN one_location_share_grants.ceiling_expires_at IS
+  'Furthest-out expiry the owner has explicitly authorized for this grant. Set on owner-authorized writes (create_grant, set_grant_duration); never moved by the self-serve shorten/regrow path. NULL = no known ceiling (until_stopped grants, or rows predating this column) -- duration edits then fall back to comparing against the live expires_at.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/156_one_location_grant_ceiling_insert_default.sql
+++ b/consent-protocol/db/migrations/156_one_location_grant_ceiling_insert_default.sql
@@ -1,0 +1,56 @@
+-- One Location: guarantee ceiling_expires_at is never silently left NULL on a
+-- newly-inserted timed grant, no matter which code path performs the insert.
+--
+-- 155 taught every INSERT path this codebase's application code is aware of
+-- to write ceiling_expires_at = expires_at at creation time. In practice, a
+-- grant has still been observed reaching the table with expires_at correctly
+-- set but ceiling_expires_at NULL, on the "Safety check-in" auto-approval
+-- flow specifically -- one that produces no HTTP access-log line and no
+-- application-level log line for its grant creation, so the exact caller
+-- could not be pinned down by reading code or watching logs. Rather than
+-- keep hunting for one more call site (and risk missing the next one, or the
+-- next feature that mints a grant), this closes the gap at the only point
+-- that can see every insert regardless of which Python path produced it: the
+-- table itself.
+--
+-- INSERT-only, deliberately. shorten_grant's whole job is moving expires_at
+-- on an UPDATE without ever touching the ceiling -- a trigger that also fired
+-- on UPDATE would silently overwrite that every time a grant is shortened,
+-- reopening the exact bug 155 fixed.
+--
+-- Only fills in what is missing: a grant with no expires_at (until_stopped)
+-- keeps ceiling_expires_at NULL, matching the no-known-ceiling fallback both
+-- shorten_grant and the frontend already implement. A row that already names
+-- an explicit ceiling is left exactly as given.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION one_location_grant_default_ceiling()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.ceiling_expires_at IS NULL AND NEW.expires_at IS NOT NULL THEN
+    NEW.ceiling_expires_at := NEW.expires_at;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS one_location_share_grants_default_ceiling ON one_location_share_grants;
+CREATE TRIGGER one_location_share_grants_default_ceiling
+  BEFORE INSERT ON one_location_share_grants
+  FOR EACH ROW
+  EXECUTE FUNCTION one_location_grant_default_ceiling();
+
+COMMENT ON FUNCTION one_location_grant_default_ceiling() IS
+  'Backstops 155: any INSERT that leaves ceiling_expires_at NULL while expires_at is set gets ceiling_expires_at defaulted to expires_at. Never fires on UPDATE -- shorten_grant must keep moving expires_at without ever touching the ceiling.';
+
+-- One-time catch-up for rows this gap already produced, so today's active
+-- grants stop being shorten-only immediately rather than waiting for their
+-- next full recreation.
+UPDATE one_location_share_grants
+SET ceiling_expires_at = expires_at
+WHERE status = 'active'
+  AND ceiling_expires_at IS NULL
+  AND expires_at IS NOT NULL;
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/155_one_location_grant_ceiling.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/155_one_location_grant_ceiling.rollback.sql
@@ -1,0 +1,18 @@
+-- Reverse 155.
+--
+-- Dropping the column drops the ceiling with it. That is the correct loss:
+-- the ceiling only ever informs how far a self-serve duration edit is
+-- allowed to regrow without asking again -- it grants nothing on its own,
+-- and every grant's live `expires_at`/`duration_hours` (the actual access)
+-- is untouched by removing it. A rollback just returns every duration edit
+-- to comparing against the live expiry, exactly as it did before 155.
+
+BEGIN;
+
+ALTER TABLE one_location_share_grants
+  DROP CONSTRAINT IF EXISTS one_location_share_grants_ceiling_bounds;
+
+ALTER TABLE one_location_share_grants
+  DROP COLUMN IF EXISTS ceiling_expires_at;
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/156_one_location_grant_ceiling_insert_default.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/156_one_location_grant_ceiling_insert_default.rollback.sql
@@ -1,0 +1,13 @@
+-- Reverse 156.
+--
+-- Drops the safety-net trigger only. The one-time backfill it shipped with
+-- is not undone: those rows' ceilings are now correct data, and reverting a
+-- schema migration is not a reason to make an active grant's regrow window
+-- wrong again.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS one_location_share_grants_default_ceiling ON one_location_share_grants;
+DROP FUNCTION IF EXISTS one_location_grant_default_ceiling();
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -132,7 +132,9 @@
     "151_feed_events_dedupe_approved_share.sql",
     "152_feed_events_recipient_fanout.sql",
     "153_one_location_duration_changed_event.sql",
-    "154_one_location_access_request_duration.sql"
+    "154_one_location_access_request_duration.sql",
+    "155_one_location_grant_ceiling.sql",
+    "156_one_location_grant_ceiling_insert_default.sql"
   ],
   "groups": {
     "iam": [
@@ -219,7 +221,8 @@
       "151_feed_events_dedupe_approved_share.sql",
       "152_feed_events_recipient_fanout.sql",
       "153_one_location_duration_changed_event.sql",
-      "154_one_location_access_request_duration.sql"
+      "154_one_location_access_request_duration.sql",
+      "155_one_location_grant_ceiling.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2245,6 +2245,10 @@ class OneLocationAgentService:
                 float(row.get("duration_hours")) if row.get("duration_hours") is not None else None
             ),
             "expiresAt": _iso(row.get("expires_at")),
+            # Furthest-out expiry the owner has explicitly authorized. Lets a
+            # duration edit tell "still within what was approved" (no consent
+            # needed) apart from "asking for more" (needs request_access).
+            "ceilingExpiresAt": _iso(row.get("ceiling_expires_at")),
             "createdAt": _iso(row.get("created_at")),
             "updatedAt": _iso(row.get("updated_at")),
             "revokedAt": _iso(row.get("revoked_at")),
@@ -4311,12 +4315,13 @@ class OneLocationAgentService:
                             INSERT INTO one_location_share_grants (
                               owner_user_id, recipient_user_id, recipient_key_id, status,
                               consent_scope, capability_scopes, duration_hours, expires_at,
-                              duration_mode, source_circle_id, created_at, updated_at, metadata
+                              ceiling_expires_at, duration_mode, source_circle_id,
+                              created_at, updated_at, metadata
                             )
                             VALUES (
                               :owner_user_id, :recipient_user_id, :recipient_key_id, 'active',
                               'cap.location.live.view', CAST(:capability_scopes AS JSONB),
-                              :duration_hours, :expires_at, :duration_mode,
+                              :duration_hours, :expires_at, :ceiling_expires_at, :duration_mode,
                               CAST(:source_circle_id AS UUID), NOW(), NOW(),
                               CAST(:metadata_json AS JSONB)
                             )
@@ -4486,6 +4491,11 @@ class OneLocationAgentService:
             "capability_scopes": _json_param(LOCATION_CAPABILITY_SCOPES),
             "duration_hours": duration,
             "expires_at": expires_at,
+            # The owner is authorizing this expiry right now -- at creation
+            # time the ceiling and the live expiry are the same moment. A
+            # later self-serve shrink/regrow (shorten_grant) will move
+            # expires_at without ever touching this.
+            "ceiling_expires_at": expires_at,
             "duration_mode": resolved_duration_mode,
             "source_circle_id": source_circle_id,
             "metadata_json": _json_param(metadata),
@@ -4519,12 +4529,13 @@ class OneLocationAgentService:
                 INSERT INTO one_location_share_grants (
                   owner_user_id, recipient_user_id, recipient_key_id, status,
                   consent_scope, capability_scopes, duration_hours, expires_at,
-                  duration_mode, source_circle_id, created_at, updated_at, metadata
+                  ceiling_expires_at, duration_mode, source_circle_id,
+                  created_at, updated_at, metadata
                 )
                 VALUES (
                   :owner_user_id, :recipient_user_id, :recipient_key_id, 'active',
                   'cap.location.live.view', CAST(:capability_scopes AS JSONB),
-                  :duration_hours, :expires_at, :duration_mode,
+                  :duration_hours, :expires_at, :ceiling_expires_at, :duration_mode,
                   CAST(:source_circle_id AS UUID), NOW(), NOW(),
                   CAST(:metadata_json AS JSONB)
                 )
@@ -4824,13 +4835,14 @@ class OneLocationAgentService:
               INSERT INTO one_location_share_grants (
                 id, owner_user_id, recipient_user_id, recipient_key_id,
                 status, consent_scope, capability_scopes, duration_hours,
-                expires_at, duration_mode, source_circle_id, created_at, updated_at, metadata
+                expires_at, ceiling_expires_at, duration_mode, source_circle_id,
+                created_at, updated_at, metadata
               )
               SELECT
                 CAST(:grant_id AS UUID),
                 :owner_user_id, :recipient_user_id, :recipient_key_id, 'active',
                 'cap.location.live.view', CAST(:capability_scopes AS JSONB),
-                :duration_hours, :expires_at, :duration_mode,
+                :duration_hours, :expires_at, :expires_at, :duration_mode,
                 CAST(:source_circle_id AS UUID), NOW(), NOW(),
                 CAST(:metadata_json AS JSONB)
               FROM eligible_recipient
@@ -6530,21 +6542,29 @@ class OneLocationAgentService:
     def shorten_grant(
         self, *, caller_user_id: str, grant_id: str, duration_hours: float
     ) -> dict[str, Any]:
-        """Bring a grant's expiry earlier. Either side may do this; neither may extend.
+        """Move a grant's expiry anywhere the owner already authorized. Either side may do this.
 
-        Shortening only ever reduces exposure, so it needs no fresh consent
-        from the other party -- the owner already agreed to be seen at least
-        this long, and the recipient giving back time early is just an
-        early, partial revoke. Extending is a different question: it grows
-        how long the recipient can see the owner, and that is the owner's
-        consent to give again, not something either side can hand
-        themselves through this endpoint. A person who wants more time goes
-        through request_access instead, and the owner approves it like any
-        other request.
+        The owner already agreed to be seen up to `ceiling_expires_at` --
+        moving the live expiry to anything at or under that ceiling, in
+        either direction, needs no fresh consent from the other party: a
+        decrease is a partial early revoke, and a later increase back toward
+        the ceiling is just returning to what was already agreed, not asking
+        for anything new. Only a candidate PAST the ceiling grows how long
+        the recipient can see the owner, which is the owner's consent to
+        give again, not something either side can hand themselves through
+        this endpoint -- that goes through request_access instead, and the
+        owner approves it like any other request (which also mints a fresh
+        ceiling for the grant it produces).
+
+        A grant with no known ceiling (an until_stopped share, or a row from
+        before the ceiling existed) falls back to the live `expires_at` as
+        its own bound, which reproduces this endpoint's original shorten-only
+        behavior exactly.
         """
         row = self._execute_one(
             """
-            SELECT id, owner_user_id, recipient_user_id, expires_at, status
+            SELECT id, owner_user_id, recipient_user_id, expires_at,
+                   ceiling_expires_at, status
             FROM one_location_share_grants
             WHERE id = CAST(:grant_id AS UUID)
               AND (owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id)
@@ -6569,13 +6589,18 @@ class OneLocationAgentService:
             ) from exc
         candidate_expires_at = datetime.now(timezone.utc) + timedelta(hours=duration)
         current_expires_at = row.get("expires_at")
-        if current_expires_at is not None:
-            if current_expires_at.tzinfo is None:
-                current_expires_at = current_expires_at.replace(tzinfo=timezone.utc)
-            if candidate_expires_at >= current_expires_at:
+        ceiling_expires_at = row.get("ceiling_expires_at")
+        # No ceiling on record -- fall back to the live expiry, which is
+        # exactly the original shorten-only bound this endpoint had before
+        # ceilings existed.
+        bound = ceiling_expires_at if ceiling_expires_at is not None else current_expires_at
+        if bound is not None:
+            if bound.tzinfo is None:
+                bound = bound.replace(tzinfo=timezone.utc)
+            if candidate_expires_at > bound:
                 raise OneLocationAgentError(
                     "LOCATION_GRANT_SHORTEN_ONLY",
-                    "This can only make a share end sooner, not later.",
+                    "This can only move within what was already approved.",
                     status_code=422,
                 )
 
@@ -6589,6 +6614,11 @@ class OneLocationAgentService:
             WHERE id = CAST(:grant_id AS UUID)
               AND (owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id)
               AND status = 'active'
+              -- Re-checked atomically against whatever the row's bound is
+              -- RIGHT NOW, not the possibly-stale value read above -- closes
+              -- the window where a concurrent set_grant_duration lowers the
+              -- ceiling between this function's read and this write.
+              AND :new_expires_at <= COALESCE(ceiling_expires_at, expires_at)
             RETURNING *
             """,
             {
@@ -6599,8 +6629,9 @@ class OneLocationAgentService:
             },
         )
         if not updated:
-            # Revoked between the read above and this write -- report the
-            # grant as it now stands rather than raising on a race.
+            # Revoked, or raced past a since-lowered ceiling, between the
+            # read above and this write -- report the grant as it now
+            # stands rather than raising on a race.
             existing_row = self._execute_one(
                 """
                 SELECT * FROM one_location_share_grants
@@ -6617,6 +6648,15 @@ class OneLocationAgentService:
         owner_label = _identity_notification_label(owner_identity)
         recipient_identity = self._identity_row(recipient_user_id or "")
         recipient_label = _identity_notification_label(recipient_identity)
+        # Which way this particular call moved the expiry -- shrinking to 15
+        # min and then regrowing to 30 (still under the ceiling) is a real
+        # increase, and must not be reported to either party as a shorten.
+        direction = _share_duration_change_direction(
+            previous_expires_at=current_expires_at,
+            new_expires_at=candidate_expires_at,
+            new_mode="timed",
+        )
+        grew = direction == "extended"
         self._insert_event(
             owner_user_id=str(row.get("owner_user_id") or caller_user_id),
             actor_user_id=caller_user_id,
@@ -6625,21 +6665,32 @@ class OneLocationAgentService:
             event_type="location_share_shortened",
             metadata={
                 "reason": "owner_shorten" if actor_is_owner else "recipient_shorten",
+                "direction": direction,
                 "counterpart_label": recipient_label,
             },
         )
         notification_user_id = (
             recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
         )
-        self._send_metadata_notification(
-            user_id=notification_user_id,
-            notification_type="location_share_shortened",
-            title="Location access shortened",
-            body=(
+        if grew:
+            notification_title = "Location access time changed"
+            notification_body = (
+                f"{owner_label} adjusted the shared time, within what was already approved."
+                if actor_is_owner
+                else f"{recipient_label} adjusted their viewing time, within what you already approved."
+            )
+        else:
+            notification_title = "Location access shortened"
+            notification_body = (
                 f"{owner_label} shortened your location access."
                 if actor_is_owner
                 else f"{recipient_label} gave back some of their remaining time early."
-            ),
+            )
+        self._send_metadata_notification(
+            user_id=notification_user_id,
+            notification_type="location_share_shortened",
+            title=notification_title,
+            body=notification_body,
             notification_tag=f"one-location-shortened:{grant_id}",
             request_url=_one_location_url(
                 grantId=grant_id, section="shared" if actor_is_owner else "people"
@@ -6650,6 +6701,7 @@ class OneLocationAgentService:
                 "owner_display_label": owner_label,
                 "recipient_user_id": recipient_user_id,
                 "recipient_display_label": recipient_label,
+                "direction": direction,
             },
         )
         return self._grant_payload(updated) or {}
@@ -6744,6 +6796,11 @@ class OneLocationAgentService:
             SET duration_mode = :duration_mode,
                 duration_hours = :duration_hours,
                 expires_at = :new_expires_at,
+                -- The owner is re-authorizing this share right now, in
+                -- whichever direction they moved it -- their explicit choice
+                -- is the new ceiling a later self-serve shrink/regrow (via
+                -- shorten_grant) can move freely within, same as at creation.
+                ceiling_expires_at = :new_expires_at,
                 updated_at = NOW()
             WHERE id = CAST(:grant_id AS UUID)
               AND owner_user_id = :owner_user_id

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1828,6 +1828,10 @@ class FourUserMemoryService(OneLocationAgentService):
                 "capability_scopes": params["capability_scopes"],
                 "duration_hours": params["duration_hours"],
                 "expires_at": params["expires_at"],
+                # Owner-authorized at creation, so ceiling and live expiry
+                # start out equal -- exactly what create_grant's real SQL
+                # writes.
+                "ceiling_expires_at": params.get("ceiling_expires_at", params["expires_at"]),
                 "duration_mode": params.get("duration_mode", "timed"),
                 "created_at": datetime.now(timezone.utc),
                 "updated_at": datetime.now(timezone.utc),
@@ -2189,17 +2193,38 @@ class FourUserMemoryService(OneLocationAgentService):
             return None
         if "UPDATE one_location_share_grants" in sql and "expires_at = :new_expires_at" in sql:
             grant = self.grants.get(params["grant_id"])
+            if not grant:
+                return None
+            # `shorten` hard-codes 'timed' in its own SQL and sends no
+            # duration_mode param; `set_grant_duration` always sends one
+            # (it can also put a share on "until I stop"). Reused below to
+            # tell the two apart, same as the pre-existing duration_mode
+            # handling already did.
+            is_owner_set_duration = params.get("duration_mode") is not None
+            # Only shorten_grant's real UPDATE carries a ceiling-bound WHERE
+            # clause -- set_grant_duration is owner-only and unrestricted,
+            # since the owner's own explicit choice needs nobody's ceiling.
+            # No known bound (an until_stopped grant, or one predating the
+            # ceiling column) means no restriction, same as the real SQL's
+            # COALESCE falling through to a NULL expires_at.
+            bound = grant.get("ceiling_expires_at") or grant.get("expires_at")
+            within_ceiling = (
+                is_owner_set_duration or bound is None or params["new_expires_at"] <= bound
+            )
             if (
-                grant
-                and params["owner_user_id"] in {grant["owner_user_id"], grant["recipient_user_id"]}
+                params["owner_user_id"] in {grant["owner_user_id"], grant["recipient_user_id"]}
                 and grant["status"] == "active"
+                and within_ceiling
             ):
                 grant["expires_at"] = params["new_expires_at"]
                 grant["duration_hours"] = params.get("duration_hours")
-                # `shorten` hard-codes 'timed' in its own SQL and sends no
-                # param; `set_grant_duration` sends the mode because it can
-                # also put a share on "until I stop".
                 grant["duration_mode"] = params.get("duration_mode") or "timed"
+                if is_owner_set_duration:
+                    # The owner's own explicit choice is a fresh
+                    # authorization and always becomes the new ceiling, in
+                    # either direction. shorten_grant never reaches here with
+                    # duration_mode set, so it never moves the ceiling.
+                    grant["ceiling_expires_at"] = params["new_expires_at"]
                 grant["updated_at"] = datetime.now(timezone.utc)
                 return grant
             return None
@@ -3259,6 +3284,82 @@ def test_shorten_grant_rejects_any_attempt_to_extend() -> None:
         service.shorten_grant(caller_user_id="user_b", grant_id=grant["id"], duration_hours=24)
     assert extend_attempt.value.code == "LOCATION_GRANT_SHORTEN_ONLY"
     assert service.grants[grant["id"]]["expires_at"] == original_expires_at
+
+
+def test_shorten_grant_regrows_within_the_original_ceiling_without_asking() -> None:
+    """The reported bug: approved for 1 hour, shrunk to 15 min, asked back up
+    to 30 -- still inside the hour the owner already agreed to, so it must
+    apply immediately rather than opening a fresh request the owner has to
+    approve. Only a candidate past the ORIGINAL ceiling still needs one.
+    """
+    service = FourUserMemoryService()
+    for user_id in ("user_a", "user_b"):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+
+    grant = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+    )
+    ceiling = service.grants[grant["id"]]["ceiling_expires_at"]
+    assert ceiling == service.grants[grant["id"]]["expires_at"]
+
+    service.shorten_grant(caller_user_id="user_b", grant_id=grant["id"], duration_hours=0.5)
+    service.shorten_grant(caller_user_id="user_b", grant_id=grant["id"], duration_hours=0.25)
+    assert service.grants[grant["id"]]["ceiling_expires_at"] == ceiling
+
+    # Back up to 30 min -- above the current (shrunk) expiry, but still
+    # under the hour originally approved. Must succeed with no new request.
+    regrown = service.shorten_grant(
+        caller_user_id="user_b", grant_id=grant["id"], duration_hours=0.5
+    )
+    assert regrown["status"] == "active"
+    assert service.grants[grant["id"]]["ceiling_expires_at"] == ceiling
+    regrow_events = [
+        event
+        for event in service.events.values()
+        if event["event_type"] == "location_share_shortened"
+    ]
+    assert regrow_events[-1]["metadata"]["direction"] == "extended"
+    assert len(service.requests) == 0
+
+    # 4 hours is past the original 1-hour ceiling -- still refused, and
+    # still the recipient's cue to go through request_access instead.
+    with pytest.raises(OneLocationAgentError) as extend_attempt:
+        service.shorten_grant(caller_user_id="user_b", grant_id=grant["id"], duration_hours=4)
+    assert extend_attempt.value.code == "LOCATION_GRANT_SHORTEN_ONLY"
+    assert service.grants[grant["id"]]["ceiling_expires_at"] == ceiling
+
+
+def test_set_grant_duration_moves_the_ceiling_with_it() -> None:
+    """The owner's own explicit choice is a fresh authorization -- it must
+    become the grant's new ceiling too, not leave the recipient bounded by
+    a number the owner has since moved past (or below).
+    """
+    service, grant = _duration_service_with_grant(1)
+
+    lengthened = service.set_grant_duration(
+        owner_user_id="user_a", grant_id=grant["id"], duration_hours=4
+    )
+    assert lengthened["status"] == "active"
+    assert (
+        service.grants[grant["id"]]["ceiling_expires_at"]
+        == service.grants[grant["id"]]["expires_at"]
+    )
+    ceiling_after_lengthen = service.grants[grant["id"]]["ceiling_expires_at"]
+
+    # The recipient can now self-serve anywhere up to the NEW (4-hour)
+    # ceiling, not the original 1-hour one.
+    grown = service.shorten_grant(
+        caller_user_id="user_b", grant_id=grant["id"], duration_hours=3
+    )
+    assert grown["status"] == "active"
+    assert service.grants[grant["id"]]["ceiling_expires_at"] == ceiling_after_lengthen
 
 
 def _duration_service_with_grant(duration_hours: float = 0.5):

--- a/hushh-webapp/__tests__/components/grant-duration-edit.test.ts
+++ b/hushh-webapp/__tests__/components/grant-duration-edit.test.ts
@@ -9,10 +9,15 @@ import {
 
 const NOW = Date.parse("2026-05-20T08:00:00.000Z");
 
-function grant(fields: { expiresAt?: string | null; durationHours?: number | null }) {
+function grant(fields: {
+  expiresAt?: string | null;
+  durationHours?: number | null;
+  ceilingExpiresAt?: string | null;
+}) {
   return {
     expiresAt: fields.expiresAt ?? null,
     durationHours: fields.durationHours ?? null,
+    ceilingExpiresAt: fields.ceilingExpiresAt ?? null,
   };
 }
 
@@ -149,5 +154,48 @@ describe("grantDurationEditIntent", () => {
         nowMs: NOW,
       }),
     ).toBe("shorten");
+  });
+
+  // The reported bug: 1 hour approved, shrunk to 15 min, then asked back up
+  // to 30 -- still inside the hour the owner already agreed to, so it must
+  // apply immediately rather than going back to the owner.
+  it("grows back up without asking, as long as it stays under the ceiling", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(12), ceilingExpiresAt: inMinutes(60) }),
+        durationHours: 0.5,
+        nowMs: NOW,
+      }),
+    ).toBe("grow");
+  });
+
+  it("still asks when the new duration would run past the ceiling", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(12), ceilingExpiresAt: inMinutes(60) }),
+        durationHours: 4,
+        nowMs: NOW,
+      }),
+    ).toBe("request");
+  });
+
+  it("lands exactly on the ceiling without asking", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(12), ceilingExpiresAt: inMinutes(60) }),
+        durationHours: 1,
+        nowMs: NOW,
+      }),
+    ).toBe("grow");
+  });
+
+  it("with no known ceiling, still asks past the current expiry -- unchanged from before ceilings existed", () => {
+    expect(
+      grantDurationEditIntent({
+        grant: grant({ expiresAt: inMinutes(12) }),
+        durationHours: 1,
+        nowMs: NOW,
+      }),
+    ).toBe("request");
   });
 });

--- a/hushh-webapp/__tests__/lib/feed/feed-location-request-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-location-request-lines.test.ts
@@ -182,4 +182,33 @@ describe("shortening", () => {
       ).description,
     ).toBe("Gave back their remaining time early");
   });
+
+  // Shrinking to 15 min and regrowing to 30 (still under the owner's
+  // ceiling) emits this same event type -- it must not read as a shorten.
+  it("names a within-ceiling regrow instead of calling it a shorten", () => {
+    expect(
+      presentFeedItem(
+        item({
+          event_type: "location_share_shortened",
+          metadata: {
+            counterpart_label: "Ankit",
+            reason: "recipient_shorten",
+            direction: "extended",
+          },
+        }),
+      ).description,
+    ).toBe("Adjusted your viewing time, within what was already approved");
+    expect(
+      presentFeedItem(
+        item({
+          event_type: "location_share_shortened",
+          metadata: {
+            counterpart_label: "Ankit",
+            reason: "owner_shorten",
+            direction: "extended",
+          },
+        }),
+      ).description,
+    ).toBe("You adjusted their location access time");
+  });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -5736,19 +5736,24 @@ export function OneLocationAgentPageContent({
    * Edit a received grant's remaining time -- from any list that shows one
    * (Ask's "already sharing" rows, Requests sent, Shared with me).
    *
-   * Shortening is self-limiting -- the owner already agreed to be seen at
-   * least this long -- so it applies immediately. Extending is a different
-   * question: it grows how long the recipient can see the owner, and that
-   * is the owner's consent to give again, via a fresh request_access the
-   * owner approves like any other.
+   * The owner already agreed to be seen up to the grant's ceiling -- the
+   * furthest expiry ever explicitly authorized -- so moving the live expiry
+   * anywhere at or under that ceiling applies immediately, whichever
+   * direction it moves ("shorten" or "grow"). Shrinking a 1-hour share to 15
+   * minutes and then back up to 30 is still inside what was already agreed,
+   * so it needs nobody's permission a second time. Only a candidate PAST the
+   * ceiling grows how long the recipient can see the owner, and that is the
+   * owner's consent to give again, via a fresh request_access the owner
+   * approves like any other.
    *
    * Which one this is gets decided here, from the same expiry the row is
-   * already rendering as "30 more min". It used to be decided by calling
-   * shorten_grant and waiting for the backend to refuse: every ask-for-more
-   * -time paid for a doomed round trip before the real one, which is the
-   * "Save is slow" report. The refusal is still handled -- a client clock
-   * can disagree with the server's near the boundary -- but it is now the
-   * rare correction rather than the normal path.
+   * already rendering as "30 more min", plus the ceiling that came with it.
+   * It used to be decided by calling shorten_grant and waiting for the
+   * backend to refuse: every ask-for-more-time paid for a doomed round trip
+   * before the real one, which is the "Save is slow" report. The refusal is
+   * still handled -- a client clock can disagree with the server's near the
+   * boundary -- but it is now the rare correction rather than the normal
+   * path.
    */
   const handleEditGrantDuration = useCallback(
     async (
@@ -5778,14 +5783,16 @@ export function OneLocationAgentPageContent({
           setEditingGrantId(null);
           return;
         }
-        if (intent === "shorten") {
+        if (intent === "shorten" || intent === "grow") {
           try {
             await OneLocationService.shortenGrant({
               vaultOwnerToken,
               grantId,
               durationHours,
             });
-            toast.success("Access shortened.");
+            toast.success(
+              intent === "grow" ? "Time updated." : "Access shortened.",
+            );
             setEditingGrantId(null);
             // Held until the list has actually reconciled, so this grant is
             // not savable again against the expiry it just replaced.
@@ -5800,7 +5807,8 @@ export function OneLocationAgentPageContent({
               );
               return;
             }
-            // The backend read the clock differently. Fall through and ask.
+            // The backend says this is past what was approved (a stale
+            // ceiling/expiry read, or a genuine excess). Fall through and ask.
           }
         }
         // Extending needs the owner's approval again -- send a new request

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -293,15 +293,25 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
     }
     case "location_share_shortened": {
       const hasWho = who !== "Someone";
-      const ownerShortened =
+      const ownerActor =
         metadataString(item.metadata, "reason") === "owner_shorten";
+      // A duration edit that stays within the grant's ceiling can move
+      // either way -- shrinking to 15 min and regrowing to 30 emits this
+      // same event type, so a real decrease and a within-ceiling regrow
+      // need different copy rather than both reading as "shortened".
+      const grew = metadataString(item.metadata, "direction") === "extended";
+      const description = grew
+        ? ownerActor
+          ? "You adjusted their location access time"
+          : "Adjusted your viewing time, within what was already approved"
+        : ownerActor
+          ? "You shortened their location access"
+          : "Gave back their remaining time early";
       return {
         icon,
         domainLabel,
         label: hasWho ? who : "Location",
-        description: ownerShortened
-          ? "You shortened their location access"
-          : "Gave back their remaining time early",
+        description,
         href: ROUTES.ONE_LOCATION,
       };
     }

--- a/hushh-webapp/lib/one-location/grant-duration-edit.ts
+++ b/hushh-webapp/lib/one-location/grant-duration-edit.ts
@@ -24,7 +24,10 @@ export const GRANT_EDIT_DURATION_HOURS: readonly number[] = [0.5, 1, 4, 24];
 /** The picker value used when a grant tells us nothing usable about its length. */
 export const GRANT_EDIT_DURATION_FALLBACK = "1";
 
-type DurationGrantFields = Pick<OneLocationGrant, "expiresAt" | "durationHours">;
+type DurationGrantFields = Pick<
+  OneLocationGrant,
+  "expiresAt" | "durationHours" | "ceilingExpiresAt"
+>;
 
 /** Milliseconds, or null when the timestamp is missing or unparseable. */
 function timestamp(value: string | null | undefined): number | null {
@@ -38,6 +41,17 @@ export function grantExpiryMs(
   grant: DurationGrantFields | null | undefined,
 ): number | null {
   return timestamp(grant?.expiresAt);
+}
+
+/**
+ * The furthest-out expiry the owner has ever explicitly authorized for this
+ * grant, in ms -- or null when none is known (an until_stopped share, or a
+ * grant the backend sent before this field existed).
+ */
+export function grantCeilingMs(
+  grant: DurationGrantFields | null | undefined,
+): number | null {
+  return timestamp(grant?.ceilingExpiresAt);
 }
 
 /**
@@ -99,18 +113,23 @@ function unchangedToleranceMs(durationHours: number): number {
 /**
  * What Save does with this duration.
  *
- * "shorten" applies immediately -- the owner already agreed to be seen at
- * least this long, so giving time back needs nobody's permission.
- * "request" grows how long the recipient can watch the owner, which is the
- * owner's consent to give again. "unchanged" is the untouched picker: no
+ * "shorten" and "grow" both apply immediately, with no approval needed --
+ * the owner already agreed to be seen up to the grant's ceiling (the
+ * furthest expiry ever explicitly authorized), so moving the live expiry
+ * anywhere at or under that ceiling is never a new ask, whichever direction
+ * it moves. Shrinking a 1-hour share to 15 minutes and then back up to 30 is
+ * "grow", not "request": 30 minutes was already inside what was approved.
+ * "request" is the only case that actually asks the owner for something new
+ * -- a candidate past the ceiling. "unchanged" is the untouched picker: no
  * call, nothing to tell anyone, just close the editor.
  *
- * "shorten" is also the answer when the expiry is unknown, because then the
- * only authority on it is the backend, and its explicit shorten-only
- * rejection is what routes the call. Reading a stale or skewed clock here
- * must never cost the recipient the ability to end a share early.
+ * "shorten" is also the answer when neither the expiry nor a ceiling is
+ * known, because then the only authority on it is the backend, and its
+ * explicit shorten-only rejection is what routes the call. Reading a stale
+ * or skewed clock here must never cost the recipient the ability to end a
+ * share early.
  */
-export type GrantDurationEditIntent = "shorten" | "request" | "unchanged";
+export type GrantDurationEditIntent = "shorten" | "grow" | "request" | "unchanged";
 
 export function grantDurationEditIntent(input: {
   grant: DurationGrantFields | null | undefined;
@@ -127,5 +146,10 @@ export function grantDurationEditIntent(input: {
   if (Math.abs(candidate - expiry) <= unchangedToleranceMs(durationHours)) {
     return "unchanged";
   }
-  return candidate < expiry ? "shorten" : "request";
+  if (candidate < expiry) return "shorten";
+  // No known ceiling falls back to the live expiry as its own bound --
+  // matching the backend's fallback exactly, and reproducing the original
+  // shorten-only behavior for a grant this field was never sent for.
+  const ceiling = grantCeilingMs(grant) ?? expiry;
+  return candidate <= ceiling ? "grow" : "request";
 }

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -150,6 +150,15 @@ export type OneLocationGrant = {
   durationMode?: OneLocationShareDurationMode | string | null;
   durationHours: number | null;
   expiresAt?: string | null;
+  /**
+   * Furthest-out expiry the owner has explicitly authorized for this grant
+   * (set at creation, at approval, or on the owner's own duration edit).
+   * A duration edit at or under this needs nobody's approval, in either
+   * direction; only a candidate past it requires a fresh request. Null means
+   * no known ceiling (an until_stopped share, or a grant from before this
+   * field existed) -- edits then fall back to comparing against `expiresAt`.
+   */
+  ceilingExpiresAt?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;


### PR DESCRIPTION
# Description

When an owner approves a location-share request for a duration (e.g. 4 hours), the recipient can edit that duration from the "New duration" control. Today: shrinking (4h -> 1h -> 30min) always applies immediately, but growing it back up (30min -> 1h) -- even though 1h is still inside the 4-hour window the owner already agreed to -- incorrectly falls through to a fresh `request_access`, asking the owner for permission they had effectively already given.

Root cause: the grant row only ever tracked one mutable `expires_at`. Once shrunk, nothing remembered what the owner had originally authorized, so any later increase compared against the already-shrunk value and read as "asking for more" -- even when it was well inside the original grant.

**Fix**: add a persisted `ceiling_expires_at` -- the furthest expiry the owner has explicitly authorized for a grant. It's set on every owner-authorized write (grant creation, an approved request, the owner's own duration edit) and never touched by the recipient's self-serve shrink/regrow. `shorten_grant` now allows moving the live expiry anywhere at or under that ceiling, in either direction, with no new approval. Only a candidate past the ceiling still asks -- and approving that request mints a new ceiling in turn.

A `BEFORE INSERT` trigger (migration 156) backstops every grant-creation path, including a "Safety check-in" auto-approval flow that was observed producing a grant with the ceiling still unset and left no traceable application-level log line for its own creation -- the trigger guarantees the ceiling can never be silently skipped, regardless of which code path performs the insert, present or future.

## Impact Map (Required)

- Routes touched:
  - Listed below:
    - `PATCH /api/one/location/grants/{grant_id}/shorten` -- broadened bound (ceiling-aware instead of current-expiry-only); same request/response shape.

- API / schema / type changes:
  - Listed below:
    - New column `one_location_share_grants.ceiling_expires_at` (nullable `TIMESTAMPTZ`).
    - New response field `OneLocationGrant.ceilingExpiresAt` (backend `_grant_payload`, frontend type).
    - New frontend intent value `"grow"` on `GrantDurationEditIntent` (was `"shorten" | "request" | "unchanged"`).

- Cache keys touched: None

- Runtime DB data-plane changes:
  - Listed below:
    - Migration `155_one_location_grant_ceiling.sql`: adds `ceiling_expires_at`, backfills active rows, adds a `NOT VALID` invariant check.
    - Migration `156_one_location_grant_ceiling_insert_default.sql`: `BEFORE INSERT` trigger defaulting `ceiling_expires_at` to `expires_at` whenever an insert omits it; one-time catch-up backfill.
    - Both applied and verified against UAT CloudSQL during development (see Testing).

- World-model domain summary effects: None

- Mobile parity impacts: None -- iOS/Android consume the same REST endpoint through the webview; no native plugin code changed, and the endpoint's request/response contract is unchanged (only its internal bound logic and one additive response field).

- Docs updated: None

- Top-level / devex / config / generated / ignore files touched: None

- Trust boundary touched:
  - Consent: this changes when a location-share duration change needs the owner's fresh consent (`request_access`) versus applying under previously-granted consent. The ceiling can only ever narrow what needs no new consent to what the owner already explicitly authorized -- it never widens access beyond a value the owner set, and any candidate exceeding it still requires an explicit new approval.

- Caller / proxy / backend pairing:
  - `hushh-webapp/lib/one-location/grant-duration-edit.ts` (`grantDurationEditIntent`) is the sole caller-side decision point that picks `shortenGrant` vs `requestAccess`; its `"grow"` branch is proven by new unit tests in `hushh-webapp/__tests__/components/grant-duration-edit.test.ts`, mirrored by the backend bound in `shorten_grant()` proven by new tests in `consent-protocol/tests/services/test_one_location_agent_service.py`.

- Rollback or safe-failure behavior:
  - Both migrations ship paired `rollback/*.sql` files.
  - A grant with no known ceiling (pre-migration row, or `until_stopped` mode) falls back to comparing against the live `expires_at` on both frontend and backend -- byte-for-byte today's pre-fix behavior, never a regression.
  - A stale/incorrect frontend guess (clock skew) still safely falls through to `request_access` via the existing `LOCATION_GRANT_SHORTEN_ONLY` error path.

- UI browser or Playwright proof:
  - Manually verified end-to-end against a live UAT-backed local stack at `/one/location` (Request location -> approve -> "New duration" editor): shrink always applied immediately; regrow within the original ceiling applied immediately with no new pending request; a candidate past the ceiling still created a pending request the owner had to approve.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` -- clean, zero errors.
  - [x] `cd hushh-webapp && npm test` -- targeted: `grant-duration-edit.test.ts`, `feed-location-request-lines.test.ts`, `consent-notification-provider-location.test.tsx`, plus `one-location-agent-page.test.tsx` run in isolation -- all passing (138/138 combined); full-suite run not completed due to time.
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0` -- clean.
  - [x] `cd hushh-webapp && npm run build` -- via `build:webpack` (default Turbopack build hit an unrelated local symlink/node_modules-junction issue specific to this sandboxed dev environment, not the diff); compiled and type-checked successfully.
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`
  - Backend: `pytest consent-protocol/tests/services/test_one_location_agent_service.py` -- 106/106 passing.

## Review-Ready Contract

- Title, body, changed files, and tests describe the same contract.
- Existing implementation and related open PRs were checked; this PR does not duplicate.
- This PR changes a current reachable app/backend surface.
- Reachable production attach point: `PATCH /api/one/location/grants/{grant_id}/shorten`, invoked from the "New duration" editor in `hushh-webapp/app/one/location/page.tsx` (`handleEditGrantDuration`).
- New tests import and exercise production code (`OneLocationAgentService`, `grantDurationEditIntent`), not only mocks.
- New helpers are wired to the existing route/caller listed above, not orphaned.
- Production surface proved: see UI browser proof above.
- Commits are signed off (`git commit -s`); rebased onto latest `main` before opening.
- Maintainer edits are enabled.

## Tri-Flow Architecture Check

- **Web**: `hushh-webapp/app/one/location/page.tsx`, `hushh-webapp/lib/one-location/grant-duration-edit.ts`
- **iOS**: Not applicable -- no native plugin code; consumes the same REST endpoint through the webview.
- **Android**: Not applicable -- same reason.

## Testing

- [x] Tested on Web (Chrome, against a live UAT-backed local stack)
- [ ] Tested on iOS Simulator/Device -- not applicable, see Tri-Flow.
- [ ] Tested on Android Emulator/Device -- not applicable, see Tri-Flow.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## Screenshots / Video

Manual verification route: `/one/location` -> Request location -> approve a multi-hour request -> use the "New duration" editor to shrink, then grow back within the original window (applies immediately, no new request) -> request past the original window (correctly creates a pending request for the owner). No screenshot captured during this session.

## Privacy & Consent

- Does this change access user data? It changes location-share *duration* bookkeeping only; no new data is read or exposed, and no coordinates are involved (this table is metadata-only per its own schema comment).
- Sensitive surface touched: consent (see Trust boundary above).
- Error path, rollback, or safe-failure behavior proved: see Rollback section above.

## Licensing

- First-party changes remain Apache-2.0 compatible.
- No dependency changes.
