### PR TITLE
fix(one-location): required address, deferred polish, and the app's own sheet on mobile

### DIFF
--- a/hushh-webapp/__tests__/onboarding/onboarding-client-navigation.test.ts
+++ b/hushh-webapp/__tests__/onboarding/onboarding-client-navigation.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Onboarding must never leave the App Router.
+ *
+ * The vault key is held in memory and nowhere else. A document navigation --
+ * `window.location.assign`, a `.href =`, a reload -- tears down the JavaScript
+ * context, so the key is gone and the person is sent back to unlock in the
+ * middle of setting something up. That is what "Skip setup wiped my session"
+ * is: not a lost cookie, a lost process.
+ *
+ * Every skip, finish and step-completion handler in these trees therefore has
+ * to navigate with the Next router (`router.push` / `router.replace`) or with
+ * `requestInternalAppNavigation`, which the app's own provider turns into a
+ * router call.
+ *
+ * This is a source scan rather than a behavioural test on purpose: the failure
+ * it guards against is a single line reintroduced anywhere in about a hundred
+ * files, and no realistic set of rendered cases would catch that.
+ */
+
+const WEBAPP_ROOT = path.resolve(__dirname, "..", "..");
+
+/** The trees an onboarding journey actually runs inside. */
+const ONBOARDING_TREES = [
+  "components/onboarding",
+  "components/one-location/onboarding",
+  "components/kai/onboarding",
+  "app/one/setup",
+];
+
+/**
+ * Reading `window.location` is fine and common -- the journey guard compares
+ * the current path, the flow reports the route it is on. Only the calls that
+ * REPLACE the document are banned.
+ */
+const HARD_NAVIGATION_PATTERNS: { name: string; pattern: RegExp }[] = [
+  {
+    name: "window.location.assign(…)",
+    pattern: /\bwindow\.location\.assign\s*\(/,
+  },
+  {
+    name: "window.location.replace(…)",
+    pattern: /\bwindow\.location\.replace\s*\(/,
+  },
+  {
+    name: "window.location.reload(…)",
+    pattern: /\bwindow\.location\.reload\s*\(/,
+  },
+  {
+    name: "assignment to window.location",
+    pattern: /\bwindow\.location(\.(href|pathname|search|hash))?\s*=[^=]/,
+  },
+  {
+    name: "location.assign / .replace / .reload without window",
+    pattern: /(^|[^.\w])location\.(assign|replace|reload)\s*\(/m,
+  },
+  {
+    name: "a document-replacing helper from lib/utils/browser-navigation",
+    pattern:
+      /import\s*\{[^}]*\b(assignWindowLocation|replaceWindowLocation|reloadWindow)\b[^}]*\}\s*from\s*["'][^"']*browser-navigation["']/s,
+  },
+];
+
+function sourceFilesUnder(relativeDir: string): string[] {
+  const root = path.join(WEBAPP_ROOT, relativeDir);
+  if (!fs.existsSync(root)) return [];
+
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+      if (/\.test\.tsx?$/.test(entry.name)) continue;
+      found.push(full);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+describe("onboarding navigates inside the App Router", () => {
+  const files = ONBOARDING_TREES.flatMap(sourceFilesUnder);
+
+  it("finds the onboarding trees it is meant to be scanning", () => {
+    // A path that silently stops matching would turn this whole file into a
+    // test that always passes.
+    for (const tree of ONBOARDING_TREES) {
+      expect(
+        sourceFilesUnder(tree).length,
+        `${tree} should contain source files`,
+      ).toBeGreaterThan(0);
+    }
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it("never replaces the document, which would drop the in-memory vault key", () => {
+    const offences: string[] = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, "utf8");
+      for (const { name, pattern } of HARD_NAVIGATION_PATTERNS) {
+        if (!pattern.test(source)) continue;
+        offences.push(`${path.relative(WEBAPP_ROOT, file)} — ${name}`);
+      }
+    }
+
+    expect(
+      offences,
+      "Use router.push / router.replace / requestInternalAppNavigation instead:\n" +
+        offences.join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -421,6 +421,12 @@ describe("SaveLocationModal", () => {
     fireEvent.change(screen.getByLabelText(/House or flat/), {
       target: { value: " Flat 4B, Tower 2 " },
     });
+
+    // Landmark and building colour are polish, so they start behind a tap.
+    expect(screen.getByLabelText(/Building colour/)).not.toBeVisible();
+    fireEvent.click(screen.getByTestId("save-location-door-details-toggle"));
+    expect(screen.getByLabelText(/Building colour/)).toBeVisible();
+
     fireEvent.change(screen.getByLabelText(/Building colour/), {
       target: { value: "Blue gate" },
     });
@@ -1127,43 +1133,47 @@ describe("SaveLocationModal", () => {
   describe("when the pin is good but no address comes back", () => {
     // On the native build before the vault exists there is no server
     // reverse-geocode and no browser geocoder either, so the lookup returns
-    // nothing however good the pin is. Blocking the save on a resolved STRING
-    // left that person pinned, correct, and permanently unable to finish.
+    // nothing however good the pin is. Requiring the address is safe anyway,
+    // because the way out is the Address box itself: it is editable and it is
+    // already on screen, so that person types the line and finishes.
     const strandedProps = {
       ...baseProps,
       address: null,
       collectAddressDetails: true,
     };
 
-    it("asks for one thing it can actually use", () => {
+    it("says what is missing beside the box, not only on the button", () => {
       render(<SaveLocationModal {...strandedProps} />);
       fireEvent.click(screen.getByRole("button", { name: "Home" }));
 
-      expect(
-        screen.getByText("Add a house, landmark or PIN."),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent("Enter the address.");
+      expect(screen.getByLabelText(/^Address$/)).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+      expect(screen.getByText("Add the address above.")).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Save location" }),
       ).toBeDisabled();
     });
 
-    it("saves once the person supplies it themselves", () => {
+    it("does not take door details in place of the address", () => {
       render(<SaveLocationModal {...strandedProps} />);
       fireEvent.click(screen.getByRole("button", { name: "Home" }));
+      fireEvent.click(screen.getByTestId("save-location-door-details-toggle"));
       fireEvent.change(screen.getByLabelText(/Landmark/), {
         target: { value: "Opposite City Mall" },
       });
+      fireEvent.change(screen.getByLabelText(/PIN \/ postcode/), {
+        target: { value: "110001" },
+      });
 
-      const save = screen.getByRole("button", { name: "Save location" });
-      expect(save).toBeEnabled();
-      fireEvent.click(save);
-
-      expect(baseProps.onSave).toHaveBeenCalledWith(
-        "home",
-        "",
-        expect.objectContaining({ landmark: "Opposite City Mall" }),
-        null,
-      );
+      // The field is marked required, so it has to actually BE required --
+      // a badge over a gate that anything else can open is a lie.
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeDisabled();
+      expect(baseProps.onSave).not.toHaveBeenCalled();
     });
 
     it("unblocks the save once the person types an address line themselves", () => {
@@ -1275,5 +1285,274 @@ describe("SaveLocationModal", () => {
     // And it is not offered as a house number.
     expect(screen.getByLabelText(/House or flat/)).toHaveValue("");
     expect(screen.getByLabelText(/PIN \/ postcode/)).toHaveValue("211004");
+  });
+
+  describe("the Address box is required, and says so", () => {
+    const detailsProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      collectAddressDetails: true,
+    };
+
+    it("marks it required on screen and to a screen reader", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+
+      const address = screen.getByLabelText(/^Address$/);
+      expect(address).toBeRequired();
+      expect(address).toHaveAttribute("aria-required", "true");
+      // The word, so the requirement does not rest on seeing a colour. Kept
+      // out of the label element, or it would join the field's own name.
+      expect(screen.getByText("Required")).toBeInTheDocument();
+      expect(address).toHaveAccessibleName("Address");
+      expect(screen.getByText("Used to find your door.")).toBeInTheDocument();
+    });
+
+    it("stays quiet while the box holds the detected address", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+
+      expect(screen.queryByText("Enter the address.")).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/^Address$/)).toHaveAttribute(
+        "aria-invalid",
+        "false",
+      );
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeEnabled();
+    });
+
+    it("waits until the person leaves the box before calling their edit wrong", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+      const address = screen.getByLabelText(/^Address$/);
+
+      // Clearing the line to retype it must not flash an error per keystroke.
+      fireEvent.change(address, { target: { value: "" } });
+      expect(screen.queryByText("Enter the address.")).not.toBeInTheDocument();
+
+      fireEvent.blur(address);
+      expect(screen.getByText("Enter the address.")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeDisabled();
+
+      fireEvent.change(address, { target: { value: "12 MG Road, Bengaluru" } });
+      expect(screen.queryByText("Enter the address.")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Save location" }),
+      ).toBeEnabled();
+    });
+
+    it("points the box at its help line, and then at its error too", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+      const address = screen.getByLabelText(/^Address$/);
+      const help = screen.getByText("Used to find your door.");
+      expect(address.getAttribute("aria-describedby")).toBe(help.id);
+
+      fireEvent.change(address, { target: { value: "" } });
+      fireEvent.blur(address);
+
+      const error = screen.getByText("Enter the address.");
+      expect(address.getAttribute("aria-describedby")?.split(" ")).toEqual([
+        help.id,
+        error.id,
+      ]);
+    });
+  });
+
+  describe("the order the details are asked in", () => {
+    const detailsProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      collectAddressDetails: true,
+    };
+
+    const isBefore = (first: Element, second: Element) =>
+      Boolean(
+        first.compareDocumentPosition(second) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+
+    it("asks the two things a save needs before anything optional", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+
+      const address = screen.getByLabelText(/^Address$/);
+      const kindOfPlace = screen.getByRole("group", {
+        name: "Saved location category",
+      });
+      const optionalGroup = screen.getByText("Optional — helps at the door.");
+      const houseOrFlat = screen.getByLabelText(/House or flat/);
+      const doorDetails = screen.getByTestId(
+        "save-location-door-details-toggle",
+      );
+      const buildingColour = screen.getByLabelText(/Building colour/);
+
+      expect(isBefore(address, kindOfPlace)).toBe(true);
+      expect(isBefore(kindOfPlace, optionalGroup)).toBe(true);
+      expect(isBefore(optionalGroup, houseOrFlat)).toBe(true);
+      expect(isBefore(houseOrFlat, doorDetails)).toBe(true);
+      expect(isBefore(doorDetails, buildingColour)).toBe(true);
+    });
+
+    it("keeps building colour behind a tap for a new place", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+
+      expect(screen.getByLabelText(/Building colour/)).not.toBeVisible();
+      expect(screen.getByLabelText(/Landmark/)).not.toBeVisible();
+      expect(
+        screen.getByTestId("save-location-door-details-toggle"),
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("opens it when the place already carries those answers", () => {
+      render(
+        <SaveLocationModal
+          {...detailsProps}
+          initialDetails={{
+            houseOrFlat: "",
+            buildingColor: "Blue gate",
+            landmark: "",
+            postalCode: "",
+          }}
+        />,
+      );
+
+      expect(screen.getByLabelText(/Building colour/)).toBeVisible();
+      expect(
+        screen.getByTestId("save-location-door-details-toggle"),
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("does not lose what was typed when the step is collapsed again", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+      const toggle = screen.getByTestId("save-location-door-details-toggle");
+
+      fireEvent.click(toggle);
+      fireEvent.change(screen.getByLabelText(/Building colour/), {
+        target: { value: "Blue gate" },
+      });
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+
+      expect(screen.getByLabelText(/Building colour/)).toHaveValue("Blue gate");
+    });
+  });
+
+  describe("on a phone it is the app's own bottom sheet", () => {
+    const sheetProps = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      collectAddressDetails: true,
+    };
+
+    /** jsdom has no layout, so the width is whatever matchMedia says it is. */
+    const setPhoneWidth = (phone: boolean) => {
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: phone && query === "(max-width: 639.98px)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+    };
+
+    /**
+     * jsdom's synthetic pointer events carry no coordinates, and a pull is
+     * nothing but coordinates.
+     */
+    const pointer = (
+      element: Element,
+      type: "pointerdown" | "pointermove" | "pointerup",
+      x: number,
+      y: number,
+    ) => {
+      const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+      });
+      Object.defineProperty(event, "pointerType", { value: "touch" });
+      fireEvent(element, event);
+    };
+
+    afterEach(() => setPhoneWidth(false));
+
+    it("renders in the shared sheet primitive, not in a dialog", () => {
+      setPhoneWidth(true);
+      render(<SaveLocationModal {...sheetProps} />);
+
+      expect(screen.getByTestId("save-location-modal")).toHaveAttribute(
+        "data-slot",
+        "sheet-content",
+      );
+      expect(
+        document.querySelector('[data-slot="sheet-overlay"]'),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the centred dialog above that width", () => {
+      setPhoneWidth(false);
+      render(<SaveLocationModal {...sheetProps} />);
+
+      expect(screen.getByTestId("save-location-modal")).toHaveAttribute(
+        "data-slot",
+        "dialog-content",
+      );
+      expect(
+        document.querySelector('[data-slot="sheet-overlay"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    it("closes on a pull down from the grabber row", async () => {
+      setPhoneWidth(true);
+      const onSkip = vi.fn();
+      render(<SaveLocationModal {...sheetProps} onSkip={onSkip} />);
+
+      const grabber = screen.getByTestId("save-location-sheet-grabber");
+      pointer(grabber, "pointerdown", 200, 100);
+      pointer(grabber, "pointermove", 200, 340);
+      pointer(grabber, "pointerup", 200, 340);
+
+      await waitFor(() => expect(onSkip).toHaveBeenCalled());
+    });
+
+    it("ignores a pull too short to be one", async () => {
+      setPhoneWidth(true);
+      const onSkip = vi.fn();
+      render(<SaveLocationModal {...sheetProps} onSkip={onSkip} />);
+
+      const grabber = screen.getByTestId("save-location-sheet-grabber");
+      pointer(grabber, "pointerdown", 200, 100);
+      pointer(grabber, "pointermove", 200, 140);
+      pointer(grabber, "pointerup", 200, 140);
+
+      await new Promise((resolve) => setTimeout(resolve, 320));
+      expect(onSkip).not.toHaveBeenCalled();
+    });
+
+    it("leaves a press on a dot to the dot", async () => {
+      setPhoneWidth(true);
+      const onSkip = vi.fn();
+      render(
+        <SaveLocationModal
+          {...sheetProps}
+          mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+          onPickExactLocation={vi.fn()}
+          startWithMapPicker
+          onSkip={onSkip}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+      const dot = screen.getByRole("tab", { name: "Pin your entrance" });
+      pointer(dot, "pointerdown", 200, 100);
+      pointer(dot, "pointermove", 200, 340);
+      pointer(dot, "pointerup", 200, 340);
+
+      await new Promise((resolve) => setTimeout(resolve, 320));
+      expect(onSkip).not.toHaveBeenCalled();
+    });
   });
 });

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { useEffect, useId, useRef, useState, type PointerEvent } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
 import {
   ArrowLeft,
   Briefcase,
   Check,
+  ChevronDown,
   Home,
   Loader2,
   Map as MapIcon,
@@ -15,12 +24,16 @@ import {
 } from "lucide-react";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Sheet, SheetContent, useSheetDragHandle } from "@/components/ui/sheet";
 import {
   LocationPickerMap,
   type LocationPickerMapHandle,
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
 import {
+  ADDRESS_LABEL_ROW_CLASSNAME,
+  DOOR_DETAILS_TOGGLE_CLASSNAME,
+  REQUIRED_BADGE_CLASSNAME,
   SHEET_BODY_CLASSNAME,
   SHEET_DETAILS_SHELL_CLASSNAME,
   SHEET_FOOTER_CLASSNAME,
@@ -163,6 +176,79 @@ function SheetGrabber() {
     <div className="flex h-[18px] items-center justify-center" aria-hidden>
       <span className="block h-[5px] w-9 rounded-full bg-[color:var(--app-neutral-fill-strong)]" />
     </div>
+  );
+}
+
+/**
+ * Makes the row it wraps the sheet's drag surface, so pulling down on the
+ * grabber -- or on the slide indicator standing in for it -- dismisses the
+ * sheet the way every other bottom sheet in the app does.
+ *
+ * Inert outside a bottom sheet: on a desktop-width screen this component sits
+ * inside a centred dialog, `useSheetDragHandle` returns null, and the wrapper
+ * is a plain div with no handlers and no `touch-none`.
+ */
+function SheetDragRegion({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const drag = useSheetDragHandle();
+  return (
+    <div
+      data-testid="save-location-sheet-grabber"
+      className={cn(drag && "touch-none select-none", className)}
+      onPointerDown={(event) => {
+        // A press that lands on a dot is a slide change. Letting it start a
+        // drag as well would both move the sheet and switch the pane from one
+        // gesture, and the pointer capture the drag takes would land the
+        // resulting click somewhere the person never pressed.
+        if ((event.target as HTMLElement).closest?.("button")) return;
+        drag?.onPointerDown(event);
+      }}
+      onPointerMove={drag?.onPointerMove}
+      onPointerUp={drag?.onPointerUp}
+      onPointerCancel={drag?.onPointerCancel}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The width at which this surface stops being a bottom sheet and becomes a
+ * centred dialog. The same 640px boundary its own `sm:` classes switch on --
+ * one number, so the presentation and the styling can never disagree.
+ */
+const SHEET_PRESENTATION_QUERY = "(max-width: 639.98px)";
+
+function sheetPresentationSupported(): boolean {
+  return (
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+  );
+}
+
+function subscribeToSheetPresentation(onChange: () => void): () => void {
+  if (!sheetPresentationSupported()) return () => {};
+  const query = window.matchMedia(SHEET_PRESENTATION_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+/**
+ * Read on the first render rather than in an effect. An effect would paint one
+ * frame of the centred dialog before swapping to the sheet, which on a phone
+ * is a visible flash on every single open.
+ */
+function useSheetPresentation(): boolean {
+  return useSyncExternalStore(
+    subscribeToSheetPresentation,
+    () =>
+      sheetPresentationSupported() &&
+      window.matchMedia(SHEET_PRESENTATION_QUERY).matches,
+    () => false,
   );
 }
 
@@ -393,6 +479,9 @@ export function SaveLocationModal({
   const rendererReady = rendererDisclosureReady || rendererDisclosureAccepted;
   const descriptionId = useId();
   const postalCodeErrorId = useId();
+  const addressHelpId = useId();
+  const addressLineErrorId = useId();
+  const doorDetailsId = useId();
   const mapTitleRef = useRef<HTMLHeadingElement | null>(null);
   const detailsTitleRef = useRef<HTMLHeadingElement | null>(null);
   // The pin, its settle state and its resolved address all live inside the
@@ -409,6 +498,15 @@ export function SaveLocationModal({
   // from it, so it is not governed by the "fill the fields below" checkbox.
   const addressLineEditedRef = useRef(false);
   const [addressLineValue, setAddressLineValue] = useState("");
+  /**
+   * An empty required field is not an error until the person has had a turn at
+   * it. Flipped by leaving the box, or by pressing Save -- so the sheet never
+   * opens already shouting, and never lets a press land on nothing.
+   */
+  const [addressTouched, setAddressTouched] = useState(false);
+  /** Progressive disclosure for the details that are polish, not address. */
+  const [doorDetailsOpen, setDoorDetailsOpen] = useState(false);
+  const sheetPresentation = useSheetPresentation();
 
   // Reset internal selection each time the modal (re)opens. When editing an
   // existing saved place, seed the category/label/detail fields from the
@@ -425,6 +523,15 @@ export function SaveLocationModal({
       );
       addressLineEditedRef.current = false;
       setAddressLineValue("");
+      setAddressTouched(false);
+      // Open the polish step only when it already holds an answer, so editing
+      // a saved place never hides something the person typed last time.
+      setDoorDetailsOpen(
+        Boolean(
+          initialDetails &&
+            (initialDetails.landmark || initialDetails.buildingColor),
+        ),
+      );
       // Editing keeps the place's own label; a new place opens on the first
       // label still free, so the primary button is live on arrival instead of
       // waiting behind "Pick Home, Work or Other first."
@@ -561,17 +668,31 @@ export function SaveLocationModal({
     ? addressLineValue
     : detectedAddress;
   /**
-   * Something the person put in themselves. This matters because a pinned
-   * point does not always come back with an address: on the native build
-   * before the vault exists there is no server reverse-geocode and no browser
-   * geocoder either, so the lookup returns nothing however good the pin is.
-   * Blocking the save on a resolved STRING left that person pinned, correct,
-   * and permanently unable to finish.
+   * The one field a saved place cannot do without. It is required, and it is
+   * marked required on screen -- an address box that quietly accepted nothing
+   * was read as optional, and the save then failed for a reason nobody could
+   * see.
+   *
+   * Requiring it is safe precisely because the box is editable. A pinned point
+   * does not always come back with an address: on the native build before the
+   * vault exists there is no server reverse-geocode and no browser geocoder
+   * either, so the lookup returns nothing however good the pin is. That person
+   * is not stuck -- they type the line themselves, in the box that is already
+   * in front of them, and the save unblocks.
    */
-  const hasOwnAddressAnswer =
-    normalizedAddressDetails.houseOrFlat.length > 0 ||
-    normalizedAddressDetails.landmark.length > 0 ||
-    normalizedAddressDetails.postalCode.length > 0;
+  const addressLineMissing =
+    collectAddressDetails && effectiveAddressLine.trim().length === 0;
+  /**
+   * Shown beside the box. Immediately when the lookup settled on nothing --
+   * that is precisely the moment the person needs telling, and the box has
+   * been sitting empty in front of them since it opened. Only on leaving the
+   * box when THEY emptied it, so clearing the line to retype does not flash an
+   * error at every keystroke.
+   */
+  const addressLineError =
+    addressLineMissing &&
+    !loadingAddress &&
+    (addressTouched || !addressLineEditedRef.current);
   const postalCodeInvalid =
     normalizedAddressDetails.postalCode.length > 0 &&
     !isValidPostalCode(normalizedAddressDetails.postalCode);
@@ -590,15 +711,12 @@ export function SaveLocationModal({
       ? null
       : category === null
         ? "Pick Home, Work or Other first."
-        : collectAddressDetails &&
-            effectiveAddressLine.length === 0 &&
-            !hasOwnAddressAnswer
-          ? // The pin is fine; only its address lookup came back empty. Name
-            // the way out that is actually open, rather than sending someone
-            // back to a map they already got right. The line above already
-            // shows there is no address, so this only has to carry the action
-            // -- and it matches the shape of its two siblings.
-            "Add a house, landmark or PIN."
+        : addressLineMissing
+          ? // Not the field's own wording. The empty Address box already says
+            // "Enter the address." right next to itself, and the same sentence
+            // twice on one screen reads as a stutter rather than as two places
+            // worth looking.
+            "Add the address above."
           : postalCodeInvalid
             ? // Not the field's own wording. The invalid PIN already says
               // "Enter a valid PIN or postcode." right next to itself, and
@@ -748,67 +866,50 @@ export function SaveLocationModal({
     setAddressDetails((current) => ({ ...current, [key]: value }));
   };
 
-  return (
-    <Dialog
-      open={open}
-      modal
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen && !interactionBusy) onSkip();
-      }}
-    >
-      <DialogContent
-        showCloseButton={false}
-        data-testid="save-location-modal"
-        aria-describedby={descriptionId}
-        onPointerDown={handleSwipeStart}
-        onPointerUp={handleSwipeEnd}
-        onPointerCancel={() => {
-          swipeOriginRef.current = null;
-        }}
-        // Location onboarding is a full-screen takeover at z-560 with an OPAQUE
-        // background. The scrim used to sit at z-559 -- underneath it -- so the
-        // dim and the blur were painted where nothing could see them, and the
-        // sheet landed on a fully lit screen with no separation at all. That is
-        // the "it looks like a patch": not a missing blur, a buried one.
-        // Above the takeover, below the app's sheets/drawers at z-711.
-        overlayClassName={cn(
-          "z-[600]",
-          nativeMapShowing
-            ? // The native map is not part of the page: @capacitor/google-maps
-              // draws it BELOW the WebView and the WebView is punched through to
-              // reveal it. This overlay is a Radix sibling of the sheet, so the
-              // rule that clears backgrounds inside [data-testid=
-              // "save-location-modal"] never reached it -- and a 55% black scrim
-              // with a 10px blur sat over the whole screen, hiding the map while
-              // the HTML pin and cards stayed crisp on top. That is exactly the
-              // "no map behind it, just one pin" report: the map was rendering
-              // the whole time, behind the scrim.
-              "bg-transparent backdrop-blur-none [-webkit-backdrop-filter:none]"
-            : "bg-black/55 backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)]",
-        )}
-        onEscapeKeyDown={(event) => {
-          if (interactionBusy) event.preventDefault();
-        }}
-        onPointerDownOutside={(event) => {
-          if (interactionBusy || flowStep === "map") event.preventDefault();
-        }}
-        className={cn(
-          "z-[601] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0",
-          "rounded-b-none rounded-t-[24px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[20px]",
-          // A real edge and a real lift, so the sheet reads as a layer above
-          // the screen rather than a rectangle pasted onto it.
-          "border border-black/[0.06] bg-[color:var(--app-card-surface-default-solid)] dark:border-white/[0.08]",
-          detailsPaneActive
-            ? SHEET_DETAILS_SHELL_CLASSNAME
-            : "gap-5 overflow-y-auto p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] sm:p-6 sm:pb-6",
-          // `!` because the sheet's arbitrary shadow does not merge away the
-          // dialog primitive's own `shadow-[var(--app-card-shadow-feature)]`:
-          // tailwind-merge leaves both classes on the element and the base one
-          // wins on stylesheet order, so the lift never actually rendered.
-          "!shadow-[0_24px_60px_-12px_rgba(16,24,40,0.35),0_8px_20px_-8px_rgba(16,24,40,0.24)] dark:!shadow-[0_24px_60px_-12px_rgba(0,0,0,0.7)]",
-        )}
-      >
-        <style>{CAROUSEL_KEYFRAMES}</style>
+  const handleSurfaceOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !interactionBusy) onSkip();
+  };
+
+  // Location onboarding is a full-screen takeover at z-560 with an OPAQUE
+  // background. The scrim used to sit at z-559 -- underneath it -- so the dim
+  // and the blur were painted where nothing could see them, and the sheet
+  // landed on a fully lit screen with no separation at all. That is the "it
+  // looks like a patch": not a missing blur, a buried one. Above the takeover,
+  // below the app's sheets/drawers at z-711 -- held at these values in BOTH
+  // presentations, so moving to the shared sheet primitive does not quietly
+  // move this surface to a different layer.
+  const surfaceOverlayClassName = cn(
+    "z-[600]",
+    nativeMapShowing
+      ? // The native map is not part of the page: @capacitor/google-maps draws
+        // it BELOW the WebView and the WebView is punched through to reveal
+        // it. This overlay is a Radix sibling of the sheet, so the rule that
+        // clears backgrounds inside [data-testid="save-location-modal"] never
+        // reached it -- and a 55% black scrim with a 10px blur sat over the
+        // whole screen, hiding the map while the HTML pin and cards stayed
+        // crisp on top. That is exactly the "no map behind it, just one pin"
+        // report: the map was rendering the whole time, behind the scrim.
+        "bg-transparent backdrop-blur-none [-webkit-backdrop-filter:none]"
+      : "bg-black/55 backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)]",
+  );
+
+  // A real edge and a real lift, so the surface reads as a layer above the
+  // screen rather than a rectangle pasted onto it.
+  const surfaceEdgeClassName =
+    "border border-black/[0.06] bg-[color:var(--app-card-surface-default-solid)] dark:border-white/[0.08]";
+  const surfacePaddingClassName = detailsPaneActive
+    ? SHEET_DETAILS_SHELL_CLASSNAME
+    : "gap-5 overflow-y-auto p-5 pb-[calc(env(safe-area-inset-bottom,0px)+20px)] sm:p-6 sm:pb-6";
+  // `!` because the arbitrary shadow does not merge away the primitive's own
+  // `shadow-[var(--app-card-shadow-feature)]`: tailwind-merge leaves both
+  // classes on the element and the base one wins on stylesheet order, so the
+  // lift never actually rendered.
+  const surfaceShadowClassName =
+    "!shadow-[0_24px_60px_-12px_rgba(16,24,40,0.35),0_8px_20px_-8px_rgba(16,24,40,0.24)] dark:!shadow-[0_24px_60px_-12px_rgba(0,0,0,0.7)]";
+
+  const surfaceChildren = (
+    <>
+      <style>{CAROUSEL_KEYFRAMES}</style>
         {flowStep === "map" && canPickOnMap ? (
           <div {...paneProps}>
             <DialogTitle ref={mapTitleRef} tabIndex={-1} className="sr-only">
@@ -862,18 +963,23 @@ export function SaveLocationModal({
                 floated over it, which is what let a 36px button starting at
                 16px cover a header padded to 36px. */}
             <header className={SHEET_HEADER_CLASSNAME}>
-              {carouselMode ? (
-                <CarouselDots
-                  compact
-                  index={1}
-                  count={2}
-                  labels={carouselLabels}
-                  canAdvance
-                  onSelect={goToSlide}
-                />
-              ) : (
-                <SheetGrabber />
-              )}
+              {/* On a phone this row IS the sheet's grabber, so a pull down on
+                  it dismisses the sheet -- the dots sit exactly where an iOS
+                  grabber sits and were already doing that job visually. */}
+              <SheetDragRegion>
+                {carouselMode ? (
+                  <CarouselDots
+                    compact
+                    index={1}
+                    count={2}
+                    labels={carouselLabels}
+                    canAdvance
+                    onSelect={goToSlide}
+                  />
+                ) : (
+                  <SheetGrabber />
+                )}
+              </SheetDragRegion>
               <div className="mt-1 flex items-center gap-2">
                 <button
                   type="button"
@@ -946,33 +1052,108 @@ export function SaveLocationModal({
                 ) : null}
               </div>
 
-              {/* Added on main while this sheet was being rebuilt: the
-                  address itself is editable, because a pin that resolves to
-                  the wrong line left no way to correct it. */}
+              {/* The address itself is editable, because a pin that resolves
+                  to the wrong line left no way to correct it. It is also the
+                  one field a saved place cannot do without, so it is first and
+                  it is marked required -- an unmarked box that quietly
+                  accepted nothing read as optional right up until the save
+                  would not go. */}
               <div>
-                <label
-                  htmlFor="saved-location-address-line"
-                  className={controlLabelClassName}
+                {/* The badge is a sibling of the label, not inside it. Inside,
+                    it becomes part of the field's accessible name -- the box
+                    would announce as "Address Required" and stop matching a
+                    query for its own label. The requirement reaches assistive
+                    technology through `aria-required` instead, which is what
+                    that attribute is for. */}
+                <div className={ADDRESS_LABEL_ROW_CLASSNAME}>
+                  <label
+                    htmlFor="saved-location-address-line"
+                    className={cn(controlLabelClassName, "mb-0")}
+                  >
+                    Address
+                  </label>
+                  {/* The word, not only a red asterisk: an asterisk is a
+                      convention people have to already know, and colour on its
+                      own carries nothing to anyone who cannot see it. */}
+                  <span aria-hidden className={REQUIRED_BADGE_CLASSNAME}>
+                    Required
+                  </span>
+                </div>
+                <p
+                  id={addressHelpId}
+                  className="mb-1.5 text-[13px] leading-[18px] text-muted-foreground"
                 >
-                  Address
-                </label>
+                  Used to find your door.
+                </p>
                 <input
                   id="saved-location-address-line"
                   type="text"
+                  required
+                  aria-required="true"
+                  aria-invalid={addressLineError}
+                  aria-describedby={
+                    addressLineError
+                      ? `${addressHelpId} ${addressLineErrorId}`
+                      : addressHelpId
+                  }
                   value={effectiveAddressLine}
                   onChange={(event) => {
                     addressLineEditedRef.current = true;
                     setAddressLineValue(event.target.value);
                   }}
+                  onBlur={() => setAddressTouched(true)}
                   disabled={interactionBusy}
                   maxLength={300}
                   autoComplete={deferredUntilVault ? "off" : "street-address"}
                   placeholder={
                     loadingAddress ? "Finding address…" : "12 MG Road, Bengaluru"
                   }
-                  className={controlInputClassName}
+                  className={cn(
+                    controlInputClassName,
+                    "aria-[invalid=true]:border-[color:var(--app-destructive)]",
+                  )}
                 />
+                {addressLineError ? (
+                  <p
+                    id={addressLineErrorId}
+                    role="alert"
+                    className="mt-1.5 text-[13px] leading-[18px] text-[color:var(--app-destructive)]"
+                  >
+                    Enter the address.
+                  </p>
+                ) : null}
               </div>
+
+              {/* Second, because naming the place is the other thing the save
+                  genuinely needs. It used to sit under four optional boxes, so
+                  the two required answers were separated by everything that
+                  was not one. */}
+              <SavedLocationCategoryPicker
+                value={category}
+                disabled={interactionBusy}
+                onChange={setCategory}
+              />
+
+              {category === "other" ? (
+                <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
+                  <label
+                    htmlFor="saved-location-details-custom-label"
+                    className={controlLabelClassName}
+                  >
+                    Name it
+                  </label>
+                  <input
+                    id="saved-location-details-custom-label"
+                    type="text"
+                    value={customLabel}
+                    onChange={(event) => setCustomLabel(event.target.value)}
+                    disabled={interactionBusy}
+                    maxLength={40}
+                    placeholder="Gym, parents' house"
+                    className={controlInputClassName}
+                  />
+                </div>
+              ) : null}
 
               {/* Ticked, the fields below are filled from that address and keep
                   following the pin. Unticked, they are cleared and left alone.
@@ -1005,51 +1186,29 @@ export function SaveLocationModal({
 
               <div className="space-y-3.5">
                 {/* Said once, for the group, instead of an "(optional)" tag
-                    hanging off all four labels. */}
+                    hanging off every label. */}
                 <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
                   Optional — helps at the door.
                 </p>
-                <div>
-                  <label
-                    htmlFor="saved-location-house-or-flat"
-                    className={controlLabelClassName}
-                  >
-                    House or flat
-                  </label>
-                  <input
-                    id="saved-location-house-or-flat"
-                    type="text"
-                    value={addressDetails.houseOrFlat}
-                    onChange={(event) =>
-                      updateAddressDetail("houseOrFlat", event.target.value)
-                    }
-                    disabled={interactionBusy}
-                    maxLength={80}
-                    autoComplete={deferredUntilVault ? "off" : "address-line1"}
-                    placeholder="Flat 4B, Tower 2"
-                    className={controlInputClassName}
-                  />
-                </div>
-
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <div>
                     <label
-                      htmlFor="saved-location-building-color"
+                      htmlFor="saved-location-house-or-flat"
                       className={controlLabelClassName}
                     >
-                      Building colour
+                      House or flat
                     </label>
                     <input
-                      id="saved-location-building-color"
+                      id="saved-location-house-or-flat"
                       type="text"
-                      value={addressDetails.buildingColor}
+                      value={addressDetails.houseOrFlat}
                       onChange={(event) =>
-                        updateAddressDetail("buildingColor", event.target.value)
+                        updateAddressDetail("houseOrFlat", event.target.value)
                       }
                       disabled={interactionBusy}
-                      maxLength={40}
-                      autoComplete="off"
-                      placeholder="Blue gate"
+                      maxLength={80}
+                      autoComplete={deferredUntilVault ? "off" : "address-line1"}
+                      placeholder="Flat 4B, Tower 2"
                       className={controlInputClassName}
                     />
                   </div>
@@ -1100,55 +1259,86 @@ export function SaveLocationModal({
                   </div>
                 </div>
 
+                {/* Behind a tap, not in front of one. Being asked the colour of
+                    your building before you have finished saying where it is
+                    reads as an odd question; asked later, of someone who chose
+                    to open this, it reads as care. Kept mounted so anything
+                    already typed survives collapsing, and opened on arrival
+                    when it holds an answer. */}
                 <div>
-                  <label
-                    htmlFor="saved-location-landmark"
-                    className={controlLabelClassName}
-                  >
-                    Landmark
-                  </label>
-                  <input
-                    id="saved-location-landmark"
-                    type="text"
-                    value={addressDetails.landmark}
-                    onChange={(event) =>
-                      updateAddressDetail("landmark", event.target.value)
-                    }
+                  <button
+                    type="button"
+                    onClick={() => setDoorDetailsOpen((shown) => !shown)}
                     disabled={interactionBusy}
-                    maxLength={100}
-                    autoComplete={deferredUntilVault ? "off" : "address-line2"}
-                    placeholder="Opposite City Mall"
-                    className={controlInputClassName}
-                  />
+                    aria-expanded={doorDetailsOpen}
+                    aria-controls={doorDetailsId}
+                    data-testid="save-location-door-details-toggle"
+                    className={DOOR_DETAILS_TOGGLE_CLASSNAME}
+                  >
+                    <span className="text-[15px] font-semibold leading-5 text-foreground">
+                      More door details
+                    </span>
+                    <ChevronDown
+                      className={cn(
+                        "h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)] transition-transform duration-200",
+                        doorDetailsOpen && "rotate-180",
+                      )}
+                      strokeWidth={2.2}
+                      aria-hidden
+                    />
+                  </button>
+                  <div
+                    id={doorDetailsId}
+                    hidden={!doorDetailsOpen}
+                    className="mt-3.5 space-y-3.5"
+                  >
+                    <div>
+                      <label
+                        htmlFor="saved-location-landmark"
+                        className={controlLabelClassName}
+                      >
+                        Landmark
+                      </label>
+                      <input
+                        id="saved-location-landmark"
+                        type="text"
+                        value={addressDetails.landmark}
+                        onChange={(event) =>
+                          updateAddressDetail("landmark", event.target.value)
+                        }
+                        disabled={interactionBusy}
+                        maxLength={100}
+                        autoComplete={
+                          deferredUntilVault ? "off" : "address-line2"
+                        }
+                        placeholder="Opposite City Mall"
+                        className={controlInputClassName}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="saved-location-building-color"
+                        className={controlLabelClassName}
+                      >
+                        Building colour
+                      </label>
+                      <input
+                        id="saved-location-building-color"
+                        type="text"
+                        value={addressDetails.buildingColor}
+                        onChange={(event) =>
+                          updateAddressDetail("buildingColor", event.target.value)
+                        }
+                        disabled={interactionBusy}
+                        maxLength={40}
+                        autoComplete="off"
+                        placeholder="Blue gate"
+                        className={controlInputClassName}
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
-
-              <SavedLocationCategoryPicker
-                value={category}
-                disabled={interactionBusy}
-                onChange={setCategory}
-              />
-
-              {category === "other" ? (
-                <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
-                  <label
-                    htmlFor="saved-location-details-custom-label"
-                    className={controlLabelClassName}
-                  >
-                    Name it
-                  </label>
-                  <input
-                    id="saved-location-details-custom-label"
-                    type="text"
-                    value={customLabel}
-                    onChange={(event) => setCustomLabel(event.target.value)}
-                    disabled={interactionBusy}
-                    maxLength={40}
-                    placeholder="Gym, parents' house"
-                    className={controlInputClassName}
-                  />
-                </div>
-              ) : null}
 
               {/* A caption, not a card. It reassures; it is not a control, and
                   the panel it used to sit in gave it a control's weight. */}
@@ -1420,7 +1610,82 @@ export function SaveLocationModal({
             </div>
           </div>
         )}
+    </>
+  );
 
+  /**
+   * On a phone this is the app's own bottom sheet -- the same component, drag
+   * handle and drag-to-dismiss the Market surfaces use -- rather than a
+   * dialog wearing a sheet's corners. Above 640px it stays the centred dialog
+   * it already was.
+   *
+   * `contentDragDismiss` is off because the details pane is a fixed frame with
+   * its own inner scroller: the outer surface never scrolls, so a body drag
+   * would engage on every downward swipe and cancel the scroll it was meant to
+   * be. The header row is the drag surface instead -- see `SheetDragRegion`.
+   */
+  if (sheetPresentation) {
+    return (
+      <Sheet open={open} modal onOpenChange={handleSurfaceOpenChange}>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          showDragHandle={false}
+          contentDragDismiss={false}
+          data-testid="save-location-modal"
+          aria-describedby={descriptionId}
+          onPointerDown={handleSwipeStart}
+          onPointerUp={handleSwipeEnd}
+          onPointerCancel={() => {
+            swipeOriginRef.current = null;
+          }}
+          overlayClassName={surfaceOverlayClassName}
+          onEscapeKeyDown={(event) => {
+            if (interactionBusy) event.preventDefault();
+          }}
+          onPointerDownOutside={(event) => {
+            if (interactionBusy || flowStep === "map") event.preventDefault();
+          }}
+          className={cn(
+            "z-[601] mx-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] rounded-t-[24px]",
+            surfaceEdgeClassName,
+            surfacePaddingClassName,
+            surfaceShadowClassName,
+          )}
+        >
+          {surfaceChildren}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Dialog open={open} modal onOpenChange={handleSurfaceOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        data-testid="save-location-modal"
+        aria-describedby={descriptionId}
+        onPointerDown={handleSwipeStart}
+        onPointerUp={handleSwipeEnd}
+        onPointerCancel={() => {
+          swipeOriginRef.current = null;
+        }}
+        overlayClassName={surfaceOverlayClassName}
+        onEscapeKeyDown={(event) => {
+          if (interactionBusy) event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          if (interactionBusy || flowStep === "map") event.preventDefault();
+        }}
+        className={cn(
+          "z-[601] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0",
+          "rounded-b-none rounded-t-[24px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[20px]",
+          surfaceEdgeClassName,
+          surfacePaddingClassName,
+          surfaceShadowClassName,
+        )}
+      >
+        {surfaceChildren}
       </DialogContent>
     </Dialog>
   );

--- a/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
@@ -47,5 +47,28 @@ export const SHEET_BODY_CLASSNAME =
 export const SHEET_FOOTER_CLASSNAME =
   "relative z-10 flex shrink-0 flex-col gap-2 border-t border-[color:var(--app-separator)] bg-[color:var(--app-card-surface-default-solid)] px-5 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+12px)]";
 
+/**
+ * The Address label and its "Required" badge, as one row.
+ *
+ * Exported for the same reason as the three above: the badge is the only place
+ * on this sheet where a label shares its line with something else, so it is
+ * the only place where a narrow phone can push a word off the edge. A JSDOM
+ * test can prove the badge is rendered; only a browser can prove it still fits
+ * beside the word "Address" at 320px.
+ */
+export const ADDRESS_LABEL_ROW_CLASSNAME = "mb-1 flex items-center gap-1.5";
+
+/** The badge itself. `shrink-0` is what keeps it a pill rather than a sliver. */
+export const REQUIRED_BADGE_CLASSNAME =
+  "shrink-0 rounded-full bg-[color:var(--app-destructive)]/12 px-1.5 py-px text-[11px] font-semibold uppercase leading-[16px] tracking-[0.02em] text-[color:var(--app-destructive)]";
+
+/**
+ * The row that opens the optional door details. A control, so it owes the
+ * platform's 44px minimum -- and `min-h-11` rather than a fixed height,
+ * because its label wraps to two lines under a large text setting.
+ */
+export const DOOR_DETAILS_TOGGLE_CLASSNAME =
+  "press-scale flex min-h-11 w-full items-center justify-between gap-2 rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] px-3.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.03] disabled:opacity-45";
+
 /** Widths the sheet has to hold its shape at, smallest phone upward. */
 export const SHEET_LAYOUT_WIDTHS = [320, 360, 375, 390, 430, 768] as const;

--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -84,6 +84,31 @@ function SheetOverlay({
   )
 }
 
+/**
+ * The pointer handlers that make an element behave as the sheet's grabber.
+ *
+ * Exposed through context so a sheet whose header ALREADY carries a grabber --
+ * or something standing in for one, like a slide indicator -- can be dragged
+ * by that row instead of stacking a second 44px handle above it. Attach all
+ * four to the SAME element: the drag takes pointer capture on the element it
+ * started from and releases it on the same one.
+ */
+type SheetDragHandleProps = {
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerCancel: (event: React.PointerEvent<HTMLDivElement>) => void
+}
+
+const SheetDragHandleContext = React.createContext<SheetDragHandleProps | null>(
+  null,
+)
+
+/** Null unless the surrounding sheet is a draggable bottom sheet. */
+function useSheetDragHandle(): SheetDragHandleProps | null {
+  return React.useContext(SheetDragHandleContext)
+}
+
 type SheetContentProps =
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> & {
     side?: "top" | "right" | "bottom" | "left"
@@ -93,6 +118,18 @@ type SheetContentProps =
      * sheets. Bottom sheets opt in by default; other sides are unaffected.
      */
     dragDismiss?: boolean
+    /**
+     * Lets a downward drag that starts anywhere in the sheet body dismiss it.
+     *
+     * On by default, because most sheets ARE their own scroll box: the drag
+     * only engages once that box is already scrolled to the top, so it cannot
+     * steal a scroll. A sheet that is a fixed frame with its own inner
+     * scroller has no such guard -- the outer surface never scrolls, so its
+     * `scrollTop` is permanently 0 and every downward drag inside the body
+     * would engage and `preventDefault()` the scroll it was trying to make.
+     * Those sheets pass `false` and keep the handle as the only drag surface.
+     */
+    contentDragDismiss?: boolean
     /** Renders the accessible drag affordance above a draggable bottom sheet. */
     showDragHandle?: boolean
     /** Optional surface-specific scrim treatment for a semantic app sheet. */
@@ -123,6 +160,7 @@ function SheetContent(
     showCloseButton = true,
     showOverlay = true,
     dragDismiss = true,
+    contentDragDismiss = true,
     showDragHandle,
     overlayClassName,
     onPointerDown,
@@ -148,6 +186,19 @@ function SheetContent(
   })
   const shouldShowDragHandle =
     side === "bottom" && dragDismiss && (showDragHandle ?? true)
+  const dragEnabled = side === "bottom" && dragDismiss
+  const dragHandleProps = React.useMemo<SheetDragHandleProps | null>(
+    () =>
+      dragEnabled
+        ? {
+            onPointerDown: onHandlePointerDown,
+            onPointerMove: onHandlePointerMove,
+            onPointerUp: onHandlePointerEnd,
+            onPointerCancel: onHandlePointerEnd,
+          }
+        : null,
+    [dragEnabled, onHandlePointerDown, onHandlePointerMove, onHandlePointerEnd],
+  )
 
   return (
     <SheetPortal>
@@ -170,19 +221,19 @@ function SheetContent(
           className
         )}
         onPointerDown={(event) => {
-          onContentPointerDown(event)
+          if (contentDragDismiss) onContentPointerDown(event)
           onPointerDown?.(event)
         }}
         onPointerMove={(event) => {
-          onContentPointerMove(event)
+          if (contentDragDismiss) onContentPointerMove(event)
           onPointerMove?.(event)
         }}
         onPointerUp={(event) => {
-          onContentPointerEnd(event)
+          if (contentDragDismiss) onContentPointerEnd(event)
           onPointerUp?.(event)
         }}
         onPointerCancel={(event) => {
-          onContentPointerEnd(event)
+          if (contentDragDismiss) onContentPointerEnd(event)
           onPointerCancel?.(event)
         }}
         {...props}
@@ -211,7 +262,9 @@ function SheetContent(
             />
           </div>
         ) : null}
-        {children}
+        <SheetDragHandleContext.Provider value={dragHandleProps}>
+          {children}
+        </SheetDragHandleContext.Provider>
         {/*
           The visible circle stays exactly 32px (p-2 + size-4) so no sheet
           changes appearance. `after:-inset-1.5` extends only the HIT region to
@@ -478,4 +531,5 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
+  useSheetDragHandle,
 }

--- a/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
+++ b/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
@@ -7,6 +7,9 @@ import { awaitProductFont, productFontStyle } from "./fixtures/product-font";
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
 import {
+  ADDRESS_LABEL_ROW_CLASSNAME,
+  DOOR_DETAILS_TOGGLE_CLASSNAME,
+  REQUIRED_BADGE_CLASSNAME,
   SHEET_BODY_CLASSNAME,
   SHEET_DETAILS_SHELL_CLASSNAME,
   SHEET_FOOTER_CLASSNAME,
@@ -77,30 +80,62 @@ async function buildFixture(): Promise<string> {
     "flex h-[52px] w-full items-center justify-center rounded-full";
   const secondary = "h-11 w-full rounded-full";
 
+  /**
+   * Split from its margin on purpose. This fixture writes raw class strings
+   * with no `cn()` behind them, so `"... mb-1.5 ... mb-0"` would leave BOTH
+   * rules standing and the stylesheet order would decide -- which is not what
+   * the component does. It composes the Address label with `cn(...)`, and
+   * tailwind-merge drops the margin outright.
+   */
+  const label = "block text-[13px] font-semibold leading-[18px]";
+
   const classes = [
     shell,
     SHEET_DETAILS_SHELL_CLASSNAME,
     SHEET_HEADER_CLASSNAME,
     SHEET_BODY_CLASSNAME,
     SHEET_FOOTER_CLASSNAME,
+    ADDRESS_LABEL_ROW_CLASSNAME,
+    REQUIRED_BADGE_CLASSNAME,
+    DOOR_DETAILS_TOGGLE_CLASSNAME,
     row,
     button,
     title,
     field,
+    label,
     primary,
     secondary,
-    "mt-1 space-y-3.5 mb-1.5 block",
+    "mt-1 space-y-3.5 mb-1.5 mb-0 block",
   ].join(" ");
   const css = compiler.build(classes.split(/\s+/).filter(Boolean));
 
+  // The Address row: the one label on this sheet that shares its line with
+  // something else, so the one that a narrow phone can break.
+  const addressRow =
+    `<div class="${ADDRESS_LABEL_ROW_CLASSNAME}">` +
+    `<label class="${label}" data-testid="address-label">Address</label>` +
+    `<span class="${REQUIRED_BADGE_CLASSNAME}" data-testid="address-required-badge">Required</span>` +
+    `</div>` +
+    `<input class="${field}" data-testid="sheet-field" value="Kartavya Path, New Delhi, Delhi 110001, India">`;
+
+  // The progressive-disclosure row. A control, so it owes 44px.
+  const doorDetails =
+    `<button class="${DOOR_DETAILS_TOGGLE_CLASSNAME}" data-testid="door-details-toggle">` +
+    `<span class="text-[15px] font-semibold leading-5" data-testid="door-details-label">More door details</span>` +
+    `<span aria-hidden>v</span>` +
+    `</button>`;
+
   // Enough fields to overflow every width under test, so the body genuinely
   // has to scroll -- a footer only bleeds when there is something behind it.
-  const fields = Array.from(
-    { length: 8 },
-    (_, i) =>
-      `<div><label class="mb-1.5 block">Field ${i + 1}</label>` +
-      `<input class="${field}" data-testid="sheet-field" value="Value ${i + 1}"></div>`,
-  ).join("");
+  const fields =
+    addressRow +
+    Array.from(
+      { length: 8 },
+      (_, i) =>
+        `<div><label class="${label} mb-1.5">Field ${i + 1}</label>` +
+        `<input class="${field}" data-testid="sheet-field" value="Value ${i + 1}"></div>`,
+    ).join("") +
+    doorDetails;
 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "save-location-sheet-"));
   fs.writeFileSync(path.join(dir, "fixture.css"), css);
@@ -216,6 +251,63 @@ test.describe("Save-location address sheet layout", () => {
       expect(Math.round(last!.y + last!.height)).toBeLessThanOrEqual(
         Math.round(footerAfter.y) + 1,
       );
+    });
+
+    test(`keeps the Required badge whole beside the Address label at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+      await awaitProductFont(page);
+
+      const body = await boxOf(page, "sheet-body");
+      const label = await boxOf(page, "address-label");
+      const badge = await boxOf(page, "address-required-badge");
+
+      // One line, in order, not stacked and not overlapping. Measured on the
+      // centres, because the row centre-aligns two boxes of different heights
+      // -- their top edges are not meant to agree.
+      expect(
+        Math.abs(label.y + label.height / 2 - (badge.y + badge.height / 2)),
+      ).toBeLessThanOrEqual(1);
+      expect(Math.round(label.x + label.width)).toBeLessThanOrEqual(
+        Math.round(badge.x),
+      );
+      // And still inside the sheet, rather than pushed off its right edge.
+      expect(Math.round(badge.x + badge.width)).toBeLessThanOrEqual(
+        Math.round(body.x + body.width),
+      );
+
+      // Neither word is clipped. The badge is the field's only visible
+      // statement that it is mandatory; a "Requir…" is not one.
+      const clipped = await page.evaluate(() =>
+        ["address-label", "address-required-badge"]
+          .map((id) => document.querySelector(`[data-testid="${id}"]`)!)
+          .filter((el) => el.scrollWidth > el.clientWidth + 1)
+          .map((el) => el.getAttribute("data-testid")),
+      );
+      expect(clipped).toEqual([]);
+    });
+
+    test(`gives the door-details row a real 44px at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+      await awaitProductFont(page);
+
+      const body = await boxOf(page, "sheet-body");
+      const toggle = await boxOf(page, "door-details-toggle");
+
+      expect(toggle.height).toBeGreaterThanOrEqual(44);
+      expect(Math.round(toggle.x + toggle.width)).toBeLessThanOrEqual(
+        Math.round(body.x + body.width),
+      );
+
+      const labelClipped = await page
+        .getByTestId("door-details-label")
+        .evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+      expect(labelClipped).toBe(false);
     });
   }
 


### PR DESCRIPTION
Closes #5397, #5398, #5399, #5400 — all four are the same screen: the address step of Location onboarding (`SaveLocationModal`, details pane).

## #5397 — the address is mandatory, and now says so

The box accepted nothing and explained nothing. The save gate also let a house number, landmark or PIN stand in for the address, so a field nobody had marked as required was, in practice, optional.

- `Required` badge beside the label — the **word**, not a red asterisk, so the requirement does not depend on seeing a colour. Kept as a sibling of `<label>`, not inside it, or it joins the field's accessible name.
- `aria-required` + `required` on the input, `aria-invalid` when empty.
- One-line reason under the label: *Used to find your door.*
- Inline error beside the box: *Enter the address.* — shown immediately when the pin's lookup settles on nothing (the moment the person needs telling), and only on blur when **they** emptied it, so clearing the line to retype does not flash an error per keystroke.
- The button's own reason changed to *Add the address above.* — deliberately not the field's wording, matching the convention the PIN field already set on this sheet.

**Contract change, called out explicitly:** door details no longer unblock a save. That escape hatch existed for a real incident — on the native build before the vault exists there is no server reverse-geocode and no browser geocoder, so a perfectly good pin returns no address. That person is still not stranded: the Address box is editable and already on screen, they type the line and finish. The test that covered the old route now covers the new one, plus a mutation-check that door details alone leave the button disabled.

## #5400 — order, and building colour behind a tap

Was: address → checkbox → house/flat → **building colour** | PIN → landmark → Home/Work/Other.

Now: address (required) → **Home/Work/Other** → *Fill from this address* → house/flat | PIN → **More door details** ▸ landmark, building colour.

The two answers a save actually needs are now adjacent instead of separated by four optional boxes. The disclosure stays mounted so anything typed survives collapsing, and opens on arrival when the place already carries those answers (editing a saved place hides nothing).

## #5398 — the app's own bottom sheet on mobile

Below 640px the surface is now `Sheet`/`SheetContent side="bottom"` — the same primitive the Market surfaces use — with a real drag-to-dismiss. Above 640px it stays the centred dialog. The breakpoint is the same 640px the sheet's own `sm:` classes already switched on, read on first render via `useSyncExternalStore` so a phone never sees one frame of dialog before the sheet.

Two **additive** props on the shared primitive, no behaviour change for any existing sheet:

- `contentDragDismiss` (default `true`) — off here. The details pane is a fixed frame with its own inner scroller, so the outer surface's `scrollTop` is permanently 0 and a body drag would engage on every downward swipe and `preventDefault()` the scroll it was meant to be.
- a drag-handle context, so the header row that already carries the grabber/slide dots **is** the drag surface, instead of stacking a second 44px handle above it. A press landing on a dot is left to the dot.

Layer, scrim and the native-map transparency hack are held at the same values in both presentations, so moving to the shared primitive does not quietly move this surface to a different z-layer.

**Not delivered:** multi-detent snap points. The canonical component has drag-to-dismiss and settle-back, not detents; inventing a second snap system here would make Location diverge from the surfaces this issue asks it to match.

## #5399 — audit result: already clean, now guarded

Swept every skip / finish / step-completion handler across Finance (`app/one/setup/kai`, `KaiPreferencesWizard`), Location (`location-onboarding-setup-client`, the onboarding flow) and KYC (`kyc-identity-preface`), plus `setup-capability-coordinator`, `capability-setup-tile` and `onboarding-journey-guard`. **No hard navigation remains** — every path is `router.push` / `router.replace` or `requestInternalAppNavigation`, and the journey guard already carries a comment explaining why.

Since the defect is one line reintroduced anywhere across ~100 files, the deliverable is a guard rather than a fix: `__tests__/onboarding/onboarding-client-navigation.test.ts` scans those trees and fails on `window.location.assign/replace/reload`, an assignment to `window.location*`, or an import of `assignWindowLocation` / `replaceWindowLocation` / `reloadWindow`. Reads of `window.location.pathname` stay allowed — the guard itself relies on them. It also asserts it still finds the trees, so a moved directory cannot turn it into a test that always passes.

## Verification

| | result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` on changed files | clean, `--max-warnings=0` |
| Full vitest, this branch | 13 files / 21 tests failing |
| Full vitest, `origin/main` baseline | 13 files / 21 tests failing — **identical set** |
| Net | +15 passing tests, +1 file, 0 regressions |
| `npm run test:layout-contracts` | 150 passed (Chromium) + 89 passed (WebKit) |

Every new assertion was mutation-checked: forcing the dialog presentation, unwiring the drag region, removing the required gate, un-hiding building colour, stacking the badge under the label, dropping the toggle's 44px floor, and planting a `window.location.assign` in an onboarding file each fail the test written for them.

Real-browser layout contracts were extended rather than added, so they stay inside the enumerated `test:layout-contracts` list: the Required badge stays whole and on one line beside the label at 320–768px, and the disclosure row keeps a real 44px. The class strings are exported from `save-location-sheet-layout.ts` and imported by both the component and the spec, so the spec measures what ships.
