### PR TITLE
fix(one-location): remove redundant Pause my location row from Settings

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1430,7 +1430,11 @@ describe("OneLocationAgentPage", () => {
     expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
-  it("keeps the header, Pause setting, and active Nearby presence synchronized", async () => {
+  it("keeps the header toggle synced with Nearby, with Settings unaffected by the removed Pause row", async () => {
+    // The Settings "Pause my location" row was removed as a duplicate of this
+    // same header switch (#5427) -- both read and wrote the identical
+    // `locationControl.paused` state, so this test now drives pause/resume
+    // from the one control that is left.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -1458,34 +1462,33 @@ describe("OneLocationAgentPage", () => {
       ).toHaveAttribute("aria-checked", "true"),
     );
 
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location off" }));
+    await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location on" }),
+      ).toHaveAttribute("aria-checked", "false"),
+    );
+
+    mockCaptureCurrentPosition.mockClear();
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location on" }));
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+
+    // Settings still opens cleanly and its unrelated toggles still work now
+    // that "Location sharing" has one fewer row.
     fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
-    const pauseSwitch = await screen.findByRole("switch", {
-      name: "Pause my location",
-    });
-    const autoApproveSwitch = screen.getByRole("switch", {
+    const autoApproveSwitch = await screen.findByRole("switch", {
       name: "Auto-approve requests",
     });
-    expect(pauseSwitch).toHaveAttribute("aria-checked", "false");
     // Off until asked for: approving a location request is consent, and a
     // default may not give it.
     expect(autoApproveSwitch).toHaveAttribute("aria-checked", "false");
-
     fireEvent.click(autoApproveSwitch);
-    expect(autoApproveSwitch).toHaveAttribute("aria-checked", "true");
-
-    fireEvent.click(pauseSwitch);
-    await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(pauseSwitch).toHaveAttribute("aria-checked", "true"),
-    );
-    expect(autoApproveSwitch).toHaveAttribute("aria-checked", "true");
-
-    mockCaptureCurrentPosition.mockClear();
-    fireEvent.click(pauseSwitch);
-    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(pauseSwitch).toHaveAttribute("aria-checked", "false"),
-    );
     expect(autoApproveSwitch).toHaveAttribute("aria-checked", "true");
   });
 
@@ -1517,22 +1520,20 @@ describe("OneLocationAgentPage", () => {
       ).toHaveAttribute("aria-checked", "true"),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
-    const pauseSwitch = await screen.findByRole("switch", {
-      name: "Pause my location",
-    });
-    fireEvent.click(pauseSwitch);
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location off" }));
 
     await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
     // The optimistic toggle reverts a render after the rejection resolves, so
     // this has to be waited for rather than read on the same tick. It passed
     // before only because onboarding left fake timers draining behind it.
     await waitFor(() =>
-      expect(pauseSwitch).toHaveAttribute("aria-checked", "false"),
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
     );
   });
 
-  it("keeps Pause enabled when resuming cannot capture a fresh point", async () => {
+  it("keeps location paused when resuming cannot capture a fresh point", async () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
     await waitFor(() =>
@@ -1550,14 +1551,12 @@ describe("OneLocationAgentPage", () => {
     mockCaptureCurrentPosition.mockRejectedValue(
       new Error("fresh location unavailable"),
     );
-    fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
-    const pauseSwitch = await screen.findByRole("switch", {
-      name: "Pause my location",
-    });
-    fireEvent.click(pauseSwitch);
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location on" }));
 
     await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
-    expect(pauseSwitch).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", { name: "Turn location on" }),
+    ).toHaveAttribute("aria-checked", "false");
   });
 
   it("shows a limited status when the captured point is too approximate for Nearby", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -8859,10 +8859,6 @@ export function OneLocationAgentPageContent({
     vaultOwnerToken,
   ]);
 
-  const handleResumeMyLocation = useCallback(() => {
-    void handleShowMyLiveLocation();
-  }, [handleShowMyLiveLocation]);
-
   // The Location surface's first two actions that DO something rather than
   // open something. Both delegate to the same callbacks the on-screen controls
   // use, so voice can never take a path a tap could not, and both report the
@@ -11410,7 +11406,6 @@ export function OneLocationAgentPageContent({
     toggleRequestOwner: (id) => toggleRequestOwner(id, "section_list"),
     onShowMyLocation: () => void handleShowMyLiveLocation(),
     onHideMyLocation: () => void handleHideMyLiveLocation(),
-    onResumeMyLocation: handleResumeMyLocation,
     onAutoApproveRequestsChange: handleAutoApproveChange,
     onRequestPermission: () => void handleRequestLocationPermission(),
     onOpenLocationSettings: () => void handleOpenLocationSettings(),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -319,7 +319,6 @@ export type LocationHubViewModel = {
   /* actions — wired 1:1 to existing handlers */
   onShowMyLocation: () => void;
   onHideMyLocation: () => void;
-  onResumeMyLocation: () => void;
   onAutoApproveRequestsChange: (enabled: boolean) => void;
   onRequestPermission: () => void;
   onOpenLocationSettings: () => void;

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1931,25 +1931,6 @@ function LocationSettingsFlow({
           }
           density="compact"
         />
-        <SettingsRow
-          title="Pause my location"
-          description="Stops new updates and checks you out of Nearby."
-          trailing={
-            <LocationToggle
-              checked={vm.locationPaused}
-              onChange={(next) => {
-                if (next) {
-                  vm.onHideMyLocation();
-                  return;
-                }
-                vm.onResumeMyLocation();
-              }}
-              label="Pause my location"
-              voiceControlId="one-location-updates-toggle"
-            />
-          }
-          density="compact"
-        />
       </SettingsGroup>
 
       <div className="flex items-start gap-2.5 px-1">


### PR DESCRIPTION
# Description

Closes #5427. The Settings subpage had a "Pause my location — Stops new updates and checks you out of Nearby." toggle that duplicated the master Location toggle already on the Location home page header. Verified in code (not just taken on the issue's word) that both controls read/write the identical `locationControl.paused` state through the identical `onHideMyLocation`/`onResumeMyLocation` handlers, and already share the same `one-location-updates-toggle` voice-control id — one piece of state exposed on two UI surfaces. Removed the Settings row; the header switch is the single remaining control.

## Impact Map (Required)

- Routes touched: `/one/location` (Settings sub-screen only; presentational)
- API / schema / type changes: None
- Cache keys touched: None
- Runtime DB data-plane changes: None
- World-model domain summary effects: None
- Mobile parity impacts: None — shared React component rendered in the same webview on iOS/Android via Capacitor, no native code touched
- Docs updated: None
- Top-level / devex / config / generated / ignore files touched: None
- Trust boundary touched: None — no data access change, removes a duplicate control only
- Caller / proxy / backend pairing: Not applicable
- Rollback or safe-failure behavior: Not applicable — the header toggle (`vm.locationEnabled`/`vm.locationPaused`) and its handlers are untouched; only the Settings row's JSX is deleted
- UI browser or Playwright proof: Not applicable — no live device/browser screenshot captured this session; verified via rewritten unit tests plus a clean production build instead
- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr` — fails locally on this Windows box because the script shells out to WSL, which isn't installed here; `Signed-off-by` trailer manually confirmed present on the commit (`git log -1`)
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` (targeted: `one-location-agent-page`, `screen-context-builder`, `navigation-journey`, `location-acting-actions` — 172/172 pass)
  - [x] `cd hushh-webapp && npm run build` (production build; verified with a non-localhost `PYTHON_API_URL`/`BACKEND_URL` since local `.env.local` points at `localhost`, which the hosted-build guard intentionally rejects)
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0`

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: `LocationSettingsFlow` in `components/one-location/redesign/location-redesign-hub.tsx`, and `LocationHeaderActions` (the remaining control) in the same file.
- [x] Production surface proved: rewrote the 3 tests in `__tests__/components/one-location-agent-page.test.tsx` that previously drove pause/resume through the removed row to drive the same business logic through the header switch instead — all pass.
- [x] Required checks are current on this head, commit is signed off (`git commit -s`).

## Tri-Flow Architecture Check

- [x] Web: Next.js implementation — the only layer changed.
- [x] iOS: Not applicable — shared web component served through the existing Capacitor webview, no native plugin touched.
- [x] Android: Not applicable — same shared webview component.

## Testing

- [ ] Tested on Web (Chrome/Safari) — not manually verified in a live browser this session
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed — the voice-action contract (`location.pause_updates`, label "Pause my location" in `page.tsx`'s action array) already routes to the shared `one-location-updates-toggle` control id, which survives on the header switch, so nothing derived from it needed regeneration.

## Screenshots / Video

Not captured this session. Route: `/one/location` → Settings. Expected: "Location sharing" group now shows only "Auto-approve requests" and "Show me on their map"; header Location switch still pauses/resumes tracking and checks the user out of Nearby exactly as before.

## Privacy & Consent

- [x] Does this change access user data? No — presentational removal of a duplicate control.
- [x] Sensitive surface touched: none.
- [x] Error path / safe-failure: unchanged — same handlers, same optimistic-revert behavior, now exercised through the header switch.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes
