### PR TITLE
fix(dark-mode): raise contrast of muted/secondary text tokens (#5417)

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1066,7 +1066,10 @@ textarea {
   --app-label: #ffffff;
   --app-secondary-label: #98989d;
   --app-section-label: #98989d;
-  --app-tertiary-label: #636366;
+  /* Was #636366 (~3.3:1 on the near-black app background — fails WCAG AA's
+     4.5:1 for normal text). #86868b keeps it visibly dimmer than
+     --app-secondary-label while clearing AA (~5.5:1). */
+  --app-tertiary-label: #86868b;
   --app-quaternary-label: #48484a;
   --app-separator: rgba(84, 84, 88, 0.65);
   --app-opaque-separator: #38383a;

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -12245,7 +12245,7 @@ export function OneLocationAgentPageContent({
                             maxLength={REQUEST_MESSAGE_MAX_LENGTH}
                             className="rounded-[14px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]"
                           />
-                          <p className="px-1 text-right text-[11px] font-medium text-[#8e8e93] dark:text-white/45">
+                          <p className="px-1 text-right text-[11px] font-medium text-[#8e8e93] dark:text-white/70">
                             {requestMessage.length}/{REQUEST_MESSAGE_MAX_LENGTH}
                           </p>
                         </div>

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -953,7 +953,7 @@ function AgentBubble({
         </div>
         <div
           className={cn(
-            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-500",
+            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-400",
             isUser && "justify-end text-right"
           )}
         >
@@ -963,7 +963,7 @@ function AgentBubble({
               <button
                 type="button"
                 onClick={handleCopy}
-                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 aria-label={copied ? "Response copied" : "Copy response"}
                 title={copied ? "Copied" : "Copy response"}
               >
@@ -980,7 +980,7 @@ function AgentBubble({
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   liked
                     ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Like response"
                 aria-pressed={liked}
@@ -999,7 +999,7 @@ function AgentBubble({
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   disliked
                     ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Dislike response"
                 aria-pressed={disliked}
@@ -1012,7 +1012,7 @@ function AgentBubble({
                   type="button"
                   onClick={onRetry}
                   disabled={retryDisabled}
-                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                   aria-label="Try again"
                   title="Try again"
                 >

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -484,7 +484,7 @@ export function AgentHistorySidebar({
           ) : null}
 
           {!collapsed && !loading && conversations.length === 0 ? (
-            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-400">
               No chats yet
             </div>
           ) : null}
@@ -493,7 +493,7 @@ export function AgentHistorySidebar({
           !loading &&
           conversations.length > 0 &&
           filteredConversations.length === 0 ? (
-            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-400">
               No chats match &ldquo;{searchQuery.trim()}&rdquo;
             </div>
           ) : null}

--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -1277,7 +1277,7 @@ export function DecisionCard({ result }: { result: DecisionResult }) {
 
         {/* DISCLAIMER */}
         <div className="pt-4">
-          <p className="text-[10px] text-muted-foreground/50 text-center leading-relaxed max-w-xs mx-auto">
+          <p className="text-[10px] text-muted-foreground/70 text-center leading-relaxed max-w-xs mx-auto">
             Agent Kai is an educational tool and does not constitute investment advice. Always consult a qualified
             financial advisor.
           </p>

--- a/hushh-webapp/components/kai/views/trinity-cards.tsx
+++ b/hushh-webapp/components/kai/views/trinity-cards.tsx
@@ -32,7 +32,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {bullCase}
             </p>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Analyzing upside potential for your portfolio...
             </div>
           )}
@@ -53,7 +53,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {bearCase}
             </p>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Identifying risks to your specific holdings...
             </div>
           )}
@@ -74,7 +74,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {renaissanceVerdict}
             </div>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Calculating FCF & Tier Status...
             </div>
           )}

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1138,7 +1138,7 @@ export function AuthStep({
                 </span>
               </div>
 
-              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/45">
+              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/70">
                 By continuing you agree to our{" "}
                 <button
                   type="button"

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
@@ -41,7 +41,7 @@ export function OnboardingStepLicense({
             onChange={(event) => onLicenseNumberChange(event.target.value)}
             placeholder="INA00123456 or 7413463"
             className={cn(
-              "min-w-0 flex-1 bg-transparent py-3 text-right text-[17px] font-medium tabular-nums text-foreground placeholder:text-muted-foreground/50 outline-none",
+              "min-w-0 flex-1 bg-transparent py-3 text-right text-[17px] font-medium tabular-nums text-foreground placeholder:text-muted-foreground/70 outline-none",
               verificationStatus === "not_found" &&
                 "text-amber-600 dark:text-amber-300",
               verificationStatus === "error" && "text-red-600 dark:text-red-300"


### PR DESCRIPTION
## Category
Fix (accessibility / dark-mode contrast)

## Problem
Across several dark-mode surfaces, muted/secondary text, timestamps, helper captions, and placeholder copy fell below WCAG AA's 4.5:1 contrast minimum for normal text against the app's near-black dark background. Text was technically present but hard to read — the classic "looks fine to the designer, unreadable at arm's length" bug.

## User story
> As a user browsing Hussh One in dark mode, I want secondary text (timestamps, helper copy, placeholders, captions) to be clearly legible without straining, so I can read status information and instructions at a glance — without that text becoming as loud as primary content.

## Root cause
One global design token, `--app-tertiary-label`, was set to `#636366` in dark mode — **~3.3:1** contrast against the app's near-black background (fails AA's 4.5:1). This single token drives captions/timestamps across Location hub, Connect, Settings row descriptions, the top app bar, and form fields. Six more isolated spots used ad-hoc low-opacity Tailwind classes (`dark:text-zinc-500`, `text-muted-foreground/50`, `dark:text-white/45`) that computed to the same ballpark (~4.0–4.5:1).

## Fix
Bumped each offending value to comfortably clear AA (verified via relative-luminance contrast math against the app's near-black background), without introducing new tokens or touching anything already passing:

| Location | Before | Contrast | After | Contrast |
|---|---|---|---|---|
| `--app-tertiary-label` (global token) | `#636366` | ~3.3:1 | `#86868b` | ~5.5:1 |
| Agent chat timestamps/icons, history empty-state (7 spots, 2 files) | `dark:text-zinc-500` | ~4.1:1 | `dark:text-zinc-400` | ~7.7:1 |
| Kai loading captions (×3) + legal disclaimer | `text-muted-foreground/50` | ~4.0:1 | `/70` | ~7:1 |
| RIA onboarding license placeholder | `placeholder:text-muted-foreground/50` | ~4.0:1 | `/70` | ~7:1 |
| Location hub message counter, onboarding legal footnote | `dark:text-white/45` | ~4.5:1 (marginal fail) | `/70` | ~9.7:1 |

**Left untouched** (already compliant, checked and confirmed rather than assumed):
- `--muted-foreground` (~13:1)
- `--app-secondary-label` (~6.9:1)
- `--app-separator` border token (0.65 alpha — visibly distinct divider, non-text 3:1 requirement already met)
- shadcn `Tabs`/`Input` primitives (already reference full-strength tokens)
- Disabled-state `/30`–`/35` text (WCAG-exempt)

One extra finding, not fixed here on purpose: a `.cinematicSettings [data-slot="settings-row-description"]` CSS rule in `app/profile/page.module.css` had the same low-alpha value, but tracing it showed the class is **never applied anywhere in the codebase** (dead CSS) — the live settings-row-description styling actually goes through `--app-tertiary-label` above, which this PR already fixes. Left the dead rule alone to keep this PR strictly scoped to real, reachable surfaces.

## Changed surfaces / routes
- `/agent` — agent chat timestamps, copy/like/dislike/retry icons, history sidebar empty-states
- `/one/location` — active-share message character counter (feeds through the global token too: Location hub row captions, Feed timestamps/captions)
- Kai analysis views (Trinity cards loading state, Decision card disclaimer)
- RIA onboarding license step (placeholder)
- Auth/onboarding legal footnote

## Tests & verification performed
- `node scripts/design/verify-accent-tokens.mjs` → OK
- `node scripts/design/verify-apple-hierarchy.mjs` → OK
- `node scripts/architecture/verify-design-system.mjs` → passed
- `vitest run` on the existing tests covering touched components (`agent-history-sidebar.test.tsx`, `onboarding-step-license.test.tsx`) → 2 files, 4 tests, all passing
- `eslint` on all 8 changed files → 0 errors
- Manual dark-mode verification, desktop, logged in: **One dashboard**, **Location hub** (Now + People tabs), **Feed**, **Onboarding** (auth screen) — muted text, timestamps, helper captions, placeholders, inactive tab labels, and card/row dividers all confirmed legible with no layout regressions. Settings verified indirectly (dead-CSS scope aside, its real styling is the same global token already proven live elsewhere).
- Live computed-style check confirmed `--app-tertiary-label` resolves to `#86868b` in the running app.
- Contrast math re-verified against the final committed values using the WCAG relative-luminance formula against the app's actual near-black background (`oklch(0.146 0.004 285.9)` / `#0a0a0c`–`#000`), not eyeballed.
- Pre-push gate (branch-freshness + consent-protocol ruff lint/format check) passed clean, no bypass.

## Visual hierarchy preserved
Every change is a **value bump on an existing token/class**, not a new design decision. Secondary text (`--app-secondary-label` / `#98989d`, ~6.9:1) stays visibly brighter than tertiary (`--app-tertiary-label` / `#86868b`, ~5.5:1), which stays visibly dimmer than primary (`--app-label` / `#ffffff`). The ordering — primary > secondary > tertiary — is unchanged; only the floor was raised so tertiary no longer dips below AA.

## Screenshots
Manual dark-mode screenshots (One dashboard, Location hub, Feed, agent chat, onboarding auth screen — before/after values) were captured and reviewed live during verification in this session; happy to attach exports to the PR if useful for reviewers who weren't in that session.

Closes #5417
