### PR TITLE
fix(one-location): refine Links tab singleton public link model and zero state ux

### DIFF
--- a/hushh-webapp/__tests__/components/links-tab-singleton-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/links-tab-singleton-flow.test.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LinksHub, type LocationHubViewModel } from "@/components/one-location/redesign/location-redesign-hub";
+
+function mockHubViewModel(overrides?: Partial<LocationHubViewModel>): LocationHubViewModel {
+  return {
+    userId: "user_123",
+    canShare: true,
+    busy: null,
+    revokingGrantId: null,
+    withdrawingRequestId: null,
+    shareCompletedTick: 0,
+    readiness: { tone: "ready", title: "Ready", description: "Location is active" },
+    permissionIsPrompt: false,
+    locationEnabled: true,
+    locationBlocked: false,
+    autoApproveRequestsEnabled: false,
+    mapPresenceEnabled: true,
+    onMapPresenceChange: vi.fn(),
+    locationPaused: false,
+    locationAccuracyLimited: false,
+    locationAcquiring: false,
+    myLocationPoint: null,
+    myLocationError: null,
+    recipients: [],
+    circles: [],
+    selectedShareCircleSelection: null,
+    incomingCircleMemberInvites: [],
+    incomingCircleMemberInvitesLoading: false,
+    incomingCircleMemberInvitesError: null,
+    incomingCircleMemberInviteFocusResolved: true,
+    visibleRecipients: [],
+    visibleShareRecipients: [],
+    activeOwnerGrants: [],
+    liveShare: null,
+    onLiveShareEnded: vi.fn(),
+    receivedGrants: [],
+    pendingOwnerRequests: [],
+    requestedByMe: [],
+    latestActivePublicInvite: null,
+    latestActiveCircleInvite: null,
+    activityReceipts: [],
+    recipientSearch: "",
+    shareRecipientSearch: "",
+    selectedRecipientIds: [],
+    selectedRequestOwnerIds: [],
+    shareDurationHours: "0.25",
+    shareMessage: "",
+    durationHours: "1",
+    requestMessage: "",
+    shareReviewOpen: false,
+    publicInviteUrl: "",
+    circleInviteUrl: "",
+    setRecipientSearch: vi.fn(),
+    setShareRecipientSearch: vi.fn(),
+    setShareDurationHours: vi.fn(),
+    setShareMessage: vi.fn(),
+    setDurationHours: vi.fn(),
+    setRequestMessage: vi.fn(),
+    setShareReviewOpen: vi.fn(),
+    resetShareComposer: vi.fn(),
+    startShareComposer: vi.fn(),
+    toggleShareRecipient: vi.fn(),
+    onSelectShareCircle: vi.fn(),
+    onResolveNamedCircleRecipients: vi.fn(),
+    toggleRequestOwner: vi.fn(),
+    onShowMyLocation: vi.fn(),
+    onHideMyLocation: vi.fn(),
+    onResumeMyLocation: vi.fn(),
+    onAutoApproveRequestsChange: vi.fn(),
+    onRequestPermission: vi.fn(),
+    onOpenLocationSettings: vi.fn(),
+    onSyncContacts: vi.fn(),
+    onOpenShareReview: vi.fn(),
+    onEnterShareConfirm: vi.fn(),
+    onConfirmShare: vi.fn(),
+    onSendRequest: vi.fn(),
+    onAskReshare: vi.fn(),
+    onApprove: vi.fn(),
+    onDeny: vi.fn(),
+    onWithdrawRequest: vi.fn(),
+    onViewGrant: vi.fn(),
+    onStopGrant: vi.fn(),
+    editingGrantId: null,
+    savingGrantId: null,
+    onEditGrantStart: vi.fn(),
+    onEditGrantCancel: vi.fn(),
+    editGrantDurationHours: "1",
+    setEditGrantDurationHours: vi.fn(),
+    onEditGrantSave: vi.fn(),
+    liveShareDurationEditing: false,
+    liveShareDurationHours: "1",
+    setLiveShareDurationHours: vi.fn(),
+    liveShareDurationSaving: false,
+    onEditLiveShareDurationStart: vi.fn(),
+    onEditLiveShareDurationCancel: vi.fn(),
+    onSaveLiveShareDuration: vi.fn(),
+    onCreatePublicInvite: vi.fn(),
+    onCopyPublicInvite: vi.fn(),
+    onSharePublicInvite: vi.fn(),
+    onRevokePublicInvite: vi.fn(),
+    onCreateCircleInvite: vi.fn(),
+    onCopyCircleInvite: vi.fn(),
+    onShareCircleInvite: vi.fn(),
+    onRevokeCircleInvite: vi.fn(),
+    onLoadNamedCircle: vi.fn(),
+    onCreateNamedCircle: vi.fn(),
+    onRenameNamedCircle: vi.fn(),
+    onResolveNamedCircleCode: vi.fn(),
+    onJoinNamedCircle: vi.fn(),
+    onGenerateNamedCircleCode: vi.fn(),
+    onCopyNamedCircleCode: vi.fn(),
+    onShareNamedCircleCode: vi.fn(),
+    onShareNamedCircleCodeById: vi.fn(),
+    onRemoveNamedCircleMember: vi.fn(),
+    onLoadNamedCircleEligibleConnections: vi.fn(),
+    onInviteNamedCircleConnections: vi.fn(),
+    onAcceptNamedCircleMemberInvite: vi.fn(),
+    onDeclineNamedCircleMemberInvite: vi.fn(),
+    onCancelNamedCircleMemberInvite: vi.fn(),
+    onRetryNamedCircleMemberInvites: vi.fn(),
+    onLeaveNamedCircle: vi.fn(),
+    onDeleteNamedCircle: vi.fn(),
+    prepareNamedCircleShare: vi.fn(),
+    clearNamedCircleShareContext: vi.fn(),
+    sosRecipients: [],
+    smsRecipients: [],
+    smsContactCandidates: [],
+    smsContactUserIds: [],
+    sosActive: false,
+    sosBusy: false,
+    sosStartedAtLabel: null,
+    sosEmergency: null,
+    sosEmergencyStatus: "idle",
+    onResolveSosLocation: vi.fn(),
+    onTriggerSos: vi.fn(),
+    onStopSos: vi.fn(),
+    onAddSmsContact: vi.fn(),
+    onAddSmsCircle: vi.fn(),
+    onRemoveSmsContact: vi.fn(),
+    onCheckIn: vi.fn(),
+    onDiscardPrivateCheckInOperation: vi.fn(),
+    recipientLabel: (r) => r.displayName,
+    recipientSubtitle: () => "",
+    isRecipientShareReady: () => true,
+    requestOwnerLabel: (r) => r.ownerDisplayName || "Someone",
+    requesterLabel: (r) => r.requesterDisplayName || "Someone",
+    grantRecipientLabel: (g) => g.recipientDisplayName || "Someone",
+    grantOwnerLabel: (g) => g.ownerDisplayName || "Someone",
+    formatDateTime: () => "5:30 PM",
+    expiresLabel: () => "until 5:30 PM",
+    expiresCountdownLabel: () => "45 min remaining",
+    nowMs: Date.now(),
+    renderMapPreview: () => null,
+    mapLocationHref: () => "#",
+    decryptedPoints: {},
+    ...overrides,
+  };
+}
+
+describe("LinksHub Singleton Public Link UX Model", () => {
+  it("Zero-State: removes empty white div box and shows Create Public Link CTA button", () => {
+    const onCreateTempLink = vi.fn();
+    const vm = mockHubViewModel({ latestActivePublicInvite: null });
+    render(<LinksHub vm={vm} onCreateTempLink={onCreateTempLink} />);
+
+    // 1. Verify "No active links" empty box container is REMOVED
+    expect(screen.queryByText("No active links")).toBeNull();
+
+    // 2. Verify clean explanation text and "Create Public Link" CTA button exist
+    expect(
+      screen.getByText("Generate a temporary link to share your live location with anyone outside your Circle."),
+    ).toBeTruthy();
+
+    const createBtn = screen.getByRole("button", { name: /Create Public Link/i });
+    expect(createBtn).toBeTruthy();
+
+    fireEvent.click(createBtn);
+    expect(onCreateTempLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("Active-State: renders active link card with live status pill and HIDES Create Public Link CTA button", () => {
+    const activeInvite = {
+      id: "pub_123",
+      inviteUrl: "https://uat.one.hushh.ai/one/location/request/xyz",
+      durationHours: 1,
+      expiresAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+      status: "active" as const,
+      createdAt: new Date().toISOString(),
+    };
+
+    const onCreateTempLink = vi.fn();
+    const vm = mockHubViewModel({ latestActivePublicInvite: activeInvite });
+    render(<LinksHub vm={vm} onCreateTempLink={onCreateTempLink} />);
+
+    // 1. Verify active link card is rendered with Live status pill and title
+    expect(screen.getByText("Live location link")).toBeTruthy();
+    expect(screen.getByText("Live")).toBeTruthy();
+    expect(screen.getByText("45 min remaining · anyone with the link")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy" })).toBeTruthy();
+
+    // 2. Verify "Create Public Link" CTA button is HIDDEN (enforces single link constraint)
+    expect(screen.queryByRole("button", { name: /Create Public Link/i })).toBeNull();
+  });
+
+  it("Active-State: tapping active link card invokes onManageTempLink", () => {
+    const activeInvite = {
+      id: "pub_123",
+      inviteUrl: "https://uat.one.hushh.ai/one/location/request/xyz",
+      durationHours: 1,
+      expiresAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+      status: "active" as const,
+      createdAt: new Date().toISOString(),
+    };
+
+    const onCreateTempLink = vi.fn();
+    const onManageTempLink = vi.fn();
+    const vm = mockHubViewModel({ latestActivePublicInvite: activeInvite });
+    render(<LinksHub vm={vm} onCreateTempLink={onCreateTempLink} onManageTempLink={onManageTempLink} />);
+
+    const activeCard = screen.getByRole("button", { name: /Live location link/i });
+    fireEvent.click(activeCard);
+
+    // Verify callback was triggered to open edit/manage flow
+    expect(onManageTempLink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -872,7 +872,7 @@ async function openAskFlow() {
 async function openTemporaryLinkFlow() {
   fireEvent.click(screen.getByRole("button", { name: "Links" }));
   fireEvent.click(
-    await screen.findByRole("button", { name: /Create link/i }),
+    await screen.findByRole("button", { name: /Create (Public )?link/i }),
   );
   expect(
     await screen.findByRole("heading", { name: "Share outside your Circle" }),
@@ -899,7 +899,19 @@ describe("OneLocationAgentPage", () => {
       error: null,
     });
     mockBusEnsure.mockResolvedValue(busSnapshot);
-    Element.prototype.scrollIntoView = vi.fn();
+    if (!window.localStorage || typeof window.localStorage.clear !== "function") {
+      const store = new Map<string, string>();
+      Object.defineProperty(window, "localStorage", {
+        value: {
+          getItem: (k: string) => store.get(k) ?? null,
+          setItem: (k: string, v: string) => store.set(k, String(v)),
+          removeItem: (k: string) => store.delete(k),
+          clear: () => store.clear(),
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
     window.localStorage.clear();
     // Most page-flow tests are not about the optional saved-place prompt.
     // A dedicated integration test below clears this outcome and proves it.
@@ -3230,10 +3242,10 @@ describe("OneLocationAgentPage", () => {
     // mock has no active links, so the empty state shows.
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
-      await screen.findByRole("button", { name: /Create link/i }),
+      await screen.findByRole("button", { name: /Create (Public )?link/i }),
     ).toBeTruthy();
     expect(screen.getByText("Active links")).toBeTruthy();
-    expect(screen.getByText("No active links")).toBeTruthy();
+    expect(screen.queryByText("No active links")).toBeNull();
     expect(screen.queryByText("Public link responses")).toBeNull();
     expect(screen.queryByText(/Share a public location link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
@@ -3653,7 +3665,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openTemporaryLinkFlow();
     fireEvent.click(
-      screen.getByRole("button", { name: /^Create link$/i }),
+      screen.getByRole("button", { name: /Create (Public )?link/i }),
     );
 
     await waitFor(() =>
@@ -4840,7 +4852,7 @@ describe("OneLocationAgentPage", () => {
     // Links hub CTA opens the flow; the flow's own CTA creates the invite.
     // Both are labelled "Create link", so take the one on screen each time.
     fireEvent.click(
-      await screen.findByRole("button", { name: /^Create link$/i }),
+      await screen.findByRole("button", { name: /Create (Public )?link/i }),
     );
     fireEvent.click(
       await screen.findByRole("button", { name: /^Create link$/i }),
@@ -5119,7 +5131,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
-      await screen.findByRole("button", { name: /Create link/i }),
+      await screen.findByRole("button", { name: /Create (Public )?link/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -38,6 +38,7 @@ import {
   Plus,
   Send,
   Check,
+  ChevronRight,
   Shield,
   ShieldCheck,
   UserPlus,
@@ -86,6 +87,7 @@ import {
   Avatar,
   EmptyState,
   SectionCard,
+  StatusPill,
   TaskFlowHeader,
   TrustNoteCard,
   WarningCard,
@@ -1306,7 +1308,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           </LocationHubPanel>
 
           <LocationHubPanel>
-            <LinksHub vm={vm} onCreateTempLink={() => openFlow("temp-link")} />
+            <LinksHub
+              vm={vm}
+              onCreateTempLink={() => openFlow("temp-link")}
+              onManageTempLink={() => openFlow("temp-link")}
+            />
           </LocationHubPanel>
         </SwipeViews>
       </div>
@@ -2377,13 +2383,14 @@ function PeopleHub({
 /* LINKS HUB                                                            */
 /* =================================================================== */
 
-/** One active-link row: tinted icon tile · title · subtitle · Copy (design). */
+/** One active-link row: interactive selectable card with live status pill & quick copy. */
 function ActiveLinkRow({
   icon,
   tileClass,
   title,
   subtitle,
   onCopy,
+  onClick,
   first,
 }: {
   icon: ReactNode;
@@ -2391,49 +2398,73 @@ function ActiveLinkRow({
   title: string;
   subtitle: string;
   onCopy: () => void;
+  onClick?: () => void;
   first: boolean;
 }) {
   return (
     <div
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       className={cn(
-        "flex min-h-[60px] items-center gap-3.5 py-3.5",
+        "flex min-h-[64px] items-center gap-3.5 py-3.5 transition-colors",
+        onClick && "cursor-pointer hover:bg-muted/40 active:bg-muted/60",
         !first && "border-t border-[color:var(--app-separator)]",
       )}
     >
       <span
         className={cn(
-          "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
+          "flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px]",
           tileClass,
         )}
       >
         {icon}
       </span>
       <div className="min-w-0 flex-1">
-        <RowLabel as="p" className="truncate">
-          {title}
-        </RowLabel>
+        <div className="flex items-center gap-2">
+          <RowLabel as="p" className="truncate font-semibold">
+            {title}
+          </RowLabel>
+          <StatusPill tone="live" className="shrink-0 text-[11px] px-2 py-0">
+            Live
+          </StatusPill>
+        </div>
         <RowDescription as="p" className="mt-0.5 truncate">
           {subtitle}
         </RowDescription>
       </div>
       <Button
         variant="outline"
-        onClick={onCopy}
+        onClick={(e) => {
+          e.stopPropagation();
+          onCopy();
+        }}
         size="sm"
-        className="shrink-0 border-[color:var(--app-accent)] px-4 text-[color:var(--app-accent)]"
+        className="shrink-0 border-[color:var(--app-accent)] px-3.5 text-[color:var(--app-accent)]"
       >
         Copy
       </Button>
+      {onClick ? (
+        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      ) : null}
     </div>
   );
 }
 
-function LinksHub({
+export function LinksHub({
   vm,
   onCreateTempLink,
+  onManageTempLink,
 }: {
   vm: LocationHubViewModel;
   onCreateTempLink: () => void;
+  onManageTempLink?: () => void;
 }) {
   const temp = vm.latestActivePublicInvite;
   const invite = vm.latestActiveCircleInvite;
@@ -2443,10 +2474,6 @@ function LinksHub({
     <div className="space-y-4">
       <div className="px-[6px]">
         <SectionTitle as="h2">Active links</SectionTitle>
-        {/* This section lists two different things — a live location link and
-            a Circle invite link — and the invite shares no location at all.
-            Copy that described only the first was wrong for half the list,
-            and neither told a new user what a "link" is here. */}
         <RowDescription as="p" className="mt-1">
           Links you can send to anyone — to show where you are, or to invite
           them to a Circle.
@@ -2463,6 +2490,7 @@ function LinksHub({
               title="Live location link"
               subtitle={`${vm.expiresCountdownLabel(temp.expiresAt)} · anyone with the link`}
               onCopy={vm.onCopyPublicInvite}
+              onClick={onManageTempLink ?? onCreateTempLink}
             />
           ) : null}
           {invite ? (
@@ -2473,23 +2501,31 @@ function LinksHub({
               title="Invite link"
               subtitle={`${vm.expiresCountdownLabel(invite.expiresAt)} · one person`}
               onCopy={vm.onCopyCircleInvite}
+              onClick={onCreateTempLink}
             />
           ) : null}
         </div>
       ) : (
-        <EmptyState
-          title="No active links"
-        />
+        /* Empty State: ZERO empty white box / div container.
+           Show clear description and prominent Create Public Link CTA button directly. */
+        <div className="space-y-1 px-1 py-1">
+          <p className={MUTED_TEXT}>
+            Generate a temporary link to share your live location with anyone outside your Circle.
+          </p>
+        </div>
       )}
 
-      <Button
-        onClick={onCreateTempLink}
-        data-voice-control-id="one-location-action-temp-link"
-        className="w-full"
-      >
-        <Plus className="mr-2 h-4 w-4" />
-        Create link
-      </Button>
+      {/* Conditionally show "Create Public Link" CTA ONLY when NO active public link exists */}
+      {!temp ? (
+        <Button
+          onClick={onCreateTempLink}
+          data-voice-control-id="one-location-action-temp-link"
+          className="h-11 w-full rounded-full font-semibold"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Create Public Link
+        </Button>
+      ) : null}
 
       <div className="flex items-start gap-2 px-1">
         <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary of Changes

This PR refines the Links tab (`/one/links` / `LocationRedesignHub`) user flow for the singleton public link model:

1. **Zero-State Container Cleanup**:
   - Eliminates the empty white container box placeholder (`<EmptyState title="No active links" />`) on zero-state.
   - Presents concise explanatory copy alongside a prominent primary **"Create Public Link"** CTA button.

2. **Active State & Single Link Constraint Enforcement**:
   - Conditionally hides the **"Create Public Link"** CTA button when a public link is currently live.
   - Renders the live public link as an interactive, selectable card displaying live status pill (`Live`), expiration countdown, quick `Copy` button, and right chevron indicator.

3. **Lifecycle & Edit/Manage Integration**:
   - Tapping anywhere on the active public link card opens the edit/manage sheet (`TemporaryLinkFlow`).
   - Revoking the link transitions the UI cleanly back to the empty state with zero white box container clutter.

## Testing & Verification

- **Vitest Suite**: `npx vitest run __tests__/components/links-tab-singleton-flow.test.tsx` (3/3 passed)
- **Integration Suite**: `npm run verify:one-location` (149/149 passed)
- **TypeScript**: `npm run typecheck` (0 errors)
- **ESLint**: `npx eslint components/one-location/redesign/location-redesign-hub.tsx` (0 errors)