### PR TITLE
fix(one-location): scroll anchor, enter transition, and header alignment on task flows

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -126,6 +126,8 @@ import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import { ROUTES } from "@/lib/navigation/routes";
+import { useScrollReset } from "@/lib/navigation/use-scroll-reset";
+import { usePageEnterAnimation } from "@/lib/morphy-ux/hooks/use-page-enter";
 import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
   CircleDetailFlow,
@@ -776,6 +778,22 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     resolveLocationHubTab(searchParams.get(LOCATION_HUB_TAB_PARAM)),
   );
   const [flow, setFlow] = useState<FlowKind>("none");
+  // Opening a flow (SOS, Share, Ask, ...) mounts a fresh subtree under
+  // whatever scroll offset the Now/People/Links tab was left at -- the
+  // app-shell scroll-reset instance only keys on tab identity, never on
+  // `?action=`, so it never sees this transition. Without this, tapping an
+  // action after scrolling down reads as an abrupt jump (#5430).
+  useScrollReset(flow, { enabled: flow !== "none", behavior: "auto" });
+  const flowContainerRef = useRef<HTMLDivElement | null>(null);
+  // The bare conditional swap below had no enter transition at all, unlike
+  // every route-level surface in the app. Same canonical Morphy page-enter
+  // used by pkm-settings-shell.tsx and route navigation generally, keyed on
+  // `flow` so swapping between task flows (not just entering/leaving one)
+  // re-triggers it (#5430).
+  usePageEnterAnimation(flowContainerRef, {
+    key: flow,
+    enabled: flow !== "none",
+  });
   const focusedCircleMemberInviteId =
     String(searchParams.get("circleInviteId") || "").trim() || null;
   // Router state can settle one paint after a tap. Keep the local focused
@@ -1100,6 +1118,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   if (flow !== "none") {
     return (
       <div
+        ref={flowContainerRef}
         className="space-y-6"
         data-ambient-chrome-ignore
         data-testid="one-location-action-flow"

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -417,8 +417,11 @@ export function SosPanel({
       />
 
       {/* The design's top-right actions. The screen's own title moved into the
-          header above, so only the two controls remain here. */}
-      <div className="mt-4 flex flex-wrap items-center justify-end gap-x-6 gap-y-2 sm:gap-x-8">
+          header above, so only the two controls remain here. Width-matched
+          to the message column below (max-w-[520px], centered) so "Cancel"
+          doesn't right-align to the section edge while the input right-aligns
+          to a narrower centered column beneath it (#5431). */}
+      <div className="mx-auto mt-4 flex w-full max-w-[520px] flex-wrap items-center justify-end gap-x-6 gap-y-2 sm:gap-x-8">
         {active ? (
           <span className="mr-auto flex items-center gap-2 sm:mr-0">
             <span


### PR DESCRIPTION
## Summary
Addresses #5430, addresses #5431 (not auto-closing on merge — issues stay open until this is verified on UAT).

Both bugs live on `LocationRedesignHub`'s full-screen task-flow branch (SOS, Share, Ask, CheckIn, ...), which bypasses the tab surface's `SwipeViews` scroll/height machinery entirely.

**#5430 — abrupt scroll jump + no transition on opening SMS/SOS:**
- Root cause of the scroll jump: the app-shell scroll-reset instance keys only on tab identity (`${shellPathname}:${tabId}:${activeTabValue}`), never on `?action=sos`, so it never sees a flow-open transition. If the user had scrolled down the Now tab to reach Quick Actions, the newly-mounted flow subtree renders under that stale scroll offset — reading as a downward jump. Added the same `useScrollReset` call three other flow-shaped surfaces already use for this exact problem (`kai-flow.tsx`, `wallet-card-workspace.tsx`, `onboarding-shell.tsx`), keyed on `flow`.
- Root cause of the missing transition: the flow container was a bare conditional swap with zero transition classes — unlike every route-level surface in the app. Added the canonical `usePageEnterAnimation` hook (same one `pkm-settings-shell.tsx` uses for route-level enter), keyed on `flow` so swapping between different flows re-triggers it too, not just entering/leaving the tab surface.

**#5431 — SOS/Emergency screen layout:**
- The one concrete, verifiable piece of the reported "awkward layout positioning": `SosPanel`'s top action row (Contacts/Cancel) spans the full section width and right-aligns to the screen edge, while the message-input column below it is capped at `max-w-[520px]` and centered. On any viewport wider than 520px, the two rows' right edges visibly disagree. Width-matched the action row to the same `max-w-[520px]` constraint the input column already uses.
- I also reviewed the emergency-dialer button's placement, which the issue names alongside Contacts/Cancel — it's already centered (`justify-center`) and consistent with the rest of the column below it, with proper `min-h-11` tap targets and accessible labels already in place. Left it untouched rather than making a speculative change to code with no verifiable defect.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on both changed files.
- [x] `vitest run` on `sos-panel.test.tsx`, `one-location-sos-emergency.contract.test.tsx`, `one-location-agent-page.test.tsx` — 142 passed, no regressions.
