### PR TITLE
fix(one-location): consolidate Circle member-row actions into a ⋮ overflow menu

### DIFF
--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -994,7 +994,7 @@ describe("named Circle flows", () => {
     );
   });
 
-  it("removes a member from a labelled destructive action rather than a bare icon", async () => {
+  it("removes a member from a labelled destructive menu action, behind a labelled overflow trigger", async () => {
     const onRemoveMember = vi.fn(async () => undefined);
     const ownerCircle = {
       ...circle("circle-1", "Meena Family"),
@@ -1019,10 +1019,15 @@ describe("named Circle flows", () => {
     );
 
     const trigger = await screen.findByRole("button", {
-      name: "Remove John Smith from this Circle",
+      name: "Actions for John Smith",
     });
-    expect(trigger).toHaveTextContent("Remove");
-    fireEvent.click(trigger);
+    // Radix opens DropdownMenuTrigger on pointerdown (no PointerEvent in
+    // jsdom) or on Enter/Space keydown — use the keyboard path here.
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    );
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Remove", hidden: true }),

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -8,6 +8,7 @@ import {
   KeyRound,
   Loader2,
   LogOut,
+  MoreVertical,
   Pencil,
   Plus,
   RotateCw,
@@ -32,6 +33,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Sheet,
   SheetContent,
@@ -715,20 +722,22 @@ function CircleMemberRow({
   onShare: () => void;
   onRemove: () => Promise<void>;
 }) {
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
   const isCurrentUser = member.userId === currentUserId;
   const canShare =
     !isCurrentUser && member.phoneVerified && member.secureLocationReady;
+  const canRemove = isOwner && member.role !== "owner";
 
   return (
-    <div className="flex min-h-16 items-center gap-3 px-4 py-3">
-      <Avatar className="h-11 w-11">
+    <div className="flex items-start gap-3 px-4 py-3">
+      <Avatar className="mt-0.5 h-11 w-11 shrink-0">
         {member.photoUrl ? (
           <AvatarImage src={member.photoUrl} alt="" />
         ) : null}
         <AvatarFallback>{circleInitials(member.displayName)}</AvatarFallback>
       </Avatar>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[15px] font-semibold text-foreground">
+      <div className="min-w-0 flex-1 py-1">
+        <p className="break-words text-[15px] font-semibold leading-snug text-foreground">
           {member.displayName}
           {isCurrentUser ? " (you)" : ""}
         </p>
@@ -740,31 +749,44 @@ function CircleMemberRow({
               : "Location setup needed"}
         </p>
       </div>
-      {canShare ? (
-        <Button
-          type="button"
-          size="sm"
-          disabled={busy}
-          onClick={onShare}
-          className="h-11 min-w-16 rounded-full"
-        >
-          Share
-        </Button>
-      ) : null}
-      {isOwner && member.role !== "owner" ? (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
+      {canShare || canRemove ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
             <Button
               type="button"
-              size="sm"
+              size="icon"
               variant="ghost"
               disabled={busy}
-              aria-label={`Remove ${member.displayName} from this Circle`}
-              className="h-11 shrink-0 rounded-full px-3 font-semibold text-destructive hover:bg-destructive/10 hover:text-destructive"
+              aria-label={`Actions for ${member.displayName}`}
+              className="mt-0.5 h-11 w-11 shrink-0 rounded-full"
             >
-              Remove
+              <MoreVertical className="h-5 w-5" />
             </Button>
-          </AlertDialogTrigger>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canShare ? (
+              <DropdownMenuItem onSelect={() => onShare()}>
+                <Share2 className="h-4 w-4" />
+                Share location
+              </DropdownMenuItem>
+            ) : null}
+            {canRemove ? (
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setConfirmRemoveOpen(true);
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+                Remove from Circle
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+      {canRemove ? (
+        <AlertDialog open={confirmRemoveOpen} onOpenChange={setConfirmRemoveOpen}>
           <AlertDialogContent size="sm">
             <AlertDialogHeader>
               <AlertDialogTitle>


### PR DESCRIPTION
## Category
Fix

## Issue
Closes #5414

## Problem
On the Circle details page (`/one/location/circle/[id]`, rendered by `CircleDetailFlow` in [`named-circle-flows.tsx`](hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx)), each `CircleMemberRow` had two problems:

1. **Premature name truncation** — the member name used Tailwind `truncate`, so it ellipsized (`Alexandria Thistlewoo…`) even on rows with room to show the full name.
2. **Action-button clutter** — two separate buttons ("Share", "Remove") sat side-by-side on the row, squeezing the name column further and giving "Remove" a sub-44px tap target.

## User story
> As a Circle owner reviewing my members, I want to read each person's full name at a glance and reach their actions through one clear control, so the row doesn't feel cramped or clip names I need to recognize.

## Fix
In `CircleMemberRow`:
- Name `<p>` drops `truncate`, adds `break-words leading-snug` — wraps instead of clipping. Status line (secondary info) keeps `truncate`.
- The two buttons are replaced by a single `⋮` (`MoreVertical`) icon button, `44×44px` (`h-11 w-11`), `aria-label="Actions for {name}"`, opening a `DropdownMenu` with **Share location** and destructive **Remove from Circle**.
- Row layout: Avatar → Name/Status → `⋮`, `items-start` (was `items-center`) with natural height (was fixed `min-h-16`), so a wrapped 2-line name doesn't stretch the avatar/trigger and the row only grows as much as the wrap actually needs.
- **Remove confirmation is unchanged** — same `AlertDialog`, same "Remove {name}?" copy/behavior — now opened via component state (`confirmRemoveOpen`) since its trigger moved out of the dialog tree and into the menu item's `onSelect`.
- Owner's own row still shows no `⋮` at all (nothing to act on self) — unchanged.

## Verification

**Tests & lint** (in a clean worktree off latest `main`, this branch):
```
vitest run components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
 Test Files  1 passed (1)
      Tests  26 passed (26)

eslint named-circle-flows.tsx named-circle-flows.test.tsx
 clean, no findings

tsc --noEmit (full project)
 exit 0, no errors in either changed file
```
One test needed updating for the new interaction (open menu → click "Remove from Circle" → confirm), and to open the menu, `fireEvent.pointerDown` doesn't work because jsdom has no `PointerEvent` global (Radix's menu opens on pointerdown or Enter/Space keydown) — switched the test to the Enter-keydown path, which Radix also supports.

**Responsive / no-overflow proof**, via a static reproduction of the exact row markup and Tailwind classes (short name, long wrapping name, long unbroken token, owner row, open-menu state), checked with computed layout (`getBoundingClientRect` / `getComputedStyle`) at:
- **375px** (iPhone): no ellipsis, no horizontal overflow, name wraps to 2 lines only when it needs to, `⋮` trigger measured 44×44px.
- **768px** (tablet): no horizontal overflow (`document.body.scrollWidth === window.innerWidth`).
- **1280px** (desktop): no horizontal overflow.

**Manual verification in the real app**, local URL: `http://localhost:3000/one/location?view=people&action=circle-detail&circleId=<id>` (this branch's code, hot-reloaded, my own unlocked Vault session):
- Created a test Circle and added a real member (Abdul Rashid).
- Member row rendered: avatar → full name "Abdul Rashid" (no truncation) → "Ready for private sharing" → `⋮` trigger, clean spacing, no crowding.
- Opened the `⋮` menu — showed **Share location** and **Remove from Circle** (red), matching the code.
- Clicked **Remove from Circle** — the existing "Remove Abdul Rashid?" confirmation dialog appeared, unchanged copy and Cancel/Remove buttons. Clicked **Cancel** — member was not removed.
- Confirmed my own (owner) row shows no `⋮` trigger at all.

## Scope
Two files only, both directly implementing/testing this fix — no unrelated changes:
- `hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx`
- `hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx`
