### PR TITLE
fix(one-location): prioritize SMS-triggered shares in Shared with me

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/shared-with-me-sort.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/shared-with-me-sort.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { isSmsTriggeredGrant } from "@/lib/one-location/notifications";
+
+function grant(id: string, shareKind: string | null, createdAt: string) {
+  return { id, shareKind, createdAt };
+}
+
+function sortSmsFirst<T extends { shareKind: string | null }>(grants: T[]): T[] {
+  return [...grants].sort(
+    (a, b) => Number(isSmsTriggeredGrant(b)) - Number(isSmsTriggeredGrant(a)),
+  );
+}
+
+describe("isSmsTriggeredGrant", () => {
+  it("is true for an sos share", () => {
+    expect(isSmsTriggeredGrant({ shareKind: "sos" })).toBe(true);
+  });
+
+  it("is false for a routine share", () => {
+    expect(isSmsTriggeredGrant({ shareKind: "share" })).toBe(false);
+  });
+
+  it("is false for an unrecognized or missing kind", () => {
+    expect(isSmsTriggeredGrant({ shareKind: null })).toBe(false);
+    expect(isSmsTriggeredGrant({ shareKind: "drive_to" })).toBe(false);
+  });
+});
+
+describe("shared-with-me SMS-first sort", () => {
+  it("moves an sos grant ahead of an older routine grant", () => {
+    const routine = grant("routine", "share", "2026-05-20T08:00:00.000Z");
+    const sos = grant("sos", "sos", "2026-05-20T07:00:00.000Z");
+
+    expect(sortSmsFirst([routine, sos]).map((g) => g.id)).toEqual([
+      "sos",
+      "routine",
+    ]);
+  });
+
+  it("keeps the existing relative order within each group (stable sort)", () => {
+    const routineA = grant("routine-a", "share", "2026-05-20T09:00:00.000Z");
+    const routineB = grant("routine-b", "check_in", "2026-05-20T08:00:00.000Z");
+    const sosA = grant("sos-a", "sos", "2026-05-20T07:00:00.000Z");
+    const sosB = grant("sos-b", "sos", "2026-05-20T06:00:00.000Z");
+
+    expect(
+      sortSmsFirst([routineA, routineB, sosA, sosB]).map((g) => g.id),
+    ).toEqual(["sos-a", "sos-b", "routine-a", "routine-b"]);
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -160,6 +160,7 @@ import {
 import { bootstrapCurrentUserLocationRecipientKey } from "@/lib/one-location/key-bootstrap";
 import {
   isOneLocationGrantUnwatched,
+  isSmsTriggeredGrant,
   markOneLocationGrantOpened,
   markOneLocationGrantUnwatched,
   ONE_LOCATION_GRANT_ID_PARAM,
@@ -2985,9 +2986,15 @@ export function OneLocationAgentPageContent({
   // here (the backend keeps them for ~12h for history only).
   const activeReceivedGrants = useMemo(
     () =>
-      (state?.receivedGrants ?? []).filter(
-        (grant) => grant.status === "active",
-      ),
+      (state?.receivedGrants ?? [])
+        .filter((grant) => grant.status === "active")
+        // Stable sort: only ever moves an SMS-triggered (Save My Soul) share
+        // earlier. Array.prototype.sort is stable, so the backend's existing
+        // most-recent-first order is untouched within each group.
+        .sort(
+          (a, b) =>
+            Number(isSmsTriggeredGrant(b)) - Number(isSmsTriggeredGrant(a)),
+        ),
     [state?.receivedGrants],
   );
   const visibleReceivedGrants = useMemo(() => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
@@ -82,6 +82,26 @@ describe("SharedWithMeCard", () => {
   });
 });
 
+describe("SharedWithMeCard SMS badge", () => {
+  const base = {
+    name: "Trusted A",
+    statusLine: "Live until Jul 28, 11:19 PM",
+    onView: () => {},
+  };
+
+  it("shows no badge for a routine share", () => {
+    render(<SharedWithMeCard {...base} />);
+    expect(screen.queryByText("Shared via SMS")).toBeNull();
+  });
+
+  it("shows the SMS badge for an SOS-triggered share", () => {
+    render(<SharedWithMeCard {...base} isSmsTriggered />);
+    expect(screen.getByText("Shared via SMS")).toBeTruthy();
+    // Still shows the ordinary status pill alongside it.
+    expect(screen.getByText("Active")).toBeTruthy();
+  });
+});
+
 /**
  * The card is what a recipient looks at while there is no location on it, and
  * for a long time that was a name, a date, and nothing else. The page computed

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -23,6 +23,7 @@ import {
   RefreshCw,
   Share2,
   ShieldCheck,
+  Siren,
   User,
   X,
 } from "lucide-react";
@@ -382,6 +383,7 @@ export function SharedWithMeCard({
   viewStatus,
   onAskReshare,
   askReshareBusy,
+  isSmsTriggered,
 }: {
   name: string;
   statusLine: string;
@@ -413,8 +415,11 @@ export function SharedWithMeCard({
   /** Re-request access from the owner. Offered only for the `blocked` tone. */
   onAskReshare?: () => void;
   askReshareBusy?: boolean;
+  /** Came from the Save My Soul panic flow -- the one this UI calls "SMS". */
+  isSmsTriggered?: boolean;
 }) {
   const warningRole = roleClasses("warning");
+  const dangerRole = roleClasses("danger");
   const canOpenMap = Boolean(previewExpanded && mapHref);
   const previewRegionId = useId();
   const isPreviewExpanded = Boolean(previewExpanded);
@@ -432,6 +437,22 @@ export function SharedWithMeCard({
       <div className="flex items-start gap-3">
         <Avatar initials={initialsFrom(name)} />
         <div className="min-w-0 flex-1">
+          {isSmsTriggered ? (
+            // Its own line, not squeezed into the status row: this has to
+            // stay legible next to a long name/status on a narrow screen,
+            // and "prominent" is the whole point of the badge.
+            <span
+              className={cn(
+                "mb-1 inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[12px] font-semibold",
+                dangerRole.tile,
+                dangerRole.border,
+                dangerRole.glyph,
+              )}
+            >
+              <Siren className="h-3 w-3 shrink-0" aria-hidden="true" />
+              Shared via SMS
+            </span>
+          ) : null}
           <p className="truncate text-base font-semibold text-foreground">
             {name}
           </p>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -52,6 +52,10 @@ import {
   locationTimestampMs,
 } from "@/lib/one-location/duration-copy";
 import { formatShareEndsAt } from "@/lib/one-location/share-countdown";
+import {
+  isSmsTriggeredGrant,
+  ONE_LOCATION_GRANT_ID_PARAM,
+} from "@/lib/one-location/notifications";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -1198,6 +1202,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <LocationDetailFlow
             kind={flow}
             vm={vm}
+            focusGrantId={searchParams.get(ONE_LOCATION_GRANT_ID_PARAM)}
             collapsedGrantIds={collapsedGrantIds}
             onCollapseGrant={(grantId) =>
               setCollapsedGrantIds((current) => new Set(current).add(grantId))
@@ -1566,12 +1571,16 @@ function NowHub({
 function LocationDetailFlow({
   kind,
   vm,
+  focusGrantId,
   collapsedGrantIds,
   onCollapseGrant,
   onExpandGrant,
 }: {
   kind: "active-shares" | "shared-with-me" | "needs-review";
   vm: LocationHubViewModel;
+  /** Grant id from a notification deep link (?grantId=...) to scroll to and
+   * briefly highlight once its card is on screen. */
+  focusGrantId?: string | null;
   collapsedGrantIds: Set<string>;
   onCollapseGrant: (grantId: string) => void;
   onExpandGrant: (grant: OneLocationGrant) => void;
@@ -1645,6 +1654,37 @@ function LocationDetailFlow({
     //    `settle` is keyed by coordinates, so a late resolution either lands
     //    on the row it belongs to or is ignored.
   }, [kind, reverseGeocodePoint, vm.receivedGrants, vm.decryptedPoints]);
+
+  // Deep link from an SOS notification (?grantId=...) scrolls to and briefly
+  // rings the matching card once it is on screen. Deliberately NOT keyed on
+  // `vm.receivedGrants`: that array gets a new reference on every live poll
+  // (LIVE_VIEW_REFRESH_INTERVAL_MS, ~5s), and re-running this per poll tick
+  // would re-scroll and re-flash the ring for as long as `grantId` stays in
+  // the URL. Instead this fires once per (kind, focusGrantId) and retries
+  // briefly on its own if the card isn't in the DOM yet (state still loading).
+  const dangerRole = roleClasses("danger");
+  useEffect(() => {
+    if (kind !== "shared-with-me" || !focusGrantId) return;
+    let cancelled = false;
+    let attempts = 0;
+    const tryHighlight = () => {
+      if (cancelled) return;
+      const node = document.querySelector(`[data-grant-id="${focusGrantId}"]`);
+      if (!node) {
+        if (attempts++ < 20) setTimeout(tryHighlight, 250);
+        return;
+      }
+      node.scrollIntoView({ behavior: "smooth", block: "center" });
+      node.classList.add("ring-2", dangerRole.border, "ring-offset-2");
+      setTimeout(() => {
+        node.classList.remove("ring-2", dangerRole.border, "ring-offset-2");
+      }, 2400);
+    };
+    tryHighlight();
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, focusGrantId, dangerRole.border]);
   const copy = {
     "active-shares": {
       title: "Active shares",
@@ -1717,8 +1757,9 @@ function LocationDetailFlow({
               const expanded =
                 Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
+                <div key={grant.id} data-grant-id={grant.id}>
                 <SharedWithMeCard
-                  key={grant.id}
+                  isSmsTriggered={isSmsTriggeredGrant(grant)}
                   name={vm.grantOwnerLabel(grant)}
                   statusLine={
                     grant.durationMode === "until_stopped"
@@ -1790,6 +1831,7 @@ function LocationDetailFlow({
                       )
                     : null}
                 </SharedWithMeCard>
+                </div>
               );
             })}
           </div>

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -7,6 +7,7 @@ import {
   formatLocationDurationLabel,
   locationAskFacts,
 } from "@/lib/one-location/duration-copy";
+import type { OneLocationGrant } from "@/lib/one-location/types";
 
 export const ONE_LOCATION_GRANT_OPENED_EVENT =
   "hushh:one-location-grant-opened";
@@ -542,6 +543,19 @@ export function oneLocationShareKindLabel(kind?: string | null): string {
     default:
       return "Share";
   }
+}
+
+/**
+ * Whether a grant came from the Save My Soul panic flow -- the one thing in
+ * this codebase the UI calls "SMS" (no real text message is ever sent; see
+ * the `_classify_share_kind` comment on the backend). The single place that
+ * decides "counts as SMS-triggered," so the "Shared with me" sort and its
+ * badge can never disagree with each other.
+ */
+export function isSmsTriggeredGrant(
+  grant: Pick<OneLocationGrant, "shareKind">,
+): boolean {
+  return normalizeOneLocationShareKind(grant.shareKind) === "sos";
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes #5432. When someone receives an SOS / "Save My Soul" panic share, it landed in
"Shared with me" indistinguishable from a routine share and with no guaranteed
position — an urgent share could sit buried under older, ordinary ones.

This adds:
- A stable sort that always puts SMS-triggered (`shareKind === "sos"`) grants
  first in "Shared with me", without disturbing the existing recency order
  within either group.
- A "Shared via SMS" badge (danger-role pill + siren icon) on that card.
- A scroll-to + brief highlight ring on the matching card when the recipient
  arrives via a notification's `?grantId=...` deep link.

Frontend-only. `shareKind` is already delivered end-to-end on the grant payload;
no backend or schema change was needed.

One correctness note worth flagging for reviewers: the scroll/highlight effect
is deliberately **not** keyed on the live grants array, because that array gets
a new reference on every 5s location poll — keying on it would have re-scrolled
and re-flashed the ring every 5 seconds for as long as `grantId` stayed in the
URL. It fires once per `(kind, focusGrantId)` and retries briefly on its own
while the target card isn't in the DOM yet (data still loading).

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/location` (existing route; `app/one/location/page.tsx`, `components/one-location/redesign/location-redesign-hub.tsx`, `components/one-location/redesign/cards.tsx`)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — this is the shared Next.js UI already rendered inside the iOS/Android Capacitor webviews; no native plugin surface involved.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None — purely presentational; the underlying grant/consent data and access checks are unchanged.

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable — additive UI only (a sort + a badge + a highlight effect); the pre-existing card renders identically for every grant that isn't SMS-triggered.

- UI browser or Playwright proof:
  - [x] Listed below:
    - Route: `/one/location` → Shared with me. Verified end-to-end against real data: queried the DB directly and confirmed a live grant's `metadata.share_kind` is `"sos"`; confirmed the local dev server serves `/one/location` without error (HTTP 200) against that data. Full manual click-through (badge visible on screen, sort order, deep-link scroll/highlight) is still pending on the reporter's machine — local dev server was unreachable at the end of this session. Component-level render tests below assert the same behavior directly (badge text renders, sort order is correct) as a substitute for the pending manual pass.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npx eslint <changed files>`
  - [x] `cd hushh-webapp && npx vitest run <targeted suites: new sort/helper test, new badge render test, grant-duration-edit, feed-location-request-lines, one-location-grant-view-status-wiring.contract, resolve-location-deep-link-focus, shared-with-me-card, live-share-status-card, check-in-flow>` — 78/78 passing
  - [ ] `cd hushh-webapp && npm test` (full suite not run this session; targeted suites above cover every file this PR touches plus its direct neighbors)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: searched for any existing SMS-send integration (none exists — this is the pre-existing `sos` share-kind convention already used by `oneLocationShareKindLabel`/`isOneLocationSmsEmergencyAlert`) and for an existing deep-link focus mechanism (`resolveLocationDeepLinkFocus` picks the *tab*; this PR adds per-*card* highlighting, which didn't exist).
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Reachable production attach point: `/one/location` → "Shared with me" tab, and the existing `?grantId=...` notification deep link.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file: `isSmsTriggeredGrant` is imported from `lib/one-location/notifications.ts`; `SharedWithMeCard` is imported and rendered from `components/one-location/redesign/cards.tsx`.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint: `isSmsTriggeredGrant` is used by both the sort in `page.tsx` and the badge wiring in `location-redesign-hub.tsx`.
- [x] Production surface proved: see UI browser proof note above (DB-verified data + rendering tests); full manual click-through still pending.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`. — commit is signed off (`git commit -s`); CI status to be confirmed once this PR is open.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here.
- [x] If this is one PR in a stack, the predecessor PR is linked here: not a stack.
- [x] If this responds to requested changes, the new commit or material explanation is described here: not applicable, first submission.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/one/location/page.tsx`, `components/one-location/redesign/{cards,location-redesign-hub}.tsx`, `lib/one-location/notifications.ts`)
- [ ] **iOS**: Not applicable — shared web UI renders inside the existing Capacitor webview; no native plugin surface touched.
- [ ] **Android**: Not applicable — same as iOS.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) — manual click-through pending (see note above); covered instead by new/updated automated tests below.
- [ ] Tested on iOS Simulator/Device — not applicable, no native surface.
- [ ] Tested on Android Emulator/Device — not applicable, no native surface.
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command listed above — not applicable, no generated files touched.

## 📸 Screenshots / Video

Not attached — local dev server (`localhost:3010`) became unreachable on the reporter's
machine before a manual screenshot pass could be taken. In its place:
- DB-level proof that a live grant's `share_kind` is `"sos"` (verified directly against the UAT database).
- `components/one-location/redesign/__tests__/shared-with-me-card.test.tsx` renders `<SharedWithMeCard isSmsTriggered />` and asserts the "Shared via SMS" text is on screen.
- `hushh-webapp/__tests__/lib/one-location/shared-with-me-sort.test.ts` asserts the SMS-first stable sort behavior directly.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it only changes how already-authorized grant data (already delivered to the recipient) is ordered and labeled on screen.
- [ ] If yes, have you implemented `checkConsentToken()`? Not applicable.
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: the highlight effect no-ops silently if the target card isn't found (after a bounded retry), and the badge/sort simply do nothing for any grant that isn't SMS-triggered — no new failure mode introduced.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies.
