### PR TITLE
fix(one-location): tint circle-member map pins instead of leaving them untinted

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -2184,6 +2184,47 @@ describe("LocationImmersiveMap reported map defects", () => {
     expect(markerPayload).not.toContain("Abdul");
   });
 
+  it("tints a fresh circle-member pin distinctly instead of leaving it untinted (#5420)", async () => {
+    // Before this fix, a real (non-demo) person marker carried no `tint` at
+    // all, so `tintColor` reached the native bridge as `undefined` -- the
+    // marker fell back to whatever the platform SDK's default pin color
+    // happens to be, with no guaranteed contrast against map tiles.
+    //
+    // `capturedAt` is set to "now" (rather than reusing the fixed fixture
+    // timestamp `incomingMarker` uses elsewhere) so this marker reads as
+    // fresh regardless of when the suite runs -- a stale pin intentionally
+    // repaints to STALE_TINT, which would otherwise mask this assertion.
+    stubPhoneGeometry();
+    const freshMarker = incomingMarker(ANKIT, 25.4358, 81.8463);
+    const freshCapturedAt = new Date().toISOString();
+    freshMarker.envelope.capturedAt = freshCapturedAt;
+    freshMarker.envelope.plainPointForTest.capturedAt = freshCapturedAt;
+    serviceHarness.getMapState.mockResolvedValue({
+      markers: [freshMarker],
+      preferences: { presenceMode: "ghost" },
+    });
+
+    await renderReadyMap();
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-marker-count",
+        "1",
+      );
+    });
+
+    await waitFor(() => {
+      const drawn = mapHarness.map.addMarkers.mock.calls.at(-1)?.[0] as Array<{
+        tintColor?: { r: number; g: number; b: number; a: number };
+      }>;
+      // The batch may also include the self pin (its own, different tint);
+      // find the incoming circle-member pin specifically.
+      const personMarker = drawn?.find(
+        (marker) => marker.tintColor && marker.tintColor.r !== 0,
+      );
+      expect(personMarker?.tintColor).toEqual({ r: 88, g: 86, b: 214, a: 255 });
+    });
+  });
+
   it("draws no name over a rotated map, and none for a pin off screen", async () => {
     stubPhoneGeometry();
     serviceHarness.getMapState.mockResolvedValue({

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -220,6 +220,14 @@ type RenderMarker = {
 const STALE_TINT = { r: 142, g: 142, b: 147, a: 255 } as const;
 /** Location blue (--app-accent). The established map accent — never cyan. */
 const SELF_TINT = { r: 0, g: 122, b: 255, a: 255 } as const;
+/**
+ * Indigo (--app-people). Circle members and private shares had no tint at
+ * all before this — falling back to whatever the native SDK's default
+ * marker color happens to be, with no guaranteed contrast against map tiles
+ * and no visual link to the "people" role color used everywhere else this
+ * relationship is shown (Circles, Connect, trusted-contact rows).
+ */
+const PERSON_TINT = { r: 88, g: 86, b: 214, a: 255 } as const;
 /** Green (--app-success). A live check-in is a settled positive fact. */
 const PLACE_ACTIVE_TINT = { r: 52, g: 199, b: 89, a: 255 } as const;
 /**
@@ -945,6 +953,7 @@ export function LocationImmersiveMap({
               kind: "person",
               grantId: marker.grant.id,
               capturedAt: marker.envelope.capturedAt ?? null,
+              tint: PERSON_TINT,
             } satisfies RenderMarker;
           } catch {
             // A device without the recipient private key must not show a stale or


### PR DESCRIPTION
## Summary
Addresses #5420 (not auto-closing on merge — issue stays open until this is verified on UAT).

Investigated the marker-styling code in `location-immersive-map.tsx` (the "Your Map" surface, native `@capacitor/google-maps` bridge). Found the real gap: **circle-member / private-share pins carried no `tint` field at all** in the production (non-demo) marker-construction path. `self` (blue) and `place` (green/orange) markers already had a reserved tint constant each; `person` markers fell through with `tint: undefined`, so `tintColor` reached the native bridge (and the web preview renderer, which reads the same field) as `undefined` on every non-stale render — no contrast guarantee against map tiles, and no reserved color at all, let alone a high-contrast one.

## Changes
- Added `PERSON_TINT` (indigo, `{r:88,g:86,b:214}`, matching `--app-people` — the same semantic color already used for this relationship everywhere else in the app: Circles, Connect, trusted-contact rows) alongside the existing `SELF_TINT`/`PLACE_ACTIVE_TINT`/`PLACE_PENDING_TINT` constants.
- Set it on the real person-marker construction path (previously the only one of the three marker kinds with no tint at all). Demo-mode markers already carry a tint from `locationMapDemoPeople()` and were unaffected.

## Scope note: the boundary-ring / halo ask
The issue also asks for "crisp boundary rings (white/black outline strokes)". Investigated the `@capacitor/google-maps` `Marker` type directly (`node_modules/@capacitor/google-maps/dist/typings/definitions.d.ts`): it exposes `tintColor` only — no `strokeColor`/`fillColor`/halo property, unlike `Polygon`/`Circle` in the same SDK. Achieving a boundary ring would require custom pre-rendered PNG icon assets via `iconUrl` (SVG is explicitly unsupported on native per the SDK's own doc comment) — asset-creation work, out of scope for this code fix. Flagging as a real follow-up, not silently dropping it.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on both changed files.
- [x] `vitest run` on `location-immersive-map.test.tsx` — 42 passed (41 existing + 1 new), including a new regression test asserting a fresh circle-member marker's `tintColor` in the payload sent to `addMarkers` matches the new constant (it previously would have been `undefined`).
