### PR TITLE
fix(one-location): quiet the map chrome above an open check-in drawer

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -764,9 +764,16 @@ describe("LocationImmersiveMap demo experience", () => {
         }),
       ]);
     });
-    expect(
-      screen.getByTestId("one-location-nearby-search-area-legend"),
-    ).toHaveTextContent("500 m around you");
+    const searchLegend = screen.getByTestId(
+      "one-location-nearby-search-area-legend",
+    );
+    // The colour key is the legend's own job: only the map can say which dot is
+    // the owner.
+    expect(searchLegend).toHaveTextContent("You are here");
+    // The ring's radius is not. With the drawer open its list is headed "Places
+    // within 500 m" a few centimetres below, and a phone header carrying the
+    // same number twice is what made this screen read as cluttered.
+    expect(searchLegend).not.toHaveTextContent("500 m around you");
     expect(mapHarness.map.fitBounds).toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("clear-nearby-search-area"));
@@ -928,7 +935,15 @@ describe("LocationImmersiveMap demo experience", () => {
     const legend = screen.getByTestId("one-location-nearby-search-area-legend");
     expect(legend).toHaveTextContent("You are here");
     expect(legend).toHaveTextContent("Checking in at Hotel Two");
-    expect(legend).toHaveTextContent("180 m from you");
+    // Naming the two pins is the contract; restating the gap between them is
+    // not. The open drawer already says "You're about 180 m from here right
+    // now." under the selected row.
+    expect(legend).not.toHaveTextContent("180 m from you");
+    // And it is a row of the header's own grid now, not a card floating at a
+    // hand-counted offset that the phone's second header row landed on top of.
+    expect(
+      screen.getByRole("banner", { name: "Check in map controls" }),
+    ).toContainElement(legend);
 
     fireEvent.click(screen.getByTestId("clear-nearby-place-focus"));
     await waitFor(() => {
@@ -979,6 +994,19 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(
       screen.getByTestId("one-location-nearby-search-area-legend"),
     ).toHaveTextContent("Checked in at Hotel Two");
+
+    // Dismissed, this legend is the only thing on screen describing the live
+    // check-in -- the drawer that was stating the distance and the radius in
+    // words is gone -- so it takes them back.
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("one-location-nearby-search-area-legend"),
+      ).toHaveTextContent("500 m around your place");
+    });
+    expect(
+      screen.getByTestId("one-location-nearby-search-area-legend"),
+    ).toHaveTextContent("180 m from you");
   });
 
   it("keeps the full search circle in the visible mobile viewport above the sheet", async () => {
@@ -1341,12 +1369,22 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(screen.getByTestId("one-location-map-close")).toHaveAccessibleName(
       "Back to Location",
     );
-    expect(
-      screen.getByTestId("one-location-map-nearby-check-in"),
-    ).toHaveAccessibleName("Check in nearby");
     expect(screen.getByTestId("one-location-map-locate")).toHaveAccessibleName(
       "Show my location",
     );
+    // The drawer opens with this route, and a pill that re-opens an open drawer
+    // is a control with nothing to do -- it spent its width saying "Nearby 0"
+    // directly above a drawer counting the same people. Its whole job is the
+    // dismissed case, so that is when it exists.
+    expect(
+      screen.queryByTestId("one-location-map-nearby-check-in"),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("one-location-map-nearby-check-in"),
+      ).toHaveAccessibleName("Check in nearby");
+    });
     await waitFor(() => {
       expect(
         screen.getByTestId("one-location-map-sharing-status"),
@@ -1373,6 +1411,39 @@ describe("LocationImmersiveMap demo experience", () => {
     await waitFor(() => {
       expect(screen.queryByText("Ankit Kumar Singh")).not.toBeInTheDocument();
     });
+  });
+
+  it("keeps the top controls clear of the open check-in drawer on both layouts", async () => {
+    experienceHarness.demoMode = false;
+    experienceHarness.nearbyAvailable = true;
+
+    render(<LocationImmersiveMap surface="check-in" />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-ready",
+        "true",
+      );
+    });
+
+    const header = screen.getByRole("banner", {
+      name: "Check in map controls",
+    });
+    // From `md` up the drawer docks down the right edge as a portalled z-[712]
+    // panel, in its own stacking context above this z-30 header. Without the
+    // inset the Locate control renders underneath it -- on screen nowhere and
+    // tappable nowhere -- for as long as the drawer is open.
+    expect(header).toHaveClass("md:pr-[27rem]");
+    // On a phone, with the pill hidden the row has the width back, so Sharing
+    // rides beside the controls instead of taking a band of its own beneath
+    // them -- the band that used to be painted over the legend.
+    expect(header).toHaveClass("grid-cols-[auto_minmax(0,1fr)_auto]");
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+    await waitFor(() => {
+      expect(header).not.toHaveClass("md:pr-[27rem]");
+    });
+    expect(header).toHaveClass("grid-cols-[auto_minmax(0,1fr)]");
   });
 
   it("does not build a synthetic history boundary on the check-in route", async () => {
@@ -1998,10 +2069,15 @@ describe("LocationImmersiveMap reported map defects", () => {
     ).toBe(true);
   });
 
-  it("keeps Check in in the header on check-in's own route", async () => {
+  it("keeps Check in in the header on check-in's own route once the drawer is dismissed", async () => {
     // That surface renders no tray at all, and this pill is the only way back
     // into the sheet after dismissing it. Removing it everywhere strands the
     // person on a map with nothing to do.
+    //
+    // "After dismissing it" is also the whole of its job, so it waits for that
+    // moment: while the drawer is up the pill re-opens what is already open,
+    // and spends its width reading "Nearby 0" above a drawer counting the same
+    // people.
     serviceHarness.getState.mockResolvedValue({
       recipients: [],
       ownerGrants: [],
@@ -2014,7 +2090,17 @@ describe("LocationImmersiveMap reported map defects", () => {
     });
     expect(
       header.querySelector('[data-testid="one-location-map-nearby-check-in"]'),
-    ).not.toBeNull();
+    ).toBeNull();
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
+    await waitFor(() => {
+      expect(
+        header.querySelector(
+          '[data-testid="one-location-map-nearby-check-in"]',
+        ),
+      ).not.toBeNull();
+    });
   });
 
   it("answers Everyone instead of sitting disabled when no one shares with you", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -98,6 +98,7 @@ import {
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
 import { motionDurations, motionEasings } from "@/lib/morphy-ux/motion";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
+import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import {
   claimNativeMap,
@@ -2339,6 +2340,25 @@ export function LocationImmersiveMap({
     visibleMarkers,
   ]);
 
+  /**
+   * The drawer is on screen, so the drawer is the authority.
+   *
+   * Open, it already names the place, the radius, the time left and how far the
+   * owner has drifted from it -- in full sentences, at the top of its own
+   * scroll. Every one of those facts also had a copy in the map chrome above
+   * it, and on a phone that chrome is a strip barely 150px tall carrying a 56px
+   * control row, a centred "Sharing with N" row of its own, and a four-line
+   * legend card that the Sharing row landed *on top of* (header z-30 over
+   * legend z-20). Reported as, simply, "too busy after tapping check in".
+   *
+   * So while it is open the chrome keeps only what the drawer cannot say: the
+   * way out, the way to recentre, and which pin is which. Dropping the pill that
+   * re-opens an already-open drawer is what frees the phone header's second row,
+   * which is what lets Sharing ride up beside the controls instead of forming a
+   * band of its own -- and the collision goes with it.
+   */
+  const checkInDrawerOpen = isCheckInSurface && nearbyCheckInOpen;
+
   return (
     <main
       className="one-location-map relative h-[100dvh] w-full overflow-hidden bg-muted"
@@ -2399,7 +2419,26 @@ export function LocationImmersiveMap({
         // widths and drops Sharing onto its own full-width row beneath them.
         // Nothing truncates, and the Sharing popover gains the room it needs to
         // open without being clipped by the screen edge.
-        className="pointer-events-none absolute inset-x-0 top-0 z-30 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 p-4 pt-[max(1rem,env(safe-area-inset-top))] sm:grid-cols-[1fr_auto_1fr]"
+        //
+        // With the check-in drawer open that second row is no longer needed:
+        // the Check-in pill is hidden (it re-opens what is already open), which
+        // gives the row back the ~95px that forced Sharing downward. A three
+        // column grid then reads the same at every width -- X, Sharing, Locate
+        // -- so the phone loses a whole band of chrome and the legend below can
+        // no longer be landed on by a row that used to sit at the same offset.
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 z-30 grid items-center gap-x-3 gap-y-2 p-4 pt-[max(1rem,env(safe-area-inset-top))]",
+          checkInDrawerOpen
+            ? "grid-cols-[auto_minmax(0,1fr)_auto]"
+            : "grid-cols-[auto_minmax(0,1fr)] sm:grid-cols-[1fr_auto_1fr]",
+          // From `md` up the drawer docks down the right edge as a portalled
+          // z-[712] panel -- above this z-30 header, and in a different stacking
+          // context, so no z-index here can win. Without this inset the Locate
+          // control renders underneath it: visible nowhere and tappable nowhere,
+          // for as long as the drawer is open. 27rem is the panel's own
+          // `md:w-[26rem]` plus the 1rem gutter this header already keeps.
+          nearbyCheckInOpen && "md:pr-[27rem]",
+        )}
       >
         <div className="col-start-1 row-start-1 flex min-w-0 items-center">
           <ShellActionSurface
@@ -2417,7 +2456,14 @@ export function LocationImmersiveMap({
             <X className="h-5 w-5 stroke-[2.25]" />
           </ShellActionSurface>
         </div>
-        <div className="col-span-2 col-start-1 row-start-2 flex min-w-0 items-center justify-center sm:col-span-1 sm:col-start-2 sm:row-start-1">
+        <div
+          className={cn(
+            "flex min-w-0 items-center justify-center",
+            checkInDrawerOpen
+              ? "col-start-2 row-start-1"
+              : "col-span-2 col-start-1 row-start-2 sm:col-span-1 sm:col-start-2 sm:row-start-1",
+          )}
+        >
           {!demoMode && (activeShareCount ?? 0) > 0 ? (
             <Popover
               open={sharingPopoverOpen}
@@ -2514,7 +2560,12 @@ export function LocationImmersiveMap({
           ) : null}
         </div>
         {rendererReady ? (
-          <div className="col-start-2 row-start-1 flex min-w-0 items-center justify-end gap-3 sm:col-start-3">
+          <div
+            className={cn(
+              "row-start-1 flex min-w-0 items-center justify-end gap-3",
+              checkInDrawerOpen ? "col-start-3" : "col-start-2 sm:col-start-3",
+            )}
+          >
             {/*
               Your Map keeps this control in the tray below, not up here. Two
               floating pills plus the Sharing status is a second row of chrome
@@ -2525,11 +2576,19 @@ export function LocationImmersiveMap({
               Check-in's own route still needs it here: that surface renders no
               tray (see the `!isCheckInSurface` gate on the tray section), and
               this pill is the only way back into the sheet after dismissing it.
+
+              "After dismissing it" is the whole of its job, so it is gated on
+              exactly that. While the drawer is open the pill is a control that
+              opens what is already open, and it spends its width saying
+              "Nearby 0" directly above a drawer whose own header counts the
+              same people. Hiding it is also what collapses the phone header to
+              a single row -- see the grid comment above.
             */}
             {rendererReady &&
             nearbyCheckInAvailable &&
             !demoMode &&
-            isCheckInSurface ? (
+            isCheckInSurface &&
+            !nearbyCheckInOpen ? (
               <ShellActionSurface
                 variant="pill"
                 // ShellActionSurface's own wrapper is shrink-0 by default (a
@@ -2584,74 +2643,107 @@ export function LocationImmersiveMap({
             ) : null}
           </div>
         ) : null}
-      </header>
-      {/*
-        Two pins on one map need naming, or the owner cannot tell which is
-        "me" and which is "the place I'm checking in to" -- and those are
-        routinely a street apart.
-      */}
-      {rendererReady &&
-      (nearbyCheckInOpen || nearbyPlaceFocus?.active) &&
-      (nearbySearchPoint || nearbyPlaceFocus) ? (
-        <div
-          className="pointer-events-none absolute left-4 right-4 z-20 flex max-w-[18rem] flex-col gap-1.5 rounded-2xl border border-[var(--app-accent-border)] bg-background/90 px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur-md md:right-auto"
-          style={{
-            top: "calc(max(1rem, env(safe-area-inset-top)) + 4.5rem)",
-          }}
-          data-testid="one-location-nearby-search-area-legend"
-        >
-          {nearbySearchPoint ? (
-            <span className="flex items-center gap-2">
-              <span
-                className="h-2.5 w-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: tintCss(SELF_TINT) }}
-                aria-hidden="true"
-              />
-              <span className="truncate text-foreground">You are here</span>
-            </span>
-          ) : null}
-          {nearbyPlaceFocus ? (
-            <span
-              className="flex items-center gap-2"
-              data-testid="one-location-nearby-place-legend"
-            >
-              <span
-                className="h-2.5 w-2.5 shrink-0 rounded-full"
-                style={{
-                  backgroundColor: tintCss(
-                    nearbyPlaceFocus.active
-                      ? PLACE_ACTIVE_TINT
-                      : PLACE_PENDING_TINT,
-                  ),
-                }}
-                aria-hidden="true"
-              />
-              <span className="truncate text-foreground">
-                {nearbyPlaceFocus.active ? "Checked in at " : "Checking in at "}
-                {nearbyPlaceFocus.label}
+        {/*
+          Two pins on one map need naming, or the owner cannot tell which is
+          "me" and which is "the place I'm checking in to" -- and those are
+          routinely a street apart.
+
+          A row of the header's own grid, not a floating card at a hand-counted
+          `top: calc(... + 4.5rem)`. That constant was measured against a
+          one-row header, so the moment the phone header grew its second row for
+          "Sharing with N" the two occupied the same band -- and since the
+          header is z-30 and this was z-20, the Sharing pill was painted
+          *through* the legend card. Being a grid row instead makes the overlap
+          unrepresentable, and it lands the legend inside the element the camera
+          padding and the name-pill layer already measure, so neither can treat
+          the space it takes as free map.
+        */}
+        {rendererReady &&
+        (nearbyCheckInOpen || nearbyPlaceFocus?.active) &&
+        (nearbySearchPoint || nearbyPlaceFocus) ? (
+          <div
+            className={cn(
+              "pointer-events-none flex w-full max-w-[18rem] flex-col gap-1.5 justify-self-start rounded-2xl border border-[var(--app-accent-border)] bg-background/90 px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur-md",
+              checkInDrawerOpen
+                ? "col-span-3 row-start-2"
+                : "col-span-2 row-start-3 sm:col-span-3 sm:row-start-2",
+            )}
+            data-testid="one-location-nearby-search-area-legend"
+          >
+            {nearbySearchPoint ? (
+              <span className="flex items-center gap-2">
+                <span
+                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: tintCss(SELF_TINT) }}
+                  aria-hidden="true"
+                />
+                <span className="truncate text-foreground">You are here</span>
               </span>
-            </span>
-          ) : null}
-          {nearbyPlaceFocus?.distanceMeters != null &&
-          nearbyPlaceFocus.distanceMeters >= 25 ? (
-            <span className="pl-[1.125rem] font-normal text-muted-foreground">
-              {nearbyPlaceFocus.distanceMeters < 1_000
-                ? `${nearbyPlaceFocus.distanceMeters} m`
-                : `${(nearbyPlaceFocus.distanceMeters / 1_000).toFixed(1)} km`}{" "}
-              from you
-            </span>
-          ) : null}
-          <span className="pl-[1.125rem] font-normal text-muted-foreground">
-            {/* "match" is the backend's word for how it pairs attendees, and it
-                also hid a real difference: the live circle is drawn around the
-                PLACE, the search circle around the PERSON (see the circle title
-                at ~1396). Naming the anchor says both things in plain words. */}
-            {nearbyPlaceFocus?.active
-              ? "500 m around your place"
-              : "500 m around you"}
-          </span>
-        </div>
-      ) : null}
+            ) : null}
+            {nearbyPlaceFocus ? (
+              <span
+                className="flex items-center gap-2"
+                data-testid="one-location-nearby-place-legend"
+              >
+                <span
+                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{
+                    backgroundColor: tintCss(
+                      nearbyPlaceFocus.active
+                        ? PLACE_ACTIVE_TINT
+                        : PLACE_PENDING_TINT,
+                    ),
+                  }}
+                  aria-hidden="true"
+                />
+                <span className="truncate text-foreground">
+                  {nearbyPlaceFocus.active
+                    ? "Checked in at "
+                    : "Checking in at "}
+                  {nearbyPlaceFocus.label}
+                </span>
+              </span>
+            ) : null}
+            {/*
+              The measurements, only when nothing else is saying them.
+
+              Open, the drawer states both a few centimetres below: the live
+              card reads "<place> · 500 m radius · 59 min left" and then "You've
+              moved about 451 m away", and the setup list is headed "Places
+              within 500 m". Printing them up here as well is the same two
+              numbers twice on the most crowded strip of a phone screen, which
+              is what turned a colour key into a four-line card.
+
+              Dismissed, this legend is the ONLY thing on screen describing a
+              live check-in, so it keeps its full form.
+            */}
+            {!nearbyCheckInOpen &&
+            nearbyPlaceFocus?.distanceMeters != null &&
+            nearbyPlaceFocus.distanceMeters >= 25 ? (
+              <span className="pl-[1.125rem] font-normal text-muted-foreground">
+                {nearbyPlaceFocus.distanceMeters < 1_000
+                  ? `${nearbyPlaceFocus.distanceMeters} m`
+                  : `${(nearbyPlaceFocus.distanceMeters / 1_000).toFixed(
+                      1,
+                    )} km`}{" "}
+                from you
+              </span>
+            ) : null}
+            {!nearbyCheckInOpen ? (
+              <span className="pl-[1.125rem] font-normal text-muted-foreground">
+                {/* "match" is the backend's word for how it pairs attendees, and
+                    it also hid a real difference: the live circle is drawn
+                    around the PLACE, the search circle around the PERSON (see
+                    the circle title at ~1396). Naming the anchor says both
+                    things in plain words. */}
+                {nearbyPlaceFocus?.active
+                  ? "500 m around your place"
+                  : "500 m around you"}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </header>
       {status !== "unavailable" && !mapReady ? (
         // The map now starts initializing as soon as this screen opens --
         // before consent it's a neutral world view with zero markers, no

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -500,6 +500,9 @@ describe("NearbyCheckInSheet", () => {
 
     expect(await screen.findByText("Maya Chen")).toBeInTheDocument();
     expect(screen.getByTestId("nearby-attendee-roster")).toBeInTheDocument();
+    // The count sits beside the heading it counts, so it reads as part of
+    // "People nearby" rather than as a loose number in the card's corner.
+    expect(screen.getByTestId("nearby-attendee-count")).toHaveTextContent("1");
     expect(
       screen.queryByTestId("nearby-private-share-card"),
     ).not.toBeInTheDocument();
@@ -519,6 +522,48 @@ describe("NearbyCheckInSheet", () => {
     expect(
       await screen.findByRole("button", { name: "Requested with Maya Chen" }),
     ).toBeDisabled();
+  });
+
+  it("prints no roster count when nobody is nearby, and states the pin rule once", async () => {
+    // Reported as "0 on right top of div": with nobody nearby the badge was a
+    // bare zero pushed to the far right of a three-line block, level with the
+    // middle of a paragraph and touching nothing. The empty state right below
+    // it already says the same thing in words, so the badge has no zero to
+    // print -- and the drawer no longer says "never pinned on your map" twice
+    // in one screen, once under the heading and once under Check out.
+    service.getNearbyPresence.mockResolvedValue({
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: false,
+        consentVersion: "one-location-nearby-presence-v3",
+        checkedInAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        placeLabel: "Stanford University",
+      },
+      attendees: [],
+    });
+
+    render(
+      <NearbyCheckInSheet
+        open
+        ownerId="user-1"
+        vaultOwnerToken="owner-token"
+        captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText("No one else is checked in nearby yet"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("nearby-attendee-count"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText(/never as pins on your map|never pinned on your map/i),
+    ).toHaveLength(1);
   });
 
   it("prepares a fresh check-in when an active presence expires while open", async () => {

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -1648,21 +1648,41 @@ export function NearbyCheckInSheet({
               </section>
 
               <section aria-labelledby="nearby-people-title">
-                <div className="flex items-end justify-between gap-3">
-                  <div>
-                    <h2 id="nearby-people-title" className="font-semibold">
-                      People nearby
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                      Nearby check-ins appear in this list, not as map pins. A
-                      pin appears only after that person explicitly shares
-                      their location with you.
-                    </p>
-                  </div>
-                  <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold">
-                    {state.attendees.length}
-                  </span>
+                {/*
+                  The count belongs to the heading it counts.
+
+                  `items-end justify-between` pushed it to the far right of a
+                  three-line block, so it floated level with the middle of a
+                  paragraph with nothing beside it -- a bare "0" adrift in the
+                  corner of the card, which is exactly how it was reported. And
+                  a zero is not a count worth printing at all: the empty state
+                  immediately below says "No one else is checked in nearby yet"
+                  in words, so the badge only appears once there is somebody.
+                */}
+                <div className="flex items-center gap-2">
+                  <h2 id="nearby-people-title" className="font-semibold">
+                    People nearby
+                  </h2>
+                  {state.attendees.length ? (
+                    <span
+                      className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums"
+                      data-testid="nearby-attendee-count"
+                    >
+                      {state.attendees.length}
+                    </span>
+                  ) : null}
                 </div>
+                {/*
+                  One statement of the privacy rule, not two. This sentence and
+                  the footnote that used to close the drawer said the same thing
+                  -- nearby people are a list, never a pin -- one under the
+                  heading and one under the Check out button, so a person reading
+                  top to bottom met the same reassurance twice in a single
+                  screen. Kept here, where the list it describes actually is.
+                */}
+                <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
+                  They appear here as a list, never as pins on your map.
+                </p>
                 {state.attendees.length ? (
                   <ul className="mt-2" data-testid="nearby-attendee-roster">
                     {state.attendees.map((attendee) => (
@@ -1713,10 +1733,6 @@ export function NearbyCheckInSheet({
                 ) : null}
                 Check out now
               </Button>
-              <p className="text-center text-xs text-muted-foreground">
-                Nearby people appear as a list. Their precise locations are
-                never pinned on your map.
-              </p>
             </div>
           ) : (
             <div className="space-y-5" data-testid="nearby-presence-setup">


### PR DESCRIPTION
## The report

> "this is too busy after tapping checkin — 0 on right top of div. On mobile after opening this Check In it looks too busy and many things are there in this view."

The strip above the drawer carried three bands on a phone: a 56px control row, a `Sharing with 3` row of its own, and a four-line legend card. The Sharing row was painted **through** the legend — the legend sat at a hand-counted `top: calc(... + 4.5rem)` measured against a *one-row* header, while the header is `z-30` and the legend was `z-20`.

Underneath the collision it was the same facts three times over:

| Fact | Drawer | Legend | Header pill |
|---|---|---|---|
| Place name | `Ratan medical Store · …` | `Checked in at Ratan medical Store` | — |
| Radius | `· 500 m radius ·` | `500 m around your place` | — |
| Drift | `You've moved about 451 m away…` | `451 m from you` | — |
| Attendee count | `People nearby  0` | — | `Nearby 0` |

## The rule

**The drawer is on screen, so the drawer is the authority.** While it is open the map chrome keeps only what the drawer cannot say: the way out, the way to recentre, and which pin is which.

- **Check-in pill hidden while the drawer is open.** Its stated job is re-opening a *dismissed* drawer, so it now waits for that moment; open, it was a control that opens what is already open, spending its width on `Nearby 0`. That gives back the ~95px that forced Sharing onto a second row, so the phone header collapses to a single row — X, Sharing, Locate — and loses a whole band of chrome.
- **The legend is a row of the header's own grid**, not a floating card at a fixed offset. The overlap becomes unrepresentable, and it lands inside the element the camera padding and the name-pill layer already measure, so neither treats the space it takes as free map. Open, it is the colour key alone; dismissed, it takes the distance and radius back — then it is the only thing on screen describing the check-in.

## Desktop

A live defect, not just tidying: from `md` up the drawer docks down the right edge as a portalled `z-[712]` panel in its own stacking context, above the `z-30` header. **The Locate control rendered underneath it** — visible nowhere and tappable nowhere — for as long as the drawer was open. The header now insets past the panel while it is docked.

## Inside the drawer

- The count badge was `items-end justify-between` against a three-line block, so a bare **`0`** floated in the card's corner level with the middle of a paragraph, beside nothing. It moves next to the heading it counts, and prints no zero at all — the empty state right below already says `No one else is checked in nearby yet` in words.
- The privacy rule ("a list, never a pin") was stated twice in one screen — once under the heading, once under Check out. It is stated once now, next to the list it describes.

## Verification

- `location-immersive-map`, `nearby-check-in-sheet`, `location-map-chrome.contract`, `one-location-check-in-destination.contract` — **99 passed**.
- `tsc --noEmit` clean; `eslint` clean on all four changed files.
- The four contracts that encoded the old chrome were updated in place with the reasoning, and new ones added for the desktop inset, the compact phone header, the pill's dismissed-only lifetime, and the zero-suppressed badge.
- Pre-existing on `main` and untouched here: 2 failures in `one-location-onboarding-flow.test.tsx` (`data-one-onboarding-design`), confirmed by re-running them with this branch stashed.
