### PR TITLE
fix(webapp): normalize Public Links action button geometry

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/public-links-actions.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/public-links-actions.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TemporaryLinkCard } from "@/components/one-location/redesign/cards";
+
+/**
+ * The Public Links surface shipped with three action buttons that disagreed on
+ * height, radius, padding and icon spacing: two carried an icon and one did
+ * not, and each restated geometry the `sm` size variant already owns. This
+ * locks the group to one geometry so a future edit cannot reintroduce the drift
+ * one button at a time.
+ */
+describe("Public Links action group", () => {
+  const renderCard = () =>
+    render(
+      <TemporaryLinkCard
+        title="Public location link active"
+        statusLine="Anyone with this link can view you"
+        expiryLabel="Expires in 30 min"
+        onCopy={vi.fn()}
+        onShare={vi.fn()}
+        onRevoke={vi.fn()}
+      />,
+    );
+
+  it("gives Copy, Share and Revoke a single geometry", () => {
+    renderCard();
+
+    const actions = ["Copy", "Share", "Revoke"].map((name) =>
+      screen.getByRole("button", { name }),
+    );
+    expect(actions).toHaveLength(3);
+
+    for (const action of actions) {
+      // Height, horizontal padding and label size come from the size variant,
+      // never from a per-button override that can drift from its neighbours.
+      expect(action.className).toContain("min-h-9");
+      expect(action.className).toContain("px-3");
+      expect(action.className).not.toContain("text-sm");
+      // The one geometry the group states for itself: the pill radius shared by
+      // every compact action on this surface.
+      expect(action.className).toContain("rounded-full");
+    }
+  });
+
+  it("keeps every cell in the group the same shape", () => {
+    renderCard();
+
+    // Equal grid columns only read as symmetric when no cell carries an icon
+    // its neighbours lack, which is what made "Revoke" sit short of Copy/Share.
+    for (const name of ["Copy", "Share", "Revoke"]) {
+      expect(
+        screen.getByRole("button", { name }).querySelector("svg"),
+      ).toBeNull();
+    }
+
+    const group = screen.getByRole("button", { name: "Copy" }).parentElement;
+    expect(group?.className).toContain("grid-cols-3");
+    expect(group?.className).toContain("gap-2");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -15,13 +15,11 @@ import {
   AlertTriangle,
   ChevronDown,
   Clock3,
-  Copy,
   ExternalLink,
   Loader2,
   MapPin,
   Pencil,
   RefreshCw,
-  Share2,
   ShieldCheck,
   Siren,
   User,
@@ -671,23 +669,29 @@ export function TemporaryLinkCard({
         </div>
         <StatusPill tone="live">Live</StatusPill>
       </div>
+      {/* One action group, one geometry. Height, horizontal padding and label
+          size all come from `size="sm"`, so the only thing this row states is
+          the pill radius every compact action on the Links surface shares.
+          The three used to disagree: `h-9` restated the size variant, and only
+          two of them carried an icon, so the odd cell read shorter than its
+          neighbours inside equal grid columns. Labels stay icon-free because at
+          a 320px viewport each column is ~81px, which an icon plus "Revoke"
+          overflows. */}
       <div className="grid grid-cols-3 gap-2">
         <Button
           variant="outline"
           size="sm"
           onClick={onCopy}
-          className="h-9 rounded-full text-sm"
+          className="rounded-full"
         >
-          <Copy className="mr-1 h-3.5 w-3.5" />
           Copy
         </Button>
         <Button
           variant="outline"
           size="sm"
           onClick={onShare}
-          className="h-9 rounded-full text-sm"
+          className="rounded-full"
         >
-          <Share2 className="mr-1 h-3.5 w-3.5" />
           Share
         </Button>
         <Button
@@ -695,7 +699,7 @@ export function TemporaryLinkCard({
           size="sm"
           onClick={onRevoke}
           isLoading={revokeBusy}
-          className="h-9 rounded-full text-sm"
+          className="rounded-full"
         >
           Revoke
         </Button>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2456,6 +2456,12 @@ function ActiveLinkRow({
           {subtitle}
         </RowDescription>
       </div>
+      {/* Same geometry as the Copy button inside TemporaryLinkCard, so the one
+          action a person meets twice on this surface is the same control both
+          times: `sm` owns height and horizontal padding (this used to force
+          `px-3.5` against the card's `px-3`), and the pill radius matches every
+          other compact action in the feature. Only the accent tint is local —
+          it is this row's own affordance, distinct from the row-wide tap. */}
       <Button
         variant="outline"
         onClick={(e) => {
@@ -2463,7 +2469,7 @@ function ActiveLinkRow({
           onCopy();
         }}
         size="sm"
-        className="shrink-0 border-[color:var(--app-accent)] px-3.5 text-[color:var(--app-accent)]"
+        className="shrink-0 rounded-full border-[color:var(--app-accent)] text-[color:var(--app-accent)]"
       >
         Copy
       </Button>


### PR DESCRIPTION
## Problem

Reported as non-uniform sizing, uneven padding and asymmetric alignment on the Public Links surface (One → Location → **Links** tab, plus its public-link task flow).

Every button there restated geometry the `Button` size variant already owns, and each restated it differently:

| Button | Height | Radius | Padding | Icon gap |
|---|---|---|---|---|
| `ActiveLinkRow` **Copy** | 36px (`sm`) | 14px (`sm`) | `px-3.5` | — |
| `TemporaryLinkCard` **Copy/Share** | `h-9` on `sm` | `rounded-full` | `px-2.5` | `gap-1.5` **+ `mr-1`** |
| `TemporaryLinkCard` **Revoke** | `h-9` on `sm` | `rounded-full` | `px-3` | no icon |

Four concrete defects:

1. The **two `Copy` buttons** a person meets on this one surface had different radius and different padding.
2. **`h-9` / `text-sm`** re-declared what `size="sm"` already sets — and `text-sm` (14px) fought the variant's 15px label.
3. The **3-up grid was asymmetric**: two cells carried icons, one didn't, so an equal-width column read visibly shorter.
4. The icon classes were both wrong. `mr-1` stacked on the button's own `gap-1.5` (10px total, vs 16px on the tab CTA's `mr-2` + `gap-2`), and `h-3.5 w-3.5` was **dead code** — the base `[&_svg:not([class*='size-'])]:size-4` rule outranks a plain `.h-3\.5` on specificity, so those icons already rendered at 16px.

## Change

The action group now states only its pill radius; height, padding and label size come from `size="sm"`. The row `Copy` picks up the same radius and drops its bespoke padding, so it is now the identical control to the card's `Copy`.

Labels are icon-free rather than adding an icon to `Revoke`: at a 320px viewport each grid column is ~81px, and an icon plus a nowrap "Revoke" overflows that. Text-only fits at every viewport and matches the row `Copy`, which was already text-only.

## Deliberately out of scope

- **Flow CTAs** (`Review public location link` at `h-12 rounded-2xl`, `Done` at `h-11`). These look like outliers against the 50px system default, but Share, Ask and Invite all use exactly the same pair — normalizing only this flow would break parity with its three siblings. Worth a separate feature-wide pass.
- **`mr-2` on the "Create a new link" `Plus` icon**, and PeopleHub's `h-12` full-width CTAs (48px where the system says 50px). Both are feature-wide patterns; fixing them one surface at a time recreates exactly the inconsistency this PR is about.

## Testing

- Adds `public-links-actions.test.tsx`, following the existing `button-compact-typography` contract-test pattern. Verified it **fails against the pre-fix markup**, so it isn't vacuous.
- `tsc --noEmit` and `eslint --max-warnings=0` clean.

Not yet verified on a live surface — UAT deploy to follow.