### PR TITLE
fix(webapp): align People tab top spacing with the other Location tabs

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2107,7 +2107,12 @@ function PeopleHub({
   );
 
   return (
-    <div className="pt-6 sm:pt-[52px]" data-testid="one-location-people-hub">
+    /* No top padding: the tab strip and PageHeader above already set the gap
+       every hub tab opens with, so Menu and Links start their first section
+       flush against it. People used to add 24px on top of that, and 52px from
+       `sm:` up — enough that "Circles" visibly floated lower here than on
+       either neighbouring tab. */
+    <div data-testid="one-location-people-hub">
       <div className="space-y-10 sm:space-y-[72px]">
         <CirclesSection
           circles={vm.circles}


### PR DESCRIPTION
## Problem

On Location Agent → **People**, the "Circles" heading sits visibly lower than the first section on the Menu and Links tabs, leaving an oversized gap under the header.

`PeopleHub` was the only hub tab adding its own top padding:

| Tab | Root className | Top padding |
|---|---|---|
| Menu (`NowHub`) | `space-y-4` | none |
| Links (`LinksHub`) | `space-y-4` | none |
| **People** (`PeopleHub`) | **`pt-6 sm:pt-[52px]`** | **24px, 52px at `sm`+** |

The tab strip and `PageHeader` above already establish the gap every tab opens with. Menu and Links start flush against it; People stacked another 24px on top, rising to 52px from `sm` up — which is the range where it reads as a layout bug rather than breathing room.

## Change

Drops the padding from the `PeopleHub` root. All three tabs now open at the same height at every width.

## Out of scope

People's internal section rhythm (`space-y-10 sm:space-y-[72px]` between Circles / Connections / Requests sent) is untouched. It is much looser than the other tabs' `space-y-4`, but it reads as a deliberate choice for this tab's larger sections, and it is a separate decision from the header gap.

## Testing

- `tsc --noEmit` and `eslint --max-warnings=0` clean.
- Full location hub suite green: 16 files, 227 tests.
- Nothing references the wrapper being changed beyond its own `data-testid`, which is preserved.

Not yet verified on a live surface.