### PR TITLE
fix(webapp): remove like/dislike buttons from the agent message footer

### DIFF
--- a/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-chat-shell.contract.test.ts
@@ -78,4 +78,20 @@ describe("private-agent chat shell contract", () => {
     expect(workspace).toContain("!message.renderAsPlainAssistantMessage;");
     expect(workspace).toContain("renderAsPlainAssistantMessage: true,");
   });
+
+  it("keeps the assistant response footer to essential utilities only", () => {
+    const workspace = read("components/agent/agent-chat-workspace.tsx");
+
+    // Like/dislike were local `useState` that never reached storage, an API or
+    // analytics — the rating died with the component. They cluttered the footer
+    // while recording nothing, so the footer carries Copy, plus Retry when a
+    // turn offers it, and no reaction affordances.
+    expect(workspace).not.toContain("ThumbsUp");
+    expect(workspace).not.toContain("ThumbsDown");
+    expect(workspace).not.toContain("Like response");
+    expect(workspace).not.toContain("Dislike response");
+    expect(workspace).toContain(
+      'aria-label={copied ? "Response copied" : "Copy response"}',
+    );
+  });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -28,8 +28,6 @@ import {
   Pencil,
   RotateCcw,
   Send,
-  ThumbsDown,
-  ThumbsUp,
   Trash2,
   UserRound,
 } from "lucide-react";
@@ -843,8 +841,6 @@ function AgentBubble({
   onPendingConsentDetails?: (item: SpecialistPendingConsentRequestItem) => void;
 }) {
   const [copied, setCopied] = useState(false);
-  const [liked, setLiked] = useState(false);
-  const [disliked, setDisliked] = useState(false);
   const isUser = message.role === "user";
   const isStreaming = message.status === "streaming";
   const isError = message.status === "error";
@@ -968,44 +964,6 @@ function AgentBubble({
                 title={copied ? "Copied" : "Copy response"}
               >
                 {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const nextLiked = !liked;
-                  setLiked(nextLiked);
-                  if (nextLiked) setDisliked(false);
-                }}
-                className={cn(
-                  "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
-                  liked
-                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
-                )}
-                aria-label="Like response"
-                aria-pressed={liked}
-                title="Like response"
-              >
-                <ThumbsUp className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const nextDisliked = !disliked;
-                  setDisliked(nextDisliked);
-                  if (nextDisliked) setLiked(false);
-                }}
-                className={cn(
-                  "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
-                  disliked
-                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
-                )}
-                aria-label="Dislike response"
-                aria-pressed={disliked}
-                title="Dislike response"
-              >
-                <ThumbsDown className="h-3.5 w-3.5" />
               </button>
               {onRetry ? (
                 <button


### PR DESCRIPTION
Closes the "remove like/dislike feedback buttons" UI simplification issue.

## What the buttons actually did

Nothing. They were backed by two local `useState` flags in `AgentBubble`:

```tsx
const [liked, setLiked] = useState(false);
const [disliked, setDisliked] = useState(false);
```

The rating was never persisted, never sent to an API, and never reported to analytics — it died with the component on unmount. A grep across the repo found no other reference to the state, the icons, or the `Like response` / `Dislike response` labels.

This confirms the issue's framing: they were unused feedback scaffolding taking two of the three slots in the response footer while recording nothing. **No data is lost, because none was ever captured.**

## Change

- Removes both buttons and the `liked`/`disliked` state.
- Removes the now-unused `ThumbsUp` / `ThumbsDown` lucide imports.
- Footer keeps **Copy**, plus **Try again** on turns that offer a retry.

The investigation boundary in the issue mentioned `components/agent/chat/message-bubble.tsx` and `message-actions.tsx` — neither exists in this codebase. All of it lived in `agent-chat-workspace.tsx`.

## Testing

- Adds a case to the existing `agent-chat-shell.contract.test.ts`, which is already the source-level contract for this file. Verified it **fails against the pre-fix source**.
  - Chose this over a render test because `AgentBubble` is a private component; asserting on it directly would have meant exporting internals purely for testing.
- `tsc --noEmit` and `eslint --max-warnings=0` clean — which is what proves the deletion left no dangling references.
- Agent suites green: 6 files, 28 tests.

Note: 4 failures in `agent-popover-provider.test.tsx` are **pre-existing on clean `main`** — verified by stashing this change and re-running. Unrelated to this PR (floating-trigger ownership).

## Left alone

The `Try again` button keeps its `ml-1`, which sat there to separate the labeled button from the icon cluster. With one icon left it reads as 4px gap + 4px margin. It still legitimately separates an icon-only button from a labeled one, so I did not touch it — flagging it in case you'd rather it collapse to the plain `gap-1`.

Not yet verified on a live surface.