### PR TITLE
fix(connections): show relationship status on ambiguous name matches

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_chat_service.py
@@ -36,6 +36,23 @@ _GAVE_UP_MESSAGE = "I couldn't finish that — please try rephrasing."
 
 ModelCall = Callable[[Any, Any], Awaitable[Any]]
 
+# Same wording ConnectionsService.search_directory's own `relationship()`
+# produces (connections_service.py) turned into the hint text a disambiguation
+# option shows. "none" -> no hint: an unrelated match needs no qualifier.
+# Two same-named candidates otherwise render identically even when one is
+# already mid-flight and the other is not (#5377, Jhumma: "if redundancy of
+# names found bring other cases as well, 1 requested other don't").
+_RELATIONSHIP_HINTS = {
+    "connected": "already connected",
+    "pending_outgoing": "already requested",
+    "pending_incoming": "requested you",
+}
+
+
+def _relationship_hint(relationship: str | None) -> str | None:
+    return _RELATIONSHIP_HINTS.get(str(relationship or "").strip())
+
+
 # Authoritative system prompt for this specialist. agents/connections/agent.yaml carries a declarative copy (not loaded in v1); keep them in sync.
 _SYSTEM_PROMPT = (
     "You are the user's Connections assistant inside hushh One. You manage the "
@@ -375,6 +392,7 @@ class ConnectionsChatService:
                     {
                         "userId": str(p.get("userId")),
                         "displayName": str(p.get("displayName") or "Someone"),
+                        "relationship": str(p.get("relationship") or "none"),
                     }
                     for p in people
                 ],
@@ -403,7 +421,7 @@ class ConnectionsChatService:
                         "addresseeUserId": c["userId"],
                         "label": c["displayName"],
                     },
-                    "hint": None,
+                    "hint": _relationship_hint(c.get("relationship", "")),
                 }
                 for c in (result.get("candidates") or [])
                 if c.get("userId")

--- a/consent-protocol/tests/services/test_connections_chat_service.py
+++ b/consent-protocol/tests/services/test_connections_chat_service.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock
 
 from google.genai import types
 
-from hushh_mcp.services.connections_chat_service import ConnectionsChatService
+from hushh_mcp.services.connections_chat_service import (
+    ConnectionsChatService,
+    _relationship_hint,
+)
 
 _TOKEN = "tok"  # noqa: S105
 
@@ -307,3 +310,40 @@ async def test_request_person_choice_multi_candidate_prompt():
     assert prompt["kind"] == "select"
     assert [o["ref"]["addresseeUserId"] for o in prompt["options"]] == ["u2", "u3"]
     assert all(o["ref"]["op"] == "send_request" for o in prompt["options"])
+    # Neither candidate has an existing relationship -- no qualifier needed.
+    assert [o["hint"] for o in prompt["options"]] == [None, None]
+
+
+async def test_request_person_choice_names_which_candidate_is_already_pending():
+    """Regression guard for #5377 (Jhumma: "if redundancy of names found
+    bring other cases as well, 1 requested other don't"). Two same-named
+    candidates must not render identically when one already has a pending
+    outgoing request and the other doesn't."""
+    fake = MagicMock()
+    fake.search_directory.return_value = {
+        "items": [
+            {"userId": "u2", "displayName": "Priya Rao", "relationship": "pending_outgoing"},
+            {"userId": "u3", "displayName": "Priya Shah", "relationship": "none"},
+        ],
+        "hasMore": False,
+    }
+    svc = _loop_service(
+        service=fake,
+        store=_FakeStore(),
+        responses=[
+            _fc_response("request_person_choice", {"name": "Priya"}),
+            _text_response("Which Priya?"),
+        ],
+    )
+    out = await svc.handle_turn(user_id="u1", message="connect me with Priya", consent_token=_TOKEN)
+    prompt = out["clientPrompt"]
+    assert [o["hint"] for o in prompt["options"]] == ["already requested", None]
+
+
+def test_relationship_hint_covers_every_state_search_directory_emits():
+    assert _relationship_hint("connected") == "already connected"
+    assert _relationship_hint("pending_outgoing") == "already requested"
+    assert _relationship_hint("pending_incoming") == "requested you"
+    assert _relationship_hint("none") is None
+    assert _relationship_hint("") is None
+    assert _relationship_hint(None) is None


### PR DESCRIPTION
## Summary
Addresses #5377 (Jhumma's follow-up comment, point 4): "if redundancy of names found bring other cases as well, 1 requested other don't; this can be managed smoothly." Not auto-closing on merge — voice item stays open until fully verified.

Disambiguation already worked before this PR: when a spoken name matches multiple directory candidates, `request_person_choice` already returns `status: "ambiguous"` and the frontend already renders a real pick-list asking the user to choose (this isn't a regression, it's existing, tested behavior).

The actual gap was narrower than the comment first reads: `search_directory` already computes each candidate's relationship (`connected` / `pending_outgoing` / `pending_incoming` / `none`), but `request_person_choice` discarded it when building the candidate list, and `_prompt_from_tool` hardcoded every option's `hint` to `None`. Two same-named people rendered identically in the pick-list even when one already had a pending request and the other didn't — exactly the "1 requested other don't" case.

## Changes
- `connections_chat_service.py`: `request_person_choice`'s candidate projection now preserves `relationship`; new `_relationship_hint()` maps it to hint text (`"already requested"`, `"already connected"`, `"requested you"`, or `None` for `"none"`), used in `_prompt_from_tool`'s option builder instead of the hardcoded `None`.
- This mirrors an existing convention already in the codebase: the Location specialist's own disambiguation tool (`hushh_mcp/agents/location/tools.py::request_recipient_choice`) already attaches a per-candidate hint for the identical select/ref/clientPrompt mechanics — this fix adopts that pattern for Connections rather than inventing a new one.

## Test plan
- [x] `pytest tests/services/test_connections_chat_service.py` — 18 passed, including a new test asserting mixed relationship states produce different hints per candidate, and a direct unit test on `_relationship_hint` covering every state `search_directory` can emit.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` clean on changed lines (1 pre-existing unrelated error elsewhere in the file, outside this diff's line ranges).