### PR TITLE
perf(consent): fetch investor location/marketplace buckets once per summary, not per surface

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -1289,7 +1289,18 @@ class ConsentCenterService:
         actor: str,
         surface: str,
         mode: str = "consents",
+        location_buckets: dict[str, list[dict[str, Any]]] | None = None,
+        marketplace_buckets: dict[str, list[dict[str, Any]]] | None = None,
     ) -> int:
+        """
+        ``location_buckets``/``marketplace_buckets`` let a caller that already
+        fetched them for the investor+consents case (get_center_summary calls
+        this once per surface) pass them straight through instead of each
+        call independently re-fetching the same ~24-query bucket 3x over
+        (#5387 -- this alone accounted for most of the query volume behind
+        "app feels slow"). ``None`` (the default) preserves the original
+        fetch-it-yourself behaviour for any other caller.
+        """
         normalized_actor = "ria" if actor == "ria" else "investor"
         normalized_mode = "connections" if mode == "connections" else "consents"
         if normalized_mode == "connections":
@@ -1308,11 +1319,12 @@ class ConsentCenterService:
                 ]
             )
         if normalized_actor == "investor":
-            location_buckets = (
-                await self._location_buckets_async(user_id)
-                if normalized_mode == "consents"
-                else None
-            )
+            if location_buckets is None:
+                location_buckets = (
+                    await self._location_buckets_async(user_id)
+                    if normalized_mode == "consents"
+                    else None
+                )
             location_count = 0
             if location_buckets:
                 if surface == "pending":
@@ -1321,11 +1333,12 @@ class ConsentCenterService:
                     location_count = len(location_buckets["active_grants"])
                 else:
                     location_count = len(location_buckets["history"])
-            marketplace_buckets = (
-                await self._marketplace_buckets_async(user_id)
-                if normalized_mode == "consents"
-                else None
-            )
+            if marketplace_buckets is None:
+                marketplace_buckets = (
+                    await self._marketplace_buckets_async(user_id)
+                    if normalized_mode == "consents"
+                    else None
+                )
             if marketplace_buckets:
                 if surface == "pending":
                     location_count += len(marketplace_buckets["incoming_requests"])
@@ -1621,6 +1634,21 @@ class ConsentCenterService:
         normalized_actor = "ria" if actor == "ria" else "investor"
         normalized_mode = "connections" if mode == "connections" else "consents"
         if not _consent_summary_v2_enabled():
+            # Pre-fetch once, outside the per-surface gather below, rather than
+            # letting each of the 3 concurrent _get_surface_count calls
+            # independently re-fetch the same investor location/marketplace
+            # buckets -- the actual cause of the ~77-query "slow to load"
+            # symptom (#5387), not per-item N+1 loops. Both are already
+            # unconditionally sliced into all three surfaces by the callee, so
+            # fetching once and reading three ways changes no filtering logic.
+            if normalized_actor == "investor" and normalized_mode == "consents":
+                location_buckets, marketplace_buckets = await asyncio.gather(
+                    self._location_buckets_async(user_id),
+                    self._marketplace_buckets_async(user_id),
+                )
+            else:
+                location_buckets = None
+                marketplace_buckets = None
             pending_count, active_count, previous_count = await asyncio.gather(
                 *(
                     self._get_surface_count(
@@ -1628,6 +1656,8 @@ class ConsentCenterService:
                         actor=normalized_actor,
                         surface=surface,
                         mode=normalized_mode,
+                        location_buckets=location_buckets,
+                        marketplace_buckets=marketplace_buckets,
                     )
                     for surface in ("pending", "active", "previous")
                 )

--- a/consent-protocol/tests/services/test_consent_center_summary_query_dedup.py
+++ b/consent-protocol/tests/services/test_consent_center_summary_query_dedup.py
@@ -1,0 +1,63 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from hushh_mcp.services.consent_center_service import ConsentCenterService
+
+_EMPTY_BUCKETS = {"incoming_requests": [], "active_grants": [], "history": []}
+
+
+def test_investor_consents_summary_fetches_buckets_once_not_per_surface():
+    """Regression guard for #5387.
+
+    get_center_summary's default (V1) path used to call _get_surface_count
+    once per surface (pending/active/previous) via asyncio.gather, and each
+    of those 3 concurrent calls independently re-fetched the same investor
+    location/marketplace buckets -- ~3x the real query cost for one summary
+    request, the actual cause behind the "app feels slow to load" report,
+    not per-item N+1 loops. Both buckets must now be fetched exactly once
+    per get_center_summary call, regardless of how many surfaces read them.
+    """
+    svc = ConsentCenterService.__new__(ConsentCenterService)
+
+    location_buckets = AsyncMock(return_value=dict(_EMPTY_BUCKETS))
+    marketplace_buckets = AsyncMock(return_value=dict(_EMPTY_BUCKETS))
+    svc._location_buckets_async = location_buckets
+    svc._marketplace_buckets_async = marketplace_buckets
+    svc._load_investor_pending_entries = AsyncMock(return_value=[])
+    svc._load_investor_active_entries = AsyncMock(return_value=[])
+    svc._load_investor_previous_entries = AsyncMock(return_value=[])
+    svc._incoming_connection_request_count = AsyncMock(return_value=0)
+
+    with patch(
+        "hushh_mcp.services.consent_center_service._consent_summary_v2_enabled",
+        return_value=False,
+    ):
+        result = asyncio.run(svc.get_center_summary("user-a", actor="investor", mode="consents"))
+
+    assert result["counts"] == {"pending": 0, "active": 0, "previous": 0}
+    location_buckets.assert_called_once_with("user-a")
+    marketplace_buckets.assert_called_once_with("user-a")
+
+
+def test_ria_actor_summary_never_touches_investor_only_buckets():
+    """The dedup pre-fetch is gated to investor+consents specifically -- an
+    RIA actor must not trigger location/marketplace bucket queries at all,
+    pre-fetched or otherwise."""
+    svc = ConsentCenterService.__new__(ConsentCenterService)
+
+    location_buckets = AsyncMock(return_value=dict(_EMPTY_BUCKETS))
+    marketplace_buckets = AsyncMock(return_value=dict(_EMPTY_BUCKETS))
+    svc._location_buckets_async = location_buckets
+    svc._marketplace_buckets_async = marketplace_buckets
+    svc._load_ria_active_entries = AsyncMock(return_value={"items": []})
+    svc._load_ria_outgoing_entries = AsyncMock(return_value=[])
+    svc._load_ria_invite_entries = AsyncMock(return_value=[])
+
+    with patch(
+        "hushh_mcp.services.consent_center_service._consent_summary_v2_enabled",
+        return_value=False,
+    ):
+        asyncio.run(svc.get_center_summary("ria-a", actor="ria", mode="consents"))
+
+    location_buckets.assert_not_called()
+    marketplace_buckets.assert_not_called()


### PR DESCRIPTION
## Summary
Addresses #5387 ("App feels slow to load/refresh — suspected caching or DB-load issue"). Not auto-closing on merge — issue stays open until this is verified on UAT.

Root-caused the "~77 queries per call" figure to `consent_center_service.py`'s default (V1, `CONSENT_CENTER_SUMMARY_V2_ENABLED` unset) `get_center_summary` path. `pending`/`active`/`previous` counts are computed via `asyncio.gather` over 3 concurrent `_get_surface_count` calls, and for `investor` + `consents` (the common case), **each of those 3 independently re-fetched the exact same `_location_buckets_async`/`_marketplace_buckets_async` result** (~24 queries each). This is a straight 3x re-fetch of identical data, not per-item N+1 loops — and it alone reconstructs the reported query count almost exactly.

## Why this fix is safe
Both bucket-fetch functions take only `user_id` and are read three different ways by the caller (`incoming_requests` / `active_grants` / `history`) — there's no per-surface filtering happening *inside* them. Hoisting one fetch of each above the `gather` and passing the already-computed dict through requires no re-implementation of authorization/filtering logic; it's the same object read three ways instead of fetched three times.

## Changes
- `_get_surface_count` accepts optional `location_buckets`/`marketplace_buckets` kwargs (default `None` preserves the original fetch-it-yourself behavior for any other caller — there's no other caller today, but the signature stays backward compatible).
- `get_center_summary`'s V1 branch, gated to `actor == "investor" and mode == "consents"` specifically (the only case that ever touched these buckets), pre-fetches both once via `asyncio.gather` and threads them through all three surface calls.
- The already-optimized V2 path (behind the still-off `CONSENT_CENTER_SUMMARY_V2_ENABLED` flag) already did this correctly on its own — left untouched.

## Not addressed here (flagged, not blocking)
`_owned_user_identifiers` memoizes per `ConsentCenterService` instance with no lock, so concurrent `gather` branches can still race past the cache before the first write lands — a smaller, separate query-count source. Lower impact than the fix above, and needs its own care (a lock or memoized coroutine) rather than a drive-by change bundled into this PR.

## Test plan
- [x] New `test_consent_center_summary_query_dedup.py`: asserts `_location_buckets_async`/`_marketplace_buckets_async` are each called exactly once (not 3x) for an investor+consents summary, and asserts an RIA-actor summary never touches either bucket function at all (confirms the gate is correctly scoped).
- [x] `pytest tests/services/test_consent_center_summary_query_dedup.py tests/services/test_consent_center_connection_requests.py tests/test_consent_center_query_bounds.py tests/test_consent_center_page_cap.py tests/test_consent_center_pure_helpers.py` — 101 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` clean on changed lines (5 pre-existing unrelated errors elsewhere in the file, outside this diff's line ranges).