### PR TITLE
fix(deploy): enable the already-built consent-summary V2 fast path on UAT

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -280,7 +280,7 @@ jobs:
             --plaid-redirect-path "/kai/plaid/oauth/return" \
             --plaid-tx-history-days "730" \
             --one-location-read-only-state-enabled "${{ vars.ONE_LOCATION_READ_ONLY_STATE_ENABLED || 'false' }}" \
-            --consent-center-summary-v2-enabled "${{ vars.CONSENT_CENTER_SUMMARY_V2_ENABLED || 'false' }}" \
+            --consent-center-summary-v2-enabled "${{ vars.CONSENT_CENTER_SUMMARY_V2_ENABLED || 'true' }}" \
             --db-bulk-batching-enabled "${{ vars.DB_BULK_BATCHING_ENABLED || 'false' }}" \
             --hushh-trusted-device-enabled "${{ vars.HUSSH_TRUSTED_DEVICE_ENABLED || 'false' }}" \
             --one-location-nearby-presence-mode "${{ vars.ONE_LOCATION_NEARBY_PRESENCE_MODE_UAT || '' }}" \


### PR DESCRIPTION
## Summary
Addresses #5387 ("App feels slow to load/refresh"). Not auto-closing on merge — issue stays open until this is verified live on UAT.

`consent_center_service.py`'s `_consent_summary_v2_enabled()` defaults **ON** when the env var is unset — its own comment describes fetching investor location/marketplace data once per summary instead of the legacy path's 3x redundant re-fetch, which the comment identifies as "most of why this endpoint was measured at ~77 queries and 37-47s+." That fix already exists in the codebase and is already tested.

`deploy-uat.yml` was the one place explicitly overriding it to `'false'` by default — that's the actual reason the slow legacy path is what runs in UAT today, not a missing fix. No equivalent override exists in any production deploy workflow, so production likely already gets the code's own good default; this brings UAT in line with that rather than introducing new behavior.

## Context: why this exists instead of a code change
An earlier attempt (#5466, closed) tried to re-optimize the legacy path directly instead of enabling the existing V2 path. That approach fought `test_consent_center_summary_explicit_opt_out_uses_legacy_surface_counts`, whose entire purpose is keeping the legacy path byte-for-byte untouched as a deliberate rollback lever for exactly this flag. This PR is the correct, much smaller fix: turn on what's already built and tested, rather than duplicating it.

## Changes
- `.github/workflows/deploy-uat.yml`: `--consent-center-summary-v2-enabled` default `'false'` → `'true'`. One line.

## Test plan
- [x] `pytest tests/test_ria_iam_service_architecture.py -k consent_center_summary` — 4 passed, confirming both the V2 path and the explicit-opt-out rollback path behave correctly and are untouched by this change (it's a deploy-config value, not a code change).
- [x] YAML validated with `yaml.safe_load`.
- [ ] Post-deploy: confirm `/api/consent/center/summary` query count/latency actually drops on UAT once this ships — will follow up on #5387 with real numbers rather than assuming this closes the loop on config alone.