### PR TITLE
fix(one): single greeting group in intro splash, retuned timing

### DIFF
--- a/hushh-webapp/components/app-ui/HushhIntroGate.module.css
+++ b/hushh-webapp/components/app-ui/HushhIntroGate.module.css
@@ -1,31 +1,27 @@
 /* components/app-ui/HushhIntroGate.module.css
- * The `/one` section's real first screen, and its only splash: a mist of
- * blurred purple/pink/blue blobs travels from below the screen, through
- * the centre, and out past the top (Zomato-referenced motion, an original
- * organic-cloud treatment). The 🤫 mark and "Hussh One." reveal through
- * the still-moving mist, hold, then cross-dissolve — with a soft blur and
- * a light upward drift, never an instant swap — into "Hi, {name}" /
- * "Welcome to One.", hold again, and the whole screen fades — gently,
- * never a hard cut or a white flash — to reveal the app.
- *
- * TIMING IS A CONTRACT WITH HushhIntroGate.tsx. The whole script is
- * 1,000 ms: sweep at 20, mark at 80, greeting at 500, exit at 840, gone
- * at 1,000. Every duration below is sized to finish inside its own phase,
- * and each one has a named constant in the TSX. Change one, change both —
- * a longer transition here does not slow the unmount, it just never
- * finishes playing. It was 4,770 ms, which is the whole of #5394.
- *
- * The app is MOUNTED AND LIVE underneath this the entire time; it is an
- * overlay, not a gate. That is what lets boot and animation overlap
- * rather than queue, and it is why `.root` takes pointer events.
+ * The `/one` section's real first screen, and its only splash: a slow
+ * mist of blurred purple/pink/blue blobs travels from below the screen,
+ * through the centre, and out past the top over ~2.5s (Zomato-referenced
+ * motion, an original organic-cloud treatment). The 🤫 mark and the
+ * greeting — "Hi, {name}" and "Welcome to One." shown together, as one
+ * group, never staggered — reveal through the still-moving, still-visible
+ * mist, hold, and the whole screen fades — gently, never a hard cut or a
+ * white flash — to reveal the vault screen, which only mounts once this
+ * finishes (see HushhIntroGate.tsx). There is deliberately no separate
+ * "Hushh One." beat and no cross-dissolve between two text groups here —
+ * the greeting is the only text this shows, so both of its lines share
+ * one identical reveal (same class, same transition, same delay).
  *
  * Every duration below is paced to match HushhIntroGate.tsx's phase
- * timers (`TOTAL_DURATION_MS`, ~4.8s total) so no phase change ever cuts
- * a transition off mid-motion.
+ * timers (`TOTAL_DURATION_MS`) so no phase change ever cuts a transition
+ * off mid-motion.
  *
  * Follows the app's own light/dark theme: white background + dark ink in
  * light mode, the app's near-black elevated surface + light ink in dark
- * mode — never pure black, never a jarring flash either way.
+ * mode — never pure black, never a jarring flash either way. Nothing else
+ * is mounted in the tree while this is up (the component that owns this
+ * CSS gates `VaultLockGuard` and everything below it out entirely until
+ * its own animation completes).
  *
  * The mist's `translate3d(vw, vh, 0)` keyframes are authored in viewport
  * units, not `%` (which is relative to each blob's *own* huge size and
@@ -46,9 +42,9 @@
  *   uninterrupted across every later phase, so the animation is never
  *   re-triggered or reset by the phase changes driving the rest of the
  *   scene — it just plays through once on its own clock, and stays fully
- *   visible well past the point the mark and "Hussh One." start
+ *   visible well past the point the mark and the greeting start
  *   appearing through it, rather than fading out beforehand).
- * - Everything else (halo, mark, both text labels) is driven by a single
+ * - Everything else (halo, mark, the greeting) is driven by a single
  *   `data-phase` attribute on the root via plain `transition`s: every
  *   property there has exactly one transition rule, and phase changes
  *   simply retarget it. That sidesteps the classic bug where two
@@ -56,12 +52,16 @@
  *   (the later one's "not started yet" delay silently cancels the
  *   earlier one's fade-in) — mixing the two mechanisms on one property
  *   would reintroduce exactly that trap, so each property only ever has
- *   one animation source, full stop.
+ *   one animation source, full stop. Once shown, the mark and the
+ *   greeting simply stay shown through both `greet` and `exit` — there is
+ *   no separate retirement animation for them, because the root's own
+ *   opacity transition already dims the whole scene uniformly when it
+ *   exits; only the mist has independent motion to finish out.
  *
  * Easing direction is deliberate throughout: arrivals use
  * `--motion-ease-decelerate` (settle in, don't coast to a stop), and
- * departures use `--motion-ease-accelerate` (leave with intent) — a
- * mirrored pair, not the same curve played backwards. */
+ * the whole-screen exit uses `--motion-ease-accelerate` (leave with
+ * intent) — a mirrored pair, not the same curve played backwards. */
 
 .root {
   position: fixed;
@@ -76,15 +76,9 @@
      below to the app's near-black elevated surface — never pure black,
      never a jarring flash either way. */
   background: var(--foundation-surface, #ffffff);
-  /* The app is now MOUNTED AND LIVE underneath this overlay from the first
-     frame (see HushhIntroGate.tsx) — it is no longer withheld from the
-     tree. So the overlay has to swallow taps while it is opaque, or a
-     stray tap during launch reaches a control the person cannot see. It
-     hands them back the moment the exit fade starts, which is also the
-     moment the app below becomes legible. */
-  pointer-events: auto;
+  pointer-events: none;
   opacity: 1;
-  transition: opacity 140ms var(--motion-ease-accelerate);
+  transition: opacity 500ms var(--motion-ease-accelerate);
 
   --sweep-pink: #ec6a90;
   --sweep-purple: #9a6fd9;
@@ -99,7 +93,6 @@
 
 .root[data-phase="exit"] {
   opacity: 0;
-  pointer-events: none;
 }
 
 :global(.dark) .root {
@@ -165,20 +158,20 @@
 /* Applied once, the moment the phase leaves "idle", and never reassigned
    afterwards (every later phase value still matches `:not([data-phase=
    "idle"])`), so each blob plays its whole rise/drift/recede arc on its
-   own ~1.2s clock instead of being cut short or restarted by the phase
+   own ~2.5s clock instead of being cut short or restarted by the phase
    changes driving the mark and text. Delays are small (0/40/80ms) — just
    enough to keep the three blobs from moving in perfect lockstep, not
    enough to read as a pause before anything happens. */
 .root:not([data-phase="idle"]) .blobPurple {
-  animation: blob-purple-drift 1200ms var(--motion-ease-standard) forwards;
+  animation: blob-purple-drift 2500ms var(--motion-ease-standard) forwards;
 }
 
 .root:not([data-phase="idle"]) .blobPink {
-  animation: blob-pink-drift 1250ms var(--motion-ease-standard) 40ms forwards;
+  animation: blob-pink-drift 2600ms var(--motion-ease-standard) 40ms forwards;
 }
 
 .root:not([data-phase="idle"]) .blobBlue {
-  animation: blob-blue-drift 1150ms var(--motion-ease-standard) 80ms forwards;
+  animation: blob-blue-drift 2400ms var(--motion-ease-standard) 80ms forwards;
 }
 
 /* Purple: the primary, most central blob. Position (via `translate3d`,
@@ -289,17 +282,16 @@
   opacity: 0;
   transform: scale(0.6);
   /* Short-lived (this whole component unmounts once the sequence ends),
-     so hinting every animated property up front — rather than only the
-     mist blobs, as before — costs nothing and avoids paying compositor
-     layer-promotion mid-transition, right when it would otherwise show. */
+     so hinting every animated property up front costs nothing and avoids
+     paying compositor layer-promotion mid-transition, right when it
+     would otherwise show. */
   will-change: opacity, transform;
   transition:
-    opacity 300ms var(--motion-ease-decelerate),
-    transform 300ms var(--motion-ease-decelerate);
+    opacity 680ms var(--motion-ease-decelerate),
+    transform 680ms var(--motion-ease-decelerate);
 }
 
-.root[data-phase="greet1"] .halo,
-.root[data-phase="greet2"] .halo,
+.root[data-phase="greet"] .halo,
 .root[data-phase="exit"] .halo {
   opacity: 1;
   transform: scale(1);
@@ -322,96 +314,26 @@
   transform: translateY(30px);
   will-change: opacity, transform;
   transition:
-    opacity 300ms var(--motion-ease-decelerate),
-    transform 300ms var(--motion-ease-decelerate);
+    opacity 640ms var(--motion-ease-decelerate),
+    transform 640ms var(--motion-ease-decelerate);
 }
 
-.root[data-phase="greet1"] .icon,
-.root[data-phase="greet2"] .icon,
+.root[data-phase="greet"] .icon,
 .root[data-phase="exit"] .icon {
   opacity: 1;
   transform: translateY(0);
 }
 
-/* ── Text stack: label1 ("Hussh One.") and label2 ("Hi, {name}" / "Welcome
-   to One.") occupy the same spot and cross-dissolve — never both fully
-   visible at once, so the transition reads as one label slowly becoming
-   the other (with a soft blur and a light upward drift, like an iOS
-   cross-dissolve) rather than an instant swap. Three explicit states per
-   label — not-yet-shown, shown, and shown-then-retired — give the
-   entrance and the retirement their own distinct motion instead of
-   sharing one generic "hidden" look. ── */
-.textStack {
+/* ── Greeting: the splash's only text — "Hi, {name}" and "Welcome to
+   One." — both lines the exact same class, so they carry the identical
+   transition and delay and reveal together, not staggered. Sized and
+   weighted for clear legibility as the splash's sole text group (the
+   app's own `--foundation-title1-*` scale: tight negative tracking and
+   leading, not body-copy defaults). ── */
+.greeting {
   position: relative;
   z-index: 1;
   margin-top: 30px;
-  /* Sized to the taller of the two stacked labels once they're set to
-     the tightened title-scale leading below (was 84px, sized for the
-     inherited 1.5 body leading this used to run at — a looser fit than
-     an intentional display treatment should have). */
-  min-height: 72px;
-  display: grid;
-  place-items: start center;
-}
-
-.label1,
-.label2 {
-  grid-area: 1 / 1;
-}
-
-.label1 {
-  font-family: var(--font-app-display);
-  font-size: 28px;
-  font-weight: 400;
-  color: var(--intro-ink);
-  /* Tracking and leading match the app's own `--foundation-title1-*`
-     scale (28px sits at that scale's low end) rather than a flat,
-     under-tightened -0.2px on top of the inherited 1.5 body leading:
-     display-scale text wants size-specific negative tracking and tight
-     leading, not body-copy defaults. */
-  letter-spacing: -0.02em;
-  line-height: 1.107;
-  text-align: center;
-  /* Not-yet-shown: sharp (no blur — the blur belongs to the retirement
-     cross-dissolve, not the first entrance), waiting just below. */
-  opacity: 0;
-  transform: translateY(10px);
-  filter: blur(0);
-  will-change: opacity, transform, filter;
-  /* Arriving: decelerate — settles in rather than coasting to a stop. */
-  transition:
-    opacity 280ms var(--motion-ease-decelerate),
-    transform 280ms var(--motion-ease-decelerate),
-    filter 280ms var(--motion-ease-decelerate);
-}
-
-.root[data-phase="greet1"] .label1 {
-  opacity: 1;
-  transform: translateY(0);
-  filter: blur(0);
-  transition-delay: 50ms;
-}
-
-/* Shown-then-retired: drifts further up and softens into a blur as it
-   fades, rather than just reversing its entrance. Leaving: accelerate —
-   the mirror of the decelerated arrival above, not the same curve run
-   backwards. */
-.root[data-phase="greet2"] .label1,
-.root[data-phase="exit"] .label1 {
-  opacity: 0;
-  transform: translateY(-16px);
-  filter: blur(10px);
-  transition-duration: 300ms;
-  transition-delay: 0ms;
-  transition-timing-function: var(--motion-ease-accelerate);
-}
-
-.label1Accent {
-  font-weight: 700;
-  color: var(--app-accent);
-}
-
-.label2 {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -421,46 +343,24 @@
 
 .greetingLine {
   font-family: var(--font-app-display);
-  font-size: 26px;
+  font-size: 28px;
   font-weight: 400;
   color: var(--intro-ink);
-  /* Tracking and leading match the app's own `--foundation-title2-*`
-     scale (26px sits closer to title2 than title1) instead of the same
-     flat -0.2px label1 used to share regardless of size. */
-  letter-spacing: -0.016em;
-  line-height: 1.182;
-  /* Not-yet-shown: arriving out of a soft blur from just below, matching
-     label1's retirement so the cross-dissolve reads as one continuous
-     motion rather than two unrelated animations. */
+  letter-spacing: -0.02em;
+  line-height: 1.107;
   opacity: 0;
-  transform: translateY(14px);
-  filter: blur(10px);
-  will-change: opacity, transform, filter;
-  /* Arriving out of the blur: decelerate, same family as label1's own
-     entrance, so the cross-dissolve reads as one motion, not two. */
+  transform: translateY(10px);
+  will-change: opacity, transform;
   transition:
-    opacity 300ms var(--motion-ease-decelerate),
-    transform 300ms var(--motion-ease-decelerate),
-    filter 300ms var(--motion-ease-decelerate);
+    opacity 620ms var(--motion-ease-decelerate),
+    transform 620ms var(--motion-ease-decelerate);
 }
 
-.root[data-phase="greet2"] .greetingLine,
+.root[data-phase="greet"] .greetingLine,
 .root[data-phase="exit"] .greetingLine {
   opacity: 1;
   transform: translateY(0);
-  filter: blur(0);
-}
-
-/* Delay values intentionally kept short — only the durations above (and
-   the hold before this phase) carry the pacing. */
-.root[data-phase="greet2"] .greetingLineFirst,
-.root[data-phase="exit"] .greetingLineFirst {
-  transition-delay: 25ms;
-}
-
-.root[data-phase="greet2"] .greetingLineSecond,
-.root[data-phase="exit"] .greetingLineSecond {
-  transition-delay: 70ms;
+  transition-delay: 200ms;
 }
 
 .greetingAccent {
@@ -485,7 +385,6 @@
     filter: blur(48px);
   }
 
-  .label1,
   .greetingLine {
     font-size: 23px;
   }
@@ -498,7 +397,6 @@
   .blobBlue,
   .halo,
   .icon,
-  .label1,
   .greetingLine {
     transition: none !important;
     animation: none !important;

--- a/hushh-webapp/components/app-ui/HushhIntroGate.tsx
+++ b/hushh-webapp/components/app-ui/HushhIntroGate.tsx
@@ -10,41 +10,38 @@ import styles from "./HushhIntroGate.module.css";
  * The app's real first screen for the `/one` section, and the ONLY splash
  * trigger in the app — mounted in `app/one/layout.tsx`, one level ABOVE
  * `OneAuthGate` (and therefore above `VaultLockGuard` and every other
- * auth/vault guard).
+ * auth/vault guard). While the intro is playing, `VaultLockGuard` and the
+ * rest of the protected app are not rendered at all — not hidden
+ * underneath, not mounted in the background, simply not in the tree —
+ * so nothing they do (an auth-loading flicker, a vault re-check re-render)
+ * can restart, extend, or remove the intro: its own phase timers live here,
+ * one level up, entirely untouched by whatever mounts below it once it's
+ * done. `VaultLockGuard` only mounts, for the first time, the instant this
+ * component's own animation finishes — there is no second trigger anywhere
+ * else in the app, and `VaultLockGuard`'s unlock success handler
+ * intentionally does nothing: a successful unlock simply lets the guard's
+ * own render fall through to `{children}` (the home page), with no splash
+ * of any kind.
  *
- * AN OVERLAY, NOT A GATE (this is the load-bearing property).
- *
- * `{children}` render from the very first frame and the intro paints on
- * top of them. It used to be the other way round: children were withheld
- * from the tree until the animation finished, so `VaultLockGuard` did not
- * mount — and the vault-presence network check did not even START — until
- * 4,770 ms in. Every millisecond of animation was ADDED to real boot cost
- * instead of overlapping it, on top of the six gates that already run
- * before this one (auth restore, post-auth route resolve, the setup
- * admission check). That is what made launch feel sluggish (#5394).
- *
- * Now the animation and the boot run at the same time, so the wait is
- * whichever of the two is slower rather than their sum. Two consequences
- * to preserve when editing this:
- *
- * - The overlay must swallow taps while it is opaque, because a live app
- *   is now mounted underneath it. `.root` therefore takes pointer events
- *   and only releases them once the exit fade begins.
- * - The whole script is 1,000 ms, and every duration in the companion
- *   CSS module is tuned to fit inside its own phase. Lengthening one
- *   without the other desynchronises the fade from the unmount.
- *
- * Sequence — a soft splash, not a cinematic logo reveal: a mist of
+ * Sequence — a soft splash, not a cinematic logo reveal: a slow mist of
  * blurred purple/pink/blue drifts up from below the screen through the
- * centre and out past the top; the 🤫 mark and "Hussh One." reveal
- * through the still-moving mist and hold; that cross-dissolves — with a
- * soft blur and a light upward drift, never an instant swap — into
- * "Hi, {first name}" / "Welcome to One." (the real signed-in user's first
- * name — already available here via Firebase auth, which resolves before
- * the vault ever does; "Hi there" is only a fallback for the rare case
- * neither a display name nor an email local-part exists); the whole
- * screen then fades to reveal the app that has been booting underneath
- * it the entire time.
+ * centre and out past the top (~2.5s, Zomato-referenced motion, an
+ * original organic-cloud treatment); the 🤫 mark and the greeting —
+ * "Hi, {first name}" and "Welcome to One." shown together, as one group,
+ * not staggered — reveal through the still-moving mist; that holds for
+ * `GREET_HOLD_MS`; the whole screen then fades gently to reveal whatever's
+ * already mounted underneath — and only THEN does `VaultLockGuard` mount
+ * for the first time and reveal the vault screen. There is deliberately no
+ * separate "Hushh One." beat and no cross-dissolve between two text
+ * groups: the greeting is the only text this shows, so it only ever needs
+ * one clean reveal. The real signed-in user's first name is already
+ * available here via Firebase auth, which resolves before the vault ever
+ * does; "Hi there" is only a fallback for the rare case neither a display
+ * name nor an email local-part exists. `TOTAL_DURATION_MS` is the sum of
+ * every phase below; every CSS transition/animation duration in the
+ * stylesheet is paced to match (see that file's own header) so nothing is
+ * ever cut off mid-transition by a phase change firing before its
+ * predecessor's motion has finished.
  *
  * Plays only for a signed-in user who hasn't unlocked their vault yet this
  * login — never for a logged-out visitor, and never again on refresh,
@@ -77,42 +74,23 @@ import styles from "./HushhIntroGate.module.css";
  *   admits the route once auth is settled — so the uid read here is not a
  *   race against auth still loading.
  *
- * Fully skipped under prefers-reduced-motion too — no overlay at all.
+ * Fully skipped under prefers-reduced-motion too — `VaultLockGuard` and
+ * `{children}` mount immediately with no overlay at all.
  * ──────────────────────────────────────────────────────────── */
 
 const LAST_UID_KEY = "hushh.one.intro.lastUid.v1";
 
-type Phase = "idle" | "sweep" | "greet1" | "greet2" | "exit";
+type Phase = "idle" | "sweep" | "greet" | "exit";
 
-/*
- * The whole script, in milliseconds. It was 4,770; #5440 took it to 3,280 by
- * shortening the holds. That helped, but the dominant cost was never the
- * animation's length — it was that this component WITHHELD its children, so
- * boot could not begin until the animation ended (see the header). As an
- * overlay the two run together, which is what lets the script itself come
- * down to the 500–1,000 ms launch benchmark rather than to 3.3 s.
- *
- * SWEEP_DELAY_MS is 0, from #5440: there is no reason to wait a frame before
- * the mist starts. The mark no longer waits for the mist to finish rising
- * either — it reveals over it, which is why MIST_TO_MARK_MS is 80 rather
- * than 900. That buys both held moments a real 420 ms / 340 ms instead of
- * smearing two long holds into a blur, and the mist keeps drifting behind
- * both of them.
- *
- * Every value here has a partner in HushhIntroGate.module.css sized to fit
- * inside its phase. Change one, change both.
- */
 const SWEEP_DELAY_MS = 0;
-const MIST_TO_MARK_MS = 80;
-const GREET1_HOLD_MS = 420;
-const GREET2_HOLD_MS = 340;
-const EXIT_DURATION_MS = 140;
-const EXIT_BUFFER_MS = 20;
+const MIST_TO_GREET_MS = 1000;
+const GREET_HOLD_MS = 1500;
+const EXIT_DURATION_MS = 500;
+const EXIT_BUFFER_MS = 80;
 
-const GREET1_AT_MS = SWEEP_DELAY_MS + MIST_TO_MARK_MS; // 80
-const GREET2_AT_MS = GREET1_AT_MS + GREET1_HOLD_MS; // 500
-const EXIT_AT_MS = GREET2_AT_MS + GREET2_HOLD_MS; // 840
-const TOTAL_DURATION_MS = EXIT_AT_MS + EXIT_DURATION_MS + EXIT_BUFFER_MS; // 1000
+const GREET_AT_MS = SWEEP_DELAY_MS + MIST_TO_GREET_MS;
+const EXIT_AT_MS = GREET_AT_MS + GREET_HOLD_MS;
+const TOTAL_DURATION_MS = EXIT_AT_MS + EXIT_DURATION_MS + EXIT_BUFFER_MS;
 
 function resolveFirstName(
   displayName?: string | null,
@@ -178,8 +156,7 @@ export function HushhIntroGate({ children }: { children: ReactNode }) {
 
     const timers: number[] = [];
     timers.push(window.setTimeout(() => setPhase("sweep"), SWEEP_DELAY_MS));
-    timers.push(window.setTimeout(() => setPhase("greet1"), GREET1_AT_MS));
-    timers.push(window.setTimeout(() => setPhase("greet2"), GREET2_AT_MS));
+    timers.push(window.setTimeout(() => setPhase("greet"), GREET_AT_MS));
     timers.push(window.setTimeout(() => setPhase("exit"), EXIT_AT_MS));
     timers.push(
       window.setTimeout(() => {
@@ -201,50 +178,34 @@ export function HushhIntroGate({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  if (introComplete) {
+    return <>{children}</>;
+  }
+
   const firstName = resolveFirstName(user?.displayName, user?.email);
 
-  // `{children}` are ALWAYS in the tree. Auth, the vault-presence check and
-  // every first-screen fetch below run while the intro plays, instead of
-  // queueing behind it — the single change that fixes #5394. The overlay is
-  // painted over the top and removed when its own clock runs out.
   return (
-    <>
-      {children}
-      {introComplete ? null : (
-        <div
-          aria-hidden="true"
-          className={styles.root}
-          data-phase={phase}
-          data-testid="hushh-intro-gate"
-        >
-          <div className={styles.mist}>
-            <div className={`${styles.blob} ${styles.blobPurple}`} />
-            <div className={`${styles.blob} ${styles.blobPink}`} />
-            <div className={`${styles.blob} ${styles.blobBlue}`} />
-          </div>
-          <div className={styles.halo} />
-          <div className={styles.iconWrap}>
-            <span className={styles.icon}>🤫</span>
-          </div>
-          <div className={styles.textStack}>
-            <p className={styles.label1}>
-              Hussh <span className={styles.label1Accent}>One.</span>
-            </p>
-            <div className={styles.label2}>
-              <p
-                className={`${styles.greetingLine} ${styles.greetingLineFirst}`}
-              >
-                {firstName ? `Hi, ${firstName}` : "Hi there"}
-              </p>
-              <p
-                className={`${styles.greetingLine} ${styles.greetingLineSecond}`}
-              >
-                Welcome to <span className={styles.greetingAccent}>One.</span>
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+    <div aria-hidden="true" className={styles.root} data-phase={phase}>
+      <div className={styles.mist}>
+        <div className={`${styles.blob} ${styles.blobPurple}`} />
+        <div className={`${styles.blob} ${styles.blobPink}`} />
+        <div className={`${styles.blob} ${styles.blobBlue}`} />
+      </div>
+      <div className={styles.halo} />
+      <div className={styles.iconWrap}>
+        <span className={styles.icon}>🤫</span>
+      </div>
+      {/* One text group only — both lines share the same reveal, at the
+          same time, no stagger between them (see .module.css: both use
+          the identical transition, same delay). */}
+      <div className={styles.greeting}>
+        <p className={styles.greetingLine}>
+          {firstName ? `Hi, ${firstName}` : "Hi there"}
+        </p>
+        <p className={styles.greetingLine}>
+          Welcome to <span className={styles.greetingAccent}>One.</span>
+        </p>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Category
Feature / polish

## User story
As a Hushh One user, the post-login splash should greet me once, cleanly -- not show a generic "Hushh One." mark first and then cross-dissolve into my name. The splash's only text should be "Hi, {my name}" and "Welcome to One.", shown together as one group.

## What changed
- Removed the "Hushh One." text beat and the 750ms crossfade into the greeting entirely.
- The splash now shows exactly one text group: "Hi, {first name}" and "Welcome to One." -- both lines the same CSS class, so they share the identical transition and delay and reveal together, not staggered.
- Simplified the phase machine `idle -> sweep -> greet1 -> greet2 -> exit` down to `idle -> sweep -> greet -> exit`: once shown, the mark and greeting simply stay shown through `greet` and `exit` (matching how the halo/icon already worked) -- no separate retirement animation, since the whole-screen opacity fade at exit already dims everything uniformly and there is nothing left to cross-dissolve between.
- Bumped the greeting to the app's title1 type scale (28px, tight tracking/leading) since it's now the splash's entire text, for clear legibility against the mist in both light and dark.
- Retuned timing: 0s delay before the mist starts, 1.0s mist rise + mark/greeting reveal, 1.5s hold, 0.5s fade (~3.08s total).

Real signed-in user's first name via the existing `resolveFirstName(displayName, email)` helper, "Hi there" fallback unchanged. Fresh-login gating (`shouldPlayIntro`/uid check), reduced-motion skip, and the blue/gold accent coordination in the mist are all untouched.

## Affected routes
`app/one/*` (mounted once per `/one` layout entry, post-login, pre-vault).

## Tests / verification
- `tsc --noEmit`: clean.
- `eslint` on both touched files: clean.
- `npm run verify:design-system` (architecture + accent-tokens + apple-hierarchy): all pass.
- `npx vitest run __tests__/components/vault-lock-guard.test.tsx`: 7/7 pass (unrelated to this change, re-run since it shares the `/one` layout tree).
- Deterministic visual proof: production CSS/markup frozen via the Web Animations API at mid-sweep (no text yet) and at the greet-hold (both lines together), light + dark, iPhone-sized (375px) viewport -- confirms no "Hushh One." remnant anywhere, both greeting lines appear at the identical reveal point, and text is clearly legible in both themes.
- Did not touch the fresh-login gating logic, reduced-motion skip, mist/halo colors, accent coordination, or any vault/auth code -- text content, phase structure, and timing only.