### PR TITLE
fix(security): CSP/security headers, native-test-bridge lockdown, vault KDF hardening

### DIFF
--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -376,9 +376,7 @@ def test_accept_request_never_imports_or_calls_location_service():
     from hushh_mcp.services.connections_service import ConnectionsService
 
     lines = inspect.getsource(ConnectionsService.accept_request).splitlines()
-    code_only = "\n".join(
-        line for line in lines if not line.strip().startswith("#")
-    )
+    code_only = "\n".join(line for line in lines if not line.strip().startswith("#"))
     assert "one_location_agent_service" not in code_only.lower()
     assert "OneLocationAgentService" not in code_only
     assert "auto_start_share_for_new_peer" not in code_only

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2120,8 +2120,7 @@ class FourUserMemoryService(OneLocationAgentService):
             grant = self.grants.get(params["grant_id"])
             if (
                 grant
-                and params["owner_user_id"]
-                in {grant["owner_user_id"], grant["recipient_user_id"]}
+                and params["owner_user_id"] in {grant["owner_user_id"], grant["recipient_user_id"]}
                 and grant["status"] == "active"
             ):
                 grant["expires_at"] = params["new_expires_at"]
@@ -3008,9 +3007,7 @@ def test_shorten_grant_lets_either_party_bring_expiry_earlier() -> None:
     original_expires_at = service.grants[grant["id"]]["expires_at"]
 
     with pytest.raises(OneLocationAgentError) as unrelated:
-        service.shorten_grant(
-            caller_user_id="user_c", grant_id=grant["id"], duration_hours=1
-        )
+        service.shorten_grant(caller_user_id="user_c", grant_id=grant["id"], duration_hours=1)
     assert unrelated.value.code == "LOCATION_GRANT_NOT_FOUND"
 
     # The recipient gives back time early -- self-limiting, needs no
@@ -3060,9 +3057,7 @@ def test_shorten_grant_rejects_any_attempt_to_extend() -> None:
     original_expires_at = service.grants[grant["id"]]["expires_at"]
 
     with pytest.raises(OneLocationAgentError) as extend_attempt:
-        service.shorten_grant(
-            caller_user_id="user_b", grant_id=grant["id"], duration_hours=24
-        )
+        service.shorten_grant(caller_user_id="user_b", grant_id=grant["id"], duration_hours=24)
     assert extend_attempt.value.code == "LOCATION_GRANT_SHORTEN_ONLY"
     assert service.grants[grant["id"]]["expires_at"] == original_expires_at
 

--- a/hushh-webapp/__tests__/components/consent-center-page-location-actions.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-location-actions.test.tsx
@@ -205,6 +205,65 @@ function receivedLocationGrantList() {
   };
 }
 
+// Regression fixture: the same counterpart appears twice in the Active tab
+// at once — once because they can see the signed-in user (owner side) and
+// once because the signed-in user can see them (recipient side). This is
+// the exact UAT shape that read as two indistinguishable "JHUMMA KUMARI —
+// Live location sharing" rows before the direction-aware summary landed.
+function bothDirectionsLocationGrantList() {
+  return {
+    user_id: "user-1",
+    actor: "investor",
+    mode: "consents",
+    surface: "active",
+    query: "",
+    page: 1,
+    limit: 20,
+    total: 2,
+    has_more: false,
+    items: [
+      {
+        id: "one_location_grant:grant-owner",
+        kind: "active_grant",
+        status: "active",
+        action: "CONSENT_GRANTED",
+        scope: "cap.location.live.view",
+        scope_description: "Live location sharing",
+        counterpart_type: "investor",
+        counterpart_label: "Jhumma Kumari",
+        issued_at: "2026-08-15T03:15:24.000Z",
+        expires_at: "2026-08-16T03:15:24.000Z",
+        metadata: {
+          request_source: "one_location_share_grant",
+          section: "people",
+          grant_id: "grant-owner",
+          requester_label: "Jhumma Kumari",
+          share_kind: "share",
+        },
+      },
+      {
+        id: "one_location_grant:grant-recipient",
+        kind: "active_grant",
+        status: "active",
+        action: "CONSENT_GRANTED",
+        scope: "cap.location.live.view",
+        scope_description: "Live location sharing",
+        counterpart_type: "investor",
+        counterpart_label: "Jhumma Kumari",
+        issued_at: "2026-08-15T03:15:24.000Z",
+        expires_at: "2026-08-16T03:15:24.000Z",
+        metadata: {
+          request_source: "one_location_share_grant",
+          section: "shared",
+          grant_id: "grant-recipient",
+          requester_label: "Jhumma Kumari",
+          share_kind: "share",
+        },
+      },
+    ],
+  };
+}
+
 function pendingLocationRequestList() {
   return {
     user_id: "user-1",
@@ -464,6 +523,41 @@ describe("ConsentCenterPage One Location action routing", () => {
       expect(mocks.handleRevoke).toHaveBeenCalledWith("attr.shopping.receipts.*");
     });
     expect(mocks.handleLocationRevoke).not.toHaveBeenCalled();
+  });
+
+  it("tells apart two active grants with the same counterpart by direction", async () => {
+    // No requestId in the search string: render the plain Active list, not a
+    // preselected detail dialog.
+    mocks.search = "tab=active";
+    mocks.getSummary.mockResolvedValue(
+      summaryResponse({ pending: 0, active: 2, previous: 0 }),
+    );
+    mocks.listEntries.mockResolvedValue(bothDirectionsLocationGrantList());
+
+    render(<ConsentCenterPage />);
+
+    // Wait for the async list to actually resolve, not just the initial
+    // "Loading consent entries" placeholder row (which also carries the
+    // settings-row testid and would otherwise satisfy findAllByTestId).
+    await screen.findByText(
+      "You're sharing your location with Jhumma Kumari.",
+    );
+    const rows = screen.getAllByTestId("settings-row");
+    const locationRows = rows.filter((row) =>
+      row.textContent?.includes("Jhumma Kumari"),
+    );
+    expect(locationRows).toHaveLength(2);
+
+    const descriptions = locationRows.map((row) => row.textContent);
+    // Before the fix both rows read identically ("Live location sharing"),
+    // so a reviewer could not tell whose location was exposed to whom.
+    expect(descriptions[0]).not.toBe(descriptions[1]);
+    expect(descriptions.join(" ")).toContain(
+      "You're sharing your location with Jhumma Kumari",
+    );
+    expect(descriptions.join(" ")).toContain(
+      "Jhumma Kumari is sharing their location with you",
+    );
   });
 
   it("does not offer revoke for a received Location grant", async () => {

--- a/hushh-webapp/__tests__/lib/consent/location-consent.test.ts
+++ b/hushh-webapp/__tests__/lib/consent/location-consent.test.ts
@@ -51,6 +51,84 @@ describe("isLocationConsent", () => {
   });
 });
 
+describe("locationConsentSummary direction", () => {
+  // Regression guard: a share grant appears in the Consent Center Active tab
+  // from both sides at once (owner side: "people who can see me"; recipient
+  // side: "shared with me"), both carrying the same counterpart name and the
+  // same generic scope_description ("Live location sharing"). Without
+  // branching on metadata.section the two rows were indistinguishable, so a
+  // user reviewing consent could not tell whose location was exposed to
+  // whom. See OneLocationCenterContributor._active_grants (backend) for
+  // where "people" vs "shared" is set.
+  it("describes a plain share from the owner's side as sharing out", () => {
+    const summary = locationConsentSummary({
+      request_source: "one_location_share_grant",
+      section: "people",
+      share_kind: "share",
+      requester_label: "Jhumma",
+    });
+    expect(summary).toBe("You're sharing your location with Jhumma.");
+  });
+
+  it("describes the same plain share from the recipient's side as sharing in", () => {
+    const summary = locationConsentSummary({
+      request_source: "one_location_share_grant",
+      section: "shared",
+      share_kind: "share",
+      requester_label: "Jhumma",
+    });
+    expect(summary).toBe("Jhumma is sharing their location with you.");
+  });
+
+  it("keeps the two directions distinguishable for the same counterpart", () => {
+    const base = {
+      request_source: "one_location_share_grant",
+      share_kind: "share",
+      requester_label: "Jhumma",
+    };
+    const ownerSide = locationConsentSummary({ ...base, section: "people" });
+    const recipientSide = locationConsentSummary({
+      ...base,
+      section: "shared",
+    });
+    expect(ownerSide).not.toBe(recipientSide);
+  });
+
+  it("describes a Check-In from the owner's side as sharing out", () => {
+    const summary = locationConsentSummary({
+      request_source: "one_location_share_grant",
+      section: "people",
+      share_kind: "check_in",
+      requester_label: "Jhumma",
+      duration_label: "1 hour",
+    });
+    expect(summary).toBe(
+      "You checked in and shared your location with Jhumma for 1 hour.",
+    );
+  });
+
+  it("describes an SOS share from the owner's side as sharing out", () => {
+    const summary = locationConsentSummary({
+      request_source: "one_location_share_grant",
+      section: "people",
+      share_kind: "sos",
+      requester_label: "Jhumma",
+    });
+    expect(summary).toBe(
+      "You're sharing your live location with Jhumma.",
+    );
+  });
+
+  it("does not treat a pending access request as owner-side (no share_kind)", () => {
+    const summary = locationConsentSummary({
+      request_source: "one_location_access_request",
+      section: "approvals",
+      requester_label: "Jhumma",
+    });
+    expect(summary).toBe("Jhumma wants to see your location through Location.");
+  });
+});
+
 describe("parseLocationConsentEntry", () => {
   it("maps an access request entry to the request kind + id", () => {
     const ref = parseLocationConsentEntry({

--- a/hushh-webapp/__tests__/lib/native-test-automation-guard.test.ts
+++ b/hushh-webapp/__tests__/lib/native-test-automation-guard.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// The real native XCUITest/Espresso harness only ever injects
+// window.__HUSHH_NATIVE_TEST__ inside the Capacitor-wrapped native app (see
+// isTrustedNativeTestBridge in lib/testing/native-test.ts, CS-6 fix). Mock a
+// native platform here so the "genuine bridge" scenarios below still model
+// that context; window.__HUSHH_NATIVE_TEST__ alone is asserted insufficient.
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => "ios",
+  },
+}));
+
 import {
   hasIncompleteNativeUiFlowSession,
   isNativeTestVaultBootstrapManaged,

--- a/hushh-webapp/__tests__/lib/native-test-config.test.tsx
+++ b/hushh-webapp/__tests__/lib/native-test-config.test.tsx
@@ -1,5 +1,15 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The bridge is only trusted on a real native platform (CS-6 fix, see
+// isTrustedNativeTestBridge in lib/testing/native-test.ts); mock one here so
+// this test still models a genuine native-harness injection.
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => "ios",
+  },
+}));
 
 import { useNativeTestConfig } from "@/lib/testing/native-test";
 

--- a/hushh-webapp/__tests__/vault/passphrase-key-kdf-versioning.test.ts
+++ b/hushh-webapp/__tests__/vault/passphrase-key-kdf-versioning.test.ts
@@ -1,0 +1,98 @@
+import {
+  createVaultWithPassphrase,
+  unlockVaultWithPassphrase,
+  unlockVaultWithRecoveryKey,
+} from "@/lib/vault/passphrase-key";
+
+// CS-4 fix (security assessment, 2026-08-17): PBKDF2 rounds went from
+// 100,000 to 600,000. Existing vaults were encrypted at 100,000 rounds, so
+// unlock must keep deriving old rows at 100,000 while new vaults use
+// 600,000 — see decodeVersionedSalt in lib/vault/passphrase-key.ts.
+describe("passphrase-key PBKDF2 round versioning (CS-4)", () => {
+  const passphrase = "correct horse battery staple";
+
+  it("stretches new vaults at the current (600,000) round count and unlocks them correctly", async () => {
+    const vault = await createVaultWithPassphrase(passphrase);
+
+    // The persisted salt string must actually carry the new round count,
+    // not just derive at it silently — this is what makes it safe for the
+    // backend to store as an opaque field forever.
+    expect(vault.salt).toContain("600000");
+    expect(vault.recoverySalt).toContain("600000");
+
+    const unlocked = await unlockVaultWithPassphrase(
+      passphrase,
+      vault.encryptedVaultKey,
+      vault.salt,
+      vault.iv,
+    );
+    expect(unlocked).toBe(vault.vaultKeyHex);
+
+    const unlockedFromRecovery = await unlockVaultWithRecoveryKey(
+      vault.recoveryKey,
+      vault.recoveryEncryptedVaultKey,
+      vault.recoverySalt,
+      vault.recoveryIv,
+    );
+    expect(unlockedFromRecovery).toBe(vault.vaultKeyHex);
+  });
+
+  it("still unlocks a legacy vault whose salt has no version prefix, at the original 100,000 rounds", async () => {
+    // Simulates a row persisted before this fix: derive+encrypt exactly the
+    // way the old, unversioned code path did (plain base64 salt, no prefix).
+    const legacySalt = crypto.getRandomValues(new Uint8Array(16));
+    const legacyIv = crypto.getRandomValues(new Uint8Array(12));
+    const vaultKey = await crypto.subtle.generateKey(
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt", "decrypt"],
+    );
+    const vaultKeyRaw = await crypto.subtle.exportKey("raw", vaultKey);
+    const vaultKeyHex = Array.from(new Uint8Array(vaultKeyRaw))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    const legacyKeyMaterial = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(passphrase),
+      { name: "PBKDF2" },
+      false,
+      ["deriveKey"],
+    );
+    const legacyDerivedKey = await crypto.subtle.deriveKey(
+      { name: "PBKDF2", salt: legacySalt, iterations: 100_000, hash: "SHA-256" },
+      legacyKeyMaterial,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+    const encryptedBuffer = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: legacyIv },
+      legacyDerivedKey,
+      vaultKeyRaw,
+    );
+
+    const toB64 = (bytes: Uint8Array) => Buffer.from(bytes).toString("base64");
+    const legacySaltB64 = toB64(legacySalt);
+    expect(legacySaltB64.startsWith("hushh-kdf-v2:")).toBe(false);
+
+    const unlocked = await unlockVaultWithPassphrase(
+      passphrase,
+      toB64(new Uint8Array(encryptedBuffer)),
+      legacySaltB64,
+      toB64(legacyIv),
+    );
+    expect(unlocked).toBe(vaultKeyHex);
+  });
+
+  it("returns an empty string (not a throw) for a wrong passphrase against a new-format vault", async () => {
+    const vault = await createVaultWithPassphrase(passphrase);
+    const unlocked = await unlockVaultWithPassphrase(
+      "definitely the wrong passphrase",
+      vault.encryptedVaultKey,
+      vault.salt,
+      vault.iv,
+    );
+    expect(unlocked).toBe("");
+  });
+});

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -932,7 +932,10 @@ textarea {
   --app-label: #ffffff;
   --app-secondary-label: #98989d;
   --app-section-label: #98989d;
-  --app-tertiary-label: #636366;
+  /* Was #636366 (~3.3:1 on the near-black app background — fails WCAG AA's
+     4.5:1 for normal text). #86868b keeps it visibly dimmer than
+     --app-secondary-label while clearing AA (~5.5:1). */
+  --app-tertiary-label: #86868b;
   --app-quaternary-label: #48484a;
   --app-separator: rgba(84, 84, 88, 0.65);
   --app-opaque-separator: #38383a;

--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { buildOrganizationGraph } from "@/lib/seo/structured-data";
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
+import { headers } from "next/headers";
 import "./globals.css";
 import { RootLayoutClient } from "./layout-client";
 import {
@@ -84,11 +85,16 @@ export const viewport: Viewport = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // CS-3 fix: the CSP set in middleware.ts binds script execution to this
+  // per-request nonce. Every inline <script> below must carry it or the
+  // browser will refuse to run it.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning className="h-full">
       <head>
@@ -98,16 +104,18 @@ export default function RootLayout({
           href="https://fonts.gstatic.com"
           crossOrigin="anonymous"
         />
-        <JsonLd data={buildOrganizationGraph()} />
+        <JsonLd data={buildOrganizationGraph()} nonce={nonce} />
         {/* Accent no-FOUC: apply the persisted accent preference before first
             paint (default iOS Blue needs no attribute; gold sets data-accent).
             Body mirrors ACCENT_NO_FOUC_SCRIPT in lib/theme/accent.ts. */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `try{var a=localStorage.getItem("hushh.app.accent.v1");if(a==="gold"){document.documentElement.setAttribute("data-accent","gold");}}catch(e){}`,
           }}
         />
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `try{var c=window.Capacitor;if(c&&typeof c.getPlatform==="function"&&c.getPlatform()==="ios"){document.documentElement.classList.add("native-ios");}}catch(e){}`,
           }}
@@ -117,6 +125,7 @@ export default function RootLayout({
             <Script
               id="ga-base"
               strategy="afterInteractive"
+              nonce={nonce}
               dangerouslySetInnerHTML={{
                 __html: `window.dataLayer = window.dataLayer || []; window.gtag = window.gtag || function(){window.dataLayer.push(arguments);}; window.gtag('js', new Date()); window.gtag('config', '${analyticsMeasurementId}', { send_page_view: false });`,
               }}
@@ -124,6 +133,7 @@ export default function RootLayout({
             <Script
               id="ga-loader"
               strategy="afterInteractive"
+              nonce={nonce}
               src={`https://www.googletagmanager.com/gtag/js?id=${analyticsMeasurementId}`}
             />
           </>
@@ -132,6 +142,7 @@ export default function RootLayout({
           <Script
             id="gtm-base"
             strategy="afterInteractive"
+            nonce={nonce}
             dangerouslySetInnerHTML={{
               __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':Date.now(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode&&f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${gtmContainerId}');`,
             }}
@@ -142,7 +153,12 @@ export default function RootLayout({
         suppressHydrationWarning
         className="font-sans antialiased min-h-[100dvh] flex flex-col overflow-x-hidden"
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          nonce={nonce}
+        >
           <RootLayoutClient fontClasses="">
             <NetworkStatusBanner />
             {children}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -10555,7 +10555,7 @@ export function OneLocationAgentPageContent({
                             maxLength={REQUEST_MESSAGE_MAX_LENGTH}
                             className="rounded-[14px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]"
                           />
-                          <p className="px-1 text-right text-[11px] font-medium text-[#8e8e93] dark:text-white/45">
+                          <p className="px-1 text-right text-[11px] font-medium text-[#8e8e93] dark:text-white/70">
                             {requestMessage.length}/{REQUEST_MESSAGE_MAX_LENGTH}
                           </p>
                         </div>

--- a/hushh-webapp/app/page.tsx
+++ b/hushh-webapp/app/page.tsx
@@ -146,6 +146,13 @@ function HomeContent() {
 export default function Home() {
   return (
     <>
+      {/* NOTE: this JSON-LD script has no CSP nonce (see middleware.ts) because
+          this route is a Client Component and next/headers is server-only.
+          Under the new strict script-src it is silently blocked by the
+          browser — SEO structured data only, no functional or security
+          impact. If this needs to actually render again, split this file
+          into a thin async Server Component wrapper (reads the nonce) around
+          a client child, the same pattern used for app/layout.tsx. */}
       <JsonLd data={buildFaqGraph(HOME_FAQ)} />
       <NativeRouteMarker
         routeId="/"

--- a/hushh-webapp/app/profile/page.module.css
+++ b/hushh-webapp/app/profile/page.module.css
@@ -82,7 +82,7 @@
   color: rgba(0, 0, 0, 0.42);
 }
 :global(.dark) .cinematicSettings [data-slot="settings-row-description"] {
-  color: rgba(255, 255, 255, 0.45);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 /* Sign out (destructive) — red circle + red label. */

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -21,6 +21,7 @@ import React, {
 import { usePathname, useRouter } from "next/navigation";
 import { AudioLines, MessageCircle, Monitor, Moon, Sun, X } from "lucide-react";
 import { useTheme } from "next-themes";
+import { Capacitor } from "@capacitor/core";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { AgentVoiceWaveform } from "@/components/agent/agent-voice-waveform";
@@ -1449,6 +1450,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     }
     if (
       typeof window !== "undefined" &&
+      Capacitor.isNativePlatform() &&
       window.__HUSHH_NATIVE_TEST__?.enabled === true
     ) {
       return;

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -953,7 +953,7 @@ function AgentBubble({
         </div>
         <div
           className={cn(
-            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-500",
+            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-400",
             isUser && "justify-end text-right"
           )}
         >
@@ -963,7 +963,7 @@ function AgentBubble({
               <button
                 type="button"
                 onClick={handleCopy}
-                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 aria-label={copied ? "Response copied" : "Copy response"}
                 title={copied ? "Copied" : "Copy response"}
               >
@@ -980,7 +980,7 @@ function AgentBubble({
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   liked
                     ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Like response"
                 aria-pressed={liked}
@@ -999,7 +999,7 @@ function AgentBubble({
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   disliked
                     ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Dislike response"
                 aria-pressed={disliked}
@@ -1012,7 +1012,7 @@ function AgentBubble({
                   type="button"
                   onClick={onRetry}
                   disabled={retryDisabled}
-                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-400 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                   aria-label="Try again"
                   title="Try again"
                 >

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -484,7 +484,7 @@ export function AgentHistorySidebar({
           ) : null}
 
           {!collapsed && !loading && conversations.length === 0 ? (
-            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-400">
               No chats yet
             </div>
           ) : null}
@@ -493,7 +493,7 @@ export function AgentHistorySidebar({
           !loading &&
           conversations.length > 0 &&
           filteredConversations.length === 0 ? (
-            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-400">
               No chats match &ldquo;{searchQuery.trim()}&rdquo;
             </div>
           ) : null}

--- a/hushh-webapp/components/app-ui/native-test-bootstrap.tsx
+++ b/hushh-webapp/components/app-ui/native-test-bootstrap.tsx
@@ -20,6 +20,11 @@ function updateBootstrapStatus(
   if (typeof window === "undefined") {
     return;
   }
+  // SECURITY: this bridge is page-writable; only trust it on a real native
+  // platform. See isTrustedNativeTestBridge in lib/testing/native-test.ts.
+  if (!Capacitor.isNativePlatform()) {
+    return;
+  }
   const bridge = window.__HUSHH_NATIVE_TEST__;
   if (!bridge?.enabled) {
     return;
@@ -340,7 +345,11 @@ export function NativeTestBootstrap() {
           "Vault owner token issue",
           VaultService.getOrIssueVaultOwnerToken(vaultUser.uid)
         );
-        if (typeof window !== "undefined" && window.__HUSHH_NATIVE_TEST__?.enabled) {
+        if (
+          typeof window !== "undefined" &&
+          Capacitor.isNativePlatform() &&
+          window.__HUSHH_NATIVE_TEST__?.enabled
+        ) {
           window.__HUSHH_NATIVE_TEST__.replayVaultUnlock = () => {
             unlockVault(decryptedKey, token, expiresAt);
           };

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -714,9 +714,21 @@ function ConsentEntryRow({
   const scopeLabel = entry.scope
     ? entry.scope_description || humanizeConsentScope(entry.scope)
     : null;
-  const supportingCopy = isIdentifierHistory
-    ? entrySummary(entry)
-    : scopeLabel || entrySummary(entry);
+  // A One Location share grant can run in either direction between the same
+  // two people (you see them / they see you), and both land in this same
+  // Active list with the counterpart's name as the only other visible field.
+  // `scope_description` is identical either way ("Live location sharing"),
+  // so two opposite-direction rows for the same person render as
+  // indistinguishable duplicates. `entrySummary` resolves to the
+  // direction-aware `locationConsentSummary`, which does tell them apart —
+  // prefer it here the same way history rows already do.
+  const isAmbiguousLocationGrant =
+    entry.kind === "active_grant" &&
+    isLocationConsent(entry.metadata, entry.scope);
+  const supportingCopy =
+    isIdentifierHistory || isAmbiguousLocationGrant
+      ? entrySummary(entry)
+      : scopeLabel || entrySummary(entry);
 
   return (
     <SettingsRow
@@ -1096,8 +1108,14 @@ function ConsentEntryDetail({
       isConnectionDecision ? "Relationship" : "Access",
       isConnectionDecision
         ? entry.scope_description || "Trusted connection"
-        : entry.scope_description ||
-          (entry.scope ? humanizeConsentScope(entry.scope) : "Not provided"),
+        : // Same identical-scope_description problem as the list row above:
+          // an active One Location share grant reads the same ("Live
+          // location sharing") whichever direction it flows, so this detail
+          // panel needs the direction-aware summary to say who sees whom.
+          entry?.kind === "active_grant" && isLocationEntry
+          ? entrySummary(entry)
+          : entry.scope_description ||
+            (entry.scope ? humanizeConsentScope(entry.scope) : "Not provided"),
     ],
     [activityDateLabel, formatDate(entry.issued_at) || "Unavailable"],
     isPendingDecision && requestDeadline

--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -1277,7 +1277,7 @@ export function DecisionCard({ result }: { result: DecisionResult }) {
 
         {/* DISCLAIMER */}
         <div className="pt-4">
-          <p className="text-[10px] text-muted-foreground/50 text-center leading-relaxed max-w-xs mx-auto">
+          <p className="text-[10px] text-muted-foreground/70 text-center leading-relaxed max-w-xs mx-auto">
             Agent Kai is an educational tool and does not constitute investment advice. Always consult a qualified
             financial advisor.
           </p>

--- a/hushh-webapp/components/kai/views/trinity-cards.tsx
+++ b/hushh-webapp/components/kai/views/trinity-cards.tsx
@@ -32,7 +32,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {bullCase}
             </p>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Analyzing upside potential for your portfolio...
             </div>
           )}
@@ -53,7 +53,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {bearCase}
             </p>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Identifying risks to your specific holdings...
             </div>
           )}
@@ -74,7 +74,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
               {renaissanceVerdict}
             </div>
           ) : (
-            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/50 italic">
+            <div className="h-20 flex items-center justify-center text-xs text-muted-foreground/70 italic">
               Calculating FCF & Tier Status...
             </div>
           )}

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1138,13 +1138,13 @@ export function AuthStep({
                 </span>
               </div>
 
-              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/45">
+              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/70">
                 By continuing, you agree to the{" "}
                 <button
                   type="button"
                   onClick={() => void openLegalDoc("terms")}
                   data-voice-control-id="auth_terms"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+                  className="-mx-1 -my-3 px-1 py-3 font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
                 >
                   Terms of Service
                 </button>
@@ -1153,7 +1153,7 @@ export function AuthStep({
                   type="button"
                   onClick={() => void openLegalDoc("privacy")}
                   data-voice-control-id="auth_privacy"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+                  className="-mx-1 -my-3 px-1 py-3 font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
                 >
                   Privacy Policy
                 </button>

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
@@ -41,7 +41,7 @@ export function OnboardingStepLicense({
             onChange={(event) => onLicenseNumberChange(event.target.value)}
             placeholder="INA00123456 or 7413463"
             className={cn(
-              "min-w-0 flex-1 bg-transparent py-3 text-right text-[17px] font-medium tabular-nums text-foreground placeholder:text-muted-foreground/50 outline-none",
+              "min-w-0 flex-1 bg-transparent py-3 text-right text-[17px] font-medium tabular-nums text-foreground placeholder:text-muted-foreground/70 outline-none",
               verificationStatus === "not_found" &&
                 "text-amber-600 dark:text-amber-300",
               verificationStatus === "error" && "text-red-600 dark:text-red-300"

--- a/hushh-webapp/components/seo/json-ld.tsx
+++ b/hushh-webapp/components/seo/json-ld.tsx
@@ -5,10 +5,17 @@
  * with JSON.stringify (no user input is interpolated), so it is safe to inject
  * via dangerouslySetInnerHTML for crawler/answer-engine consumption (AEO).
  */
-export function JsonLd({ data }: { data: Record<string, unknown> }) {
+export function JsonLd({
+  data,
+  nonce,
+}: {
+  data: Record<string, unknown>;
+  nonce?: string;
+}) {
   return (
     <script
       type="application/ld+json"
+      nonce={nonce}
       dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
     />
   );

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -95,6 +95,16 @@ export function locationConsentShareKindLabel(metadata: MetadataLike): string {
  * is a share grant the summary is kind-aware so the Consent Manager can tell an
  * Save My Soul from a friendly Check-In (with its note) from a plain share,
  * instead of the same generic "wants to see your location" line for every row.
+ *
+ * Share grants are bidirectional between the same two people: the owner side
+ * ("people who can see me") and the recipient side ("shared with me") both
+ * land in this same Active-tab bucket, with the counterpart's name as the
+ * only other visible field. `metadata.section` (set by
+ * `OneLocationCenterContributor._active_grants`) is "people" for the owner
+ * side and "shared" for the recipient side — the one signal that tells the
+ * two apart. Without branching on it, "JHUMMA KUMARI — Live location
+ * sharing" reads identically whichever way the grant actually flows, so a
+ * user reviewing consent cannot tell whose location is exposed to whom.
  */
 export function locationConsentSummary(metadata: MetadataLike): string {
   const requesterLabel = readString(metadata, "requester_label");
@@ -107,6 +117,23 @@ export function locationConsentSummary(metadata: MetadataLike): string {
     return `${who} invited you to join ${circleName}. Membership connects the group, while location and SMS stay private until you choose to share.`;
   }
   const durationSuffix = durationLabel ? ` for ${durationLabel}` : "";
+  // Only share grants (not access requests, public links, or circle invites)
+  // carry a share_kind, and only they can run in either direction.
+  const isOwnerSideGrant =
+    Boolean(shareKind) && readString(metadata, "section") === "people";
+  if (isOwnerSideGrant) {
+    if (shareKind === "sos") {
+      return shareMessage
+        ? `You sent an SMS to ${who}: ${shareMessage}`
+        : `You're sharing your live location with ${who}${durationSuffix}.`;
+    }
+    if (shareKind === "check_in" || shareKind === "checkin") {
+      return shareMessage
+        ? `You checked in with ${who}: ${shareMessage}`
+        : `You checked in and shared your location with ${who}${durationSuffix}.`;
+    }
+    return `You're sharing your location with ${who}${durationSuffix}.`;
+  }
   if (shareKind === "sos") {
     return shareMessage
       ? `${who}: ${shareMessage}`

--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -459,6 +459,7 @@ async function initializeNativeFCM(
   try {
     if (
       typeof window !== "undefined" &&
+      Capacitor.isNativePlatform() &&
       window.__HUSHH_NATIVE_TEST__?.enabled === true
     ) {
       return {

--- a/hushh-webapp/lib/persona/persona-context.tsx
+++ b/hushh-webapp/lib/persona/persona-context.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
+import { Capacitor } from "@capacitor/core";
 
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { useAuth } from "@/hooks/use-auth";
@@ -356,6 +357,11 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // SECURITY: this bridge is page-writable. Without the native-platform
+    // check, an injected script could set `enabled: true` itself and get a
+    // callable `switchPersona` hook attached to the global below.
+    // See isTrustedNativeTestBridge in lib/testing/native-test.ts.
+    if (!Capacitor.isNativePlatform()) return;
     const bridge = window.__HUSHH_NATIVE_TEST__;
     if (!bridge?.enabled) return;
 

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -188,6 +188,9 @@ function updateNativePortfolioImportDebug(
   updates: Record<string, string | number | null | undefined>,
 ): void {
   if (typeof window === "undefined") return;
+  // SECURITY: page-writable global; only trust it on a real native platform.
+  // See isTrustedNativeTestBridge in lib/testing/native-test.ts.
+  if (!Capacitor.isNativePlatform()) return;
   const bridge = window.__HUSHH_NATIVE_TEST__;
   if (!bridge?.enabled) return;
   for (const [key, value] of Object.entries(updates)) {
@@ -3532,7 +3535,7 @@ export class ApiService {
                     return;
                   }
                   const nativeBridge =
-                    typeof window !== "undefined"
+                    typeof window !== "undefined" && Capacitor.isNativePlatform()
                       ? window.__HUSHH_NATIVE_TEST__
                       : undefined;
                   if (nativeBridge?.enabled) {
@@ -3568,7 +3571,7 @@ export class ApiService {
                   "Native import stream ended without terminal event",
                 );
                 const nativeBridge =
-                  typeof window !== "undefined"
+                  typeof window !== "undefined" && Capacitor.isNativePlatform()
                     ? window.__HUSHH_NATIVE_TEST__
                     : undefined;
                 if (nativeBridge?.enabled) {
@@ -3580,7 +3583,7 @@ export class ApiService {
               close();
             } catch (error) {
               const nativeBridge =
-                typeof window !== "undefined"
+                typeof window !== "undefined" && Capacitor.isNativePlatform()
                   ? window.__HUSHH_NATIVE_TEST__
                   : undefined;
               if (nativeBridge?.enabled) {

--- a/hushh-webapp/lib/services/phone-mandate-service.ts
+++ b/hushh-webapp/lib/services/phone-mandate-service.ts
@@ -1,3 +1,4 @@
+import { Capacitor } from "@capacitor/core";
 import { resolveAppEnvironment } from "@/lib/app-env";
 import {
   normalizeStaticExportPathname,
@@ -26,6 +27,13 @@ export function shouldBypassPhoneMandateForLocalhost(hostname?: string | null): 
 
 function shouldBypassPhoneMandateForNativeRouteAudit(): boolean {
   if (typeof window === "undefined") {
+    return false;
+  }
+  // SECURITY: `window.__HUSHH_NATIVE_TEST__` is page-writable. Without the
+  // native-platform check, any injected script on the web origin could set
+  // `{ enabled: true, expectedUserId }` itself and bypass the phone mandate.
+  // See isTrustedNativeTestBridge in lib/testing/native-test.ts.
+  if (!Capacitor.isNativePlatform()) {
     return false;
   }
 

--- a/hushh-webapp/lib/testing/native-test.ts
+++ b/hushh-webapp/lib/testing/native-test.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Capacitor } from "@capacitor/core";
 
 declare global {
   interface Window {
@@ -76,20 +77,34 @@ function sanitizeConfiguredValue(value: string | null | undefined) {
   return trimmed;
 }
 
-function readNativeTestBridgeEnabled(): boolean {
+// SECURITY: `window.__HUSHH_NATIVE_TEST__` is an ordinary page global. Any
+// script running in the page (injected content script, extension, XSS) can
+// set `window.__HUSHH_NATIVE_TEST__ = { enabled: true, ... }` itself — a
+// bare `enabled === true` check is therefore not proof the real native
+// XCUITest/Espresso harness injected it. The harness only ever runs inside
+// the Capacitor-wrapped native app, so we additionally require
+// `Capacitor.isNativePlatform()`, which a page script on the web origin
+// cannot forge. This is the single trust boundary for the bridge; every
+// consumer must go through it instead of reading the raw global.
+export function isTrustedNativeTestBridge(): boolean {
   if (typeof window === "undefined") {
     return false;
   }
-  // Require the injected bridge from -UITestMode launch args.
-  // Do not treat DOM dataset hints alone as a test session.
+  if (!Capacitor.isNativePlatform()) {
+    return false;
+  }
   return window.__HUSHH_NATIVE_TEST__?.enabled === true;
 }
 
+function readNativeTestBridgeEnabled(): boolean {
+  // Require the injected bridge from -UITestMode launch args, running on a
+  // real native platform. Do not treat DOM dataset hints alone as a test
+  // session.
+  return isTrustedNativeTestBridge();
+}
+
 export function getNativeUiTestVaultPassphrase(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  if (window.__HUSHH_NATIVE_TEST__?.enabled !== true) {
+  if (!isTrustedNativeTestBridge()) {
     return null;
   }
   const value = String(window.__HUSHH_NATIVE_TEST__?.vaultPassphrase || "").trim();
@@ -194,9 +209,14 @@ export function getNativeTestConfig(): NativeTestConfig {
 
   const raw = window.__HUSHH_NATIVE_TEST__ ?? {};
   const root = document.documentElement;
+  // Dataset attributes are just as page-writable as the window global, so
+  // they only count on a real native platform (see isTrustedNativeTestBridge).
+  const isNativePlatform = Capacitor.isNativePlatform();
   const enabledFromDataset =
+    isNativePlatform &&
     root.getAttribute("data-hushh-native-test-enabled") === "true";
   const autoReviewerLoginFromDataset =
+    isNativePlatform &&
     root.getAttribute("data-hushh-native-test-auto-reviewer-login") === "true";
   const expectedMarkerFromDataset =
     root.getAttribute("data-hushh-native-test-expected-marker");
@@ -205,7 +225,7 @@ export function getNativeTestConfig(): NativeTestConfig {
   const expectedRouteFromDataset =
     root.getAttribute("data-hushh-native-test-expected-route");
   return {
-    enabled: raw.enabled === true || enabledFromDataset,
+    enabled: isNativePlatform && (raw.enabled === true || enabledFromDataset),
     autoReviewerLogin:
       raw.autoReviewerLogin === true || autoReviewerLoginFromDataset,
     vaultPassphrase:

--- a/hushh-webapp/lib/vault/passphrase-key.ts
+++ b/hushh-webapp/lib/vault/passphrase-key.ts
@@ -1,4 +1,5 @@
 // lib/vault/passphrase-key.ts
+import { Capacitor } from "@capacitor/core";
 import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
 
 /**
@@ -60,6 +61,54 @@ function toCryptoBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
   return out;
 }
 
+// CS-4 fix (security assessment, 2026-08-17): PBKDF2 ran at 100,000 rounds,
+// well under the ~600,000 current OWASP-recommended minimum. Bumping the
+// constant alone would break every existing vault: unlock re-derives the key
+// with whatever iteration count is hardcoded here, so an old vault encrypted
+// at 100,000 rounds would silently fail to decrypt (indistinguishable from a
+// wrong passphrase) the moment this file started deriving at 600,000.
+//
+// The backend never interprets `salt`/`recoverySalt` — they are stored and
+// returned as opaque strings (see consent-protocol's VaultKeysService) — so
+// the iteration count can travel inside that same opaque string without any
+// backend/schema change. New vaults are versioned and stretched at
+// PBKDF2_ITERATIONS_CURRENT; existing rows have no version prefix, are
+// detected as such, and keep unlocking at the original 100,000 forever.
+const PBKDF2_ITERATIONS_LEGACY = 100_000;
+export const PBKDF2_ITERATIONS_CURRENT = 600_000;
+const KDF_SALT_VERSION_PREFIX = "hushh-kdf-v2:";
+
+export function encodeVersionedSalt(saltBytes: Uint8Array, iterations: number): string {
+  return `${KDF_SALT_VERSION_PREFIX}${iterations}:${bytesToBase64(saltBytes)}`;
+}
+
+function decodeVersionedSalt(saltField: string): {
+  iterations: number;
+  saltBytes: Uint8Array<ArrayBuffer>;
+} {
+  const trimmed = saltField.trim();
+  if (trimmed.startsWith(KDF_SALT_VERSION_PREFIX)) {
+    const rest = trimmed.slice(KDF_SALT_VERSION_PREFIX.length);
+    const separatorIndex = rest.indexOf(":");
+    if (separatorIndex > 0) {
+      const iterations = Number.parseInt(rest.slice(0, separatorIndex), 10);
+      const encodedSalt = rest.slice(separatorIndex + 1);
+      if (Number.isFinite(iterations) && iterations > 0 && encodedSalt) {
+        return {
+          iterations,
+          saltBytes: toCryptoBytes(decodeBytesCompat(encodedSalt)),
+        };
+      }
+    }
+  }
+  // No recognized version prefix: this is a pre-existing row where the whole
+  // field is just the encoded salt bytes, derived at the legacy round count.
+  return {
+    iterations: PBKDF2_ITERATIONS_LEGACY,
+    saltBytes: toCryptoBytes(decodeBytesCompat(trimmed)),
+  };
+}
+
 function updateNativeTestCryptoDiagnostics(
   values: Partial<{
     stage: string;
@@ -73,6 +122,11 @@ function updateNativeTestCryptoDiagnostics(
   }>
 ): void {
   if (typeof window === "undefined") return;
+  // SECURITY: this bridge is a page-writable global. Without the native
+  // platform check, an injected script could set `vaultPassphrase` to a
+  // guess and read `passphraseMatchesConfig` back as a passphrase oracle.
+  // See isTrustedNativeTestBridge in lib/testing/native-test.ts.
+  if (!Capacitor.isNativePlatform()) return;
   const bridge = window.__HUSHH_NATIVE_TEST__;
   if (!bridge?.enabled) return;
   if (values.stage !== undefined) bridge.vaultCryptoStage = values.stage;
@@ -98,7 +152,8 @@ function updateNativeTestCryptoDiagnostics(
  */
 export async function deriveKeyFromPassphrase(
   passphrase: string,
-  salt: Uint8Array
+  salt: Uint8Array,
+  iterations: number = PBKDF2_ITERATIONS_CURRENT
 ): Promise<CryptoKey> {
   const encoder = new TextEncoder();
   const encodedPassphrase = encoder.encode(passphrase);
@@ -143,13 +198,21 @@ export async function deriveKeyFromPassphrase(
       {
         name: "PBKDF2",
         salt: salt.buffer as ArrayBuffer,
-        iterations: 100000, // High iteration count for security
+        iterations,
         hash: "SHA-256",
       },
       keyMaterial,
       { name: "AES-GCM", length: 256 },
-      true, // extractable for export
-      ["encrypt", "decrypt", "wrapKey", "unwrapKey"]
+      // CS-7 fix (security assessment, 2026-08-17): this key wraps/unwraps
+      // the vault master key via encrypt/decrypt below — every call site
+      // (createVaultWithPassphrase, unlockVaultWithPassphrase,
+      // unlockVaultWithRecoveryKey, rewrapVaultKeyWithPassphrase) only ever
+      // encrypts/decrypts with it, never exports it. Non-extractable so an
+      // injected script can't call exportKey() on this key even if it
+      // manages to get a reference to it; encrypt/decrypt are the only
+      // capabilities actually used, so wrapKey/unwrapKey are dropped too.
+      false,
+      ["encrypt", "decrypt"]
     );
   } catch (error: unknown) {
     updateNativeTestCryptoDiagnostics({
@@ -197,7 +260,11 @@ export async function createVaultWithPassphrase(passphrase: string): Promise<{
   const salt = crypto.getRandomValues(new Uint8Array(16));
 
   // Derive encryption key from passphrase
-  const encryptionKey = await deriveKeyFromPassphrase(passphrase, salt);
+  const encryptionKey = await deriveKeyFromPassphrase(
+    passphrase,
+    salt,
+    PBKDF2_ITERATIONS_CURRENT
+  );
 
   // Encrypt vault key with passphrase-derived key
   const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -226,7 +293,8 @@ export async function createVaultWithPassphrase(passphrase: string): Promise<{
   // Derive key from recovery key
   const recoveryDerivedKey = await deriveKeyFromPassphrase(
     recoveryKey,
-    recoverySalt
+    recoverySalt,
+    PBKDF2_ITERATIONS_CURRENT
   );
 
   // Encrypt vault key with recovery-derived key
@@ -241,11 +309,11 @@ export async function createVaultWithPassphrase(passphrase: string): Promise<{
     recoveryKey,
     // Passphrase encrypted
     encryptedVaultKey: bytesToBase64(new Uint8Array(encryptedVaultKeyBuffer)),
-    salt: bytesToBase64(salt),
+    salt: encodeVersionedSalt(salt, PBKDF2_ITERATIONS_CURRENT),
     iv: bytesToBase64(iv),
     // Recovery encrypted
     recoveryEncryptedVaultKey: bytesToBase64(new Uint8Array(recoveryEncryptedBuffer)),
-    recoverySalt: bytesToBase64(recoverySalt),
+    recoverySalt: encodeVersionedSalt(recoverySalt, PBKDF2_ITERATIONS_CURRENT),
     recoveryIv: bytesToBase64(recoveryIv),
   };
 }
@@ -259,8 +327,10 @@ export async function unlockVaultWithPassphrase(
   salt: string,
   iv: string
 ): Promise<string> {
-  // Decode from base64
-  const saltBytes = toCryptoBytes(decodeBytesCompat(salt));
+  // Decode from base64. Salt may carry a version+iterations prefix (CS-4
+  // fix) so a pre-existing row (no prefix) still derives at the original
+  // 100,000 rounds it was actually encrypted with.
+  const { iterations, saltBytes } = decodeVersionedSalt(salt);
   const ivBytes = toCryptoBytes(decodeBytesCompat(iv));
   const encryptedBytes = toCryptoBytes(decodeBytesCompat(encryptedVaultKey));
 
@@ -273,7 +343,7 @@ export async function unlockVaultWithPassphrase(
   });
 
   // Derive key from passphrase
-  const decryptionKey = await deriveKeyFromPassphrase(passphrase, saltBytes);
+  const decryptionKey = await deriveKeyFromPassphrase(passphrase, saltBytes, iterations);
 
   let vaultKeyRaw: ArrayBuffer;
   try {
@@ -323,13 +393,13 @@ export async function unlockVaultWithRecoveryKey(
   recoverySalt: string,
   recoveryIv: string
 ): Promise<string> {
-  // Decode from base64
-  const saltBytes = toCryptoBytes(decodeBytesCompat(recoverySalt));
+  // Decode from base64 (see decodeVersionedSalt: CS-4 fix)
+  const { iterations, saltBytes } = decodeVersionedSalt(recoverySalt);
   const ivBytes = toCryptoBytes(decodeBytesCompat(recoveryIv));
   const encryptedBytes = toCryptoBytes(decodeBytesCompat(recoveryEncryptedVaultKey));
 
   // Derive key from recovery key using stored salt
-  const unwrapKey = await deriveKeyFromPassphrase(recoveryKey, saltBytes);
+  const unwrapKey = await deriveKeyFromPassphrase(recoveryKey, saltBytes, iterations);
 
   let vaultKeyRaw: ArrayBuffer;
   try {

--- a/hushh-webapp/lib/vault/prf-auth.ts
+++ b/hushh-webapp/lib/vault/prf-auth.ts
@@ -190,103 +190,18 @@ function generateRecoveryKey(): string {
     .toUpperCase()}`;
 }
 
-/**
- * Wrap vault key with recovery key for backup
- */
-async function wrapVaultKey(
-  vaultKey: CryptoKey,
-  recoveryKey: string
-): Promise<{
-  wrappedKey: string;
-  iv: string;
-}> {
-  // Derive wrapping key from recovery key
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(recoveryKey),
-    { name: "PBKDF2" },
-    false,
-    ["deriveKey"]
-  );
-
-  const wrappingKey = await crypto.subtle.deriveKey(
-    {
-      name: "PBKDF2",
-      salt: encoder.encode("hushh-recovery-salt"),
-      iterations: 100000,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    { name: "AES-GCM", length: 256 },
-    false,
-    ["wrapKey"]
-  );
-
-  // Wrap the vault key
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const wrappedKeyBuffer = await crypto.subtle.wrapKey(
-    "raw",
-    vaultKey,
-    wrappingKey,
-    { name: "AES-GCM", iv }
-  );
-
-  return {
-    wrappedKey: bytesToBase64(new Uint8Array(wrappedKeyBuffer)),
-    iv: bytesToBase64(iv),
-  };
-}
-
-/**
- * Unwrap vault key using recovery key
- */
-export async function unwrapVaultKey(
-  wrappedKey: string,
-  iv: string,
-  recoveryKey: string
-): Promise<CryptoKey> {
-  const encoder = new TextEncoder();
-
-  // Derive unwrapping key from recovery key
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(recoveryKey),
-    { name: "PBKDF2" },
-    false,
-    ["deriveKey"]
-  );
-
-  const unwrappingKey = await crypto.subtle.deriveKey(
-    {
-      name: "PBKDF2",
-      salt: encoder.encode("hushh-recovery-salt"),
-      iterations: 100000,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    { name: "AES-GCM", length: 256 },
-    false,
-    ["unwrapKey"]
-  );
-
-  // Decode wrapped key and IV
-  const wrappedKeyBuffer = base64ToBytes(wrappedKey);
-  const ivBuffer = base64ToBytes(iv);
-
-  // Unwrap the vault key
-  const vaultKey = await crypto.subtle.unwrapKey(
-    "raw",
-    wrappedKeyBuffer,
-    unwrappingKey,
-    { name: "AES-GCM", iv: ivBuffer },
-    { name: "AES-GCM", length: 256 },
-    true,
-    ["encrypt", "decrypt"]
-  );
-
-  return vaultKey;
-}
+// CS-5 fix (security assessment, 2026-08-17): this file used to also export
+// wrapVaultKey/unwrapVaultKey, a second, unused vault-key-backup code path
+// that derived its wrapping key with a salt hardcoded to the literal string
+// "hushh-recovery-salt" for every user — a real bug (one cracking table would
+// work against every account), but confirmed dead code: registerWithPrf's
+// wrappedVaultKey/wrappedIv outputs were never read by any caller in this
+// repo (grep across web, iOS, Android, and the backend turned up nothing).
+// The recovery key users actually get is generated correctly, with a random
+// per-user salt, by createVaultWithPassphrase in ./passphrase-key.ts. Removed
+// rather than patched: there was no live behavior depending on it, so
+// deleting the vulnerable path is strictly safer than leaving a "fixed but
+// still unused" copy around.
 
 /**
  * Register a new passkey with PRF extension
@@ -300,8 +215,6 @@ export async function registerWithPrf(
   vaultKeyHex: string;
   recoveryKey: string;
   prfSalt: string;
-  wrappedVaultKey: string;
-  wrappedIv: string;
 }> {
   const prfSalt = generateSalt();
   const prfSaltB64 = bytesToBase64(prfSalt);
@@ -373,9 +286,10 @@ export async function registerWithPrf(
   const vaultKey = await deriveVaultKey(prfResult as ArrayBuffer, prfSalt);
   const vaultKeyHex = await exportKeyToHex(vaultKey);
 
-  // Generate recovery key and wrap vault key
+  // Generate recovery key. (Actual vault recovery is handled by
+  // createVaultWithPassphrase's recovery wrapper, which is what gets
+  // persisted and shown to the user; see the CS-5 note above.)
   const recoveryKey = generateRecoveryKey();
-  const { wrappedKey, iv } = await wrapVaultKey(vaultKey, recoveryKey);
 
   // Get credential ID
   const credentialId = bytesToBase64(new Uint8Array(credential.rawId));
@@ -385,8 +299,6 @@ export async function registerWithPrf(
     vaultKeyHex,
     recoveryKey,
     prfSalt: prfSaltB64,
-    wrappedVaultKey: wrappedKey,
-    wrappedIv: iv,
   };
 }
 

--- a/hushh-webapp/lib/vault/rewrap-vault-key.ts
+++ b/hushh-webapp/lib/vault/rewrap-vault-key.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { bytesToBase64 } from "@/lib/vault/base64";
-import { deriveKeyFromPassphrase } from "@/lib/vault/passphrase-key";
+import {
+  deriveKeyFromPassphrase,
+  encodeVersionedSalt,
+  PBKDF2_ITERATIONS_CURRENT,
+} from "@/lib/vault/passphrase-key";
 
 function hexToBytes(hex: string): Uint8Array {
   const normalized = hex.trim();
@@ -35,7 +39,11 @@ export async function rewrapVaultKeyWithPassphrase(params: {
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const iv = crypto.getRandomValues(new Uint8Array(12));
 
-  const wrappingKey = await deriveKeyFromPassphrase(params.wrappingSecret, salt);
+  const wrappingKey = await deriveKeyFromPassphrase(
+    params.wrappingSecret,
+    salt,
+    PBKDF2_ITERATIONS_CURRENT
+  );
   const encrypted = await crypto.subtle.encrypt(
     { name: "AES-GCM", iv },
     wrappingKey,
@@ -44,7 +52,11 @@ export async function rewrapVaultKeyWithPassphrase(params: {
 
   return {
     encryptedVaultKey: bytesToBase64(new Uint8Array(encrypted)),
-    salt: bytesToBase64(salt),
+    // CS-4 fix: version-tag the salt with its iteration count (see
+    // decodeVersionedSalt in passphrase-key.ts) so this new wrapper unlocks
+    // at PBKDF2_ITERATIONS_CURRENT while older untouched wrappers keep
+    // unlocking at the legacy round count.
+    salt: encodeVersionedSalt(salt, PBKDF2_ITERATIONS_CURRENT),
     iv: bytesToBase64(iv),
   };
 }

--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -53,6 +53,10 @@ const config: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     minimumCacheTTL: 60,
     dangerouslyAllowSVG: true,
+    // CS-3 fix: served SVGs are sandboxed and cannot run script or be framed,
+    // which is Next.js's documented mitigation for allowing SVG at all.
+    // https://nextjs.org/docs/app/api-reference/components/image#dangerouslyallowsvg
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     contentDispositionType: "inline",
   },
 

--- a/hushh-webapp/proxy.ts
+++ b/hushh-webapp/proxy.ts
@@ -2,8 +2,94 @@
 // Next.js 16 Proxy for Route Protection (formerly middleware.ts)
 
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import type { NextRequest, NextMiddlewareResult } from "next/server";
 import { ROUTES, isPublicRoute } from "./lib/navigation/routes";
+
+// ============================================================================
+// Security headers (CS-3 fix, security assessment 2026-08-17)
+// ============================================================================
+// The app shipped with no Content-Security-Policy and no clickjacking/
+// HSTS/MIME-sniffing headers, so nothing in the browser stopped an injected
+// script from running or the page from being framed. The CSP uses a
+// per-request nonce (Next.js's documented pattern:
+// https://nextjs.org/docs/app/guides/content-security-policy) so the app's
+// own inline bootstrap/analytics scripts keep working without falling back
+// to 'unsafe-inline' on script-src, which would defeat the point.
+//
+// Only web/Cloud Run builds run this proxy (Capacitor static export does
+// not execute it), which matches the live host this was assessed against
+// (https://uat.one.hushh.ai).
+
+function buildCsp(nonce: string, isDev: boolean): string {
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      `'nonce-${nonce}'`,
+      // Next.js dev overlay/HMR needs eval; production never sets this.
+      ...(isDev ? ["'unsafe-eval'"] : []),
+      "https://www.googletagmanager.com",
+      "https://cdn.plaid.com",
+    ],
+    // style-src cannot execute JS, so 'unsafe-inline' here doesn't defeat the
+    // policy the way it would on script-src; kept permissive so component
+    // <style> blocks (e.g. chart theming) don't need per-component nonces.
+    "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "https://fonts.gstatic.com", "data:"],
+    "connect-src": [
+      "'self'",
+      "https://api.hushh.ai",
+      "https://api.uat.hushh.ai",
+      "https://*.googleapis.com",
+      "https://www.google-analytics.com",
+      "https://www.googletagmanager.com",
+      "https://cdn.plaid.com",
+      "https://*.plaid.com",
+      ...(isDev ? ["ws:", "http://127.0.0.1:*"] : []),
+    ],
+    "frame-src": ["'self'", "https://cdn.plaid.com", "https://*.plaid.com"],
+    "worker-src": ["'self'", "blob:"],
+    "object-src": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+    "frame-ancestors": ["'self'"],
+  };
+
+  const policy = Object.entries(directives)
+    .map(([key, values]) => `${key} ${values.join(" ")}`)
+    .join("; ");
+
+  return isDev ? policy : `${policy}; upgrade-insecure-requests`;
+}
+
+/** Stamps the CSP + the rest of the security headers onto any response this
+ * proxy returns (redirect or pass-through). */
+function withSecurityHeaders(
+  response: NextMiddlewareResult,
+  nonce: string,
+): NextMiddlewareResult {
+  if (!response) return response;
+
+  const isDev = process.env.NODE_ENV !== "production";
+
+  response.headers.set("Content-Security-Policy", buildCsp(nonce, isDev));
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set(
+    "Permissions-Policy",
+    "camera=(self), microphone=(self), geolocation=(self), payment=(), usb=(), interest-cohort=()",
+  );
+  if (!isDev) {
+    response.headers.set(
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  }
+
+  return response;
+}
 
 // Routes that don't require authentication (VaultLockGuard handles protected routes)
 const PUBLIC_ROUTES = [
@@ -45,6 +131,15 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const host = request.headers.get("host") || "";
 
+  // CS-3 fix: one nonce per request, forwarded to Server Components (see
+  // app/layout.tsx) via the x-nonce request header and bound into the CSP
+  // response header below via withSecurityHeaders.
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  const next = () =>
+    NextResponse.next({ request: { headers: requestHeaders } });
+
   const legacyHostTargets: Record<string, string> = {
     "uat.kai.hushh.ai": "uat.one.hushh.ai",
     "dev.kai.hushh.ai": "dev.one.hushh.ai",
@@ -55,7 +150,7 @@ export function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.host = legacyHostTarget;
     url.protocol = "https:";
-    return NextResponse.redirect(url, 301);
+    return withSecurityHeaders(NextResponse.redirect(url, 301), nonce);
   }
 
   const legacyRedirectTarget = LEGACY_ROUTE_REDIRECTS[pathname];
@@ -71,7 +166,7 @@ export function proxy(request: NextRequest) {
         if (!url.searchParams.has(key)) url.searchParams.set(key, value);
       });
     }
-    return NextResponse.redirect(url);
+    return withSecurityHeaders(NextResponse.redirect(url), nonce);
   }
 
   for (const [legacyRoot, canonicalRoot] of [
@@ -83,17 +178,17 @@ export function proxy(request: NextRequest) {
     }
     const url = request.nextUrl.clone();
     url.pathname = `${canonicalRoot}${pathname.slice(legacyRoot.length)}`;
-    return NextResponse.redirect(url);
+    return withSecurityHeaders(NextResponse.redirect(url), nonce);
   }
 
   // Allow all API routes (they handle their own auth)
   if (pathname.startsWith(API_PREFIX)) {
-    return NextResponse.next();
+    return withSecurityHeaders(next(), nonce);
   }
 
   // Allow public routes
   if (PUBLIC_ROUTES.includes(pathname) || isPublicRoute(pathname)) {
-    return NextResponse.next();
+    return withSecurityHeaders(next(), nonce);
   }
 
   // Allow static files and Next.js internals
@@ -102,7 +197,7 @@ export function proxy(request: NextRequest) {
     pathname.startsWith("/favicon") ||
     pathname.includes(".")
   ) {
-    return NextResponse.next();
+    return withSecurityHeaders(next(), nonce);
   }
 
   // =========================================================================
@@ -119,7 +214,7 @@ export function proxy(request: NextRequest) {
   // Protected pages will redirect to "/login" if not authenticated.
   // =========================================================================
 
-  return NextResponse.next();
+  return withSecurityHeaders(next(), nonce);
 }
 
 export const config = {


### PR DESCRIPTION
## What this fixes

From the 2026-08-17 security assessment:

- **Content-Security-Policy + security headers.** Added a nonce-based CSP plus X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and HSTS (`proxy.ts`). Served SVGs are sandboxed. Verified against a real production build (`npm run build` + `npm run start`): all headers present, zero CSP violations in the browser console on a fresh load.

- **Native test-mode bridge locked down.** `window.__HUSHH_NATIVE_TEST__` is now only trusted when `Capacitor.isNativePlatform()` is true, everywhere it's read — previously any script running on the page could set it directly. Auditing every call site also found it could skip phone verification and attach a callable persona-switch hook to the page; both closed by the same fix.

- **Passphrase stretching raised 100,000 → 600,000 PBKDF2 rounds** for new vaults, with full backward compatibility — the round count travels inside the (already backend-opaque) salt field, so existing vaults keep unlocking at their original round count. New coverage in `__tests__/vault/passphrase-key-kdf-versioning.test.ts`.

- **Removed a dead recovery-key code path** that derived a wrapping key from a salt hardcoded to the same value for every user. Confirmed via full-repo search it was unused.

- **Vault-wrapping key is now non-extractable** — it was extractable with unused wrapKey/unwrapKey capabilities; every call site only ever encrypts/decrypts with it.

- **Reviewed the cookie/CSRF surface** flagged in the assessment: no backend route reads `request.cookies` and nothing ever sets one, so there's no cookie today for a forged request to ride on.

## Verification

- Full production build + live header/console check against it
- `tsc --noEmit` clean, `eslint` clean
- Full vitest suite: 940/942 passing (2 pre-existing failures, unrelated, verified in isolation)
