### PR TITLE
fix(circle): remove redundant pencil icon on circle-name field

### DIFF
--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -897,8 +897,11 @@ describe("named Circle flows", () => {
     const input = (await screen.findByLabelText(
       "Circle name",
     )) as HTMLInputElement;
-    // Untouched: the trailing control is the edit affordance, never a write.
-    expect(screen.getByRole("button", { name: "Edit Circle name" })).toBeTruthy();
+    // Untouched: no edit affordance is needed, and the trailing slot is never
+    // a write until the name actually changes.
+    expect(
+      screen.getByTestId("one-location-circle-name-placeholder"),
+    ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
 
     // Only an empty name blocks the write; one character is a name.
@@ -921,19 +924,19 @@ describe("named Circle flows", () => {
     // renamed Circle without waiting for a refetch.
     expect(await screen.findByText("Meena Home")).toBeTruthy();
     expect(input.value).toBe("Meena Home");
-    // Saved state collapses back to the edit affordance.
+    // Saved state collapses back to the reserved placeholder.
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
     );
     expect(onLoad).toHaveBeenCalledTimes(1);
   });
 
-  it("gives Save and Edit one box, so the field never resizes mid-edit", async () => {
+  it("gives Save and the placeholder one box, so the field never resizes mid-edit", async () => {
     // QA: "Save CTA, not looking good". The cause was measurable. Save took
     // `Button`'s `default` size, whose `min-h-[50px]` outlives an `h-11` --
     // `h-` and `min-h-` are separate tailwind-merge groups -- so it rendered
-    // 50px against a 44px field. And because Save is wider than a pencil
-    // glyph, swapping one for the other resized the input on the first
+    // 50px against a 44px field. And because Save is wider than the reserved
+    // slot beside it, letting them differ resized the input on the first
     // keystroke.
     //
     // JSDOM cannot see either of those; it applies no CSS. What it can prove is
@@ -947,8 +950,10 @@ describe("named Circle flows", () => {
       "Circle name",
     )) as HTMLInputElement;
 
-    const edit = screen.getByRole("button", { name: "Edit Circle name" });
-    expect(edit.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
+    const placeholder = screen.getByTestId(
+      "one-location-circle-name-placeholder",
+    );
+    expect(placeholder.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
 
     fireEvent.change(input, { target: { value: "Meena Home" } });
     const save = screen.getByRole("button", { name: "Save" });

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -9,7 +9,6 @@ import {
   Loader2,
   LogOut,
   MoreVertical,
-  Pencil,
   Plus,
   RotateCw,
   Search,
@@ -888,7 +887,6 @@ export function CircleDetailFlow({
   const [cancellingInviteId, setCancellingInviteId] = useState<string | null>(
     null,
   );
-  const nameInputRef = useRef<HTMLInputElement | null>(null);
   const loadRequestRef = useRef(0);
   const peopleRequestRef = useRef(0);
   const peopleSubmitInFlightRef = useRef(false);
@@ -1223,7 +1221,6 @@ export function CircleDetailFlow({
               <div className={CIRCLE_NAME_ROW_CLASSNAME}>
                 <input
                   id={CIRCLE_NAME_INPUT_ID}
-                  ref={nameInputRef}
                   value={circleName}
                   onChange={(event) => setCircleName(event.target.value)}
                   onKeyDown={(event) => {
@@ -1252,16 +1249,15 @@ export function CircleDetailFlow({
                     Save
                   </Button>
                 ) : (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    aria-label="Edit Circle name"
-                    onClick={() => nameInputRef.current?.focus()}
+                  // Reserves the Save button's exact box so focusing the field
+                  // never shifts its width — see circle-name-row-layout.ts. The
+                  // pencil affordance itself was redundant: the input is already
+                  // focusable and clickable on its own.
+                  <div
+                    aria-hidden="true"
+                    data-testid="one-location-circle-name-placeholder"
                     className={CIRCLE_NAME_ACTION_CLASSNAME}
-                  >
-                    <Pencil className="h-4 w-4" />
-                  </Button>
+                  />
                 )}
               </div>
               <p className={cn(MUTED_TEXT, "mt-2")}>


### PR DESCRIPTION
## Summary
Addresses #5410. The Circle detail route (`/one/location/circle/[id]`) showed
a decorative pencil icon beside the circle-name input even though the field
is already focusable/clickable on its own and a "Save" button already appears
once the name is edited.

- Removed the pencil `Button` and its `onClick` focus handler.
- Kept the trailing slot's exact box (an invisible `aria-hidden` placeholder)
  so focusing the field still never shifts width when Save appears — this
  geometry is deliberately locked down by `circle-name-row-layout.ts` and
  `e2e/connect-circle-cta.layout.spec.ts`.
- Updated the two unit tests that asserted on the old "Edit Circle name"
  button to assert on the new placeholder instead.

## Test plan
- [x] `npx vitest run components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx` — 26/26 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on both touched files — clean