### PR TITLE
fix(one-location): exempt /circle/join from the onboarding admission guard

### DIFF
--- a/hushh-webapp/__tests__/app/circle-join-page.test.tsx
+++ b/hushh-webapp/__tests__/app/circle-join-page.test.tsx
@@ -1,13 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OneLocationCircleInvitePreview } from "@/lib/one-location/types";
 
 const mockReplace = vi.fn();
 const mockPreview = vi.fn();
+const mockRememberPendingCircleJoin = vi.fn();
+const mockIsResolved = vi.fn();
 let searchParams = new URLSearchParams();
 let authState: {
-  user: { getIdToken: () => Promise<string> } | null;
+  user: { uid: string; getIdToken: () => Promise<string> } | null;
   isAuthenticated: boolean;
   loading: boolean;
 };
@@ -34,9 +36,21 @@ vi.mock("@/lib/one-location/service", () => ({
   },
 }));
 
+vi.mock("@/lib/one-location/pending-circle-join", () => ({
+  rememberPendingCircleJoin: (userId: string, code: string) =>
+    mockRememberPendingCircleJoin(userId, code),
+}));
+
+vi.mock("@/lib/services/one-setup-completion-hint-service", () => ({
+  OneSetupCompletionHintService: {
+    isResolved: (userId: string) => mockIsResolved(userId),
+  },
+}));
+
 import CircleJoinPage from "@/app/circle/join/page";
 
 const CODE = "SWDXENDPB954";
+const USER_ID = "user-1";
 
 function preview(
   overrides: Partial<OneLocationCircleInvitePreview> = {},
@@ -54,7 +68,7 @@ function preview(
 
 function signedIn() {
   authState = {
-    user: { getIdToken: () => Promise.resolve("id-token") },
+    user: { uid: USER_ID, getIdToken: () => Promise.resolve("id-token") },
     isAuthenticated: true,
     loading: false,
   };
@@ -64,6 +78,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   searchParams = new URLSearchParams({ code: CODE });
   authState = { user: null, isAuthenticated: false, loading: false };
+  // Resolved (setup already finished) unless a test says otherwise -- the
+  // parking behaviour under test is the exception, not the default.
+  mockIsResolved.mockReturnValue(true);
 });
 
 describe("/circle/join landing", () => {
@@ -213,6 +230,40 @@ describe("/circle/join landing", () => {
     expect(status).toHaveAttribute("aria-live", "polite");
     await waitFor(() =>
       expect(status).toHaveTextContent("JHUMMA's Circle. JHUMMA KUMARI · 1 person."),
+    );
+  });
+
+  // #5307: /circle/join now renders for a mid-setup recipient (it is exempt
+  // from OnboardingJourneyGuard -- see routes.test.ts), but /one/location,
+  // where "Join this Circle" hands off to, still is not. Without parking the
+  // code here first, that redirect into /one/setup drops it silently.
+  it("parks the code before handing off when setup has not resolved (#5307)", async () => {
+    signedIn();
+    mockIsResolved.mockReturnValue(false);
+    mockPreview.mockResolvedValue(preview());
+
+    render(<CircleJoinPage />);
+
+    fireEvent.click(await screen.findByTestId("circle-join-continue"));
+
+    expect(mockRememberPendingCircleJoin).toHaveBeenCalledWith(USER_ID, CODE);
+    expect(mockReplace).toHaveBeenCalledWith(
+      `/one/location?action=join-circle&code=${CODE}`,
+    );
+  });
+
+  it("does not park the code once setup has already resolved", async () => {
+    signedIn();
+    mockIsResolved.mockReturnValue(true);
+    mockPreview.mockResolvedValue(preview());
+
+    render(<CircleJoinPage />);
+
+    fireEvent.click(await screen.findByTestId("circle-join-continue"));
+
+    expect(mockRememberPendingCircleJoin).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith(
+      `/one/location?action=join-circle&code=${CODE}`,
     );
   });
 });

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -218,6 +218,17 @@ describe("navigation routes", () => {
     );
   });
 
+  it("exempts the Circle join landing from onboarding admission (#5307)", () => {
+    // An entry point from outside the app, like /login: the destination is
+    // the reason the person opened the app, so a mid-setup user must still
+    // see the invitation instead of being bounced to /one/setup with the
+    // code dropped.
+    expect(ROUTES.CIRCLE_JOIN).toBe("/circle/join");
+    expect(isOnboardingAdmissionExemptRoute(ROUTES.CIRCLE_JOIN)).toBe(true);
+    // The destination it hands off to once a code is accepted stays gated.
+    expect(isOnboardingAdmissionExemptRoute(ROUTES.ONE_LOCATION)).toBe(false);
+  });
+
   it("preserves ria route classification for nested workspace paths", () => {
     expect(isRiaRoute("/ria")).toBe(true);
     expect(isRiaRoute("/ria/clients")).toBe(true);

--- a/hushh-webapp/app/circle/join/page.tsx
+++ b/hushh-webapp/app/circle/join/page.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/one-location/circle-join-url";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { OneLocationCircleInvitePreview } from "@/lib/one-location/types";
+import { rememberPendingCircleJoin } from "@/lib/one-location/pending-circle-join";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 
 /**
  * An invitation is one short column. `width="reading"` (54rem) stretches it
@@ -224,7 +226,20 @@ function CircleJoinLanding() {
           type="button"
           size="lg"
           className="mt-6 w-full"
-          onClick={() => router.replace(joinPath(code))}
+          onClick={() => {
+            const userId = auth.user?.uid;
+            // Joining needs a vault, which exists only once /one/setup
+            // finishes -- and /one/location itself is gated for a mid-setup
+            // user, so the query-string code below would otherwise be
+            // dropped by that redirect. Parking it here reuses the same
+            // mechanism /one/location already redeems from the moment a
+            // vault token exists, resolved or not, so the join survives an
+            // unresolved bootstrap read too.
+            if (userId && !OneSetupCompletionHintService.isResolved(userId)) {
+              rememberPendingCircleJoin(userId, code);
+            }
+            router.replace(joinPath(code));
+          }}
           data-testid="circle-join-continue"
         >
           {canJoin ? "Join this Circle" : "Open One Location"}

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -141,6 +141,12 @@ export const ROUTES = {
    * as the same feature.
    */
   ONE_LOCATION_CHECK_IN: "/one/location/check-in",
+  /**
+   * Recipient landing for a shared Circle join link. An entry point from
+   * outside the app, like LOGIN — the destination is the reason the person
+   * opened the app at all, so it must render before setup is checked.
+   */
+  CIRCLE_JOIN: "/circle/join",
   LEGACY_GMAIL: "/gmail",
   LEGACY_PKM: "/pkm",
   LEGACY_CONNECTED_SYSTEMS: "/connected-systems",
@@ -438,7 +444,8 @@ export function isOnboardingAdmissionExemptRoute(pathname: string): boolean {
     normalizedPathname === ROUTES.LOGOUT ||
     normalizedPathname === ROUTES.PROFILE ||
     normalizedPathname.startsWith(`${ROUTES.PROFILE}/`) ||
-    normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`)
+    normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`) ||
+    normalizedPathname === ROUTES.CIRCLE_JOIN
   );
 }
 


### PR DESCRIPTION
## Summary
Addresses #5307. A signed-in user who has not finished `/one/setup` and taps
a shared Circle link (`/circle/join?code=…`) never saw the invitation — they
got "Returning to setup..." and landed on `/one/setup` with the code dropped.

`OnboardingJourneyGuard` wraps every route, and `/circle/join` was absent
from `isOnboardingAdmissionExemptRoute` in `lib/navigation/routes.ts`, so the
guard's redirect fired before the page could render.

- Added `ROUTES.CIRCLE_JOIN` and exempted it from onboarding admission — same
  category as `/login`: an entry point from outside the app where the
  destination is the reason the person opened the app at all.
- `/one/location`, which "Join this Circle" hands off to, stays gated on
  purpose, so that follow-on redirect can still swallow the code for a
  still-incomplete setup. The landing page now parks the code first via the
  existing `rememberPendingCircleJoin` storage before navigating — the exact
  mechanism `/one/location` already redeems from the moment a vault token
  exists, so the join survives setup instead of being discarded.
- Only parks when `OneSetupCompletionHintService.isResolved` says setup has
  *not* resolved, so an already-onboarded recipient's flow (code pre-filled
  into the Join sheet via `location-redesign-hub.tsx`) is untouched.

## Test plan
- [x] New test: `isOnboardingAdmissionExemptRoute(ROUTES.CIRCLE_JOIN)` is
      `true`, `ROUTES.ONE_LOCATION` stays `false` (`routes.test.ts`)
- [x] New test: a mid-setup signed-in recipient parks the code before the
      `/one/location` hand-off (`circle-join-page.test.tsx`)
- [x] New test: an already-resolved recipient does not park a code
- [x] `npx vitest run __tests__/navigation/routes.test.ts __tests__/app/circle-join-page.test.tsx __tests__/one-location/pending-circle-join.test.ts __tests__/components/onboarding-journey-guard.test.tsx` — 54/54 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all touched files — clean