### PR TITLE
fix(one): restore overlay architecture silently reverted by my prior PR

### DIFF
--- a/hushh-webapp/components/app-ui/HushhIntroGate.module.css
+++ b/hushh-webapp/components/app-ui/HushhIntroGate.module.css
@@ -1,27 +1,31 @@
 /* components/app-ui/HushhIntroGate.module.css
- * The `/one` section's real first screen, and its only splash: a slow
- * mist of blurred purple/pink/blue blobs travels from below the screen,
- * through the centre, and out past the top over ~2.5s (Zomato-referenced
- * motion, an original organic-cloud treatment). The 🤫 mark and the
- * greeting — "Hi, {name}" and "Welcome to One." shown together, as one
- * group, never staggered — reveal through the still-moving, still-visible
- * mist, hold, and the whole screen fades — gently, never a hard cut or a
- * white flash — to reveal the vault screen, which only mounts once this
- * finishes (see HushhIntroGate.tsx). There is deliberately no separate
- * "Hushh One." beat and no cross-dissolve between two text groups here —
- * the greeting is the only text this shows, so both of its lines share
- * one identical reveal (same class, same transition, same delay).
+ * The `/one` section's real first screen, and its only splash: a mist of
+ * blurred purple/pink/blue blobs travels from below the screen, through
+ * the centre, and out past the top (Zomato-referenced motion, an original
+ * organic-cloud treatment). The 🤫 mark and the greeting — "Hi, {name}"
+ * and "Welcome to One." shown together, as one group, never staggered —
+ * reveal through the still-moving mist, hold, and the whole screen fades
+ * — gently, never a hard cut or a white flash — to reveal the app. There
+ * is deliberately no separate "Hushh One." beat and no cross-dissolve
+ * between two text groups here — the greeting is the only text this
+ * shows, so both of its lines share one identical reveal (same class,
+ * same transition, same delay).
  *
- * Every duration below is paced to match HushhIntroGate.tsx's phase
- * timers (`TOTAL_DURATION_MS`) so no phase change ever cuts a transition
- * off mid-motion.
+ * TIMING IS A CONTRACT WITH HushhIntroGate.tsx (see #5394). The whole
+ * script is 1,000 ms: sweep at 20, greeting at 80, exit at 840, gone at
+ * 1,000. Every duration below is sized to finish inside its own phase,
+ * and each one has a named constant in the TSX. Change one, change both
+ * — a longer transition here does not slow the unmount, it just never
+ * finishes playing.
+ *
+ * The app is MOUNTED AND LIVE underneath this the entire time; it is an
+ * overlay, not a gate. That is what lets boot and animation overlap
+ * rather than queue, and it is why `.root` takes pointer events until the
+ * exit fade releases them.
  *
  * Follows the app's own light/dark theme: white background + dark ink in
  * light mode, the app's near-black elevated surface + light ink in dark
- * mode — never pure black, never a jarring flash either way. Nothing else
- * is mounted in the tree while this is up (the component that owns this
- * CSS gates `VaultLockGuard` and everything below it out entirely until
- * its own animation completes).
+ * mode — never pure black, never a jarring flash either way.
  *
  * The mist's `translate3d(vw, vh, 0)` keyframes are authored in viewport
  * units, not `%` (which is relative to each blob's *own* huge size and
@@ -59,9 +63,9 @@
  *   exits; only the mist has independent motion to finish out.
  *
  * Easing direction is deliberate throughout: arrivals use
- * `--motion-ease-decelerate` (settle in, don't coast to a stop), and
- * the whole-screen exit uses `--motion-ease-accelerate` (leave with
- * intent) — a mirrored pair, not the same curve played backwards. */
+ * `--motion-ease-decelerate` (settle in, don't coast to a stop), and the
+ * whole-screen exit uses `--motion-ease-accelerate` (leave with intent) —
+ * a mirrored pair, not the same curve played backwards. */
 
 .root {
   position: fixed;
@@ -76,9 +80,15 @@
      below to the app's near-black elevated surface — never pure black,
      never a jarring flash either way. */
   background: var(--foundation-surface, #ffffff);
-  pointer-events: none;
+  /* The app is MOUNTED AND LIVE underneath this overlay from the first
+     frame (see HushhIntroGate.tsx) — it is not withheld from the tree.
+     So the overlay has to swallow taps while it is opaque, or a stray
+     tap during launch reaches a control the person cannot see. It hands
+     them back the moment the exit fade starts, which is also the moment
+     the app below becomes legible. */
+  pointer-events: auto;
   opacity: 1;
-  transition: opacity 500ms var(--motion-ease-accelerate);
+  transition: opacity 140ms var(--motion-ease-accelerate);
 
   --sweep-pink: #ec6a90;
   --sweep-purple: #9a6fd9;
@@ -93,6 +103,7 @@
 
 .root[data-phase="exit"] {
   opacity: 0;
+  pointer-events: none;
 }
 
 :global(.dark) .root {
@@ -158,20 +169,20 @@
 /* Applied once, the moment the phase leaves "idle", and never reassigned
    afterwards (every later phase value still matches `:not([data-phase=
    "idle"])`), so each blob plays its whole rise/drift/recede arc on its
-   own ~2.5s clock instead of being cut short or restarted by the phase
+   own ~1.2s clock instead of being cut short or restarted by the phase
    changes driving the mark and text. Delays are small (0/40/80ms) — just
    enough to keep the three blobs from moving in perfect lockstep, not
    enough to read as a pause before anything happens. */
 .root:not([data-phase="idle"]) .blobPurple {
-  animation: blob-purple-drift 2500ms var(--motion-ease-standard) forwards;
+  animation: blob-purple-drift 1200ms var(--motion-ease-standard) forwards;
 }
 
 .root:not([data-phase="idle"]) .blobPink {
-  animation: blob-pink-drift 2600ms var(--motion-ease-standard) 40ms forwards;
+  animation: blob-pink-drift 1250ms var(--motion-ease-standard) 40ms forwards;
 }
 
 .root:not([data-phase="idle"]) .blobBlue {
-  animation: blob-blue-drift 2400ms var(--motion-ease-standard) 80ms forwards;
+  animation: blob-blue-drift 1150ms var(--motion-ease-standard) 80ms forwards;
 }
 
 /* Purple: the primary, most central blob. Position (via `translate3d`,
@@ -287,8 +298,8 @@
      would otherwise show. */
   will-change: opacity, transform;
   transition:
-    opacity 680ms var(--motion-ease-decelerate),
-    transform 680ms var(--motion-ease-decelerate);
+    opacity 300ms var(--motion-ease-decelerate),
+    transform 300ms var(--motion-ease-decelerate);
 }
 
 .root[data-phase="greet"] .halo,
@@ -314,8 +325,8 @@
   transform: translateY(30px);
   will-change: opacity, transform;
   transition:
-    opacity 640ms var(--motion-ease-decelerate),
-    transform 640ms var(--motion-ease-decelerate);
+    opacity 300ms var(--motion-ease-decelerate),
+    transform 300ms var(--motion-ease-decelerate);
 }
 
 .root[data-phase="greet"] .icon,
@@ -352,15 +363,15 @@
   transform: translateY(10px);
   will-change: opacity, transform;
   transition:
-    opacity 620ms var(--motion-ease-decelerate),
-    transform 620ms var(--motion-ease-decelerate);
+    opacity 300ms var(--motion-ease-decelerate),
+    transform 300ms var(--motion-ease-decelerate);
 }
 
 .root[data-phase="greet"] .greetingLine,
 .root[data-phase="exit"] .greetingLine {
   opacity: 1;
   transform: translateY(0);
-  transition-delay: 200ms;
+  transition-delay: 50ms;
 }
 
 .greetingAccent {

--- a/hushh-webapp/components/app-ui/HushhIntroGate.tsx
+++ b/hushh-webapp/components/app-ui/HushhIntroGate.tsx
@@ -10,38 +10,38 @@ import styles from "./HushhIntroGate.module.css";
  * The app's real first screen for the `/one` section, and the ONLY splash
  * trigger in the app — mounted in `app/one/layout.tsx`, one level ABOVE
  * `OneAuthGate` (and therefore above `VaultLockGuard` and every other
- * auth/vault guard). While the intro is playing, `VaultLockGuard` and the
- * rest of the protected app are not rendered at all — not hidden
- * underneath, not mounted in the background, simply not in the tree —
- * so nothing they do (an auth-loading flicker, a vault re-check re-render)
- * can restart, extend, or remove the intro: its own phase timers live here,
- * one level up, entirely untouched by whatever mounts below it once it's
- * done. `VaultLockGuard` only mounts, for the first time, the instant this
- * component's own animation finishes — there is no second trigger anywhere
- * else in the app, and `VaultLockGuard`'s unlock success handler
- * intentionally does nothing: a successful unlock simply lets the guard's
- * own render fall through to `{children}` (the home page), with no splash
- * of any kind.
+ * auth/vault guard).
  *
- * Sequence — a soft splash, not a cinematic logo reveal: a slow mist of
+ * AN OVERLAY, NOT A GATE (this is the load-bearing property — see #5394).
+ *
+ * `{children}` render from the very first frame and the intro paints on
+ * top of them. It used to be the other way round: children were withheld
+ * from the tree until the animation finished, so `VaultLockGuard` did not
+ * mount — and the vault-presence network check did not even START — until
+ * the animation was over. Every millisecond of animation was ADDED to real
+ * boot cost instead of overlapping it. Now the animation and the boot run
+ * at the same time, so the wait is whichever of the two is slower rather
+ * than their sum. Two consequences to preserve when editing this:
+ *
+ * - The overlay must swallow taps while it is opaque, because a live app
+ *   is mounted underneath it. `.root` therefore takes pointer events and
+ *   only releases them once the exit fade begins.
+ * - The whole script is 1,000 ms, and every duration in the companion CSS
+ *   module is tuned to fit inside its own phase. Lengthening one without
+ *   the other desynchronises the fade from the unmount.
+ *
+ * Sequence — a soft splash, not a cinematic logo reveal: a mist of
  * blurred purple/pink/blue drifts up from below the screen through the
- * centre and out past the top (~2.5s, Zomato-referenced motion, an
- * original organic-cloud treatment); the 🤫 mark and the greeting —
- * "Hi, {first name}" and "Welcome to One." shown together, as one group,
- * not staggered — reveal through the still-moving mist; that holds for
- * `GREET_HOLD_MS`; the whole screen then fades gently to reveal whatever's
- * already mounted underneath — and only THEN does `VaultLockGuard` mount
- * for the first time and reveal the vault screen. There is deliberately no
- * separate "Hushh One." beat and no cross-dissolve between two text
- * groups: the greeting is the only text this shows, so it only ever needs
- * one clean reveal. The real signed-in user's first name is already
- * available here via Firebase auth, which resolves before the vault ever
- * does; "Hi there" is only a fallback for the rare case neither a display
- * name nor an email local-part exists. `TOTAL_DURATION_MS` is the sum of
- * every phase below; every CSS transition/animation duration in the
- * stylesheet is paced to match (see that file's own header) so nothing is
- * ever cut off mid-transition by a phase change firing before its
- * predecessor's motion has finished.
+ * centre and out past the top; the 🤫 mark and the greeting — "Hi,
+ * {first name}" and "Welcome to One." shown together, as one group, never
+ * staggered — reveal through the still-moving mist; that holds; the whole
+ * screen then fades to reveal the app that has been booting underneath it
+ * the entire time. There is deliberately no separate "Hushh One." beat and
+ * no cross-dissolve between two text groups: the greeting is the only text
+ * this shows, so it only ever needs one clean reveal. The real signed-in
+ * user's first name is already available here via Firebase auth, which
+ * resolves before the vault ever does; "Hi there" is only a fallback for
+ * the rare case neither a display name nor an email local-part exists.
  *
  * Plays only for a signed-in user who hasn't unlocked their vault yet this
  * login — never for a logged-out visitor, and never again on refresh,
@@ -74,23 +74,34 @@ import styles from "./HushhIntroGate.module.css";
  *   admits the route once auth is settled — so the uid read here is not a
  *   race against auth still loading.
  *
- * Fully skipped under prefers-reduced-motion too — `VaultLockGuard` and
- * `{children}` mount immediately with no overlay at all.
+ * Fully skipped under prefers-reduced-motion too — no overlay at all.
  * ──────────────────────────────────────────────────────────── */
 
 const LAST_UID_KEY = "hushh.one.intro.lastUid.v1";
 
 type Phase = "idle" | "sweep" | "greet" | "exit";
 
-const SWEEP_DELAY_MS = 0;
-const MIST_TO_GREET_MS = 1000;
-const GREET_HOLD_MS = 1500;
-const EXIT_DURATION_MS = 500;
-const EXIT_BUFFER_MS = 80;
+/*
+ * The whole script, in milliseconds: 1,000 exactly — the industry bar for
+ * launch-to-interactive is 500–1,000 (see #5394).
+ *
+ * The mark and the greeting reveal over the still-rising mist rather than
+ * waiting for it to finish, which is why MIST_TO_GREET_MS is 60. That
+ * buys the single hold a real 760 ms rather than splitting it across two
+ * beats, and the mist keeps drifting behind it the whole time.
+ *
+ * Every value here has a partner in HushhIntroGate.module.css sized to
+ * fit inside its phase. Change one, change both.
+ */
+const SWEEP_DELAY_MS = 20;
+const MIST_TO_GREET_MS = 60;
+const GREET_HOLD_MS = 760;
+const EXIT_DURATION_MS = 140;
+const EXIT_BUFFER_MS = 20;
 
-const GREET_AT_MS = SWEEP_DELAY_MS + MIST_TO_GREET_MS;
-const EXIT_AT_MS = GREET_AT_MS + GREET_HOLD_MS;
-const TOTAL_DURATION_MS = EXIT_AT_MS + EXIT_DURATION_MS + EXIT_BUFFER_MS;
+const GREET_AT_MS = SWEEP_DELAY_MS + MIST_TO_GREET_MS; // 80
+const EXIT_AT_MS = GREET_AT_MS + GREET_HOLD_MS; // 840
+const TOTAL_DURATION_MS = EXIT_AT_MS + EXIT_DURATION_MS + EXIT_BUFFER_MS; // 1000
 
 function resolveFirstName(
   displayName?: string | null,
@@ -178,34 +189,44 @@ export function HushhIntroGate({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (introComplete) {
-    return <>{children}</>;
-  }
-
   const firstName = resolveFirstName(user?.displayName, user?.email);
 
+  // `{children}` are ALWAYS in the tree. Auth, the vault-presence check and
+  // every first-screen fetch below run while the intro plays, instead of
+  // queueing behind it — the single change that fixes #5394. The overlay is
+  // painted over the top and removed when its own clock runs out.
   return (
-    <div aria-hidden="true" className={styles.root} data-phase={phase}>
-      <div className={styles.mist}>
-        <div className={`${styles.blob} ${styles.blobPurple}`} />
-        <div className={`${styles.blob} ${styles.blobPink}`} />
-        <div className={`${styles.blob} ${styles.blobBlue}`} />
-      </div>
-      <div className={styles.halo} />
-      <div className={styles.iconWrap}>
-        <span className={styles.icon}>🤫</span>
-      </div>
-      {/* One text group only — both lines share the same reveal, at the
-          same time, no stagger between them (see .module.css: both use
-          the identical transition, same delay). */}
-      <div className={styles.greeting}>
-        <p className={styles.greetingLine}>
-          {firstName ? `Hi, ${firstName}` : "Hi there"}
-        </p>
-        <p className={styles.greetingLine}>
-          Welcome to <span className={styles.greetingAccent}>One.</span>
-        </p>
-      </div>
-    </div>
+    <>
+      {children}
+      {introComplete ? null : (
+        <div
+          aria-hidden="true"
+          className={styles.root}
+          data-phase={phase}
+          data-testid="hushh-intro-gate"
+        >
+          <div className={styles.mist}>
+            <div className={`${styles.blob} ${styles.blobPurple}`} />
+            <div className={`${styles.blob} ${styles.blobPink}`} />
+            <div className={`${styles.blob} ${styles.blobBlue}`} />
+          </div>
+          <div className={styles.halo} />
+          <div className={styles.iconWrap}>
+            <span className={styles.icon}>🤫</span>
+          </div>
+          {/* One text group only — both lines share the same reveal, at
+              the same time, no stagger between them (see .module.css:
+              both use the identical transition, same delay). */}
+          <div className={styles.greeting}>
+            <p className={styles.greetingLine}>
+              {firstName ? `Hi, ${firstName}` : "Hi there"}
+            </p>
+            <p className={styles.greetingLine}>
+              Welcome to <span className={styles.greetingAccent}>One.</span>
+            </p>
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Category
Bug fix (regression I introduced)

## What happened
My PR #5470 (merged onto `main`) silently reverted #5394 -- a separate, already-merged PR by another engineer (@ankitkumarsingh1702) that fixed launch performance by turning `HushhIntroGate` from a blocking *gate* (children withheld from the tree until the ~4.77s/3.28s animation finished) into a non-blocking *overlay* (children mount on the first frame, boot and animation overlap, whole script capped at 1,000ms total).

#5470 branched off a stale local copy of these two files -- created *before* #5394 landed -- and did a full-file overwrite rather than a diff-based change. Because there was no textual conflict (git had no way to know), the overwrite silently discarded #5394's architecture, its `pointer-events` tap-swallow/release handling, its `data-testid="hushh-intro-gate"` hook, and regressed the seven-test suite `__tests__/components/hushh-intro-gate.test.tsx` down to 3/7 failing -- caught only after the fact, not before merge.

## What this PR does
Restores #5394's overlay architecture, 1,000ms total budget, and pointer-events handling exactly, and applies my intended content change (drop the separate "Hushh One." beat; show "Hi, {name}" and "Welcome to One." together as one un-staggered group) on top of it instead of over it.

## Tests / verification
- `__tests__/components/hushh-intro-gate.test.tsx`: 7/7 pass (was 3/7 failing against what's currently on `main`).
- `npx vitest run __tests__/components/vault-lock-guard.test.tsx`: 7/7 pass.
- `tsc --noEmit`: clean.
- `eslint` on both touched files: clean.
- `npm run verify:design-system`: all pass.

## Process note
I'm flagging this pattern explicitly because it's the second time it's bitten this file: "create a fresh branch off latest main, `cp` my own full file content over it" does not account for *other* changes landing on the same file between when I last touched it and when I push again. I'll diff against main and apply a real patch instead of a full overwrite going forward.