### PR TITLE
fix(profile): trim the delete-account confirmation dialog copy

### DIFF
--- a/hushh-webapp/__tests__/app/profile/security-delete-contract.test.ts
+++ b/hushh-webapp/__tests__/app/profile/security-delete-contract.test.ts
@@ -43,7 +43,7 @@ describe("profile security deletion contract", () => {
     expect(profilePageSource).toContain("executeVerifiedAccountDeletion");
     expect(topAppBarSource).toContain("executeVerifiedAccountDeletion");
     expect(topAppBarSource).toContain("requestDeleteAccount");
-    expect(topAppBarSource).toContain("Unlock Vault to Delete Account");
+    expect(topAppBarSource).toContain("Unlock to delete account");
     expect(topAppBarSource).toContain("skipFcmCleanup: true");
     expect(deleteFlowSource).toContain(
       'AccountService.deleteAccount(params.vaultOwnerToken, "both")',
@@ -56,6 +56,15 @@ describe("profile security deletion contract", () => {
     expect(profilePageSource).not.toContain("Delete Investor, RIA");
     expect(profilePageSource).not.toContain('"Yes, Delete Investor"');
     expect(profilePageSource).not.toContain('"Yes, Delete RIA"');
+  });
+
+  it("keeps the delete-account copy short and free of internal vault language", () => {
+    const dialogDescriptionLine =
+      "This can't be undone — it deletes your account, private data, and every connected service.";
+    expect(deleteFlowSource).toContain(dialogDescriptionLine);
+    expect(dialogDescriptionLine.toLowerCase()).not.toContain("vault");
+    expect(topAppBarSource).toContain("Unlock to delete account");
+    expect(topAppBarSource).not.toContain("Unlock Vault to Delete Account");
   });
 
   it("offers a reset-account path that keeps the account and re-runs setup", () => {

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -1442,8 +1442,8 @@ function OnboardingRouteActions() {
           user={user}
           open={vaultUnlockOpen}
           onOpenChange={setVaultUnlockOpen}
-          title="Unlock Vault to Delete Account"
-          description="Unlock your vault to confirm deletion. This is permanent and removes all encrypted records."
+          title="Unlock to delete account"
+          description="This can't be undone — it removes everything you've saved."
           onSuccess={() => {
             setVaultUnlockOpen(false);
             window.setTimeout(() => void requestDeleteAccount(), 300);

--- a/hushh-webapp/lib/flows/delete-account.ts
+++ b/hushh-webapp/lib/flows/delete-account.ts
@@ -21,7 +21,7 @@ export type DeleteAccountAuthResolution =
  */
 export const DELETE_ACCOUNT_DIALOG_TITLE = "Delete your One account?";
 export const DELETE_ACCOUNT_DIALOG_DESCRIPTION =
-  "This action cannot be undone. This permanently deletes your One account, your encrypted vault and saved details, every connected service, and your cloud-linked identity.";
+  "This can't be undone — it deletes your account, private data, and every connected service.";
 
 export async function resolveDeleteAccountAuth(params: {
   userId: string;


### PR DESCRIPTION
## Summary
- The delete-account confirmation dialog repeated the "cannot be undone" warning across two sentences and named internal terms ("encrypted vault", "cloud-linked identity") no user needs to see.
- Shortened it to one sentence that leads with permanence and states what's removed (account, private data, connected services), with no jargon.
- Also fixed the adjacent unlock-before-delete gate in the same flow (top bar), which said "vault" twice — that phrasing violates the product's "no vault in user-facing copy" rule.

Before: "This action cannot be undone. This permanently deletes your One account, your encrypted vault and saved details, every connected service, and your cloud-linked identity."
After: "This can't be undone — it deletes your account, private data, and every connected service."

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run __tests__/app/profile/security-delete-contract.test.ts` — added a new assertion locking in the shorter copy and the absence of "vault"; the file's 2 pre-existing failures (unrelated stale string assertions) are unchanged
- [x] `npx vitest run` (full suite) — 30 failed / 4571 passed, same as this branch's baseline; all 30 failures are in files untouched by this PR (WebCrypto/environment skew, unrelated layout contracts)