### PR TITLE
feat(one-location): simplify People and Create Circle screens

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -826,7 +826,7 @@ async function openLocationPermissionsStep() {
 }
 
 async function switchLocationTab(
-  name: "Menu" | "People" | "Links",
+  name: "Home" | "People" | "Links",
   expectedHeading: string,
 ) {
   fireEvent.click(screen.getByRole("button", { name }));
@@ -1926,7 +1926,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     fireEvent.change(
-      await screen.findByPlaceholderText("Search trusted people"),
+      await screen.findByPlaceholderText("Search people"),
       { target: { value: "Investor" } },
     );
     fireEvent.click(
@@ -2003,9 +2003,9 @@ describe("OneLocationAgentPage", () => {
     ).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(
-      await screen.findByPlaceholderText("Search trusted people"),
+      await screen.findByPlaceholderText("Search people"),
     ).toHaveValue("Investor");
-    fireEvent.click(screen.getByRole("button", { name: "Menu" }));
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
     fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
@@ -3161,7 +3161,7 @@ describe("OneLocationAgentPage", () => {
     );
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Menu" }));
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
     expect(screen.getByRole("button", { name: /Active shares/i })).toBeTruthy();
     await openSharePersonStep();
     fireEvent.change(screen.getByPlaceholderText("Search trusted people"), {
@@ -3231,7 +3231,7 @@ describe("OneLocationAgentPage", () => {
     // empty state. Invite button assertions are covered by the empty-state test.
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(
-      await screen.findByPlaceholderText("Search trusted people"),
+      await screen.findByPlaceholderText("Search people"),
     ).toBeTruthy();
     expect(
       screen.queryByRole("heading", { name: "Pending invites" }),
@@ -4877,9 +4877,9 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
+    await switchLocationTab("People", "Your circles");
 
-    const search = await screen.findByPlaceholderText("Search trusted people");
+    const search = await screen.findByPlaceholderText("Search people");
     const person = await screen.findByText("Trusted B");
     expect(screen.getByTestId("one-location-people-list")).toHaveClass(
       "max-h-[50vh]",
@@ -4949,10 +4949,10 @@ describe("OneLocationAgentPage", () => {
       render(<OneLocationAgentPage />);
       await skipLocationEntryFlow();
       await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-      await switchLocationTab("People", "Circles");
+      await switchLocationTab("People", "Your circles");
 
       const addPeople = screen.getByRole("button", { name: /Add people/i });
-      const search = await screen.findByPlaceholderText("Search trusted people");
+      const search = await screen.findByPlaceholderText("Search people");
       const syncContacts = screen.getByRole("button", {
         name: /Find contacts/i,
       });
@@ -4975,19 +4975,19 @@ describe("OneLocationAgentPage", () => {
     }
   });
 
-  it("offers New circle and Join with code beside the circles heading", async () => {
+  it("offers Create circle and Join with code beside the circles heading", async () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
+    await switchLocationTab("People", "Your circles");
 
     const section = screen.getByTestId("one-location-named-circles");
     const heading = within(section).getByRole("heading", {
-      name: "Circles",
+      name: "Your circles",
     });
     const create = within(section).getByRole("button", {
-      name: /^New circle$/i,
+      name: /^Create circle$/i,
     });
     const join = within(section).getByRole("button", {
       name: /Join with code/i,
@@ -5105,7 +5105,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
+    await switchLocationTab("People", "Your circles");
     // Empty state keeps connection management and invite/sync/share actions.
     // Request-location affordances are populated-state-only, and the redundant
     // approval explainer must not add another card below these actions.

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -84,9 +84,9 @@ describe("One Location — link durations stay inside the server's ceiling", () 
 describe("One Location — hub tab naming", () => {
   const locationTabs = TOP_SHELL_TAB_REGISTRY.location;
 
-  it("labels the first tab Menu while keeping its `now` query value", () => {
+  it("labels the first tab Home while keeping its `now` query value", () => {
     const first = locationTabs.tabs[0];
-    expect(first.label).toBe("Menu");
+    expect(first.label).toBe("Home");
     // The value is the deep-link contract (`?view=now`, Kai's
     // `location.open_now`). Renaming the label must not move it.
     expect(first.value).toBe("now");

--- a/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
@@ -61,7 +61,7 @@ describe("the circle row's second line", () => {
     // `memberCount` includes the viewer, so a circle of one is a circle with
     // nobody else in it yet -- the exact row in the report.
     renderCircles([circle({ memberCount: 1 })]);
-    expect(screen.getByText("0 members")).toBeTruthy();
+    expect(screen.getByText("No members yet")).toBeTruthy();
   });
 
   it("never names the category the person did not choose", () => {
@@ -77,12 +77,12 @@ describe("the circle row's second line", () => {
     }
   });
 
-  it("still counts everyone but the viewer, and says member once", () => {
+  it("still counts everyone but the viewer, and says person once", () => {
     renderCircles([
       circle({ id: "c_two", name: "Two", memberCount: 2 }),
       circle({ id: "c_four", name: "Four", memberCount: 4 }),
     ]);
-    expect(screen.getByText("1 member")).toBeTruthy();
-    expect(screen.getByText("3 members")).toBeTruthy();
+    expect(screen.getByText("1 person")).toBeTruthy();
+    expect(screen.getByText("3 people")).toBeTruthy();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -98,7 +98,7 @@ describe("named Circle flows", () => {
 
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByPlaceholderText("e.g. Meena Family"), {
+    fireEvent.change(screen.getByPlaceholderText("e.g. Family"), {
       target: { value: "Meena Family" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Create circle" }));
@@ -117,7 +117,7 @@ describe("named Circle flows", () => {
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
 
     const create = screen.getByRole("button", { name: "Create circle" });
-    const input = screen.getByPlaceholderText("e.g. Meena Family");
+    const input = screen.getByPlaceholderText("e.g. Family");
 
     // Nothing typed: the button is genuinely blocked, and it is painted as a
     // neutral fill rather than a half-opacity accent that still reads as live.

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -86,7 +86,7 @@ const CIRCLES_EMPTY_STATE_WRAPPER =
 /**
  * A circle is a group of trusted people, so its glyph carries the PEOPLE role
  * rather than the accent used for things you can DO. The action controls that
- * sit alongside it (New circle, Join, Share, Add people) stay accent, which is
+ * sit alongside it (Create circle, Join, Share, Add people) stay accent, which is
  * what keeps "this is a group" and "this is a button" from looking alike.
  *
  * Glyph only. The wells this sits in ask for `--app-accent-soft`, a token that
@@ -128,7 +128,8 @@ function circleInitials(value: string): string {
  */
 function circleListMemberCountLabel(memberCount: number): string {
   const others = Math.max(0, memberCount - 1);
-  return `${others} ${others === 1 ? "member" : "members"}`;
+  if (others === 0) return "No members yet";
+  return `${others} ${others === 1 ? "person" : "people"}`;
 }
 
 function circleFlowErrorMessage(error: unknown, fallback: string): string {
@@ -224,7 +225,7 @@ export function CirclesSection({
     <div className="space-y-[14px]" data-testid="one-location-named-circles">
       <div className="flex items-baseline justify-between gap-4">
         <h2 className="text-[13px] font-normal leading-[17px] tracking-[-0.2px] text-[color:var(--app-section-label)]">
-          Circles
+          Your circles
         </h2>
 
         {/* The static phone reference omits Join, but it remains a shipped
@@ -239,7 +240,7 @@ export function CirclesSection({
             data-voice-control-id="one-location-action-create-circle"
             className="relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]"
           >
-            New circle
+            Create circle
           </Button>
           <Button
             type="button"
@@ -479,28 +480,28 @@ export function CreateCircleFlow({
 
   return (
     <div className="space-y-6" data-testid="one-location-create-circle-flow">
+      {/* No `eyebrow` — a single-screen flow does not need the route name
+          repeated above the title (location-header-system treats the
+          eyebrow as optional). */}
       <TaskFlowHeader
-        eyebrow="People"
         title="Create a circle"
-        description="Name the group."
+        description="A private group for people you trust."
       />
 
       <label className="block space-y-2">
-        <span className="text-sm font-semibold text-foreground">
-          Circle name
-        </span>
+        <span className="text-sm font-semibold text-foreground">Name</span>
         <input
           value={name}
           onChange={(event) => setName(event.target.value)}
           maxLength={80}
           autoComplete="off"
           spellCheck
-          placeholder="e.g. Meena Family"
-          className="h-12 w-full rounded-2xl border border-border bg-[color:var(--app-card-surface-default-solid)] px-4 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+          placeholder="e.g. Family"
+          className="h-14 w-full rounded-2xl border border-border bg-[color:var(--app-card-surface-default-solid)] px-4 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
         />
       </label>
 
-      <SettingsGroup title="Circle type" separatorInset>
+      <SettingsGroup title="Who is it for?" separatorInset>
         {CIRCLE_KIND_OPTIONS.map((option) => (
           <SettingsRow
             key={option.value}
@@ -514,7 +515,6 @@ export function CreateCircleFlow({
             icon={UsersRound}
             iconTone={option.value === "family" ? "purple" : "blue"}
             title={option.label}
-            description={option.description}
             trailing={
               kind === option.value ? (
                 <Check className="h-5 w-5 text-[color:var(--app-accent)]" />
@@ -526,10 +526,13 @@ export function CreateCircleFlow({
         ))}
       </SettingsGroup>
 
-      <TrustNoteCard
-        title="Connected, still private"
-        description="Members connect. Sharing stays explicit."
-      />
+      <p className="flex items-center gap-1.5 text-[14px] leading-4 text-[color:var(--app-secondary-label)]">
+        <ShieldCheck
+          className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400"
+          aria-hidden="true"
+        />
+        Sharing starts only when you choose.
+      </p>
 
       <Button
         type="button"
@@ -537,7 +540,7 @@ export function CreateCircleFlow({
         isLoading={busy}
         onClick={() => void submit()}
         className={cn(
-          "h-12 w-full rounded-full text-base font-semibold",
+          "h-[54px] w-full rounded-full text-base font-semibold",
           BLOCKED_CTA,
         )}
       >

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1251,16 +1251,28 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   /* ----------------------------------------------------------------- */
   return (
     <div className="space-y-4 sm:space-y-5">
-      <PageHeader
-        title="Location Agent"
-        icon={MapPin}
-        accent="location"
-        titleRole="agent"
-        // No `description` — the switch and its status render together as
-        // one group inside `actions`. See LocationHeaderActions.
-        actionsInlineMobile
-        actions={<LocationHeaderActions vm={vm} />}
-      />
+      {tab === "people" ? (
+        // The People tab gets its own plain title instead of the Location
+        // toggle header: the switch already lives on the Home tab, and
+        // repeating it here read as two Location controls on the same
+        // screen. Still the same `PageHeader` (keeps the shared collapsing
+        // top-bar title behavior), just without the icon/accent/actions.
+        <PageHeader
+          title="People you trust"
+          description="Choose who can see your location."
+        />
+      ) : (
+        <PageHeader
+          title="Location Agent"
+          icon={MapPin}
+          accent="location"
+          titleRole="agent"
+          // No `description` — the switch and its status render together as
+          // one group inside `actions`. See LocationHeaderActions.
+          actionsInlineMobile
+          actions={<LocationHeaderActions vm={vm} />}
+        />
+      )}
 
       {/*
         Directly under the header, above the tabs, because a blocked permission
@@ -2096,6 +2108,7 @@ function PeopleHub({
 }) {
   const hasSearch = vm.recipientSearch.trim().length > 0;
   const filtered = vm.visibleRecipients;
+  const hasAnyRecipients = vm.recipients.length > 0;
   const isDesktopPeopleLayout = useMediaQuery("(min-width: 640px)");
   const addPeopleAction = (
     <Button
@@ -2162,7 +2175,7 @@ function PeopleHub({
               id="one-location-connections-heading"
               className="col-start-1 row-start-1 text-[13px] font-normal leading-[18px] tracking-[-0.2px] text-[color:var(--app-section-label)]"
             >
-              Connections
+              Trusted people
             </h2>
 
             {isDesktopPeopleLayout ? (
@@ -2194,20 +2207,23 @@ function PeopleHub({
                 : syncContactsAction}
             </div>
 
-            <div
-              className={cn(
-                "col-span-3 row-start-2 mt-3 sm:col-span-4 sm:mt-3.5",
-                "[&_input]:h-[46px] [&_input]:rounded-full [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[17px] [&_input]:leading-[22px] [&_input]:tracking-[-0.3px]",
-                "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
-                "sm:[&_input]:h-12 sm:[&_input]:rounded-[var(--app-radius-md)] sm:[&_input]:pl-12 sm:[&_input]:pr-5 sm:[&_input]:text-base sm:[&_svg]:left-5",
-              )}
-              data-testid="one-location-people-search"
-            >
-              <PersonSearchInput
-                value={vm.recipientSearch}
-                onChange={vm.setRecipientSearch}
-              />
-            </div>
+            {hasAnyRecipients ? (
+              <div
+                className={cn(
+                  "col-span-3 row-start-2 mt-3 sm:col-span-4 sm:mt-3.5",
+                  "[&_input]:h-[46px] [&_input]:rounded-full [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[17px] [&_input]:leading-[22px] [&_input]:tracking-[-0.3px]",
+                  "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
+                  "sm:[&_input]:h-12 sm:[&_input]:rounded-[var(--app-radius-md)] sm:[&_input]:pl-12 sm:[&_input]:pr-5 sm:[&_input]:text-base sm:[&_svg]:left-5",
+                )}
+                data-testid="one-location-people-search"
+              >
+                <PersonSearchInput
+                  value={vm.recipientSearch}
+                  onChange={vm.setRecipientSearch}
+                  placeholder="Search people"
+                />
+              </div>
+            ) : null}
 
             <div className="col-span-3 row-start-3 mt-3 sm:col-span-4 sm:mt-3.5">
               {filtered.length ? (
@@ -2274,12 +2290,12 @@ function PeopleHub({
                 <div className="[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]">
                   <EmptyState
                     title={
-                      hasSearch ? "No matching people" : "No connections yet"
+                      hasSearch ? "No matching people" : "No people added"
                     }
                     description={
                       hasSearch
                         ? "Try a different name."
-                        : "Invite someone to start sharing."
+                        : "Add family or friends to start sharing."
                     }
                   />
                 </div>

--- a/hushh-webapp/e2e/one-location-tab-strip.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-tab-strip.layout.spec.ts
@@ -145,7 +145,7 @@ async function buildFixture(): Promise<string> {
       <div style="position:relative;width:100%;flex-shrink:0">
         <div class="flex h-14 w-full items-center justify-center">
           <div data-testid="tablist" role="tablist" class="${TABLIST_CLASS}">
-            <button class="flex h-full flex-1 items-center justify-center px-3">Menu</button>
+            <button class="flex h-full flex-1 items-center justify-center px-3">Home</button>
             <button class="flex h-full flex-1 items-center justify-center px-3">People</button>
             <button class="flex h-full flex-1 items-center justify-center px-3">Links</button>
           </div>

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -64,6 +64,10 @@ function oneLocationActionLabel(action: string): string {
     "temp-link": "Public link",
     "check-in": "Check-In",
     "private-check-in": "Private Check-In",
+    // Matches the flow's own `TaskFlowHeader title` so the crumb and the
+    // on-screen title read as the same place — otherwise it fell back to
+    // `titleizeSegment` ("Create Circle"), which disagreed with the screen.
+    "create-circle": "Create a circle",
     "active-shares": "Active shares",
     "shared-with-me": "Shared with me",
     "needs-review": "Needs my review",

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -85,12 +85,12 @@ export const TOP_SHELL_TAB_REGISTRY = {
     queryParam: "view",
     defaultValue: "now",
     tabs: [
-      // Labelled "Menu", not "Now". Nothing on this tab is time-scoped — it
+      // Labelled "Home", not "Now". Nothing on this tab is time-scoped — it
       // holds Share location, Your Map, Settings and the rest of the action
       // list, so "Now" promised live status the tab never showed. The `value`
       // stays "now" so existing `?view=now` links and Kai's
       // `location.open_now` action keep resolving.
-      { value: "now", label: "Menu", href: "/one/location" },
+      { value: "now", label: "Home", href: "/one/location" },
       {
         value: "people",
         label: "People",


### PR DESCRIPTION
## Summary
- People tab: drops the duplicate "Location Agent" heading + toggle (already on Home), renames sections to plain copy ("Your circles", "Trusted people"), hides the search box until people exist, and simplifies empty-state/member-count copy.
- Create Circle: drops the eyebrow and per-option descriptions, renames "Circle name" -> "Name" and "Circle type" -> "Who is it for?", replaces the two-line privacy card with one quiet line, and bumps the name field / submit button to the 56px/54px minimum touch targets.
- Fixes a pre-existing breadcrumb/title mismatch on the Create Circle flow (crumb fell back to a titleized slug that disagreed with the on-screen title).
- Copy, visibility and spacing only — no route, handler, validation, permission, or backend changes. All existing click handlers, data and analytics IDs are untouched.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all 9 changed files — clean
- [x] `npx vitest run` on every test file that imports these components (named-circle-flows, circles-section-subtitle, one-location-copy-pass contract, one-location-agent-page, top-shell-tabs/-breadcrumbs, top-app-bar, and 12 other coupled contract/navigation suites) — 220+ tests passing; the only 2 non-pre-existing-unrelated failures were a 5s timeout on two polling tests that pass cleanly with more headroom (confirmed unrelated to this diff)
- [x] `npm run build` — Turbopack/webpack compile succeeds; page-data collection fails only on unrelated `/api/*` routes needing real Firebase/backend credentials this worktree doesn't have (pre-existing environment gap, not a code issue)
- [ ] Live visual check at 390×844 — blocked in this sandboxed worktree by the app's route-governance layer (an ad-hoc preview route 404'd) and missing real auth credentials; recommend a quick manual look on UAT after deploy