### PR TITLE
fix(one-location): fix circle member-count consistency and voice-context drift

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -532,7 +532,7 @@ const LOCATION_HUB_TAB_LABELS: Readonly<Record<string, string>> = {
 
 const LOCATION_TAB_MODULES: Readonly<Record<string, string[]>> = {
   now: ["Sharing status", "Active shares", "Shared with me", "Quick actions"],
-  people: ["Circles", "Connections"],
+  people: ["Your circles", "Trusted people"],
   links: ["Temporary links"],
 };
 

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -45,6 +45,7 @@ import {
   type CircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
 import { CircleGrowActions } from "@/components/one-location/redesign/circles/circle-grow-actions";
+import { circleListMemberCountLabel } from "@/components/one-location/redesign/circles/named-circle-flows";
 
 import { TaskFlowHeader } from "./primitives";
 import type { LocationHubViewModel } from "./location-redesign-hub";
@@ -658,7 +659,7 @@ export function CheckInFlow({
                   <span className="block text-[15px] leading-5 text-muted-foreground">
                     {selected
                       ? `${circleSelection.ready.length} ready now`
-                      : `${circle.memberCount} members`}
+                      : circleListMemberCountLabel(circle.memberCount)}
                   </span>
                 </span>
                 <span className="text-[13px] font-semibold leading-[18px] text-[color:var(--app-accent)]">

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -126,10 +126,14 @@ function circleInitials(value: string): string {
  * There are three kinds and nothing on this screen acts on any of them, so
  * the word was decoration in front of the fact. The count stands alone.
  */
-function circleListMemberCountLabel(memberCount: number): string {
-  const others = Math.max(0, memberCount - 1);
-  if (others === 0) return "No members yet";
+/** Wording for a member count that has already excluded the viewer. */
+export function othersCountLabel(others: number): string {
+  if (others <= 0) return "No members yet";
   return `${others} ${others === 1 ? "person" : "people"}`;
+}
+
+export function circleListMemberCountLabel(memberCount: number): string {
+  return othersCountLabel(Math.max(0, memberCount - 1));
 }
 
 function circleFlowErrorMessage(error: unknown, fallback: string): string {
@@ -1184,9 +1188,7 @@ export function CircleDetailFlow({
             ? // Same line as the list row this screen was opened from, so the
               // count does not change wording between the two. The kind is
               // dropped here for the same reason it is dropped there.
-              `${externalMembersCount} ${
-                externalMembersCount === 1 ? "member" : "members"
-              }`
+              othersCountLabel(externalMembersCount)
             : "Loading Circle…"
         }
       />

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -137,6 +137,7 @@ import { usePageEnterAnimation } from "@/lib/morphy-ux/hooks/use-page-enter";
 import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
   CircleDetailFlow,
+  circleListMemberCountLabel,
   CirclesSection,
   CreateCircleFlow,
   JoinCircleFlow,
@@ -2310,10 +2311,12 @@ function PeopleHub({
                 <div className="[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]">
                   <EmptyState
                     title={
-                      hasSearch ? "No matching people" : "No people added"
+                      hasSearch && hasAnyRecipients
+                        ? "No matching people"
+                        : "No people added"
                     }
                     description={
-                      hasSearch
+                      hasSearch && hasAnyRecipients
                         ? "Try a different name."
                         : "Add family or friends to start sharing."
                     }
@@ -3081,9 +3084,7 @@ function ShareFlow({
                     ? "Loading…"
                     : selected
                       ? `${selectedReady.length} ready now`
-                      : `${circle.memberCount} ${
-                          circle.memberCount === 1 ? "member" : "members"
-                        }`
+                      : circleListMemberCountLabel(circle.memberCount)
                 }
                 trailing={<SelectionDot selected={selected} />}
               />


### PR DESCRIPTION
## Summary
Fast-follow from an independent adversarial review of #5489 (already merged/deployed), run right after it shipped.

- Extracted the People tab's "No members yet" / "1 person" / "N people" wording into an exported `othersCountLabel`/`circleListMemberCountLabel` pair and reused it in two other places that still showed the same circle's member count with the old "0 members"/"1 member"/"N members" wording — and, in the Share-flow circle picker, a different *number* entirely (raw total including the viewer, instead of others-only): Share location's circle picker and Check-In's circle list. (A third site, SMS Contacts' circle row, was rewritten into a per-member picker by unrelated concurrent work merged in the meantime and no longer shows a bare member count — nothing to fix there anymore.)
- Fixed `LOCATION_TAB_MODULES.people`, the internal list of section names fed to One's voice/agent screen-context builder: it still said `["Circles", "Connections"]` after #5489 renamed those on-screen headings to "Your circles" / "Trusted people", so the agent's understanding of the screen had silently drifted from what the user actually sees.
- Fixed the People tab's empty-state copy to key off both `hasSearch` AND `hasAnyRecipients`: previously, typing a search then losing every recipient (the search box disappears once the list is empty) could strand the screen on "No matching people" with no visible field to explain what was being matched.

No routes, handlers, or data changed — member-count wording and one internal metadata table only.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all 4 changed files — clean
- [x] `npx vitest run` — 205 tests passing across every touched/coupled suite (one-location-agent-page, copy-pass contract, named-circle-flows, circles-section-subtitle, check-in-flow, top-shell-breadcrumbs, location-flow-labels, sos-emergency contract, top-shell-tabs)