### PR TITLE
fix(onboarding): put the shush mark back, and stop the welcome stretching

### DIFF
--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -117,6 +117,25 @@ describe("IntroStep welcome clarity", () => {
     expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 
+  it("keeps the quiet mark with the wordmark, as one brand lockup", () => {
+    render(<IntroStep onLogin={vi.fn()} />);
+
+    // The shush IS the brand — "hushh" is the word for it. It went missing in
+    // the first simplification pass and that is the regression this guards.
+    const quietMark = screen.getByText("🤫");
+    const wordmark = screen.getByText("hussh");
+    const one = screen.getByRole("heading", { name: "One" });
+
+    expect(wordmark.compareDocumentPosition(quietMark)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(quietMark.compareDocumentPosition(one)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    // Decorative twin of the wordmark: it must not be announced twice.
+    expect(quietMark).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("carries no marketing text ahead of the decision", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
@@ -129,7 +148,6 @@ describe("IntroStep welcome clarity", () => {
       /Acts/i,
       /stays locked/i,
       /Nothing moves without/i,
-      /🤫/,
     ]) {
       expect(screen.queryByText(removed)).toBeNull();
     }

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -31,6 +31,8 @@
   min-block-size: calc(100svh - var(--app-scroll-bottom-pad, 0px));
   width: 100%;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
 }
 
@@ -49,7 +51,15 @@
   position: relative;
   z-index: 10;
   display: grid;
-  block-size: calc(100svh - var(--app-scroll-bottom-pad, 0px));
+  /* A phone is ~844px tall; a laptop is not. Without a ceiling the `1fr`
+     middle row turned every extra pixel of a desktop viewport into empty
+     space above and below One, which read as a broken page rather than a
+     calm one. 760px is exactly what a 390x844 phone already gives this
+     screen (844 minus the 84px the scroll root reserves), so the cap is a
+     no-op on a phone and only stops a laptop from stretching it. */
+  max-block-size: 760px;
+  align-self: center;
+  block-size: 100%;
   min-height: 0;
   width: 100%;
   max-width: 34rem;
@@ -66,9 +76,18 @@
 
 .brand {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 10px;
   animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+
+/* Small on purpose. At the 48px it used to be it competed with One for the
+   eye; at 26px it reads as the brand's own mark sitting under its wordmark. */
+.quietMark {
+  font-size: 26px;
+  line-height: 1;
 }
 
 .wordmark {

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -87,9 +87,15 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
       <OnboardingHeroBackground variant="plain" />
 
       <div className={styles.stage}>
-        {/* One centered brand anchor. */}
+        {/* One centered brand anchor. The quiet mark is part of the brand,
+            not decoration: "hushh" IS the shush. It sits with the wordmark as
+            a single lockup rather than floating alone above One, so the brand
+            reads as one thing and One stays the only bold element. */}
         <div className={styles.brand}>
           <HushhWordmark className={styles.wordmark} />
+          <span aria-hidden className={styles.quietMark}>
+            🤫
+          </span>
         </div>
 
         {/* ── The single message: the name, then what it does. ── */}

--- a/hushh-webapp/e2e/one-intro-welcome.layout.spec.ts
+++ b/hushh-webapp/e2e/one-intro-welcome.layout.spec.ts
@@ -116,7 +116,7 @@ function welcomeMarkup(): string {
       >
         <main class="shell">
           <div class="stage">
-            <div class="brand"><span class="wordmark" data-wordmark>hussh</span></div>
+            <div class="brand"><span class="wordmark" data-wordmark>hussh</span><span aria-hidden class="quietMark" data-quiet-mark>&#129323;</span></div>
 
             <div class="hero">
               <h1 class="title"><span class="oneMark">One</span></h1>
@@ -237,6 +237,7 @@ for (const phone of PHONES) {
 
       const parts = {
         wordmark: page.locator("[data-wordmark]"),
+        quietMark: page.locator("[data-quiet-mark]"),
         one: page.getByRole("heading", { name: "One" }),
         supporting: page.getByText(
           "Your personal assistant for everyday tasks.",


### PR DESCRIPTION
Closes #5492

## The mark should not have gone

The shush is the hushh brand — "hushh" is the word for it. The simplification pass removed it along with the marketing copy, and that was the wrong call: the eyebrow, the punchline and the four motions were text a person reads *instead of* deciding, but the mark is identity.

It returns as a lockup with the wordmark rather than floating alone above `One` at 48px, where it competed with `One` for the eye. At 26px under the wordmark the brand reads as one thing, and `One` stays the single bold element.

## The screen was stretching

`.stage` sized itself to the viewport and gave its middle row `1fr`, so every extra pixel of a laptop viewport turned into empty space above and below `One` — two large voids that read as a broken page rather than a calm one.

It now caps at **760px** and centres in what's left. That number is exactly what a 390×844 phone already gives this screen (844 minus the 84px the scroll root reserves for the Agent Bar), so the cap is a **no-op on a phone** and only stops a desktop from spreading.

Measured gap above `One`:

| viewport | before | after |
|---|---|---|
| 390×844 (phone) | 166px | 166px — unchanged |
| 1440×900 | 194px | 164px |
| 1512×1200 | grew with height | 164px |

## Guarded so it can't vanish again

That's the actual point of this PR — the mark disappeared silently once and nothing caught it.

- Unit test: the mark sits between the wordmark and `One`, and stays `aria-hidden` so it isn't announced twice alongside the wordmark.
- Layout contract: it's measured as part of the composition at 375/390/430 on Chromium and WebKit.
- **Mutation-checked** — deleting the mark turns the unit test red.

## Results

- `tsc --noEmit` clean
- `eslint --max-warnings=0` clean
- Layout contracts: **198 passed** chromium, **168 passed** webkit
- No scrolling at 390×844, 375×667, 1440×900 or 1512×1200

Frontend only. No backend, API, database, auth, route or analytics change. Handler, action id `onboarding.claim_one`, control id and `/login` destination all untouched.