### PR TITLE
fix(auth): cut repeated copy on the phone verification screen

### DIFF
--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -369,7 +369,7 @@ export function PhoneMandatePageContent() {
             Verify your phone number
           </h1>
           <p className="mx-auto mt-1.5 max-w-[20rem] text-[15px] leading-[1.4] text-[rgba(23,19,12,0.6)] dark:text-[rgba(250,246,238,0.62)]">
-            Add your phone number to continue.
+            We’ll text you a code.
           </p>
         </div>
 

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -1073,10 +1073,11 @@ export function PhoneVerificationFlow({
             </Field>
           </FieldGroup>
 
-          <FieldDescription className="type-callout text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]">
-            {helperText ||
-              "Choose your country code and enter your phone number. We’ll send you a verification code."}
-          </FieldDescription>
+          {helperText ? (
+            <FieldDescription className="type-callout text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]">
+              {helperText}
+            </FieldDescription>
+          ) : null}
           <div className="grid gap-3">
             <Button
               type="submit"


### PR DESCRIPTION
## Summary
- The register-phone screen said the same thing three times: title ("Verify your phone number"), subtitle ("Add your phone number to continue"), and a form helper line ("Choose your country code and enter your phone number...") that just repeated the two field labels above it.
- Subtitle now tells the user what happens next instead of repeating the title: "We'll text you a code."
- Removed the redundant helper line's default text. Profile's phone-add/replace flows are unaffected — they always pass their own explicit `helperText` prop.

## Copy change
| Element | Before | After |
|---|---|---|
| Subtitle | "Add your phone number to continue." | "We'll text you a code." |
| Form helper (default, register-phone only) | "Choose your country code and enter your phone number. We'll send you a verification code." | *(removed — redundant with field labels + subtitle)* |

No backend, route, handler, or state logic changed — text and one conditional render only.

## Test plan
- [x] `vitest run` on the 5 register-phone / phone-verification-flow test files — 31/31 pass
- [x] `eslint` on both changed files — clean
- [x] `tsc --noEmit` — clean
- [x] `npm run verify:design-system` (design-system + accent tokens + Apple hierarchy guards) — pass