### PR TITLE
fix(ci): cache Playwright browsers so Web Targeted Contracts can finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,13 @@ jobs:
     needs: [preflight-gate]
     if: needs.preflight-gate.outputs.frontend == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Was 15, which the job could not fit. Downloading Chromium and WebKit
+    # took 13-15 minutes on its own, so the lane either died mid-download or
+    # reached the checks with ~100 seconds left and was cancelled part-way
+    # through them. Both outcomes report as "cancelled", which reads like
+    # infrastructure noise rather than a budget that was never large enough.
+    # 30 leaves room for a cold cache; a warm one finishes far inside it.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -326,6 +332,16 @@ jobs:
           cache: "npm"
           cache-dependency-path: hushh-webapp/package-lock.json
 
+      # The browsers are the whole cost of this lane, and they only change when
+      # the Playwright dependency does. Keying on the lockfile means a normal
+      # PR restores them instead of re-downloading ~400MB per run.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('hushh-webapp/package-lock.json') }}
+
       # The layout-contract pack drives real Chromium and WebKit. WebKit is not
       # optional: it is the engine iOS ships, and a native <select> there
       # ignores an author border-radius that Chromium honours, so a
@@ -334,7 +350,15 @@ jobs:
         run: |
           set -euo pipefail
           npm ci --prefix hushh-webapp
-          (cd hushh-webapp && npx playwright install --with-deps chromium webkit)
+          # `--with-deps` installs the browsers AND the apt libraries they link
+          # against. The apt half is not covered by the cache (it writes outside
+          # ~/.cache/ms-playwright), so on a cache hit install only the system
+          # deps and let the restored browser binaries stand.
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            (cd hushh-webapp && npx playwright install-deps chromium webkit)
+          else
+            (cd hushh-webapp && npx playwright install --with-deps chromium webkit)
+          fi
 
       - name: Run targeted web contract checks
         run: bash scripts/ci/orchestrate.sh web-targeted


### PR DESCRIPTION
## This lane cannot pass, and "cancelled" hides why

`Web Targeted Contracts` was cancelled **four times today across four different branches** — `fix/intro-welcome-simplify`, `fix/location-hub-simplify`, `fix/auth-welcome-clarity`, `feat/circle-capacity-100-and-contact-picker`. It reports as `cancelled`, which reads like runner flakiness. It isn't. The budget was never large enough to hold the work.

Two consecutive runs of the same commit, from the job's own step timings:

```
cancelled: Install Playwright browsers        [18:10:23 -> 18:25:25]   15m02s, killed mid-download
success:   Install Playwright browsers        [18:26:45 -> 18:39:59]   13m14s
cancelled: Run targeted web contract checks   [18:39:59 -> 18:41:39]   100s, killed mid-run
```

Downloading Chromium **and** WebKit with their system libraries costs 13–15 minutes against a `timeout-minutes: 15` ceiling. So the lane either dies during the download, or reaches the checks with a minute or two left and is cancelled part-way through them. Nothing is wrong with the tests — they never get to run. Locally the same pack passes 198 chromium / 168 webkit in ~97 seconds.

Every PR touching `e2e/*.layout.spec.ts`, `playwright.config.ts`, `app/globals.css` or the guarded component directories pays that coin flip, and a lost flip costs ~15 minutes.

## The fix

Scoped to this one job — it is the only lane in the workflow that installs browsers (`grep -n "playwright install" .github/workflows/ci.yml` returns this job alone).

1. **Cache `~/.cache/ms-playwright`**, keyed on `hushh-webapp/package-lock.json`. The browsers only change when the Playwright dependency does, so a normal PR restores ~400MB instead of re-downloading it.
2. **`timeout-minutes: 15` → `30`**, so a cold cache still completes. A warm one finishes far inside it.

On a cache hit the step runs `playwright install-deps` instead of `install --with-deps`. That distinction matters: `--with-deps` installs the browsers *and* the apt libraries they link against, and the apt half writes outside `~/.cache/ms-playwright` so the cache never restores it. On a hit we still install the system deps and let the cached binaries stand.

## Blast radius

One job in one workflow. No test, no application code, no deploy config, no secret, no IAM. It cannot change what the checks assert — only whether they get the time to assert it.