### PR TITLE
fix(one-location): clarify optional entrance fields, drop redundant caption

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -1424,7 +1424,6 @@ describe("SaveLocationModal", () => {
       const kindOfPlace = screen.getByRole("group", {
         name: "Saved location category",
       });
-      const optionalGroup = screen.getByText("Optional — helps at the door.");
       const houseOrFlat = screen.getByLabelText(/House or flat/);
       const doorDetails = screen.getByTestId(
         "save-location-door-details-toggle",
@@ -1432,10 +1431,28 @@ describe("SaveLocationModal", () => {
       const buildingColour = screen.getByLabelText(/Building colour/);
 
       expect(isBefore(address, kindOfPlace)).toBe(true);
-      expect(isBefore(kindOfPlace, optionalGroup)).toBe(true);
-      expect(isBefore(optionalGroup, houseOrFlat)).toBe(true);
+      expect(isBefore(kindOfPlace, houseOrFlat)).toBe(true);
       expect(isBefore(houseOrFlat, doorDetails)).toBe(true);
       expect(isBefore(doorDetails, buildingColour)).toBe(true);
+    });
+
+    it("marks House/flat and PIN as optional right beside each field's own label", () => {
+      render(<SaveLocationModal {...detailsProps} />);
+
+      const houseOrFlatLabel = screen.getByText("House or flat");
+      const postalCodeLabel = screen.getByText("PIN / postcode");
+      const optionalBadges = screen.getAllByText("Optional");
+      expect(optionalBadges).toHaveLength(2);
+
+      // Each badge is a sibling of its own field's label -- the same row
+      // Address uses for "Required" -- not one sentence above the whole group
+      // that a person can scroll past before reaching the fields it described.
+      expect(houseOrFlatLabel.parentElement).toContainElement(
+        optionalBadges[0],
+      );
+      expect(postalCodeLabel.parentElement).toContainElement(
+        optionalBadges[1],
+      );
     });
 
     it("keeps building colour behind a tap for a new place", () => {

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -33,6 +33,7 @@ import {
 import {
   ADDRESS_LABEL_ROW_CLASSNAME,
   DOOR_DETAILS_TOGGLE_CLASSNAME,
+  OPTIONAL_BADGE_CLASSNAME,
   REQUIRED_BADGE_CLASSNAME,
   SHEET_BODY_CLASSNAME,
   SHEET_DETAILS_SHELL_CLASSNAME,
@@ -1255,19 +1256,23 @@ export function SaveLocationModal({
               </label>
 
               <div className="space-y-3.5">
-                {/* Said once, for the group, instead of an "(optional)" tag
-                    hanging off every label. */}
-                <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
-                  Optional — helps at the door.
-                </p>
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <div>
-                    <label
-                      htmlFor="saved-location-house-or-flat"
-                      className={controlLabelClassName}
-                    >
-                      House or flat
-                    </label>
+                    {/* A badge on the field itself, the same place Address
+                        carries "Required" -- a box shaped exactly like the
+                        required Address box above it reads as required no
+                        matter what a sentence higher up the screen said. */}
+                    <div className={ADDRESS_LABEL_ROW_CLASSNAME}>
+                      <label
+                        htmlFor="saved-location-house-or-flat"
+                        className={cn(controlLabelClassName, "mb-0")}
+                      >
+                        House or flat
+                      </label>
+                      <span aria-hidden className={OPTIONAL_BADGE_CLASSNAME}>
+                        Optional
+                      </span>
+                    </div>
                     <input
                       id="saved-location-house-or-flat"
                       type="text"
@@ -1283,12 +1288,17 @@ export function SaveLocationModal({
                     />
                   </div>
                   <div>
-                    <label
-                      htmlFor="saved-location-postal-code"
-                      className={controlLabelClassName}
-                    >
-                      PIN / postcode
-                    </label>
+                    <div className={ADDRESS_LABEL_ROW_CLASSNAME}>
+                      <label
+                        htmlFor="saved-location-postal-code"
+                        className={cn(controlLabelClassName, "mb-0")}
+                      >
+                        PIN / postcode
+                      </label>
+                      <span aria-hidden className={OPTIONAL_BADGE_CLASSNAME}>
+                        Optional
+                      </span>
+                    </div>
                     <input
                       id="saved-location-postal-code"
                       type="text"
@@ -1410,13 +1420,15 @@ export function SaveLocationModal({
                 </div>
               </div>
 
-              {/* A caption, not a card. It reassures; it is not a control, and
-                  the panel it used to sit in gave it a control's weight. */}
-              <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
-                {deferredUntilVault
-                  ? "Saves once your lock is set."
-                  : "Private to you."}
-              </p>
+              {/* Only shown pre-vault, where it is new information: the save
+                  is deferred. Once a vault exists the place saves right away,
+                  and "private to you" was already said on the summary pane --
+                  repeating it here answered a question nobody was asking. */}
+              {deferredUntilVault ? (
+                <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
+                  Saves once your lock is set.
+                </p>
+              ) : null}
             </div>
 
             <div className={SHEET_FOOTER_CLASSNAME}>

--- a/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
@@ -106,12 +106,30 @@ export const REQUIRED_BADGE_CLASSNAME =
   "shrink-0 rounded-full bg-[color:var(--app-destructive)]/12 px-1.5 py-px text-[11px] font-semibold uppercase leading-[16px] tracking-[0.02em] text-[color:var(--app-destructive)]";
 
 /**
+ * The Optional counterpart of the Required badge above, on House/flat and
+ * PIN. A single sentence once said this for the whole group below it, but a
+ * field styled exactly like the required Address box above it reads as
+ * required regardless of a caption a screen above -- people go by the shape
+ * of the box, not by a sentence they have already scrolled past. Outlined
+ * rather than filled, so it is legible as the calmer sibling of the solid red
+ * Required pill rather than an equally loud claim.
+ */
+export const OPTIONAL_BADGE_CLASSNAME =
+  "shrink-0 rounded-full border border-border/70 px-1.5 py-px text-[11px] font-semibold uppercase leading-[16px] tracking-[0.02em] text-muted-foreground";
+
+/**
  * The row that opens the optional door details. A control, so it owes the
  * platform's 44px minimum -- and `min-h-11` rather than a fixed height,
  * because its label wraps to two lines under a large text setting.
+ *
+ * Deliberately no border or filled background. Bordered and card-shaped is
+ * the same visual language this sheet uses for the Kind-of-place buttons and
+ * every text input on it -- things you select or fill in -- so this row read
+ * as one more of those rather than as a disclosure. Text plus a chevron is
+ * enough; `aria-expanded` and the rotating chevron already carry "opens more".
  */
 export const DOOR_DETAILS_TOGGLE_CLASSNAME =
-  "press-scale flex min-h-11 w-full items-center justify-between gap-2 rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] px-3.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.03] disabled:opacity-45";
+  "press-scale flex min-h-11 w-full items-center justify-between gap-2 rounded-[10px] px-1 text-left transition-colors hover:bg-foreground/[0.03] disabled:opacity-45";
 
 /** Widths the sheet has to hold its shape at, smallest phone upward. */
 export const SHEET_LAYOUT_WIDTHS = [320, 360, 375, 390, 430, 768] as const;

--- a/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
+++ b/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
@@ -9,6 +9,7 @@ import { awaitProductFont, productFontStyle } from "./fixtures/product-font";
 import {
   ADDRESS_LABEL_ROW_CLASSNAME,
   DOOR_DETAILS_TOGGLE_CLASSNAME,
+  OPTIONAL_BADGE_CLASSNAME,
   REQUIRED_BADGE_CLASSNAME,
   SHEET_BODY_CLASSNAME,
   SHEET_DETAILS_SHELL_CLASSNAME,
@@ -108,6 +109,7 @@ async function buildFixture(): Promise<string> {
     SHEET_FOOTER_CLASSNAME,
     ADDRESS_LABEL_ROW_CLASSNAME,
     REQUIRED_BADGE_CLASSNAME,
+    OPTIONAL_BADGE_CLASSNAME,
     DOOR_DETAILS_TOGGLE_CLASSNAME,
     row,
     button,
@@ -123,7 +125,7 @@ async function buildFixture(): Promise<string> {
     dotSmall,
     STEP_DOT_REACHED_CLASSNAME,
     STEP_DOT_UPCOMING_CLASSNAME,
-    "mt-1 space-y-3.5 mb-1.5 mb-0 block",
+    "mt-1 space-y-3.5 mb-1.5 mb-0 block grid grid-cols-1 gap-3 sm:grid-cols-2",
   ].join(" ");
   const css = compiler.build(classes.split(/\s+/).filter(Boolean));
 
@@ -143,10 +145,26 @@ async function buildFixture(): Promise<string> {
     `<span aria-hidden>v</span>` +
     `</button>`;
 
+  // House or flat / PIN sit side by side from 640px up (the desktop dialog
+  // width), so this is the one row on the sheet whose column narrows instead
+  // of just its own width shrinking -- the Optional badge has half the room
+  // the Required one does at the same viewport.
+  const optionalRow = (fieldTestId: string, fieldLabel: string) =>
+    `<div><div class="${ADDRESS_LABEL_ROW_CLASSNAME}">` +
+    `<label class="${label}" data-testid="${fieldTestId}-label">${fieldLabel}</label>` +
+    `<span class="${OPTIONAL_BADGE_CLASSNAME}" data-testid="${fieldTestId}-optional-badge">Optional</span>` +
+    `</div><input class="${field}" data-testid="sheet-field"></div>`;
+  const optionalFieldsGrid =
+    `<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">` +
+    optionalRow("house-or-flat", "House or flat") +
+    optionalRow("postal-code", "PIN / postcode") +
+    `</div>`;
+
   // Enough fields to overflow every width under test, so the body genuinely
   // has to scroll -- a footer only bleeds when there is something behind it.
   const fields =
     addressRow +
+    optionalFieldsGrid +
     Array.from(
       { length: 8 },
       (_, i) =>
@@ -313,6 +331,45 @@ test.describe("Save-location address sheet layout", () => {
       );
       expect(clipped).toEqual([]);
     });
+
+    for (const fieldTestId of ["house-or-flat", "postal-code"]) {
+      test(`keeps the Optional badge whole beside the ${fieldTestId} label at ${width}px`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width, height: 844 });
+        await page.goto(await buildFixture());
+        await awaitProductFont(page);
+
+        const body = await boxOf(page, "sheet-body");
+        const label = await boxOf(page, `${fieldTestId}-label`);
+        const badge = await boxOf(page, `${fieldTestId}-optional-badge`);
+
+        // House or flat and PIN sit in a two-column row from 640px up, so this
+        // is the one badge on the sheet with HALF the column width Required
+        // gets on the full-width Address row above it.
+        expect(
+          Math.abs(label.y + label.height / 2 - (badge.y + badge.height / 2)),
+        ).toBeLessThanOrEqual(1);
+        expect(Math.round(label.x + label.width)).toBeLessThanOrEqual(
+          Math.round(badge.x),
+        );
+        expect(Math.round(badge.x + badge.width)).toBeLessThanOrEqual(
+          Math.round(body.x + body.width),
+        );
+
+        // Neither word is clipped. This badge is the only reason the field
+        // does not read as mandatory next to the required Address box above
+        // it -- a clipped "Optiona…" gives back exactly the confusion it was
+        // added to remove.
+        const clipped = await page.evaluate((ids) =>
+          ids
+            .map((id) => document.querySelector(`[data-testid="${id}"]`)!)
+            .filter((el) => el.scrollWidth > el.clientWidth + 1)
+            .map((el) => el.getAttribute("data-testid")),
+        [`${fieldTestId}-label`, `${fieldTestId}-optional-badge`]);
+        expect(clipped).toEqual([]);
+      });
+    }
 
     test(`gives the door-details row a real 44px at ${width}px`, async ({
       page,


### PR DESCRIPTION
Closes #5503

## Summary
- House/flat and PIN/postcode now carry their own **Optional** badge (same pattern Address already uses for **Required**), instead of relying on one group sentence above them that a bordered, input-styled field pair could still read as mandatory.
- The "More door details" disclosure toggle no longer looks like a bordered, selectable card (it matched the Kind-of-place buttons and every text input on the sheet) — plain row + chevron only, same expand/collapse behavior.
- Dropped the trailing "Private to you." caption on the details pane; the summary pane already says this. The pre-vault "Saves once your lock is set." notice is kept — that one is new information, not a repeat.

Prompted by direct user feedback on the Address details sheet (WhatsApp screenshots): optional fields read as mandatory, the door-details toggle read as "something to select", and the closing caption was noise.

## Test plan
- [x] `vitest run` — save-location-modal.test.tsx: 66/66 passing (2 tests updated/added for the new Optional-badge placement)
- [x] `test:layout-contracts` — save-location-sheet.layout.spec.ts on chromium + webkit: 46/46 passing (added a real-browser no-clip contract for the new Optional badges at all 6 sheet widths, mirroring the existing Required-badge contract)
- [x] `tsc --noEmit` clean, `eslint` clean on all 4 touched files
- [x] True-diff guard: exactly 4 task-scoped files, no deletions/renames, branch already contains latest origin/main