### PR TITLE
fix(one-setup): stop the lock-dialog trap, and remove "vault" from every remaining user-facing string

### DIFF
--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -780,7 +780,7 @@ describe("ConsentCenterPage requestId deep links", () => {
 
     render(<ConsentCenterPage />);
 
-    expect(await screen.findByText("Unlock vault to review")).toBeTruthy();
+    expect(await screen.findByText("Unlock to review")).toBeTruthy();
     expect(mocks.lookupPendingRequests).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -397,6 +397,60 @@ describe("One setup hub terminal action contract", () => {
     );
   });
 
+  it("never traps the person behind the lock dialog on a flaky durable exit write", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // acknowledgeOneSetupExit primes its local completion latch SYNCHRONOUSLY,
+    // before it ever awaits the durable cross-device write (see
+    // one-setup-exit-service.ts, whose own test proves the write can reject
+    // after retries while the latch stays set). A rejection from that settling
+    // must never stop the dialog from closing -- that IS the "glitch, then
+    // setup comes up again" report: the dialog is undismissable while the
+    // recovery key shows, so an uncaught throw here froze the screen with no
+    // visible way out.
+    const exitCallIndex = source.indexOf("await acknowledgeOneSetupExit(");
+    const catchIndex = source.indexOf(
+      "} catch (exitSyncError) {",
+      exitCallIndex,
+    );
+    const dialogCloseIndex = source.indexOf(
+      "setVaultDialogOpen(false);",
+      exitCallIndex,
+    );
+
+    expect(exitCallIndex).toBeGreaterThan(-1);
+    expect(catchIndex).toBeGreaterThan(exitCallIndex);
+    expect(dialogCloseIndex).toBeGreaterThan(catchIndex);
+
+    const exitCatchBody = source.slice(catchIndex, dialogCloseIndex);
+    // The catch must swallow (log + continue), never rethrow -- rethrowing is
+    // the exact regression.
+    expect(exitCatchBody).not.toContain("throw exitSyncError");
+    expect(exitCatchBody).toContain("console.warn(");
+  });
+
+  it("surfaces a finalize failure with a toast, since the retry banner sits under an undismissable dialog", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // setFinalizationError renders a "Try again" banner on the hub page, but
+    // the lock dialog sits on top of it and cannot be dismissed while the
+    // recovery key is showing -- so it was invisible exactly when it mattered.
+    // A toast renders above the dialog.
+    expect(source).toContain(
+      'import { morphyToast as toast } from "@/lib/morphy-ux/morphy";',
+    );
+    expect(source).toContain("toast.error(message);");
+    expect(source.indexOf("setFinalizationError(message);")).toBeLessThan(
+      source.indexOf("toast.error(message);"),
+    );
+  });
+
   it("does not allow a setup route to create a first vault before Finish setup", () => {
     const vaultFreeSetupSurfaces = [
       "app/one/setup/email/email-onboarding-setup-client.tsx",

--- a/hushh-webapp/__tests__/components/permission-gate.test.tsx
+++ b/hushh-webapp/__tests__/components/permission-gate.test.tsx
@@ -58,7 +58,7 @@ describe("PermissionGate", () => {
     );
 
     expect(screen.getByTestId("permission-locked-state")).toBeTruthy();
-    expect(screen.getByText("Vault permission required")).toBeTruthy();
+    expect(screen.getByText("Lock required")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Review permissions" }).getAttribute("href")).toBe(
       buildConsentCenterHref("pending")
     );

--- a/hushh-webapp/__tests__/components/portfolio-source-switcher.test.tsx
+++ b/hushh-webapp/__tests__/components/portfolio-source-switcher.test.tsx
@@ -99,7 +99,7 @@ describe("PortfolioSourceSwitcher", () => {
 
     expect(screen.getByRole("button", { name: "Brokerage" })).toBeDisabled();
     expect(
-      screen.getByText("Unlock your Vault to change the active portfolio."),
+      screen.getByText("Unlock to change the active portfolio."),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/__tests__/components/runtime-secret-settings-card.test.tsx
+++ b/hushh-webapp/__tests__/components/runtime-secret-settings-card.test.tsx
@@ -126,7 +126,7 @@ describe("RuntimeSecretSettingsCard", () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Unlock vault" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Unlock" })[0]);
 
     expect(unlock).toHaveBeenCalledTimes(1);
     expect(storeSpy).not.toHaveBeenCalled();

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -235,7 +235,7 @@ describe("Top app bar responsive contract", () => {
 
     expect(source).toContain("showVaultUnlockAction");
     expect(source).toContain("VaultService.checkVault(user.uid)");
-    expect(source).toContain('aria-label="Unlock vault"');
+    expect(source).toContain('aria-label="Unlock"');
     expect(source).toContain("<KeyRound");
     expect(source).not.toContain(
       "Notifications unavailable until your vault is unlocked",

--- a/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
@@ -522,7 +522,7 @@ describe("encrypted saved-locations PKM store", () => {
         vaultKey: null,
         vaultOwnerToken: null,
       }),
-    ).rejects.toThrow(/unlock your vault/i);
+    ).rejects.toThrow(/unlock before managing saved locations/i);
     expect(pkm.getStaleFirst).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/__tests__/services/consent-export-refresh-orchestrator.test.ts
+++ b/hushh-webapp/__tests__/services/consent-export-refresh-orchestrator.test.ts
@@ -209,7 +209,7 @@ describe("ConsentExportRefreshOrchestrator", () => {
       expect(updateTaskMock).toHaveBeenCalledWith(
         expect.stringContaining(BASE_PARAMS.userId),
         expect.objectContaining({
-          description: expect.stringContaining("Unlock your vault"),
+          description: expect.stringContaining("Unlock to resume"),
           metadata: expect.objectContaining({
             pausedForLocalAuth: true,
           }),
@@ -273,7 +273,7 @@ describe("ConsentExportRefreshOrchestrator", () => {
       expect(failTaskMock).toHaveBeenCalledWith(
         expect.stringContaining(BASE_PARAMS.userId),
         "Could not update approved sharing.",
-        expect.stringContaining("retry after Vault unlock"),
+        expect.stringContaining("retry after you unlock"),
         expect.objectContaining({ failureKind: "Error" }),
       );
     });

--- a/hushh-webapp/__tests__/services/pkm-write-coordinator.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-write-coordinator.test.ts
@@ -503,7 +503,9 @@ describe("PkmWriteCoordinator", () => {
       expect(result.success).toBe(false);
       // The raw backend error text must never reach the caller/UI verbatim.
       expect(result.message).not.toContain("Failed to store domain data: 500");
-      expect(result.message).toMatch(/vault/i);
+      expect(result.message).toBe(
+        "We couldn't save this. Try again, or make sure you've set a lock.",
+      );
     });
 
     it("requires recipient re-review when sharing changes during the write", async () => {

--- a/hushh-webapp/__tests__/voice/kai-action-gateway.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-action-gateway.test.ts
@@ -521,7 +521,7 @@ describe("kai-action-gateway", () => {
     expect(firstUnavailableIndex).toBeGreaterThan(0);
     expect(
       results.some(
-        (entry) => entry.availability.reason === "Unlock the vault to use this action."
+        (entry) => entry.availability.reason === "Unlock to use this action."
       )
     ).toBe(true);
     expect(

--- a/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
+++ b/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
@@ -115,7 +115,7 @@ export function ConnectedSystemDetailClient({
           user={user}
           open={showUnlock}
           onOpenChange={setShowUnlock}
-          title="Unlock vault"
+          title="Unlock"
           description="Unlock to review CRM."
           onSuccess={() => setShowUnlock(false)}
         />

--- a/hushh-webapp/app/one/connected-systems/page.tsx
+++ b/hushh-webapp/app/one/connected-systems/page.tsx
@@ -75,8 +75,8 @@ export default function ConnectedSystemsPage() {
           user={user}
           open={showUnlock}
           onOpenChange={setShowUnlock}
-          title="Set up your private vault"
-          description="Open your vault to review CRM."
+          title="Set a lock"
+          description="Unlock to review CRM."
           onSuccess={() => setShowUnlock(false)}
         />
       ) : null}

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1076,13 +1076,13 @@ export function KaiAnalysisPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="unavailable-valid"
           errorCode="vault_locked"
-          errorMessage="Vault locked"
+          errorMessage="Locked"
         />
         <SurfaceCard>
           <SurfaceCardContent className="p-5 text-center">
-          <h2 className="text-lg font-semibold">Unlock your Vault to continue</h2>
+          <h2 className="text-lg font-semibold">Unlock to continue</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            Your portfolio and saved analysis stay encrypted in Vault. Unlock it to reopen analysis,
+            Your portfolio and saved analysis stay encrypted in your private place. Unlock it to reopen analysis,
             review history, or start a new debate with your stored holdings context.
           </p>
           <div className="mt-4 grid gap-2 sm:grid-cols-2">

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -128,7 +128,7 @@ import {
 } from "./tokens";
 
 const STATUS_LABELS: Record<OneKycWorkflowStatus, string> = {
-  needs_client_connector: "Needs vault setup",
+  needs_client_connector: "Needs a lock",
   needs_scope: "Needs access",
   needs_documents: "Needs documents",
   needs_confirm: "Needs confirmation",
@@ -1345,7 +1345,7 @@ export function OneKycWorkspace({
       ) {
         return {
           status: "blocked" as const,
-          summary: "A reviewable draft and an unlocked vault are required.",
+          summary: "A reviewable draft and an unlocked private place are required.",
         };
       }
       const localDraft = localDrafts[selected.workflow_id];
@@ -1422,7 +1422,7 @@ export function OneKycWorkspace({
     async (workflow: OneKycWorkflow) => {
       if (workflowConsentRequestIds(workflow).length > 0) return workflow;
       if (!auth.userId || !vaultOwnerToken) {
-        throw new Error("Vault owner token required.");
+        throw new Error("Not ready yet. Try again.");
       }
       const selectedScopes = selectedScopesForWorkflow(
         workflow,
@@ -1670,7 +1670,7 @@ export function OneKycWorkspace({
       description?: string;
     }) => {
       if (!auth.userId || !vaultKey || !vaultOwnerToken) {
-        setError("Unlock your vault to preview saved information.");
+        setError("Unlock to preview saved information.");
         return;
       }
       const parsed = parseAttrScope(candidate.scope);
@@ -1876,11 +1876,11 @@ export function OneKycWorkspace({
 
         <div className="w-full">
           {(!vaultKey || !vaultOwnerToken) ? (
-            <SettingsGroup title="Vault required" description="Set up your vault to use KYC.">
+            <SettingsGroup title="Lock required" description="Set a lock to use KYC.">
               <SettingsRow
                 icon={AlertTriangle}
-                title="Vault missing"
-                description="Set up your vault first."
+                title="No lock yet"
+                description="Set a lock first."
               />
             </SettingsGroup>
           ) : (
@@ -2047,7 +2047,7 @@ export function OneKycWorkspace({
               </SettingsGroup>
 
               {selected.status === "needs_client_connector" ? (
-                <SettingsGroup embedded title="Vault connector">
+                <SettingsGroup embedded title="Data connector">
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Sync required"
@@ -2537,7 +2537,7 @@ export function OneKycWorkspace({
             <SettingsGroup embedded title="Loading saved information">
               <SettingsRow
                 icon={RefreshCw}
-                title="Checking your vault"
+                title="Checking..."
                 description="Loading the saved values for this information section."
                 trailing={<Loader2 className="size-4 animate-spin text-muted-foreground" />}
                 stackTrailingOnMobile

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -8944,7 +8944,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see who you are connected to while the vault is locked, so I cannot tell whether they are there.",
+          "Unlock One first -- I cannot see who you are connected to while it's locked, so I cannot tell whether they are there.",
       };
     }
     // A navigation journey can arrive before the full Location workspace
@@ -9265,7 +9265,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see who you are connected to while the vault is locked, so I cannot tell whether they are there.",
+          "Unlock One first -- I cannot see who you are connected to while it's locked, so I cannot tell whether they are there.",
       };
     }
     if (resolved.kind === "none" && vaultOwnerToken) {
@@ -9442,7 +9442,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see who you are connected to while the vault is locked.",
+          "Unlock One first -- I cannot see who you are connected to while it's locked.",
       };
     }
     // Resolved against the people who are ELIGIBLE to receive an SOS, not the
@@ -9506,7 +9506,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see your emergency contacts while the vault is locked.",
+          "Unlock One first -- I cannot see your emergency contacts while it's locked.",
       };
     }
     // Only the people actually ON the list. Matching the wider connection list
@@ -9699,7 +9699,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot create a circle while the vault is locked.",
+          "Unlock One first -- I cannot create a circle while it's locked.",
       };
     }
     const spokenKind = String(slots?.kind ?? "")
@@ -9750,7 +9750,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see your circles while the vault is locked.",
+          "Unlock One first -- I cannot see your circles while it's locked.",
       };
     }
     const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
@@ -9858,7 +9858,7 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "Unlock One first -- I cannot see your circles while the vault is locked.",
+            "Unlock One first -- I cannot see your circles while it's locked.",
         };
       }
       const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
@@ -9973,7 +9973,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see your circles while the vault is locked.",
+          "Unlock One first -- I cannot see your circles while it's locked.",
       };
     }
     const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
@@ -10025,7 +10025,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see your circles while the vault is locked.",
+          "Unlock One first -- I cannot see your circles while it's locked.",
       };
     }
     const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
@@ -10077,7 +10077,7 @@ export function OneLocationAgentPageContent({
       return {
         status: "blocked" as const,
         summary:
-          "Unlock One first -- I cannot see your circles while the vault is locked.",
+          "Unlock One first -- I cannot see your circles while it's locked.",
       };
     }
     const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
@@ -10132,7 +10132,7 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "Unlock One first -- I cannot see your circle invitations while the vault is locked.",
+            "Unlock One first -- I cannot see your circle invitations while it's locked.",
         };
       }
       const resolved = resolveVoiceCircleInvite(
@@ -10163,7 +10163,7 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "Unlock One first -- I cannot see your circle invitations while the vault is locked.",
+            "Unlock One first -- I cannot see your circle invitations while it's locked.",
         };
       }
       const resolved = resolveVoiceCircleInvite(
@@ -10204,7 +10204,7 @@ export function OneLocationAgentPageContent({
       if (!vaultKey || !vaultOwnerToken || !auth.userId) {
         return {
           status: "blocked" as const,
-          summary: "Unlock One first -- I cannot save a place while the vault is locked.",
+          summary: "Unlock One first -- I cannot save a place while it's locked.",
         };
       }
       const normalized = normalizeSpokenName(spokenLabel);
@@ -10261,7 +10261,7 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "Unlock One first -- I cannot see your saved places while the vault is locked.",
+            "Unlock One first -- I cannot see your saved places while it's locked.",
         };
       }
       let saved: SavedLocation[];
@@ -10754,7 +10754,7 @@ export function OneLocationAgentPageContent({
         toast.success(
           canPersistNow
             ? "Location saved securely."
-            : "Location ready. One will save it after your private vault is set up.",
+            : "Location ready. One will save it after you set a lock.",
         );
       } catch (error) {
         if (

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -310,7 +310,7 @@ function SharedDataPreview({
   useEffect(() => {
     let cancelled = false;
     if (!userId || !vaultKey) {
-      setErr("Unlock your vault to preview the shared summary.");
+      setErr("Unlock to preview the shared summary.");
       return;
     }
     setLoading(true);
@@ -566,7 +566,7 @@ function OneMarketplacePageImpl() {
   const viewDelivery = useCallback(
     async (request: MarketplaceRequest) => {
       if (!vaultOwnerToken || !user?.uid) {
-        toast.error("Unlock your vault to open the delivered slice.");
+        toast.error("Unlock to open the delivered slice.");
         return;
       }
       setDeliveries((current) => ({ ...current, [request.id]: { status: "loading" } }));
@@ -757,7 +757,7 @@ function OneMarketplacePageImpl() {
   const runPosture = useCallback(
     async (section: Section, nextPosture: PkmVisibilityPosture) => {
       if (!user?.uid || !vaultOwnerToken) {
-        toast.error("Unlock your vault to change sharing.");
+        toast.error("Unlock to change sharing.");
         return;
       }
       const previousManifest = section.manifest;
@@ -832,7 +832,7 @@ function OneMarketplacePageImpl() {
   const runPublish = useCallback(
     async (section: Section) => {
       if (!user?.uid || !vaultOwnerToken || !vaultKey) {
-        toast.error("Unlock your vault to publish a public profile.");
+        toast.error("Unlock to publish a public profile.");
         return;
       }
       if (isStructurallyBlockedForPublish(section.permission.topLevelScopePath)) {

--- a/hushh-webapp/app/one/setup/connected-systems/connected-systems-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/connected-systems/connected-systems-onboarding-setup-client.tsx
@@ -93,8 +93,8 @@ export function ConnectedSystemsOnboardingSetupClient() {
             user={user}
             open={showUnlock}
             onOpenChange={setShowUnlock}
-            title="Set up your private vault"
-            description="Open your vault to review CRM."
+            title="Set a lock"
+            description="Unlock to review CRM."
             allowVaultCreation={false}
             onSuccess={() => setShowUnlock(false)}
           />

--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -589,8 +589,8 @@ function KaiOnboardingPageContent({
           user={user}
           open={vaultOpen}
           onOpenChange={setVaultOpen}
-          title="Open your private vault"
-          description="Continue Finance setup after your private vault is ready."
+          title="Open your private place"
+          description="Continue Finance setup after you set a lock."
           allowVaultCreation={false}
           onSuccess={() => setVaultOpen(false)}
         />
@@ -710,7 +710,7 @@ function KaiOnboardingPageContent({
 
               if (source === "vault") {
                 if (!vaultKey || !vaultOwnerToken) {
-                  toast.error("Set up or open your private vault to continue.");
+                  toast.error("Set a lock or unlock it to continue.");
                   return;
                 }
 

--- a/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
+++ b/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
@@ -759,7 +759,7 @@ export default function PkmAgentLabPageClient() {
     if (!user) return;
     if (!vaultCapability.canMutateSecureData || !vaultKey || !vaultOwnerToken) {
       handleVaultAccessRequired(
-        "Unlock your vault to continue the Personal Knowledge Model upgrade."
+        "Unlock to continue the Personal Knowledge Model upgrade."
       );
       return;
     }
@@ -815,7 +815,7 @@ export default function PkmAgentLabPageClient() {
 
   const handlePreview = useCallback(async () => {
     if (!user || !vaultCapability.canReadSecureData || !vaultOwnerToken) {
-      handleVaultAccessRequired("Unlock your vault before previewing PKM changes.");
+      handleVaultAccessRequired("Unlock before previewing PKM changes.");
       return;
     }
 
@@ -864,7 +864,7 @@ export default function PkmAgentLabPageClient() {
 
   const persistPreview = useCallback(async () => {
     if (!user || !vaultCapability.canMutateSecureData || !vaultKey || !vaultOwnerToken) {
-      handleVaultAccessRequired("Unlock your vault before saving to PKM.");
+      handleVaultAccessRequired("Unlock before saving to PKM.");
       return;
     }
 
@@ -1017,7 +1017,7 @@ export default function PkmAgentLabPageClient() {
       }>
     ) => {
       if (!user || !vaultCapability.canReadSecureData || !vaultOwnerToken) {
-        handleVaultAccessRequired("Unlock your vault before changing PKM permissions.");
+        handleVaultAccessRequired("Unlock before changing PKM permissions.");
         return;
       }
       const manifest = manifests[domainKey];
@@ -1168,14 +1168,14 @@ export default function PkmAgentLabPageClient() {
               />
             ) : vaultAccess.vaultUnknown ? (
               <SettingsRow
-                title="Checking vault access"
-                description="Confirming whether this workspace should unlock your existing vault or help you create one first."
+                title="Checking access"
+                description="Confirming whether this workspace should unlock your existing lock or help you set one up first."
                 leading={<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
               />
             ) : vaultAccess.needsVaultCreation ? (
               <SettingsRow
-                title="Set up your vault first"
-                description="PKM Agent Lab only becomes available after you create or import a vault from the Privacy workspace."
+                title="Set a lock first"
+                description="PKM Agent Lab only becomes available after you set a lock from the Privacy workspace."
                 leading={<ShieldAlert className="h-4 w-4 text-amber-500" />}
                 trailing={
                   <Button
@@ -1189,8 +1189,8 @@ export default function PkmAgentLabPageClient() {
               />
             ) : !vaultAccess.canReadSecureData ? (
               <SettingsRow
-                title="Vault unlock required"
-                description="This route now uses the shared signed-in unlock flow. Once your vault is unlocked, PKM permissions will load automatically."
+                title="Unlock required"
+                description="This route now uses the shared signed-in unlock flow. Once it's unlocked, PKM permissions will load automatically."
                 leading={<Lock className="h-4 w-4 text-amber-500" />}
               />
             ) : domains.length === 0 ? (
@@ -1436,7 +1436,7 @@ export default function PkmAgentLabPageClient() {
                   }
                   description={
                     upgradeStatus?.upgradeStatus === "awaiting_local_auth_resume"
-                      ? "Unlocking the vault will automatically resume the Personal Knowledge Model upgrade."
+                      ? "Unlocking will automatically resume the Personal Knowledge Model upgrade."
                       : upgradeStatus?.upgradeStatus === "failed"
                         ? "Automatic retries hit a recovery state. Use the advanced recovery action in the status card if you need to retry."
                         : "Kai is refreshing this domain in the background. Section controls will unlock automatically when it completes."

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -841,7 +841,7 @@ function ProfilePageContent() {
         status: "updating" as const,
         label: "Unlock required",
         description:
-          "These details stay readable while locked. Unlock the vault to manage section-level sharing controls.",
+          "These details stay readable while locked. Unlock to manage section-level sharing controls.",
         canManagePermissions: false,
       };
     }
@@ -1366,7 +1366,7 @@ function ProfilePageContent() {
 
     if (resolution.kind === "needs_unlock") {
       morphyToast.info(
-        "Please unlock your vault first to delete your account.",
+        "Unlock first to delete your account.",
       );
       setIsDeleting(false);
       setShowDeleteConfirm(false);
@@ -1458,7 +1458,7 @@ function ProfilePageContent() {
     }
 
     if (resolution.kind === "needs_unlock") {
-      morphyToast.info("Please unlock your vault first to reset your account.");
+      morphyToast.info("Unlock first to reset your account.");
       setIsResetting(false);
       setShowResetConfirm(false);
       setVaultUnlockReason("reset_account");
@@ -1747,7 +1747,7 @@ function ProfilePageContent() {
     if (!user?.uid) return;
 
     if (!vaultAccess.canMutateSecureData || !vaultKey) {
-      toast.info("Unlock your vault to change security method.");
+      toast.info("Unlock to change security method.");
       requestVaultUnlock("profile_data");
       return;
     }
@@ -1763,7 +1763,7 @@ function ProfilePageContent() {
 
       setVaultMethod(result.method);
       toast.success(
-        `Vault method updated to ${readableMethod(result.method)}.`,
+        `Unlock method updated to ${readableMethod(result.method)}.`,
       );
       await refreshVaultMethodState(user.uid);
     } catch (error) {
@@ -1785,7 +1785,7 @@ function ProfilePageContent() {
     if (!user?.uid) return;
 
     if (!vaultAccess.canMutateSecureData || !vaultKey) {
-      toast.info("Unlock your vault to change security method.");
+      toast.info("Unlock to change security method.");
       requestVaultUnlock("profile_data");
       return;
     }
@@ -1821,7 +1821,7 @@ function ProfilePageContent() {
     if (!user?.uid) return;
 
     if (!vaultAccess.canMutateSecureData || !vaultKey) {
-      toast.info("Unlock your vault to change security method.");
+      toast.info("Unlock to change security method.");
       requestVaultUnlock("profile_data");
       return;
     }
@@ -1852,12 +1852,12 @@ function ProfilePageContent() {
     if (!user?.uid) return;
 
     if (!vaultAccess.canMutateSecureData || !vaultKey) {
-      toast.info("Unlock your vault to remove a passkey.");
+      toast.info("Unlock to remove a passkey.");
       requestVaultUnlock("profile_data");
       return;
     }
     if (!vaultOwnerToken) {
-      toast.info("Unlock your vault to remove a passkey.");
+      toast.info("Unlock to remove a passkey.");
       requestVaultUnlock("profile_data");
       return;
     }
@@ -1893,7 +1893,7 @@ function ProfilePageContent() {
     if (!user?.uid) return;
 
     if (!vaultAccess.canMutateSecureData || !vaultKey) {
-      toast.info("Unlock your vault to change passphrase.");
+      toast.info("Unlock to change passphrase.");
       requestVaultUnlock("profile_data");
       return;
     }
@@ -1937,7 +1937,7 @@ function ProfilePageContent() {
     "Clears saved details. Keeps sign-in.";
   const resetDialogTitle = "Reset account?";
   const resetDialogDescription =
-    "This clears all your saved details: connected services, finance and Gmail, your knowledge base, consents, and saved preferences. It keeps your account, your sign-in, and your vault. You will start onboarding again.";
+    "This clears all your saved details: connected services, finance and Gmail, your knowledge base, consents, and saved preferences. It keeps your account, your sign-in, and your lock. You will start onboarding again.";
 
   const handleVaultUnlockOpenChange = (open: boolean) => {
     setShowVaultUnlock(open);
@@ -1959,12 +1959,12 @@ function ProfilePageContent() {
       ? "Unlock to delete"
       : vaultUnlockReason === "reset_account"
         ? "Unlock to reset"
-        : "Unlock vault";
+        : "Unlock";
   const unlockDialogDescription =
     vaultUnlockReason === "delete_account"
       ? "This permanently removes encrypted records."
       : vaultUnlockReason === "reset_account"
-        ? "Saved details reset. Account and vault stay."
+        ? "Saved details reset. Account and lock stay."
         : "Unlock to continue.";
 
   const displayedUnlockMethod = effectiveVaultMethod ?? vaultMethod;
@@ -1997,9 +1997,9 @@ function ProfilePageContent() {
   );
   const defaultUnlockDescription =
     vaultMethod === "passphrase"
-      ? "Passphrase opens your vault by default."
+      ? "Passphrase opens it by default."
       : vaultMethod
-        ? `${readableMethod(vaultMethod)} opens your vault by default.`
+        ? `${readableMethod(vaultMethod)} opens it by default.`
         : "Default unlock is not set.";
   const canEditKaiPreferences = Boolean(
     user?.uid && vaultAccess.hasVault && vaultAccess.canMutateSecureData,
@@ -2042,7 +2042,7 @@ function ProfilePageContent() {
       ? (activeDetail.slice("support-compose:".length) as SupportMessageKind)
       : null;
   const securitySummaryText = vaultAccess.needsVaultCreation
-    ? "Vault not created yet"
+    ? "No lock yet"
     : loadingVaultMethod
       ? "Loading methods…"
       : vaultAccess.needsUnlock
@@ -2067,14 +2067,14 @@ function ProfilePageContent() {
       {
         id: "profile_security",
         label: PROFILE_LABELS.security,
-        purpose: "opens vault, account access, and account deletion controls.",
+        purpose: "opens your lock, account access, and account deletion controls.",
         actionId: "route.profile_security_panel",
         role: "card",
         voiceAliases: [
-          "vault",
-          "create your vault",
-          "unlock vault",
-          "vault security",
+          "lock",
+          "set a lock",
+          "unlock",
+          "lock security",
         ],
       },
       {
@@ -2200,8 +2200,8 @@ function ProfilePageContent() {
                 : activePanel === "security"
                   ? [
                       vaultAccess.needsVaultCreation
-                        ? "Create your vault"
-                        : "Unlock vault",
+                        ? "Set a lock"
+                        : "Unlock",
                       "Change passphrase",
                       "Delete account",
                     ]
@@ -2232,7 +2232,7 @@ function ProfilePageContent() {
                         : PROFILE_LABELS.support
           : "Profile",
         purpose:
-          "This surface manages account details, appearance, help, and vault privacy.",
+          "This surface manages account details, appearance, help, and your lock's privacy.",
         sections: [
           {
             id: "account",
@@ -2247,7 +2247,7 @@ function ProfilePageContent() {
           {
             id: "security",
             title: PROFILE_LABELS.security,
-            purpose: "Vault and account access controls.",
+            purpose: "Your lock and account access controls.",
           },
           {
             id: "support",
@@ -3219,7 +3219,7 @@ function ProfilePageContent() {
       <SettingsGroup>
         <SettingsRow
           icon={Fingerprint}
-          title="Vault methods"
+          title="Lock methods"
           description="Passphrase, passkey, and unlock method."
           chevron
           onClick={() =>
@@ -3310,11 +3310,11 @@ function ProfilePageContent() {
 
   const vaultMethodsContent = (
     <div className="space-y-4 sm:space-y-5">
-      <SettingsGroup title="Vault">
+      <SettingsGroup title="Lock">
         {vaultAccess.needsVaultCreation ? (
           <SettingsRow
             icon={KeyRound}
-            title="Create your vault"
+            title="Set a lock"
             description="Secure saved details."
             chevron
             onClick={() => setShowVaultCreation(true)}
@@ -3382,7 +3382,7 @@ function ProfilePageContent() {
             {!vaultAccess.canMutateSecureData ? (
               <SettingsRow
                 icon={KeyRound}
-                title="Unlock vault"
+                title="Unlock"
                 description="Change methods or passphrase."
                 chevron
                 onClick={() => requestVaultUnlock("profile_data")}
@@ -3479,7 +3479,7 @@ function ProfilePageContent() {
               <SettingsRow
                 icon={RefreshCw}
                 title="Change passphrase"
-                description="Update vault protection."
+                description="Update your lock."
                 disabled={switchingVaultMethod}
                 chevron
                 onClick={() => setPassphraseDialogOpen(true)}
@@ -3946,13 +3946,13 @@ function ProfilePageContent() {
     profileStackEntries.push({
       key: "panel:security",
       title: PROFILE_LABELS.security,
-      description: "Vault and sign-in.",
+      description: "Your lock and sign-in.",
       content: securityContent,
     });
     if (activeDetail === "vault") {
       profileStackEntries.push({
         key: "detail:vault",
-        title: "Vault methods",
+        title: "Lock methods",
         description: "Unlock methods.",
         content: vaultMethodsContent,
       });
@@ -4075,7 +4075,7 @@ function ProfilePageContent() {
                 voiceControlId="profile_security"
                 voiceActionId="route.profile_security_panel"
                 voiceLabel={PROFILE_LABELS.security}
-                voicePurpose="Opens vault, account access, and account deletion controls."
+                voicePurpose="Opens your lock, account access, and account deletion controls."
                 onClick={openSecurityPanel}
               />
               <SettingsRow
@@ -4171,7 +4171,7 @@ function ProfilePageContent() {
               setTimeout(() => {
                 vaultUnlockCompletingRef.current = false;
               }, 0);
-              toast.success("Vault unlocked.");
+              toast.success("Unlocked.");
               return;
             }
             if (pendingProfileTarget) {
@@ -4187,7 +4187,7 @@ function ProfilePageContent() {
             setTimeout(() => {
               vaultUnlockCompletingRef.current = false;
             }, 0);
-            toast.success("Vault unlocked.");
+            toast.success("Unlocked.");
           }}
         />
       )}
@@ -4197,7 +4197,7 @@ function ProfilePageContent() {
           user={user}
           open={showVaultCreation}
           onOpenChange={setShowVaultCreation}
-          title="Create your vault"
+          title="Set a lock"
           description="Set up a passphrase to secure your saved details."
           onSuccess={() => {
             setShowVaultCreation(false);
@@ -4208,7 +4208,7 @@ function ProfilePageContent() {
               vaultReturnToRef.current = null;
               router.replace(returnTo);
             }
-            toast.success("Vault created and unlocked.");
+            toast.success("Lock created.");
           }}
         />
       )}
@@ -4220,7 +4220,7 @@ function ProfilePageContent() {
         <DialogContent className="w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] overflow-y-auto sm:max-w-md">
           <DialogTitle>Change passphrase</DialogTitle>
           <DialogDescription>
-            Set a new passphrase for Vault unlock. Your passkey and biometric
+            Set a new passphrase to unlock. Your passkey and biometric
             methods stay active.
           </DialogDescription>
           <div className="space-y-3 pt-2">

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2063,7 +2063,7 @@ export default function RiaPicksPage() {
     try {
       setSubmitting(true);
       if (!vaultKey || !vaultOwnerToken) {
-        throw new Error("Unlock the vault before importing advisor picks.");
+        throw new Error("Unlock before importing advisor picks.");
       }
       const idToken = await user.getIdToken();
       await RiaService.importPickCsv({
@@ -2099,7 +2099,7 @@ export default function RiaPicksPage() {
     try {
       setPackageSaving(true);
       if (!vaultKey || !vaultOwnerToken) {
-        throw new Error("Unlock the vault before saving advisor picks.");
+        throw new Error("Unlock before saving advisor picks.");
       }
       const { payload, validation } = await validateDraft(draftPackage);
       setValidationState(validation);
@@ -2126,7 +2126,7 @@ export default function RiaPicksPage() {
     () => ({
       screenId: "ria_picks",
       title: "RIA Picks",
-      purpose: "Advisor stock universe with Kai reference picks and vault-backed advisor package.",
+      purpose: "Advisor stock universe with Kai reference picks and an encrypted advisor package.",
       sections: [
         {
           id: "ria_picks_source",

--- a/hushh-webapp/components/agent/__tests__/opportunity-nudge-card.test.tsx
+++ b/hushh-webapp/components/agent/__tests__/opportunity-nudge-card.test.tsx
@@ -99,7 +99,7 @@ describe("OpportunityNudgeStack", () => {
     );
 
     const trigger = await findOpportunityTrigger();
-    const dismiss = screen.getByLabelText("Hide marketplace opportunities for this vault session");
+    const dismiss = screen.getByLabelText("Hide marketplace opportunities for this session");
 
     fireEvent.click(dismiss);
 

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -1990,7 +1990,7 @@ export function AgentChatWorkspace({
       if (nextConversationId === conversationId || historyInteractionDisabled) return;
       const token = getVaultOwnerToken();
       if (!token) {
-        toast.error("Vault access expired. Unlock again to continue.");
+        toast.error("Locked. Unlock again to continue.");
         return;
       }
       abortAgentTurnWork();
@@ -2050,7 +2050,7 @@ export function AgentChatWorkspace({
     async (targetConversationId: string, title: string) => {
       const token = getVaultOwnerToken();
       if (!token) {
-        toast.error("Vault access expired. Unlock again to continue.");
+        toast.error("Locked. Unlock again to continue.");
         return;
       }
       setHistoryActionPendingId(targetConversationId);
@@ -2081,7 +2081,7 @@ export function AgentChatWorkspace({
       if (historyInteractionDisabled) return;
       const token = getVaultOwnerToken();
       if (!token || !user?.uid) {
-        toast.error("Vault access expired. Unlock again to continue.");
+        toast.error("Locked. Unlock again to continue.");
         return;
       }
       if (conversationId === targetConversationId) {
@@ -2146,7 +2146,7 @@ export function AgentChatWorkspace({
       const review = pkmReviews.find((item) => item.id === reviewId);
       const token = getVaultOwnerToken();
       if (!review || !user?.uid || !vaultKey || !token) {
-        toast.error("Unlock your vault before saving to Memory.");
+        toast.error("Unlock before saving to Memory.");
         return;
       }
 
@@ -2499,7 +2499,7 @@ export function AgentChatWorkspace({
           reason: !vaultKey ? "vault_key_unavailable" : "vault_owner_token_unavailable",
           tool: toolEvent,
         });
-        upsertPkmStatusMessage("Unlock your vault before saving to Memory.", "error");
+        upsertPkmStatusMessage("Unlock before saving to Memory.", "error");
         return;
       }
 
@@ -2883,7 +2883,7 @@ export function AgentChatWorkspace({
       });
       updateMessage(assistantMessageId, (message) => ({
         ...message,
-        text: "Vault access expired. Unlock again to continue.",
+        text: "Locked. Unlock again to continue.",
         status: "error",
         streamEvents: [],
       }));
@@ -2977,7 +2977,7 @@ export function AgentChatWorkspace({
         });
         updateMessage(assistantMessageId, (message) => ({
           ...message,
-          text: "One couldn't load your private memory for this turn. Keep your vault unlocked and try again.",
+          text: "One couldn't load your private memory for this turn. Keep it unlocked and try again.",
           status: "error",
           streamEvents: [],
         }));
@@ -3197,7 +3197,7 @@ export function AgentChatWorkspace({
     const userId = user.uid;
     const token = getVaultOwnerToken();
     if (!token) {
-      addErrorMessage("Vault access expired. Unlock again to continue.");
+      addErrorMessage("Locked. Unlock again to continue.");
       return;
     }
 
@@ -3769,9 +3769,9 @@ export function AgentChatWorkspace({
   const accessMessage = authLoading
     ? null
     : !user?.uid
-      ? "You're chatting with One. Sign in and unlock your vault for personalized help."
+      ? "You're chatting with One. Sign in and unlock for personalized help."
       : needsVaultUnlock
-        ? "You're chatting with One. Unlock your vault to work with your private information."
+        ? "You're chatting with One. Unlock to work with your private information."
         : null;
   const accessAction = authLoading
     ? null
@@ -3783,7 +3783,7 @@ export function AgentChatWorkspace({
         }
       : needsVaultUnlock
         ? {
-            label: "Unlock vault",
+            label: "Unlock",
             icon: KeyRound,
             // Just-in-time unlock in place via the shared dialog, instead of
             // navigating away to /one/profile and losing the agent context.
@@ -4518,7 +4518,7 @@ export function AgentChatWorkspace({
                       }
                       const token = getVaultOwnerToken();
                       if (!token || !user?.uid) {
-                        addErrorMessage("Vault access expired. Unlock again to continue.");
+                        addErrorMessage("Locked. Unlock again to continue.");
                         return;
                       }
                       enqueueCalendarDirective(directive, token, user.uid);
@@ -4545,7 +4545,7 @@ export function AgentChatWorkspace({
                       try {
                         const token = getVaultOwnerToken();
                         if (!token) {
-                          addErrorMessage("Vault access expired. Unlock again to continue.");
+                          addErrorMessage("Locked. Unlock again to continue.");
                           return;
                         }
                         const confirmLabel = String(
@@ -4620,7 +4620,7 @@ export function AgentChatWorkspace({
                         // other authed call uses (never hardcoded/invented).
                         const token = getVaultOwnerToken();
                         if (!token) {
-                          addErrorMessage("Vault access expired. Unlock again to continue.");
+                          addErrorMessage("Locked. Unlock again to continue.");
                           return;
                         }
                         appendMessage({
@@ -4891,8 +4891,8 @@ export function AgentChatWorkspace({
           user={user}
           open={vaultDialogOpen}
           onOpenChange={setVaultDialogOpen}
-          title="Unlock Vault to use Agent"
-          description="Unlock your Vault so the agent can work with your private information."
+          title="Unlock to use Agent"
+          description="Unlock so the agent can work with your private information."
           onSuccess={() => setVaultDialogOpen(false)}
         />
       ) : null}

--- a/hushh-webapp/components/agent/opportunity-nudge-card.tsx
+++ b/hushh-webapp/components/agent/opportunity-nudge-card.tsx
@@ -456,8 +456,8 @@ export function OpportunityNudgeStack({
                   onDismissPanel();
                 }}
                 className="mr-1 grid h-7 w-7 shrink-0 place-items-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-                aria-label="Hide marketplace opportunities for this vault session"
-                title="Hide for this vault session"
+                aria-label="Hide marketplace opportunities for this session"
+                title="Hide for this session"
               >
                 <X className="h-3.5 w-3.5" aria-hidden />
               </button>

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -1236,7 +1236,7 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                         {showVaultUnlockAction ? (
                           <ShellActionSurface
                             variant="icon"
-                            aria-label="Unlock vault"
+                            aria-label="Unlock"
                             onClick={() => setVaultUnlockOpen(true)}
                           >
                             <KeyRound className="h-5 w-5 text-amber-600 dark:text-amber-300" />
@@ -1312,12 +1312,12 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
           user={user}
           open={vaultUnlockOpen}
           onOpenChange={setVaultUnlockOpen}
-          title="Unlock vault"
-          description="Unlock your vault to use secure memory and background activity."
+          title="Unlock"
+          description="Unlock to use secure memory and background activity."
           onSuccess={() => {
             setVaultUnlockOpen(false);
             setHasVault(true);
-            toast.success("Vault unlocked.");
+            toast.success("Unlocked.");
           }}
         />
       ) : null}

--- a/hushh-webapp/components/app-ui/vault-status-inline.tsx
+++ b/hushh-webapp/components/app-ui/vault-status-inline.tsx
@@ -64,7 +64,7 @@ export function VaultStatusInline({
         )}
       >
         <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
-        Vault ready
+        Unlocked
       </p>
     );
   }
@@ -79,7 +79,7 @@ export function VaultStatusInline({
         )}
       >
         <Lock className="h-3.5 w-3.5 shrink-0" />
-        Vault locked, unlock to continue
+        Locked, unlock to continue
       </p>
     );
   }
@@ -94,7 +94,7 @@ export function VaultStatusInline({
         )}
       >
         <Database className="h-3.5 w-3.5 shrink-0" />
-        Vault setup required
+        Lock required
       </p>
     );
   }
@@ -107,7 +107,7 @@ export function VaultStatusInline({
       )}
     >
       <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
-      Checking vault status…
+      Checking…
     </p>
   );
 }

--- a/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
@@ -303,10 +303,10 @@ export function GeminiRuntimeConfigurationPage({
           onOpenChange={setUnlockOpen}
           title={
             needsVaultCreation
-              ? "Set up your private vault"
-              : "Open your private vault"
+              ? "Set a lock"
+              : "Open your private place"
           }
-          description="Gemini access stays in your vault."
+          description="Gemini access stays private."
           onSuccess={() => setUnlockOpen(false)}
         />
       ) : null}

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -236,7 +236,7 @@ export function GeminiRuntimeSettingsCard({
           ? "This setting changed on another device. Refresh and try again."
           : requiresExplicitSelection
             ? "We couldn’t save this setup choice. Try again."
-            : "Open your private vault again, then try this setting.",
+            : "Unlock again, then try this setting.",
       );
     } finally {
       selectionPendingRef.current = false;
@@ -411,7 +411,7 @@ export function GeminiRuntimeSettingsCard({
         await onSelectionReadyChange?.("byok_pending_vault");
       }
       notifyGeminiRuntimeConfigurationChanged();
-      toast.success("Your Gemini configuration is saved in your encrypted vault.");
+      toast.success("Your Gemini configuration is saved.");
     } catch {
       toast.error("Gemini key could not be saved.");
     } finally {
@@ -548,7 +548,7 @@ export function GeminiRuntimeSettingsCard({
             <div className="flex items-center justify-between gap-3">
               <CardTitle as="p">Gemini connection</CardTitle>
               <Badge variant={hasSavedKey ? "secondary" : "outline"}>
-                {needsVaultCreation ? "Vault needed" : needsUnlock ? "Locked" : hasSavedKey ? "Saved" : "Not set"}
+                {needsVaultCreation ? "Set up lock" : needsUnlock ? "Locked" : hasSavedKey ? "Saved" : "Not set"}
               </Badge>
             </div>
             <FormLabel className="block space-y-1">

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -3011,8 +3011,8 @@ export function ConsentCenterPage() {
               />
             ) : selectedRequestNeedsUnlock ? (
               <SettingsRow
-                title="Unlock vault to review"
-                description="Unlock your vault to load this request securely."
+                title="Unlock to review"
+                description="Unlock to load this request securely."
               />
             ) : selectedPendingLookupResource.error ? (
               <SettingsRow

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -1149,7 +1149,7 @@ export default function GmailReceiptsPage({
 
   const requestVaultUnlock = useCallback(() => {
     setShowVaultUnlock(true);
-    toast.info("Set up your private vault to save this summary to memory.");
+    toast.info("Set a lock to save this summary to memory.");
   }, []);
 
   const handleBuildReceiptMemoryPreview = useCallback(
@@ -1225,7 +1225,7 @@ export default function GmailReceiptsPage({
       if (!vaultKey || !vaultOwnerToken || !isVaultUnlocked) {
         setReceiptMemorySaveState("error");
         setReceiptMemoryMessage(
-          "Set up your private vault to save this summary to memory.",
+          "Set a lock to save this summary to memory.",
         );
         return;
       }
@@ -1644,7 +1644,7 @@ export default function GmailReceiptsPage({
               ) : null}
               {!vaultKey || !vaultOwnerToken || !isVaultUnlocked ? (
                 <p className="text-xs text-muted-foreground">
-                  Set up your private vault to create and save this summary to
+                  Set a lock to create and save this summary to
                   memory.
                 </p>
               ) : null}
@@ -1714,10 +1714,10 @@ export default function GmailReceiptsPage({
             <SurfaceInset className="flex flex-col items-start gap-3 px-4 py-4 text-sm text-muted-foreground">
               <div className="flex items-center gap-2 text-foreground">
                 <Lock className="h-4 w-4" />
-                Set up or open your private vault to view and summarize synced
+                Set a lock, or unlock it, to view and summarize synced
                 receipts.
               </div>
-              <Button onClick={requestVaultUnlock}>Set up vault</Button>
+              <Button onClick={requestVaultUnlock}>Set a lock</Button>
             </SurfaceInset>
           ) : null}
 
@@ -1786,11 +1786,11 @@ export default function GmailReceiptsPage({
           user={user}
           open={showVaultUnlock}
           onOpenChange={setShowVaultUnlock}
-          title="Set up your private vault"
-          description="Set up your private vault to create and save receipt summaries to memory."
+          title="Set a lock"
+          description="Set a lock to create and save receipt summaries to memory."
           onSuccess={() => {
             setShowVaultUnlock(false);
-            toast.success("Private vault is ready.");
+            toast.success("Lock ready.");
           }}
         />
       ) : null}

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -1842,7 +1842,7 @@ export function KaiFlow({
           });
           setError(null);
           toast.info(
-            "Your statement will import after you finish setting up your private vault.",
+            "Your statement will import after you set a lock.",
           );
           router.push(ROUTES.ONE_SETUP);
           return;
@@ -1851,7 +1851,7 @@ export function KaiFlow({
         setResumeImportAfterVault(false);
         setVaultDialogOpen(true);
         setError(null);
-        toast.info("Set up or open your private vault to import a portfolio.");
+        toast.info("Set a lock, or unlock it, to import a portfolio.");
         return;
       }
 
@@ -3379,7 +3379,7 @@ export function KaiFlow({
             environment: environment ?? null,
           });
           toast.info(
-            "Plaid will open after you finish setting up your private vault.",
+            "Plaid will open after you set a lock.",
           );
           router.push(ROUTES.ONE_SETUP);
           return;
@@ -3387,7 +3387,7 @@ export function KaiFlow({
         setPendingPlaidConnection(true);
         setResumePlaidAfterVault(false);
         setVaultDialogOpen(true);
-        toast.info("Set up your private vault to connect your portfolio.");
+        toast.info("Set a lock to connect your portfolio.");
         return;
       }
       setIsConnectingPlaid(true);
@@ -3508,7 +3508,7 @@ export function KaiFlow({
                     setResumePlaidAfterVault(false);
                     setVaultDialogOpen(true);
                     toast.info(
-                      "Set up or open your private vault to save Plaid details.",
+                      "Set a lock, or unlock it, to save Plaid details.",
                     );
                   } else if (mode === "import") {
                     if (onSetupSourceSettled && !shouldSettleSetupSource) {
@@ -3660,7 +3660,7 @@ export function KaiFlow({
       setError(null);
       toast.success(
         vaultKey
-          ? "Sample brokerage information loaded. Review and save to Vault."
+          ? "Sample brokerage information loaded. Review and save."
           : "Sample brokerage information loaded. Review it and continue setup when ready.",
       );
     } catch (preloadError) {
@@ -3729,7 +3729,7 @@ export function KaiFlow({
   const handleAnalyzeStock = useCallback(
     (symbol: string, _options?: AnalysisLaunchOptions) => {
       if (!symbol || !effectiveVaultOwnerToken) {
-        toast.error("Set up or open your private vault first.");
+        toast.error("Set a lock, or unlock it, first.");
         return;
       }
       useKaiSession.getState().setAnalysisParams(null);
@@ -3942,13 +3942,13 @@ export function KaiFlow({
           onOpenChange={setVaultDialogOpen}
           title={
             pendingPlaidConnection
-              ? "Set up your private vault for Plaid"
-              : "Set up your private vault for Finance"
+              ? "Set a lock for Plaid"
+              : "Set a lock for Finance"
           }
           description={
             pendingPlaidConnection
-              ? "Open your private vault so One can save the Plaid portfolio details you approved."
-              : "Set up or open your private vault before importing your statement."
+              ? "Unlock so One can save the Plaid portfolio details you approved."
+              : "Set a lock, or unlock it, before importing your statement."
           }
           enableGeneratedDefault={!preferPassphraseUnlockForAutomation()}
           onSuccess={() => {

--- a/hushh-webapp/components/kai/kai-market-news-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-news-page.tsx
@@ -291,7 +291,7 @@ export function KaiMarketNewsPage() {
         description={
           mode === "personalized"
             ? "Latest reporting around the holdings currently available in your private workspace."
-            : "A current market briefing. Unlock your vault to tailor this to your holdings."
+            : "A current market briefing. Unlock to tailor this to your holdings."
         }
         actions={
           <Button

--- a/hushh-webapp/components/kai/layout/dashboard-route-tabs.tsx
+++ b/hushh-webapp/components/kai/layout/dashboard-route-tabs.tsx
@@ -39,7 +39,7 @@ export function DashboardRouteTabs({ embedded = false }: DashboardRouteTabsProps
   const handleTabChange = useCallback(
     (nextTab: string) => {
       if (busyOperations["portfolio_save"]) {
-        toast.info("Saving to vault. Please wait until encryption completes.");
+        toast.info("Saving. Please wait until encryption completes.");
         return;
       }
       const target = KAI_ROUTE_TABS.find((tab) => tab.id === nextTab);

--- a/hushh-webapp/components/kai/portfolio-source-switcher.tsx
+++ b/hushh-webapp/components/kai/portfolio-source-switcher.tsx
@@ -134,7 +134,7 @@ export function PortfolioSourceSwitcher({
           selectionBusy
             ? "Saving your portfolio choice."
             : !canChangePortfolioSource
-              ? "Unlock your Vault to change the active portfolio."
+              ? "Unlock to change the active portfolio."
             : "Choose the holdings you want to review."
         }
         separatorInset

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -834,7 +834,7 @@ export function DashboardMasterView({
   const openPlaidLinkFlow = useCallback(
     async (itemId?: string, environment?: string | null) => {
       if (!vaultOwnerToken) {
-        toast.error("Please unlock your Vault and try again.");
+        toast.error("Unlock and try again.");
         return;
       }
 
@@ -1199,7 +1199,7 @@ export function DashboardMasterView({
 
   const persistHoldingsChanges = useCallback(async () => {
     if (!userId || !vaultKey || !statementEditablePortfolio) {
-      toast.error("Unlock your Vault to save holdings.");
+      toast.error("Unlock to save holdings.");
       return;
     }
 
@@ -1363,7 +1363,7 @@ export function DashboardMasterView({
 
   const handleDeletePortfolioData = useCallback(async () => {
     if (!userId || !vaultKey || !vaultOwnerToken) {
-      toast.error("Unlock your Vault to delete portfolio data.");
+      toast.error("Unlock to delete portfolio data.");
       return;
     }
 
@@ -2193,8 +2193,8 @@ export function DashboardMasterView({
           </AlertDialogTitle>
           <AlertDialogDescription>
             {activeSource === "plaid"
-              ? "This disconnects the Plaid brokerage portfolio and removes the local portfolio mirror from your Vault. Profile and consent data are kept."
-              : "This removes imported holdings and statement snapshots from your Vault. Profile and consent data are kept."}
+              ? "This disconnects the Plaid brokerage portfolio and removes the local portfolio mirror. Profile and consent data are kept."
+              : "This removes imported holdings and statement snapshots. Profile and consent data are kept."}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -316,7 +316,7 @@ export function ManagePortfolioView() {
   // Handle save
   const handleSave = useCallback(async () => {
     if (!user?.uid || !vaultKey) {
-      toast.error("Please unlock your vault first");
+      toast.error("Unlock first");
       return;
     }
 

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1413,8 +1413,8 @@ export function PortfolioReviewView({
       setVaultDialogOpen(true);
       toast.info(
         resolvedHasVault === false
-          ? "Create your Vault to save your portfolio."
-          : "Unlock your Vault to save your portfolio."
+          ? "Set a lock to save your portfolio."
+          : "Unlock to save your portfolio."
       );
       return;
     }
@@ -1436,7 +1436,7 @@ export function PortfolioReviewView({
 
       if (!resolvedVaultOwnerToken) {
         throw new Error(
-          "We could not complete Vault access. Unlock once and try again."
+          "We could not finish. Unlock once and try again."
         );
       }
 
@@ -1486,7 +1486,7 @@ export function PortfolioReviewView({
         userId,
         kind: "portfolio_save",
         title: "Portfolio save",
-        description: "Securing and storing your portfolio in Vault.",
+        description: "Securing your portfolio...",
         routeHref: ROUTES.KAI_DASHBOARD,
       });
 
@@ -1862,7 +1862,7 @@ export function PortfolioReviewView({
         if (financialResult.conflict) {
           throw new Error(
             financialResult.message ||
-              "Vault changed on another device. Refresh and save again."
+              "Changed on another device. Refresh and save again."
           );
         }
         throw new Error("Backend returned failure on store");
@@ -1899,8 +1899,8 @@ export function PortfolioReviewView({
         AppBackgroundTaskService.completeTask(
           saveTaskId,
           createdVaultCopyRef.current
-            ? "Vault created and portfolio saved."
-            : "Portfolio saved to Vault."
+            ? "Lock created and portfolio saved."
+            : "Portfolio saved."
         );
       }
       if (typeof window !== "undefined") {
@@ -1912,7 +1912,7 @@ export function PortfolioReviewView({
           })
         );
       }
-      toast.success("Portfolio saved to Vault.");
+      toast.success("Portfolio saved.");
       if (shouldVerifySave) {
         void (async () => {
           try {
@@ -2003,8 +2003,8 @@ export function PortfolioReviewView({
 	              {onStageForFinish && !effectiveVaultKey
 	                ? "Review now. Your portfolio is protected when setup finishes."
 	                : hasVault === false
-	                  ? "Review your portfolio, then create your Vault to save it."
-	                  : "Review before saving to Vault"}
+	                  ? "Review your portfolio, then set a lock to save it."
+	                  : "Review before saving"}
 	            </p>
 	          </div>
 	        </div>
@@ -2475,15 +2475,15 @@ export function PortfolioReviewView({
                   )}
                   {isBusySaving
                     ? hasVault === false
-                      ? "Creating Vault and saving portfolio..."
+                      ? "Setting up and saving portfolio..."
                       : isSaving
-                        ? "Securing portfolio in Vault..."
+                        ? "Securing portfolio..."
                         : "Saving portfolio in background..."
                     : onStageForFinish && !effectiveVaultKey
                       ? "Save portfolio"
                     : hasVault === false
-                    ? "Create Vault"
-                    : "Save to Vault"}
+                    ? "Set a lock"
+                    : "Save"}
                 </MorphyButton>
               </div>
             </CardContent>
@@ -2520,10 +2520,10 @@ export function PortfolioReviewView({
           }}
           title={
             hasVault === false
-              ? "Create Vault to save portfolio"
-              : "Unlock Vault to save portfolio"
+              ? "Set a lock to save portfolio"
+              : "Unlock to save portfolio"
           }
-          description="Create or unlock your Vault to save this portfolio securely."
+          description="Set a lock, or unlock it, to save this portfolio securely."
           enableGeneratedDefault={hasVault === false}
           onSuccess={(meta) => {
             createdVaultModeRef.current = meta?.mode ?? null;
@@ -2539,7 +2539,7 @@ export function PortfolioReviewView({
           <div className="mx-4 w-full max-w-sm rounded-[var(--app-card-radius-standard)] border border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-default)] p-5 shadow-[var(--app-card-shadow-feature)]">
             <div className="flex items-center gap-3">
               <Loader2 className="h-5 w-5 animate-spin text-primary" />
-              <p className="text-sm font-semibold">Securing and saving to Vault</p>
+              <p className="text-sm font-semibold">Securing and saving</p>
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
               {toInvestorMessage("SAVE_IN_PROGRESS")}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -416,7 +416,7 @@ export const Navbar = ({
 
   const navigateTo = (value: string) => {
     if (busyOperations["portfolio_save"]) {
-      toast.info("Saving to vault. Please wait until encryption completes.");
+      toast.info("Saving. Please wait until encryption completes.");
       return;
     }
 

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -835,7 +835,7 @@ export function AuthStep({
       screenId: "login",
       title: "Sign in to One",
       purpose:
-        "This is the sign-in screen. Help the person sign in with Apple or Google so they can open their private vault. Terms and Privacy Policy open as inline documents.",
+        "This is the sign-in screen. Help the person sign in with Apple or Google so they can open their private place. Terms and Privacy Policy open as inline documents.",
       actions: [
         ...(!providerBusy
           ? [

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -50,7 +50,7 @@ export function PreviewCarouselStep({
         title: "Your world,",
         accent: "kept private",
         subtitle:
-          "Everything lives in an encrypted vault. Only you hold the key, not even we can read it.",
+          "Everything is encrypted. Only you hold the key, not even we can read it.",
         preview: <VaultPreviewCompact />,
       },
       {

--- a/hushh-webapp/components/onboarding/previews/VaultPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/VaultPreviewCompact.tsx
@@ -38,7 +38,7 @@ export function VaultPreviewCompact() {
     >
       <div className="morphy-theme-content relative flex flex-col gap-3 p-4">
         <div className="flex items-center justify-between gap-4">
-          <span className="type-caption text-muted-foreground">Your vault</span>
+          <span className="type-caption text-muted-foreground">Your private place</span>
           <span className="type-caption inline-flex items-center rounded-full bg-emerald-500/12 px-2.5 py-0.5 text-emerald-600 dark:text-emerald-300">
             Private
           </span>

--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -112,7 +112,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
               <Textarea
                 value={aboutMe}
                 onChange={(event) => setAboutMe(event.target.value)}
-                placeholder="Share details about your professional background, interests, residency, or other details. Only you and One can see this, and it stays entirely inside your private vault."
+                placeholder="Share details about your professional background, interests, residency, or other details. Only you and One can see this, and it stays entirely inside your private place."
                 className="min-h-[140px] rounded-2xl p-5 text-[15px] leading-relaxed resize-none bg-background shadow-sm border border-input/60 focus-visible:ring-primary/20 focus-visible:ring-[4px] focus-visible:border-primary/40 transition-all"
                 aria-label="Tell us about yourself"
                 disabled={saving}

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -18,6 +18,7 @@ import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-compl
 import { SettingsGroup } from "@/components/app-ui/settings-ui";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { Button } from "@/lib/morphy-ux/button";
+import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import styles from "./one-setup-hub.module.css";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { useVault } from "@/lib/vault/vault-context";
@@ -239,13 +240,28 @@ export function OneSetupHub() {
       });
       notifyGeminiRuntimeConfigurationChanged(user.uid);
 
-      await acknowledgeOneSetupExit({
-        userId: user.uid,
-        skipped: false,
-        isVaultUnlocked: true,
-        vaultKey,
-        vaultOwnerToken,
-      });
+      try {
+        await acknowledgeOneSetupExit({
+          userId: user.uid,
+          skipped: false,
+          isVaultUnlocked: true,
+          vaultKey,
+          vaultOwnerToken,
+        });
+      } catch (exitSyncError) {
+        // acknowledgeOneSetupExit primes the local completion latch
+        // SYNCHRONOUSLY, before it ever awaits the durable cross-device
+        // write (see one-setup-exit-service.ts) -- a flaky retry of that
+        // write rejecting here must not trap the person behind the
+        // undismissable lock dialog. That is exactly the "glitch, then
+        // setup comes up again" report: the dialog can't be dismissed while
+        // the recovery key is showing, so an error thrown past this point
+        // froze the screen with no visible way out.
+        console.warn(
+          "[OneSetupHub] Setup exit durable write did not land yet:",
+          exitSyncError,
+        );
+      }
       setVaultDialogOpen(false);
       setVaultInvitationOpen(false);
       // Finance source intents intentionally remain process-memory-only until
@@ -261,11 +277,17 @@ export function OneSetupHub() {
     try {
       await finalize;
     } catch (error) {
-      setFinalizationError(
+      const message =
         error instanceof Error
           ? error.message
-          : "Couldn't save your setup. Try again.",
-      );
+          : "Couldn't save your setup. Try again.";
+      setFinalizationError(message);
+      // The retry banner this sets lives on the hub page, underneath the
+      // still-open (and, while the recovery key shows, undismissable) lock
+      // dialog -- so it is invisible exactly when it matters most. A toast
+      // renders above the dialog and is the only way the person learns
+      // anything went wrong instead of the screen just going quiet.
+      toast.error(message);
       throw error;
     } finally {
       if (finalizationInFlightRef.current === finalize) {

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -217,7 +217,7 @@ describe("SavedLocationsSection", () => {
     render(<SavedLocationsSection />);
 
     expect(
-      await screen.findByText(/unlock your vault to view saved places/i),
+      await screen.findByText(/unlock to view saved places/i),
     ).toBeInTheDocument();
     expect(mocks.loadSavedLocations).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: /add place/i })).toBeDisabled();
@@ -295,7 +295,7 @@ describe("SavedLocationsSection", () => {
     resolveLoad([HOME]);
 
     expect(
-      await screen.findByText(/unlock your vault to view saved places/i),
+      await screen.findByText(/unlock to view saved places/i),
     ).toBeInTheDocument();
     await waitFor(() =>
       expect(

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -227,7 +227,7 @@ export function SavedLocationsSection() {
   const handleAdd = useCallback(async () => {
     if (!userId || !vaultKey || !vaultOwnerToken || capturing) {
       if (!hasVaultAccess) {
-        toast.error("Unlock your vault before adding a saved location.");
+        toast.error("Unlock before adding a saved location.");
       }
       return;
     }
@@ -331,7 +331,7 @@ export function SavedLocationsSection() {
       addressLine?: string | null,
     ) => {
       if (!userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
-        toast.error("Unlock your vault and capture the location again.");
+        toast.error("Unlock and capture the location again.");
         return;
       }
 
@@ -420,7 +420,7 @@ export function SavedLocationsSection() {
   const handleEditSavedLocation = useCallback(
     (location: SavedLocation) => {
       if (!hasVaultAccess) {
-        toast.error("Unlock your vault before editing a saved location.");
+        toast.error("Unlock before editing a saved location.");
         return;
       }
       addressResolutionIdRef.current += 1;
@@ -553,7 +553,7 @@ export function SavedLocationsSection() {
 
   const acceptSavedLocationMapRenderer = useCallback(async () => {
     if (!vaultOwnerToken) {
-      throw new Error("Unlock your vault before opening Google Maps.");
+      throw new Error("Unlock before opening Google Maps.");
     }
     const next = await OneLocationService.updateMapPreferences({
       vaultOwnerToken,
@@ -598,11 +598,11 @@ export function SavedLocationsSection() {
               </span>
               <div className="min-w-0">
                 <p className="text-[17px] font-normal leading-[22px] text-foreground">
-                  Unlock your vault to view saved places
+                  Unlock to view saved places
                 </p>
                 <p className="mt-0.5 text-[15px] leading-5 text-muted-foreground">
                   Exact locations stay encrypted and are available only while
-                  your vault is unlocked.
+                  it's unlocked.
                 </p>
               </div>
             </div>
@@ -746,7 +746,7 @@ export function SavedLocationsSection() {
             <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
             {locationControl.paused
               ? "Resume Location to save another place."
-              : "Encrypted in your vault."}
+              : "Encrypted and private."}
           </p>
         ) : null}
       </section>

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
@@ -81,7 +81,7 @@ export function MarketplaceChatPanel(props: {
           <MarketBotAvatar />
           <div>
             <p className="text-sm font-semibold text-foreground">Information Marketplace</p>
-            <p className={MARKET_MUTED_TEXT}>Unlock your vault to use the assistant.</p>
+            <p className={MARKET_MUTED_TEXT}>Unlock to use the assistant.</p>
           </div>
         </div>
       </section>

--- a/hushh-webapp/components/privacy/permission-gate/permission-rules.ts
+++ b/hushh-webapp/components/privacy/permission-gate/permission-rules.ts
@@ -11,8 +11,8 @@ export const permissionRules: Record<SensitivePermission, PermissionRule> = {
   portfolio_valuation: {
     permission: "portfolio_valuation",
     eyebrow: "Nav privacy guard",
-    title: "Vault permission required",
+    title: "Lock required",
     description:
-      "Unlock your vault and review consent before Kai uses portfolio information for personalized market context.",
+      "Unlock and review consent before Kai uses portfolio information for personalized market context.",
   },
 };

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -656,7 +656,7 @@ export function ConnectedSystemsPanel({
   const loadSelectedSchema = useCallback(
     async (options?: { force?: boolean }) => {
       if (!vaultOwnerToken || !selectedSystem) {
-        throw new Error("Unlock your vault to review CRM fields.");
+        throw new Error("Unlock to review CRM fields.");
       }
       return ConnectedSystemsResourceService.loadSchema({
         userId: cacheScope,
@@ -1297,7 +1297,7 @@ export function ConnectedSystemsPanel({
 
   const readEncryptedFieldsRecord = async (returnFields: string[]) => {
     if (!selectedSystem || !vaultOwnerToken) {
-      throw new Error("Unlock your vault to read this CRM record privately.");
+      throw new Error("Unlock to read this CRM record privately.");
     }
     if (!encryptedFieldsReadReady) {
       throw new Error("This CRM is not ready for encrypted field reads.");
@@ -1654,7 +1654,7 @@ export function ConnectedSystemsPanel({
         if (encryptedFieldsEnabled) {
           if (!selectedSystem || !vaultOwnerToken) {
             throw new Error(
-              "Unlock your vault to approve this encrypted CRM update.",
+              "Unlock to approve this encrypted CRM update.",
             );
           }
           if (!encryptedFieldsUpdateReady) {
@@ -2040,8 +2040,8 @@ export function ConnectedSystemsPanel({
       <SettingsGroup title="CRM system">
         <SettingsRow
           icon={Database}
-          title="Unlock vault"
-          description="Unlock your vault to inspect connected CRM systems."
+          title="Unlock"
+          description="Unlock to inspect connected CRM systems."
           chevron
           onClick={onRequestUnlock}
         />

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -674,7 +674,7 @@ export function PkmNaturalPanel({
           : "Nothing new needs to be saved from that note."
       );
     } catch {
-      setCaptureMessage("That note couldn’t be prepared. Unlock your vault again and retry.");
+      setCaptureMessage("That note couldn’t be prepared. Unlock again and retry.");
     } finally {
       setCaptureLoading(false);
     }
@@ -700,7 +700,7 @@ export function PkmNaturalPanel({
       void morphyToast.promise(operation, {
         loading: "Saving reviewed memory…",
         success: "Reviewed memory saved.",
-        error: "Memory couldn’t be saved. Unlock your vault again and retry.",
+        error: "Memory couldn’t be saved. Unlock again and retry.",
       });
       const result = await operation;
       clearAgentPkmContext(user.uid);
@@ -715,7 +715,7 @@ export function PkmNaturalPanel({
         setRefreshNonce((value) => value + 1);
       }
     } catch {
-      setCaptureMessage("Memory couldn’t be saved. Unlock your vault again and retry.");
+      setCaptureMessage("Memory couldn’t be saved. Unlock again and retry.");
     } finally {
       setCaptureSaving(false);
     }
@@ -846,7 +846,7 @@ export function PkmNaturalPanel({
       <>{nativeBeacon}<SurfaceInset className="space-y-2 px-4 py-4 text-sm text-muted-foreground">
         <div className="flex items-center gap-2 font-semibold text-foreground">
           <Lock className="h-4 w-4" aria-hidden />
-          Unlock your vault to open Memory
+          Unlock to open Memory
         </div>
         <p>Your saved details are decrypted only for this unlocked session.</p>
       </SurfaceInset></>

--- a/hushh-webapp/components/profile/pkm-upgrade-status-card.tsx
+++ b/hushh-webapp/components/profile/pkm-upgrade-status-card.tsx
@@ -68,7 +68,7 @@ export function PkmUpgradeStatusCard({
               : status?.upgradeStatus === "current"
                 ? "Your saved details are up to date."
                 : status?.upgradeStatus === "awaiting_local_auth_resume"
-                  ? "Unlock your vault to continue updating your saved details."
+                  ? "Unlock to continue updating your saved details."
                   : status?.upgradeStatus === "running"
                     ? "Updating your saved details in the background while you keep using the app."
                     : status?.upgradeStatus === "failed"
@@ -133,7 +133,7 @@ export function PkmUpgradeStatusCard({
             Update paused
           </p>
           <p className="mt-1 text-sm text-foreground">
-            We could not finish updating your saved details. Try again after unlocking your vault.
+            We could not finish updating your saved details. Try again after unlocking.
           </p>
         </div>
       ) : null}

--- a/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
+++ b/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
@@ -195,7 +195,7 @@ export function RuntimeSecretSettingsCard({
       setRevealedKeys((current) => ({ ...current, [provider.id]: null }));
       setShowKeys((current) => ({ ...current, [provider.id]: false }));
       setConfiguredKeys((current) => ({ ...current, [provider.id]: true }));
-      toast.success(`${provider.label} key saved to your encrypted vault.`);
+      toast.success(`${provider.label} key saved.`);
     } catch (error) {
       const message =
         error instanceof Error
@@ -276,7 +276,7 @@ export function RuntimeSecretSettingsCard({
       setRevealedKeys((current) => ({ ...current, [provider.id]: null }));
       setShowKeys((current) => ({ ...current, [provider.id]: false }));
       setConfiguredKeys((current) => ({ ...current, [provider.id]: false }));
-      toast.success(`${provider.label} key removed from your encrypted vault.`);
+      toast.success(`${provider.label} key removed.`);
     } catch (error) {
       const message =
         error instanceof Error
@@ -319,7 +319,7 @@ export function RuntimeSecretSettingsCard({
       });
       if (!secret) {
         setConfiguredKeys((current) => ({ ...current, [provider.id]: false }));
-        toast.error(`No saved ${provider.label} key found in your encrypted vault.`);
+        toast.error(`No saved ${provider.label} key found.`);
         return;
       }
       setRevealedKeys((current) => ({ ...current, [provider.id]: secret }));
@@ -337,7 +337,7 @@ export function RuntimeSecretSettingsCard({
 
   const statusLabel = (providerId: RuntimeSecretProviderId) =>
     needsVaultCreation
-      ? "Vault needed"
+      ? "Set up lock"
       : needsUnlock
         ? "Locked"
         : loadingStatus
@@ -349,7 +349,7 @@ export function RuntimeSecretSettingsCard({
   return (
     <SettingsGroup
       title="Runtime keys"
-      description="Store model provider keys in your encrypted PKM vault."
+      description="Store model provider keys securely."
       testId="runtime-secret-settings"
     >
       <div className="space-y-3 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
@@ -363,7 +363,7 @@ export function RuntimeSecretSettingsCard({
                 Model provider keys
               </p>
               <p className="text-[12px] leading-[1.45] text-muted-foreground">
-                Encrypted in your PKM vault.
+                Encrypted and private.
               </p>
             </div>
           </div>
@@ -488,9 +488,9 @@ export function RuntimeSecretSettingsCard({
                         Saving...
                       </>
                     ) : needsVaultCreation ? (
-                      "Create vault"
+                      "Set a lock"
                     ) : needsUnlock || !vaultReady ? (
-                      "Unlock vault"
+                      "Unlock"
                     ) : (
                       "Save"
                     )}

--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -46,7 +46,7 @@ export function RecoveryKeyDialog({
   };
 
   const handleDownload = async () => {
-    const content = `Hussh Vault Recovery Key\n\n${recoveryKey}\n\nKeep this safe! You'll need it if you forget your passphrase.`;
+    const content = `Hussh Recovery Key\n\n${recoveryKey}\n\nKeep this safe! You'll need it if you forget your passphrase.`;
     const success = await downloadTextFile(content, 'hushh-recovery-key.txt');
     if (success) {
       setDownloaded(true);
@@ -62,7 +62,7 @@ export function RecoveryKeyDialog({
             Save Your Recovery Key
           </DialogTitle>
           <DialogDescription>
-            This is the ONLY way to recover your vault if you forget your passphrase.
+            This is the ONLY way to recover access if you forget your passphrase.
             Save it somewhere safe!
           </DialogDescription>
         </DialogHeader>

--- a/hushh-webapp/components/wallet-card/wallet-card-copy.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-copy.ts
@@ -98,7 +98,7 @@ export const WALLET_CARD_OWNER_COPY = {
   lastScannedLabel: "Last scan",
   noLinkOnThisDevice:
     "Your share link isn't stored on this device, so the QR can't be shown here. Rotate QR access to create a new link — the current QR stops working.",
-  vaultLocked: "Unlock your vault to set up your Wallet Profile.",
+  vaultLocked: "Unlock to set up your Wallet Profile.",
   featureUnavailable: "Wallet Profile isn't available on this account yet.",
   loadFailed: "We couldn't load your Wallet Profile. Please try again in a moment.",
   saveFailed: "We couldn't save your Wallet Profile. Please try again in a moment.",

--- a/hushh-webapp/lib/agent/agent-pkm-memory.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-memory.ts
@@ -592,7 +592,7 @@ export async function loadAgentPkmContext(params: {
 }): Promise<AgentPkmContext> {
   if (params.requireDecrypted && (!params.vaultKey || params.metadataOnly)) {
     throw new AgentPkmContextNotReadyError(
-      "Unlock your vault before asking Agent about your private memory."
+      "Unlock before asking Agent about your private memory."
     );
   }
 
@@ -640,7 +640,7 @@ export async function loadAgentPkmContext(params: {
   }
   if (params.requireDecrypted) {
     throw new AgentPkmContextNotReadyError(
-      "Unlock your vault before asking Agent about your private memory."
+      "Unlock before asking Agent about your private memory."
     );
   }
   const metadata = await PersonalKnowledgeModelService.getMetadata(

--- a/hushh-webapp/lib/agent/agent-welcome-prompts.ts
+++ b/hushh-webapp/lib/agent/agent-welcome-prompts.ts
@@ -15,7 +15,7 @@ export type AgentWelcomePromptContext = {
 const WELCOME_PROMPT_DECK: readonly (readonly AgentWelcomePrompt[])[] = [
   ["Review my portfolio", "Save a memory", "Explain consent flows"],
   ["Analyze a stock", "Help me organize a memory", "What can I safely share?"],
-  ["Review my portfolio", "How does my vault stay private?", "Show my consent requests"],
+  ["Review my portfolio", "How is my data kept private?", "Show my consent requests"],
   ["What moved in the market today?", "Save a memory", "What can One help with?"],
 ] as const;
 

--- a/hushh-webapp/lib/consent/consent-display.ts
+++ b/hushh-webapp/lib/consent/consent-display.ts
@@ -58,7 +58,7 @@ export function humanizeConsentScope(scope: string | null | undefined): string {
       .replace(/\b\w/g, (char) => char.toUpperCase());
   }
 
-  if (normalized === "vault.owner") return "Full vault access";
+  if (normalized === "vault.owner") return "Full private access";
   if (normalized === "pkm.read") return "Personal Knowledge Model access";
   if (normalized === "pkm.write") return "Personal Knowledge Model updates";
 

--- a/hushh-webapp/lib/consent/use-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-consent-actions.ts
@@ -262,9 +262,9 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
       markAsHandling(consent.id);
 
       if (!userId || !vaultKey) {
-        toast.error("Vault not unlocked", {
+        toast.error("Locked", {
           id: toastId,
-          description: "Unlock your vault to approve this request.",
+          description: "Unlock to approve this request.",
           duration: 6000,
           action: {
             label: "Unlock",
@@ -281,7 +281,7 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
       const promise = (async () => {
         const vaultOwnerToken = getVaultOwnerToken();
         if (!vaultOwnerToken) {
-          throw new Error("Vault owner token required");
+          throw new Error("Not ready yet. Try again.");
         }
 
         let scopeData: Record<string, unknown> = {};
@@ -303,7 +303,7 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
           } catch (err) {
             if (err instanceof SyntaxError) {
               console.error("[Consent] Failed to parse PKM blob after decrypt");
-              throw new Error("Could not prepare export; check vault.");
+              throw new Error("Could not prepare export. Try again.");
             }
             if (err instanceof ConsentExportNoDataError) {
               throw err;
@@ -575,7 +575,7 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
       const promise = (async () => {
         const vaultOwnerToken = getVaultOwnerToken();
         if (!vaultOwnerToken) {
-          throw new Error("Vault owner token required");
+          throw new Error("Not ready yet. Try again.");
         }
 
         const response = await ApiService.denyPendingConsent({
@@ -730,8 +730,8 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
             detail: { reason: "VAULT_OWNER token revoked" }
           }));
           
-          toast.info("Vault locked", {
-            description: "Your VAULT_OWNER access has been revoked. Please unlock again to continue.",
+          toast.info("Locked", {
+            description: "Your access has been revoked. Please unlock again to continue.",
             duration: 5000,
           });
         }

--- a/hushh-webapp/lib/consent/use-marketplace-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-marketplace-consent-actions.ts
@@ -140,7 +140,7 @@ export function useMarketplaceConsentActions(
   const requireToken = useCallback((): string | null => {
     const token = getVaultOwnerToken();
     if (!token) {
-      toast.error("Unlock your vault to manage this marketplace request.");
+      toast.error("Unlock to manage this marketplace request.");
       return null;
     }
     return token;
@@ -165,7 +165,7 @@ export function useMarketplaceConsentActions(
         { key: actionKey, kind: "approve", requestId },
         async () => {
           if (!userId || !vaultKey) {
-            toast.error("Unlock your vault to approve this request.");
+            toast.error("Unlock to approve this request.");
             return;
           }
           const vaultOwnerToken = requireToken();

--- a/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
@@ -151,7 +151,7 @@ export function useOneLocationConsentActions(
   const requireToken = useCallback((): string | null => {
     const token = getVaultOwnerToken();
     if (!token) {
-      toast.error("Unlock your vault to manage this location request.");
+      toast.error("Unlock to manage this location request.");
       return null;
     }
     return token;

--- a/hushh-webapp/lib/copy/investor-language.ts
+++ b/hushh-webapp/lib/copy/investor-language.ts
@@ -49,11 +49,11 @@ export function toInvestorMessage(
     case "ONBOARDING_STATE_UNAVAILABLE":
       return "We could not load your onboarding progress. Please try again.";
     case "VAULT_STATUS_UNAVAILABLE":
-      return "We could not reach Vault right now. Check your connection and try again.";
+      return "We could not reach it right now. Check your connection and try again.";
     case "LOCAL_BACKEND_UNAVAILABLE":
       return "Local backend information is unavailable right now. Start the local backend with the proxy-aware launcher, then try again.";
     case "VAULT_UNLOCK_FAILED":
-      return "We could not unlock your Vault. Please confirm your details and try again.";
+      return "We could not unlock it. Please confirm your details and try again.";
     case "VAULT_PASSKEY_ENROLL_REQUIRED":
       return "This passkey was enrolled under an older domain. Use your passphrase once, then enable passkey again for one.hushh.ai.";
     case "MARKET_DATA_UNAVAILABLE":
@@ -89,7 +89,7 @@ export function toInvestorVaultUnlockError(value: unknown): string {
   }
 
   if (lowered.includes("bluetooth")) {
-    return "Turn on Bluetooth to use a passkey from another device, or use your Vault Key or Recovery Key below.";
+    return "Turn on Bluetooth to use a passkey from another device, or use your passphrase or recovery key below.";
   }
 
   if (
@@ -102,7 +102,7 @@ export function toInvestorVaultUnlockError(value: unknown): string {
     lowered.includes("cancelled") ||
     lowered.includes("canceled")
   ) {
-    return "Passkey unlock did not finish. Try again, or use your Vault Key or Recovery Key below.";
+    return "Passkey unlock did not finish. Try again, or use your passphrase or recovery key below.";
   }
 
   if (
@@ -110,7 +110,7 @@ export function toInvestorVaultUnlockError(value: unknown): string {
     lowered.includes("quick unlock is not enabled") ||
     lowered.includes("not enabled on this device")
   ) {
-    return "Passkey unlock is not ready on this device yet. Use your Vault Key once, then try passkey again.";
+    return "Passkey unlock is not ready on this device yet. Use your passphrase once, then try passkey again.";
   }
 
   if (
@@ -136,7 +136,7 @@ export function toInvestorLoading(stage: InvestorLoadingStage): string {
     case "ANALYSIS":
       return "Preparing your analysis...";
     case "VAULT":
-      return "Opening your Vault...";
+      return "Opening...";
     default:
       return "Loading...";
   }

--- a/hushh-webapp/lib/kai/brokerage/use-portfolio-sources.ts
+++ b/hushh-webapp/lib/kai/brokerage/use-portfolio-sources.ts
@@ -740,7 +740,7 @@ export function usePortfolioSources({
   const deleteStatementSnapshot = useCallback(
     async (snapshotId: string) => {
       if (!userId || !vaultOwnerToken || !vaultKey) {
-        throw new Error("Unlock your Vault to delete this statement.");
+        throw new Error("Unlock to delete this statement.");
       }
       if (sourceChangeInflightRef.current || statementSnapshotChangeInflightRef.current) {
         throw new Error("Finish the current portfolio change before deleting a statement.");
@@ -797,7 +797,7 @@ export function usePortfolioSources({
   const refreshPlaid = useCallback(
     async (itemId?: string) => {
       if (!userId || !vaultOwnerToken) {
-        throw new Error("Vault owner token missing.");
+        throw new Error("Not ready yet. Try again.");
       }
       const runningRunIds = collectRunningRunIds(plaidStatus, itemId);
       if (runningRunIds.length > 0) {
@@ -848,7 +848,7 @@ export function usePortfolioSources({
   const cancelPlaidRefresh = useCallback(
     async (params?: { itemId?: string; runIds?: string[] }) => {
       if (!userId || !vaultOwnerToken) {
-        throw new Error("Vault owner token missing.");
+        throw new Error("Not ready yet. Try again.");
       }
       const targetRunIds = (
         params?.runIds?.length

--- a/hushh-webapp/lib/legal/kai-legal-content.ts
+++ b/hushh-webapp/lib/legal/kai-legal-content.ts
@@ -67,7 +67,7 @@ export const KAI_LEGAL_DOCUMENTS: Record<KaiLegalDocumentType, KaiLegalDocument>
         title: "Consent-First Access",
         points: [
           "All protected information access requires a consent token; signed-in identity alone is not sufficient.",
-          "Vault-owner flows are consent-gated and all consent operations are auditable.",
+          "Access to a client's data is consent-gated end to end, and every consent operation is auditable.",
         ],
       },
       {

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -183,7 +183,7 @@ function requireUnlockedVault(
   vaultOwnerToken: string;
 } {
   if (!context.userId || !context.vaultKey || !context.vaultOwnerToken) {
-    throw new Error("Unlock your vault before managing saved locations.");
+    throw new Error("Unlock before managing saved locations.");
   }
 }
 
@@ -263,7 +263,7 @@ async function mutateSavedLocations(params: {
   });
 
   if (!result.success) {
-    throw new Error(result.message || "Could not save locations to your vault.");
+    throw new Error(result.message || "Could not save your locations.");
   }
   return persistedLocations;
 }

--- a/hushh-webapp/lib/personal-knowledge-model/natural-language.ts
+++ b/hushh-webapp/lib/personal-knowledge-model/natural-language.ts
@@ -278,7 +278,7 @@ function describeScopeForDomain(
   }
   if (normalizedScope === "vault.owner") {
     return {
-      label: "Can manage your full vault and everything inside it.",
+      label: "Can manage everything you've saved.",
       coverageKind: "broad",
     };
   }

--- a/hushh-webapp/lib/profile/pkm-profile-presentation.ts
+++ b/hushh-webapp/lib/profile/pkm-profile-presentation.ts
@@ -541,7 +541,7 @@ function visibilityPostureCopy(params: {
     return {
       label: "Private to your private agent",
       description:
-        "One can use this after you unlock your vault. Sharing is disabled for external recipients.",
+        "One can use this after you unlock. Sharing is disabled for external recipients.",
       counterpartSummary: "Sharing disabled",
     };
   }

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -119,7 +119,7 @@ export const RIA_COPY = {
       title: "Avoid list is empty",
       description: "Add names for Kai to exclude from debates.",
     },
-    unlockRail: "Unlock the vault to edit or publish.",
+    unlockRail: "Unlock to edit or publish.",
   },
 
   debate: {

--- a/hushh-webapp/lib/seo/faq-data.ts
+++ b/hushh-webapp/lib/seo/faq-data.ts
@@ -8,7 +8,7 @@ export const HOME_FAQ: readonly FaqItem[] = [
   {
     question: "What is Hussh?",
     answer:
-      "Hussh is the platform and trust infrastructure for consent-first private AI agents. It provides scoped access, bring-your-own-key (BYOK), a zero-knowledge vault, and encrypted personal knowledge memory (PKM), so your information stays yours.",
+      "Hussh is the platform and trust infrastructure for consent-first private AI agents. It provides scoped access, bring-your-own-key (BYOK), zero-knowledge encryption, and encrypted personal knowledge memory (PKM), so your information stays yours.",
   },
   {
     question: "What is One?",
@@ -18,12 +18,12 @@ export const HOME_FAQ: readonly FaqItem[] = [
   {
     question: "What are Kai, Nav, and KYC?",
     answer:
-      "Kai is the finance specialist for portfolio, market intelligence, and investing workflows. Nav is the privacy and consent guardian for scope review, vault, and deletion. KYC is the identity workflow specialist for verification and structured PKM writeback.",
+      "Kai is the finance specialist for portfolio, market intelligence, and investing workflows. Nav is the privacy and consent guardian for scope review, access, and deletion. KYC is the identity workflow specialist for verification and structured PKM writeback.",
   },
   {
     question: "How does Hussh protect my information?",
     answer:
-      "Every read or action happens only after you grant a scoped consent token. Keys are yours through BYOK, the vault is zero-knowledge, and your personal knowledge memory is encrypted. There are no silent reads and no implied platform access.",
+      "Every read or action happens only after you grant a scoped consent token. Keys are yours through BYOK, storage is zero-knowledge, and your personal knowledge memory is encrypted. There are no silent reads and no implied platform access.",
   },
   {
     question: "Is Hussh available on mobile?",

--- a/hushh-webapp/lib/seo/structured-data.ts
+++ b/hushh-webapp/lib/seo/structured-data.ts
@@ -28,7 +28,7 @@ export function buildOrganizationGraph(): Record<string, unknown> {
         url: SITE_URL,
         logo: absoluteUrl("/quiet-emoji-icon.png"),
         description:
-          "Hussh is the platform and trust infrastructure for consent-first private AI agents: scoped access, BYOK, zero-knowledge vault, and encrypted PKM.",
+          "Hussh is the platform and trust infrastructure for consent-first private AI agents: scoped access, BYOK, zero-knowledge encryption, and encrypted PKM.",
         sameAs: ["https://hushh.ai"],
       },
       {
@@ -66,10 +66,10 @@ export function buildOrganizationGraph(): Record<string, unknown> {
         featureList: [
           "One: relationship layer and specialist handoffs",
           "Kai: finance, portfolio, and market intelligence",
-          "Nav: privacy, consent, and vault guardian",
+          "Nav: privacy, consent, and access guardian",
           "KYC: identity workflow specialist",
           "Consent-first scoped access with BYOK",
-          "Zero-knowledge vault and encrypted personal information memory",
+          "Zero-knowledge encryption and encrypted personal information memory",
         ],
       },
     ],

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -2192,7 +2192,7 @@ export class ApiService {
 
     if (!vaultOwnerToken) {
       const response = new Response(
-        JSON.stringify({ error: "Vault must be unlocked" }),
+        JSON.stringify({ error: "Please unlock" }),
         { status: 401 },
       );
       trackEvent("consent_action_result", {
@@ -2304,7 +2304,7 @@ export class ApiService {
 
     if (!vaultOwnerToken) {
       const response = new Response(
-        JSON.stringify({ error: "Vault must be unlocked" }),
+        JSON.stringify({ error: "Please unlock" }),
         { status: 401 },
       );
       trackEvent("consent_action_result", {
@@ -2380,7 +2380,7 @@ export class ApiService {
     });
     if (!vaultOwnerToken) {
       const response = new Response(
-        JSON.stringify({ error: "Vault must be unlocked" }),
+        JSON.stringify({ error: "Please unlock" }),
         { status: 401 },
       );
       trackEvent("consent_action_result", {
@@ -2485,7 +2485,7 @@ export class ApiService {
       options?.loadSurface ?? "screen";
     if (!vaultOwnerToken) {
       const response = new Response(
-        JSON.stringify({ error: "Vault must be unlocked" }),
+        JSON.stringify({ error: "Please unlock" }),
         { status: 401 },
       );
       trackEvent("consent_pending_loaded", {
@@ -2563,7 +2563,7 @@ export class ApiService {
     openedVia?: string;
   }): Promise<Response> {
     if (!data.vaultOwnerToken) {
-      return new Response(JSON.stringify({ error: "Vault must be unlocked" }), {
+      return new Response(JSON.stringify({ error: "Please unlock" }), {
         status: 401,
       });
     }
@@ -2680,7 +2680,7 @@ export class ApiService {
     vaultOwnerToken: string,
   ): Promise<Response> {
     if (!vaultOwnerToken) {
-      return new Response(JSON.stringify({ error: "Vault must be unlocked" }), {
+      return new Response(JSON.stringify({ error: "Please unlock" }), {
         status: 401,
       });
     }
@@ -2725,7 +2725,7 @@ export class ApiService {
     limit: number = 50,
   ): Promise<Response> {
     if (!vaultOwnerToken) {
-      return new Response(JSON.stringify({ error: "Vault must be unlocked" }), {
+      return new Response(JSON.stringify({ error: "Please unlock" }), {
         status: 401,
       });
     }
@@ -3054,7 +3054,7 @@ export class ApiService {
 
     const vaultOwnerToken = this.getVaultOwnerToken();
     if (!vaultOwnerToken) {
-      return new Response(JSON.stringify({ error: "Vault must be unlocked" }), {
+      return new Response(JSON.stringify({ error: "Please unlock" }), {
         status: 401,
       });
     }
@@ -3801,7 +3801,7 @@ export class ApiService {
             portfolioStreamLastError: "Vault must be unlocked",
           });
           return new Response(
-            JSON.stringify({ error: "Vault must be unlocked" }),
+            JSON.stringify({ error: "Please unlock" }),
             { status: 401 },
           );
         }
@@ -4014,7 +4014,7 @@ export class ApiService {
     // Use VAULT_OWNER token for consent-gated access
     if (!data.vaultOwnerToken) {
       const response = new Response(
-        JSON.stringify({ error: "Vault must be unlocked to import portfolio" }),
+        JSON.stringify({ error: "Please unlock to import portfolio" }),
         { status: 401 },
       );
       trackEvent("import_quality_gate_failed", {
@@ -4528,7 +4528,7 @@ export class ApiService {
         const vaultOwnerToken = data.vaultOwnerToken;
         if (!vaultOwnerToken) {
           return new Response(
-            JSON.stringify({ error: "Vault must be unlocked" }),
+            JSON.stringify({ error: "Please unlock" }),
             { status: 401 },
           );
         }
@@ -4673,7 +4673,7 @@ export class ApiService {
         const vaultOwnerToken = data.vaultOwnerToken;
         if (!vaultOwnerToken) {
           return new Response(
-            JSON.stringify({ error: "Vault must be unlocked" }),
+            JSON.stringify({ error: "Please unlock" }),
             { status: 401 },
           );
         }
@@ -4752,7 +4752,7 @@ export class ApiService {
         const vaultOwnerToken = data.vaultOwnerToken;
         if (!vaultOwnerToken) {
           return new Response(
-            JSON.stringify({ error: "Vault must be unlocked" }),
+            JSON.stringify({ error: "Please unlock" }),
             { status: 401 },
           );
         }
@@ -4981,7 +4981,7 @@ export class ApiService {
         const vaultOwnerToken = data.vaultOwnerToken;
         if (!vaultOwnerToken) {
           return new Response(
-            JSON.stringify({ error: "Vault must be unlocked" }),
+            JSON.stringify({ error: "Please unlock" }),
             { status: 401 },
           );
         }

--- a/hushh-webapp/lib/services/consent-export-refresh-orchestrator.ts
+++ b/hushh-webapp/lib/services/consent-export-refresh-orchestrator.ts
@@ -42,7 +42,7 @@ export class ConsentExportRefreshOrchestrator {
   static pauseForLocalAuthResume(params: { userId: string }): void {
     this.pauseRequestedByUser.add(params.userId);
     AppBackgroundTaskService.updateTask(taskIdForUser(params.userId), {
-      description: "Unlock your vault to resume updating approved sharing.",
+      description: "Unlock to resume updating approved sharing.",
       routeHref: TASK_ROUTE,
       metadata: {
         pausedForLocalAuth: true,
@@ -67,7 +67,7 @@ export class ConsentExportRefreshOrchestrator {
         AppBackgroundTaskService.failTask(
           taskId,
           "Could not update approved sharing.",
-          "We could not finish updating approved sharing. It will retry after Vault unlock.",
+          "We could not finish updating approved sharing. It will retry after you unlock.",
           {
             failureKind:
               error instanceof Error ? error.name || "Error" : "unknown",
@@ -244,7 +244,7 @@ export class ConsentExportRefreshOrchestrator {
     } catch (error) {
       if (error instanceof ConsentExportRefreshPausedError) {
         AppBackgroundTaskService.updateTask(taskId, {
-          description: "Unlock your vault to resume updating approved sharing.",
+          description: "Unlock to resume updating approved sharing.",
           routeHref: TASK_ROUTE,
           metadata: {
             pausedForLocalAuth: true,
@@ -273,7 +273,7 @@ export class ConsentExportRefreshOrchestrator {
             } and left ${failureCount} update${
               failureCount === 1 ? "" : "s"
             } pending for retry.`
-          : "We paused while updating approved sharing. Try again after unlocking your vault."
+          : "We paused while updating approved sharing. Try again after unlocking."
       );
       return;
     }

--- a/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
+++ b/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
@@ -1321,7 +1321,7 @@ export class OneKycClientZkService {
     const next = await generateConnectorRecord();
     const save = await this.storeConnector({ ...params, connector: next });
     if (!save.success) {
-      throw new Error(save.message || "Unable to save KYC connector in your vault.");
+      throw new Error(save.message || "Unable to save KYC connector.");
     }
     await OneKycService.registerClientConnector({
       userId: params.userId,

--- a/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
+++ b/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
@@ -232,7 +232,7 @@ function descriptionForStatus(
     return `Checking ${domainLabel} without changing anything.`;
   }
   if (status === "awaiting_local_auth_resume") {
-    return `We will continue updating ${domainLabel} after you unlock your vault.`;
+    return `We will continue updating ${domainLabel} after you unlock.`;
   }
   if (status === "completed") {
     return "Your saved details are up to date.";

--- a/hushh-webapp/lib/services/pkm-write-coordinator.ts
+++ b/hushh-webapp/lib/services/pkm-write-coordinator.ts
@@ -151,7 +151,7 @@ function pkmWriteFailureResult(error: unknown): PkmWriteCoordinatorResult {
   console.error("[PkmWriteCoordinator] PKM write failed:", error);
   return emptyResult(
     "failed",
-    "We couldn't save this to your vault. Try again, or make sure your vault is set up.",
+    "We couldn't save this. Try again, or make sure you've set a lock.",
   );
 }
 
@@ -273,7 +273,7 @@ export class PkmWriteCoordinator {
     build: (context: BaseContext) => Promise<MergedWritePlan> | MergedWritePlan;
   }): Promise<PkmWriteCoordinatorResult> {
     if (!params.vaultKey || !params.vaultOwnerToken) {
-      return emptyResult("blocked_pending_unlock", "Unlock your vault before saving.");
+      return emptyResult("blocked_pending_unlock", "Unlock before saving.");
     }
 
     let upgradedInSession = false;
@@ -385,7 +385,7 @@ export class PkmWriteCoordinator {
     build: (context: BaseContext) => Promise<PreparedWritePlan> | PreparedWritePlan;
   }): Promise<PkmWriteCoordinatorResult> {
     if (!params.vaultKey || !params.vaultOwnerToken) {
-      return emptyResult("blocked_pending_unlock", "Unlock your vault before saving.");
+      return emptyResult("blocked_pending_unlock", "Unlock before saving.");
     }
 
     let upgradedInSession = false;

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -2580,7 +2580,7 @@ export class RiaService {
     screening_sections?: RiaScreeningSection[];
   }): Promise<RiaPicksResponse> {
     if (!params.vaultKey || !params.vaultOwnerToken) {
-      throw new Error("Unlock the vault before saving advisor picks.");
+      throw new Error("Unlock before saving advisor picks.");
     }
 
     const nextPackage = normalizePickPackage({

--- a/hushh-webapp/lib/vault/trusted-device-passkey-handoff.ts
+++ b/hushh-webapp/lib/vault/trusted-device-passkey-handoff.ts
@@ -112,7 +112,7 @@ export async function buildTrustedDevicePasskeyHandoff(params: {
     wrapper.iv,
   );
   if (!vaultKey) {
-    throw new Error("The selected One passkey could not unlock this vault.");
+    throw new Error("The selected One passkey could not unlock this.");
   }
   await VaultService.assertVaultKeyMatchesState(vaultState, vaultKey);
 

--- a/hushh-webapp/lib/voice/investor-kai-action-registry.ts
+++ b/hushh-webapp/lib/voice/investor-kai-action-registry.ts
@@ -138,7 +138,7 @@ function describeGuard(guardId: string): string {
     case "auth_signed_in":
       return "User must be signed in.";
     case "vault_unlocked":
-      return "Vault must be unlocked.";
+      return "Unlock first.";
     case "portfolio_required":
       return "Portfolio information must already exist.";
     case "analysis_idle_required":

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -924,7 +924,7 @@ export function evaluateKaiActionAvailability(input: {
     ) {
       return {
         status: "blocked",
-        reason: "Unlock the vault to use this action.",
+        reason: "Unlock to use this action.",
         target_persona: null,
         blocked_guidance: null,
       };


### PR DESCRIPTION
## Summary

Closes #5496.

**The bug** — after finishing "Set a lock" during onboarding, the flow could silently stall and land the person back on the setup hub ("glitch, then setup comes up again").

Root cause: `completeSetupAfterVault()` awaited `acknowledgeOneSetupExit()` directly. That service primes its local "setup dismissed" latch *synchronously*, before it ever awaits the durable cross-device write — its own existing test proves the write can reject after retries while the latch stays set ("Skip is never a dead end"). The caller didn't honor that contract: a rejection from the retry-exhausted write aborted the whole finalize step, leaving the dialog open. It can't be dismissed while the recovery key is showing (by design, so nobody loses it), so the only visible symptom was the screen going quiet.

Fix: swallow that one rejection (log + continue) so the dialog still closes and the person still leaves, matching the service's documented intent. The three genuinely-blocking finalize steps (encrypted pre-vault/finance draft writes) still block correctly — but now also raise a toast, since their existing retry banner renders underneath the still-open dialog and was invisible exactly when it mattered.

**The copy sweep** — the 2026-08-16 pass renamed the setup/create-passphrase screens to plain language ("Set a lock", "your private place", "passphrase") but left the rest of the app saying "Vault": profile security, agent chat, Kai portfolio flows, Location, KYC, consent, connections, onboarding, RIA/marketplace, and public FAQ/legal copy. This PR finishes that pass app-wide, per founder directive: "vault" stays in code (service names, props, test ids) and never reaches anything a person reads.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Full `vitest run` compared against an `origin/main` baseline at the same SHA: **23/23 failing test files identical on both** (all pre-existing, unrelated — WebCrypto/jsdom polyfill gaps and known-flaky component timing tests). Zero regressions introduced.
- [x] Added 2 regression tests for the exit-trap fix (contract tests on `one-setup-hub.tsx` asserting the rejection is swallowed, not rethrown, and that a toast fires).
- [x] Updated the handful of existing tests whose assertions were pinned to retired "vault"-labeled copy.