### PR TITLE
fix(one-location): clear the SMS send-button hold label once the alert goes live

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -361,6 +361,35 @@ describe("SosPanel", () => {
     expect(onTrigger).not.toHaveBeenCalled();
   });
 
+  // Regression: the send button's "Hold to send..." label snaps its hold
+  // progress to 1 on fire, and used to only unwind once `busy` cleared with
+  // `active` still false -- never true on a successful send, since `busy`
+  // and `active` flip together. The label stayed stuck on screen for as
+  // long as the alert stayed live.
+  it("clears the send-button hold label once the alert goes live", () => {
+    const onTrigger = vi.fn();
+    const { rerender } = render(
+      <SosPanel {...baseProps} onTrigger={onTrigger} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Add a message"), {
+      target: { value: "Emergency" },
+    });
+    const send = screen.getByTestId("sos-send-custom-message");
+    fireEvent.pointerDown(send, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.pointerUp(send, { pointerId: 1 });
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+
+    // Parent goes busy while the request is in flight...
+    rerender(<SosPanel {...baseProps} onTrigger={onTrigger} busy />);
+    // ...then settles into the live state once it succeeds, same as a real
+    // successful send: `busy` and `active` flip together.
+    rerender(<SosPanel {...baseProps} onTrigger={onTrigger} active />);
+
+    expect(screen.queryByText(/Hold to send…/)).toBeNull();
+  });
+
   it("passes the selected fixed message and opens contacts from the Emergency contacts row", () => {
     const onTrigger = vi.fn();
     const onEditContacts = vi.fn();
@@ -380,9 +409,7 @@ describe("SosPanel", () => {
     act(() => vi.advanceTimersByTime(2_000));
     expect(onTrigger).toHaveBeenCalledWith("I'm not safe");
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /will be alerted/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /will be alerted/i }));
     expect(onEditContacts).toHaveBeenCalledTimes(1);
   });
 
@@ -549,9 +576,7 @@ describe("SosPanel — shell header contract", () => {
     const onEditContacts = vi.fn();
     render(<SosPanel {...baseProps} onEditContacts={onEditContacts} />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /will be alerted/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /will be alerted/i }));
     expect(onEditContacts).toHaveBeenCalledTimes(1);
   });
 

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -480,9 +480,20 @@ export function SosPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ringHold.cancel, sendHold.cancel]);
 
+  // `!active` used to gate this reset -- written only for the bail-out case
+  // (trigger returned without ever going live). On a SUCCESSFUL send, `busy`
+  // goes true -> false at the same moment `active` goes false -> true, so
+  // that guard meant this never ran on the normal path: `sendHold.progress`
+  // (and the ring's own progress) stayed stuck at 1 for as long as the alert
+  // stayed live. Harmless for the ring, whose progress-driven UI is already
+  // unmounted once `active` (swapped for the "SENT" checkmark), but visible
+  // for the send button's floating "Hold to send..." label, which has no such
+  // unmount. Dropping `!active` resets on every busy edge; nothing can
+  // re-arm early from this alone, since `hardDisabled` (and therefore both
+  // holds' own `disabled`) already includes `active`.
   useEffect(() => {
     if (busy) observedBusyRef.current = true;
-    if (!busy && observedBusyRef.current && !active) {
+    if (!busy && observedBusyRef.current) {
       observedBusyRef.current = false;
       firedRef.current = false;
       resetHoldsRef.current();
@@ -844,7 +855,15 @@ export function SosPanel({
                 (#5433): a typed message used to send on a single tap, which
                 made this the one control on the screen where one accidental
                 tap dispatched a real emergency broadcast. */}
-            {sendHold.progress > 0 ? (
+            {/* Gated on `!messageLocked`, not just `progress > 0`: a fired
+                hold snaps `progress` to 1 and it only comes back down once
+                `busy` clears (see the reset effect above), which can be a beat
+                after the button is already locked mid-send, or -- before that
+                effect dropped its own `!active` guard -- indefinitely once the
+                alert went live. Matches the ring's own precedent of hiding its
+                progress UI entirely once locked, rather than trusting the
+                numeric state alone to unwind in time. */}
+            {sendHold.progress > 0 && !messageLocked ? (
               <span
                 role="status"
                 className="pointer-events-none absolute -top-9 right-0 whitespace-nowrap rounded-full bg-[color:var(--sos-control-surface)] px-2.5 py-1 text-[12px] text-[color:var(--sos-label)] shadow-sm"
@@ -861,7 +880,7 @@ export function SosPanel({
               data-testid="sos-send-custom-message"
               disabled={hardDisabled || !selectedMessage}
               aria-label={
-                sendHold.progress > 0
+                sendHold.progress > 0 && !messageLocked
                   ? `Sending in ${(
                       (HOLD_DURATION_MS / 1000) *
                       (1 - sendHold.progress)


### PR DESCRIPTION
## Description

Follow-up fix to the hold-to-send change from #5478 (issue #5433). Reported with a screenshot: after holding the custom-message send button to completion, the alert sends and the panel settles into "Alert sent" / "Live location" -- but the floating grey "Hold to send... X.Xs" label above the send button stays stuck on screen instead of disappearing.

Root cause: the shared reset effect that brings hold progress back to 0 after a send only ran on `!busy && observedBusyRef.current && !active`. That `!active` guard was written for the bail-out case (trigger returned without ever going live) -- on a *successful* send, `busy` and `active` flip together, so the reset never fired. `sendHold.progress` (snapped to 1 the instant the hold completed) stayed stuck for as long as the alert stayed live. This was invisible for the big ring, whose progress UI is unmounted once `active` (swapped for the "SENT" checkmark) -- the new send-button label had no equivalent guard.

Fix: drop the `!active` condition so the reset runs on every busy edge (safe -- `hardDisabled` already includes `active`, so nothing can re-arm early from resetting sooner), and additionally gate the label + its dynamic aria-label on `!messageLocked` so they only ever render in the genuine "pressable, counting down" state, matching the ring's own precedent.

Added a regression test that reproduces the screenshot exactly (hold to completion, simulate the parent's busy-then-active transition, assert the label is gone) -- confirmed it fails on the prior code and passes with this fix.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (existing `/one/location` route, component-internal change)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None -- same component, no native/bridge change.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None -- purely a visual-state bug in the already-shipped hold gate; no change to what data is accessed or who can trigger a send.

- Caller / proxy / backend pairing:
  - [x] Not applicable -- frontend-only.

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Dropping `!active` on the reset effect only makes cleanup happen sooner; `hardDisabled`/`disabled` on both hold controls already includes `active`, so nothing can re-arm a hold early because of this change.
    - The `!messageLocked` render guard is purely additive/defensive -- worst case if the state-level fix somehow didn't cover an edge, the label still can't render while locked.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location` -> "Emergency help" -> type a message -> hold the send button to completion -> confirm the label disappears once settled into "Alert sent" / "Live location", instead of staying stuck.
    - No new Playwright spec -- follows this file's existing convention of unit-testing the interaction state machine directly (fake timers + `fireEvent.pointerDown/pointerUp` + `rerender`).

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr` -- not run
  - [x] `cd hushh-webapp && npm run typecheck` -- 0 errors, full project
  - [x] `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/sos-panel.test.tsx` -- 31/31 pass (30 pre-existing + 1 new regression test). Confirmed the new test fails on the pre-fix source (stashed the source fix, kept the test, reran -- failed with the exact stuck-label output from the screenshot) and passes with the fix restored.
  - [ ] `cd hushh-webapp && npm run build` -- not run this pass; typecheck + targeted eslint + full test file are clean, and CI's own build check is authoritative.
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` -- not applicable
  - [ ] `python scripts/ops/kai-system-audit.py ...` -- not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate -- it's a direct follow-up fix to #5478, same file, same feature.
- [x] This PR changes a current reachable app surface (`/one/location`, Emergency help panel).
- [x] Reachable production attach point: `components/one-location/redesign/sos-panel.tsx`.
- [x] New tests import and exercise production code -- renders the real exported `SosPanel`.
- [x] New test is wired into the existing suite for this component, no orphaned code.
- [x] Production surface proved: unit test above, reproduces the exact reported screenshot.
- [x] Required checks are current on this head, commit is signed off (`git commit -s`), branch created fresh off latest `main`.
- [x] Maintainer edits are enabled (pushed directly to the org repo).
- [x] Not part of a PR stack.
- [x] Responding to a user-reported bug (screenshot in issue thread), described above.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (`components/one-location/redesign/sos-panel.tsx`).
- [x] **iOS**: Not applicable -- no native change.
- [x] **Android**: Not applicable -- no native change.

## 🧪 Testing

- [x] Tested on Web (unit test reproduces the exact reported bug)
- [ ] Tested on iOS Simulator/Device -- not tested this pass
- [ ] Tested on Android Emulator/Device -- not tested this pass
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

## 📸 Screenshots / Video

See the reporter's screenshot in the issue/PR thread: grey "Hold to send... 0.0s" pill stuck above the "I'm not safe" quick-message button after the alert had already settled into "Alert sent" / "Live location".

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? -- No. Purely a visual-state bug fix in the send-button's hold UI; the underlying send/consent path is unchanged.
- [x] Sensitive surface touched: none of the listed categories -- UI-only fix.
- [x] Error path, rollback, or safe-failure behavior proved: see Impact Map above.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependencies added or changed.