### PR TITLE
fix(onboarding): match the welcome and sign-in screens to the approved design

### DIFF
--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1095,17 +1095,24 @@ export function AuthStep({
           data-auth-signin-clusters
         >
           <div className="flex flex-col items-center gap-4">
-            {/* The One mark. The glyph is the logo, so it is never restyled;
-                only the geometry around it shrank — a 64px box under an 80px
-                halo, instead of a 92px box under a 112px blur that washed the
-                whole top of the screen blue. The drop-shadow went with it: at 25%
-                black it read as a smudge on the #f2f2f7 canvas. */}
+            {/* The One mark, at the size and wash the approved design gives
+                it and identical to the welcome screen's — the two entry
+                screens must not disagree about how big the brand is. The
+                glyph is the logo, so it is never restyled; the geometry is a
+                168px box carrying a closest-side accent wash, which keeps the
+                halo a circle regardless of how the emoji font measures. */}
             <div
-              className="relative flex h-[64px] w-[64px] items-center justify-center"
+              className="relative flex h-[168px] w-[168px] items-center justify-center [@media(max-height:780px)]:h-[116px] [@media(max-height:780px)]:w-[116px]"
               aria-hidden="true"
             >
-              <span className="pointer-events-none absolute h-[80px] w-[80px] rounded-full bg-accent/[0.18] blur-[24px]" />
-              <span className="relative select-none text-[52px] leading-none">
+              <span
+                className="pointer-events-none absolute inset-0 rounded-full blur-[5px]"
+                style={{
+                  background:
+                    "radial-gradient(closest-side, color-mix(in oklab, var(--app-accent-deep) 28%, transparent), color-mix(in oklab, var(--app-accent-deep) 7%, transparent) 56%, transparent 74%)",
+                }}
+              />
+              <span className="relative select-none font-[family-name:'Apple_Color_Emoji','Segoe_UI_Emoji','Noto_Color_Emoji'] text-[80px] leading-none [@media(max-height:780px)]:text-[58px]">
                 🤫
               </span>
             </div>

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -76,22 +76,13 @@
 
 .brand {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
   animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
-/* Small on purpose. At the 48px it used to be it competed with One for the
-   eye; at 26px it reads as the brand's own mark sitting under its wordmark. */
-.quietMark {
-  font-size: 26px;
-  line-height: 1;
-}
-
 .wordmark {
-  height: 31px;
+  height: 33px;
   width: auto;
 }
 
@@ -108,11 +99,65 @@
   align-items: center;
 }
 
+/* The mark and its wash. `closest-side` keeps the gradient a circle inside
+   the square box no matter how the emoji font measures, and the accent is
+   read from the glyph token so Molten Gold repaints the wash with it. */
+.markWrap {
+  position: relative;
+  display: flex;
+  width: 168px;
+  height: 168px;
+  align-items: center;
+  justify-content: center;
+  animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 160ms both;
+}
+
+.markGlow {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    closest-side,
+    color-mix(in oklab, var(--intro-blue-text) 28%, transparent),
+    color-mix(in oklab, var(--intro-blue-text) 7%, transparent) 56%,
+    transparent 74%
+  );
+  filter: blur(5px);
+}
+
+/* Apple Color Emoji first: the mark is the brand's glyph and must render as
+   the colour emoji, not a monochrome fallback glyph. */
+.quietMark {
+  position: relative;
+  font-family:
+    "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-size: 80px;
+  line-height: 1;
+}
+
 .title {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 0;
+  margin-top: 22px;
   font-family: var(--font-app-display);
   line-height: 1;
-  animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 200ms both;
+  animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 240ms both;
+}
+
+.titleGlow {
+  position: absolute;
+  width: 280px;
+  height: 150px;
+  border-radius: 50%;
+  background: radial-gradient(
+    closest-side,
+    color-mix(in oklab, var(--intro-blue-text) 16%, transparent),
+    transparent 72%
+  );
+  filter: blur(8px);
 }
 
 /* The one bold element on the screen. Solid accent, no foil gradient, no
@@ -122,9 +167,9 @@
   display: inline-block;
   color: var(--intro-blue-text);
   font-family: var(--font-app-display);
-  font-size: clamp(72px, 20.5vw, 84px);
+  font-size: clamp(76px, 26vw, 104px);
   font-weight: 700;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.045em;
   line-height: 1.02;
 }
 
@@ -134,13 +179,13 @@
      two-line supporting line from looking accidental. */
   text-wrap: balance;
   max-width: 19rem;
-  margin: 14px auto 0;
+  margin: 16px auto 0;
   color: var(--foundation-ink);
-  font-size: 17px;
+  font-size: 20px;
   font-weight: 400;
-  letter-spacing: -0.01em;
-  line-height: 1.4;
-  animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 300ms both;
+  letter-spacing: -0.02em;
+  line-height: 1.36;
+  animation: reveal 720ms cubic-bezier(0.16, 1, 0.3, 1) 320ms both;
 }
 
 .footer {
@@ -155,19 +200,29 @@
   position: relative;
   overflow: hidden;
   display: inline-flex;
-  min-height: 56px;
+  min-height: 58px;
   width: 100%;
   align-items: center;
   justify-content: center;
   gap: 10px;
   border: 0;
-  border-radius: 19px;
+  border-radius: 980px;
   background: var(--intro-blue);
+  /* A wash of the accent, not a drop shadow: it lifts the only action on the
+     screen without putting a grey edge under it. */
+  box-shadow: 0 12px 30px
+    color-mix(in oklab, var(--intro-blue) 32%, transparent);
   color: var(--intro-blue-fg);
   font-family: var(--font-app-body);
-  font-size: 17px;
+  font-size: 19px;
   font-weight: 600;
-  line-height: 1;
+  letter-spacing: -0.02em;
+  /* Not `1`. The arrow glyph's box is taller than a 19px line box, and this
+     button sets `overflow: hidden` for the ripple, so a line-height of 1
+     genuinely clips the label's descender rather than merely looking tight.
+     Chromium reports it; WebKit does not — which is why the contract runs on
+     both. */
+  line-height: 1.2;
   transition:
     background-color var(--motion-duration-sm) var(--motion-ease-standard);
 }
@@ -185,9 +240,9 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  margin: 14px 0 0;
+  margin: 18px 0 0;
   color: var(--intro-secondary);
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 400;
   line-height: 1.3;
 }
@@ -205,7 +260,7 @@
   margin-top: 18px;
   border-top: 1px solid var(--foundation-hairline);
   color: var(--intro-secondary);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -245,13 +300,32 @@
 /* Short screens (iPhone SE and the landscape/keyboard cases) give back space
    from the gaps first, exactly as the master rules require, before anything
    touches type size or the 56px button. */
-@media (max-height: 700px) {
+@media (max-height: 780px) {
+  .markWrap {
+    width: 116px;
+    height: 116px;
+  }
+
+  .quietMark {
+    font-size: 58px;
+  }
+
+  .title {
+    margin-top: 14px;
+  }
+
+  .titleGlow {
+    width: 220px;
+    height: 112px;
+  }
+
   .oneMark {
-    font-size: clamp(60px, 17vw, 68px);
+    font-size: clamp(64px, 20vw, 84px);
   }
 
   .tagline {
-    margin-top: 10px;
+    margin-top: 12px;
+    font-size: 18px;
   }
 
   .privacy {

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -87,20 +87,25 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
       <OnboardingHeroBackground variant="plain" />
 
       <div className={styles.stage}>
-        {/* One centered brand anchor. The quiet mark is part of the brand,
-            not decoration: "hushh" IS the shush. It sits with the wordmark as
-            a single lockup rather than floating alone above One, so the brand
-            reads as one thing and One stays the only bold element. */}
+        {/* One centered brand anchor. */}
         <div className={styles.brand}>
           <HushhWordmark className={styles.wordmark} />
-          <span aria-hidden className={styles.quietMark}>
-            🤫
-          </span>
         </div>
 
-        {/* ── The single message: the name, then what it does. ── */}
+        {/* ── The single message: the mark, the name, then what it does.
+              The quiet mark leads the hero — "hushh" IS the shush, so it is
+              the brand's own glyph, not decoration. The glow behind it and
+              behind One is one soft accent wash, never a second colour. ── */}
         <div className={styles.hero}>
+          <div className={styles.markWrap}>
+            <span aria-hidden className={styles.markGlow} />
+            <span aria-hidden className={styles.quietMark}>
+              🤫
+            </span>
+          </div>
+
           <h1 className={styles.title}>
+            <span aria-hidden className={styles.titleGlow} />
             <span className={styles.oneMark}>One</span>
           </h1>
 

--- a/hushh-webapp/e2e/one-intro-welcome.layout.spec.ts
+++ b/hushh-webapp/e2e/one-intro-welcome.layout.spec.ts
@@ -116,10 +116,14 @@ function welcomeMarkup(): string {
       >
         <main class="shell">
           <div class="stage">
-            <div class="brand"><span class="wordmark" data-wordmark>hussh</span><span aria-hidden class="quietMark" data-quiet-mark>&#129323;</span></div>
+            <div class="brand"><span class="wordmark" data-wordmark>hussh</span></div>
 
             <div class="hero">
-              <h1 class="title"><span class="oneMark">One</span></h1>
+              <div class="markWrap">
+                <span aria-hidden class="markGlow"></span>
+                <span aria-hidden class="quietMark" data-quiet-mark>&#129323;</span>
+              </div>
+              <h1 class="title"><span aria-hidden class="titleGlow"></span><span class="oneMark">One</span></h1>
               <p class="tagline">Your personal assistant for everyday tasks.</p>
             </div>
 
@@ -333,7 +337,7 @@ for (const phone of PHONES) {
       const cta = (await page
         .getByRole("button", { name: /get started/i })
         .boundingBox())!;
-      expect(cta.height).toBeGreaterThanOrEqual(56 - SLACK_PX);
+      expect(cta.height).toBeGreaterThanOrEqual(58 - SLACK_PX);
 
       for (const label of ["Research", "Blog", "Developers"]) {
         const box = (await page
@@ -350,7 +354,7 @@ for (const phone of PHONES) {
 test.describe("welcome composition", () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
-  test("Get started is a full-width 56px control", async ({ page }) => {
+  test("Get started is a full-width 58px control", async ({ page }) => {
     await gotoWelcome(page);
 
     const box = (await page


### PR DESCRIPTION
Closes #5512

Implements `One iPhone.dc.html` from the Claude Design project (the real spec lives in the `One Screen.dc.html` it imports).

## What changed

The shush mark moves into the hero instead of sitting tucked under the wordmark. It leads the screen at **80px inside a 168px box** with a soft accent wash, **One** follows at **104px** with its own wider wash, and the supporting line sits at **20px**. The primary button becomes the design's **58px pill** with its accent glow.

Applied to **both** entry screens, so they stop disagreeing about how big the brand is — sign-in carried a 52px mark in a 64px box and now uses the same geometry and wash.

Measured against the design's own canvas (402×874): mark 80px, One 104px, supporting 20px, button 58px pill — exact.

## Kept from the product, not the design file

| | why |
|---|---|
| Inter, not the design's Geist | your instruction — the font stays ours |
| near-white canvas, not `#f5f5f7` | "no grey-purple" was an explicit earlier requirement, and `#f5f5f7` is a shade of the grey it replaced |
| 46px footer link targets | the design's bare anchors measure ~17px; 44px is a hard accessibility minimum |
| **Talk to One bar and every control in it** | untouched, exactly as asked |

The washes use `color-mix` on the glyph token rather than the design's literal `rgba`, so the Molten Gold preference repaints them instead of stranding two blue halos in a gold app.

## Two real bugs caught while building

**The button label was clipping.** At 19px with `line-height: 1` the arrow glyph's box is taller than its line box, and the button sets `overflow: hidden` for the ripple — so it genuinely clipped, not merely looked tight. Chromium reported it, WebKit did not. That divergence is the reason the contract runs on both engines.

**A width query masquerading as a height query.** The sign-in mark first used `max-[780px]`, which Tailwind reads as max-*width* — so it fired on every phone and shrank the mark on exactly the devices it was meant to stay large on. Now `[@media(max-height:780px)]`.

## Verified

Real browser at **320×568, 375×667, 390×844, 402×874, 430×932, 1440×900**:

- no vertical or horizontal scrolling on any scrollable box
- nothing clipped, nothing covered by the Talk to One bar
- the sign-in mark never reaches the fixed Back control (checked at 320px, where clearance is tightest)
- every footer target ≥44px

- Layout contracts: **210 chromium / 180 webkit**
- Full suite: **33 failed / 4604 passed**, byte-identical failing set to `origin/main`
- `tsc --noEmit` clean, `eslint --max-warnings=0` clean

Frontend only. No backend, API, database, auth, route or analytics change.