### PR TITLE
fix(profile,location): round map preview corners, unbreak passkey label, tighten reset copy

### DIFF
--- a/hushh-webapp/__tests__/app/one/local-map-preview-corner-radius.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one/local-map-preview-corner-radius.contract.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// The map's own tiles (Google Maps JS canvas) or its iframe fallback are each
+// GPU-composited, and Safari/WebKit does not reliably clip a composited
+// layer to an ancestor two DOM levels up — the square top corners of the map
+// bled past LocalMapPreview's rounded card frame on every surface that
+// reuses it (Location, Connect access cards). Rounding LiveMap's own element
+// via the className it already forwards is what actually clips it.
+describe("LocalMapPreview corner-radius contract", () => {
+  it("rounds LiveMap's own element instead of relying on an ancestor clip", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/one/location/page.tsx"),
+      "utf8",
+    );
+
+    const liveMapCallSite = source.match(
+      /<LiveMap\b[\s\S]*?\/>/,
+    )?.[0];
+
+    expect(liveMapCallSite).toBeDefined();
+    expect(liveMapCallSite).toContain(
+      'className="rounded-t-[var(--app-card-radius-standard)]"',
+    );
+  });
+});

--- a/hushh-webapp/__tests__/services/vault-bootstrap-service-passkey-label.test.ts
+++ b/hushh-webapp/__tests__/services/vault-bootstrap-service-passkey-label.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveWebPasskeyDeviceLabel } from "@/lib/services/vault-bootstrap-service";
+
+// Chrome's Client Hints spec requires browsers to ship a randomized "GREASE"
+// brand entry in navigator.userAgentData.brands so sites can't hardcode a
+// match against it — the punctuation between "Not"/"A"/"Brand" varies by
+// session. A label built from an unfiltered brand read "Not-A?Brand passkey
+// on Windows" in production because the old filter only recognized one
+// punctuation combination.
+const GREASE_BRAND_VARIANTS = [
+  "Not;A Brand",
+  "Not.A/Brand",
+  "Not-A?Brand",
+  "Not A;Brand",
+  "Not_A_Brand",
+  "Not/A)Brand",
+];
+
+function stubUserAgentData(
+  brands: Array<{ brand: string; version: string }>,
+  platform = "Windows",
+) {
+  Object.defineProperty(window.navigator, "userAgentData", {
+    value: { brands, platform },
+    configurable: true,
+  });
+}
+
+describe("resolveWebPasskeyDeviceLabel", () => {
+  afterEach(() => {
+    // @ts-expect-error test-only cleanup of a stubbed property
+    delete window.navigator.userAgentData;
+  });
+
+  it.each(GREASE_BRAND_VARIANTS)(
+    "filters out the GREASE placeholder brand %j and falls back to a real brand",
+    (greaseBrand) => {
+      stubUserAgentData([
+        { brand: greaseBrand, version: "24" },
+        { brand: "Chromium", version: "128" },
+        { brand: "Google Chrome", version: "128" },
+      ]);
+
+      const label = resolveWebPasskeyDeviceLabel();
+
+      expect(label).toBe("Google Chrome passkey on Windows");
+      expect(label.toLowerCase()).not.toContain("not");
+    },
+  );
+
+  it("falls back to the user-agent string when every brand is filtered out", () => {
+    stubUserAgentData([{ brand: "Not-A?Brand", version: "24" }]);
+
+    const label = resolveWebPasskeyDeviceLabel();
+
+    // No usable brand survives the filter, so this must never surface the
+    // placeholder text — it should read from navigator.userAgent instead.
+    expect(label.toLowerCase()).not.toContain("not-a");
+    expect(label.toLowerCase()).not.toContain("not;a");
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1526,7 +1526,17 @@ function LocalMapPreview({
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
       <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
-        <LiveMap point={point} viewportResetKey={viewportResetKey} />
+        <LiveMap
+          point={point}
+          viewportResetKey={viewportResetKey}
+          // The map's own tiles (JS canvas) or the iframe fallback are each
+          // GPU-composited, and Safari/WebKit doesn't reliably clip a
+          // composited layer to an ancestor two levels up — the square top
+          // corners bled past this card's rounded frame. Rounding the map's
+          // own element (LiveMap forwards className onto whichever DOM node
+          // actually holds the map) clips it where the compositing happens.
+          className="rounded-t-[var(--app-card-radius-standard)]"
+        />
         <div className="pointer-events-none absolute left-3 top-3">
           <span
             className={cn(

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -437,22 +437,14 @@ function isPasskeyVaultMethod(method: VaultMethod | null): boolean {
 }
 
 const VAULT_INLINE_CONTROL_CLASS =
-  "inline-flex h-8 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
+  "inline-flex h-11 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
 const VAULT_INLINE_BADGE_CLASS =
-  "inline-flex h-8 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
+  "inline-flex h-11 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
 
 function vaultWrapperKey(
   wrapper: Pick<VaultWrapper, "method" | "wrapperId">,
 ): string {
   return `${wrapper.method}:${wrapper.wrapperId ?? "default"}`;
-}
-
-function formatPasskeyIdentifier(wrapper: VaultWrapper): string {
-  const raw = wrapper.passkeyCredentialId || wrapper.wrapperId || "";
-  if (!raw) return "Identifier unavailable";
-  const compact = raw.replace(/\s+/g, "");
-  if (compact.length <= 10) return `Identifier ${compact}`;
-  return `Identifier ending ${compact.slice(-6)}`;
 }
 
 function formatPasskeyLabel(wrapper: VaultWrapper): string {
@@ -462,9 +454,12 @@ function formatPasskeyLabel(wrapper: VaultWrapper): string {
   return "Saved passkey";
 }
 
+// A raw credential-id fragment ("Identifier ending FnkQ==") reads as broken
+// output, not information — nobody can act on it. The row title already
+// numbers multiple passkeys ("Passkey 1", "Passkey 2"), so the label alone
+// is enough to tell them apart.
 function describePasskeyWrapper(wrapper: VaultWrapper): string {
-  const parts = [formatPasskeyLabel(wrapper), formatPasskeyIdentifier(wrapper)];
-  return parts.join(" / ");
+  return formatPasskeyLabel(wrapper);
 }
 
 function VaultComingSoonLogos() {
@@ -1937,7 +1932,7 @@ function ProfilePageContent() {
     "Clears saved details. Keeps sign-in.";
   const resetDialogTitle = "Reset account?";
   const resetDialogDescription =
-    "This clears all your saved details: connected services, finance and Gmail, your knowledge base, consents, and saved preferences. It keeps your account, your sign-in, and your lock. You will start onboarding again.";
+    "Clears connected services, finance, Gmail, and memory. Keeps your account, sign-in, and lock. You'll onboard again.";
 
   const handleVaultUnlockOpenChange = (open: boolean) => {
     setShowVaultUnlock(open);
@@ -3324,7 +3319,7 @@ function ProfilePageContent() {
         {vaultAccess.hasVault && loadingVaultMethod ? (
           <SurfaceInset className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
             <Icon icon={Loader2} size="sm" className="animate-spin" />
-            Loading vault methods...
+            Loading lock methods...
           </SurfaceInset>
         ) : null}
 

--- a/hushh-webapp/lib/services/vault-bootstrap-service.ts
+++ b/hushh-webapp/lib/services/vault-bootstrap-service.ts
@@ -122,7 +122,7 @@ function resolveRpId(): string {
   });
 }
 
-function resolveWebPasskeyDeviceLabel(): string {
+export function resolveWebPasskeyDeviceLabel(): string {
   if (typeof navigator === "undefined") return "Browser passkey";
 
   const nav = navigator as Navigator & {
@@ -134,8 +134,14 @@ function resolveWebPasskeyDeviceLabel(): string {
   const brands = nav.userAgentData?.brands || [];
   const brand =
     brands.find(
-      (item) =>
-        item.brand && !/chromium|not.a\/brand|not a brand/i.test(item.brand),
+      // Chrome's GREASE placeholder brand ("Not;A Brand", "Not.A/Brand",
+      // "Not-A?Brand", ...) randomizes its punctuation every session so sites
+      // can't key off one literal string — matching only "not.a/brand" let
+      // every other variant through as if it were a real browser name, which
+      // is how a passkey label ended up reading "Not-A?Brand passkey on
+      // Windows". `.?` treats each separator slot as optional-any-char so it
+      // catches all of them.
+      (item) => item.brand && !/chromium|not.?a.?brand/i.test(item.brand),
     )?.brand || "";
   const platform = nav.userAgentData?.platform || "";
   const ua = navigator.userAgent || "";


### PR DESCRIPTION
## Summary
- **Map preview corner clipping** — `LocalMapPreview` now rounds `LiveMap`'s own element (its iframe or JS-map canvas) instead of relying on an ancestor two DOM levels up. Safari/WebKit doesn't reliably clip a GPU-composited layer through a grandparent's `overflow-hidden`, so the map's square corners bled past the card frame on every surface that reuses this preview (Location, Connect access cards).
- **"Passkey not tappable"** — root cause was a garbled label, not a dead button. `resolveWebPasskeyDeviceLabel` only filtered one punctuation variant of Chrome's randomized GREASE placeholder brand string, so labels could read `"Not-A?Brand passkey on Windows"`. Fixed the regex to catch all separator variants, and dropped the raw credential-id fragment (`"Identifier ending FnkQ=="`) from passkey descriptions — the row title already numbers multiple passkeys.
- **Reset-account dialog** — shortened the body copy and finished the vault → lock wording pass; fixed a stray `"Loading vault methods..."` string.
- **Touch targets** — bumped passkey action buttons (Default / Remove / Set default) from 32px to 44px.
- Verified `Appearance & preferences` naming already matches what was asked for — no change needed there.

Closes #5518

## Test plan
- [x] `npx vitest run` on touched suites + 2 new regression tests (8/8 passing) — one covers the GREASE-brand regex against 6 real Chrome punctuation variants, the other is a source-contract test locking in the map's own corner radius
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all touched files — clean
- [x] Broader vault/passkey/profile suites re-run for regressions — no new failures (pre-existing WebCrypto jsdom failures and one unrelated `profile-home-copy` string-drift failure confirmed present on baseline, untouched by this diff)