### PR TITLE
fix(copy): drop the last "vault" leaks in the security breadcrumb and unlock-method errors

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -446,7 +446,7 @@ describe("top shell breadcrumbs", () => {
       items: [
         { label: "Profile", href: "/one/profile" },
         { label: "Security", href: "/one/profile/security" },
-        { label: "Vault methods" },
+        { label: "Lock methods" },
       ],
     });
 

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -170,7 +170,7 @@ function profileDetailLabel(detail: string | null): string | null {
   if (detail === "kai-preferences") return "Kai preferences";
   if (detail === "gemini") return "Gemini";
   if (detail === "device") return "On-device first";
-  if (detail === "vault") return "Vault methods";
+  if (detail === "vault") return "Lock methods";
   if (detail === "session") return "Session";
   if (detail === "danger") return "Danger zone";
   if (detail === "gmail-connection") return "Connection";

--- a/hushh-webapp/lib/services/vault-method-service.ts
+++ b/hushh-webapp/lib/services/vault-method-service.ts
@@ -22,7 +22,7 @@ function ensureVaultKeyHex(value: string): string {
   const normalized = value.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(normalized)) {
     throw new Error(
-      "Vault key in memory is invalid. Unlock vault again and retry.",
+      "Your unlock key is invalid. Unlock again and retry.",
     );
   }
   return normalized;
@@ -49,7 +49,7 @@ function normalizeVaultMethodError(error: unknown): Error {
 
   if (lowered.includes("passphrase wrapper missing")) {
     return new Error(
-      "Passphrase wrapper is missing for this vault. Use passphrase/recovery flow once to repair wrapper enrollment.",
+      "Passphrase is missing. Use passphrase or recovery once to repair it.",
     );
   }
 
@@ -128,7 +128,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       if (params.targetMethod === "passphrase") {
@@ -241,7 +241,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       const nextPassphrase = params.newPassphrase.trim();
@@ -306,7 +306,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       const wrapperId = params.wrapperId ?? "default";


### PR DESCRIPTION
## Summary

Follow-up to #5504 (the app-wide vault->lock copy sweep). Found two more spots while verifying #5504's copy was actually live on UAT — both slipped past a plain-quoted-string grep because they build the string differently from typical JSX/toast copy:

- `lib/navigation/top-shell-breadcrumbs.ts`'s `profileDetailLabel()` maps the (unchanged, internal) `detail === "vault"` routing id to the display breadcrumb text `"Vault methods"`. Confirmed this was still present in the live UAT JS bundle after #5504 deployed.
- `lib/services/vault-method-service.ts` throws five error messages (key-in-memory invalid, wrapper missing, three key-mismatch checks) that every caller in `profile-workspace-page.tsx` (switch/remove/change-passphrase handlers) passes straight to a toast via `error.message` — as user-facing as any JSX string, just one layer removed.

No behavior change, no identifiers touched — pure copy.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Updated the one test asserting the old breadcrumb string
- [x] Ran both affected test files (`top-shell-breadcrumbs.test.ts`, `vault-method-service.test.ts`, `vault-flow-create-validation.test.tsx`) — 47/47 pass, none asserted the old error strings