### PR TITLE
fix(one-location): widen the invite-code max_uses ceiling to match 100-member Circles

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 158,
+  "expected_migration_version": 159,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 158,
+  "expected_migration_version": 159,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 158,
+  "expected_migration_version": 159,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
+++ b/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
@@ -1,0 +1,60 @@
+-- One Location: raise the invite-code use ceiling to match 100-member Circles.
+--
+-- 134 bound `max_uses` to the old 20-member cap: column default 20 and inline
+-- CHECK (max_uses BETWEEN 1 AND 20). 158 raised `one_location_circles.member_limit`
+-- to 100 but never touched this table, so `create_code`'s
+-- `max_uses = member_limit - 1` now computes 99 for any circle sitting at the
+-- new default -- and the INSERT fails that stale CHECK on every call. That
+-- IntegrityError is exactly what `_safe_db_failure` turns into "Circle service
+-- is temporarily unavailable", so every invite-code creation has been failing
+-- since 158 shipped. This migration is the other half of 158.
+
+BEGIN;
+
+-- 134 declared the bound inline, so Postgres auto-named it
+-- `one_location_circle_invite_codes_max_uses_check`. Dropping by that name
+-- covers every environment migrated from 134 forward; the DO block behind it
+-- catches any environment where the constraint carries a different name (a
+-- hand-repaired database, or a restore that re-derived it), so the old
+-- 20-use ceiling cannot survive this migration in one environment and not
+-- another. Scoped to CHECK constraints whose definition actually mentions
+-- max_uses, so the sibling `use_count BETWEEN 0 AND max_uses` check (which
+-- also references the column but is not a fixed bound) is never a candidate.
+ALTER TABLE one_location_circle_invite_codes
+  DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_check;
+
+DO $$
+DECLARE
+  stale_constraint TEXT;
+BEGIN
+  FOR stale_constraint IN
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE rel.relname = 'one_location_circle_invite_codes'
+      AND nsp.nspname = current_schema()
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) ILIKE '%max_uses%'
+      AND pg_get_constraintdef(con.oid) NOT ILIKE '%use_count%'
+      AND con.conname <> 'one_location_circle_invite_codes_max_uses_bounds'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE one_location_circle_invite_codes DROP CONSTRAINT %I',
+      stale_constraint
+    );
+  END LOOP;
+END
+$$;
+
+ALTER TABLE one_location_circle_invite_codes
+  ADD CONSTRAINT one_location_circle_invite_codes_max_uses_bounds
+    CHECK (max_uses BETWEEN 1 AND 100);
+
+ALTER TABLE one_location_circle_invite_codes
+  ALTER COLUMN max_uses SET DEFAULT 100;
+
+COMMENT ON COLUMN one_location_circle_invite_codes.max_uses IS
+  'How many times this code may be redeemed, stamped at INSERT from the owning Circle''s member_limit - 1. Defaults to 100 (raised from 20 in migration 159, matching the member_limit ceiling raised in 158) and is bounded 1..100 by one_location_circle_invite_codes_max_uses_bounds.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/159_one_location_circle_invite_max_uses_100.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/159_one_location_circle_invite_max_uses_100.rollback.sql
@@ -1,0 +1,32 @@
+-- Reverse 159: return the invite-code use ceiling to 20.
+--
+-- Mirrors 158's rollback rather than 134's original shape: by the time anyone
+-- reverses this, live codes may already carry a `max_uses` up to 99 from
+-- Circles at the 100-member default, and a hard 1..20 CHECK would make those
+-- rows violate their own invariant. So this reverses the CAPABILITY without
+-- rewriting rows that already exist:
+--
+--   * The default returns to 20, so every code created after the rollback is
+--     bounded exactly as it was before 159.
+--   * The 1..20 bound is re-added NOT VALID -- it still governs every future
+--     INSERT and UPDATE from this point on, and only declines to re-scan rows
+--     that already exist. Codes already sitting above 20 are left alone
+--     rather than truncated, which would silently shrink how many people a
+--     circle owner already told could redeem their code.
+
+BEGIN;
+
+ALTER TABLE one_location_circle_invite_codes
+  DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_bounds;
+
+ALTER TABLE one_location_circle_invite_codes
+  ALTER COLUMN max_uses SET DEFAULT 20;
+
+ALTER TABLE one_location_circle_invite_codes
+  ADD CONSTRAINT one_location_circle_invite_codes_max_uses_check
+    CHECK (max_uses BETWEEN 1 AND 20) NOT VALID;
+
+COMMENT ON COLUMN one_location_circle_invite_codes.max_uses IS
+  'How many times this code may be redeemed.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -136,7 +136,8 @@
     "155_one_location_grant_ceiling.sql",
     "156_one_location_grant_ceiling_insert_default.sql",
     "157_hussh_crm_delete_operation.sql",
-    "158_one_location_circle_member_limit_100.sql"
+    "158_one_location_circle_member_limit_100.sql",
+    "159_one_location_circle_invite_max_uses_100.sql"
   ],
   "groups": {
     "iam": [
@@ -225,7 +226,8 @@
       "153_one_location_duration_changed_event.sql",
       "154_one_location_access_request_duration.sql",
       "155_one_location_grant_ceiling.sql",
-      "158_one_location_circle_member_limit_100.sql"
+      "158_one_location_circle_member_limit_100.sql",
+      "159_one_location_circle_invite_max_uses_100.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
@@ -1,0 +1,112 @@
+"""Migration 159 raises the invite-code use ceiling to match 100-member Circles.
+
+158 raised `one_location_circles.member_limit` to 100 but left
+`one_location_circle_invite_codes.max_uses` bound to 134's old
+CHECK (max_uses BETWEEN 1 AND 20). `create_code` computes
+`max_uses = member_limit - 1`, so every code created for a Circle at the new
+100 default violated that stale CHECK -- an IntegrityError that
+`_safe_db_failure` turned into "Circle service is temporarily unavailable" on
+every invite-code creation. This migration is the other half of 158.
+
+These assertions are deliberately about SHAPE rather than a live database: the
+release-migration gate reads these same files, and a migration that silently
+stops widening the bound, stops raising the default, or reintroduces the old
+20-use ceiling is exactly the drift worth failing on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+CONTRACTS_DIR = REPO_ROOT / "db" / "contracts"
+SERVICE_PATH = REPO_ROOT / "hushh_mcp" / "services" / "one_location_circle_service.py"
+
+MIGRATION = "159_one_location_circle_invite_max_uses_100.sql"
+ROLLBACK = "159_one_location_circle_invite_max_uses_100.rollback.sql"
+
+
+def _migration() -> str:
+    return (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+
+def _rollback() -> str:
+    return (MIGRATIONS_DIR / "rollback" / ROLLBACK).read_text(encoding="utf-8")
+
+
+def _statements(sql: str) -> str:
+    """The executable half of a migration, with `--` commentary stripped.
+
+    These files explain themselves at length, and the commentary necessarily
+    quotes the old shape it is replacing. Asserting "the old bound is gone"
+    against the raw text would therefore fail on the sentence describing why
+    it went.
+    """
+    lines = [
+        line.split("--", 1)[0] for line in sql.splitlines() if not line.lstrip().startswith("--")
+    ]
+    return chr(10).join(lines)
+
+
+def test_max_uses_migration_is_registered_in_release_order() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert (MIGRATIONS_DIR / MIGRATION).exists()
+    assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
+    assert manifest["ordered_migrations"][-1] == MIGRATION
+    # Structural One Location migrations belong to the iam group, as 158 does.
+    assert MIGRATION in manifest["groups"]["iam"]
+
+
+def test_schema_contracts_advance_to_the_new_migration_head() -> None:
+    for name in (
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+        "dev_minimum_schema.json",
+    ):
+        contract = json.loads((CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] >= 159, name
+
+
+def test_migration_widens_the_bound_and_the_default_together() -> None:
+    migration = _migration()
+
+    assert "DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_check" in migration
+    assert "one_location_circle_invite_codes_max_uses_bounds" in migration
+    assert "CHECK (max_uses BETWEEN 1 AND 100)" in migration
+    assert "ALTER COLUMN max_uses SET DEFAULT 100" in migration
+    assert "BETWEEN 1 AND 20" not in _statements(migration)
+
+
+def test_migration_never_touches_use_count_or_membership_rows() -> None:
+    migration = _migration()
+    statements = _statements(migration)
+
+    # This is a bound-and-default fix, not a data rewrite -- no existing code's
+    # use_count, no membership, no grant.
+    assert "UPDATE one_location_circle_invite_codes" not in statements
+    assert "INSERT INTO one_location_circle_memberships" not in migration
+    assert "INSERT INTO one_location_share_grants" not in migration
+
+
+def test_rollback_restores_the_ceiling_without_truncating_live_codes() -> None:
+    rollback = _rollback()
+
+    assert "ALTER COLUMN max_uses SET DEFAULT 20" in rollback
+    # NOT VALID is the load-bearing word: codes already issued above 20 uses
+    # (from Circles at the 100-member default) are left alone rather than
+    # silently shrinking how many people they can still admit.
+    assert "CHECK (max_uses BETWEEN 1 AND 20) NOT VALID" in rollback
+    assert "UPDATE one_location_circle_invite_codes" not in rollback
+
+
+def test_service_computes_max_uses_from_the_same_ceiling_migration_159_covers() -> None:
+    service = SERVICE_PATH.read_text(encoding="utf-8")
+
+    # The line this migration exists to unblock: max_uses derived from
+    # member_limit, which can now legitimately reach 99.
+    assert "member_limit" in service
+    assert "CIRCLE_DEFAULT_MEMBER_LIMIT = 100" in service

--- a/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
@@ -55,9 +55,9 @@ def test_member_limit_migration_is_registered_in_release_order() -> None:
 
     assert (MIGRATIONS_DIR / MIGRATION).exists()
     assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
-    # Last in release order: it is the current migration head, which is what
-    # the "exact" contracts below are pinned to.
-    assert manifest["ordered_migrations"][-1] == MIGRATION
+    # Present and in order, not necessarily last -- 159 supersedes it as the
+    # migration head once the invite-code ceiling catches up to this one.
+    assert MIGRATION in manifest["ordered_migrations"]
     # Structural One Location migrations belong to the iam group, as 155 does.
     assert MIGRATION in manifest["groups"]["iam"]
 


### PR DESCRIPTION
## Summary
- Migration 158 raised `one_location_circles.member_limit` to 100 but never touched `one_location_circle_invite_codes.max_uses`, which 134 still bounds to `CHECK (max_uses BETWEEN 1 AND 20)`.
- `create_code` computes `max_uses = member_limit - 1`, so every invite-code INSERT for a Circle at the new 100 default has been violating that stale CHECK since the 158 deploy — an IntegrityError that `_safe_db_failure` turns into the generic "Circle service is temporarily unavailable" the user is seeing on onboarding and Circle detail.
- Confirmed live in UAT Cloud Run logs (`consent-protocol`, `hushh-pda-uat`): repeated `one_location.circle_db_failed operation=create_code error_type=IntegrityError` starting ~2026-08-18 17:51 UTC, right after the 100-member-circle deploy.
- Migration 159 widens the `max_uses` bound to 1..100 and raises the default to match, mirroring 158's own drop/DO-block/re-add shape (defensive against a differently-named constraint in any environment). Rollback restores the 20-use ceiling `NOT VALID`, without truncating codes already issued above 20.

Closes #5530.

## Test plan
- [x] `pytest consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py consent-protocol/tests/test_one_location_circle_member_limit_migration.py` — 13 passed
- [x] `ruff check` / `ruff format --check` on the touched Python files — clean
- [x] `scripts/ops/db_migration_release_guard.py --skip-db` static check — no violations, manifest head advances to 159
- [ ] Live UAT verification after deploy: confirm `circle_db_failed` stops appearing in Cloud Run logs and onboarding's "You're on the map" screen produces a real invite code