### PR TITLE
fix(one-location): make circle max_uses/member_limit migrations replay-safe

### DIFF
--- a/consent-protocol/db/migrations/158_one_location_circle_member_limit_100.sql
+++ b/consent-protocol/db/migrations/158_one_location_circle_member_limit_100.sql
@@ -57,6 +57,13 @@ BEGIN
 END
 $$;
 
+-- Same name, dropped and re-added together: the DO block above deliberately
+-- leaves a constraint already carrying this name untouched, so a replay
+-- against an environment where this migration already ran would otherwise
+-- collide with the ADD below.
+ALTER TABLE one_location_circles
+  DROP CONSTRAINT IF EXISTS one_location_circles_member_limit_bounds;
+
 ALTER TABLE one_location_circles
   ADD CONSTRAINT one_location_circles_member_limit_bounds
     CHECK (member_limit BETWEEN 2 AND 100);

--- a/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
+++ b/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
@@ -47,6 +47,14 @@ BEGIN
 END
 $$;
 
+-- Same name, dropped and re-added together: the DO block above deliberately
+-- leaves a constraint already carrying this name untouched, so a replay
+-- against an environment where this migration already ran would otherwise
+-- collide with the ADD below -- exactly the bug 158 shipped with, caught here
+-- before it could repeat.
+ALTER TABLE one_location_circle_invite_codes
+  DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_bounds;
+
 ALTER TABLE one_location_circle_invite_codes
   ADD CONSTRAINT one_location_circle_invite_codes_max_uses_bounds
     CHECK (max_uses BETWEEN 1 AND 100);

--- a/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
@@ -81,6 +81,30 @@ def test_migration_widens_the_bound_and_the_default_together() -> None:
     assert "BETWEEN 1 AND 20" not in _statements(migration)
 
 
+def test_migration_is_replay_safe_against_itself() -> None:
+    """UAT and prod both run the full migration set in `replay` mode on every
+    deploy, so a migration must survive running twice against a database
+    where it already applied cleanly once.
+
+    158 shipped without that property and took down the very next UAT
+    deploy: `DuplicateObjectError: constraint
+    "one_location_circles_member_limit_bounds" ... already exists`, because
+    its DO block deliberately leaves a constraint already carrying the final
+    name untouched, and nothing dropped it before the ADD tried to recreate
+    it. This migration was written by copying that same shape, so it carried
+    the identical bug into a second file before ever running once. The fix
+    is the drop-then-add-by-the-same-name idiom the rest of this migration
+    set already follows (see 134, 155): a DROP CONSTRAINT IF EXISTS for the
+    bounds constraint, immediately before the ADD that recreates it.
+    """
+    migration = _migration()
+
+    drop = "DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_bounds"
+    add = "ADD CONSTRAINT one_location_circle_invite_codes_max_uses_bounds"
+    assert drop in migration
+    assert migration.index(drop) < migration.index(add)
+
+
 def test_migration_never_touches_use_count_or_membership_rows() -> None:
     migration = _migration()
     statements = _statements(migration)

--- a/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
@@ -88,6 +88,31 @@ def test_migration_widens_the_bound_and_the_default_together() -> None:
     assert "BETWEEN 2 AND 20" not in _statements(migration)
 
 
+def test_migration_is_replay_safe_against_itself() -> None:
+    """UAT and prod both run this file in `replay` mode: the full migration
+    set re-executes on every deploy, so a migration must survive running
+    against a database where it already applied cleanly once.
+
+    This migration shipped without that property: the DO block above
+    deliberately skips a constraint already carrying the final name, but
+    nothing dropped that constraint before the ADD re-created it -- so the
+    second replay (the very next deploy after this one shipped) failed with
+    `DuplicateObjectError: constraint "one_location_circles_member_limit_bounds"
+    ... already exists`, taking the UAT release down. The fix is the same
+    drop-then-add-by-the-same-name idiom every other constraint change in
+    this migration set already follows (see 134, 155): a DROP CONSTRAINT IF
+    EXISTS for the bounds constraint, immediately before the ADD that
+    recreates it.
+    """
+    migration = _migration()
+
+    drop = "DROP CONSTRAINT IF EXISTS one_location_circles_member_limit_bounds"
+    add = "ADD CONSTRAINT one_location_circles_member_limit_bounds"
+    assert drop in migration
+    # Order matters: the drop must run before the add it protects.
+    assert migration.index(drop) < migration.index(add)
+
+
 def test_migration_lifts_only_circles_still_on_the_old_default() -> None:
     migration = _migration()
 


### PR DESCRIPTION
## Summary

Follow-up to #5531, which just broke the UAT deploy pipeline it shipped through.

Both consent-protocol environments run the **full** migration set in `replay` mode on every deploy — there is no ledger, so every migration file must survive being re-executed against a database it already applied cleanly to once.

Migration **158** (already merged and live, `feat(one-location): 100-member Circles`) didn't have that property: its DO block deliberately leaves a constraint already carrying the final name (`one_location_circles_member_limit_bounds`) untouched, and nothing dropped it before the `ADD CONSTRAINT` tried to recreate it. Tonight's #5531 deploy run was the *first* time 158 ever got replayed a second time — and it broke immediately:

```
asyncpg.exceptions.DuplicateObjectError: constraint "one_location_circles_member_limit_bounds" for relation "one_location_circles" already exists
```

The deploy pipeline correctly detected this (`UAT release finished with status: rolled_back`) and rolled back, so nothing new broke — but it also means migration 159 (this session's fix for #5530) never got a chance to apply, and since 159 copied 158's exact structure, it carried the identical bug into a second file before it ever ran once.

## Fix

Drop-then-add the bounds constraint by the same final name in both files — the idiom every other constraint change in this migration set already follows (see 134, 155, which do this correctly). Added a regression test to each migration's test file asserting the `DROP CONSTRAINT IF EXISTS` precedes the `ADD CONSTRAINT` of the same name, so this class of bug fails CI instead of the next deploy.

I checked the other ~30 historical migrations with an `ADD CONSTRAINT` — they all use an equivalent `DO $$ IF EXISTS(...) THEN DROP ... END IF; END $$;` guard (see 028) and are not affected. 158 and 159 were the only two missing it.

## Test plan
- [x] `pytest` on both migration test files — 15 passed, including the two new replay-safety regression tests
- [x] `ruff check` / `ruff format --check` — clean
- [x] `scripts/ops/db_migration_release_guard.py --skip-db` — no violations
- [ ] Live UAT verification after deploy: this deploy must reach `status: healthy`, not `rolled_back`, and the invite-code error from #5530 must stop appearing in logs