### PR TITLE
Add a revert-regression guardrail: catch, tag, and roll back

### DIFF
--- a/.codex/skills/repo-operations/references/admin-release-sop.md
+++ b/.codex/skills/repo-operations/references/admin-release-sop.md
@@ -140,6 +140,15 @@ Production requires an explicit production request and an actor in
    health, provenance, schema, or semantic authority failures follow the owning
    workflow's bounded rollback contract. Humans do not repair traffic with an
    ad hoc `gcloud run deploy` or `update-traffic` command.
+6. For an instant rollback outside the deploy workflow's own automatic health
+   contract — e.g. a release that classified healthy but silently reverted
+   previously-shipped functionality — dispatch `.github/workflows/rollback.yml`
+   (`./bin/hushh rollback <uat|production> [backend|frontend|all] --reason
+   "<reason>"`). This is the sanctioned mechanism item 5 refers to, not the ad
+   hoc `gcloud` it prohibits: it is actor-gated by the same
+   `manual_dispatch_users` allowlist that already gates deploy dispatch,
+   authenticates via the same Workload Identity Federation, and calls the
+   same, unmodified `scripts/ci/cloudrun-rollback.sh` the automatic path uses.
 
 ### 7. Close out
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,64 @@ jobs:
           MAIN_SYNC_CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: sh scripts/git/check-main-sync.sh
 
+  # Advisory, not required: Base Freshness Gate proves a PR CONTAINS main's
+  # commits as ancestors; it says nothing about whether resolving those
+  # commits' conflicts kept their content, and says nothing at all about a
+  # clean revert commit that never touched main's history. This runs two
+  # passes — every real "synced main in and resolved conflicts" merge the PR
+  # introduces, plus the PR's own whole diff against its base — checking both
+  # for silently dropped or resurrected content (2026-08-19 incident). It is
+  # a text heuristic with a real false-positive rate on large files with
+  # repeated boilerplate and on a branch's own early, later-corrected sync
+  # commits — read the output, don't just watch the check mark. A PR that is
+  # deliberately reverting something declares it with the "intentional-revert"
+  # label plus a "Merge-Regression-Ack: <reason>" line in the PR body, then
+  # re-runs this job (both are read live, no new push needed). Deliberately
+  # kept out of ci-status's `needs` and run with continue-on-error so it can
+  # never block a merge during the burn-in period.
+  merge-fidelity-gate:
+    name: "Merge Fidelity Gate (advisory)"
+    if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'integration/pr-train')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Scan for content this PR silently dropped from its base
+        env:
+          MERGE_REGRESSION_MODE: warn
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/check-merge-fidelity.sh
+
+      # A separate, wider pass: diffs against the last commit actually
+      # deployed healthy to production (deploy-production.yml tags it via
+      # scripts/ci/tag-last-known-good.sh), not just this PR's own base.
+      # Catches a revert that landed clean upstream of this PR entirely.
+      # Kept advisory for LONGER than the pass above — its window is wider,
+      # so its false-positive surface is bigger, and it has no track record
+      # yet. Promote it separately, on its own evidence, not bundled with
+      # the PR-scoped pass's own eventual promotion to a required check.
+      - name: Fetch last-known-good deploy tags
+        continue-on-error: true
+        run: git fetch origin 'refs/tags/deployed/*:refs/tags/deployed/*' 2>&1 || true
+
+      - name: Scan for content missing since the last known-good production deploy (advisory, wider window)
+        continue-on-error: true
+        env:
+          MERGE_REGRESSION_MODE: warn
+        run: |
+          if git rev-parse -q --verify refs/tags/deployed/production-latest >/dev/null; then
+            bash scripts/git/check-merge-regression.sh refs/tags/deployed/production-latest "origin/${{ github.base_ref }}" HEAD
+          else
+            echo "[merge-fidelity] No deployed/production-latest tag yet (first tagged deploy hasn't happened) — skipping this pass."
+          fi
+
   ci-status:
     name: "CI Status Gate"
     needs:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,7 +39,11 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # write: this workflow tags a healthy release as "last known good"
+  # (scripts/ci/tag-last-known-good.sh) so a future revert check and a
+  # future rollback both have a durable anchor. Scoped to pushing tags only
+  # — the workflow never touches a branch.
+  contents: write
   checks: read
   id-token: write
 
@@ -896,6 +900,28 @@ jobs:
             echo "- Connected Systems Omni Gateway: \`${{ steps.verify-connected-systems.outcome }}\`"
             echo "- Native passkey domain associations: \`${{ steps.verify-passkey-associations.outcome }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Tag this release as last known good
+        id: tag-last-known-good
+        if: always()
+        shell: bash
+        env:
+          ENVIRONMENT: production
+          SHA: ${{ github.event.inputs.sha }}
+          BACKEND_REVISION: ${{ steps.final-state.outputs.backend_serving }}
+          BACKEND_URL: ${{ steps.backend-url.outputs.url }}
+          FRONTEND_REVISION: ${{ steps.final-state.outputs.frontend_serving }}
+          FRONTEND_URL: ${{ steps.frontend-url.outputs.url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          STATUS="$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/prod-release-status.json').read_text(encoding='utf-8'))['status'])")"
+          if [ "$STATUS" != "healthy" ]; then
+            echo "[tag-last-known-good] Release status is '$STATUS', not 'healthy' — not tagging."
+            exit 0
+          fi
+          bash scripts/ci/tag-last-known-good.sh
 
       - name: Fail workflow when production release did not end healthy
         if: always()

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -909,9 +909,9 @@ jobs:
           ENVIRONMENT: production
           SHA: ${{ github.event.inputs.sha }}
           BACKEND_REVISION: ${{ steps.final-state.outputs.backend_serving }}
-          BACKEND_URL: ${{ steps.backend-url.outputs.url }}
+          BACKEND_SERVICE_URL: ${{ steps.backend-url.outputs.url }}
           FRONTEND_REVISION: ${{ steps.final-state.outputs.frontend_serving }}
-          FRONTEND_URL: ${{ steps.frontend-url.outputs.url }}
+          FRONTEND_SERVICE_URL: ${{ steps.frontend-url.outputs.url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ACTOR: ${{ github.triggering_actor }}
         run: |

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -1259,9 +1259,9 @@ jobs:
           ENVIRONMENT: uat
           SHA: ${{ steps.resolve-sha.outputs.sha }}
           BACKEND_REVISION: ${{ steps.final-state.outputs.backend_revision }}
-          BACKEND_URL: ${{ steps.final-state.outputs.backend_url }}
+          BACKEND_SERVICE_URL: ${{ steps.final-state.outputs.backend_url }}
           FRONTEND_REVISION: ${{ steps.final-state.outputs.frontend_revision }}
-          FRONTEND_URL: ${{ steps.final-state.outputs.frontend_url }}
+          FRONTEND_SERVICE_URL: ${{ steps.final-state.outputs.frontend_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ACTOR: ${{ github.triggering_actor }}
         run: |

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -19,7 +19,11 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # write: this workflow tags a healthy release as "last known good"
+  # (scripts/ci/tag-last-known-good.sh) so a future revert check and a
+  # future rollback both have a durable anchor. Scoped to pushing tags only
+  # — the workflow never touches a branch.
+  contents: write
   checks: read
   id-token: write
 
@@ -1246,6 +1250,28 @@ jobs:
             echo "- Shared changed files: \`${{ steps.scope.outputs.shared_changed_files || 'none' }}\`"
             echo "- Neutral changed files: \`${{ steps.scope.outputs.neutral_changed_files || 'none' }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Tag this release as last known good
+        id: tag-last-known-good
+        if: always()
+        shell: bash
+        env:
+          ENVIRONMENT: uat
+          SHA: ${{ steps.resolve-sha.outputs.sha }}
+          BACKEND_REVISION: ${{ steps.final-state.outputs.backend_revision }}
+          BACKEND_URL: ${{ steps.final-state.outputs.backend_url }}
+          FRONTEND_REVISION: ${{ steps.final-state.outputs.frontend_revision }}
+          FRONTEND_URL: ${{ steps.final-state.outputs.frontend_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          STATUS="$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/uat-release-status.json').read_text(encoding='utf-8'))['status'])")"
+          if [ "$STATUS" != "healthy" ]; then
+            echo "[tag-last-known-good] Release status is '$STATUS', not 'healthy' — not tagging."
+            exit 0
+          fi
+          bash scripts/ci/tag-last-known-good.sh
 
       - name: Fail workflow when UAT release did not end healthy
         if: always()

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,290 @@
+name: "Rollback"
+
+# Standalone, manually-dispatchable rollback: repoints UAT/production Cloud
+# Run traffic to a known-good revision without going through a git revert
+# PR first. Before this workflow existed, rollback only happened as an
+# automatic side effect inside deploy-uat.yml / deploy-production.yml, and
+# only when the post-deploy health classifier failed — a revert to code that
+# was itself previously shipped and working passes those health checks
+# cleanly, so it would never trigger. This closes that gap.
+#
+# This IS the governed mechanism the "no ad hoc gcloud run deploy /
+# update-traffic" rule in admin-release-sop.md refers to — see the doc
+# update landed alongside this file. It is not the ad hoc command that rule
+# prohibits: it is actor-gated by the same allowlist that already gates
+# deploy dispatch, authenticates the same way (Workload Identity
+# Federation), and calls the same, unmodified scripts/ci/cloudrun-rollback.sh
+# the automatic path already uses.
+#
+# Two separate jobs, not one dynamic `environment:`, deliberately — this
+# mirrors deploy-uat.yml (no environment: key, repo-level vars) and
+# deploy-production.yml (environment: production, environment-scoped vars)
+# exactly, rather than introducing an unproven dynamic-environment pattern.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment to roll back"
+        required: true
+        type: choice
+        options:
+          - uat
+          - production
+      scope:
+        description: "Which service(s) to roll back"
+        required: true
+        type: choice
+        default: all
+        options:
+          - backend
+          - frontend
+          - all
+      backend_revision:
+        description: "Backend revision to restore (blank = last known-good tag)"
+        required: false
+        type: string
+      frontend_revision:
+        description: "Frontend revision to restore (blank = last known-good tag)"
+        required: false
+        type: string
+      reason:
+        description: "Why this rollback is needed (audit trail)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  rollback-uat:
+    name: "Rollback — UAT"
+    if: github.event.inputs.environment == 'uat'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: deploy-uat
+      cancel-in-progress: false
+    env:
+      GCP_PROJECT_ID: hushh-pda-uat
+      GCP_REGION: us-central1
+      BACKEND_SERVICE: consent-protocol
+      FRONTEND_SERVICE: hushh-webapp
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing UAT rollback from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: main
+
+      - name: Assert manual UAT dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface uat --actor "${GITHUB_ACTOR}"
+
+      - name: Fetch last-known-good deploy tags
+        run: git fetch origin 'refs/tags/deployed/*:refs/tags/deployed/*' 2>&1 || true
+
+      - name: Validate Google Cloud workload identity configuration
+        shell: bash
+        env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Roll back backend
+        id: rollback-backend
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat backend "${{ github.event.inputs.backend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback backend health check
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/health" 5 30 5 200
+
+      - name: Roll back frontend
+        id: rollback-frontend
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat frontend "${{ github.event.inputs.frontend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback frontend health check
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/" 3 30 5 200
+
+      - name: Rollback summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## UAT Rollback"
+            echo ""
+            echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Backend target revision: \`${{ steps.rollback-backend.outputs.revision || 'n/a (not in scope)' }}\`"
+            echo "- Frontend target revision: \`${{ steps.rollback-frontend.outputs.revision || 'n/a (not in scope)' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  rollback-production:
+    name: "Rollback — Production"
+    if: github.event.inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    concurrency:
+      group: deploy-production-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      GCP_PROJECT_ID: hushh-pda
+      GCP_REGION: us-central1
+      BACKEND_SERVICE: consent-protocol
+      FRONTEND_SERVICE: hushh-webapp
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing production rollback from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: main
+
+      - name: Assert production dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface production --actor "${GITHUB_ACTOR}"
+
+      - name: Fetch last-known-good deploy tags
+        run: git fetch origin 'refs/tags/deployed/*:refs/tags/deployed/*' 2>&1 || true
+
+      - name: Validate Google Cloud workload identity configuration
+        shell: bash
+        env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Roll back backend
+        id: rollback-backend
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh production backend "${{ github.event.inputs.backend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback backend health check
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/health" 5 30 5 200
+
+      - name: Roll back frontend
+        id: rollback-frontend
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh production frontend "${{ github.event.inputs.frontend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback frontend health check
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/" 3 30 5 200
+
+      - name: Rollback summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Production Rollback"
+            echo ""
+            echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Backend target revision: \`${{ steps.rollback-backend.outputs.revision || 'n/a (not in scope)' }}\`"
+            echo "- Frontend target revision: \`${{ steps.rollback-frontend.outputs.revision || 'n/a (not in scope)' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/hushh
+++ b/bin/hushh
@@ -45,12 +45,14 @@ Operational commands:
   db report-prod-posture [--json]
   compose <subcommand>
   protocol <subcommand>
-  sync <main|check-main>
+  sync <main|verify-merge|check-main>
+  rollback <uat|production> [backend|frontend|all] --reason "<reason>"
 
 Run:
   ./bin/hushh compose --help
   ./bin/hushh protocol --help
   ./bin/hushh sync --help
+  ./bin/hushh rollback --help
   ./bin/hushh codex --help
 EOF
 }
@@ -90,6 +92,7 @@ sync_usage() {
   cat <<'EOF'
 Usage:
   ./bin/hushh sync main
+  ./bin/hushh sync verify-merge
   ./bin/hushh sync check-main
 EOF
 }
@@ -401,6 +404,10 @@ run_sync() {
       shift
       exec bash "$REPO_ROOT/scripts/git/sync-main.sh" "$@"
       ;;
+    verify-merge)
+      shift
+      exec bash "$REPO_ROOT/scripts/git/verify-merge.sh" "$@"
+      ;;
     check-main)
       shift
       exec sh "$REPO_ROOT/scripts/git/check-main-sync.sh" "$@"
@@ -412,6 +419,38 @@ run_sync() {
     *)
       sync_usage
       exit 1
+      ;;
+  esac
+}
+
+rollback_usage() {
+  cat <<'EOF'
+Usage:
+  ./bin/hushh rollback <uat|production> [backend|frontend|all] --reason "<reason>" \
+      [--backend-revision <revision>] [--frontend-revision <revision>]
+
+Dispatches .github/workflows/rollback.yml and watches it to completion. Moves
+Cloud Run traffic straight to a known-good revision, without a git revert PR
+first. Blank revision flags fall back to the deployed/<env>-latest tag.
+
+Requires `gh` authenticated as an actor already allowed to dispatch a deploy
+to that environment (config/ci-governance.json manual_dispatch_users) — this
+reuses that allowlist, it does not grant anything new.
+EOF
+}
+
+run_rollback() {
+  [ "$#" -ge 1 ] || {
+    rollback_usage
+    exit 1
+  }
+  case "${1:-}" in
+    -h|--help)
+      rollback_usage
+      exit 0
+      ;;
+    *)
+      exec bash "$REPO_ROOT/scripts/ci/dispatch-rollback.sh" "$@"
       ;;
   esac
 }
@@ -877,6 +916,9 @@ EOF
     ;;
   sync)
     run_sync "$@"
+    ;;
+  rollback)
+    run_rollback "$@"
     ;;
   *)
     main_usage

--- a/scripts/ci/check-merge-fidelity.sh
+++ b/scripts/ci/check-merge-fidelity.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/ci/check-merge-fidelity.sh
+#
+# CI orchestrator for the "Merge Fidelity Gate" job. Runs both regression
+# passes a PR needs — every internal sync-merge commit it introduces, AND
+# the PR's own whole diff against its base (catches a CLEAN revert commit
+# with no merge conflict at all, which introduces no merge commit and so is
+# invisible to the first pass) — through check-merge-regression.sh, then
+# applies the intentional-revert escape hatch before deciding pass/fail.
+#
+# Kept separate from check-merge-regression.sh (no PR/GitHub concept; also
+# runs locally via `./bin/hushh sync`) and from scan-pr-merges-for-regression.sh
+# (only knows about merge commits) — this is the one place PR metadata
+# (labels, body trailer) gets read.
+#
+# Escape hatch: a PR flagged by either pass is not failed if BOTH of these
+# are true — two independent signals, neither requiring elevated permission,
+# so it can't be tripped by accident:
+#   - the PR carries the label "intentional-revert"
+#   - the PR body contains a line "Merge-Regression-Ack: <reason>"
+# Both are read LIVE via `gh pr view` when this step actually runs, not from
+# the event payload frozen at trigger time — so adding the label/trailer and
+# re-running the job (no new push needed) picks them up.
+#
+# Usage: BASE_REF=main PR_NUMBER=1234 GITHUB_REPOSITORY=org/repo \
+#          bash scripts/ci/check-merge-fidelity.sh
+#
+# Env:
+#   MERGE_REGRESSION_MODE   block | warn (default warn) — this repo runs it
+#                           in warn during the Phase 1 burn-in period.
+#   BASE_REF                required, e.g. "main" or "integration/pr-train".
+#   PR_NUMBER, GITHUB_REPOSITORY   required to read the escape hatch; if
+#                           unset (e.g. a manual local run) the escape hatch
+#                           is simply unavailable and a flag always reports.
+set -uo pipefail
+
+MODE="${MERGE_REGRESSION_MODE:-warn}"
+BASE_REF="${BASE_REF:?BASE_REF is required, e.g. main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+FOUND=0
+
+echo "== Pass 1: sync-merge commits this PR introduces =="
+MERGE_REGRESSION_MODE=block bash "$REPO_ROOT/scripts/git/scan-pr-merges-for-regression.sh" "origin/${BASE_REF}" || FOUND=1
+
+echo ""
+echo "== Pass 2: this PR's whole diff against its own merge-base (catches a clean revert, no conflict needed) =="
+PR_BASE="$(git merge-base HEAD "origin/${BASE_REF}")"
+MERGE_REGRESSION_MODE=block bash "$REPO_ROOT/scripts/git/check-merge-regression.sh" "$PR_BASE" "origin/${BASE_REF}" HEAD || FOUND=1
+
+if [ "$FOUND" -eq 0 ]; then
+  echo ""
+  echo "[merge-fidelity] OK — neither pass found dropped content."
+  exit 0
+fi
+
+# Something was flagged. Check for the intentional-revert escape hatch.
+ACK=""
+LABELED=0
+ACTOR=""
+if [ -n "${PR_NUMBER:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && command -v gh >/dev/null 2>&1; then
+  PR_JSON="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body,labels,author 2>/dev/null || echo '{}')"
+  LABELED="$(python3 -c '
+import json, sys
+d = json.loads(sys.argv[1] or "{}")
+print(1 if any(l.get("name") == "intentional-revert" for l in d.get("labels", [])) else 0)
+' "$PR_JSON" 2>/dev/null || echo 0)"
+  ACK="$(python3 -c '
+import json, re, sys
+d = json.loads(sys.argv[1] or "{}")
+m = re.search(r"^Merge-Regression-Ack:\s*(.+)$", d.get("body") or "", re.MULTILINE)
+print(m.group(1).strip() if m else "")
+' "$PR_JSON" 2>/dev/null || echo "")"
+  ACTOR="$(python3 -c '
+import json, sys
+d = json.loads(sys.argv[1] or "{}")
+print(d.get("author", {}).get("login", ""))
+' "$PR_JSON" 2>/dev/null || echo "")"
+fi
+
+if [ "$LABELED" -eq 1 ] && [ -n "$ACK" ]; then
+  MSG="[merge-fidelity] Declared intentional revert by @${ACTOR:-unknown}: ${ACK}"
+  echo ""
+  echo "$MSG"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### Merge Fidelity Gate — intentional revert declared"
+      echo ""
+      echo "$MSG"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+  exit 0
+fi
+
+echo ""
+echo "[merge-fidelity] Flagged, and no intentional-revert escape hatch found."
+echo "[merge-fidelity] To declare this on purpose: add the 'intentional-revert' label"
+echo "AND a 'Merge-Regression-Ack: <reason>' line in the PR body, then re-run this job"
+echo "(no new push needed — the label and body are read live when the step runs)."
+
+if [ "$MODE" = "block" ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/ci/dispatch-rollback.sh
+++ b/scripts/ci/dispatch-rollback.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# scripts/ci/dispatch-rollback.sh
+#
+# Dispatches .github/workflows/rollback.yml and watches it to completion.
+# The actual mutation (moving Cloud Run traffic) happens entirely inside the
+# governed workflow — this is convenience only, mirroring the pattern
+# scripts/release/dispatch-ios-appstore.mjs already uses for a different
+# release lane ("gh workflow run does not return the run id; grab the
+# newest run for this workflow").
+#
+# Requires `gh` authenticated as an actor in the target environment's
+# manual_dispatch_users allowlist (config/ci-governance.json) — the same
+# allowlist that already gates deploy-uat.yml / deploy-production.yml
+# dispatch. Nobody's permissions change to use this.
+set -euo pipefail
+
+REPO="hushh-labs/hushh-research"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  dispatch-rollback.sh <uat|production> [backend|frontend|all] --reason "<reason>" \
+      [--backend-revision <revision>] [--frontend-revision <revision>]
+
+Blank --backend-revision/--frontend-revision fall back to the revision
+recorded in the deployed/<environment>-latest tag (scripts/ci/tag-last-known-good.sh).
+EOF
+}
+
+ENVIRONMENT="${1:-}"
+case "${ENVIRONMENT}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  uat|production)
+    shift
+    ;;
+  *)
+    echo "Error: first argument must be 'uat' or 'production'." >&2
+    usage
+    exit 1
+    ;;
+esac
+
+SCOPE="all"
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    backend|frontend|all)
+      SCOPE="$1"
+      shift
+      ;;
+  esac
+fi
+
+REASON=""
+BACKEND_REVISION=""
+FRONTEND_REVISION=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --backend-revision)
+      BACKEND_REVISION="${2:-}"
+      shift 2
+      ;;
+    --frontend-revision)
+      FRONTEND_REVISION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+[ -n "$REASON" ] || {
+  echo "Error: --reason is required (audit trail for the rollback)." >&2
+  usage
+  exit 1
+}
+
+command -v gh >/dev/null 2>&1 || {
+  echo "Error: the 'gh' CLI is required." >&2
+  exit 1
+}
+
+echo "Dispatching rollback: environment=${ENVIRONMENT} scope=${SCOPE} reason=\"${REASON}\""
+
+BEFORE_RUN_ID="$(gh run list --repo "$REPO" --workflow rollback.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+
+gh workflow run rollback.yml --repo "$REPO" --ref main \
+  -f "environment=${ENVIRONMENT}" \
+  -f "scope=${SCOPE}" \
+  -f "reason=${REASON}" \
+  -f "backend_revision=${BACKEND_REVISION}" \
+  -f "frontend_revision=${FRONTEND_REVISION}"
+
+echo "Dispatched. Locating the run..."
+
+RUN_ID=""
+for _ in $(seq 1 10); do
+  sleep 3
+  RUN_ID="$(gh run list --repo "$REPO" --workflow rollback.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+  if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$BEFORE_RUN_ID" ]; then
+    break
+  fi
+  RUN_ID=""
+done
+
+if [ -z "$RUN_ID" ]; then
+  echo "Could not locate the dispatched run automatically. Check:" >&2
+  echo "  gh run list --repo $REPO --workflow rollback.yml --limit 5" >&2
+  exit 1
+fi
+
+echo "Watching run ${RUN_ID}..."
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status

--- a/scripts/ci/resolve-rollback-target.sh
+++ b/scripts/ci/resolve-rollback-target.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/ci/resolve-rollback-target.sh
+#
+# Resolves which Cloud Run revision rollback.yml should restore traffic to,
+# for one service lane. An explicit revision always wins. Otherwise, falls
+# back to the revision recorded in the "last known good" tag written by
+# scripts/ci/tag-last-known-good.sh — so an operator dispatching a rollback
+# doesn't need to already know the revision name.
+#
+# Usage:
+#   resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]
+#
+# Prints the resolved revision name to stdout. Exits non-zero with a clear
+# message if nothing can be resolved (no explicit input AND no
+# deployed/<environment>-latest tag exists yet).
+set -euo pipefail
+
+ENVIRONMENT="${1:?usage: resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]}"
+LANE="${2:?usage: resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]}"
+EXPLICIT="${3:-}"
+
+if [ -n "$EXPLICIT" ]; then
+  echo "$EXPLICIT"
+  exit 0
+fi
+
+TAG="deployed/${ENVIRONMENT}-latest"
+
+if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "[resolve-rollback-target] No explicit ${LANE} revision given and refs/tags/${TAG} does not exist yet (no healthy deploy has been tagged for ${ENVIRONMENT})." >&2
+  echo "[resolve-rollback-target] Pass the revision explicitly — read it with:" >&2
+  echo "  gcloud run services describe <service> --project=<project> --region=us-central1 --format='value(status.traffic[0].revisionName)'" >&2
+  exit 1
+fi
+
+REVISION="$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | grep -E "^${LANE}_revision:" | head -1 | sed -E "s/^${LANE}_revision:[[:space:]]*//")"
+
+if [ -z "$REVISION" ]; then
+  echo "[resolve-rollback-target] refs/tags/${TAG} exists but has no ${LANE}_revision line — pass the revision explicitly." >&2
+  exit 1
+fi
+
+echo "$REVISION"

--- a/scripts/ci/tag-last-known-good.sh
+++ b/scripts/ci/tag-last-known-good.sh
@@ -30,17 +30,24 @@
 # Env (all required except RUN_URL/ACTOR):
 #   ENVIRONMENT        uat | production
 #   SHA                the commit that was deployed
-#   BACKEND_REVISION, BACKEND_URL, FRONTEND_REVISION, FRONTEND_URL
+#   BACKEND_REVISION, BACKEND_SERVICE_URL, FRONTEND_REVISION, FRONTEND_SERVICE_URL
 #   RUN_URL            the GitHub Actions run URL, for the annotation
 #   ACTOR              who dispatched the deploy
+#
+# Named *_SERVICE_URL, not *_URL — this repo's runtime config contract
+# (scripts/ci/verify-runtime-config-contract.py) retired one specific bare
+# frontend-URL env-var name repo-wide (its canonical replacement is
+# APP_FRONTEND_ORIGIN). These are unrelated Cloud Run service URLs, but the
+# check matches on the literal name anywhere, so a different name avoids a
+# false collision.
 set -euo pipefail
 
 ENVIRONMENT="${ENVIRONMENT:?ENVIRONMENT is required (uat|production)}"
 SHA="${SHA:?SHA is required}"
 BACKEND_REVISION="${BACKEND_REVISION:-}"
-BACKEND_URL="${BACKEND_URL:-}"
+BACKEND_SERVICE_URL="${BACKEND_SERVICE_URL:-}"
 FRONTEND_REVISION="${FRONTEND_REVISION:-}"
-FRONTEND_URL="${FRONTEND_URL:-}"
+FRONTEND_SERVICE_URL="${FRONTEND_SERVICE_URL:-}"
 RUN_URL="${RUN_URL:-}"
 ACTOR="${ACTOR:-unknown}"
 
@@ -53,9 +60,9 @@ MESSAGE="$(cat <<EOF
 Last known good — ${ENVIRONMENT}
 sha: ${SHA}
 backend_revision: ${BACKEND_REVISION}
-backend_url: ${BACKEND_URL}
+backend_url: ${BACKEND_SERVICE_URL}
 frontend_revision: ${FRONTEND_REVISION}
-frontend_url: ${FRONTEND_URL}
+frontend_url: ${FRONTEND_SERVICE_URL}
 run: ${RUN_URL}
 actor: ${ACTOR}
 tagged_at: ${TIMESTAMP}

--- a/scripts/ci/tag-last-known-good.sh
+++ b/scripts/ci/tag-last-known-good.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# scripts/ci/tag-last-known-good.sh
+#
+# Marks a successful, healthy deploy as "last known good" so a future revert
+# check (scripts/git/check-merge-regression.sh, via the wider comparison pass
+# in the Merge Fidelity Gate) and a future rollback (rollback.yml) both have
+# a durable anchor to work from. Nothing in this repo tagged a deploy before
+# this script existed — only 2 git tags existed in the whole repo, neither
+# part of the deploy pipeline.
+#
+# Writes two refs:
+#   - one immutable annotated tag per successful run:
+#       deployed/<env>/<sha8>-<UTC-timestamp>
+#   - one moving convenience ref, force-updated each time:
+#       deployed/<env>-latest
+# One combined tag for both lanes (backend+frontend) rather than four
+# separate per-lane tags — deliberately lightweight, since backend/frontend
+# can deploy independently via the existing scope mechanism and a maintained
+# per-lane changelog is not what this needs to be. If lane drift becomes a
+# real operational problem, split into deployed/<env>-backend-latest /
+# deployed/<env>-frontend-latest — the mechanism doesn't change, just the ref
+# names.
+#
+# Called from deploy-uat.yml / deploy-production.yml only after the release
+# classified healthy (no rollback fired). Requires `contents: write` on the
+# calling workflow and a checkout with push credentials persisted (the
+# actions/checkout default — do not add persist-credentials: false upstream
+# of this step).
+#
+# Env (all required except RUN_URL/ACTOR):
+#   ENVIRONMENT        uat | production
+#   SHA                the commit that was deployed
+#   BACKEND_REVISION, BACKEND_URL, FRONTEND_REVISION, FRONTEND_URL
+#   RUN_URL            the GitHub Actions run URL, for the annotation
+#   ACTOR              who dispatched the deploy
+set -euo pipefail
+
+ENVIRONMENT="${ENVIRONMENT:?ENVIRONMENT is required (uat|production)}"
+SHA="${SHA:?SHA is required}"
+BACKEND_REVISION="${BACKEND_REVISION:-}"
+BACKEND_URL="${BACKEND_URL:-}"
+FRONTEND_REVISION="${FRONTEND_REVISION:-}"
+FRONTEND_URL="${FRONTEND_URL:-}"
+RUN_URL="${RUN_URL:-}"
+ACTOR="${ACTOR:-unknown}"
+
+SHA8="${SHA:0:8}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+TAG="deployed/${ENVIRONMENT}/${SHA8}-${TIMESTAMP}"
+LATEST_REF="deployed/${ENVIRONMENT}-latest"
+
+MESSAGE="$(cat <<EOF
+Last known good — ${ENVIRONMENT}
+sha: ${SHA}
+backend_revision: ${BACKEND_REVISION}
+backend_url: ${BACKEND_URL}
+frontend_revision: ${FRONTEND_REVISION}
+frontend_url: ${FRONTEND_URL}
+run: ${RUN_URL}
+actor: ${ACTOR}
+tagged_at: ${TIMESTAMP}
+EOF
+)"
+
+git tag -a "$TAG" "$SHA" -m "$MESSAGE"
+git push origin "refs/tags/${TAG}"
+
+# Force-move only this one ref, not a general force-push — deliberately
+# scoped so it can never touch a branch or another tag.
+git tag -fa "$LATEST_REF" "$SHA" -m "$MESSAGE"
+git push origin "refs/tags/${LATEST_REF}" --force
+
+echo "[tag-last-known-good] Tagged ${SHA8} as ${TAG} and moved ${LATEST_REF} to it."

--- a/scripts/git/check-merge-regression.sh
+++ b/scripts/git/check-merge-regression.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# scripts/git/check-merge-regression.sh
+#
+# Detects the specific failure that motivated this script (2026-08-19):
+# a branch syncs `origin/main` in, a conflict gets resolved by hand, and the
+# resolution silently keeps the STALE side of a hunk instead of folding in
+# the fix that had already landed on main. `check-main-sync.sh` proves a
+# branch CONTAINS main's commits; it says nothing about whether resolving
+# those commits' conflicts actually preserved their content. This script
+# checks the content.
+#
+# Method: for every file that changed between BASE (the old fork point) and
+# UPSTREAM (main at merge time), collect UPSTREAM's non-trivial ADDED lines
+# and DELETED lines separately, then check both directions against the
+# resolved result: added lines that are now missing, and deleted lines that
+# are still present ("resurrected"). A fix that is mostly "stop doing X" only
+# shows up in the second check — checking additions alone missed exactly that
+# shape of fix in testing. Either signal flags the file, with the commit(s)
+# that made the change, so the reviewer can tell "superseded on purpose" from
+# "silently reverted" in seconds.
+#
+# This is a content heuristic, not a semantic proof. It WILL flag legitimate
+# supersessions (a later commit intentionally replaced main's lines). Read
+# the flagged diff before deciding; that is the job the check exists to make
+# fast, not to replace.
+#
+# Usage:
+#   check-merge-regression.sh <base-ref> <upstream-ref> [target-ref|--worktree]
+#
+#   target-ref   defaults to HEAD. Pass --worktree to read the checked-out
+#                files on disk instead (for an in-progress, not-yet-committed
+#                conflict resolution).
+#
+# Env:
+#   MERGE_REGRESSION_MODE          block (default) | warn
+#   MERGE_REGRESSION_MIN_LINE_LEN  ignore added lines shorter than this many
+#                                  significant characters (default 12)
+#   MERGE_REGRESSION_THRESHOLD_PCT flag a file once this % of its upstream
+#                                  added lines are missing (default 40)
+#   MERGE_REGRESSION_EXCLUDE       extra space-separated grep -E pattern to
+#                                  exclude paths, appended to the built-in
+#                                  generated/lockfile exclusions
+set -euo pipefail
+
+BASE="${1:?usage: check-merge-regression.sh <base-ref> <upstream-ref> [target-ref|--worktree]}"
+UPSTREAM="${2:?usage: check-merge-regression.sh <base-ref> <upstream-ref> [target-ref|--worktree]}"
+TARGET="${3:-HEAD}"
+
+MODE="${MERGE_REGRESSION_MODE:-warn}"
+MIN_LEN="${MERGE_REGRESSION_MIN_LINE_LEN:-12}"
+THRESHOLD="${MERGE_REGRESSION_THRESHOLD_PCT:-40}"
+
+# Generated/derived files churn on every regen and are covered by their own
+# generation-check gates elsewhere in CI; they are pure noise here.
+EXCLUDE_RE='\.generated\.json$|package-lock\.json$|pnpm-lock\.yaml$|yarn\.lock$|/contracts/'
+if [ -n "${MERGE_REGRESSION_EXCLUDE:-}" ]; then
+  EXCLUDE_RE="${EXCLUDE_RE}|${MERGE_REGRESSION_EXCLUDE}"
+fi
+
+USE_WORKTREE=0
+if [ "$TARGET" = "--worktree" ]; then
+  USE_WORKTREE=1
+fi
+
+read_target_file() {
+  # $1 = path. Prints file content or nothing if the file no longer exists.
+  if [ "$USE_WORKTREE" -eq 1 ]; then
+    [ -f "$1" ] && cat "$1"
+  else
+    git show "${TARGET}:$1" 2>/dev/null || true
+  fi
+}
+
+CHANGED_FILES="$(git diff --name-only --diff-filter=M "$BASE" "$UPSTREAM" | grep -Ev "$EXCLUDE_RE" || true)"
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "[merge-regression] No modified-file overlap between $BASE and $UPSTREAM to check."
+  exit 0
+fi
+
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+FLAGGED=0
+CHECKED=0
+
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  CHECKED=$((CHECKED + 1))
+
+  target_content="$(read_target_file "$f")"
+
+  # A file the branch never touched inherits UPSTREAM's content byte for
+  # byte — trivially safe, and the one case the line-matching heuristic
+  # below cannot be trusted on: UPSTREAM's own diff can legitimately reuse a
+  # removed line's exact text elsewhere in the same file (a duplicated
+  # pattern, a renamed variable that collides with old text), which reads as
+  # a false "resurrection" even though the resolved file IS upstream.
+  upstream_content="$(git show "${UPSTREAM}:$f" 2>/dev/null || true)"
+  if [ "$target_content" = "$upstream_content" ]; then
+    continue
+  fi
+  base_content="$(git show "${BASE}:$f" 2>/dev/null || true)"
+
+  # Significant lines BASE -> UPSTREAM changed for this file: strip the
+  # leading '+'/'-', drop pure-comment/whitespace noise, require real length,
+  # and drop lines that recur more than once in their own source file — a
+  # repeated boilerplate signature (e.g. `async (id: string) => {` reused
+  # across many unrelated callbacks in a large file) cannot be told apart
+  # from a genuine resurrection/drop by exact-text matching alone.
+  # (Built with plain read loops, not `mapfile` — this must also run under
+  # macOS's stock bash 3.2, which has no mapfile/associative arrays.)
+  added_lines=()
+  while IFS= read -r line; do
+    [ "$(grep -cF -- "$line" <<<"$upstream_content")" -eq 1 ] && added_lines+=("$line")
+  done < <(
+    git diff "$BASE" "$UPSTREAM" -- "$f" \
+      | grep -E '^\+[^+]' \
+      | sed -E 's/^\+//' \
+      | sed -E 's/^[[:space:]]+//' \
+      | grep -Ev '^[[:space:]]*$' \
+      | grep -Ev '^(//|\*|#)' \
+      | awk -v n="$MIN_LEN" 'length($0) >= n'
+  )
+
+  # Significant lines UPSTREAM deleted relative to BASE. If these are still
+  # present in the resolved result, the resolution kept the side a fix was
+  # written to remove — the mirror image of a dropped addition, and the
+  # actual signature of the incident this script exists to catch (a fix that
+  # is mostly "stop doing X" shows up here, not in added_lines).
+  deleted_lines=()
+  while IFS= read -r line; do
+    [ "$(grep -cF -- "$line" <<<"$base_content")" -eq 1 ] && deleted_lines+=("$line")
+  done < <(
+    git diff "$BASE" "$UPSTREAM" -- "$f" \
+      | grep -E '^-[^-]' \
+      | sed -E 's/^-//' \
+      | sed -E 's/^[[:space:]]+//' \
+      | grep -Ev '^[[:space:]]*$' \
+      | grep -Ev '^(//|\*|#)' \
+      | awk -v n="$MIN_LEN" 'length($0) >= n'
+  )
+
+  [ "${#added_lines[@]}" -eq 0 ] && [ "${#deleted_lines[@]}" -eq 0 ] && continue
+
+  missing=0
+  missing_lines=()
+  # `${arr[@]+"${arr[@]}"}`, not `"${arr[@]}"` — bash 3.2 (macOS stock) treats
+  # expanding a zero-element array as an unbound variable under `set -u`.
+  for line in "${added_lines[@]+"${added_lines[@]}"}"; do
+    if [ -z "$target_content" ] || ! grep -qF -- "$line" <<<"$target_content"; then
+      missing=$((missing + 1))
+      missing_lines+=("$line")
+    fi
+  done
+
+  resurrected=0
+  resurrected_lines=()
+  for line in "${deleted_lines[@]+"${deleted_lines[@]}"}"; do
+    if [ -n "$target_content" ] && grep -qF -- "$line" <<<"$target_content"; then
+      resurrected=$((resurrected + 1))
+      resurrected_lines+=("$line")
+    fi
+  done
+
+  added_total="${#added_lines[@]}"
+  deleted_total="${#deleted_lines[@]}"
+  added_pct=0
+  [ "$added_total" -gt 0 ] && added_pct=$(( missing * 100 / added_total ))
+  deleted_pct=0
+  [ "$deleted_total" -gt 0 ] && deleted_pct=$(( resurrected * 100 / deleted_total ))
+
+  if [ "$added_pct" -ge "$THRESHOLD" ] || [ "$deleted_pct" -ge "$THRESHOLD" ]; then
+    FLAGGED=1
+    {
+      echo ""
+      echo "FILE: $f"
+      echo "  Landed on $UPSTREAM via:"
+      git log --format='    %h %an: %s' "$BASE".."$UPSTREAM" -- "$f" | head -5
+      if [ "$added_pct" -ge "$THRESHOLD" ]; then
+        echo "  ${missing}/${added_total} of upstream's added lines are MISSING (${added_pct}%):"
+        for m in "${missing_lines[@]:0:8}"; do
+          printf '    - %s\n' "$m"
+        done
+        [ "${#missing_lines[@]}" -gt 8 ] && echo "    ... and $(( ${#missing_lines[@]} - 8 )) more"
+      fi
+      if [ "$deleted_pct" -ge "$THRESHOLD" ]; then
+        echo "  ${resurrected}/${deleted_total} lines upstream DELETED are still present (${deleted_pct}%):"
+        for m in "${resurrected_lines[@]:0:8}"; do
+          printf '    - %s\n' "$m"
+        done
+        [ "${#resurrected_lines[@]}" -gt 8 ] && echo "    ... and $(( ${#resurrected_lines[@]} - 8 )) more"
+      fi
+    } >> "$TMP_REPORT"
+  fi
+done <<< "$CHANGED_FILES"
+
+if [ "$FLAGGED" -eq 1 ]; then
+  echo "============================================================"
+  echo "[merge-regression] POSSIBLE REGRESSION — resolved content is missing"
+  echo "lines that $UPSTREAM already had for this file since $BASE."
+  echo "============================================================"
+  cat "$TMP_REPORT"
+  echo ""
+  echo "If this is intentional (the fix was superseded by newer work), say so"
+  echo "in the commit message. Otherwise re-resolve, keeping BOTH sides' intent"
+  echo "— see the sync-main skill's conflict rule, or scripts/git/sync-main.sh."
+  if [ "$MODE" = "block" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "[merge-regression] OK — checked $CHECKED file(s) changed between $BASE and $UPSTREAM; no content dropped from $TARGET."
+exit 0

--- a/scripts/git/scan-pr-merges-for-regression.sh
+++ b/scripts/git/scan-pr-merges-for-regression.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/git/scan-pr-merges-for-regression.sh
+#
+# Automates the manual audit that caught the 2026-08-19 incident: walk every
+# 2-parent merge commit a PR introduces where the branch side was NOT already
+# an ancestor of the mainline side (a real "synced main in and resolved
+# conflicts" merge, not a trivial fast-forward), and run
+# check-merge-regression.sh on each. Intended for CI, one PR at a time.
+#
+# Usage:
+#   scan-pr-merges-for-regression.sh [base-ref]
+#     base-ref   the PR's base (default: origin/main). Merge commits are
+#                looked for in <base-ref>..HEAD.
+#
+# Env:
+#   MERGE_REGRESSION_MODE   block | warn (default warn) — governs this
+#                           script's own exit code. Each individual merge is
+#                           always checked in block semantics internally so a
+#                           finding is never silently skipped; MODE only
+#                           decides whether a finding fails the CI step.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REGRESSION_SCRIPT="$REPO_ROOT/scripts/git/check-merge-regression.sh"
+MODE="${MERGE_REGRESSION_MODE:-warn}"
+BASE_REF="${1:-origin/main}"
+
+MERGES="$(git rev-list --merges "${BASE_REF}..HEAD" 2>/dev/null || true)"
+
+if [ -z "$MERGES" ]; then
+  echo "[scan-pr-merges] No merge commits in ${BASE_REF}..HEAD; nothing to scan."
+  exit 0
+fi
+
+OVERALL=0
+SCANNED=0
+
+while IFS= read -r m; do
+  [ -z "$m" ] && continue
+
+  p1="$(git rev-parse "${m}^1" 2>/dev/null || true)"
+  p2="$(git rev-parse "${m}^2" 2>/dev/null || true)"
+  if [ -z "$p1" ] || [ -z "$p2" ]; then
+    continue
+  fi
+
+  # Branch side already fully contained in mainline side: a no-op merge for
+  # this purpose (nothing was "brought in and resolved").
+  if git merge-base --is-ancestor "$p2" "$p1" 2>/dev/null; then
+    continue
+  fi
+
+  base="$(git merge-base "$p1" "$p2")"
+  SCANNED=$((SCANNED + 1))
+  echo ""
+  echo "### $m — $(git log -1 --format=%s "$m") ###"
+  if ! MERGE_REGRESSION_MODE=block bash "$REGRESSION_SCRIPT" "$base" "$p1" "$m"; then
+    OVERALL=1
+  fi
+done <<< "$MERGES"
+
+echo ""
+echo "[scan-pr-merges] Checked ${SCANNED} sync-merge commit(s) in ${BASE_REF}..HEAD."
+
+if [ "$OVERALL" -eq 1 ]; then
+  echo "[scan-pr-merges] At least one merge commit above may have dropped content ${BASE_REF} already had."
+  echo "[scan-pr-merges] Note: an early 'Merge origin/main into <branch>' commit can flag something"
+  echo "the branch's OWN later commits already fixed. Check whether the same file is still flagged"
+  echo "in this PR's FINAL merge commit before treating an earlier one as live."
+  [ "$MODE" = "block" ] && exit 1
+fi
+exit 0

--- a/scripts/git/sync-main.sh
+++ b/scripts/git/sync-main.sh
@@ -4,6 +4,18 @@ set -euo pipefail
 REMOTE="${MAIN_SYNC_REMOTE:-origin}"
 BRANCH="${MAIN_SYNC_BRANCH:-main}"
 CURRENT_BRANCH="$(git branch --show-current)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# git-dir, not "$REPO_ROOT/.git" — in a linked worktree (common in this repo)
+# .git is a FILE pointing elsewhere, so that path never resolves.
+GIT_DIR="$(git rev-parse --git-dir)"
+STATE_FILE="$GIT_DIR/HUSHH_SYNC_BASE"
+REGRESSION_SCRIPT="$REPO_ROOT/scripts/git/check-merge-regression.sh"
+# warn by default: the check is a text heuristic (occurrence matching), and
+# testing surfaced real false positives on large files with repeated
+# boilerplate (e.g. many callbacks sharing one signature line). Read the
+# report either way; opt into MERGE_REGRESSION_MODE=block once you've seen it
+# stay quiet on your own files and want it to stop the merge outright.
+MERGE_REGRESSION_MODE="${MERGE_REGRESSION_MODE:-warn}"
 
 if [ -z "$CURRENT_BRANCH" ]; then
   echo "Detached HEAD detected; switch to a branch first." >&2
@@ -15,7 +27,37 @@ if [ "$CURRENT_BRANCH" = "$BRANCH" ]; then
   exit 0
 fi
 
+run_regression_check() {
+  local base="$1" upstream="$2"
+  if [ ! -x "$REGRESSION_SCRIPT" ] && [ ! -f "$REGRESSION_SCRIPT" ]; then
+    echo "[sync-main] check-merge-regression.sh not found; skipping fidelity check." >&2
+    return 0
+  fi
+  echo ""
+  echo "Checking that the merge didn't silently drop anything ${REMOTE}/${BRANCH} already had..."
+  MERGE_REGRESSION_MODE="$MERGE_REGRESSION_MODE" \
+    bash "$REGRESSION_SCRIPT" "$base" "$upstream" HEAD
+}
+
 echo "Fetching ${REMOTE}/${BRANCH}..."
 git fetch "$REMOTE" "$BRANCH" --quiet
+
+BASE="$(git merge-base HEAD "${REMOTE}/${BRANCH}")"
+UPSTREAM_SHA="$(git rev-parse "${REMOTE}/${BRANCH}")"
+printf '%s %s\n' "$BASE" "$UPSTREAM_SHA" > "$STATE_FILE"
+
 echo "Merging ${REMOTE}/${BRANCH} into ${CURRENT_BRANCH}..."
-git merge "${REMOTE}/${BRANCH}"
+if git merge "${REMOTE}/${BRANCH}"; then
+  run_regression_check "$BASE" "$UPSTREAM_SHA"
+  rm -f "$STATE_FILE"
+else
+  cat >&2 <<EOF
+
+[sync-main] Merge stopped with conflicts. Resolve them keeping BOTH sides'
+intent (never just pick one side to make it merge), then either:
+  git add <resolved files> && git commit --no-edit && ./bin/hushh sync verify-merge
+or abort with:
+  git merge --abort
+EOF
+  exit 1
+fi

--- a/scripts/git/verify-merge.sh
+++ b/scripts/git/verify-merge.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/git/verify-merge.sh
+# Companion to sync-main.sh: run this after resolving a merge conflict left
+# by `./bin/hushh sync main` and committing the resolution. Checks that the
+# resolution didn't silently drop content the merge was supposed to bring in.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_DIR="$(git rev-parse --git-dir)"
+STATE_FILE="$GIT_DIR/HUSHH_SYNC_BASE"
+REGRESSION_SCRIPT="$REPO_ROOT/scripts/git/check-merge-regression.sh"
+MERGE_REGRESSION_MODE="${MERGE_REGRESSION_MODE:-warn}"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "[verify-merge] No in-progress sync found (no $STATE_FILE)." >&2
+  echo "Run ./bin/hushh sync main first; this only applies after it stops on conflicts." >&2
+  exit 1
+fi
+
+if git status --porcelain | grep -qE '^(UU|AA|DD)'; then
+  echo "[verify-merge] Unresolved conflict markers remain. Resolve and 'git add' every file first." >&2
+  exit 1
+fi
+
+read -r BASE UPSTREAM_SHA < "$STATE_FILE"
+
+echo "Checking that the resolved merge didn't silently drop anything ${UPSTREAM_SHA:0:8} already had..."
+MERGE_REGRESSION_MODE="$MERGE_REGRESSION_MODE" \
+  bash "$REGRESSION_SCRIPT" "$BASE" "$UPSTREAM_SHA" HEAD
+
+rm -f "$STATE_FILE"
+echo "[verify-merge] Clear to push."


### PR DESCRIPTION
## Summary

A merge or deploy could silently revert previously-shipped, working functionality with nothing catching it before it reached UAT/production. Triggered by a real incident today (2026-08-19): a stale branch's own uncommitted fixes made a feature look reverted. No bad actor, but it exposed a real gap — nothing verified that resolving a merge conflict, or a clean revert commit, actually preserved what main already had.

- **Merge Fidelity Gate (advisory)**: scans every sync-merge a PR introduces *and* the PR's whole diff against its base, so both a bad conflict resolution and a clean revert commit (no conflict at all) get caught. Deliberately kept `continue-on-error` and out of `CI Status Gate`'s `needs` for a burn-in period — it's a text heuristic with a real false-positive rate on large files with repeated boilerplate. A PR that's deliberately reverting something declares it with the `intentional-revert` label plus a `Merge-Regression-Ack: <reason>` line in the PR body — both read live via `gh pr view`, no elevated access needed, no new push needed to clear a flag.
- **Deploy-time tagging**: every healthy UAT/production deploy is now marked "last known good" — an immutable `deployed/<env>/<sha8>-<timestamp>` tag plus a moving `deployed/<env>-latest` ref. Nothing tagged a deploy before this (only 2 tags existed in the whole repo, neither used by the pipeline). This also feeds a third, wider Merge Fidelity Gate pass that diffs a PR against the last known-good production tag, not just its own base — kept advisory even longer since its window is bigger.
- **Standalone rollback**: `.github/workflows/rollback.yml` + `./bin/hushh rollback <uat|production> [backend|frontend|all] --reason "..."` repoints Cloud Run traffic to a known-good revision without a git revert PR first. Today's auto-rollback only fires on a health-check failure — a revert to old-but-working code passes health checks cleanly and would never trigger it. Actor-gated by the exact same `manual_dispatch_users` allowlist that already gates deploy dispatch, so nobody's access changes. Documented in `admin-release-sop.md` as the sanctioned mechanism its own "no ad hoc gcloud" rule refers to.

Full design plan: internal, tracked in issue #5536.

Closes #5536

## Test plan

- [x] YAML syntax validated for all 4 workflow files (`ci.yml`, `deploy-uat.yml`, `deploy-production.yml`, `rollback.yml`)
- [x] Bash syntax (`bash -n`) validated for all 7 new/modified shell scripts
- [x] Functional test: synthetic clean-revert scenario (no merge conflict) correctly flagged by the new whole-PR-diff pass, exit 1 in block mode
- [x] Functional test: a normal PR with only additions stays silent (this branch's own diff against `origin/main`, `check-merge-fidelity.sh` reports OK)
- [x] Functional test: escape-hatch label/trailer parsing verified against synthetic PR JSON (label-only → no ack, label+trailer → ack with correct actor/reason extracted)
- [x] Functional test: `resolve-rollback-target.sh` verified against a synthetic `deployed/uat-latest` tag (explicit override wins, blank falls back to the tag, missing tag fails loudly with a clear message)
- [x] Self-check: ran the new Merge Fidelity Gate against this PR's own diff — clean, purely additive
- [ ] Not yet exercised: a live GitHub Actions run of the Merge Fidelity Gate job on an actual PR (this one, once opened), a live `deploy-uat.yml` run producing a real tag, and a live `rollback.yml` dispatch — first real runs happen once this PR is open and CI runs