### PR TITLE
fix(one-location): remove redundant map-presence toggle from Settings

### DIFF
--- a/hushh-webapp/__tests__/components/links-tab-singleton-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/links-tab-singleton-flow.test.tsx
@@ -15,8 +15,6 @@ function mockHubViewModel(overrides?: Partial<LocationHubViewModel>): LocationHu
     locationEnabled: true,
     locationBlocked: false,
     autoApproveRequestsEnabled: false,
-    mapPresenceEnabled: true,
-    onMapPresenceChange: vi.fn(),
     locationPaused: false,
     locationAccuracyLimited: false,
     locationAcquiring: false,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2903,58 +2903,6 @@ export function OneLocationAgentPageContent({
       ),
     [contactSignalRecipients, selectedRequestOwnerIds],
   );
-  // Whether this person appears as a pin on the maps of people they already
-  // share with.
-  //
-  // The preference itself is not new -- it is `presence_mode`, and it defaults
-  // to 'ghost'. What was new is being able to find it: it lived only behind a
-  // Ghost toggle on the immersive map screen, so somebody who shared their
-  // location and then wondered why they never appeared on the other person's
-  // map had no way to discover the switch that decided it. Null while loading,
-  // so the control can be shown disabled rather than lying about its state.
-  const [mapPresenceEnabled, setMapPresenceEnabled] = useState<boolean | null>(
-    null,
-  );
-  useEffect(() => {
-    if (!vaultOwnerToken) return;
-    let cancelled = false;
-    void OneLocationService.getMapPreferences(vaultOwnerToken)
-      .then((preferences) => {
-        if (cancelled) return;
-        setMapPresenceEnabled(preferences.presenceMode === "foreground_private");
-      })
-      .catch(() => {
-        // Unknown is not the same as off, but the control has to say something
-        // -- and offering it as "off" is the honest failure: it cannot make a
-        // person more visible than they already are.
-        if (!cancelled) setMapPresenceEnabled(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [vaultOwnerToken]);
-  const handleMapPresenceChange = useCallback(
-    (next: boolean) => {
-      if (!vaultOwnerToken) return;
-      // Optimistic, then corrected by the server's answer. A privacy switch
-      // that lags behind the finger reads as broken, and people toggle it
-      // again -- which is how somebody ends up visible when they meant not to.
-      setMapPresenceEnabled(next);
-      void OneLocationService.updateMapPreferences({
-        vaultOwnerToken,
-        presenceMode: next ? "foreground_private" : "ghost",
-      })
-        .then((preferences) => {
-          setMapPresenceEnabled(preferences.presenceMode === "foreground_private");
-        })
-        .catch(() => {
-          setMapPresenceEnabled(!next);
-          toast.error("Could not change map visibility.");
-        });
-    },
-    [vaultOwnerToken],
-  );
-
   const pendingOwnerRequests = useMemo(
     () =>
       (state?.requests ?? []).filter(
@@ -11373,8 +11321,6 @@ export function OneLocationAgentPageContent({
         observedDenial: locationDenialObserved,
       }) === "blocked",
     autoApproveRequestsEnabled: locationControl.autoApproveRequestsEnabled,
-    mapPresenceEnabled,
-    onMapPresenceChange: handleMapPresenceChange,
     locationPaused: locationControl.paused,
     locationAccuracyLimited,
     // The switch is already on and the device has not found us yet. This is the

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -245,14 +245,6 @@ export type LocationHubViewModel = {
    * waiting stay the person's own decision.
    */
   autoApproveRequestsEnabled: boolean;
-  /**
-   * Whether this person appears as a pin on the maps of people they already
-   * share with. Opt-in, and separate from sharing itself: sharing sends a
-   * position to one person, this decides whether it becomes a pin they can
-   * watch move. Null while the preference is still loading.
-   */
-  mapPresenceEnabled: boolean | null;
-  onMapPresenceChange: (next: boolean) => void;
   locationPaused: boolean;
   locationAccuracyLimited: boolean;
   /**
@@ -2003,19 +1995,6 @@ function LocationSettingsFlow({
               checked={vm.autoApproveRequestsEnabled}
               onChange={vm.onAutoApproveRequestsChange}
               label="Auto-approve requests"
-            />
-          }
-          density="compact"
-        />
-        <SettingsRow
-          title="Show me on their map"
-          description="People you share with can watch you move."
-          trailing={
-            <LocationToggle
-              checked={vm.mapPresenceEnabled === true}
-              onChange={vm.onMapPresenceChange}
-              disabled={vm.mapPresenceEnabled === null}
-              label="Show me on their map"
             />
           }
           density="compact"


### PR DESCRIPTION
# Description

Removes the "Show me on their map" toggle from Location → Settings. It duplicated the existing Ghost Mode toggle on the immersive map screen (`location-immersive-map.tsx`) for the same `presence_mode` preference — the Settings row was a second, redundant surface for the same on/off state. UI-only removal; the underlying preference, its API (`OneLocationService.getMapPreferences` / `updateMapPreferences`), and the Ghost Mode toggle are untouched.

Closes #5517.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` (Settings screen only — existing route, no route added/removed)

- API / schema / type changes:
  - [x] Listed below: removed `mapPresenceEnabled` / `onMapPresenceChange` from the frontend `LocationHubViewModel` type (`components/one-location/redesign/location-redesign-hub.tsx`). No backend API, DB schema, or consent-protocol change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — shared React component via Capacitor webview, no native code touched.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None — no auth/consent/vault/PKM change; `presence_mode` preference and its API are unchanged.

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable — pure UI removal, revert-safe.

- UI browser or Playwright proof:
  - [x] Listed below: manually verified locally against a running `next dev` instance (`/one/location` → Settings) that only "Auto-approve requests" remains in the "Location sharing" group, with no orphaned spacing/separator.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [ ] `cd hushh-webapp && npm test` — targeted test (`links-tab-singleton-flow.test.tsx`, 3/3) passes; a full-suite run locally was inconclusive due to Windows `spawn EPERM` worker-launch errors from local process-count limits (unrelated to this diff — a repo-wide `grep` confirms zero remaining references to the removed fields), not re-run clean before opening this PR. Deferring to CI Status Gate as the authoritative signal.
  - [ ] `cd hushh-webapp && npm run build` — not run locally; a `next dev` server for this repo was already running and holding `.next` locked (Windows file-rename conflict), so this is deferred to CI as well.
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

Also ran `cd hushh-webapp && npm run lint` — clean (`--max-warnings=0`).

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (`/one/location` Settings).
- [x] Reachable production attach point: `LocationSettingsFlow` in `components/one-location/redesign/location-redesign-hub.tsx`, rendered from `app/one/location/page.tsx`.
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file. — N/A, no new tests added; existing test's mock updated to match the trimmed type.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint. — N/A, nothing added.
- [x] Production surface proved: see UI browser proof above.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`. — commit is signed off (`git commit -s`); CI status pending as of PR open.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here: N/A
- [ ] If this responds to requested changes, the new commit or material explanation is described here: N/A

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/one/location/page.tsx`) — only layer touched.
- [ ] **iOS**: Not applicable — shared webview component, no native plugin change.
- [ ] **Android**: Not applicable — shared webview component, no native plugin change.

## 🧪 Testing

- [x] Tested on Web (local `next dev`)
- [ ] Tested on iOS Simulator/Device — not applicable, no native surface touched
- [ ] Tested on Android Emulator/Device — not applicable, no native surface touched
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above — N/A, no generated files touched

## 📸 Screenshots / Video

Route: `/one/location` → Settings. Before: "Location sharing" group had two rows, "Auto-approve requests" and "Show me on their map". After: only "Auto-approve requests" remains.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? — No.
- [ ] If yes, have you implemented `checkConsentToken()`? — N/A
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A — pure UI removal, no new error paths introduced.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — N/A, no dependency changes