### PR TITLE
Fix tag-last-known-good.sh: set a git committer identity before tagging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -904,6 +904,11 @@ jobs:
       - name: Tag this release as last known good
         id: tag-last-known-good
         if: always()
+        # Advisory annotation, not a release-health signal: the deploy above
+        # already succeeded and classified healthy by this point. A tagging
+        # failure (e.g. a transient push conflict) must never turn a healthy
+        # release red or trigger the rollback investigation that implies.
+        continue-on-error: true
         shell: bash
         env:
           ENVIRONMENT: production

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -1254,6 +1254,11 @@ jobs:
       - name: Tag this release as last known good
         id: tag-last-known-good
         if: always()
+        # Advisory annotation, not a release-health signal: the deploy above
+        # already succeeded and classified healthy by this point. A tagging
+        # failure (e.g. a transient push conflict) must never turn a healthy
+        # release red or trigger the rollback investigation that implies.
+        continue-on-error: true
         shell: bash
         env:
           ENVIRONMENT: uat

--- a/scripts/ci/tag-last-known-good.sh
+++ b/scripts/ci/tag-last-known-good.sh
@@ -69,6 +69,16 @@ tagged_at: ${TIMESTAMP}
 EOF
 )"
 
+# A fresh actions/checkout has no committer identity configured, and an
+# annotated tag needs one (2026-08-19: first real run failed here with
+# "empty ident name"). Scoped to this repo checkout only, never --global.
+if [ -z "$(git config user.email || true)" ]; then
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+fi
+if [ -z "$(git config user.name || true)" ]; then
+  git config user.name "github-actions[bot]"
+fi
+
 git tag -a "$TAG" "$SHA" -m "$MESSAGE"
 git push origin "refs/tags/${TAG}"
 


### PR DESCRIPTION
## Summary

Follow-up to #5537 (the revert-regression guardrail), found on its first real UAT run.

- `scripts/ci/tag-last-known-good.sh` now sets a scoped (never `--global`) git committer identity when none is already configured, before running `git tag -a`. A fresh `actions/checkout` on a GitHub-hosted runner has no committer identity, so the first live deploy after merging #5537 failed with `fatal: empty ident name`.
- The "Tag this release as last known good" step in both `deploy-uat.yml` and `deploy-production.yml` is now `continue-on-error: true`. It's an advisory annotation written *after* the release already classified healthy — a tagging hiccup should never turn a healthy, successfully-deployed release red or imply a rollback investigation is needed. (This is exactly what happened on the failed run: backend and frontend both deployed, promoted, and passed every verification gate; the only red step was the tag.)

Related to #5536 (already closed by #5537's merge) — not reopening it, this PR is what actually finishes proving that work live.

## Test plan

- [x] Reproduced the exact failure locally with an isolated \`HOME\` (no gitconfig anywhere, matching a fresh runner) — \`git tag -a\` fails with the same "empty ident name" error before the fix
- [x] Same isolated-\`HOME\` repro succeeds cleanly after the fix, tag created with the fallback identity
- [x] YAML syntax validated for both workflow files
- [x] Bash syntax validated for the script
- [x] \`scripts/ci/verify-runtime-config-contract.py\` passes locally
- [ ] Live UAT deploy once merged, to confirm the actual tag now gets written