### PR TITLE
fix(one-location): compact add-minutes control on Ask flow's live-share row

### DIFF
--- a/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
+++ b/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
@@ -92,10 +92,12 @@ describe("Request location wires the take-back to the pending ask", () => {
     expect(ask).toContain("const pendingRequestId = status.pendingRequestId");
   });
 
-  it("keeps the live-share revoke on rows that have a grant", () => {
-    // One control, two acts, decided by which state the row is in. Losing the
-    // grant branch would turn every "stop sharing" into a request withdrawal.
-    expect(ask).toContain("vm.onStopGrant(activeGrant.id)");
+  it("no longer wires a live grant's X to revoke on this screen", () => {
+    // Ending a share you're receiving already has a home: Shared with me's
+    // own X calls the same vm.onStopGrant. A second X here was a redundant
+    // entry point to the identical action, so Request location's X is now
+    // only ever the pending-request withdrawal.
+    expect(ask).not.toContain("vm.onStopGrant(activeGrant.id)");
   });
 
   it("spins on the request being taken back, not on a grant id", () => {

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -4456,10 +4456,11 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("removes an already-live person's access from the Ask flow's own list", async () => {
-    // Ask's person list already showed "Live" for someone sharing with you --
-    // it just gave you nothing to do about that but leave the screen and
-    // hunt through Shared with me / Requests sent instead.
+  it("no longer offers a live grant's Remove from the Ask flow's own list", async () => {
+    // Ending a share you're receiving already has a home: Shared with me's
+    // own X, which calls this identical revoke. A second X here was a
+    // redundant entry point to the same action, so it's gone from this row;
+    // Ask's list keeps X only for taking back an unanswered request.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -4484,23 +4485,24 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openAskFlow();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Remove Trusted B's access" }),
-    );
-    await waitFor(() =>
-      expect(mockRevokeGrant).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        grantId: "grant_live_ask",
-      }),
-    );
+    expect(
+      screen.queryByRole("button", { name: "Remove Trusted B's access" }),
+    ).toBeNull();
   });
 
   /**
    * A live received share, expiring `minutes` from the real clock so the
-   * inline duration editor is judged against a time that is actually left --
-   * which is the whole question it has to answer.
+   * inline add-minutes control is judged against a time that is actually
+   * left -- which is the whole question it has to answer.
+   *
+   * `ceilingMinutes`, when given, sets `ceilingExpiresAt` -- the furthest the
+   * owner ever explicitly approved. Without it (the default), the backend's
+   * own fallback treats the current expiry as its own ceiling, so ANY chip
+   * tap has zero room to grow into and always asks the owner. Tests of the
+   * "grow inside what's already approved" path need real headroom, or they
+   * silently end up testing "request" instead.
    */
-  function liveReceivedGrant(minutes: number) {
+  function liveReceivedGrant(minutes: number, ceilingMinutes?: number) {
     return {
       id: "grant_live_ask",
       ownerUserId: "user_b",
@@ -4512,14 +4514,27 @@ describe("OneLocationAgentPage", () => {
       capabilityScopes: ["cap.location.live.view"],
       durationHours: minutes / 60,
       expiresAt: new Date(Date.now() + minutes * 60_000).toISOString(),
+      ...(ceilingMinutes !== undefined
+        ? {
+            ceilingExpiresAt: new Date(
+              Date.now() + ceilingMinutes * 60_000,
+            ).toISOString(),
+          }
+        : {}),
     };
   }
 
-  it("edits an already-live person's duration from the Ask flow's own list", async () => {
+  it("adds minutes on top of what the share actually has left, not a constant", async () => {
+    // The old picker opened on "1 hour" every time, whatever the row said
+    // was actually left. A chip adds to the true remaining time, so the
+    // resulting call is the proof: +15 min on a 4-hour grant lands near
+    // 4h15m, not 1h15m.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      receivedGrants: [liveReceivedGrant(4 * 60)],
+      // Ceiling well above any candidate this test taps, so the request
+      // actually exercises the in-ceiling grow path, not a fallback ask.
+      receivedGrants: [liveReceivedGrant(4 * 60, 24 * 60)],
     });
 
     render(<OneLocationAgentPage />);
@@ -4528,83 +4543,28 @@ describe("OneLocationAgentPage", () => {
     await openAskFlow();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
-    fireEvent.click(screen.getByRole("option", { name: "30 min" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
+    );
 
-    await waitFor(() =>
-      expect(mockShortenGrant).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        grantId: "grant_live_ask",
-        durationHours: 0.5,
-      }),
-    );
-    // Shortening is the recipient's own call to make -- nobody is asked.
+    await waitFor(() => expect(mockShortenGrant).toHaveBeenCalled());
+    const call = mockShortenGrant.mock.calls[0][0];
+    expect(call).toMatchObject({
+      vaultOwnerToken: "vault-token",
+      grantId: "grant_live_ask",
+    });
+    expect(call.durationHours).toBeCloseTo(4.25, 2);
+    // Growing within the ceiling is the recipient's own call -- nobody is asked.
     expect(mockRequestAccess).not.toHaveBeenCalled();
   });
 
-  it("opens the duration editor on what the share actually has left", async () => {
-    // It opened on "1 hour" every time, one line under "Sharing with you,
-    // 4 more hours". So the field was never the current duration, and Save on
-    // the untouched default asked for MORE time instead of changing anything.
-    mockGetState.mockResolvedValue({
-      ...locationState(),
-      ownerGrants: [],
-      receivedGrants: [liveReceivedGrant(4 * 60)],
-    });
-
-    render(<OneLocationAgentPage />);
-    await skipLocationEntryFlow();
-    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await openAskFlow();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
-    );
-
-    expect(
-      screen.getByRole("combobox", { name: "New duration" }).textContent,
-    ).toContain("4 hours");
-  });
-
-  it("does nothing at all when Save is pressed on an untouched duration", async () => {
-    // A one-hour share a minute old reads "59 more min" and the picker opens
-    // on "1 hour", because that is what it is. Pressing Save there is not a
-    // request for one more minute of somebody's location: it used to spend a
-    // refused shorten, then ask the owner, then report "Asked Trusted B for
-    // more time" over a row whose time never moved.
-    mockGetState.mockResolvedValue({
-      ...locationState(),
-      ownerGrants: [],
-      receivedGrants: [liveReceivedGrant(59)],
-    });
-
-    render(<OneLocationAgentPage />);
-    await skipLocationEntryFlow();
-    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await openAskFlow();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    // The editor closes, and no call goes anywhere.
-    await waitFor(() =>
-      expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
-    );
-    expect(mockShortenGrant).not.toHaveBeenCalled();
-    expect(mockRequestAccess).not.toHaveBeenCalled();
-  });
-
-  it("asks the owner for more time without first spending a refused shorten", async () => {
-    // Every ask-for-more-time used to call shorten_grant, wait for the 422,
-    // and only then send the request the user was always going to need. Two
-    // round trips to change nothing on screen is the "Save is slow" report;
-    // the expiry needed to skip the first one is already rendered as
-    // "12 more min" one line above the picker.
+  it("asks the owner for more time when a chip would push past the ceiling", async () => {
+    // A grant with 12 minutes left and no separate ceiling has one 12-minute
+    // window to grow inside; any chip tap exceeds it, so this always has to
+    // ask, and the exact amount travels with the ask instead of a bare
+    // "Requesting more time."
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -4617,23 +4577,18 @@ describe("OneLocationAgentPage", () => {
     await openAskFlow();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
-    fireEvent.click(screen.getByRole("option", { name: "4 hours" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
+    );
 
-    // The amount asked for travels with the request, and the grant it
-    // would lengthen is named. This used to send the literal string
-    // "Requesting more time." -- the number the person had just picked
-    // from the control above the button was the one fact the owner
-    // never received.
     await waitFor(() =>
       expect(mockRequestAccess).toHaveBeenCalledWith({
         vaultOwnerToken: "vault-token",
         ownerUserId: "user_b",
-        message: "Requesting 4 hours more of your live location.",
-        requestedDurationHours: 4,
+        message: "Requesting 27 min more of your live location.",
+        requestedDurationHours: expect.closeTo(0.45, 2),
         requestedDurationMode: "timed",
         extendsGrantId: "grant_live_ask",
       }),
@@ -4641,13 +4596,15 @@ describe("OneLocationAgentPage", () => {
     expect(mockShortenGrant).not.toHaveBeenCalled();
   });
 
-  it("says what to do when shortening fails, and lets the row be tried again", async () => {
+  it("says what to do when growing the time fails, and lets the row be tried again", async () => {
     // A toast that only names the failure ("Could not update access.") leaves
     // the person with no idea whether to wait, retry, or go elsewhere.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      receivedGrants: [liveReceivedGrant(4 * 60)],
+      // Ceiling well above any candidate this test taps, so the request
+      // actually exercises the in-ceiling grow path, not a fallback ask.
+      receivedGrants: [liveReceivedGrant(4 * 60, 24 * 60)],
     });
     // Not an Error instance, so no backend-curated message exists to prefer.
     mockShortenGrant.mockRejectedValueOnce({ code: "BOOM" });
@@ -4658,20 +4615,22 @@ describe("OneLocationAgentPage", () => {
     await openAskFlow();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
-    fireEvent.click(screen.getByRole("option", { name: "30 min" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
+    );
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         "Couldn't change the time. Try again.",
       ),
     );
-    // A failed save is not a reason to strand the row: the editor stays open
-    // on what was picked, and Save is pressable again.
-    const retry = await screen.findByRole("button", { name: "Save" });
+    // A failed save is not a reason to strand the row: the control stays
+    // open, and the chip is pressable again.
+    const retry = await screen.findByRole("button", {
+      name: "Add 15 minutes for Trusted B",
+    });
     expect(retry.hasAttribute("disabled")).toBe(false);
   });
 
@@ -4689,31 +4648,34 @@ describe("OneLocationAgentPage", () => {
     await openAskFlow();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
-    fireEvent.click(screen.getByRole("option", { name: "4 hours" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
+    );
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         "Couldn't ask Trusted B for more time. Try again.",
       ),
     );
-    const retry = await screen.findByRole("button", { name: "Save" });
+    const retry = await screen.findByRole("button", {
+      name: "Add 15 minutes for Trusted B",
+    });
     expect(retry.hasAttribute("disabled")).toBe(false);
   });
 
   it("leaves the row usable after a duration save, instead of stuck busy", async () => {
     // The save flag was the revoke flag, and the shorten path returned
-    // without clearing it. So one successful save disabled that person's
-    // Remove button for good, and the next Edit opened with Save already
-    // spinning and permanently disabled -- the "save button taking more time
-    // after edit time" report.
+    // without clearing it. So one successful save left the row disabled for
+    // good, and the next open showed a chip already spinning and permanently
+    // disabled -- the "save button taking more time after edit time" report.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      receivedGrants: [liveReceivedGrant(4 * 60)],
+      // Ceiling well above any candidate this test taps, so the request
+      // actually exercises the in-ceiling grow path, not a fallback ask.
+      receivedGrants: [liveReceivedGrant(4 * 60, 24 * 60)],
     });
 
     render(<OneLocationAgentPage />);
@@ -4722,28 +4684,30 @@ describe("OneLocationAgentPage", () => {
     await openAskFlow();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    fireEvent.click(screen.getByRole("combobox", { name: "New duration" }));
-    fireEvent.click(screen.getByRole("option", { name: "30 min" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
+    );
     await waitFor(() => expect(mockShortenGrant).toHaveBeenCalled());
 
-    // Remove never belonged to the save in the first place.
+    // The trigger never belonged to the save in the first place.
     await waitFor(() =>
       expect(
         screen
-          .getByRole("button", { name: "Remove Trusted B's access" })
+          .getByRole("button", { name: "Add time for Trusted B" })
           .hasAttribute("disabled"),
       ).toBe(false),
     );
 
-    // And the same person can be edited again straight away.
+    // And the same person can be acted on again straight away.
     fireEvent.click(
-      screen.getByRole("button", { name: "Edit access for Trusted B" }),
+      screen.getByRole("button", { name: "Add time for Trusted B" }),
     );
-    const saveAgain = await screen.findByRole("button", { name: "Save" });
-    expect(saveAgain.hasAttribute("disabled")).toBe(false);
+    const chipAgain = await screen.findByRole("button", {
+      name: "Add 30 minutes for Trusted B",
+    });
+    expect(chipAgain.hasAttribute("disabled")).toBe(false);
   });
 
   it("fans out approval-first requests to multiple selected owners without coordinates", async () => {

--- a/hushh-webapp/__tests__/components/request-recipient-status.test.ts
+++ b/hushh-webapp/__tests__/components/request-recipient-status.test.ts
@@ -122,7 +122,7 @@ describe("someone already sharing with you", () => {
     // Asking somebody to share while they already are is the clearest possible
     // sign the list is not looking at anything.
     const status = statusFor({ receivedGrants: [grant({})] });
-    expect(status.subtitle).toBe("Sharing with you, 55 more min");
+    expect(status.subtitle).toBe("Sharing with you, 55 min");
     expect(status.statusLabel).toBe("Live");
     expect(status.selectable).toBe(false);
   });
@@ -130,14 +130,14 @@ describe("someone already sharing with you", () => {
   it("says both when there is also an unanswered ask, because both are true", () => {
     // "Live" used to win outright. But a request for MORE time is made by
     // somebody who is already being shared with, so the row showed "Sharing
-    // with you, 55 more min" and nothing else -- the extra time they had just
+    // with you, 55 min" and nothing else -- the extra time they had just
     // asked for left no trace on the screen they asked it from.
     const status = statusFor({
       requestedByMe: [request({ requestedDurationHours: 4 })],
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for 4 hours more",
+      "Sharing with you, 55 min · asked for 4 hours more",
     );
     expect(status.statusLabel).toBe("Asked");
     expect(status.selectable).toBe(false);
@@ -157,7 +157,7 @@ describe("someone already sharing with you", () => {
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for more time",
+      "Sharing with you, 55 min · asked for more time",
     );
   });
 
@@ -167,7 +167,7 @@ describe("someone already sharing with you", () => {
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for no end time",
+      "Sharing with you, 55 min · asked for no end time",
     );
   });
 
@@ -205,16 +205,16 @@ describe("relative labels", () => {
 
   it("never reports remaining time on access that already ended", () => {
     expect(shortRemaining(NOW - 1, NOW)).toBeNull();
-    expect(shortRemaining(NOW + 55 * 60_000, NOW)).toBe("55 more min");
-    expect(shortRemaining(NOW + 60 * 60_000, NOW)).toBe("1 more hour");
-    expect(shortRemaining(NOW + 3 * 3_600_000, NOW)).toBe("3 more hours");
+    expect(shortRemaining(NOW + 55 * 60_000, NOW)).toBe("55 min");
+    expect(shortRemaining(NOW + 60 * 60_000, NOW)).toBe("1 hour");
+    expect(shortRemaining(NOW + 3 * 3_600_000, NOW)).toBe("3 hours");
   });
 
   it("never overstates the time left", () => {
-    // 90 minutes used to round to "2 more hours". A countdown that claims more
+    // 90 minutes used to round to "2 hours". A countdown that claims more
     // time than exists is worse than none: it is the number people use to
     // decide when to leave, or when to ask for more.
-    expect(shortRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m more");
-    expect(shortRemaining(NOW + 119 * 60_000, NOW)).toBe("1h 59m more");
+    expect(shortRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m");
+    expect(shortRemaining(NOW + 119 * 60_000, NOW)).toBe("1h 59m");
   });
 });

--- a/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
@@ -31,7 +31,7 @@ describe("the owner's popup", () => {
     // even read -- extra time on a running share is not a fresh ask.
     expect(copy.title).toBe("More location time requested");
     expect(copy.description).toBe(
-      "Ankit Kumar Singh is asking for 3 hours more of your live location. They have 45 more min left.",
+      "Ankit Kumar Singh is asking for 3 hours more of your live location. They have 45 min left.",
     );
   });
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -11422,8 +11422,11 @@ export function OneLocationAgentPageContent({
     onSaveLiveShareDuration: () => void handleSaveLiveShareDuration(),
     editGrantDurationHours,
     setEditGrantDurationHours,
-    onEditGrantSave: (params) =>
-      void handleEditGrantDuration(params, Number(editGrantDurationHours)),
+    onEditGrantSave: (params, durationHoursOverride) =>
+      void handleEditGrantDuration(
+        params,
+        Number(durationHoursOverride ?? editGrantDurationHours),
+      ),
     onCreatePublicInvite: () => void handleCreatePublicInvite(),
     onCopyPublicInvite: () => void handleCopyPublicInvite(),
     onSharePublicInvite: () => void handleSharePublicInvite(),

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -18,7 +18,6 @@ import {
   ExternalLink,
   Loader2,
   MapPin,
-  Pencil,
   RefreshCw,
   ShieldCheck,
   Siren,
@@ -77,9 +76,9 @@ export function TrustedPersonCard({
   actionBusy?: boolean;
   actionDisabled?: boolean;
   selected?: boolean;
-  /** Edit this person's live grant duration (shorten now / ask for more). */
+  /** Open/close the compact "add minutes" control for this person's live grant. */
   onEdit?: () => void;
-  /** True while `expandedContent` is the open duration editor for this row. */
+  /** True while `expandedContent` is the open add-time control for this row. */
   editActive?: boolean;
   /** Revoke this person's live grant. */
   onRemove?: () => void;
@@ -139,11 +138,11 @@ export function TrustedPersonCard({
           <ShellActionSurface
             variant="icon"
             className="h-9 w-9 shrink-0"
-            aria-label={`${editActive ? "Cancel editing" : "Edit"} access for ${name}`}
+            aria-label={`${editActive ? "Close add time for" : "Add time for"} ${name}`}
             aria-pressed={editActive}
             onClick={onEdit}
           >
-            <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+            <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
           </ShellActionSurface>
         ) : null}
         {onRemove ? (

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -108,6 +108,12 @@ import {
 } from "./cards";
 
 export type { GrantViewStatus } from "./cards";
+import {
+  DURATION_CELL_CLASS,
+  DURATION_CELL_OFF_CLASS,
+  DURATION_GRID_CLASS,
+} from "./duration-presets";
+import { grantRemainingHours } from "@/lib/one-location/grant-duration-edit";
 // LocationTypeSelector stays exported from ./selectors, unused for now, so
 // PR #4767 can wire it back to a real precision mode without rebuilding it.
 import {
@@ -357,11 +363,13 @@ export type LocationHubViewModel = {
   onEditGrantCancel: () => void;
   editGrantDurationHours: string;
   setEditGrantDurationHours: (v: string) => void;
-  onEditGrantSave: (params: {
-    ownerUserId: string;
-    grantId: string;
-    ownerLabel: string;
-  }) => void;
+  onEditGrantSave: (
+    params: { ownerUserId: string; grantId: string; ownerLabel: string },
+    /** Bypasses `editGrantDurationHours` state for a same-tick apply (the
+     * compact add-minutes chips compute their own total and can't wait for
+     * a state update to flush before saving it). */
+    durationHoursOverride?: number,
+  ) => void;
   /*
    * The same edit, for the share you are giving rather than the one you are
    * receiving. It is separate state because it is a different consent: the
@@ -3458,51 +3466,63 @@ function AskFlow({
                       : undefined
                   }
                   editActive={isEditingThis}
-                  // Two different acts share this one control, because the row
-                  // is only ever in one of the two states: a live share ends
-                  // access, an unanswered ask ends the ask. A row that is
-                  // neither keeps no X at all.
+                  // A live share is ended from Shared with me now, not here
+                  // (SharedWithMeCard's own X calls the same vm.onStopGrant)
+                  // -- this row keeps X only for taking back an unanswered
+                  // ask. A row that is neither keeps no X at all.
                   onRemove={
-                    activeGrant
-                      ? () => vm.onStopGrant(activeGrant.id)
-                      : pendingRequestId
-                        ? () => vm.onWithdrawRequest(pendingRequestId)
-                        : undefined
+                    pendingRequestId
+                      ? () => vm.onWithdrawRequest(pendingRequestId)
+                      : undefined
                   }
                   removeAriaLabel={
-                    !activeGrant && pendingRequestId
+                    pendingRequestId
                       ? `Take back your request to ${recipientLabel}`
                       : undefined
                   }
                   removeBusy={
-                    activeGrant
-                      ? vm.revokingGrantId === activeGrant.id
-                      : vm.withdrawingRequestId === pendingRequestId
+                    pendingRequestId
+                      ? vm.withdrawingRequestId === pendingRequestId
+                      : undefined
                   }
                   expandedContent={
                     isEditingThis && activeGrant ? (
-                      <>
-                        <DurationSelector
-                          value={vm.editGrantDurationHours}
-                          onChange={vm.setEditGrantDurationHours}
-                          label="New duration"
-                          presentation="select"
-                        />
-                        <Button
-                          size="sm"
-                          className="h-9 w-full rounded-full bg-[color:var(--app-accent)] text-sm text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-                          onClick={() =>
-                            vm.onEditGrantSave({
-                              ownerUserId: r.userId,
-                              grantId: activeGrant.id,
-                              ownerLabel: recipientLabel,
-                            })
-                          }
-                          isLoading={vm.savingGrantId === activeGrant.id}
-                        >
-                          Save
-                        </Button>
-                      </>
+                      <div className={DURATION_GRID_CLASS}>
+                        {(
+                          [
+                            { delta: 15 / 60, label: "+15 min", spoken: "15 minutes" },
+                            { delta: 30 / 60, label: "+30 min", spoken: "30 minutes" },
+                            { delta: 1, label: "+1 hour", spoken: "1 hour" },
+                          ] as const
+                        ).map(({ delta, label, spoken }) => (
+                          <button
+                            key={label}
+                            type="button"
+                            className={cn(DURATION_CELL_CLASS, DURATION_CELL_OFF_CLASS)}
+                            disabled={vm.savingGrantId === activeGrant.id}
+                            aria-label={`Add ${spoken} for ${recipientLabel}`}
+                            onClick={() =>
+                              vm.onEditGrantSave(
+                                {
+                                  ownerUserId: r.userId,
+                                  grantId: activeGrant.id,
+                                  ownerLabel: recipientLabel,
+                                },
+                                // Not vm.editGrantDurationHours: that's seeded to
+                                // the nearest of the old picker's four rungs
+                                // (30m/1h/4h/24h), not the true time left, so
+                                // "+15 min" on a 40-min grant would round to a
+                                // 30-min base first. The chip adds to what the
+                                // row actually has left.
+                                (grantRemainingHours(activeGrant, statusNowMs) ??
+                                  Number(vm.editGrantDurationHours)) + delta,
+                              )
+                            }
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
                     ) : undefined
                   }
                 />

--- a/hushh-webapp/e2e/one-location-duration-editor.spec.ts
+++ b/hushh-webapp/e2e/one-location-duration-editor.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
 
 /**
- * The inline "New duration" editor on a live share, in a real browser.
+ * The inline "add minutes" control on a live share, in a real browser.
  *
  * The component tests prove the logic; these prove the thing a person
  * actually touches -- against the deployed bundle when BASE_URL points at
@@ -12,6 +12,12 @@ import { expect, test, type Page, type Route } from "@playwright/test";
  *
  * The live grant is supplied by intercepting the workspace state, so this
  * needs one reviewer account rather than two real people mid-share.
+ *
+ * The control used to be a pencil opening a full "New duration" dropdown +
+ * Save, with an X beside it that revoked the grant. It's now a compact,
+ * immediate-apply "add minutes" chip row -- shortening and the X are both
+ * gone from this row (ending a received share now lives only on Shared with
+ * me), so these specs test extend-only behavior and confirm the X is gone.
  */
 
 const REQUIRED_VALUES = ["REVIEWER_UID", "REVIEWER_VAULT_PASSPHRASE"] as const;
@@ -46,7 +52,15 @@ const OWNER_USER_ID = "e2e_owner_duration";
 const GRANT_ID = "e2e_grant_duration";
 const OWNER_NAME = "Duration Fixture";
 
-function liveGrant(minutes: number) {
+/**
+ * `ceilingMinutes`, when given, sets `ceilingExpiresAt` -- the furthest the
+ * owner ever explicitly approved. Without it, the backend's own fallback
+ * treats the current expiry as its own ceiling, so any chip tap has zero
+ * room to grow into and always asks the owner instead of applying directly.
+ * Tests of the in-ceiling grow path need real headroom or they silently end
+ * up testing the ask-the-owner path instead.
+ */
+function liveGrant(minutes: number, ceilingMinutes?: number) {
   return {
     id: GRANT_ID,
     ownerUserId: OWNER_USER_ID,
@@ -58,6 +72,9 @@ function liveGrant(minutes: number) {
     capabilityScopes: ["cap.location.live.view"],
     durationHours: minutes / 60,
     expiresAt: expiresInMinutes(minutes),
+    ...(ceilingMinutes !== undefined
+      ? { ceilingExpiresAt: expiresInMinutes(ceilingMinutes) }
+      : {}),
   };
 }
 
@@ -66,7 +83,11 @@ function liveGrant(minutes: number) {
  * projection exactly as the backend sent it. Rewriting the whole payload
  * would test a fixture rather than the screen.
  */
-async function stubLiveGrant(page: Page, minutes: number) {
+async function stubLiveGrant(
+  page: Page,
+  minutes: number,
+  ceilingMinutes?: number,
+) {
   await page.route("**/api/one/location/state", async (route: Route) => {
     const response = await route.fetch();
     let body: Record<string, unknown>;
@@ -75,7 +96,7 @@ async function stubLiveGrant(page: Page, minutes: number) {
     } catch {
       return route.fulfill({ response });
     }
-    const grant = liveGrant(minutes);
+    const grant = liveGrant(minutes, ceilingMinutes);
     const recipients = Array.isArray(body.recipients) ? body.recipients : [];
     return route.fulfill({
       response,
@@ -98,7 +119,7 @@ async function stubLiveGrant(page: Page, minutes: number) {
   });
 }
 
-/** Every call the editor could make, recorded in order. */
+/** Every call the control could make, recorded in order. */
 function recordDurationCalls(page: Page) {
   const calls: string[] = [];
   page.on("request", (request) => {
@@ -133,23 +154,23 @@ async function signInAsReviewer(page: Page) {
   }
 }
 
-/** Land on Request with context, with the fixture's row on screen. */
-async function openDurationEditor(page: Page) {
+/** Land on Request with context, open the add-minutes control on the fixture's row. */
+async function openAddTimeControl(page: Page) {
   await page.goto("/one/location?action=ask", { waitUntil: "domcontentloaded" });
   await page
     .getByRole("heading", { name: "Request with context" })
     .waitFor({ state: "visible", timeout: 90_000 });
-  const edit = page.getByRole("button", {
-    name: `Edit access for ${OWNER_NAME}`,
+  const trigger = page.getByRole("button", {
+    name: `Add time for ${OWNER_NAME}`,
   });
-  await edit.waitFor({ state: "visible", timeout: 30_000 });
-  await edit.click();
+  await trigger.waitFor({ state: "visible", timeout: 30_000 });
+  await trigger.click();
   await page
-    .getByRole("combobox", { name: "New duration" })
+    .getByRole("button", { name: `Add 15 minutes for ${OWNER_NAME}` })
     .waitFor({ state: "visible", timeout: 15_000 });
 }
 
-test.describe("One Location inline duration editor", () => {
+test.describe("One Location inline add-minutes control", () => {
   test.skip(
     !hasReviewerAuthority(),
     "needs reviewer credentials AND a /login sign-in path for automation (E2E_REVIEWER_SIGNIN=1); the 'Continue as reviewer' control these specs click does not exist in this repository",
@@ -157,72 +178,48 @@ test.describe("One Location inline duration editor", () => {
   test.use({ viewport: { width: 390, height: 844 }, isMobile: true });
   test.setTimeout(180_000);
 
-  test("opens on what the share has left, not a constant hour", async ({ page }) => {
-    // The row said "4 more hours" while the picker underneath said "1 hour".
+  test("does not offer Remove on this screen -- that lives on Shared with me", async ({ page }) => {
     await stubLiveGrant(page, 4 * 60);
     await signInAsReviewer(page);
-    await openDurationEditor(page);
+    await openAddTimeControl(page);
 
     await expect(
-      page.getByRole("combobox", { name: "New duration" }),
-    ).toHaveText(/4 hours/);
+      page.getByRole("button", { name: `Remove ${OWNER_NAME}'s access` }),
+    ).toHaveCount(0);
   });
 
-  test("Save on an untouched picker calls nothing and closes", async ({ page }) => {
-    // This is "time reset is not working": Save spent a refused shorten, then
-    // asked the owner for one more minute, and the row never moved.
-    const calls = recordDurationCalls(page);
-    await stubLiveGrant(page, 59);
-    await signInAsReviewer(page);
-    await openDurationEditor(page);
-
-    await expect(
-      page.getByRole("combobox", { name: "New duration" }),
-    ).toHaveText(/1 hour/);
-
-    await page.getByRole("button", { name: "Save" }).click();
-    await expect(page.getByRole("button", { name: "Save" })).toBeHidden({
-      timeout: 15_000,
-    });
-    expect(calls).toEqual([]);
-  });
-
-  test("shortening applies immediately and leaves the row usable", async ({ page }) => {
+  test("a chip within the ceiling applies immediately and leaves the row usable", async ({ page }) => {
     // The saving flag used to be the revoke flag, and the shorten path left
-    // it set -- so Remove stayed disabled and the next Edit opened on a Save
-    // that spun forever.
+    // it set -- so the next open showed a chip already spinning and
+    // permanently disabled. That is the "save button takes more time" report.
     const calls = recordDurationCalls(page);
-    await stubLiveGrant(page, 4 * 60);
+    await stubLiveGrant(page, 4 * 60, 24 * 60);
     await signInAsReviewer(page);
-    await openDurationEditor(page);
+    await openAddTimeControl(page);
 
-    await page.getByRole("combobox", { name: "New duration" }).click();
-    await page.getByRole("option", { name: "30 min" }).click();
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: `Add 15 minutes for ${OWNER_NAME}` }).click();
 
     await expect.poll(() => calls, { timeout: 20_000 }).toContain("shorten PATCH");
-    // One call, not a refused shorten followed by a request.
     expect(calls.filter((c) => c === "request POST")).toEqual([]);
 
-    const remove = page.getByRole("button", {
-      name: `Remove ${OWNER_NAME}'s access`,
-    });
-    await expect(remove).toBeEnabled({ timeout: 20_000 });
-
-    // And the same person can be edited again straight away.
-    await page.getByRole("button", { name: `Edit access for ${OWNER_NAME}` }).click();
-    await expect(page.getByRole("button", { name: "Save" })).toBeEnabled();
+    // The trigger and its chips are usable again straight away.
+    const trigger = page.getByRole("button", { name: `Add time for ${OWNER_NAME}` });
+    await expect(trigger).toBeEnabled({ timeout: 20_000 });
+    await trigger.click();
+    await expect(
+      page.getByRole("button", { name: `Add 30 minutes for ${OWNER_NAME}` }),
+    ).toBeEnabled();
   });
 
-  test("asks the owner directly when the new duration would extend", async ({ page }) => {
+  test("asks the owner directly when a chip would push past the ceiling", async ({ page }) => {
     const calls = recordDurationCalls(page);
+    // No ceiling given -- the fallback treats the current expiry as its own
+    // ceiling, so any chip tap has to ask.
     await stubLiveGrant(page, 12);
     await signInAsReviewer(page);
-    await openDurationEditor(page);
+    await openAddTimeControl(page);
 
-    await page.getByRole("combobox", { name: "New duration" }).click();
-    await page.getByRole("option", { name: "4 hours" }).click();
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: `Add 15 minutes for ${OWNER_NAME}` }).click();
 
     await expect.poll(() => calls, { timeout: 20_000 }).toContain("request POST");
     // The doomed shorten that made Save slow must not be spent.
@@ -230,7 +227,7 @@ test.describe("One Location inline duration editor", () => {
   });
 
   for (const width of [320, 390, 430]) {
-    test(`editor fits and stays tappable at ${width}px`, async ({ page }) => {
+    test(`add-minutes control fits and stays tappable at ${width}px`, async ({ page }) => {
       const consoleErrors: string[] = [];
       page.on("console", (message) => {
         if (message.type() === "error") consoleErrors.push(message.text());
@@ -238,11 +235,11 @@ test.describe("One Location inline duration editor", () => {
       page.on("pageerror", (error) => consoleErrors.push(error.message));
 
       await page.setViewportSize({ width, height: 844 });
-      await stubLiveGrant(page, 4 * 60);
+      await stubLiveGrant(page, 4 * 60, 24 * 60);
       await signInAsReviewer(page);
-      await openDurationEditor(page);
+      await openAddTimeControl(page);
 
-      // RES-001: the editor must not push the page sideways.
+      // RES-001: the control must not push the page sideways.
       const overflow = await page.evaluate(() => {
         const root = document.documentElement;
         return (
@@ -252,15 +249,15 @@ test.describe("One Location inline duration editor", () => {
       });
       expect(overflow).toBeLessThanOrEqual(1);
 
-      // RES-002/005: Save is inside the viewport and big enough to hit.
-      const save = page.getByRole("button", { name: "Save" });
-      const box = await save.boundingBox();
+      // RES-002/005: the chip is inside the viewport and big enough to hit.
+      const chip = page.getByRole("button", { name: `Add 15 minutes for ${OWNER_NAME}` });
+      const box = await chip.boundingBox();
       expect(box).not.toBeNull();
       expect(box!.left).toBeGreaterThanOrEqual(-1);
       expect(box!.right).toBeLessThanOrEqual(width + 1);
       expect(box!.height).toBeGreaterThanOrEqual(36);
 
-      // RES-012: opening the editor introduces no runtime errors.
+      // RES-012: opening the control introduces no runtime errors.
       expect(
         consoleErrors.filter(
           (text) => !/favicon|Failed to load resource|net::ERR_/i.test(text),

--- a/hushh-webapp/lib/one-location/__tests__/duration-copy.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/duration-copy.test.ts
@@ -60,11 +60,11 @@ describe("formatLocationDurationLabel", () => {
 
 describe("formatLocationRemaining", () => {
   it("never overstates what is left", () => {
-    expect(formatLocationRemaining(NOW + 45 * 60_000, NOW)).toBe("45 more min");
-    expect(formatLocationRemaining(NOW + 60 * 60_000, NOW)).toBe("1 more hour");
-    expect(formatLocationRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m more");
+    expect(formatLocationRemaining(NOW + 45 * 60_000, NOW)).toBe("45 min");
+    expect(formatLocationRemaining(NOW + 60 * 60_000, NOW)).toBe("1 hour");
+    expect(formatLocationRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m");
     expect(formatLocationRemaining(NOW + 4 * 3_600_000, NOW)).toBe(
-      "4 more hours",
+      "4 hours",
     );
   });
 
@@ -88,7 +88,7 @@ describe("locationAskFacts", () => {
     expect(facts).toEqual({
       isExtension: true,
       amountLabel: "3 hours",
-      remainingLabel: "45 more min",
+      remainingLabel: "45 min",
     });
   });
 
@@ -120,7 +120,7 @@ describe("describeLocationAsk", () => {
       ),
     );
     expect(extension).toBe(
-      "is asking for 3 hours more of your live location. They have 45 more min left.",
+      "is asking for 3 hours more of your live location. They have 45 min left.",
     );
 
     const fresh = describeLocationAsk(
@@ -158,7 +158,7 @@ describe("locationAskPromptLine", () => {
         }),
         NOW,
       ),
-    ).toBe("Asks for 4 hours more · 45 more min left");
+    ).toBe("Asks for 4 hours more · 45 min left");
   });
 
   it("names the amount on a fresh ask too", () => {

--- a/hushh-webapp/lib/one-location/duration-copy.ts
+++ b/hushh-webapp/lib/one-location/duration-copy.ts
@@ -29,12 +29,17 @@ export function formatLocationDurationLabel(
 }
 
 /**
- * "45 more min", "1h 30m more", "3 more hours" — what is actually left.
+ * "45 min", "1h 30m", "3 hours" — what is actually left.
  *
- * Truthful over tidy. The previous rounding turned 90 minutes into "2 more
- * hours", so a share said it had more time left than it did; a countdown that
- * overstates itself is worse than no countdown, because it is the number people
- * decide when to leave on.
+ * No "more": a fresh share that was never extended read "37 more min" as if
+ * time had been added to it, when nothing had. This is a plain remaining-time
+ * countdown, not a record of an extension -- that distinction belongs to the
+ * "${amount} more" wording used elsewhere for an actual add-time request.
+ *
+ * Truthful over tidy on the rounding, still: the previous version turned 90
+ * minutes into "2 hours", so a share said it had more time left than it did;
+ * a countdown that overstates itself is worse than no countdown, because it
+ * is the number people decide when to leave on.
  */
 export function formatLocationRemaining(
   untilMs: number,
@@ -43,11 +48,11 @@ export function formatLocationRemaining(
   const remainingMs = untilMs - nowMs;
   if (!Number.isFinite(remainingMs) || remainingMs <= 0) return null;
   const totalMinutes = Math.ceil(remainingMs / 60_000);
-  if (totalMinutes < 60) return `${totalMinutes} more min`;
+  if (totalMinutes < 60) return `${totalMinutes} min`;
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
-  if (minutes) return `${hours}h ${minutes}m more`;
-  return hours === 1 ? "1 more hour" : `${hours} more hours`;
+  if (minutes) return `${hours}h ${minutes}m`;
+  return hours === 1 ? "1 hour" : `${hours} hours`;
 }
 
 /** Milliseconds for an ISO timestamp, or null when missing/unparseable. */
@@ -64,7 +69,7 @@ export type LocationAskFacts = {
   isExtension: boolean;
   /** "3 hours", "as long as they need", or "" when no amount was named. */
   amountLabel: string;
-  /** "45 more min" left on the share being extended, when known. */
+  /** "45 min" left on the share being extended, when known. */
   remainingLabel: string;
 };
 

--- a/hushh-webapp/lib/one-location/request-recipient-status.ts
+++ b/hushh-webapp/lib/one-location/request-recipient-status.ts
@@ -66,11 +66,11 @@ export function shortAgo(fromMs: number, nowMs: number): string {
 }
 
 /**
- * "55 more min", "1h 30m more", "3 more hours" -- how much access is left.
+ * "55 min", "1h 30m", "3 hours" -- how much access is left.
  *
  * Delegates to the shared formatter so this row, the countdown on the share
  * card, and the notification copy cannot drift apart. The old local rounding
- * turned 90 minutes into "2 more hours", which overstated the time left on the
+ * turned 90 minutes into "2 hours", which overstated the time left on the
  * exact number people use to decide when to leave.
  */
 export function shortRemaining(untilMs: number, nowMs: number): string | null {


### PR DESCRIPTION
## In plain terms

On the Request location screen, the row for someone already sharing their
location with you had a pencil icon that opened a whole dropdown just to
give them a bit more time, plus a red X to stop the share — even though
you can already stop a share from Shared with me. Now there's a small
clock icon that opens three quick buttons (+15 min / +30 min / +1 hour) to
add time in one tap, and the X is gone from this row since it was doing
the same thing as a control that already exists elsewhere.

Also fixed along the way: the "time left" text used to say "37 more min"
even on a share nobody had ever extended, which read like extra time had
just been added. It now just says "37 min."

---

# Description

Fixes #5520.

Two problems on the Request location screen's row for someone already
live-sharing with you:

1. The pencil icon opened a full "New duration" dropdown + Save inline —
   heavier than needed for "just give me more time."
2. The X revoked the grant, redundant with Shared with me's own identical
   revoke control — a second entry point to the same action.

Also fixes a wording bug found while testing this: the plain remaining-time
countdown ("Sharing with you, 37 more min") said "more" even on a share
that was never extended, reading as if time had been added when nothing
had.

## Fix

- Pencil + dropdown -> small clock icon opening three immediate-apply
  chips: **+15 min / +30 min / +1 hour**, computed off the grant's true
  remaining time (not the old picker's nearest-of-four-presets seed, which
  would have silently misrepresented what a chip actually added).
- X removed entirely from this row. Ending a live share stays available
  only from Shared with me.
- Shortening a live grant from this row is intentionally dropped — this
  was the only place a recipient could shorten a received grant.
- `formatLocationRemaining` (the one shared formatter behind this
  countdown everywhere it appears) no longer appends "more" to plain
  remaining time. The separate "{amount} more" wording used for an actual
  extend request/toast is untouched — that one is semantically correct.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None (widened one internal callback signature with an optional
        param; no wire-format change)
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None (pure web component; no native plugin code touched)
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable (presentational + copy change; underlying
        shorten/grow/request business logic in
        `lib/one-location/grant-duration-edit.ts` is unchanged)
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location?action=ask`
    - Spec: `hushh-webapp/e2e/one-location-duration-editor.spec.ts`
      (gated on reviewer creds, same pre-existing gate as before)
    - Manually verified on a local dev server
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` (targeted files: 99/99 pass on the
        main suite; 3 unrelated Share-flow tests intermittently time out
        under this machine's 2-CPU constraint — confirmed pre-existing by
        re-running the identical file against clean `upstream/main` with
        this diff stashed out, where 2 *different* tests timed out instead;
        same flake class noted in existing repo memory for this file)
  - [x] `cd hushh-webapp && npm run build` (Compiled + TypeScript phases
        both green; page-data collection fails locally on an unrelated
        route, `/api/consent/cancel`, needing `PYTHON_API_URL`/
        `BACKEND_URL` not set in this local environment — unrelated to
        this diff)
  - [x] `cd hushh-webapp && npm run lint -- --max-warnings=0`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR
      does not duplicate.
- [x] This PR changes a current reachable app surface (`AskFlow` /
      `TrustedPersonCard`, mounted at `/one/location?action=ask`).
- [x] Reachable production attach point:
      `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx`
      (`AskFlow`) and `cards.tsx` (`TrustedPersonCard`).
- [x] New tests import and exercise production code (render the real
      `OneLocationAgentPage`; e2e drives the real route).
- [x] Production surface proved: unit assertions on the rendered chip row
      and its resulting service calls, plus updated e2e coverage.
- [x] Required checks are current on this head, commits are signed off,
      and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`hushh-webapp/components/one-location/redesign/`, `hushh-webapp/app/one/location/page.tsx`, `hushh-webapp/lib/one-location/duration-copy.ts`)
- [ ] **iOS**: Not applicable — shared web component rendered through the same webview, no native plugin touched.
- [ ] **Android**: Not applicable — same reason.

## 🧪 Testing

- [x] Tested on Web (local dev server)
- [ ] Tested on iOS Simulator/Device — not applicable, no native code changed.
- [ ] Tested on Android Emulator/Device — same reason.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Manually verified locally: the live-share row now shows a clock icon that
opens +15 min / +30 min / +1 hour chips, no X on this row, and the
remaining-time subtitle reads "Sharing with you, 37 min" (no "more").

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — presentational control
      change plus a copy fix; the underlying shorten/grow/request/revoke
      business logic and its permission checks are unchanged.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes
