### PR TITLE
fix(one-location): align SOS Stop sharing with the emergency-call row

### DIFF
--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -975,6 +975,18 @@ export function SosPanel({
             </div>
           </div>
 
+        </div>
+
+        {/* Stop sharing (while an alert is live) and the dialer share one row:
+            Stop sharing anchors the left edge, the call/lookup control anchors
+            the right, at the same width as the message column above. With no
+            live alert the row has only the dialer, so it stays centered. */}
+        <div
+          className={cn(
+            "mt-10 flex min-h-[52px] w-full max-w-[520px] items-center gap-3 lg:mt-14",
+            active ? "justify-between" : "justify-center",
+          )}
+        >
           {/* While an alert is live the primary action becomes stopping it.
               This revokes the location grants the alert created AND clears the
               incident, so the live state resets here and in Active shares. */}
@@ -985,7 +997,7 @@ export function SosPanel({
               disabled={stopBusy}
               aria-label="Cancel the alert and stop sharing your location"
               data-testid="sos-cancel-alert"
-              className="press-scale mt-1 flex h-[52px] w-full items-center justify-center gap-2 self-center rounded-xl bg-[color:var(--sos-control-surface)] text-[16px] text-[color:var(--sos-control-text)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60 lg:h-14 lg:w-[220px] lg:text-[17px]"
+              className="press-scale flex h-[52px] items-center justify-center gap-2 rounded-xl bg-[color:var(--sos-control-surface)] px-5 text-[16px] text-[color:var(--sos-control-text)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60 lg:h-14 lg:text-[17px]"
             >
               {stopBusy ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -993,15 +1005,13 @@ export function SosPanel({
               {stopBusy ? "Stopping…" : "Stop sharing"}
             </button>
           ) : null}
-        </div>
 
-        {/* The dialer. Outlined and tinted, never filled — it needs to read as
-            tappable without becoming a peer of the SOS control.
-            It had no surface at all and measured ~35px tall, under the 44px
-            this product enforces everywhere else, on the one screen where the
-            person is least able to aim. An outline buys the affordance; the
-            filled treatment stays reserved for SOS. */}
-        <div className="mt-10 flex min-h-[52px] items-center justify-center lg:mt-14">
+          {/* The dialer. Outlined and tinted, never filled — it needs to read as
+              tappable without becoming a peer of the SOS control.
+              It had no surface at all and measured ~35px tall, under the 44px
+              this product enforces everywhere else, on the one screen where the
+              person is least able to aim. An outline buys the affordance; the
+              filled treatment stays reserved for SOS. */}
           {emergencyStatus === "resolved" && emergency ? (
             shouldFallbackWindowsEmergencyCall ? (
               <button


### PR DESCRIPTION
# Description

Aligns the SOS "Stop sharing" control with the emergency-call (dialer) control on `/one/location?action=sos`. They previously rendered as two separate, independently-centered rows — Stop sharing full-width/centered above, the call/lookup control centered alone below. They now share one row: Stop sharing anchors the left edge, the call/lookup control anchors the right, at the same width as the message column above. With no live alert, Stop sharing is absent and the row falls back to centering the dialer alone (unchanged from before).

Pure layout change in `hushh-webapp/components/one-location/redesign/sos-panel.tsx` — no behavior, prop, or contract changes.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/location?action=sos` (existing route; only `components/one-location/redesign/sos-panel.tsx` changed)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None
    - Shared React component; the Capacitor webview renders the same JSX. No native Swift/Kotlin code touched.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable
    - Pure CSS/layout reorder; no new failure mode.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location?action=sos` — verified interactively in local dev server.
    - `components/one-location/redesign/__tests__/sos-panel.test.tsx` — 31/31 passing (unchanged assertions, layout-agnostic).

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [x] `cd hushh-webapp && npm test` — `components/one-location/redesign/__tests__/sos-panel.test.tsx` 31/31 pass. Full suite has 53 pre-existing failures across 30 files (vault, KYC, navbar, profile, calendar onboarding, RIA picks, etc.) on this local Windows environment — none touch `sos-panel.tsx`, `location-redesign-hub.tsx`, or `cards.tsx`. Reproduced against a clean `upstream/main` checkout of the same file, i.e. present before this diff.
  - [x] `cd hushh-webapp && npm run build` — succeeds
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (not applicable — no native change)
  - [ ] `python scripts/ops/kai-system-audit.py ...` (not applicable — no backend/Kai change)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: no open PR touches `sos-panel.tsx`'s Stop sharing/dialer row.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `SosPanel` rendered by `app/one/location/page.tsx` at `?action=sos`.
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file. (no new tests added — pure layout change, existing coverage already exercises the affected buttons)
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: existing `sos-panel.test.tsx` suite passes against the changed markup.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] Not a stacked PR.
- [x] Not a response to requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`hushh-webapp/components/one-location/redesign/sos-panel.tsx`)
- [ ] **iOS**: Not applicable — shared React component, no native Swift/Capacitor plugin code touched.
- [ ] **Android**: Not applicable — shared React component, no native Kotlin/Capacitor plugin code touched.

## 🧪 Testing

- [x] Tested on Web (Chrome, local dev server)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above (not applicable — no generated files touched)

## 📸 Screenshots / Video

Route: `/one/location?action=sos`. Layout verified interactively in the local dev server (before: Stop sharing centered on its own row above a separately-centered dialer row; after: both share one row, Stop sharing left / dialer right). No screenshot attached in this session — happy to add one on request.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? No.
- [ ] If yes, have you implemented `checkConsentToken()`? Not applicable.
- Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: not applicable — pure layout reorder, no new code path.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed (no dependency changes)
