### PR TITLE
fix(one-location): an SMS alert no longer revokes a normal location share

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4361,7 +4361,10 @@ class OneLocationAgentService:
                         SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
                         WHERE owner_user_id = :owner_user_id
                           AND recipient_user_id = :recipient_user_id
-                          AND status = 'active'"""
+                          AND status = 'active'"""  # nosec B608 - the lane predicate
+                        # below is a module-level constant of static SQL text and the
+                        # lane itself is BOUND as `:is_sos_lane`; nothing
+                        # caller-supplied reaches this statement.
                         + _share_lane_match_sql()
                         + """
                         """
@@ -4587,7 +4590,10 @@ class OneLocationAgentService:
                 SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
                 WHERE owner_user_id = :owner_user_id
                   AND recipient_user_id = :recipient_user_id
-                  AND status = 'active'"""
+                  AND status = 'active'"""  # nosec B608 - the lane predicate below
+                # is a module-level constant of static SQL text and the lane itself is
+                # BOUND as `:is_sos_lane`; nothing caller-supplied reaches this
+                # statement.
                 + _share_lane_match_sql()
                 + """
                 RETURNING id
@@ -4905,7 +4911,10 @@ class OneLocationAgentService:
               SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
               WHERE g.owner_user_id = :owner_user_id
                 AND g.recipient_user_id = :recipient_user_id
-                AND g.status = 'active'"""
+                AND g.status = 'active'"""  # nosec B608 - the lane predicate below
+            # is a module-level constant of static SQL text with a fixed alias
+            # substituted, and the lane itself is BOUND as `:is_sos_lane`; nothing
+            # caller-supplied reaches this statement.
             + _share_lane_match_sql("g")
             + """
                 AND EXISTS (SELECT 1 FROM eligible_recipient)
@@ -6816,7 +6825,10 @@ class OneLocationAgentService:
             WHERE owner_user_id = :owner_user_id
               AND recipient_user_id = :recipient_user_id
               AND status = 'active'
-              AND (expires_at IS NULL OR expires_at > NOW())"""
+              AND (expires_at IS NULL OR expires_at > NOW())"""  # nosec B608 -
+            # `lane_predicate` is either empty or a module-level constant of static
+            # SQL text, and the lane itself is BOUND as `:is_sos_lane`; nothing
+            # caller-supplied reaches this statement.
             + lane_predicate
             + """
             ORDER BY created_at DESC

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -528,6 +528,54 @@ _INTERNAL_SHARE_REASONS = {
 }
 
 
+# Which replacement lane a grant belongs to. Replacement of a live share is
+# scoped to a LANE, and there are exactly TWO of them: the emergency lane
+# (``share_kind == 'sos'``) and everything else. This is deliberately NOT one
+# lane per share kind. `_classify_share_kind` below can return four kinds, the
+# `/api/one/location/grants` route accepts `share_kind` as free text up to 40
+# characters with no enum, and the web client already sends values this module
+# never produces (e.g. `pick_me_up`). Per-exact-kind scoping would therefore let
+# a single owner/recipient pair accumulate an unbounded number of live grants
+# that no surface exposes a Stop for. Two lanes caps a pair at exactly two live
+# grants: one normal share and one SOS.
+#
+# The invariant this enforces: an SOS grant must never supersede a normal share,
+# and a normal share must never supersede an SOS grant. Within a lane, the newest
+# grant still replaces the older one exactly as it always has -- `drive_to`,
+# `check_in`, `pick_me_up` and plain `share` all sit in the non-emergency lane
+# together and keep replacing each other.
+#
+# Bound as ``:is_sos_lane`` (a boolean) by every caller. The second arm reads the
+# legacy `reason` marker for rows written before `share_kind` was persisted in
+# metadata; it is belt-and-braces only and must never be relied on alone, because
+# a user-typed SOS message REPLACES the `sos_panic` reason on the way in.
+#
+# Defined once, on purpose. Three hand-copied divergent versions of the
+# replacement UPDATE are exactly what let an SMS alert silently revoke a normal
+# share (#5506); a fourth write path must not be addable without this predicate.
+_SHARE_LANE_MATCH_SQL = """
+                AND (
+                  COALESCE({alias}metadata->>'share_kind', '') = 'sos'
+                  OR (
+                    {alias}metadata->>'share_kind' IS NULL
+                    AND {alias}metadata->>'reason' = 'sos_panic'
+                  )
+                ) = CAST(:is_sos_lane AS BOOLEAN)"""
+
+
+def _share_lane_match_sql(alias: str = "") -> str:
+    """The lane predicate, optionally qualified for an aliased UPDATE target."""
+    return _SHARE_LANE_MATCH_SQL.format(alias=f"{alias}." if alias else "")
+
+
+def _is_sos_lane(share_kind: str | None) -> bool:
+    """True when a grant belongs to the emergency replacement lane.
+
+    The lane split is `sos` vs everything-else -- NOT one lane per share kind.
+    """
+    return str(share_kind or "").strip() == "sos"
+
+
 def _classify_share_kind(reason: str | None) -> str:
     """Classify a grant's share kind from its stored ``reason`` marker.
 
@@ -4296,6 +4344,16 @@ class OneLocationAgentService:
                     ),
                     "source_circle_id": source_circle_id,
                 }
+                # Replacement is scoped to ONE LANE, and there are exactly two
+                # of them: the emergency lane (`share_kind == 'sos'`) and
+                # everything else. An SOS grant must never supersede a normal
+                # share, and a normal share must never supersede an SOS grant --
+                # a person who shared their location for four hours and then
+                # raised an SMS alert with the same person had the four-hour
+                # share silently revoked at SEND time (#5506). This is two lanes,
+                # NOT one lane per share kind: `drive_to`, `check_in`,
+                # `pick_me_up` and plain `share` all sit in the non-emergency
+                # lane together and go on replacing each other exactly as before.
                 conn.execute(
                     text(
                         """
@@ -4303,7 +4361,9 @@ class OneLocationAgentService:
                         SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
                         WHERE owner_user_id = :owner_user_id
                           AND recipient_user_id = :recipient_user_id
-                          AND status = 'active'
+                          AND status = 'active'"""
+                        + _share_lane_match_sql()
+                        + """
                         """
                     ),
                     params,
@@ -4484,10 +4544,15 @@ class OneLocationAgentService:
         }
         if capability is not None:
             metadata["capability_token"] = capability["token"]
+        # Which of the two replacement lanes this grant lands in. Bound into
+        # BOTH write paths below -- the enforced transaction reads it out of
+        # `grant_params`, the non-enforced branch binds it on its own revoke.
+        is_sos_lane = _is_sos_lane(resolved_kind)
         grant_params = {
             "owner_user_id": owner_user_id,
             "recipient_user_id": recipient_user_id,
             "recipient_key_id": key_id,
+            "is_sos_lane": is_sos_lane,
             "capability_scopes": _json_param(LOCATION_CAPABILITY_SCOPES),
             "duration_hours": duration,
             "expires_at": expires_at,
@@ -4510,18 +4575,27 @@ class OneLocationAgentService:
                 grant_params=grant_params,
             )
         else:
+            # Same two-lane replacement rule as the enforced path above: an
+            # SOS grant never supersedes a normal share and vice versa, and the
+            # split is `sos` vs everything-else rather than one lane per share
+            # kind. This is the branch `approve_request` reaches (it calls
+            # `create_grant` without `enforce_connection`), so approving a
+            # plain access request must not tear down a live SOS share either.
             self._execute_many(
                 """
                 UPDATE one_location_share_grants
                 SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
                 WHERE owner_user_id = :owner_user_id
                   AND recipient_user_id = :recipient_user_id
-                  AND status = 'active'
+                  AND status = 'active'"""
+                + _share_lane_match_sql()
+                + """
                 RETURNING id
                 """,
                 {
                     "owner_user_id": owner_user_id,
                     "recipient_user_id": recipient_user_id,
+                    "is_sos_lane": is_sos_lane,
                 },
             )
             row = self._execute_one(
@@ -4822,11 +4896,18 @@ class OneLocationAgentService:
               LIMIT 1
             ),
             revoked_grants AS (
+              -- Two-lane replacement, same invariant as the two non-atomic
+              -- create paths: replacement is scoped to the emergency lane, so
+              -- an SOS grant never supersedes a normal share and a normal share
+              -- never supersedes an SOS grant. Two lanes (`sos` vs
+              -- everything-else), NOT one lane per share kind.
               UPDATE one_location_share_grants g
               SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
               WHERE g.owner_user_id = :owner_user_id
                 AND g.recipient_user_id = :recipient_user_id
-                AND g.status = 'active'
+                AND g.status = 'active'"""
+            + _share_lane_match_sql("g")
+            + """
                 AND EXISTS (SELECT 1 FROM eligible_recipient)
                 AND NOT EXISTS (SELECT 1 FROM replayed_grant)
               RETURNING g.id
@@ -4959,6 +5040,10 @@ class OneLocationAgentService:
                 "enforce_connection": enforce_connection,
                 "source_circle_id": grant_source_circle_id,
                 "require_sms_contact": resolved_kind == "sos",
+                # The `revoked_grants` CTE above is lane-scoped. This dict is
+                # built independently of `create_grant`'s, so a missing bind
+                # here fails OPEN to the old kind-blind replacement.
+                "is_sos_lane": _is_sos_lane(resolved_kind),
                 "envelope_metadata_json": envelope_fields["metadata_json"],
                 **{key: value for key, value in envelope_fields.items() if key != "metadata_json"},
             },
@@ -6707,9 +6792,23 @@ class OneLocationAgentService:
         return self._grant_payload(updated) or {}
 
     def _active_grant_between(
-        self, *, owner_user_id: str, recipient_user_id: str
+        self, *, owner_user_id: str, recipient_user_id: str, is_sos_lane: bool | None
     ) -> dict[str, Any] | None:
-        """The live share from owner to recipient, if there is one right now."""
+        """The live share from owner to recipient IN ONE LANE, if there is one.
+
+        A pair can now hold two live grants at once -- one normal share and one
+        SOS -- so "the live share between these two people" is no longer a
+        single well-defined row and this read must say which one it means.
+        ``is_sos_lane`` is required for exactly that reason: left implicit, the
+        ``ORDER BY created_at DESC`` below silently resolves to whichever grant
+        was created most recently, which during an emergency is the SOS grant.
+
+        Pass ``False`` for the normal-share lane, ``True`` for the emergency
+        lane, or ``None`` to deliberately mean "either lane, newest wins" --
+        which is the pre-#5506 behaviour and is almost never what a caller
+        wants.
+        """
+        lane_predicate = "" if is_sos_lane is None else _share_lane_match_sql()
         return self._execute_one(
             """
             SELECT id, expires_at, duration_mode, duration_hours
@@ -6717,11 +6816,17 @@ class OneLocationAgentService:
             WHERE owner_user_id = :owner_user_id
               AND recipient_user_id = :recipient_user_id
               AND status = 'active'
-              AND (expires_at IS NULL OR expires_at > NOW())
+              AND (expires_at IS NULL OR expires_at > NOW())"""
+            + lane_predicate
+            + """
             ORDER BY created_at DESC
             LIMIT 1
             """,
-            {"owner_user_id": owner_user_id, "recipient_user_id": recipient_user_id},
+            {
+                "owner_user_id": owner_user_id,
+                "recipient_user_id": recipient_user_id,
+                "is_sos_lane": bool(is_sos_lane),
+            },
         )
 
     def set_grant_duration(
@@ -6923,8 +7028,18 @@ class OneLocationAgentService:
         # crafted id cannot attach an ask to somebody else's grant. When it does
         # not check out we fall back to the real active grant rather than
         # failing: the person is asking for time either way.
+        # Scoped to the NORMAL-SHARE lane on purpose. An access request is an
+        # ask for ordinary visibility, and the only grant it can sensibly be an
+        # extension of is the ordinary one. Unscoped, this read returns the
+        # newest live grant -- so while the owner has an SOS share running with
+        # this same person, a client correctly naming the share it wants
+        # extended was silently redirected onto the SOS grant by the mismatch
+        # fallback below, and `remaining_label` then quoted the SOS grant's
+        # hours back at them. Nobody may extend an emergency share by asking.
         active_grant = self._active_grant_between(
-            owner_user_id=owner_user_id, recipient_user_id=requester_user_id
+            owner_user_id=owner_user_id,
+            recipient_user_id=requester_user_id,
+            is_sos_lane=False,
         )
         active_grant_id = str(active_grant.get("id") or "") if active_grant else ""
         requested_grant_id = str(extends_grant_id or "").strip()

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -22,6 +22,7 @@ from hushh_mcp.services.one_location_agent_service import (
     _json_param,
     _notification_safe_data,
     _redact_location_metadata,
+    _share_lane_match_sql,
 )
 
 PUBLIC_LOCATION_SNAPSHOT = {
@@ -148,6 +149,7 @@ class AtomicPrivateShareProbe(OneLocationAgentService):
         self.atomic_sql: list[str] = []
         self.recipient_key_lock_keys: list[str] = []
         self.pair_lock_keys: list[str] = []
+        self.atomic_params: list[dict] = []
         self.notifications: list[dict] = []
         self.expiry_normalizations: list[str | None] = []
 
@@ -187,6 +189,11 @@ class AtomicPrivateShareProbe(OneLocationAgentService):
         self.recipient_key_lock_keys.append(recipient_key_lock_key)
         self.pair_lock_keys.append(pair_lock_key)
         self.atomic_sql.append(mutation_sql)
+        # The atomic path builds its params dict independently of
+        # `create_grant`'s, so a lane predicate in the SQL with no matching
+        # bind would fail OPEN to the old pair-wide revoke. This probe never
+        # executes SQL, so capturing the binds is the only way to catch that.
+        self.atomic_params.append(dict(params))
         if self.fail_write:
             raise RuntimeError("transaction failed")
         if not self.replay and not values["freshness_valid"]:
@@ -416,6 +423,15 @@ def test_atomic_private_share_commits_grant_envelope_and_events_together() -> No
     assert "k.key_id = :recipient_key_id" in sql
     assert "NOW() - CAST(:confirmed_at AS TIMESTAMPTZ)" in sql
     assert "UPDATE one_location_share_grants" in sql
+    # The `revoked_grants` CTE must carry the two-lane predicate, or this path
+    # goes on doing what #5506 was: a `check_in` share tearing down the SOS
+    # grant to the same person (and vice versa). This probe never executes the
+    # mutation, so the SQL substring and the bind are the only guards there are
+    # -- and both are needed, since the predicate without its `:is_sos_lane`
+    # bind fails open rather than loudly.
+    assert _share_lane_match_sql("g") in sql
+    assert "CAST(:is_sos_lane AS BOOLEAN)" in sql
+    assert service.atomic_params[0]["is_sos_lane"] is False
     assert "INSERT INTO one_location_share_grants" in sql
     assert "INSERT INTO one_location_envelopes" in sql
     assert sql.count("INSERT INTO one_location_events") == 2
@@ -997,13 +1013,21 @@ class FourUserMemoryService(OneLocationAgentService):
                 requested_circle_id if requested_circle_id is not None else relationship_circle_id
             ),
         }
+        # Replacement is LANE-SCOPED in production (`_create_enforced_grant_row`),
+        # and this stub stands in for that transaction. The predicate is
+        # imported from the service rather than retyped, so the fake cannot
+        # quietly go on reproducing the kind-blind revoke that #5506 was: a
+        # copy here that drifted from production would make every lane test in
+        # this file pass while the real UPDATE stayed broken.
         self._execute_many(
             """
             UPDATE one_location_share_grants
             SET status = 'revoked'
             WHERE owner_user_id = :owner_user_id
               AND recipient_user_id = :recipient_user_id
-              AND status = 'active'
+              AND status = 'active'"""
+            + _share_lane_match_sql()
+            + """
             """,
             params,
         )
@@ -1038,6 +1062,22 @@ class FourUserMemoryService(OneLocationAgentService):
                 },
             )
         return row
+
+    @staticmethod
+    def _grant_is_sos_lane(grant: dict) -> bool:
+        """Which replacement lane a stored row is in, as `_SHARE_LANE_MATCH_SQL` reads it.
+
+        `share_kind` is not a column -- it lives in the `metadata` JSONB, which
+        is the whole reason the original revoke could not see it. Present and
+        not 'sos' means the ordinary lane; the legacy `reason == 'sos_panic'`
+        arm applies only when `share_kind` is absent entirely, matching the
+        COALESCE/IS NULL structure of the production predicate.
+        """
+        metadata = grant.get("metadata") or {}
+        share_kind = metadata.get("share_kind")
+        if share_kind is not None:
+            return str(share_kind) == "sos"
+        return str(metadata.get("reason") or "") == "sos_panic"
 
     def _add_sms_contact_with_locked_eligibility(
         self,
@@ -1500,7 +1540,47 @@ class FourUserMemoryService(OneLocationAgentService):
                     }
                 )
             return rows[: params.get("limit", 40)]
+        # `list_state` reads the two grant directions as separate parallel
+        # queries. Neither was modelled here, so `ownerGrants`/`receivedGrants`
+        # came back empty from every route test that read state -- the section
+        # simply logged `parallel_query_failed` and fell back to nothing. That
+        # is the only seam through which `_grant_payload` (and so the
+        # `shareKind` the whole client-side lane split depends on) is
+        # observable over HTTP, so the coexistence test needs it to be real.
+        if "FROM one_location_share_grants g" in sql and (
+            "WHERE g.owner_user_id = :user_id" in sql
+            or "WHERE g.recipient_user_id = :user_id" in sql
+        ):
+            as_owner = "WHERE g.owner_user_id = :user_id" in sql
+            column = "owner_user_id" if as_owner else "recipient_user_id"
+            counterpart_column = "recipient_user_id" if as_owner else "owner_user_id"
+            label = "recipient" if as_owner else "owner"
+            rows = []
+            for grant in sorted(
+                self.grants.values(),
+                key=lambda item: item["created_at"],
+                reverse=True,
+            ):
+                if grant[column] != params["user_id"]:
+                    continue
+                identity = self.identities.get(grant[counterpart_column] or "", {})
+                rows.append(
+                    {
+                        **grant,
+                        f"{label}_display_name": identity.get("display_name"),
+                        f"{label}_phone_number": identity.get("phone_number"),
+                    }
+                )
+            return rows[:50]
         if "UPDATE one_location_share_grants" in sql and "status = 'revoked'" in sql:
+            # Lane-scoped exactly when the SQL says so, reading the lane out of
+            # the BOUND PARAMS rather than out of anything the test hands us.
+            # That is what keeps this fake a mirror: a production write path
+            # that appends the predicate but forgets to bind `:is_sos_lane`
+            # raises KeyError right here instead of silently falling back to
+            # the pair-wide revoke that #5506 was.
+            lane_scoped = ":is_sos_lane" in sql
+            is_sos_lane = bool(params["is_sos_lane"]) if lane_scoped else None
             revoked = []
             for grant in self.grants.values():
                 if (
@@ -1508,6 +1588,8 @@ class FourUserMemoryService(OneLocationAgentService):
                     and grant["recipient_user_id"] == params["recipient_user_id"]
                     and grant["status"] == "active"
                 ):
+                    if lane_scoped and self._grant_is_sos_lane(grant) != is_sos_lane:
+                        continue
                     grant["status"] = "revoked"
                     revoked.append({"id": grant["id"]})
             return revoked
@@ -4786,4 +4868,228 @@ def test_sms_grant_fails_closed_until_recipient_is_selected() -> None:
     )
     assert service.notifications[0]["data"]["notification_category"] == (
         "ONE_LOCATION_SMS_EMERGENCY"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Two-lane grant replacement (#5506)
+#
+# Replacement of a live share is scoped to a LANE, and there are exactly two:
+# the emergency lane (`share_kind == 'sos'`) and everything else. Before this,
+# every create path opened with a kind-blind revoke of every active grant for
+# the pair, so raising an SMS alert with somebody you were already sharing with
+# silently revoked that share -- at SEND time, not at "I'm safe".
+# ---------------------------------------------------------------------------
+
+
+class _ShareCreatedNotificationSpy(FourUserMemoryService):
+    """Records every `_send_location_share_created_notification` call.
+
+    "Two rows are active" is not on its own enough to prove the fix. An
+    implementation that RE-USED the pair's existing grant instead of inserting
+    a new one would satisfy several of the obvious assertions while quietly
+    reintroducing the bug at stop time -- "I'm safe" would then revoke the
+    normal share, because the normal share would BE the SOS grant. Watching the
+    notification the create path fires is what distinguishes "a new SOS grant
+    was created" from "an old grant was handed back".
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.share_created_calls: list[dict] = []
+
+    def _send_location_share_created_notification(self, **kwargs) -> bool:
+        self.share_created_calls.append(kwargs)
+        return super()._send_location_share_created_notification(**kwargs)
+
+
+def _lane_service() -> _ShareCreatedNotificationSpy:
+    """A connected owner/recipient pair with the recipient's key registered."""
+    service = _ShareCreatedNotificationSpy()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    service._seed_connection("user_a", "user_b")
+    return service
+
+
+def test_sos_grant_does_not_revoke_an_existing_normal_share() -> None:
+    """The regression #5506 was reported as. Confirmed failing on `main`.
+
+    A shares location with B for four hours, then raises an SMS alert with that
+    same B. Before the lane split the four-hour grant was `status = 'revoked'`
+    the instant the SOS grant was created -- silently, with no
+    `location_share_revoked` event and no push, so B's card went on showing a
+    live share and the loss only surfaced at "I'm safe".
+    """
+    service = _lane_service()
+
+    normal = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=4,
+        share_kind="share",
+        enforce_connection=True,
+    )
+    normal_expires_at = service.grants[normal["id"]]["expires_at"]
+
+    service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b")
+
+    sos = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=8,
+        share_kind="sos",
+        reason="Come get me",
+        enforce_connection=True,
+    )
+
+    # 1. Both grants survive. Two live grants per pair is now legal, and this
+    #    is the pair that has to be able to hold them.
+    assert normal["id"] != sos["id"]
+    assert service.grants[normal["id"]]["status"] == "active"
+    assert service.grants[sos["id"]]["status"] == "active"
+    assert service.grants[normal["id"]]["metadata"]["share_kind"] == "share"
+    assert service.grants[sos["id"]]["metadata"]["share_kind"] == "sos"
+
+    # 2. The normal share keeps its ORIGINAL window. Revoke-and-reinsert under
+    #    a new expiry would leave one active row per lane too, while having
+    #    thrown away the four hours the owner actually consented to.
+    assert service.grants[normal["id"]]["expires_at"] == normal_expires_at
+
+    # 3. A genuinely new SOS grant was created, rather than the existing normal
+    #    grant being handed back relabelled. Save My Soul defers its
+    #    notification until the first envelope is durably stored, so this is
+    #    where the create path's intent becomes observable.
+    service.store_encrypted_envelope(
+        owner_user_id="user_a",
+        grant_id=sos["id"],
+        envelope=encrypted_envelope("key-user_b", "sos-ciphertext"),
+    )
+    sos_notifications = [
+        call for call in service.share_created_calls if call["resolved_kind"] == "sos"
+    ]
+    assert len(sos_notifications) == 1
+    assert sos_notifications[0]["grant"]["id"] == sos["id"]
+    assert service.notifications[-1]["title"] == "Save my Soul"
+
+
+def test_approving_an_access_request_does_not_revoke_an_active_sos_grant() -> None:
+    """The NON-enforced create branch, which `approve_request` is the only way in to.
+
+    `approve_request` calls `create_grant` without `enforce_connection`, so it
+    lands in a completely different revoke statement from the one the SOS test
+    above exercises. Both had the same kind-blind WHERE clause, and approving
+    an ordinary access request while an alert was live would have torn the
+    alert's grant down.
+    """
+    service = _lane_service()
+    service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b")
+
+    sos = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=8,
+        share_kind="sos",
+        enforce_connection=True,
+    )
+    sos_expires_at = service.grants[sos["id"]]["expires_at"]
+
+    request = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        message="Can you share where you are?",
+    )
+    approved = service.approve_request(
+        owner_user_id="user_a",
+        request_id=request["id"],
+        duration_hours=1,
+    )
+    approved_grant = approved["grant"]
+
+    assert approved_grant["id"] != sos["id"]
+    assert service.grants[approved_grant["id"]]["status"] == "active"
+    assert service.grants[sos["id"]]["status"] == "active"
+    assert service.grants[sos["id"]]["expires_at"] == sos_expires_at
+
+
+def test_same_lane_replacement_still_revokes_the_previous_grant() -> None:
+    """The other half of the invariant, and the reason this is TWO lanes.
+
+    Scoping replacement per exact share kind would let one pair accumulate
+    unbounded live grants -- `share`, `check_in`, `drive_to`, `pick_me_up` and
+    anything else a client sends, none of which any surface offers a single
+    Stop for. Within a lane the newest grant must still replace the older one
+    exactly as it always did, or the fix degrades into "never replace
+    anything".
+    """
+    service = _lane_service()
+
+    first_share = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+        share_kind="share",
+        enforce_connection=True,
+    )
+    second_share = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=2,
+        share_kind="share",
+        enforce_connection=True,
+    )
+    assert service.grants[first_share["id"]]["status"] == "revoked"
+    assert service.grants[second_share["id"]]["status"] == "active"
+
+    # A different NON-emergency kind shares the same lane and keeps replacing.
+    check_in = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+        share_kind="check_in",
+        enforce_connection=True,
+    )
+    assert service.grants[second_share["id"]]["status"] == "revoked"
+    assert service.grants[check_in["id"]]["status"] == "active"
+
+    service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b")
+    first_sos = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=8,
+        share_kind="sos",
+        enforce_connection=True,
+    )
+    second_sos = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=8,
+        share_kind="sos",
+        enforce_connection=True,
+    )
+    assert service.grants[first_sos["id"]]["status"] == "revoked"
+    assert service.grants[second_sos["id"]]["status"] == "active"
+    # ...and the ordinary share sitting in the other lane never noticed any of
+    # it. A pair tops out at exactly two live grants, one per lane.
+    assert service.grants[check_in["id"]]["status"] == "active"
+    assert (
+        sum(
+            1
+            for grant in service.grants.values()
+            if grant["status"] == "active"
+            and grant["owner_user_id"] == "user_a"
+            and grant["recipient_user_id"] == "user_b"
+        )
+        == 2
     )

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -887,3 +887,80 @@ def test_create_grant_without_share_kind_preserves_existing_classification(monke
     )
     assert resp2.status_code == 200
     assert resp2.json()["grant"]["shareKind"] == "share"
+
+    # Both of those are in the NON-emergency lane -- `check_in` and `share`
+    # are not separate lanes -- so the second still replaces the first, and
+    # the pair is still left holding exactly one live ordinary grant. Two
+    # lanes, not one lane per kind: without this the fix could quietly become
+    # "never replace anything" and grants would pile up with no Stop for them.
+    assert service.grants[grant["id"]]["status"] == "revoked"
+    assert service.grants[resp2.json()["grant"]["id"]]["status"] == "active"
+
+
+def test_sos_grant_and_normal_share_coexist_over_the_api(monkeypatch) -> None:
+    """End to end over HTTP: the pair holds one live grant in each lane (#5506).
+
+    The service-level tests prove the revoke predicate; this proves the whole
+    route stack agrees, right through to what `getState` hands the client. It
+    is the client-visible half of the fix: `shareKind` comes back on every
+    grant, which is what lets the web app tell the two apart and stop treating
+    one grant as one person.
+    """
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    service._seed_connection("user_a", "user_b")
+    current_user["user_id"] = "user_a"
+
+    share = client.post(
+        "/api/one/location/grants",
+        json={
+            "recipientUserId": "user_b",
+            "recipientKeyId": "key-user_b",
+            "durationHours": 4,
+            "shareKind": "share",
+        },
+    )
+    assert share.status_code == 200
+    share_grant = share.json()["grant"]
+    assert share_grant["shareKind"] == "share"
+
+    # Save My Soul only accepts a recipient the owner has already chosen as an
+    # SMS contact, so this is a precondition of the alert, not part of it.
+    contact = client.post(
+        "/api/one/location/sms-contacts",
+        json={"recipientUserId": "user_b"},
+    )
+    assert contact.status_code == 200
+
+    sos = client.post(
+        "/api/one/location/grants",
+        json={
+            "recipientUserId": "user_b",
+            "recipientKeyId": "key-user_b",
+            "durationHours": 8,
+            "shareKind": "sos",
+        },
+    )
+    assert sos.status_code == 200
+    sos_grant = sos.json()["grant"]
+    assert sos_grant["shareKind"] == "sos"
+    assert sos_grant["id"] != share_grant["id"]
+
+    state = client.get("/api/one/location/state").json()
+    active = [
+        grant
+        for grant in state["ownerGrants"]
+        if grant["status"] == "active" and grant["recipientUserId"] == "user_b"
+    ]
+    # TWO active grants to one person, which used to be impossible: creating
+    # the SOS grant revoked the four-hour share as a matter of course.
+    assert len(active) == 2
+    assert {grant["id"] for grant in active} == {share_grant["id"], sos_grant["id"]}
+    assert sorted(grant["shareKind"] for grant in active) == ["share", "sos"]
+    # The four-hour share kept its own window; the alert did not shorten it or
+    # stretch it to the emergency lane's eight.
+    surviving = next(grant for grant in active if grant["id"] == share_grant["id"])
+    assert surviving["expiresAt"] == share_grant["expiresAt"]

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -5323,9 +5323,17 @@ describe("OneLocationAgentPage", () => {
           "one_location_live_share_v1:user_a",
         );
         expect(raw).toBeTruthy();
+        // Still only ids and times. `recipientUserId` joins the record
+        // because the count on the status card is a HEADCOUNT and a headcount
+        // needs the head -- one person holding both an ordinary share and an
+        // SOS share is one person. It is an opaque id the device already
+        // holds, which is exactly the standard `grantId` meets: no name, no
+        // number, no coordinates, no token.
         expect(JSON.parse(raw ?? "[]")).toEqual([
           {
             grantId: "grant_1",
+            recipientUserId: "user_b",
+            shareKind: "share",
             startedAt: expect.any(String),
             expiresAt: "2026-05-20T08:00:00.000Z",
           },

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -245,6 +245,7 @@ import {
   loadLiveShareEntries,
   pruneLiveShareEntries,
   reconcileLiveShareEntries,
+  resolveStoppableGrantId,
   saveLiveShareEntries,
   summarizeLiveShareEntries,
   type LiveShareSessionEntry,
@@ -3031,10 +3032,7 @@ export function OneLocationAgentPageContent({
         .filter(Boolean),
       startedAt: shareWindow.startedAt,
       endsAt: shareWindow.endsAt,
-      stoppableGrantId:
-        liveShareEntries.length === 1
-          ? (liveShareEntries[0]?.grantId ?? null)
-          : null,
+      stoppableGrantId: resolveStoppableGrantId(liveShareEntries),
     };
   }, [activeOwnerGrants, liveShareEntries]);
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3026,10 +3026,22 @@ export function OneLocationAgentPageContent({
       // Names come from the server state only. The device record stays
       // coordinate- and identity-free, so a cold start shows "2 people" rather
       // than inventing who they are.
-      names: activeOwnerGrants
-        .filter((grant) => liveGrantIds.has(grant.id))
-        .map((grant) => grantCounterpartyLabel(grant))
-        .filter(Boolean),
+      //
+      // One name per PERSON, matching the count beside it. A pair can hold two
+      // live grants at once, and mapping the grant list straight to labels put
+      // the same friend in here twice -- which the card turns into "Sharing
+      // with 2 people" via `Math.max(names.length, count)`, a headline that
+      // names one person and counts two.
+      names: Array.from(
+        new Map(
+          activeOwnerGrants
+            .filter((grant) => liveGrantIds.has(grant.id))
+            .map((grant) => [
+              grant.recipientUserId || grant.id,
+              grantCounterpartyLabel(grant),
+            ]),
+        ).values(),
+      ).filter(Boolean),
       startedAt: shareWindow.startedAt,
       endsAt: shareWindow.endsAt,
       stoppableGrantId: resolveStoppableGrantId(liveShareEntries),

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -187,6 +187,35 @@ describe("LiveShareStatusCard", () => {
     expect(onManage).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Stop for ONE person who happens to hold two shares", () => {
+    // The affordance is driven by a headcount, not a grant count. After the
+    // two-lane split one friend can hold an ordinary share and an SOS share at
+    // once; the summarizer reports that as `count: 1` with one name and a
+    // resolved `stoppableGrantId`, and the card must go on offering the
+    // one-tap Stop rather than degrading to Manage at the exact moment the
+    // owner has the most sharing running.
+    const onStop = vi.fn();
+    render(
+      <LiveShareStatusCard
+        status={status({
+          count: 1,
+          names: ["Rohan Mehta"],
+          // The ordinary share: the SMS one has its own Stop on the Emergency
+          // screen, and after the lane split neither ends the other.
+          stoppableGrantId: "grant_ordinary",
+          endsAt: "2026-08-16T18:00:00.000Z",
+        })}
+        onManage={vi.fn()}
+        onStop={onStop}
+      />,
+    );
+
+    expect(screen.getByText("Sharing with Rohan Mehta")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Manage" })).toBeNull();
+    screen.getByRole("button", { name: "Stop" }).click();
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
   it("offers Change time on a single share, beside the end time", () => {
     // The reported bug: a 30-minute share could be stopped and nothing else.
     // The control has to be there, and it has to be the footer's sibling --

--- a/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+//
+// One row per PERSON, one control per SHARE (#5506).
+//
+// The backend now scopes replacement of a live location share to a lane --
+// the emergency one (`shareKind === "sos"`) and everything else -- so a pair
+// can hold two live grants at once. Every surface that lists people used to
+// equate one grant with one person: the People row bound its single Stop to
+// `activeOwnerGrants.find(...)`, which is whichever grant came first, and the
+// recipient's "Shared with me" rendered the same name as two separate cards.
+//
+// Shipping the backend half without this would turn a silent full revoke into
+// a silent half revoke, which is the same consent bug wearing a different hat.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SharedWithMeCard } from "@/components/one-location/redesign/cards";
+import { PersonShareLanes } from "@/components/one-location/redesign/share-lanes";
+import {
+  grantLaneLabel,
+  groupGrantsByCounterpart,
+} from "@/lib/one-location/grant-lanes";
+import type { OneLocationGrant } from "@/lib/one-location/types";
+
+function grant(overrides: Partial<OneLocationGrant> = {}): OneLocationGrant {
+  return {
+    id: "grant_ordinary",
+    ownerUserId: "user_a",
+    recipientUserId: "user_b",
+    recipientKeyId: "key_b",
+    status: "active",
+    consentScope: "cap.location.live.view",
+    capabilityScopes: ["cap.location.live.view"],
+    durationHours: 4,
+    createdAt: "2026-08-16T09:30:00.000Z",
+    expiresAt: "2026-08-16T13:30:00.000Z",
+    shareKind: "share",
+    ...overrides,
+  };
+}
+
+const ordinary = grant();
+const sos = grant({
+  id: "grant_sos",
+  shareKind: "sos",
+  durationHours: 8,
+  expiresAt: "2026-08-16T18:00:00.000Z",
+});
+
+describe("grouping grants by the person on the other end", () => {
+  it("puts one person's two shares in ONE group, and names each lane", () => {
+    const groups = groupGrantsByCounterpart([sos, ordinary], "owner");
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.counterpartUserId).toBe("user_b");
+    expect(groups[0]?.grants.map((g) => g.id)).toEqual([
+      "grant_sos",
+      "grant_ordinary",
+    ]);
+    expect(groups[0]?.smsGrant?.id).toBe("grant_sos");
+    expect(groups[0]?.ordinaryGrant?.id).toBe("grant_ordinary");
+    // The caller's order decides what leads, so an existing sort (received
+    // grants already float SMS-triggered shares to the top) keeps deciding.
+    expect(groups[0]?.primaryGrant.id).toBe("grant_sos");
+  });
+
+  it("keeps two different people apart", () => {
+    const groups = groupGrantsByCounterpart(
+      [ordinary, grant({ id: "to_c", recipientUserId: "user_c" })],
+      "owner",
+    );
+    expect(groups.map((g) => g.counterpartUserId)).toEqual([
+      "user_b",
+      "user_c",
+    ]);
+  });
+
+  it("groups the OTHER end when you are the recipient", () => {
+    const groups = groupGrantsByCounterpart(
+      [
+        grant({ id: "from_c", ownerUserId: "user_c" }),
+        grant({ id: "from_c_sos", ownerUserId: "user_c", shareKind: "sos" }),
+      ],
+      "recipient",
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.counterpartUserId).toBe("user_c");
+  });
+
+  it("never merges two grants that have no counterpart id into one person", () => {
+    // A split row is cosmetic. A merged row would wire one person's Stop to
+    // another person's share, so the ambiguous case has to over-split.
+    const groups = groupGrantsByCounterpart(
+      [
+        grant({ id: "anon_1", recipientUserId: "" }),
+        grant({ id: "anon_2", recipientUserId: "" }),
+      ],
+      "owner",
+    );
+    expect(groups).toHaveLength(2);
+  });
+
+  it("labels the SMS lane with the copy the recipient's card already uses", () => {
+    expect(grantLaneLabel(sos)).toBe("Shared via SMS");
+    expect(grantLaneLabel(ordinary)).toBe("Location share");
+  });
+});
+
+describe("per-share Stop inside a person's row", () => {
+  it("stops ONLY its own lane's grant", () => {
+    // The whole of #5506, made operable. Stopping the SMS share here is the
+    // same grant id through the same revoke the Emergency screen's "Stop
+    // sharing" calls, and the ordinary share keeps its own countdown.
+    const onStopGrant = vi.fn();
+    const [group] = groupGrantsByCounterpart([sos, ordinary], "owner");
+
+    render(
+      <PersonShareLanes
+        group={group!}
+        counterpartName="Rohan Mehta"
+        onStopGrant={onStopGrant}
+      />,
+    );
+
+    const rows = screen.getAllByTestId("one-location-share-lane");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.getAttribute("data-share-lane"))).toEqual([
+      "sos",
+      "ordinary",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Stop the SMS share with Rohan Mehta",
+      }),
+    );
+    expect(onStopGrant).toHaveBeenCalledTimes(1);
+    expect(onStopGrant).toHaveBeenCalledWith("grant_sos");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Stop the location share with Rohan Mehta",
+      }),
+    );
+    expect(onStopGrant).toHaveBeenCalledTimes(2);
+    expect(onStopGrant).toHaveBeenLastCalledWith("grant_ordinary");
+  });
+
+  it("disables only the share actually being revoked", () => {
+    const [group] = groupGrantsByCounterpart([sos, ordinary], "owner");
+    render(
+      <PersonShareLanes
+        group={group!}
+        counterpartName="Rohan Mehta"
+        onStopGrant={vi.fn()}
+        revokingGrantId="grant_sos"
+      />,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Stop the SMS share with Rohan Mehta",
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Stop the location share with Rohan Mehta",
+      }),
+    ).not.toBeDisabled();
+  });
+
+  it("offers no Stop at all on the receiving side", () => {
+    // A recipient cannot revoke somebody else's grant server-side, so the
+    // breakdown they see is the honest list and nothing more.
+    const [group] = groupGrantsByCounterpart([sos, ordinary], "recipient");
+    render(
+      <PersonShareLanes
+        group={group!}
+        counterpartName="Rohan Mehta"
+        formatEndsAt={() => "6:00 PM"}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /^Stop/ })).toBeNull();
+    expect(screen.getAllByText("Access until 6:00 PM")).toHaveLength(2);
+  });
+});
+
+describe("one card per owner in Shared with me", () => {
+  it("carries the SMS badge and both shares behind one name", () => {
+    const [group] = groupGrantsByCounterpart([sos, ordinary], "recipient");
+    render(
+      <SharedWithMeCard
+        isSmsTriggered={Boolean(group?.smsGrant)}
+        name="Rohan Mehta"
+        statusLine="2 live shares"
+        onView={vi.fn()}
+        shareLanes={
+          <div data-testid="one-location-received-share-lanes">
+            <PersonShareLanes
+              group={group!}
+              counterpartName="Rohan Mehta"
+              formatEndsAt={(value) =>
+                value === sos.expiresAt ? "6:00 PM" : "1:30 PM"
+              }
+            />
+          </div>
+        }
+      />,
+    );
+
+    // ONE name, not two cards for the same person.
+    expect(screen.getAllByText("Rohan Mehta")).toHaveLength(1);
+    // The badge is the treatment `isSmsTriggeredGrant` already drives here --
+    // no new copy was invented for the grouped case. Twice: the card's badge
+    // and the lane's own label, and they say the same words on purpose.
+    expect(screen.getAllByText("Shared via SMS")).toHaveLength(2);
+    // Both underlying shares, each with its OWN expiry. A single folded status
+    // line could only ever have been right about one of them.
+    expect(screen.getByTestId("one-location-received-share-lanes")).toBeTruthy();
+    expect(screen.getAllByTestId("one-location-share-lane")).toHaveLength(2);
+    expect(screen.getByText("Access until 6:00 PM")).toBeTruthy();
+    expect(screen.getByText("Access until 1:30 PM")).toBeTruthy();
+  });
+
+  it("renders no breakdown at all for a single share", () => {
+    render(
+      <SharedWithMeCard
+        isSmsTriggered={false}
+        name="Rohan Mehta"
+        statusLine="Access until 1:30 PM"
+        onView={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("one-location-share-lane")).toBeNull();
+    expect(screen.queryByText("Shared via SMS")).toBeNull();
+  });
+});
+
+// The hub's people list and its detail flows are internals of a ~4000-line
+// module, so their wiring is asserted as a source contract -- the pattern this
+// repo already uses for hub placement -- while the pieces above are rendered
+// for real.
+const HUB = path.join(
+  process.cwd(),
+  "components/one-location/redesign/location-redesign-hub.tsx",
+);
+const source = readFileSync(HUB, "utf8");
+
+describe("hub wiring", () => {
+  it("no longer binds a person's Stop to the FIRST grant it can find", () => {
+    // `activeOwnerGrants.find((g) => g.recipientUserId === r.userId)` is the
+    // exact shape of the bug: one tap, one grant stopped, the other left live
+    // with nothing on screen admitting it exists.
+    expect(source).not.toContain("(g) => g.recipientUserId === r.userId");
+    expect(source).toContain("ownerGroupsByUserId.get(r.userId)");
+  });
+
+  it("renders every people-listing surface from grouped grants", () => {
+    // Active shares, People and Shared with me all group first. A surface that
+    // went back to mapping the raw grant list would render one person twice.
+    expect(source).toContain(
+      'groupGrantsByCounterpart(vm.activeOwnerGrants, "owner")',
+    );
+    expect(source).toContain(
+      'groupGrantsByCounterpart(vm.receivedGrants, "recipient")',
+    );
+    expect(source).toContain("{ownerGrantGroups.map((group) => {");
+    expect(source).toContain("{receivedGrantGroups.map((group) => {");
+    expect(source).not.toContain("{vm.receivedGrants.map((grant) => {");
+    expect(source).not.toContain("{vm.activeOwnerGrants.map((grant) => (");
+  });
+
+  it("keeps the one-tap Stop for a person with a single share", () => {
+    // The common case must not have grown a step: the chevron appears only for
+    // somebody who genuinely holds two.
+    expect(source).toContain("group.grants.length === 1");
+    expect(source).toContain("shareGroup.grants.length === 1");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
@@ -172,9 +172,40 @@ describe("per-share Stop inside a person's row", () => {
     ).not.toBeDisabled();
   });
 
-  it("offers no Stop at all on the receiving side", () => {
-    // A recipient cannot revoke somebody else's grant server-side, so the
-    // breakdown they see is the honest list and nothing more.
+  it("says Remove, not Stop, on the receiving side -- and still one per share", () => {
+    // `revoke_grant` accepts the recipient as well as the owner and records
+    // the difference as `recipient_revoke`, so this side really can act. The
+    // card's own single Remove could only ever drop one of two shares, and
+    // silently, which is why each share carries its own.
+    const onStopGrant = vi.fn();
+    const [group] = groupGrantsByCounterpart([sos, ordinary], "recipient");
+    render(
+      <PersonShareLanes
+        group={group!}
+        counterpartName="Rohan Mehta"
+        formatEndsAt={() => "6:00 PM"}
+        action="remove"
+        onStopGrant={onStopGrant}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /^Stop/ })).toBeNull();
+    expect(screen.getAllByText("Access until 6:00 PM")).toHaveLength(2);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove the SMS share from Rohan Mehta",
+      }),
+    );
+    expect(onStopGrant).toHaveBeenCalledWith("grant_sos");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove the location share from Rohan Mehta",
+      }),
+    );
+    expect(onStopGrant).toHaveBeenLastCalledWith("grant_ordinary");
+  });
+
+  it("renders no control at all when this side is given none", () => {
     const [group] = groupGrantsByCounterpart([sos, ordinary], "recipient");
     render(
       <PersonShareLanes
@@ -183,8 +214,7 @@ describe("per-share Stop inside a person's row", () => {
         formatEndsAt={() => "6:00 PM"}
       />,
     );
-    expect(screen.queryByRole("button", { name: /^Stop/ })).toBeNull();
-    expect(screen.getAllByText("Access until 6:00 PM")).toHaveLength(2);
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });
 
@@ -202,6 +232,8 @@ describe("one card per owner in Shared with me", () => {
             <PersonShareLanes
               group={group!}
               counterpartName="Rohan Mehta"
+              action="remove"
+              onStopGrant={vi.fn()}
               formatEndsAt={(value) =>
                 value === sos.expiresAt ? "6:00 PM" : "1:30 PM"
               }
@@ -223,6 +255,14 @@ describe("one card per owner in Shared with me", () => {
     expect(screen.getAllByTestId("one-location-share-lane")).toHaveLength(2);
     expect(screen.getByText("Access until 6:00 PM")).toBeTruthy();
     expect(screen.getByText("Access until 1:30 PM")).toBeTruthy();
+    // One Remove per share, and none at the card level -- a single card-level
+    // Remove standing for two consents could only ever drop one of them.
+    expect(screen.getAllByRole("button", { name: /^Remove the/ })).toHaveLength(
+      2,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Remove Rohan Mehta from/ }),
+    ).toBeNull();
   });
 
   it("renders no breakdown at all for a single share", () => {
@@ -271,6 +311,12 @@ describe("hub wiring", () => {
     expect(source).toContain("{receivedGrantGroups.map((group) => {");
     expect(source).not.toContain("{vm.receivedGrants.map((grant) => {");
     expect(source).not.toContain("{vm.activeOwnerGrants.map((grant) => (");
+  });
+
+  it("suppresses the card-level Remove when one owner holds two shares", () => {
+    expect(source).toContain(
+      "multiLane ? undefined : () => vm.onStopGrant(grant.id)",
+    );
   });
 
   it("keeps the one-tap Stop for a person with a single share", () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -540,6 +540,55 @@ describe("SosPanel", () => {
     expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
   });
 
+  it("puts the emergency number and Stop sharing in ONE row, number left", () => {
+    // They used to be stacked, which put two unrelated decisions on the axis
+    // the eye reads as a sequence and buried the dialer under a control that
+    // only exists once an alert is already running.
+    // jsdom's default UA trips the Windows copy fallback, which swaps the
+    // <a tel:> for a copy button. The row is the same either way; pin the
+    // real dialer so this is testing the layout and not the fallback.
+    const navigatorUserAgent = vi
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (X11; Linux x86_64)");
+    const navigatorPlatform = vi
+      .spyOn(window.navigator, "platform", "get")
+      .mockReturnValue("Linux x86_64");
+    try {
+    render(<SosPanel {...baseProps} active onStopSos={vi.fn()} />);
+
+    const row = screen.getByTestId("sos-emergency-actions");
+    const dialer = screen.getByRole("link", {
+      name: "Call 112 emergency services (India)",
+    });
+    const stop = screen.getByTestId("sos-cancel-alert");
+
+    // One row: both controls are inside it, and nothing else claims them.
+    expect(row).toContainElement(dialer);
+    expect(row).toContainElement(stop);
+    expect(row.className).toContain("justify-between");
+    // Number LEFT, Stop sharing RIGHT.
+    expect(
+      dialer.compareDocumentPosition(stop) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // `flex-wrap` is the narrow-screen escape hatch rather than a breakpoint,
+    // and neither control may shrink when it fires.
+    expect(row.className).toContain("flex-wrap");
+    expect(stop.className).toContain("shrink-0");
+    } finally {
+      navigatorUserAgent.mockRestore();
+      navigatorPlatform.mockRestore();
+    }
+  });
+
+  it("centres the dialer when there is no alert to sit opposite", () => {
+    render(<SosPanel {...baseProps} active={false} />);
+    const row = screen.getByTestId("sos-emergency-actions");
+    expect(row.className).toContain("justify-center");
+    expect(row.className).not.toContain("justify-between");
+    expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
+  });
+
   it("keeps the SOS action in one centered stack on large screens", () => {
     const { container } = render(<SosPanel {...baseProps} />);
     // The press ring + controls must not split into a desktop grid. Width is

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -417,6 +417,7 @@ export function SharedWithMeCard({
   onAskReshare,
   askReshareBusy,
   isSmsTriggered,
+  shareLanes,
 }: {
   name: string;
   statusLine: string;
@@ -450,6 +451,17 @@ export function SharedWithMeCard({
   askReshareBusy?: boolean;
   /** Came from the Save My Soul panic flow -- the one this UI calls "SMS". */
   isSmsTriggered?: boolean;
+  /**
+   * Every live share from this person, when there is more than one.
+   *
+   * One owner can now hold two live grants with you at once -- an ordinary
+   * share and an SMS (SOS) one -- and they end at different moments. The card
+   * stays ONE card per person (two cards for one name is the thing this
+   * replaced), so the per-share breakdown hangs here, under the name, rather
+   * than being folded into a single `statusLine` that could only be right
+   * about one of them.
+   */
+  shareLanes?: ReactNode;
 }) {
   const warningRole = roleClasses("warning");
   const dangerRole = roleClasses("danger");
@@ -534,6 +546,7 @@ export function SharedWithMeCard({
           ) : null}
         </div>
       </div>
+      {shareLanes}
       {address || addressLoading || coordinatesFallback ? (
         <div className="flex items-start gap-1.5">
           <MapPin

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -21,6 +21,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -38,10 +39,12 @@ import {
   Plus,
   Send,
   Check,
+  ChevronDown,
   ChevronRight,
   Shield,
   ShieldCheck,
   UserPlus,
+  Siren,
   Users,
   UsersRound,
 } from "lucide-react";
@@ -58,6 +61,11 @@ import {
   isSmsTriggeredGrant,
   ONE_LOCATION_GRANT_ID_PARAM,
 } from "@/lib/one-location/notifications";
+import {
+  grantLaneLabel,
+  groupGrantsByCounterpart,
+  type OneLocationGrantLaneGroup,
+} from "@/lib/one-location/grant-lanes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -1617,6 +1625,180 @@ function NowHub({
 }
 
 /** Focused detail surfaces replace the former mixed inbox tab. */
+/**
+ * One live share inside a per-person row: what kind it is, when it ends, and
+ * its own Stop.
+ *
+ * Per-share-type rather than per-person, because after the two-lane split the
+ * two shares to one person are genuinely different consents with different end
+ * times. Stopping the SMS one here revokes exactly the grant the SOS screen's
+ * "Stop sharing" would revoke -- same grant id, same `revokeGrant` call -- and
+ * leaves the ordinary share running, which is the whole point of #5506.
+ */
+function ShareLaneRow({
+  grant,
+  counterpartName,
+  onStop,
+  stopping,
+  formatEndsAt,
+}: {
+  grant: OneLocationGrant;
+  counterpartName: string;
+  /** Omitted on the receiving side: a recipient cannot revoke an owner's grant. */
+  onStop?: () => void;
+  stopping?: boolean;
+  formatEndsAt?: (value: string) => string;
+}) {
+  const isSms = isSmsTriggeredGrant(grant);
+  return (
+    <div
+      className="flex min-h-[52px] items-center gap-3 py-2"
+      data-testid="one-location-share-lane"
+      data-share-lane={isSms ? "sos" : "ordinary"}
+      data-grant-id={grant.id}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="flex min-w-0 items-center gap-1.5 truncate text-[15px] font-medium text-foreground">
+          {isSms ? (
+            <Siren
+              className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-destructive)]"
+              aria-hidden="true"
+            />
+          ) : null}
+          {grantLaneLabel(grant)}
+        </p>
+        <p className={cn(MUTED_TEXT, "truncate text-[13px]")}>
+          {grant.durationMode === "until_stopped" ? (
+            "Until you stop"
+          ) : formatEndsAt && grant.expiresAt ? (
+            `Access until ${formatEndsAt(grant.expiresAt)}`
+          ) : (
+            <ShareCountdownText expiresAt={grant.expiresAt} />
+          )}
+        </p>
+      </div>
+      {onStop ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 shrink-0 text-destructive"
+          onClick={onStop}
+          disabled={stopping}
+          aria-label={
+            isSms
+              ? `Stop the SMS share with ${counterpartName}`
+              : `Stop the location share with ${counterpartName}`
+          }
+        >
+          Stop
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The disclosure body of a per-person row: every live share with that person.
+ *
+ * Rendered only when there is more than one, so the ordinary single-share case
+ * keeps the one-tap Stop it has always had rather than growing a chevron for a
+ * list of one.
+ */
+function PersonShareLanes({
+  group,
+  counterpartName,
+  onStopGrant,
+  revokingGrantId,
+  formatEndsAt,
+}: {
+  group: OneLocationGrantLaneGroup;
+  counterpartName: string;
+  onStopGrant?: (grantId: string) => void;
+  revokingGrantId?: string | null;
+  formatEndsAt?: (value: string) => string;
+}) {
+  return (
+    <div className="divide-y divide-[color:var(--app-separator)]">
+      {group.grants.map((grant) => (
+        <ShareLaneRow
+          key={grant.id}
+          grant={grant}
+          counterpartName={counterpartName}
+          formatEndsAt={formatEndsAt}
+          onStop={onStopGrant ? () => onStopGrant(grant.id) : undefined}
+          stopping={revokingGrantId === grant.id}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A chevron toggle that reads as one control.
+ *
+ * Matches the disclosure treatment `SharedWithMeCard` already uses for its map
+ * preview: a real button, `aria-expanded`, `aria-controls`, and a ChevronDown
+ * that rotates 180 degrees. Reused rather than re-styled so the two kinds of
+ * expandable row on this screen do not diverge.
+ */
+function ShareLanesDisclosure({
+  expanded,
+  onToggle,
+  controlsId,
+  label,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  controlsId: string;
+  label: string;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-9 shrink-0 gap-1 rounded-full px-3 text-[15px] font-semibold"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls={controlsId}
+      aria-label={label}
+    >
+      Manage
+      <ChevronDown
+        className={cn(
+          "h-4 w-4 transition-transform duration-200",
+          expanded && "rotate-180",
+        )}
+        aria-hidden="true"
+      />
+    </Button>
+  );
+}
+
+/**
+ * Which people have their per-share breakdown open, keyed by PERSON.
+ *
+ * Keyed by person rather than by grant so the disclosure stays put while the
+ * grants underneath are replaced wholesale on every live poll. Shared by the
+ * three surfaces that list people -- Active shares, People and Shared with me
+ * -- because an owner who expands a row on one of them and finds it collapsed
+ * on the next has learned that expanding means nothing.
+ */
+function useExpandedShareLanes() {
+  const [expandedLaneUserIds, setExpandedLaneUserIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleLaneExpansion = useCallback((counterpartUserId: string) => {
+    setExpandedLaneUserIds((current) => {
+      const next = new Set(current);
+      if (next.has(counterpartUserId)) next.delete(counterpartUserId);
+      else next.add(counterpartUserId);
+      return next;
+    });
+  }, []);
+  return { expandedLaneUserIds, toggleLaneExpansion };
+}
+
 function LocationDetailFlow({
   kind,
   vm,
@@ -1634,6 +1816,20 @@ function LocationDetailFlow({
   onCollapseGrant: (grantId: string) => void;
   onExpandGrant: (grant: OneLocationGrant) => void;
 }) {
+  // One row/card per PERSON, not per grant. A pair can now hold two live
+  // grants -- an ordinary share and an SMS (SOS) one -- and rendering a grant
+  // list rendered the same person twice, each row offering a Stop that left the
+  // other share running.
+  const ownerGrantGroups = useMemo(
+    () => groupGrantsByCounterpart(vm.activeOwnerGrants, "owner"),
+    [vm.activeOwnerGrants],
+  );
+  const receivedGrantGroups = useMemo(
+    () => groupGrantsByCounterpart(vm.receivedGrants, "recipient"),
+    [vm.receivedGrants],
+  );
+  const { expandedLaneUserIds, toggleLaneExpansion } = useExpandedShareLanes();
+
   const [grantViewportResetKeys, setGrantViewportResetKeys] = useState<
     Record<string, number>
   >({});
@@ -1757,65 +1953,154 @@ function LocationDetailFlow({
         description={copy.description}
       />
       {kind === "active-shares" ? (
-        vm.activeOwnerGrants.length ? (
+        ownerGrantGroups.length ? (
           <SettingsGroup separatorInset>
-            {vm.activeOwnerGrants.map((grant) => (
-              <SettingsRow
-                key={grant.id}
-                icon={UsersRound}
-                // Green, matching the "Active shares" row that opens this
-                // screen. Each row here IS one of those live grants, and
-                // "purple" renders byte-identically to blue in the tone map —
-                // so tapping a green row reporting 3 landed on three blue rows
-                // for the same 3 grants. One object, one colour.
-                iconTone="green"
-                title={vm.grantRecipientLabel(grant)}
-                description={
-                  grant.durationMode === "until_stopped" ? (
-                    "Until you stop"
-                  ) : (
-                    // Was a string computed once per render, so it froze the
-                    // moment the screen stopped re-rendering.
-                    <ShareCountdownText expiresAt={grant.expiresAt} />
-                  )
-                }
-                trailing={
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-9 text-destructive"
-                    onClick={() => vm.onStopGrant(grant.id)}
-                    disabled={vm.revokingGrantId === grant.id}
-                  >
-                    Stop
-                  </Button>
-                }
-              />
-            ))}
+            {ownerGrantGroups.map((group) => {
+              const name = vm.grantRecipientLabel(group.primaryGrant);
+              const expanded = expandedLaneUserIds.has(group.counterpartUserId);
+              const lanesId = `one-location-share-lanes-${group.counterpartUserId}`;
+              // One share is still one tap. The chevron only appears for a
+              // person who genuinely has two, so nothing about the common case
+              // grew a step.
+              const single = group.grants.length === 1 ? group.primaryGrant : null;
+              return (
+                <SettingsRow
+                  key={group.counterpartUserId}
+                  icon={UsersRound}
+                  // Green, matching the "Active shares" row that opens this
+                  // screen. Each row here IS one of those live grants, and
+                  // "purple" renders byte-identically to blue in the tone map —
+                  // so tapping a green row reporting 3 landed on three blue rows
+                  // for the same 3 grants. One object, one colour.
+                  iconTone="green"
+                  title={name}
+                  description={
+                    single ? (
+                      single.durationMode === "until_stopped" ? (
+                        "Until you stop"
+                      ) : (
+                        // Was a string computed once per render, so it froze the
+                        // moment the screen stopped re-rendering.
+                        <ShareCountdownText expiresAt={single.expiresAt} />
+                      )
+                    ) : (
+                      <>
+                        {/* Deliberately not a folded end time. The two shares
+                            end at different moments and each has its own Stop,
+                            so the honest summary is how many there are; the
+                            times live one tap away, beside the control that
+                            ends them.
+
+                            The breakdown lives in the row's own description
+                            slot rather than as a sibling of the row, so the
+                            group keeps its iOS first/last radii and hairline
+                            separators -- those are structural CSS on the row's
+                            position among its siblings, and inserting a panel
+                            between rows would round every row in the list. */}
+                        <span>{`${group.grants.length} live shares`}</span>
+                        <div id={lanesId} hidden={!expanded} className="pt-1">
+                          <PersonShareLanes
+                            group={group}
+                            counterpartName={name}
+                            onStopGrant={vm.onStopGrant}
+                            revokingGrantId={vm.revokingGrantId}
+                          />
+                        </div>
+                      </>
+                    )
+                  }
+                  trailing={
+                    single ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-9 text-destructive"
+                        onClick={() => vm.onStopGrant(single.id)}
+                        disabled={vm.revokingGrantId === single.id}
+                      >
+                        Stop
+                      </Button>
+                    ) : (
+                      <ShareLanesDisclosure
+                        expanded={expanded}
+                        onToggle={() => toggleLaneExpansion(group.counterpartUserId)}
+                        controlsId={lanesId}
+                        label={`Manage your shares with ${name}`}
+                      />
+                    )
+                  }
+                />
+              );
+            })}
           </SettingsGroup>
         ) : (
           <EmptyState title="No active shares" />
         )
       ) : null}
       {kind === "shared-with-me" ? (
-        vm.receivedGrants.length ? (
+        receivedGrantGroups.length ? (
           <div className="space-y-3">
-            {vm.receivedGrants.map((grant) => {
+            {receivedGrantGroups.map((group) => {
+              // ONE card per OWNER, never one per grant. That person can now
+              // be sharing with you twice at once -- an ordinary share and an
+              // SMS (SOS) one -- and rendering the grant list rendered the
+              // same name twice, two cards deep, each with its own map and its
+              // own countdown and no way to tell which was which.
+              //
+              // `receivedGrants` is already sorted SMS-first, so the leading
+              // grant of a group is the SMS one whenever there is one: the
+              // card's map, its "view" affordance and its badge all follow the
+              // share that matters most.
+              const grant = group.primaryGrant;
+              const multiLane = group.grants.length > 1;
+              const lanesExpanded = expandedLaneUserIds.has(
+                group.counterpartUserId,
+              );
+              const lanesId = `one-location-received-lanes-${group.counterpartUserId}`;
+              const ownerName = vm.grantOwnerLabel(grant);
               const point = vm.decryptedPoints[grant.id];
               const addressEntry = addressByGrant[grant.id];
               const expanded =
                 Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
-                <div key={grant.id} data-grant-id={grant.id}>
+                <div key={group.counterpartUserId} data-grant-id={grant.id}>
                 <SharedWithMeCard
-                  isSmsTriggered={isSmsTriggeredGrant(grant)}
-                  name={vm.grantOwnerLabel(grant)}
+                  isSmsTriggered={Boolean(group.smsGrant)}
+                  name={ownerName}
                   statusLine={
-                    grant.durationMode === "until_stopped"
-                      ? "Until stopped"
-                      : grant.expiresAt
-                        ? `Access until ${vm.formatDateTime(grant.expiresAt)}`
-                        : "Active"
+                    multiLane
+                      ? `${group.grants.length} live shares`
+                      : grant.durationMode === "until_stopped"
+                        ? "Until stopped"
+                        : grant.expiresAt
+                          ? `Access until ${vm.formatDateTime(grant.expiresAt)}`
+                          : "Active"
+                  }
+                  shareLanes={
+                    multiLane ? (
+                      // Display-only on this side. A recipient cannot revoke
+                      // somebody else's grant server-side, so there is no Stop
+                      // here -- only the honest breakdown of what each of the
+                      // two shares is and when it ends, which a single folded
+                      // status line could only ever be right about one of.
+                      <div data-testid="one-location-received-share-lanes">
+                        <ShareLanesDisclosure
+                          expanded={lanesExpanded}
+                          onToggle={() =>
+                            toggleLaneExpansion(group.counterpartUserId)
+                          }
+                          controlsId={lanesId}
+                          label={`Show the shares ${ownerName} has with you`}
+                        />
+                        <div id={lanesId} hidden={!lanesExpanded}>
+                          <PersonShareLanes
+                            group={group}
+                            counterpartName={ownerName}
+                            formatEndsAt={vm.formatDateTime}
+                          />
+                        </div>
+                      </div>
+                    ) : null
                   }
                   previewExpanded={expanded}
                   mapHref={point ? vm.mapLocationHref(point) : undefined}
@@ -2078,6 +2363,7 @@ function PersonRow({
   active,
   first,
   action,
+  expansion,
 }: {
   name: string;
   subtitle: string;
@@ -2085,12 +2371,24 @@ function PersonRow({
   active: boolean;
   first: boolean;
   action: ReactNode;
+  /**
+   * The row's per-share breakdown, when this person holds more than one live
+   * share. Rendered UNDER the row rather than beside it: it is a list with its
+   * own controls, and the row's own line has one name, one status and one
+   * action's worth of room.
+   */
+  expansion?: ReactNode;
 }) {
   return (
     <div
       className={cn(
-        "flex min-h-[74px] items-center gap-3.5 px-[18px] py-2 transition-colors hover:bg-[color:var(--app-neutral-fill)] motion-reduce:transition-none sm:min-h-[76px] sm:gap-[18px] sm:px-6",
+        "transition-colors hover:bg-[color:var(--app-neutral-fill)] motion-reduce:transition-none",
         !first && "border-t border-[color:var(--app-separator)]",
+      )}
+    >
+    <div
+      className={cn(
+        "flex min-h-[74px] items-center gap-3.5 px-[18px] py-2 sm:min-h-[76px] sm:gap-[18px] sm:px-6",
       )}
     >
       <div className="relative shrink-0">
@@ -2110,6 +2408,10 @@ function PersonRow({
         </p>
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+      {expansion ? (
+        <div className="px-[18px] pb-2 sm:px-6">{expansion}</div>
+      ) : null}
     </div>
   );
 }
@@ -2138,6 +2440,23 @@ function PeopleHub({
   const hasSearch = vm.recipientSearch.trim().length > 0;
   const filtered = vm.visibleRecipients;
   const hasAnyRecipients = vm.recipients.length > 0;
+  // Your live shares, by the person they point at -- ALL of them, not the
+  // first one found. This list used to read `activeOwnerGrants.find(...)`,
+  // which was correct only while a pair could hold one grant. Once an ordinary
+  // share and an SMS (SOS) share can both be live with the same person, `find`
+  // bound the row's single Stop to whichever happened to come first and left
+  // the other share running with no way to see it, let alone end it.
+  const ownerGroupsByUserId = useMemo(() => {
+    const byUserId = new globalThis.Map<string, OneLocationGrantLaneGroup>();
+    for (const group of groupGrantsByCounterpart(
+      vm.activeOwnerGrants,
+      "owner",
+    )) {
+      byUserId.set(group.counterpartUserId, group);
+    }
+    return byUserId;
+  }, [vm.activeOwnerGrants]);
+  const { expandedLaneUserIds, toggleLaneExpansion } = useExpandedShareLanes();
   const isDesktopPeopleLayout = useMediaQuery("(min-width: 640px)");
   const addPeopleAction = (
     <Button
@@ -2261,10 +2580,17 @@ function PeopleHub({
                   data-testid="one-location-people-list"
                 >
                   {filtered.map((r, i) => {
-                    const grant = vm.activeOwnerGrants.find(
-                      (g) => g.recipientUserId === r.userId,
-                    );
-                    const sharing = Boolean(grant);
+                    const shareGroup = ownerGroupsByUserId.get(r.userId) ?? null;
+                    const sharing = Boolean(shareGroup);
+                    // One share is still one tap: the row keeps its single
+                    // Stop and grows nothing. The breakdown appears only for a
+                    // person who genuinely has two.
+                    const singleGrant =
+                      shareGroup && shareGroup.grants.length === 1
+                        ? shareGroup.primaryGrant
+                        : null;
+                    const lanesExpanded = expandedLaneUserIds.has(r.userId);
+                    const lanesId = `one-location-people-lanes-${r.userId}`;
                     const receiving = vm.receivedGrants.some(
                       (g) => g.ownerUserId === r.userId,
                     );
@@ -2274,6 +2600,25 @@ function PeopleHub({
                       <PersonRow
                         key={r.userId}
                         name={name}
+                        expansion={
+                          shareGroup && !singleGrant ? (
+                            <div id={lanesId} hidden={!lanesExpanded}>
+                              {/* Stopping the SMS share here is exactly the
+                                  same act as stopping it from the Emergency
+                                  help screen: the same grant id through the
+                                  same `revokeGrant`. The normal share keeps
+                                  its original countdown, and stopping the
+                                  normal share never touches the SMS one --
+                                  that is the whole of #5506, made visible. */}
+                              <PersonShareLanes
+                                group={shareGroup}
+                                counterpartName={name}
+                                onStopGrant={vm.onStopGrant}
+                                revokingGrantId={vm.revokingGrantId}
+                              />
+                            </div>
+                          ) : null
+                        }
                         // Someone sharing their location with you right now
                         // used to read "Ready for private location sharing" —
                         // the recommendation line, which describes what COULD
@@ -2289,17 +2634,24 @@ function PeopleHub({
                         active={sharing || receiving}
                         first={i === 0}
                         action={
-                          sharing && grant ? (
+                          singleGrant ? (
                             <Button
                               variant="secondary"
                               size="sm"
-                              onClick={() => vm.onStopGrant(grant.id)}
-                              isLoading={vm.revokingGrantId === grant.id}
+                              onClick={() => vm.onStopGrant(singleGrant.id)}
+                              isLoading={vm.revokingGrantId === singleGrant.id}
                               aria-label={`Stop sharing with ${name}`}
                               className="relative h-9 min-h-9 rounded-full px-4 text-[15px] font-semibold after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] sm:px-5"
                             >
                               Stop
                             </Button>
+                          ) : shareGroup ? (
+                            <ShareLanesDisclosure
+                              expanded={lanesExpanded}
+                              onToggle={() => toggleLaneExpansion(r.userId)}
+                              controlsId={lanesId}
+                              label={`Manage your shares with ${name}`}
+                            />
                           ) : ready ? (
                             <Button
                               size="sm"
@@ -2775,8 +3127,18 @@ function ShareFlow({
    * that was already running. Showing the remaining time on the row is what
    * makes that consequence visible before it is chosen.
    */
+  //
+  // The grant a row reports is the ORDINARY one when the person holds both.
+  // Building this straight from the grant list made it a last-one-wins map, so
+  // while an SMS (SOS) share was live with somebody, their row quoted the SOS
+  // grant's hours -- time that re-picking them would not have restarted, since
+  // replacement is lane-scoped and a plain share only ever supersedes a plain
+  // share. The number on the row has to be the one the tap would reset.
   const activeGrantByRecipientId = new globalThis.Map(
-    vm.activeOwnerGrants.map((grant) => [grant.recipientUserId, grant]),
+    groupGrantsByCounterpart(vm.activeOwnerGrants, "owner").map((group) => [
+      group.counterpartUserId,
+      group.ordinaryGrant ?? group.primaryGrant,
+    ]),
   );
   const alreadySharing = filtered.filter((recipient) =>
     activeGrantByRecipientId.has(recipient.userId),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1903,11 +1903,13 @@ function LocationDetailFlow({
                   }
                   shareLanes={
                     multiLane ? (
-                      // Display-only on this side. A recipient cannot revoke
-                      // somebody else's grant server-side, so there is no Stop
-                      // here -- only the honest breakdown of what each of the
-                      // two shares is and when it ends, which a single folded
-                      // status line could only ever be right about one of.
+                      // One control per SHARE. The card's own Remove is a
+                      // single button, and with two shares behind one card it
+                      // could only ever drop one of them -- silently, since
+                      // nothing on screen would say which. `revoke_grant`
+                      // accepts the recipient as well as the owner (it records
+                      // the difference as `recipient_revoke`), so these are
+                      // real controls, not decoration.
                       <div data-testid="one-location-received-share-lanes">
                         <ShareLanesDisclosure
                           expanded={lanesExpanded}
@@ -1922,6 +1924,9 @@ function LocationDetailFlow({
                             group={group}
                             counterpartName={ownerName}
                             formatEndsAt={vm.formatDateTime}
+                            action="remove"
+                            onStopGrant={vm.onStopGrant}
+                            revokingGrantId={vm.revokingGrantId}
                           />
                         </div>
                       </div>
@@ -1934,7 +1939,12 @@ function LocationDetailFlow({
                   onRecenter={
                     point ? () => recenterGrantViewport(grant.id) : undefined
                   }
-                  onRemove={() => vm.onStopGrant(grant.id)}
+                  // Suppressed for a person holding two shares: the card's
+                  // single Remove would silently act on only one of them, and
+                  // the breakdown above already carries one per share.
+                  onRemove={
+                    multiLane ? undefined : () => vm.onStopGrant(grant.id)
+                  }
                   removeBusy={vm.revokingGrantId === grant.id}
                   viewBusy={vm.busy === "view"}
                   message={

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -39,12 +39,10 @@ import {
   Plus,
   Send,
   Check,
-  ChevronDown,
   ChevronRight,
   Shield,
   ShieldCheck,
   UserPlus,
-  Siren,
   Users,
   UsersRound,
 } from "lucide-react";
@@ -58,14 +56,17 @@ import {
 } from "@/lib/one-location/duration-copy";
 import { formatShareEndsAt } from "@/lib/one-location/share-countdown";
 import {
-  isSmsTriggeredGrant,
   ONE_LOCATION_GRANT_ID_PARAM,
 } from "@/lib/one-location/notifications";
 import {
-  grantLaneLabel,
   groupGrantsByCounterpart,
   type OneLocationGrantLaneGroup,
 } from "@/lib/one-location/grant-lanes";
+import {
+  PersonShareLanes,
+  ShareLanesDisclosure,
+  useExpandedShareLanes,
+} from "./share-lanes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -1625,180 +1626,6 @@ function NowHub({
 }
 
 /** Focused detail surfaces replace the former mixed inbox tab. */
-/**
- * One live share inside a per-person row: what kind it is, when it ends, and
- * its own Stop.
- *
- * Per-share-type rather than per-person, because after the two-lane split the
- * two shares to one person are genuinely different consents with different end
- * times. Stopping the SMS one here revokes exactly the grant the SOS screen's
- * "Stop sharing" would revoke -- same grant id, same `revokeGrant` call -- and
- * leaves the ordinary share running, which is the whole point of #5506.
- */
-function ShareLaneRow({
-  grant,
-  counterpartName,
-  onStop,
-  stopping,
-  formatEndsAt,
-}: {
-  grant: OneLocationGrant;
-  counterpartName: string;
-  /** Omitted on the receiving side: a recipient cannot revoke an owner's grant. */
-  onStop?: () => void;
-  stopping?: boolean;
-  formatEndsAt?: (value: string) => string;
-}) {
-  const isSms = isSmsTriggeredGrant(grant);
-  return (
-    <div
-      className="flex min-h-[52px] items-center gap-3 py-2"
-      data-testid="one-location-share-lane"
-      data-share-lane={isSms ? "sos" : "ordinary"}
-      data-grant-id={grant.id}
-    >
-      <div className="min-w-0 flex-1">
-        <p className="flex min-w-0 items-center gap-1.5 truncate text-[15px] font-medium text-foreground">
-          {isSms ? (
-            <Siren
-              className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-destructive)]"
-              aria-hidden="true"
-            />
-          ) : null}
-          {grantLaneLabel(grant)}
-        </p>
-        <p className={cn(MUTED_TEXT, "truncate text-[13px]")}>
-          {grant.durationMode === "until_stopped" ? (
-            "Until you stop"
-          ) : formatEndsAt && grant.expiresAt ? (
-            `Access until ${formatEndsAt(grant.expiresAt)}`
-          ) : (
-            <ShareCountdownText expiresAt={grant.expiresAt} />
-          )}
-        </p>
-      </div>
-      {onStop ? (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-9 shrink-0 text-destructive"
-          onClick={onStop}
-          disabled={stopping}
-          aria-label={
-            isSms
-              ? `Stop the SMS share with ${counterpartName}`
-              : `Stop the location share with ${counterpartName}`
-          }
-        >
-          Stop
-        </Button>
-      ) : null}
-    </div>
-  );
-}
-
-/**
- * The disclosure body of a per-person row: every live share with that person.
- *
- * Rendered only when there is more than one, so the ordinary single-share case
- * keeps the one-tap Stop it has always had rather than growing a chevron for a
- * list of one.
- */
-function PersonShareLanes({
-  group,
-  counterpartName,
-  onStopGrant,
-  revokingGrantId,
-  formatEndsAt,
-}: {
-  group: OneLocationGrantLaneGroup;
-  counterpartName: string;
-  onStopGrant?: (grantId: string) => void;
-  revokingGrantId?: string | null;
-  formatEndsAt?: (value: string) => string;
-}) {
-  return (
-    <div className="divide-y divide-[color:var(--app-separator)]">
-      {group.grants.map((grant) => (
-        <ShareLaneRow
-          key={grant.id}
-          grant={grant}
-          counterpartName={counterpartName}
-          formatEndsAt={formatEndsAt}
-          onStop={onStopGrant ? () => onStopGrant(grant.id) : undefined}
-          stopping={revokingGrantId === grant.id}
-        />
-      ))}
-    </div>
-  );
-}
-
-/**
- * A chevron toggle that reads as one control.
- *
- * Matches the disclosure treatment `SharedWithMeCard` already uses for its map
- * preview: a real button, `aria-expanded`, `aria-controls`, and a ChevronDown
- * that rotates 180 degrees. Reused rather than re-styled so the two kinds of
- * expandable row on this screen do not diverge.
- */
-function ShareLanesDisclosure({
-  expanded,
-  onToggle,
-  controlsId,
-  label,
-}: {
-  expanded: boolean;
-  onToggle: () => void;
-  controlsId: string;
-  label: string;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      className="h-9 shrink-0 gap-1 rounded-full px-3 text-[15px] font-semibold"
-      onClick={onToggle}
-      aria-expanded={expanded}
-      aria-controls={controlsId}
-      aria-label={label}
-    >
-      Manage
-      <ChevronDown
-        className={cn(
-          "h-4 w-4 transition-transform duration-200",
-          expanded && "rotate-180",
-        )}
-        aria-hidden="true"
-      />
-    </Button>
-  );
-}
-
-/**
- * Which people have their per-share breakdown open, keyed by PERSON.
- *
- * Keyed by person rather than by grant so the disclosure stays put while the
- * grants underneath are replaced wholesale on every live poll. Shared by the
- * three surfaces that list people -- Active shares, People and Shared with me
- * -- because an owner who expands a row on one of them and finds it collapsed
- * on the next has learned that expanding means nothing.
- */
-function useExpandedShareLanes() {
-  const [expandedLaneUserIds, setExpandedLaneUserIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const toggleLaneExpansion = useCallback((counterpartUserId: string) => {
-    setExpandedLaneUserIds((current) => {
-      const next = new Set(current);
-      if (next.has(counterpartUserId)) next.delete(counterpartUserId);
-      else next.add(counterpartUserId);
-      return next;
-    });
-  }, []);
-  return { expandedLaneUserIds, toggleLaneExpansion };
-}
-
 function LocationDetailFlow({
   kind,
   vm,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -55,18 +55,11 @@ import {
   locationTimestampMs,
 } from "@/lib/one-location/duration-copy";
 import { formatShareEndsAt } from "@/lib/one-location/share-countdown";
-import {
-  ONE_LOCATION_GRANT_ID_PARAM,
-} from "@/lib/one-location/notifications";
+import { ONE_LOCATION_GRANT_ID_PARAM } from "@/lib/one-location/notifications";
 import {
   groupGrantsByCounterpart,
   type OneLocationGrantLaneGroup,
 } from "@/lib/one-location/grant-lanes";
-import {
-  PersonShareLanes,
-  ShareLanesDisclosure,
-  useExpandedShareLanes,
-} from "./share-lanes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -123,6 +116,11 @@ import {
   DURATION_CELL_OFF_CLASS,
   DURATION_GRID_CLASS,
 } from "./duration-presets";
+import {
+  PersonShareLanes,
+  ShareLanesDisclosure,
+  useExpandedShareLanes,
+} from "./share-lanes";
 import { grantRemainingHours } from "@/lib/one-location/grant-duration-edit";
 // LocationTypeSelector stays exported from ./selectors, unused for now, so
 // PR #4767 can wire it back to a real precision mode without rebuilding it.
@@ -2207,35 +2205,34 @@ function PersonRow({
   expansion?: ReactNode;
 }) {
   return (
+    // The separator and the hover wash belong to the whole row INCLUDING its
+    // breakdown: a person's two shares are one row, and a hairline cutting
+    // between the name and the shares underneath it would read as two people.
     <div
       className={cn(
         "transition-colors hover:bg-[color:var(--app-neutral-fill)] motion-reduce:transition-none",
         !first && "border-t border-[color:var(--app-separator)]",
       )}
     >
-    <div
-      className={cn(
-        "flex min-h-[74px] items-center gap-3.5 px-[18px] py-2 sm:min-h-[76px] sm:gap-[18px] sm:px-6",
-      )}
-    >
-      <div className="relative shrink-0">
-        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--app-accent-surface)] text-[14px] font-semibold text-[color:var(--app-accent-deep)]">
-          {personInitials(name)}
-        </span>
-        {active ? (
-          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]" />
-        ) : null}
+      <div className="flex min-h-[74px] items-center gap-3.5 px-[18px] py-2 sm:min-h-[76px] sm:gap-[18px] sm:px-6">
+        <div className="relative shrink-0">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--app-accent-surface)] text-[14px] font-semibold text-[color:var(--app-accent-deep)]">
+            {personInitials(name)}
+          </span>
+          {active ? (
+            <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]" />
+          ) : null}
+        </div>
+        <div className="min-w-0 flex-1 sm:flex sm:items-baseline sm:gap-3">
+          <p className="truncate text-[17px] font-normal leading-[22px] tracking-[-0.37px] text-foreground">
+            {name}
+          </p>
+          <p className="truncate text-[14px] leading-[18px] tracking-[-0.22px] text-[color:var(--app-tertiary-label)]">
+            {subtitle}
+          </p>
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
       </div>
-      <div className="min-w-0 flex-1 sm:flex sm:items-baseline sm:gap-3">
-        <p className="truncate text-[17px] font-normal leading-[22px] tracking-[-0.37px] text-foreground">
-          {name}
-        </p>
-        <p className="truncate text-[14px] leading-[18px] tracking-[-0.22px] text-[color:var(--app-tertiary-label)]">
-          {subtitle}
-        </p>
-      </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
-    </div>
       {expansion ? (
         <div className="px-[18px] pb-2 sm:px-6">{expansion}</div>
       ) : null}

--- a/hushh-webapp/components/one-location/redesign/share-lanes.tsx
+++ b/hushh-webapp/components/one-location/redesign/share-lanes.tsx
@@ -44,15 +44,26 @@ export function ShareLaneRow({
   onStop,
   stopping,
   formatEndsAt,
+  action = "stop",
 }: {
   grant: OneLocationGrant;
   counterpartName: string;
-  /** Omitted on the receiving side: a recipient cannot revoke an owner's grant. */
+  /** Omitted when there is nothing this side may do about the share. */
   onStop?: () => void;
   stopping?: boolean;
   formatEndsAt?: (value: string) => string;
+  /**
+   * Whose share this is, in the only way that changes the words.
+   *
+   * `"stop"` is the owner ending their own share. `"remove"` is the recipient
+   * dropping one they were given -- `revoke_grant` accepts either party and
+   * records the difference as `owner_revoke` vs `recipient_revoke`, so both are
+   * real, and the copy has to say which one the tap is.
+   */
+  action?: "stop" | "remove";
 }) {
   const isSms = isSmsTriggeredGrant(grant);
+  const removing = action === "remove";
   return (
     <div
       className="flex min-h-[52px] items-center gap-3 py-2"
@@ -88,12 +99,16 @@ export function ShareLaneRow({
           onClick={onStop}
           disabled={stopping}
           aria-label={
-            isSms
-              ? `Stop the SMS share with ${counterpartName}`
-              : `Stop the location share with ${counterpartName}`
+            removing
+              ? isSms
+                ? `Remove the SMS share from ${counterpartName}`
+                : `Remove the location share from ${counterpartName}`
+              : isSms
+                ? `Stop the SMS share with ${counterpartName}`
+                : `Stop the location share with ${counterpartName}`
           }
         >
-          Stop
+          {removing ? "Remove" : "Stop"}
         </Button>
       ) : null}
     </div>
@@ -106,6 +121,12 @@ export function ShareLaneRow({
  * Rendered only when there is more than one, so the ordinary single-share case
  * keeps the one-tap Stop it has always had rather than growing a chevron for a
  * list of one.
+ *
+ * Every share gets its OWN control, on both sides. The recipient's card carries
+ * a single Remove, and with two shares behind one card that button could only
+ * ever drop one of them -- silently, since nothing on screen would say which.
+ * One control per share is the only honest arrangement once one card can stand
+ * for two consents.
  */
 export function PersonShareLanes({
   group,
@@ -113,12 +134,15 @@ export function PersonShareLanes({
   onStopGrant,
   revokingGrantId,
   formatEndsAt,
+  action,
 }: {
   group: OneLocationGrantLaneGroup;
   counterpartName: string;
   onStopGrant?: (grantId: string) => void;
   revokingGrantId?: string | null;
   formatEndsAt?: (value: string) => string;
+  /** See {@link ShareLaneRow}. Defaults to the owner's "stop". */
+  action?: "stop" | "remove";
 }) {
   return (
     <div className="divide-y divide-[color:var(--app-separator)]">
@@ -128,6 +152,7 @@ export function PersonShareLanes({
           grant={grant}
           counterpartName={counterpartName}
           formatEndsAt={formatEndsAt}
+          action={action}
           onStop={onStopGrant ? () => onStopGrant(grant.id) : undefined}
           stopping={revokingGrantId === grant.id}
         />

--- a/hushh-webapp/components/one-location/redesign/share-lanes.tsx
+++ b/hushh-webapp/components/one-location/redesign/share-lanes.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+/**
+ * Per-share-type controls for a person who holds more than one live share.
+ *
+ * Replacement of a live location share is scoped to a LANE on the backend --
+ * the emergency one (`share_kind === "sos"`, what this UI calls SMS / Save My
+ * Soul) and everything else -- so one pair can legitimately hold two live
+ * grants at once. Three surfaces list people (Active shares, People, and the
+ * recipient's Shared with me) and all three used to equate one grant with one
+ * person. These are the pieces they share so they cannot answer "which share
+ * is this and how do I end it" three different ways.
+ */
+
+import { useCallback, useState } from "react";
+
+import { ChevronDown, Siren } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  grantLaneLabel,
+  type OneLocationGrantLaneGroup,
+} from "@/lib/one-location/grant-lanes";
+import { isSmsTriggeredGrant } from "@/lib/one-location/notifications";
+import type { OneLocationGrant } from "@/lib/one-location/types";
+import { cn } from "@/lib/utils";
+
+import { ShareCountdownText } from "./live-share-status-card";
+import { MUTED_TEXT } from "./tokens";
+
+/**
+ * One live share inside a per-person row: what kind it is, when it ends, and
+ * its own Stop.
+ *
+ * Per-share-type rather than per-person, because after the two-lane split the
+ * two shares to one person are genuinely different consents with different end
+ * times. Stopping the SMS one here revokes exactly the grant the SOS screen's
+ * "Stop sharing" would revoke -- same grant id, same `revokeGrant` call -- and
+ * leaves the ordinary share running, which is the whole point of #5506.
+ */
+export function ShareLaneRow({
+  grant,
+  counterpartName,
+  onStop,
+  stopping,
+  formatEndsAt,
+}: {
+  grant: OneLocationGrant;
+  counterpartName: string;
+  /** Omitted on the receiving side: a recipient cannot revoke an owner's grant. */
+  onStop?: () => void;
+  stopping?: boolean;
+  formatEndsAt?: (value: string) => string;
+}) {
+  const isSms = isSmsTriggeredGrant(grant);
+  return (
+    <div
+      className="flex min-h-[52px] items-center gap-3 py-2"
+      data-testid="one-location-share-lane"
+      data-share-lane={isSms ? "sos" : "ordinary"}
+      data-grant-id={grant.id}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="flex min-w-0 items-center gap-1.5 truncate text-[15px] font-medium text-foreground">
+          {isSms ? (
+            <Siren
+              className="h-3.5 w-3.5 shrink-0 text-[color:var(--app-destructive)]"
+              aria-hidden="true"
+            />
+          ) : null}
+          {grantLaneLabel(grant)}
+        </p>
+        <p className={cn(MUTED_TEXT, "truncate text-[13px]")}>
+          {grant.durationMode === "until_stopped" ? (
+            "Until you stop"
+          ) : formatEndsAt && grant.expiresAt ? (
+            `Access until ${formatEndsAt(grant.expiresAt)}`
+          ) : (
+            <ShareCountdownText expiresAt={grant.expiresAt} />
+          )}
+        </p>
+      </div>
+      {onStop ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 shrink-0 text-destructive"
+          onClick={onStop}
+          disabled={stopping}
+          aria-label={
+            isSms
+              ? `Stop the SMS share with ${counterpartName}`
+              : `Stop the location share with ${counterpartName}`
+          }
+        >
+          Stop
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The disclosure body of a per-person row: every live share with that person.
+ *
+ * Rendered only when there is more than one, so the ordinary single-share case
+ * keeps the one-tap Stop it has always had rather than growing a chevron for a
+ * list of one.
+ */
+export function PersonShareLanes({
+  group,
+  counterpartName,
+  onStopGrant,
+  revokingGrantId,
+  formatEndsAt,
+}: {
+  group: OneLocationGrantLaneGroup;
+  counterpartName: string;
+  onStopGrant?: (grantId: string) => void;
+  revokingGrantId?: string | null;
+  formatEndsAt?: (value: string) => string;
+}) {
+  return (
+    <div className="divide-y divide-[color:var(--app-separator)]">
+      {group.grants.map((grant) => (
+        <ShareLaneRow
+          key={grant.id}
+          grant={grant}
+          counterpartName={counterpartName}
+          formatEndsAt={formatEndsAt}
+          onStop={onStopGrant ? () => onStopGrant(grant.id) : undefined}
+          stopping={revokingGrantId === grant.id}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A chevron toggle that reads as one control.
+ *
+ * Matches the disclosure treatment `SharedWithMeCard` already uses for its map
+ * preview: a real button, `aria-expanded`, `aria-controls`, and a ChevronDown
+ * that rotates 180 degrees. Reused rather than re-styled so the two kinds of
+ * expandable row on this screen do not diverge.
+ */
+export function ShareLanesDisclosure({
+  expanded,
+  onToggle,
+  controlsId,
+  label,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  controlsId: string;
+  label: string;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-9 shrink-0 gap-1 rounded-full px-3 text-[15px] font-semibold"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls={controlsId}
+      aria-label={label}
+    >
+      Manage
+      <ChevronDown
+        className={cn(
+          "h-4 w-4 transition-transform duration-200",
+          expanded && "rotate-180",
+        )}
+        aria-hidden="true"
+      />
+    </Button>
+  );
+}
+
+/**
+ * Which people have their per-share breakdown open, keyed by PERSON.
+ *
+ * Keyed by person rather than by grant so the disclosure stays put while the
+ * grants underneath are replaced wholesale on every live poll. Shared by the
+ * three surfaces that list people -- Active shares, People and Shared with me
+ * -- because an owner who expands a row on one of them and finds it collapsed
+ * on the next has learned that expanding means nothing.
+ */
+export function useExpandedShareLanes() {
+  const [expandedLaneUserIds, setExpandedLaneUserIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleLaneExpansion = useCallback((counterpartUserId: string) => {
+    setExpandedLaneUserIds((current) => {
+      const next = new Set(current);
+      if (next.has(counterpartUserId)) next.delete(counterpartUserId);
+      else next.add(counterpartUserId);
+      return next;
+    });
+  }, []);
+  return { expandedLaneUserIds, toggleLaneExpansion };
+}

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -1004,89 +1004,89 @@ export function SosPanel({
           )}
         >
           <div className="flex shrink-0 items-center">
-          {emergencyStatus === "resolved" && emergency ? (
-            shouldFallbackWindowsEmergencyCall ? (
+            {emergencyStatus === "resolved" && emergency ? (
+              shouldFallbackWindowsEmergencyCall ? (
+                <button
+                  type="button"
+                  onClick={handleWindowsEmergencyCopy}
+                  aria-label={`Copy ${emergency.number} emergency services (${emergency.countryName})`}
+                  className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
+                >
+                  <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
+                  <span className="text-left leading-tight">
+                    <span className="block text-[16px] font-medium tracking-[-0.3px] lg:text-[17px] lg:tracking-[-0.37px]">
+                      {windowsCopyStatus === "copied"
+                        ? `Copied ${emergency.number}`
+                        : `Copy ${emergency.number}`}
+                    </span>
+                    <span className="block text-[12px] text-[color:var(--sos-label)]">
+                      {windowsCopyStatus === "copied"
+                        ? "Dial it from your phone"
+                        : emergency.countryName}
+                    </span>
+                  </span>
+                </button>
+              ) : (
+                <a
+                  href={`tel:${emergency.number}`}
+                  aria-label={`Call ${emergency.number} emergency services (${emergency.countryName})`}
+                  className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
+                >
+                  <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
+                  <span className="text-left leading-tight">
+                    <span className="block text-[16px] font-medium tracking-[-0.3px] lg:text-[17px] lg:tracking-[-0.37px]">
+                      Call {emergency.number}
+                    </span>
+                    <span className="block text-[12px] text-[color:var(--sos-label)]">
+                      {emergency.countryName}
+                    </span>
+                  </span>
+                </a>
+              )
+            ) : (
               <button
                 type="button"
-                onClick={handleWindowsEmergencyCopy}
-                aria-label={`Copy ${emergency.number} emergency services (${emergency.countryName})`}
-                className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
+                onClick={onResolveEmergencyNumber}
+                // "resolving" is the only state that must stay inert -- it means
+                // a lookup is already in flight. "idle" (nothing looked up yet)
+                // and "unavailable" (a lookup failed) both stay tappable, since
+                // each needs the tap to be the thing that starts the next lookup.
+                disabled={emergencyStatus === "resolving"}
+                aria-label={
+                  emergencyStatus === "unavailable"
+                    ? "Retry local emergency number"
+                    : emergencyStatus === "resolving"
+                      ? "Finding local emergency number"
+                      : "Find local emergency number"
+                }
+                className="press-scale flex items-center gap-2.5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-70 disabled:cursor-wait disabled:opacity-75"
               >
-                <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
+                {emergencyStatus === "resolving" ? (
+                  <Loader2
+                    className="h-[17px] w-[17px] animate-spin"
+                    aria-hidden
+                  />
+                ) : (
+                  <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
+                )}
                 <span className="text-left leading-tight">
                   <span className="block text-[16px] font-medium tracking-[-0.3px] lg:text-[17px] lg:tracking-[-0.37px]">
-                    {windowsCopyStatus === "copied"
-                      ? `Copied ${emergency.number}`
-                      : `Copy ${emergency.number}`}
+                    {emergencyStatus === "unavailable"
+                      ? "Retry local number"
+                      : emergencyStatus === "resolving"
+                        ? "Finding local number"
+                        : "Find local number"}
                   </span>
                   <span className="block text-[12px] text-[color:var(--sos-label)]">
-                    {windowsCopyStatus === "copied"
-                      ? "Dial it from your phone"
-                      : emergency.countryName}
+                    {emergencyStatus === "unavailable"
+                      ? "Location unavailable"
+                      : emergencyStatus === "resolving"
+                        ? "Using current location"
+                        : "Tap to look up"}
                   </span>
                 </span>
               </button>
-            ) : (
-              <a
-                href={`tel:${emergency.number}`}
-                aria-label={`Call ${emergency.number} emergency services (${emergency.countryName})`}
-                className="press-scale flex min-h-11 items-center gap-2.5 rounded-full border border-[color:var(--app-destructive)]/25 bg-[color:var(--app-destructive)]/8 px-4 py-2 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/14"
-              >
-                <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
-                <span className="text-left leading-tight">
-                  <span className="block text-[16px] font-medium tracking-[-0.3px] lg:text-[17px] lg:tracking-[-0.37px]">
-                    Call {emergency.number}
-                  </span>
-                  <span className="block text-[12px] text-[color:var(--sos-label)]">
-                    {emergency.countryName}
-                  </span>
-                </span>
-              </a>
-            )
-          ) : (
-            <button
-              type="button"
-              onClick={onResolveEmergencyNumber}
-              // "resolving" is the only state that must stay inert -- it means
-              // a lookup is already in flight. "idle" (nothing looked up yet)
-              // and "unavailable" (a lookup failed) both stay tappable, since
-              // each needs the tap to be the thing that starts the next lookup.
-              disabled={emergencyStatus === "resolving"}
-              aria-label={
-                emergencyStatus === "unavailable"
-                  ? "Retry local emergency number"
-                  : emergencyStatus === "resolving"
-                    ? "Finding local emergency number"
-                    : "Find local emergency number"
-              }
-              className="press-scale flex items-center gap-2.5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-70 disabled:cursor-wait disabled:opacity-75"
-            >
-              {emergencyStatus === "resolving" ? (
-                <Loader2
-                  className="h-[17px] w-[17px] animate-spin"
-                  aria-hidden
-                />
-              ) : (
-                <Phone className="h-[17px] w-[17px] fill-current" aria-hidden />
-              )}
-              <span className="text-left leading-tight">
-                <span className="block text-[16px] font-medium tracking-[-0.3px] lg:text-[17px] lg:tracking-[-0.37px]">
-                  {emergencyStatus === "unavailable"
-                    ? "Retry local number"
-                    : emergencyStatus === "resolving"
-                      ? "Finding local number"
-                      : "Find local number"}
-                </span>
-                <span className="block text-[12px] text-[color:var(--sos-label)]">
-                  {emergencyStatus === "unavailable"
-                    ? "Location unavailable"
-                    : emergencyStatus === "resolving"
-                      ? "Using current location"
-                      : "Tap to look up"}
-                </span>
-              </span>
-            </button>
-          )}
+            )}
           </div>
 
           {/* Ending the alert revokes the location grants the alert created AND

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -975,24 +975,6 @@ export function SosPanel({
             </div>
           </div>
 
-          {/* While an alert is live the primary action becomes stopping it.
-              This revokes the location grants the alert created AND clears the
-              incident, so the live state resets here and in Active shares. */}
-          {active ? (
-            <button
-              type="button"
-              onClick={onStopSos}
-              disabled={stopBusy}
-              aria-label="Cancel the alert and stop sharing your location"
-              data-testid="sos-cancel-alert"
-              className="press-scale mt-1 flex h-[52px] w-full items-center justify-center gap-2 self-center rounded-xl bg-[color:var(--sos-control-surface)] text-[16px] text-[color:var(--sos-control-text)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60 lg:h-14 lg:w-[220px] lg:text-[17px]"
-            >
-              {stopBusy ? (
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-              ) : null}
-              {stopBusy ? "Stopping…" : "Stop sharing"}
-            </button>
-          ) : null}
         </div>
 
         {/* The dialer. Outlined and tinted, never filled — it needs to read as
@@ -1001,7 +983,27 @@ export function SosPanel({
             this product enforces everywhere else, on the one screen where the
             person is least able to aim. An outline buys the affordance; the
             filled treatment stays reserved for SOS. */}
-        <div className="mt-10 flex min-h-[52px] items-center justify-center lg:mt-14">
+        {/* One row, two ends: the local emergency number on the LEFT, "Stop
+            sharing" on the RIGHT. They used to be stacked, which put two
+            unrelated decisions on the vertical axis the eye reads as a
+            sequence.
+
+            `flex-wrap` is the narrow-screen escape hatch rather than a
+            breakpoint: at 360px the pair fits comfortably, but a long country
+            name ("Copied 112 / Dial it from your phone") plus a spinner can
+            push past the line, and wrapping keeps BOTH controls at full size
+            and fully tappable instead of squashing the dialer's two-line
+            label. Neither control ever shrinks. */}
+        <div
+          data-testid="sos-emergency-actions"
+          className={cn(
+            "mt-10 flex min-h-[52px] w-full max-w-[520px] flex-wrap items-center gap-x-3 gap-y-3 lg:mt-14",
+            // Nothing to sit opposite when no alert is live, so the dialer
+            // keeps the centred placement it has always had.
+            active ? "justify-between" : "justify-center",
+          )}
+        >
+          <div className="flex shrink-0 items-center">
           {emergencyStatus === "resolved" && emergency ? (
             shouldFallbackWindowsEmergencyCall ? (
               <button
@@ -1085,6 +1087,27 @@ export function SosPanel({
               </span>
             </button>
           )}
+          </div>
+
+          {/* Ending the alert revokes the location grants the alert created AND
+              clears the incident, so the live state resets here and in Active
+              shares. Post-#5506 that teardown is lane-scoped: it ends the SMS
+              share only, and a normal share to the same person keeps running. */}
+          {active ? (
+            <button
+              type="button"
+              onClick={onStopSos}
+              disabled={stopBusy}
+              aria-label="Cancel the alert and stop sharing your location"
+              data-testid="sos-cancel-alert"
+              className="press-scale flex h-[52px] shrink-0 items-center justify-center gap-2 rounded-xl bg-[color:var(--sos-control-surface)] px-5 text-[16px] text-[color:var(--sos-control-text)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60 lg:h-14 lg:min-w-[200px] lg:px-6 lg:text-[17px]"
+            >
+              {stopBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : null}
+              {stopBusy ? "Stopping…" : "Stop sharing"}
+            </button>
+          ) : null}
         </div>
       </div>
     </section>

--- a/hushh-webapp/lib/one-location/__tests__/live-share-session.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/live-share-session.test.ts
@@ -6,6 +6,7 @@ import {
   loadLiveShareEntries,
   pruneLiveShareEntries,
   reconcileLiveShareEntries,
+  resolveStoppableGrantId,
   saveLiveShareEntries,
   summarizeLiveShareEntries,
   type LiveShareSessionEntry,
@@ -39,6 +40,8 @@ describe("live share session record", () => {
     const entries: LiveShareSessionEntry[] = [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -52,6 +55,8 @@ describe("live share session record", () => {
     saveLiveShareEntries("user_a", [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -64,6 +69,8 @@ describe("live share session record", () => {
     saveLiveShareEntries("user_a", [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -71,9 +78,17 @@ describe("live share session record", () => {
 
     const raw = window.localStorage.getItem("one_location_live_share_v1:user_a");
     expect(raw).toBeTruthy();
+    // Deliberately still an EXACT key set, not a subset check. The point of
+    // this assertion is what is ABSENT: no names, no phone numbers, no
+    // coordinates, no capability token. `recipientUserId` joins the list
+    // because a headcount needs the head -- one person holding two grants is
+    // one person -- and it is an opaque id the device already holds, which is
+    // the same standard `grantId` meets.
     expect(Object.keys(JSON.parse(raw ?? "[]")[0]).sort()).toEqual([
       "expiresAt",
       "grantId",
+      "recipientUserId",
+      "shareKind",
       "startedAt",
     ]);
   });
@@ -82,11 +97,15 @@ describe("live share session record", () => {
     saveLiveShareEntries("user_a", [
       {
         grantId: "expired",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T08:00:00.000Z",
         expiresAt: "2026-08-16T09:00:00.000Z",
       },
       {
         grantId: "running",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -101,12 +120,20 @@ describe("live share session record", () => {
     const stale: LiveShareSessionEntry[] = [
       {
         grantId: "open",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-14T10:00:00.000Z",
         expiresAt: null,
       },
     ];
     const fresh: LiveShareSessionEntry[] = [
-      { grantId: "open", startedAt: "2026-08-16T08:00:00.000Z", expiresAt: null },
+      {
+        grantId: "open",
+        recipientUserId: "user_b",
+        shareKind: "share",
+        startedAt: "2026-08-16T08:00:00.000Z",
+        expiresAt: null,
+      },
     ];
 
     expect(pruneLiveShareEntries(stale, NOW)).toEqual([]);
@@ -131,6 +158,8 @@ describe("live share session record", () => {
     saveLiveShareEntries("user_a", [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -141,6 +170,8 @@ describe("live share session record", () => {
     saveLiveShareEntries("user_a", [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -155,6 +186,8 @@ describe("reconciling against the server", () => {
     const previous: LiveShareSessionEntry[] = [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -179,6 +212,8 @@ describe("reconciling against the server", () => {
     const previous: LiveShareSessionEntry[] = [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -212,6 +247,8 @@ describe("reconciling against the server", () => {
     expect(next).toEqual([
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: null,
       },
@@ -242,11 +279,17 @@ describe("summarising the live window", () => {
     const summary = summarizeLiveShareEntries([
       {
         grantId: "soon",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:45:00.000Z",
         expiresAt: "2026-08-16T10:10:00.000Z",
       },
       {
         grantId: "late",
+        // A DIFFERENT person, so the count is genuinely two. The
+        // same-person case is the test below.
+        recipientUserId: "user_c",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T12:00:00.000Z",
       },
@@ -259,15 +302,73 @@ describe("summarising the live window", () => {
     });
   });
 
+  it("counts one person twice-shared-with once, but keeps their LATER expiry", () => {
+    // The two halves of this file's rule, in one case. Count is per PERSON:
+    // an ordinary share and an SOS share to the same friend is one friend, and
+    // "2 people" would be a plain lie about who can see you. Time is per
+    // EXPOSURE: `endsAt` means "when you stop being visible to everyone", so
+    // it folds over EVERY entry. Deduping before that fold would render this
+    // as "ends at 10:10" while the owner stays visible until 18:00 --
+    // under-claiming your own exposure, the one direction a privacy status
+    // must never round.
+    const summary = summarizeLiveShareEntries([
+      {
+        grantId: "ordinary",
+        recipientUserId: "user_b",
+        shareKind: "share",
+        startedAt: "2026-08-16T09:45:00.000Z",
+        expiresAt: "2026-08-16T10:10:00.000Z",
+      },
+      {
+        grantId: "sos",
+        recipientUserId: "user_b",
+        shareKind: "sos",
+        startedAt: "2026-08-16T10:00:00.000Z",
+        expiresAt: "2026-08-16T18:00:00.000Z",
+      },
+    ]);
+
+    expect(summary).toEqual({
+      count: 1,
+      startedAt: "2026-08-16T09:45:00.000Z",
+      endsAt: "2026-08-16T18:00:00.000Z",
+    });
+  });
+
+  it("still counts two different people as two", () => {
+    const summary = summarizeLiveShareEntries([
+      {
+        grantId: "to_b",
+        recipientUserId: "user_b",
+        shareKind: "share",
+        startedAt: "2026-08-16T09:45:00.000Z",
+        expiresAt: "2026-08-16T10:10:00.000Z",
+      },
+      {
+        grantId: "to_c",
+        recipientUserId: "user_c",
+        shareKind: "share",
+        startedAt: "2026-08-16T09:30:00.000Z",
+        expiresAt: "2026-08-16T12:00:00.000Z",
+      },
+    ]);
+
+    expect(summary?.count).toBe(2);
+  });
+
   it("has no end at all when any share runs until you stop it", () => {
     const summary = summarizeLiveShareEntries([
       {
         grantId: "timed",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
       {
         grantId: "open",
+        recipientUserId: "user_c",
+        shareKind: "share",
         startedAt: "2026-08-16T09:40:00.000Z",
         expiresAt: null,
       },
@@ -283,6 +384,8 @@ describe("liveShareEntriesEqual", () => {
     const a: LiveShareSessionEntry[] = [
       {
         grantId: "grant_1",
+        recipientUserId: "user_b",
+        shareKind: "share",
         startedAt: "2026-08-16T09:30:00.000Z",
         expiresAt: "2026-08-16T10:30:00.000Z",
       },
@@ -295,5 +398,59 @@ describe("liveShareEntriesEqual", () => {
         { ...a[0]!, expiresAt: "2026-08-16T11:30:00.000Z" },
       ]),
     ).toBe(false);
+  });
+});
+
+describe("resolveStoppableGrantId", () => {
+  function entry(
+    overrides: Partial<LiveShareSessionEntry>,
+  ): LiveShareSessionEntry {
+    return {
+      grantId: "grant_1",
+      recipientUserId: "user_b",
+      shareKind: "share",
+      startedAt: "2026-08-16T09:30:00.000Z",
+      expiresAt: "2026-08-16T10:30:00.000Z",
+      ...overrides,
+    };
+  }
+
+  it("offers Stop for one person's single share", () => {
+    expect(resolveStoppableGrantId([entry({ grantId: "only" })])).toBe("only");
+  });
+
+  it("keeps offering Stop when that one person holds BOTH shares", () => {
+    // The regression this function exists for. The rule used to be "exactly
+    // one live entry", which read a GRANT count as a PERSON count -- so a
+    // friend holding an ordinary share and an SOS share silently took away the
+    // owner's Stop button and their duration editor at the exact moment the
+    // most sharing was running. It resolves to the ORDINARY share: the SMS one
+    // has its own Stop on the Emergency screen, and after the lane split
+    // neither one ends the other.
+    expect(
+      resolveStoppableGrantId([
+        entry({ grantId: "sos", shareKind: "sos", expiresAt: null }),
+        entry({ grantId: "ordinary" }),
+      ]),
+    ).toBe("ordinary");
+  });
+
+  it("resolves to the SOS share when it is the only thing running", () => {
+    expect(
+      resolveStoppableGrantId([entry({ grantId: "sos", shareKind: "sos" })]),
+    ).toBe("sos");
+  });
+
+  it("offers no single Stop for two different people", () => {
+    expect(
+      resolveStoppableGrantId([
+        entry({ grantId: "to_b", recipientUserId: "user_b" }),
+        entry({ grantId: "to_c", recipientUserId: "user_c" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("offers nothing when nothing is live", () => {
+    expect(resolveStoppableGrantId([])).toBeNull();
   });
 });

--- a/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
@@ -499,6 +499,54 @@ describe("runSosPanic", () => {
     expect(new Date(incident.startedAt).toString()).not.toBe("Invalid Date");
   });
 
+  it("records ONLY the ids this alert created, never a share that was already live", async () => {
+    // What makes "I'm safe" safe. `handleStopSos` revokes exactly the ids in
+    // the incident, and `revokeGrant` is single-id with no cascade -- so the
+    // stop path was innocent in #5506 all along, and it stays innocent only
+    // for as long as this list contains nothing but grants this alert made.
+    //
+    // Pinned as a property rather than as a value, because the tempting future
+    // "optimisation" is to reuse an existing live share instead of creating a
+    // second grant. That would put a pre-existing grant id in here and
+    // reintroduce the exact bug at stop time: ending the alert would revoke
+    // the ordinary share the owner never meant to end.
+    const rA = makeRecipient("userA");
+    const rB = makeRecipient("userB");
+    createGrantMock
+      .mockResolvedValueOnce(makeGrant("sos-1", "userA"))
+      .mockResolvedValueOnce(makeGrant("sos-2", "userB"));
+    const publish = vi.fn().mockResolvedValue(undefined);
+
+    const incident = await runSosPanic({
+      vaultOwnerToken: "tok",
+      recipients: [rA, rB],
+      point: makePoint(),
+      publish,
+    });
+
+    // `createGrant` is async, so each recorded result is the promise it
+    // returned. Reading the ids back OUT of those results is the point: the
+    // assertion below compares the incident against what the service actually
+    // handed back, not against the literals the mock was primed with.
+    const created = await Promise.all(
+      createGrantMock.mock.results.map(
+        (result) => result.value as Promise<OneLocationGrant>,
+      ),
+    );
+    const createdIds = created.map((grant) => grant.id);
+    expect(createdIds).toEqual(["sos-1", "sos-2"]);
+    expect(incident.grantIds).toEqual(createdIds);
+    // Every call that produced one of these ids asked for the SOS lane. An id
+    // in here that came from an ordinary `createGrant` would mean "I'm safe"
+    // could revoke an ordinary share.
+    for (const call of createGrantMock.mock.calls) {
+      expect(call[0].shareKind).toBe("sos");
+      expect(call[0].reason).toBe("sos_panic");
+    }
+    const saved = saveSosIncidentMock.mock.calls[0][0];
+    expect(saved.grantIds).toEqual(createdIds);
+  });
+
   it("on full success calls saveSosIncident exactly once", async () => {
     const rA = makeRecipient("userA");
     const rB = makeRecipient("userB");

--- a/hushh-webapp/lib/one-location/grant-lanes.ts
+++ b/hushh-webapp/lib/one-location/grant-lanes.ts
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * Grouping live grants by PERSON, now that a person can hold two of them.
+ *
+ * Replacement of a live location share is scoped to a lane on the backend, and
+ * there are exactly two lanes: the emergency one (`share_kind === "sos"`, what
+ * this UI calls SMS / Save My Soul) and everything else. So an owner and a
+ * recipient can legitimately have two live grants between them at once -- an
+ * ordinary share and an SOS share -- and a great deal of client code was
+ * written when "a grant" and "a person" were the same thing.
+ *
+ * Every surface that lists people has to stop equating the two, and it has to
+ * do it the same way, using the same discriminator the server stamps on every
+ * grant (`shareKind`, read through {@link isSmsTriggeredGrant}). Hence one
+ * grouping function rather than one per screen: the owner's Active shares list,
+ * the People directory and the recipient's "Shared with me" column all have to
+ * agree on what counts as the same person and which of their shares is which.
+ */
+
+import { isSmsTriggeredGrant } from "@/lib/one-location/notifications";
+import type { OneLocationGrant } from "@/lib/one-location/types";
+
+export type OneLocationGrantLaneGroup = {
+  /** The other person: the recipient of your shares, or the owner of theirs. */
+  counterpartUserId: string;
+  /**
+   * Every live grant with this person, in the order the caller supplied them.
+   * At most two after the lane split, but nothing here assumes that.
+   */
+  grants: OneLocationGrant[];
+  /**
+   * The grant a surface acts on when it can only show one. First in the
+   * caller's order, so an existing sort (received grants already float
+   * SMS-triggered shares to the top) keeps deciding what leads.
+   */
+  primaryGrant: OneLocationGrant;
+  /** The live emergency-lane grant with this person, if there is one. */
+  smsGrant: OneLocationGrant | null;
+  /** The live ordinary-lane grant with this person, if there is one. */
+  ordinaryGrant: OneLocationGrant | null;
+};
+
+/**
+ * Collapse a flat grant list into one entry per person, preserving order.
+ *
+ * `side` says which end of the grant you are: `"owner"` groups your outgoing
+ * shares by who can see you, `"recipient"` groups incoming ones by whose
+ * location you can see.
+ *
+ * A grant whose counterpart id is missing becomes its own group rather than
+ * merging into somebody else's -- splitting a row is a cosmetic defect, while
+ * merging two people into one row would attach one person's Stop button to
+ * another person's share.
+ */
+export function groupGrantsByCounterpart(
+  grants: OneLocationGrant[],
+  side: "owner" | "recipient",
+): OneLocationGrantLaneGroup[] {
+  const order: string[] = [];
+  const byCounterpart = new Map<string, OneLocationGrant[]>();
+
+  grants.forEach((grant, index) => {
+    const counterpartUserId =
+      (side === "owner" ? grant.recipientUserId : grant.ownerUserId) ||
+      `grant:${grant.id || index}`;
+    const existing = byCounterpart.get(counterpartUserId);
+    if (existing) {
+      existing.push(grant);
+      return;
+    }
+    order.push(counterpartUserId);
+    byCounterpart.set(counterpartUserId, [grant]);
+  });
+
+  return order.map((counterpartUserId) => {
+    const groupGrants = byCounterpart.get(counterpartUserId) ?? [];
+    return {
+      counterpartUserId,
+      grants: groupGrants,
+      // Non-null by construction: a key only exists because a grant created it.
+      primaryGrant: groupGrants[0] as OneLocationGrant,
+      smsGrant: groupGrants.find((grant) => isSmsTriggeredGrant(grant)) ?? null,
+      ordinaryGrant:
+        groupGrants.find((grant) => !isSmsTriggeredGrant(grant)) ?? null,
+    };
+  });
+}
+
+/**
+ * How to label one share inside a per-person row.
+ *
+ * Reuses the badge copy the recipient's card already shows for an SMS-triggered
+ * share, so the same share is not called two different things on two screens.
+ */
+export function grantLaneLabel(grant: OneLocationGrant): string {
+  return isSmsTriggeredGrant(grant) ? "Shared via SMS" : "Location share";
+}

--- a/hushh-webapp/lib/one-location/live-share-session.ts
+++ b/hushh-webapp/lib/one-location/live-share-session.ts
@@ -20,10 +20,32 @@
  * and this record never adds a share the backend does not report.
  */
 
+import {
+  normalizeOneLocationShareKind,
+  type OneLocationShareKind,
+} from "@/lib/one-location/notifications";
 import type { OneLocationGrant } from "@/lib/one-location/types";
 
 export type LiveShareSessionEntry = {
   grantId: string;
+  /**
+   * Who can see you through this grant.
+   *
+   * A pair can hold TWO live grants at once -- one ordinary share and one SOS
+   * -- so a grant is no longer a person. The count in {@link LiveShareWindow}
+   * is a headcount, and a headcount needs the head.
+   *
+   * Still identity-free by the standard this file sets: an opaque user id the
+   * device already holds, never a name, never a number.
+   */
+  recipientUserId: string;
+  /**
+   * Which replacement lane this share belongs to. Normalized to the same four
+   * kinds the rest of the client uses, from the `shareKind` the server puts on
+   * every grant -- so "is this the SMS one?" is answered here exactly as
+   * `isSmsTriggeredGrant` answers it everywhere else.
+   */
+  shareKind: OneLocationShareKind;
   /** When this share started, ISO 8601. */
   startedAt: string;
   /** When it auto-stops, ISO 8601. `null` means "until you stop". */
@@ -32,6 +54,11 @@ export type LiveShareSessionEntry = {
 
 /** The window every currently-live share of yours adds up to. */
 export type LiveShareWindow = {
+  /**
+   * How many PEOPLE can see you -- distinct recipients, not grants. One person
+   * holding both an ordinary share and an SOS share is one person, and saying
+   * "2 people" for a pair of shares to the same friend is simply wrong.
+   */
   count: number;
   /** Earliest start across the live shares. */
   startedAt: string;
@@ -68,6 +95,11 @@ function isEntry(value: unknown): value is LiveShareSessionEntry {
   if (!value || typeof value !== "object") return false;
   const entry = value as Partial<LiveShareSessionEntry>;
   if (typeof entry.grantId !== "string" || !entry.grantId) return false;
+  // `recipientUserId`/`shareKind` are deliberately NOT required here. Records
+  // written by a build from before this change are still perfectly good
+  // countdowns, and refusing them would blank a running share's first paint
+  // on the very upgrade that introduced the fields. They are normalized on
+  // read instead, and the server reconciliation fills them in within a second.
   if (typeof entry.startedAt !== "string" || toTime(entry.startedAt) === null) {
     return false;
   }
@@ -102,6 +134,9 @@ export function loadLiveShareEntries(
     return pruneLiveShareEntries(
       parsed.filter(isEntry).map((entry) => ({
         grantId: entry.grantId,
+        recipientUserId:
+          typeof entry.recipientUserId === "string" ? entry.recipientUserId : "",
+        shareKind: normalizeOneLocationShareKind(entry.shareKind),
         startedAt: entry.startedAt,
         expiresAt: entry.expiresAt ?? null,
       })),
@@ -168,6 +203,8 @@ export function reconcileLiveShareEntries(
     }
     next.push({
       grantId: grant.id,
+      recipientUserId: grant.recipientUserId ?? "",
+      shareKind: normalizeOneLocationShareKind(grant.shareKind),
       startedAt: knownStart.get(grant.id) ?? grant.createdAt ?? nowIso,
       expiresAt,
     });
@@ -194,10 +231,57 @@ export function liveShareEntriesEqual(
     return (
       Boolean(other) &&
       entry.grantId === other?.grantId &&
+      entry.recipientUserId === other?.recipientUserId &&
+      entry.shareKind === other?.shareKind &&
       entry.startedAt === other?.startedAt &&
       entry.expiresAt === other?.expiresAt
     );
   });
+}
+
+/**
+ * A stable grouping key for "which person is this share pointing at".
+ *
+ * Records written before recipient ids were stored have none. Such an entry
+ * becomes its own person rather than silently merging into somebody else's
+ * row -- over-counting for the second it takes the server state to reconcile,
+ * which is the safe direction for a privacy status.
+ */
+function recipientKey(entry: LiveShareSessionEntry, index: number): string {
+  return entry.recipientUserId || `grant:${entry.grantId || index}`;
+}
+
+/**
+ * The one grant the hero card's Stop (and its duration editor) may act on.
+ *
+ * The rule was "exactly one live entry", which read a GRANT count as a PERSON
+ * count. Once an ordinary share and an SOS share to the same person can both be
+ * live, that silently returned `null` for a single friend -- taking away the
+ * owner's Stop button and their end-time editor at the exact moment they had
+ * the most sharing running.
+ *
+ * The rule is a headcount now. With more than one person there is still no
+ * single share to end, so the card keeps offering Manage. With one person the
+ * ORDINARY share is what this resolves to: the SMS-lane share has its own Stop
+ * on the SOS screen, ending it is a distinct decision ("I'm safe") from ending
+ * a normal share, and after the two-lane split neither one stops the other.
+ * When the SOS share is the only thing running it resolves to that, which is
+ * exactly what happened before.
+ */
+export function resolveStoppableGrantId(
+  entries: LiveShareSessionEntry[],
+): string | null {
+  if (!entries.length) return null;
+  const people = new Set(entries.map(recipientKey));
+  if (people.size !== 1) return null;
+
+  const ordinary = entries.filter((entry) => entry.shareKind !== "sos");
+  const candidates = ordinary.length ? ordinary : entries;
+  // Same-lane replacement still guarantees one live grant per lane per pair, so
+  // this is a belt-and-braces refusal: given an ambiguity that should not exist,
+  // offer Manage rather than guess which share a tap meant to end.
+  if (candidates.length !== 1) return null;
+  return candidates[0]?.grantId ?? null;
 }
 
 /** Collapse the live shares into the one window the status card renders. */
@@ -229,8 +313,22 @@ export function summarizeLiveShareEntries(
     }
   }
 
+  // Count is per PERSON; time is per EXPOSURE. Only the headcount collapses to
+  // distinct recipients -- the start/end fold above deliberately ran over EVERY
+  // entry, because `endsAt` is documented as "when you stop being visible to
+  // everyone". Dropping a duplicate recipient's second grant to dedupe would
+  // render a 1-hour share plus an 8-hour SOS to one person as "ends in 1 hour"
+  // while the owner stays visible for eight: under-claiming your own exposure,
+  // which is the one direction this file must never round.
+  //
+  // An entry restored from a record written before recipient ids were stored
+  // has no id to group on. It counts as its own person rather than silently
+  // merging into somebody else's row -- over-counting for the second it takes
+  // the server to reconcile, which is the safe direction for a privacy status.
+  const people = new Set(entries.map(recipientKey));
+
   return {
-    count: entries.length,
+    count: people.size,
     startedAt,
     endsAt: openEnded ? null : endsAt,
   };

--- a/hushh-webapp/lib/one-location/sos-incident.ts
+++ b/hushh-webapp/lib/one-location/sos-incident.ts
@@ -1,10 +1,23 @@
 "use client";
 
 /**
- * Client-side record of an active SOS incident. The grant `metadata.reason`
- * ("sos_panic") is written server-side but NOT exposed via getState/OneLocationGrant,
- * so we persist the incident (its grant ids + start time) here to drive the
- * "LIVE LOCATION ACTIVE" banner and the "I'm safe" stop across reloads.
+ * Client-side record of an active SOS incident: which grants THIS device
+ * created when the alert went out, so the "LIVE LOCATION ACTIVE" banner and the
+ * "I'm safe" stop survive a reload.
+ *
+ * What this record is NOT is the only way to tell an SOS grant from an ordinary
+ * one. An earlier version of this comment claimed the server-side `sos_panic`
+ * marker was "not exposed via getState/OneLocationGrant"; that was already
+ * false, and acting on it would mean re-deriving a workaround for something the
+ * API already answers. `_grant_payload` puts `shareKind` on EVERY grant it
+ * returns, owner grants included, and `isSmsTriggeredGrant` in
+ * `lib/one-location/notifications.ts` is the single client-side reader of it.
+ * Use that to ask "is this the SMS share?" -- the two-lane replacement rule the
+ * backend now enforces depends on client and server agreeing on that question.
+ *
+ * What this record still uniquely holds is the SET of grants one particular
+ * "hold SOS" produced, which is what makes "I'm safe" tear down exactly what it
+ * created and nothing else.
  *
  * Coordinate-free by construction: only grant ids and an ISO timestamp are stored.
  */


### PR DESCRIPTION
Closes #5506
Closes #5550

## The share dies at SEND, not at stop

The bug was reported as "when A stops the alert, B's original 4h share is also revoked". The stop path was innocent throughout. `handleStopSos` revokes only the ids `runSosPanic` itself created, and `revoke_grant` is single-id with no cascade.

The 4h share died the moment the SOS grant was **created**. Every grant-creation path opened with a kind-blind

```sql
UPDATE one_location_share_grants
   SET status = 'revoked'
 WHERE owner_user_id = :o AND recipient_user_id = :r AND status = 'active'
```

There is no `share_kind` predicate, and `share_kind` is not a column — it lives in the `metadata` JSONB, which is why the replacement never saw it. So creating the 8h SOS grant tore down the 4h share as a matter of course, and did it **silently**: the replacement path emits `location_share_created` only, never `location_share_revoked`, and sends no push, unlike `revoke_grant` which does both. The SOS grant kept B's card looking alive, so the loss only surfaced at "I'm safe".

## Two lanes, not one lane per kind

Replacement is now scoped to a **lane**, and there are exactly **two**: the emergency lane (`share_kind == 'sos'`) and everything else.

This is deliberately not per-kind. `_classify_share_kind` returns four kinds, the `/api/one/location/grants` route accepts `share_kind` as free text with no enum, and the web client already sends values the backend never produces (`pick_me_up`). Per-exact-kind scoping would let one pair accumulate an unbounded number of live grants that no surface offers a Stop for. Two lanes caps a pair at exactly two: `drive_to`, `check_in`, `pick_me_up` and plain `share` all sit in the non-emergency lane together and go on replacing each other exactly as before.

The predicate is defined **once**, as a module-level SQL fragment, and applied at all three write sites (`_create_enforced_grant_row`, `create_grant`'s non-enforced branch, and the `revoked_grants` CTE in `create_grant_with_initial_envelope`). Three hand-copied divergent versions of that UPDATE are what let this bug exist; a fourth write path must not be addable without it. `is_sos_lane` is bound in **both** param builders, since the atomic path builds its own dict and a missing bind there fails open.

`_active_grant_between` becomes lane-aware in the same change, because coexistence breaks it: it resolves `ORDER BY created_at DESC LIMIT 1`, so during an emergency it returns the SOS grant — and `request_access`'s hardening fallback then silently redirected a client that correctly named the share it wanted extended onto the SOS grant, quoting its 8h back at them. The lane argument is required, so no future caller can leave it implicit.

## No migration is needed

There is no UNIQUE constraint or index on `(owner_user_id, recipient_user_id)` anywhere. Migrations 061, 065, 081, 134, 150, 154, 155 and 156 and their rollbacks were all checked. Two active rows per pair were already physically legal; the one-active-grant rule was pure application policy.

## The frontend half is not optional

The backend change legalises two active grants per pair, and three client paths equated one grant with one person. Shipping the lane split alone would turn a silent full revoke into a silent half-revoke — the same consent bug wearing a different hat. These land together.

The discriminator is the one that already exists: `isSmsTriggeredGrant`, reading the `shareKind` that `_grant_payload` puts on **every** grant, owner grants included. No second notion of lane was invented.

- **`live-share-session.ts`** — entries carry `recipientUserId` and `shareKind`. `summarizeLiveShareEntries` dedupes **only the count**, to distinct recipients; the start/end fold still runs over every entry. That split is load-bearing: `endsAt` is documented as "when you stop being visible to everyone", so folding a deduped list would render a 1h share plus an 8h SOS to one person as "ends in 1 hour" while the owner stays visible for eight. **Count is per person; time is per exposure**, and a privacy status may only round toward more exposure, never less.
- **`stoppableGrantId`** was `entries.length === 1`, a grant count read as a person count. One friend holding both shares silently returned null, taking away the hero card's Stop *and* the duration editor (the effect that force-closes it watches the same value) at the exact moment the most sharing was running. It resolves to the ordinary share now.
- **Active shares and People** render one row per person, expanding to a per-share list with its own expiry and its own Stop. People previously did `activeOwnerGrants.find(g => g.recipientUserId === r.userId)`, binding its single Stop to whichever grant came first.
- **"Shared with me"** renders one card per owner, SMS-badged while an sos-lane grant is live, expandable to both shares with their own expiries and their own control. The brief said display-only here, on the premise that a recipient cannot revoke an owner's grant server-side — that premise is wrong. `revoke_grant` matches `owner_user_id = :actor OR recipient_user_id = :actor` and records the difference as `owner_revoke` vs `recipient_revoke`, and the received card has always carried a Remove that goes through it. Grouping two shares behind one card therefore made that single button a *partial* action: it drops the leading grant (the SMS one, since received grants sort SMS-first) and leaves the other running with nothing saying which just went — the same silent-half-revoke shape this PR exists to remove, one layer up. Each share carries its own control now, the card-level Remove is suppressed while there are two, and the verb follows the side: the owner **stops** a share they are giving, the recipient **removes** one they were given.
- The card headline was wrong in the coexisting case: `names` mapped the grant list straight to labels, so one friend appeared twice and `Math.max(names.length, count)` printed "Sharing with 2 people" over a single name.

## Product decisions

Confirmed with the reporter: **one row per person on the owner side, expandable, with per-share-type control**. Stopping the SMS-lane share there is exactly equivalent to stopping it from the Emergency help screen — same grant id, same `revokeGrant` — and the normal share keeps its original countdown. Stopping the normal share never touches the SMS one. The recipient side is **one card per owner**, carrying the existing SMS badge, expandable to both shares — never the same person as two top-level cards.

One rule underneath both: **one control per share, never one per card**. A single button standing for two consents can only ever act on one of them, and cannot say which.

A person with a single share keeps the one-tap Stop they have always had; the disclosure appears only for someone who genuinely holds two.

## Closes #5550

On the SOS screen the local emergency dialer and "Stop sharing" were stacked vertically, which put two unrelated decisions on the axis the eye reads as a sequence and buried the dialer under a control that only exists while an alert is running. They are one row now: emergency number LEFT, "Stop sharing" RIGHT, with `flex-wrap` as the narrow-screen escape hatch rather than a breakpoint. Neither control ever shrinks. With no alert live the dialer keeps its centred placement. Behaviour, testids, aria labels and the Windows copy fallback are untouched.

## The regression test was confirmed red on `main`

`test_sos_grant_does_not_revoke_an_existing_normal_share` was run against `origin/main`'s service and fails with the bug verbatim:

```
tests/services/test_one_location_agent_service.py:4959: in test_sos_grant_does_not_revoke_an_existing_normal_share
    assert service.grants[normal["id"]]["status"] == "active"
E   AssertionError: assert 'revoked' == 'active'
```

Its two siblings fail on `main` too. It asserts three things, because the first alone would also pass under a "reuse the existing grant" implementation: both rows active, the normal grant's `expires_at` untouched, and a share-created notification actually fired for `resolved_kind='sos'`.

A test-infrastructure prerequisite came first: `FourUserMemoryService` faithfully reproduced the buggy semantics in both revoke seams. It is lane-scoped now exactly when the SQL says so, reading the lane out of the bound params, and its enforced-path stub imports the production predicate rather than retyping it — a copy that drifted would make every lane test green while the real UPDATE stayed broken.

## Residual exposure (follow-up, not this PR)

"I'm safe" is purely client-side — `handleStopSos` iterating ids out of localStorage. There is no server-side stop-SOS endpoint; the only SOS route is `/location/sos-email-recipients`. This PR removes the last incidental server-side reaper of an orphaned SOS grant: previously, any later share to the same person would have revoked it as a side effect of the kind-blind replacement.

Exposure stays bounded — `_resolve_share_duration` hard-refuses `until_stopped` for `sos`, so 8h is the ceiling — but a `revoke_active_grants(owner, lane='sos')` would close it properly. Filed as a follow-up.

## Test results

Backend, `consent-protocol`:

```
tests/test_one_location_routes.py ....................                   [ 13%]
tests/services/test_one_location_agent_service.py ...................... [ 28%]
........................................................................ [ 78%]
...............                                                          [ 88%]
tests/services/test_one_location_sos_email_service.py ................   [100%]

======================= 145 passed, 6 warnings in 8.41s =======================
```

Frontend, `hushh-webapp` (`lib/one-location/__tests__` + `components/one-location/redesign/__tests__`, plus the page suite):

```
 Test Files  60 passed (60)
      Tests  571 passed (571)

 Test Files  1 passed (1)     __tests__/components/one-location-agent-page.test.tsx
      Tests  101 passed (101)
```

`tsc --noEmit` clean, `eslint` clean on every changed file, and `verify:design-system`, `verify:surface-map`, `verify:service-boundary`, `verify-accent-tokens` and `verify-apple-hierarchy` all pass.

## Follow-ups filed

- #5553 — residual emergency exposure: no server-side stop-SOS endpoint, so "I'm safe" is client-side only. This PR removes the last incidental server-side reaper of an orphaned SOS grant.
- #5554 — same-lane replacement is still silent: no `location_share_revoked` event, no push, and the recipient's card shows a hardcoded green "Active" pill for up to 5 minutes. This is why the bug class was invisible.
- #5555 — single localStorage incident key: a second SOS overwrites the first and orphans its grant ids from "I'm safe".
- #5556 — chat and agent SOS paths never call `setSosIncident`, so those grants have no "I'm safe" at all.
- #5557 — the key-rotation sweep is lane-blind and can revoke an in-flight SOS grant.
- #5558 — `approve_request` quotes the wrong end time when an SOS grant to the same person is live.
