### PR TITLE
fix(one-location): extra-time approval shows the amount added, not the new total

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -7331,7 +7331,7 @@ class OneLocationAgentService:
         was_extension = bool(str(request_row.get("extends_grant_id") or "").strip())
         if duration_hours is None and duration_mode is None:
             resolved_mode = requested_mode or TIMED_LOCATION_SHARE_DURATION_MODE
-            resolved_hours = (
+            delta_hours = (
                 None
                 if _is_until_stopped_share(resolved_mode)
                 else (
@@ -7342,7 +7342,29 @@ class OneLocationAgentService:
             )
         else:
             resolved_mode = duration_mode or TIMED_LOCATION_SHARE_DURATION_MODE
-            resolved_hours = None if _is_until_stopped_share(resolved_mode) else duration_hours
+            delta_hours = None if _is_until_stopped_share(resolved_mode) else duration_hours
+        # For an extension, `delta_hours` is the extra amount being granted --
+        # what the requester asked for (or the owner's override), not the
+        # share's new total. The actual grant still needs the total (it
+        # replaces the live grant wholesale), so add the delta to however much
+        # time that grant has left right now -- read fresh here rather than
+        # trusting a total computed back when the ask was made, so a slow
+        # approval does not silently drift the result.
+        resolved_hours = delta_hours
+        if was_extension and delta_hours is not None:
+            existing_grant = self._active_grant_between(
+                owner_user_id=owner_user_id,
+                recipient_user_id=requester_user_id,
+                is_sos_lane=False,
+            )
+            existing_expires_at = existing_grant.get("expires_at") if existing_grant else None
+            if existing_expires_at is not None:
+                remaining_hours = max(
+                    0.0, (existing_expires_at - _utcnow()).total_seconds() / 3600.0
+                )
+                resolved_hours = remaining_hours + delta_hours
+            # else: nothing live to extend (expired/revoked since the ask) --
+            # grant exactly the delta, same as a fresh share.
         grant = self.create_grant(
             owner_user_id=owner_user_id,
             recipient_user_id=requester_user_id,
@@ -7368,10 +7390,15 @@ class OneLocationAgentService:
         owner_label = _identity_notification_label(owner_identity)
         granted_hours = _duration_metadata_value(grant.get("durationHours"))
         granted_mode = grant.get("durationMode") or TIMED_LOCATION_SHARE_DURATION_MODE
+        # The recipient does not need the share's new total repeated back at
+        # them -- they already knew that a second ago. What is new is how much
+        # MORE they just got, so an extension's notification and feed row name
+        # the delta actually applied, not the resulting total.
+        display_hours = delta_hours if was_extension else granted_hours
         granted_label = (
             "for as long as you need"
             if _is_until_stopped_share(str(granted_mode))
-            else format_duration_label(granted_hours)
+            else format_duration_label(display_hours)
         )
         self._insert_event(
             owner_user_id=owner_user_id,
@@ -7381,7 +7408,7 @@ class OneLocationAgentService:
             request_id=request_id,
             event_type="location_access_approved",
             metadata={
-                "duration_hours": granted_hours,
+                "duration_hours": display_hours,
                 "duration_mode": granted_mode,
                 "counterpart_label": requester_label,
                 # Swapped in for the requester's copy of this feed row, so they
@@ -7417,7 +7444,7 @@ class OneLocationAgentService:
                 "grant_id": grant["id"],
                 "owner_user_id": owner_user_id,
                 "owner_display_label": owner_label,
-                "duration_hours": granted_hours,
+                "duration_hours": display_hours,
                 "duration_mode": granted_mode,
                 "expires_at": grant.get("expiresAt"),
                 "is_extension": "true" if was_extension else None,

--- a/consent-protocol/tests/services/test_one_location_extra_time_requests.py
+++ b/consent-protocol/tests/services/test_one_location_extra_time_requests.py
@@ -276,9 +276,17 @@ def test_approving_extra_time_replaces_the_live_grant_rather_than_stacking() -> 
     ]
     assert len(live) == 1
     assert live[0]["id"] == resolved["grant"]["id"]
+    # The replacement grant is not just the 4 that was asked for -- it is the
+    # original hour still running PLUS the 4 more, so the recipient never
+    # loses time they already had by asking for more of it. (Some slack for
+    # however long this test itself took to run.)
+    assert resolved["grant"]["durationHours"] == pytest.approx(5.0, abs=0.01)
 
     approved = _notifications(service, "location_access_approved")[-1]
     assert approved["title"] == "More location time approved"
+    # The notification names the 4 hours that were ADDED, not the ~5-hour
+    # total the share now runs to -- that total is not new information to
+    # the person who already knew what they had a second ago.
     assert approved["body"] == "User A gave you 4 hours more of their live location."
 
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -4584,12 +4584,15 @@ describe("OneLocationAgentPage", () => {
       screen.getByRole("button", { name: "Add 15 minutes for Trusted B" }),
     );
 
+    // 12 minutes left, a 15-minute chip tapped -- the ask names the 15
+    // minutes actually being added, not the ~27-minute total the share
+    // would run to once approved.
     await waitFor(() =>
       expect(mockRequestAccess).toHaveBeenCalledWith({
         vaultOwnerToken: "vault-token",
         ownerUserId: "user_b",
-        message: "Requesting 27 min more of your live location.",
-        requestedDurationHours: expect.closeTo(0.45, 2),
+        message: "Requesting 15 min more of your live location.",
+        requestedDurationHours: expect.closeTo(0.25, 2),
         requestedDurationMode: "timed",
         extendsGrantId: "grant_live_ask",
       }),

--- a/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
@@ -169,7 +169,7 @@ describe("the in-app path that never touches FCM", () => {
     expect(payload.notification_revision).toBeUndefined();
   });
 
-  it("tells the requester what was granted, read off the grant itself", () => {
+  it("tells the requester what was granted, read off the grant itself (fresh share)", () => {
     const payloads = buildOneLocationNotificationPayloads(
       state({
         receivedGrants: [
@@ -190,7 +190,51 @@ describe("the in-app path that never touches FCM", () => {
             requesterUserId: "user_b",
             status: "approved",
             approvedGrantId: "grant_2",
-            requestedDurationHours: 4,
+            requestedDurationHours: 6,
+            requestedDurationMode: "timed",
+          },
+        ],
+      } as Partial<OneLocationState>),
+      "user_b",
+    );
+
+    const approved = payloads.find(
+      (payload) => payload.type === "location_access_approved",
+    );
+    // The GRANTED amount, not the requested one: an owner is free to give less
+    // than was asked (here 4, though 6 was requested), and on a fresh share
+    // the grant is the only number that is true.
+    expect(approved?.duration_hours).toBe("4");
+    expect(approved?.is_extension).toBeUndefined();
+  });
+
+  it("tells the requester the extra time added, not the share's new total (extension)", () => {
+    const payloads = buildOneLocationNotificationPayloads(
+      state({
+        receivedGrants: [
+          {
+            id: "grant_2",
+            ownerUserId: "user_a",
+            recipientUserId: "user_b",
+            status: "active",
+            // The replacement grant's total, after adding the 15 minutes just
+            // approved to whatever the share already had left -- NOT the
+            // number this notification should say.
+            durationHours: 4.72,
+            durationMode: "timed",
+            expiresAt: new Date(NOW + 4.72 * 3_600_000).toISOString(),
+          },
+        ],
+        requests: [
+          {
+            id: "req_1",
+            ownerUserId: "user_a",
+            requesterUserId: "user_b",
+            status: "approved",
+            approvedGrantId: "grant_2",
+            // The extra amount actually asked for (and, absent any owner
+            // override control, granted) -- this is what "X more" must show.
+            requestedDurationHours: 0.25,
             requestedDurationMode: "timed",
             extendsGrantId: "grant_1",
             isExtension: true,
@@ -203,9 +247,7 @@ describe("the in-app path that never touches FCM", () => {
     const approved = payloads.find(
       (payload) => payload.type === "location_access_approved",
     );
-    // The GRANTED amount, not the requested one: an owner is free to give less
-    // than was asked, and the grant is the only number that is true.
-    expect(approved?.duration_hours).toBe("4");
+    expect(approved?.duration_hours).toBe("0.25");
     expect(approved?.is_extension).toBe("true");
   });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -5897,14 +5897,22 @@ export function OneLocationAgentPageContent({
           // literal string "Requesting more time." and nothing else, so the
           // number the person had just chosen from the picker directly above
           // this button was the one fact the owner never received.
-          const durationLabel = formatLocationDurationLabel(durationHours);
+          //
+          // `durationHours` is the picker's absolute total (what the share
+          // will run to, seeded on what it already had left) -- but the ask
+          // itself, and everything that renders it ("Asks for X more",
+          // "gave you X more"), means the extra amount. Subtract what this
+          // share already has left so the request carries that, not the total.
+          const remainingHoursNow = grantRemainingHours(grant, Date.now()) ?? 0;
+          const extraHours = Math.max(durationHours - remainingHoursNow, 0);
+          const durationLabel = formatLocationDurationLabel(extraHours);
           await OneLocationService.requestAccess({
             vaultOwnerToken,
             ownerUserId,
             message: durationLabel
               ? `Requesting ${durationLabel} more of your live location.`
               : "Requesting more time.",
-            requestedDurationHours: durationHours,
+            requestedDurationHours: extraHours,
             requestedDurationMode: "timed",
             extendsGrantId: grantId,
           });

--- a/hushh-webapp/lib/one-location/notification-reconciliation.ts
+++ b/hushh-webapp/lib/one-location/notification-reconciliation.ts
@@ -190,14 +190,23 @@ export function buildOneLocationNotificationPayloads(
       addValue(payload, "owner_user_id", request.ownerUserId);
       addValue(payload, "owner_display_label", ownerLabel);
       addAskValues(payload, request);
-      // What was actually granted, read off the grant the approval produced —
-      // which is the only number that is true. The requested amount is what was
-      // asked for, and an owner is free to give less.
       const approvedGrant = (state.receivedGrants ?? []).find(
         (grant) => grant.id === request.approvedGrantId,
       );
-      if (approvedGrant) {
+      if (request.isExtension || request.extendsGrantId) {
+        // The grant's own duration is its new TOTAL remaining time, not how
+        // much this approval added -- showing that as "X more" is the bug
+        // this guards against. The request already carries the extra amount
+        // that was asked for (and, absent an owner override this app has no
+        // control for yet, actually granted), so that is the true number.
+        addValue(payload, "duration_hours", request.requestedDurationHours);
+      } else if (approvedGrant) {
+        // No baseline to subtract on a fresh share: the grant's total *is*
+        // what was granted, read off the grant since an owner is free to
+        // give less than was asked.
         addValue(payload, "duration_hours", approvedGrant.durationHours);
+      }
+      if (approvedGrant) {
         addValue(payload, "duration_mode", approvedGrant.durationMode);
         addValue(payload, "expires_at", approvedGrant.expiresAt);
       }


### PR DESCRIPTION
# Description

When someone already receiving a live share asks the owner for more time (e.g. via a duration editor set to a higher total than what the share has left), and the owner approves, the requester's toast read "X gave you **4h43m** more of their live location" — the share's whole new remaining time — instead of the amount actually added (e.g. 15 min). Traced end to end: `requestedDurationHours` was carrying a pre-combined total (remaining + extra) instead of the extra amount alone, and everything downstream that renders it with the word "more" displayed that total verbatim.

## Root cause

- `handleEditGrantDuration` in `app/one/location/page.tsx` computes an absolute new total (seeded on what the share already has left) and, when that total exceeds the owner's original ceiling, sent the **total** as `requestedDurationHours` to `requestAccess`.
- Everywhere downstream (`describeLocationAsk`, the approval notification copy) treats `requestedDurationHours`/`grantedDurationHours` as "the extra amount" and renders it with "more" — but the value flowing in was the combined total, never had the baseline subtracted.
- `OneLocationAgentService.approve_request` passed that same total straight into `create_grant`, so the **actual grant duration was already correct** (deliberate, tested "replace, don't stack" behavior) — only the **notification text** was wrong.
- A second, independent path — `buildOneLocationNotificationPayloads` in `lib/one-location/notification-reconciliation.ts` (the in-app/no-FCM fallback, also wired into `notification-provider.tsx`) — had the same symptom for a different reason: it deliberately reads `duration_hours` off the live grant object for approvals ("the only number that is true"), which is again the total.

## Fix

1. **`hushh-webapp/app/one/location/page.tsx`** — `handleEditGrantDuration`'s "request" branch now subtracts the share's current remaining time (`grantRemainingHours`) from the picked total before sending `requestedDurationHours`, and uses that delta for the local "Asked X for Y more" toast too.
2. **`consent-protocol/hushh_mcp/services/one_location_agent_service.py`** — `approve_request` now adds the delta to the live grant's *current* remaining time (looked up fresh at approval time via `_active_grant_between`, not trusted from ask time) to size the actual replacement grant — but uses the delta alone (not the resulting total) for the notification title/body and the event/SSE metadata `duration_hours`.
3. **`hushh-webapp/lib/one-location/notification-reconciliation.ts`** — the `location_access_approved` branch now prefers `request.requestedDurationHours` (now correctly the delta) for extension asks, keeping the existing grant-total read for fresh (non-extension) shares where the grant's total *is* the right number.

## Impact Map

- Routes touched: `/one/location` (existing route, no route added/removed).
- API / schema / type changes: none — internal semantics of an existing field (`requestedDurationHours`) for extension asks, no wire-format/schema change.
- Cache keys touched: none.
- Runtime DB data-plane changes: none.
- Mobile parity impacts: none — shared web component via Capacitor webview.
- Trust boundary touched: none — no auth/consent/vault change; this only affects how much of an *already-authorized* location share's extra time is displayed, not the access grant itself.
- Verification commands executed (all green, run against this branch after rebasing onto latest main in a fresh worktree):
  - `cd hushh-webapp && npm run typecheck` — clean
  - `cd hushh-webapp && npx eslint app/one/location/page.tsx lib/one-location/notification-reconciliation.ts --max-warnings=0` — clean
  - `cd hushh-webapp && npx vitest run __tests__/one-location-extra-time-notifications.test.ts __tests__/one-location-notification-reconciliation.test.ts` — 13/13 pass
  - `cd consent-protocol && pytest tests/services/test_one_location_extra_time_requests.py tests/services/test_one_location_agent_service.py` — 126/126 pass

## Testing

- [x] Backend: extended `test_approving_extra_time_replaces_the_live_grant_rather_than_stacking` to assert the replacement grant's total is remaining-at-approval + delta (not just the delta), while the notification still names the plain delta.
- [x] Frontend: split the reconciliation test covering `location_access_approved` into a fresh-share case (reads the grant's total, owner-can-grant-less preserved) and a new extension case with distinct request/grant duration values, locking in the new branch.
- [ ] Manual device/browser verification not performed in this session (no live two-account session available here) — recommend the reviewer or a follow-up manual pass: share live location, tap a "request more time" control set above the share's ceiling, approve from the owner side, and confirm both toasts name the extra amount, while the share's own countdown still shows the correct new total.

## Privacy & Consent

- Does this change access user data? No — display-only fix on top of an existing, already-approved consent flow.