### PR TITLE
fix(account): stop Reset/Delete 500ing on the SMS system Circle

### DIFF
--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -478,6 +478,28 @@ class AccountService:
         self._table_exists_cache[table_name] = exists
         return exists
 
+    def _column_exists(self, conn, table_name: str, column_name: str) -> bool:
+        cache_key = f"{table_name}.{column_name}"
+        cached = self._table_exists_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        exists = bool(
+            conn.execute(
+                text(
+                    """
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = :table_name
+                      AND column_name = :column_name
+                    """
+                ),
+                {"table_name": table_name, "column_name": column_name},
+            ).scalar()
+        )
+        self._table_exists_cache[cache_key] = exists
+        return exists
+
     def _delete_user_rows_if_table_exists(
         self,
         conn,
@@ -741,6 +763,28 @@ class AccountService:
                       AND circle.owner_user_id = :user_id
                       AND origin.origin_kind = 'named_circle'
                       AND origin.status = 'revoked'
+                    """
+                ),
+                params,
+            )
+        if self._table_exists(conn, "one_location_circles") and self._column_exists(
+            conn, "one_location_circles", "is_system"
+        ):
+            # Migration 160 added `one_location_circles_block_system_delete`, a
+            # trigger that refuses to hard- or soft-delete a Circle with
+            # is_system=true (the SMS/Emergency Circle) so an ordinary product
+            # code path can't silently switch off a user's SOS roster. That
+            # protection has no meaning once the SAME owner's account is being
+            # fully deleted or reset to fresh: the identity the Circle served
+            # is being wiped along with it, so demote it first in this same
+            # transaction and let the delete below proceed normally.
+            conn.execute(
+                text(
+                    """
+                    UPDATE one_location_circles
+                    SET is_system = FALSE
+                    WHERE owner_user_id = :user_id
+                      AND is_system
                     """
                 ),
                 params,

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -416,3 +416,198 @@ async def test_reset_account_returns_failure_on_error(monkeypatch):
     assert result["success"] is False
     assert result["account_reset"] is False
     assert result["error"] == "account_reset_failed"
+
+
+def _owned_circle_conn(monkeypatch, service, *, circle_rows):
+    """A conn double shaped like the real owned-Circle cleanup queries.
+
+    Regression coverage for migration 160
+    (`one_location_circles_block_system_delete`): the hard
+    `DELETE FROM one_location_circles WHERE owner_user_id = :user_id` in
+    `_delete_owned_named_circles` is refused by that trigger for any row with
+    `is_system = true` (the SMS/Emergency Circle every user gets provisioned
+    on login), because the trigger's job is to stop an ordinary code path from
+    silently switching off SOS. Account-level cleanup is not an ordinary code
+    path -- it is the same owner's entire account being deleted or reset -- so
+    it must demote is_system before the hard delete instead of being blocked
+    by it. This reproduces the exact production failure
+    (psycopg2.errors.RestrictViolation, UAT 2026-08-19) and proves the fix.
+    """
+    conn = MagicMock()
+    circle_result = MagicMock()
+    circle_result.mappings.return_value.all.return_value = circle_rows
+    member_result = MagicMock()
+    member_result.mappings.return_value.all.return_value = []
+
+    def execute(query, _params=None):
+        sql = str(query)
+        if (
+            "circle.id" in sql
+            and "FROM one_location_circles circle" in sql
+            and "FOR UPDATE OF circle" in sql
+        ):
+            return circle_result
+        if "SELECT DISTINCT membership.user_id" in sql:
+            return member_result
+        return MagicMock()
+
+    conn.execute.side_effect = execute
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: True)
+    monkeypatch.setattr(service, "_column_exists", lambda _conn, _table, _column: True)
+    monkeypatch.setattr(
+        "hushh_mcp.services.one_location_circle_service."
+        "OneLocationCircleService._cleanup_ineligible_sms_contacts",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.connection_graph_service."
+        "ConnectionGraphService.revoke_named_circle_origins",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.one_location_circle_service."
+        "OneLocationCircleService._reconcile_circle_sourced_grants",
+        lambda *_a, **_k: None,
+    )
+    return conn
+
+
+def test_owned_circle_cleanup_demotes_system_circle_before_hard_delete(monkeypatch):
+    service = AccountService()
+    conn = _owned_circle_conn(
+        monkeypatch,
+        service,
+        circle_rows=[
+            {"id": "circle_system", "is_owner": True, "has_active_membership": True},
+            {"id": "circle_ordinary", "is_owner": True, "has_active_membership": True},
+        ],
+    )
+
+    results: dict[str, bool] = {}
+    service._delete_owned_named_circles(conn, user_id="owner", results=results)
+
+    executed_sql = [str(call.args[0]) for call in conn.execute.call_args_list]
+    demote_index = next(
+        index
+        for index, sql in enumerate(executed_sql)
+        if "UPDATE one_location_circles" in sql and "SET is_system = FALSE" in sql
+    )
+    demote_params = conn.execute.call_args_list[demote_index].args[1]
+    delete_index = next(
+        index for index, sql in enumerate(executed_sql) if "DELETE FROM one_location_circles" in sql
+    )
+
+    # The demotion runs in the SAME transaction, scoped to this owner only,
+    # and strictly before the hard delete -- otherwise the trigger still fires.
+    assert demote_index < delete_index
+    assert "AND is_system" in executed_sql[demote_index]
+    assert demote_params == {"user_id": "owner"}
+    assert results["one_location_circles"] is True
+
+
+def test_owned_circle_cleanup_skips_is_system_demotion_when_column_missing(monkeypatch):
+    """Environments that have not yet run migration 160 must not regress.
+
+    `is_system` is a real column, not an optional-table cleanup entry, so this
+    guards the one case `_table_exists` alone would miss: the table is there
+    (migration 134) but migration 160 has not applied yet on that replica.
+    """
+    service = AccountService()
+    conn = _owned_circle_conn(
+        monkeypatch,
+        service,
+        circle_rows=[{"id": "circle_a", "is_owner": True, "has_active_membership": True}],
+    )
+    monkeypatch.setattr(service, "_column_exists", lambda _conn, _table, _column: False)
+
+    results: dict[str, bool] = {}
+    service._delete_owned_named_circles(conn, user_id="owner", results=results)
+
+    executed_sql = [str(call.args[0]) for call in conn.execute.call_args_list]
+    assert not any("SET is_system = FALSE" in sql for sql in executed_sql)
+    assert any("DELETE FROM one_location_circles" in sql for sql in executed_sql)
+
+
+def test_owned_circle_cleanup_handles_owner_with_no_circles(monkeypatch):
+    """Legacy / already-cleaned accounts: zero owned Circles must not crash."""
+    service = AccountService()
+    conn = _owned_circle_conn(monkeypatch, service, circle_rows=[])
+
+    results: dict[str, bool] = {}
+    service._delete_owned_named_circles(conn, user_id="owner_no_circles", results=results)
+    # Idempotent: calling it again (e.g. a retried delete request) is also safe.
+    service._delete_owned_named_circles(conn, user_id="owner_no_circles", results=results)
+
+    assert results["one_location_circles"] is True
+
+
+@pytest.mark.asyncio
+async def test_full_account_deletion_demotes_system_circle_before_deleting_it(monkeypatch):
+    """End-to-end reproduction of the DELETE /api/account/delete regression."""
+    service = AccountService()
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: True)
+    monkeypatch.setattr(service, "_column_exists", lambda _conn, _table, _column: True)
+
+    conn = _owned_circle_conn(
+        monkeypatch,
+        service,
+        circle_rows=[{"id": "sms_circle", "is_owner": True, "has_active_membership": True}],
+    )
+
+    with patch("hushh_mcp.services.account_service.get_db_connection", return_value=_db(conn)):
+        result = await service._delete_full_account(
+            "user_with_system_circle", requested_target="both"
+        )
+
+    assert result["success"] is True
+    assert result["account_deleted"] is True
+
+    executed_sql = [str(call.args[0]) for call in conn.execute.call_args_list]
+    demote_index = next(
+        index
+        for index, sql in enumerate(executed_sql)
+        if "UPDATE one_location_circles" in sql and "SET is_system = FALSE" in sql
+    )
+    delete_index = next(
+        index for index, sql in enumerate(executed_sql) if "DELETE FROM one_location_circles" in sql
+    )
+    assert demote_index < delete_index
+
+
+@pytest.mark.asyncio
+async def test_reset_account_demotes_system_circle_before_deleting_it(monkeypatch):
+    """End-to-end reproduction of the POST /api/account/reset regression."""
+    service = AccountService()
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: True)
+    monkeypatch.setattr(service, "_column_exists", lambda _conn, _table, _column: True)
+
+    conn = _owned_circle_conn(
+        monkeypatch,
+        service,
+        circle_rows=[{"id": "sms_circle", "is_owner": True, "has_active_membership": True}],
+    )
+
+    with patch("hushh_mcp.services.account_service.get_db_connection", return_value=_db(conn)):
+        result = await service.reset_account("user_with_system_circle")
+
+    assert result["success"] is True
+    assert result["account_reset"] is True
+
+    executed_sql = [str(call.args[0]) for call in conn.execute.call_args_list]
+    demote_index = next(
+        index
+        for index, sql in enumerate(executed_sql)
+        if "UPDATE one_location_circles" in sql and "SET is_system = FALSE" in sql
+    )
+    delete_index = next(
+        index for index, sql in enumerate(executed_sql) if "DELETE FROM one_location_circles" in sql
+    )
+    assert demote_index < delete_index
+    # Reset keeps sign-in: the identity/vault spine is never deleted.
+    spine_fragments = [
+        "DELETE FROM actor_profiles",
+        "DELETE FROM vault_keys",
+        "DELETE FROM vault_key_wrappers",
+    ]
+    for fragment in spine_fragments:
+        assert fragment not in "\n".join(executed_sql)


### PR DESCRIPTION
Closes #5574.

## What broke

Both `Reset account` and `Delete account` return 500 on UAT for any user who has a system Circle (the SMS/Emergency Circle every account gets provisioned on login):

```
DELETE /api/account/delete → 500 {"detail":"Account deletion failed"}
POST   /api/account/reset  → 500 {"detail":"Account reset failed"}
```

## Root cause

PR #5505 (migration `160_one_location_system_circles.sql`, merged 2026-08-19) added a Postgres trigger, `one_location_circles_block_system_delete`, that refuses to hard- or soft-delete any `one_location_circles` row with `is_system = true` — intentionally, so an ordinary in-product code path can't silently switch off a user's SOS roster.

That PR never touched `hushh_mcp/services/account_service.py`. Its `_delete_owned_named_circles` helper — shared by both `reset_account` and `_delete_full_account` — issues an unconditional `DELETE FROM one_location_circles WHERE owner_user_id = :user_id` as part of full account cleanup. Since `ensure_sms_system_circle` provisions the system Circle for every owner at bootstrap, that DELETE now hits the new trigger for effectively every active UAT user, raising `psycopg2.errors.RestrictViolation`. The route layer maps that to a generic 500 (logging the real exception, per `logger.error`/`logger.exception`, which is how this was diagnosed from UAT Cloud Logging).

Confirmed via `consent-protocol` logs in `hushh-pda-uat`:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.RestrictViolation)
one_location_circles: system Circle f6c0f282-... cannot be deleted
CONTEXT:  PL/pgSQL function one_location_circles_block_system_delete() line 6 at RAISE
[SQL: DELETE FROM one_location_circles WHERE owner_user_id = %(user_id)s]
```

Both endpoints fail for the **same shared-helper root cause**, not two separate bugs.

## Fix

In `_delete_owned_named_circles`, demote `is_system` to `false` for the owner's own circles in the same transaction, immediately before the existing hard delete. The protection exists to stop casual in-product deletion while the account is in active use — it has no purpose once the same owner's entire account is being deleted or reset, since the identity the Circle served is being wiped along with it. Guarded with a new `_column_exists` check (matching the file's existing `_table_exists` idiom) so an environment that hasn't run migration 160 yet is unaffected.

No trigger, migration, or frontend change — the frontend proxy routes already forward the real status/error and never fake a success on a backend failure.

## Contracts preserved

- **Reset**: still keeps sign-in (never touches `actor_profiles`/`vault_keys`/`vault_key_wrappers`), still clears the same personal-data tables it always did.
- **Delete**: still removes the full account, including the SMS/Emergency Circle itself (now successfully, instead of 500ing).
- Ordinary (non-system) Circles are unaffected — this only touches the owner's own rows, only during account-level cleanup.

## Tests

`consent-protocol/tests/services/test_account_service_cleanup_tables.py`:
- `test_owned_circle_cleanup_demotes_system_circle_before_hard_delete` — exact regression repro at the helper level.
- `test_owned_circle_cleanup_skips_is_system_demotion_when_column_missing` — schema-drift safety (migration 160 not yet applied).
- `test_owned_circle_cleanup_handles_owner_with_no_circles` — legacy/already-cleaned account, called twice (idempotency).
- `test_full_account_deletion_demotes_system_circle_before_deleting_it` — end-to-end delete regression repro.
- `test_reset_account_demotes_system_circle_before_deleting_it` — end-to-end reset regression repro, plus re-asserts sign-in is preserved.

All 5 new tests fail on the pre-fix code (verified by reverting the fix locally and re-running — 3 fail with `StopIteration`/`RuntimeError`, since the demote statement doesn't exist yet — the other 2 are drift/idempotency tests that pass either way and were kept for coverage) and pass with it applied. Full account/circle-scoped sweep: `pytest tests/ -k "account or circle"` → 248 passed. `ruff check` + `ruff format --check` clean.

## Test plan

- [x] Backend regression tests added and mutation-checked against the pre-fix code
- [x] `pytest tests/ -k "account or circle"` — 248 passed
- [x] `ruff check` / `ruff format --check` clean
- [ ] Deploy to UAT and verify Reset + Delete against disposable test accounts (real system-Circle case)
- [ ] Re-verify unrelated Location/Circle/SOS flows are untouched