### PR TITLE
fix(one-location): stop the nearby check-in countdown rounding up a minute

### DIFF
--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -928,6 +928,39 @@ describe("NearbyCheckInSheet", () => {
     expect(screen.getByText("Not accepting requests")).toBeInTheDocument();
   });
 
+  it("rounds the live countdown to the nearest minute instead of always up", async () => {
+    service.getNearbyPresence.mockResolvedValue({
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: false,
+        consentVersion: "one-location-nearby-presence-v3",
+        checkedInAt: new Date().toISOString(),
+        // A 30-minute check-in rendered a beat after the server stamped
+        // `expiresAt` -- realistic request latency, not clock skew. Ceiling
+        // rounding turned any such overage into "31 min left"; nearest-minute
+        // rounding must not.
+        expiresAt: new Date(Date.now() + 30 * 60_000 + 500).toISOString(),
+        placeLabel: "Stanford University",
+      },
+      attendees: [],
+    });
+
+    render(
+      <NearbyCheckInSheet
+        open
+        ownerId="user-1"
+        vaultOwnerToken="owner-token"
+        captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(/30 min left/)).toBeInTheDocument();
+    expect(screen.queryByText(/31 min left/)).not.toBeInTheDocument();
+  });
+
   it("clears the previous owner's roster before loading a new owner", async () => {
     service.getNearbyPresence
       .mockResolvedValueOnce({

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -310,7 +310,7 @@ function coarseAccuracyNotice(point: PlainLocationPoint): string {
 function timeLeftLabel(expiresAt: string): string {
   const remainingMs = Date.parse(expiresAt) - Date.now();
   if (!Number.isFinite(remainingMs) || remainingMs <= 0) return "Ending now";
-  const minutes = Math.max(1, Math.ceil(remainingMs / 60_000));
+  const minutes = Math.max(1, Math.round(remainingMs / 60_000));
   if (minutes < 60) return `${minutes} min left`;
   const hours = Math.floor(minutes / 60);
   const remainder = minutes % 60;


### PR DESCRIPTION
# Description

On the Nearby Check-in screen, the live "X min left" countdown on the active check-in card showed one minute more than was actually picked -- selecting "30 min" reliably read "31 min left" on first render.

`timeLeftLabel()` in `nearby-check-in-sheet.tsx` computed `remainingMs = Date.parse(expiresAt) - Date.now()` and rounded with `Math.ceil`. `expiresAt` is stamped server-side, so by the time the client renders it, ordinary request latency (client asks to check in -> server stamps `expiresAt` -> client renders) has already put `remainingMs` a small positive fraction past the exact `durationMinutes * 60_000` boundary. `Math.ceil` turns *any* such overage into a full extra minute, so this reproduced essentially every time, not occasionally.

Fix: `Math.ceil` -> `Math.round`. Only rounds up once the remainder passes 30 real seconds, which normal latency never reaches, while still rounding down cleanly as the countdown actually ticks toward zero. Kept the existing `Math.max(1, ...)` floor.

Pure client-side display-rounding fix -- no backend or `service.ts` changes; `expiresAt`'s origin is unaffected.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/location` -> Nearby check-in (only `components/one-location/nearby-check-in/nearby-check-in-sheet.tsx` changed)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None
    - Shared React component; the Capacitor webview renders the same JSX. No native code touched.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable
    - Pure rounding-direction change; no new failure mode.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location` -> Nearby check-in.
    - `components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx` -- new test "rounds the live countdown to the nearest minute instead of always up" reproduces the exact latency-overage case (30 min + 500ms) and asserts "30 min left", not "31 min left". Full file: 40/40 passing.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` (`npx tsc --noEmit -p tsconfig.json`) -- clean
  - [x] `cd hushh-webapp && npx vitest run components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx` -- 40/40 pass
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (not applicable -- no native change)
  - [ ] `python scripts/ops/kai-system-audit.py ...` (not applicable -- no backend/Kai change)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Reachable production attach point: `timeLeftLabel()` inside `NearbyCheckInSheet`, rendered from `/one/location`'s nearby check-in flow.
- [x] New tests import and exercise production code (the real `NearbyCheckInSheet` component via RTL render), not mock-only helpers.
- [x] New helpers/components/services are wired to an existing route -- no new files.
- [x] Production surface proved: new test renders the real component and asserts the rendered text.
- [x] Required checks are current on this head, commit is signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] Not a stacked PR.
- [x] Not a response to requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx`)
- [ ] **iOS**: Not applicable -- shared React component, no native code touched.
- [ ] **Android**: Not applicable -- shared React component, no native code touched.

## 🧪 Testing

- [x] Tested on Web (Chrome, local dev server)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command (not applicable)

## 📸 Screenshots / Video

Route: `/one/location` -> Nearby check-in. Reproduced and verified interactively in the local dev server: picking "30 min" now reads "30 min left" immediately, not "31 min left". Automated proof is the new regression test above (asserts the exact latency-overage scenario).

## 🛡️ Privacy & Consent

- Does this change access user data? No.
- Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: not applicable -- pure rounding change, no new code path.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed (no dependency changes)
