### PR TITLE
fix(one-location): restore the Save my Soul emergency screen

### DIFF
--- a/config/protected-behaviors.json
+++ b/config/protected-behaviors.json
@@ -477,7 +477,7 @@
     },
     {
       "name": "one-location-emergency-control-is-labelled-sms",
-      "summary": "The emergency control reads \"SMS\" on every surface a person meets it: the hold button on the Emergency help screen, and the Home hub quick-action tile. The screen description names the same word the button shows.",
+      "summary": "The emergency control reads \"SMS\" on every surface a person meets it: the hold button on the Save my Soul screen, and the Home hub quick-action tile. The screen description names the same word the button shows.",
       "fixed_by": "#5587",
       "why_it_needs_a_lock": [
         "This label flipped twice in two days -- SMS -> SOS on 2026-08-18 across",

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2114,7 +2114,7 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("resolves a fresh local emergency number as Save My Soul opens", async () => {
-    const { rerender } = render(<OneLocationAgentPage />);
+    render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
     mockCaptureCurrentPosition.mockClear();
     const envelopeWritesBeforeOpen = mockStoreEnvelope.mock.calls.length;
@@ -2122,7 +2122,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /^SMS$/i }));
 
     expect(
-      await screen.findByRole("heading", { name: "Emergency help", level: 1 }),
+      await screen.findByRole("heading", { name: "Save my Soul", level: 1 }),
     ).toBeTruthy();
     await waitFor(() =>
       expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1),
@@ -2135,27 +2135,7 @@ describe("OneLocationAgentPage", () => {
     await expectEmergencyAction("112", "India");
     expect(mockStoreEnvelope).toHaveBeenCalledTimes(envelopeWritesBeforeOpen);
 
-    // SOS no longer draws an in-content Cancel — the shell's single back
-    // control is the only way out, same as every other Location screen. In
-    // production it strips `?action=` and the flow-sync effect closes the
-    // flow, the same mechanism the OS/chrome back button drives. This test
-    // simulates that URL change directly rather than clicking a control that
-    // no longer exists.
-    //
-    // Two renders, not one: the flow was opened by clicking the hub tile,
-    // which sets `pendingFlowRef` to guard the flow against the effect
-    // "correcting" it back to "none" before the URL has caught up — the mock
-    // router never actually updates `useSearchParams()`, so that ref is still
-    // armed. Reflecting `action=sos` first lets the effect's own pass-through
-    // clear the guard (see `location-redesign-hub.tsx`'s flow-sync effect);
-    // only then does dropping the action param actually close the flow.
-    const sosParams = new URLSearchParams("action=sos");
-    mockUseSearchParams.mockReturnValue(sosParams);
-    rerender(<OneLocationAgentPage />);
-
-    const hubParams = new URLSearchParams();
-    mockUseSearchParams.mockReturnValue(hubParams);
-    rerender(<OneLocationAgentPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(
       await screen.findByTestId("one-location-status-card"),
     ).toBeTruthy();
@@ -2220,7 +2200,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: "Emergency help", level: 1 }),
+      await screen.findByRole("heading", { name: "Save my Soul", level: 1 }),
     ).toBeTruthy();
     await expectEmergencyAction("112", "India");
     expect(
@@ -2266,7 +2246,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: "Emergency help", level: 1 }),
+      await screen.findByRole("heading", { name: "Save my Soul", level: 1 }),
     ).toBeTruthy();
     expect(
       await screen.findByRole("button", {
@@ -2309,7 +2289,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     expect(
-      await screen.findByRole("heading", { name: "Emergency help", level: 1 }),
+      await screen.findByRole("heading", { name: "Save my Soul", level: 1 }),
     ).toBeTruthy();
     expect(
       await screen.findByRole("button", {

--- a/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
@@ -74,7 +74,7 @@ describe("One Location SMS emergency actions", () => {
 
   it("uses the shared TaskFlowHeader, titled with its own crumb", () => {
     expect(SMS_PANEL_SOURCE).toContain("TaskFlowHeader");
-    expect(SMS_PANEL_SOURCE).toContain('title="Emergency help"');
+    expect(SMS_PANEL_SOURCE).toContain('title="Save my Soul"');
     // No route-local <h1>: the header primitive owns the title element.
     expect(SMS_PANEL_SOURCE).not.toContain("<h1");
   });

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -543,8 +543,8 @@ describe("top shell breadcrumbs", () => {
     const cases: Array<[string, string]> = [
       ["check-in", "Check-In"],
       ["private-check-in", "Private Check-In"],
-      // The crumb mirrors the screen's own <h1>, which reads "Emergency help".
-      ["sos", "Emergency help"],
+      // The crumb mirrors the screen's own <h1>, which reads "Save my Soul".
+      ["sos", "Save my Soul"],
       // NOTE: sms-contacts is deliberately absent from this table — it is the
       // one flow whose back target is not the hub (it retraces to whoever
       // opened it), so its label and back href are asserted separately below.

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -167,14 +167,14 @@ describe("SosPanel", () => {
       // Header grammar shared with every other Location task flow: the <h1>
       // repeats the last breadcrumb crumb, and the top bar owns the trail.
       expect(
-        screen.getByRole("heading", { level: 1, name: "Emergency help" }),
+        screen.getByRole("heading", { level: 1, name: "Save my Soul" }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Hold SMS to alert your people and share your location.",
+          "Alerts your emergency contacts with your live location.",
         ),
       ).toBeInTheDocument();
-      expect(screen.getByText("1 person will be alerted")).toBeInTheDocument();
+      expect(screen.getByText(/Alerts Carol/)).toBeInTheDocument();
       expect(screen.getByRole("link", { name: /call 112/i })).toHaveAttribute(
         "href",
         "tel:112",
@@ -390,13 +390,15 @@ describe("SosPanel", () => {
     expect(screen.queryByText(/Hold to send…/)).toBeNull();
   });
 
-  it("passes the selected fixed message and opens contacts from the Emergency contacts row", () => {
+  it("passes the selected fixed message and exposes Contacts and Cancel", () => {
     const onTrigger = vi.fn();
+    const onClose = vi.fn();
     const onEditContacts = vi.fn();
     render(
       <SosPanel
         {...baseProps}
         onTrigger={onTrigger}
+        onClose={onClose}
         onEditContacts={onEditContacts}
       />,
     );
@@ -409,8 +411,10 @@ describe("SosPanel", () => {
     act(() => vi.advanceTimersByTime(2_000));
     expect(onTrigger).toHaveBeenCalledWith("I'm not safe");
 
-    fireEvent.click(screen.getByRole("button", { name: /will be alerted/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit SMS contacts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onEditContacts).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("counts the message to 140 characters and fails closed above the limit", () => {
@@ -423,9 +427,8 @@ describe("SosPanel", () => {
       name: /press and hold for two seconds/i,
     });
 
-    // An empty field shows no counter — "0/140" is not information worth
-    // printing before anyone has typed a character.
-    expect(screen.queryByText("0/140")).toBeNull();
+    // An empty field is a valid alert: the payload is the location.
+    expect(screen.getByText("0/140")).toBeInTheDocument();
     expect(hold).toBeEnabled();
 
     fireEvent.change(composer, { target: { value: "a".repeat(140) } });
@@ -508,6 +511,7 @@ describe("SosPanel", () => {
     expect(screen.getByTestId("sos-status-label")).toHaveTextContent(
       "Live location",
     );
+    expect(screen.getByText("Live")).toBeInTheDocument();
     const cancel = screen.getByRole("button", {
       name: "Cancel the alert and stop sharing your location",
     });
@@ -589,7 +593,7 @@ describe("SosPanel", () => {
     expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
   });
 
-  it("keeps the SOS action in one centered stack on large screens", () => {
+  it("keeps the SMS action in one centered stack on large screens", () => {
     const { container } = render(<SosPanel {...baseProps} />);
     // The press ring + controls must not split into a desktop grid. Width is
     // owned by the shell's AppPageShell container, not by this panel.
@@ -617,15 +621,15 @@ describe("SosPanel — shell header contract", () => {
     render(<SosPanel {...baseProps} />);
 
     expect(
-      screen.getByRole("heading", { level: 1, name: "Emergency help" }),
+      screen.getByRole("heading", { level: 1, name: "Save my Soul" }),
     ).toBeInTheDocument();
   });
 
-  it("keeps the Emergency contacts action reachable above the SOS button", () => {
+  it("keeps the design's Contacts action reachable from the header row", () => {
     const onEditContacts = vi.fn();
     render(<SosPanel {...baseProps} onEditContacts={onEditContacts} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /will be alerted/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit SMS contacts" }));
     expect(onEditContacts).toHaveBeenCalledTimes(1);
   });
 
@@ -636,16 +640,12 @@ describe("SosPanel — shell header contract", () => {
     expect(screen.queryByLabelText("Back to Location")).toBeNull();
   });
 
-  // #5253/#5251 removed the in-content back button; this redesign goes
-  // further and drops the in-content Cancel too, since a second exit next to
-  // a real emergency control invites the wrong tap under stress. The shell's
-  // single back control is the only way out, same as every other Location
-  // screen — `onClose` stays in the props contract (see SosPanelProps) but
-  // the panel itself no longer wires it to a visible control.
-  it("draws no in-content Cancel control — the shell's back control is the only exit", () => {
-    render(<SosPanel {...baseProps} />);
+  it("keeps a Cancel control that returns to the Location hub", () => {
+    const onClose = vi.fn();
+    render(<SosPanel {...baseProps} onClose={onClose} />);
 
-    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("declares no inline <style> block — motion lives in globals.css", () => {

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -10,13 +10,7 @@ import {
   type MutableRefObject,
   type PointerEvent,
 } from "react";
-import {
-  Check,
-  Loader2,
-  Phone,
-  SendHorizontal,
-  UsersRound,
-} from "lucide-react";
+import { Check, Loader2, Phone, Plus, SendHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
@@ -99,12 +93,6 @@ export type SosPanelProps = {
   onStopSos: () => void;
   /** True while the stop request is in flight (shows a spinner on Stop sharing). */
   stopBusy: boolean;
-  /**
-   * Kept for interface parity with the other Location flows the caller
-   * renders interchangeably. The panel itself draws no in-content Cancel —
-   * the shell's single back control is the only way out — so this is unused
-   * inside `SosPanel` today.
-   */
   onClose: () => void;
   onEditContacts: () => void;
 
@@ -286,6 +274,18 @@ function useHoldToConfirm({
   };
 }
 
+function firstNameOf(label: string): string {
+  return label.trim().split(/\s+/)[0] || label.trim();
+}
+
+function formatNames(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0]!;
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  if (names.length === 3) return `${names[0]}, ${names[1]} and ${names[2]}`;
+  return `${names[0]}, ${names[1]} and ${names.length - 2} others`;
+}
+
 export function SosPanel({
   recipients,
   active,
@@ -293,14 +293,9 @@ export function SosPanel({
   onTrigger,
   onStopSos,
   stopBusy,
-  // The shell's single back control is this screen's only way out now — see
-  // the SosPanelProps doc comment on `onClose` for why the prop stays.
-  onClose: _onClose,
+  onClose,
   onEditContacts,
-  // No longer read directly: the per-recipient name line this once fed was
-  // dropped as a duplicate of the "N people will be alerted" row above (see
-  // that row's comment). Kept in the props contract for interface parity.
-  recipientLabel: _recipientLabel,
+  recipientLabel,
   isRecipientShareReady,
   emergency,
   emergencyStatus,
@@ -327,6 +322,15 @@ export function SosPanel({
   const readyRecipients = useMemo(
     () => recipients.filter(isRecipientShareReady),
     [isRecipientShareReady, recipients],
+  );
+  const names = useMemo(
+    () =>
+      formatNames(
+        readyRecipients.map((recipient) =>
+          firstNameOf(recipientLabel(recipient)),
+        ),
+      ),
+    [readyRecipients, recipientLabel],
   );
   const customMessageLength = customMessage.length;
   const customMessageLimitExceeded =
@@ -547,58 +551,58 @@ export function SosPanel({
     // SOS is a Location task flow, not a separate app. It renders INSIDE the
     // signed-in shell like every other `?action=…` flow (Settings, Check-In,
     // Shared with me), so the top bar keeps showing the single back control,
-    // the "Location › Emergency help" breadcrumb and the profile avatar. It
-    // used to escape the shell as a pinned full-viewport black overlay, which
-    // is what removed all three and forced a second back button into the
-    // content. The shell's single back control is also this screen's only
-    // way out now — no separate in-content Cancel — since a second exit next
-    // to a real emergency control invites the wrong tap under stress.
+    // the "Location › Save my Soul" breadcrumb and the profile avatar. It used
+    // to escape the shell as a pinned full-viewport black overlay, which is
+    // what removed all three and forced a second back button into the content.
     <section data-testid="sms-safety-screen">
       {/* Same header grammar as every other Location screen: the crumb text and
           the heading are the same words. Back lives in the top bar only. */}
       <TaskFlowHeader
-        title="Emergency help"
+        title="Save my Soul"
         // Two facts, and only the two the screen cannot show: who it reaches,
-        // and that it sends where you are — the literal truth, since this
-        // creates a location grant and fires one push over the network rather
-        // than an offline text message, and someone may hold this instead of
-        // calling for help.
-        description="Hold SMS to alert your people and share your location."
+        // and that it sends where you are. "Hold to…" was the third statement
+        // of an instruction the button itself carries and the line under it
+        // repeats verbatim.
+        //
+        // Still the literal truth, which matters more here than anywhere else
+        // in the product: this creates a location grant and fires one push, so
+        // it needs the network and it is not an offline text message. Someone
+        // may hold this instead of calling for help.
+        description="Alerts your emergency contacts with your live location."
       />
 
-      {/* Emergency contacts live above the button that uses them: who gets
-          alerted is a fact the person should see before they commit to
-          sending, not a settings link tucked beside a Cancel action. Reuses
-          the existing edit-contacts destination and the same ready-recipient
-          count the status line below already computes. */}
-      <div className="mx-auto mt-6 w-full max-w-[520px]">
-        <p className="mb-2 text-[13px] font-semibold tracking-[-0.1px] text-[color:var(--sos-label)]">
-          Emergency contacts
-        </p>
+      {/* The design's top-right actions. The screen's own title moved into the
+          header above, so only the two controls remain here. Width-matched
+          to the message column below (max-w-[520px], centered) so "Cancel"
+          doesn't right-align to the section edge while the input right-aligns
+          to a narrower centered column beneath it (#5431). */}
+      <div className="mx-auto mt-4 flex w-full max-w-[520px] flex-wrap items-center justify-end gap-x-6 gap-y-2 sm:gap-x-8">
+        {active ? (
+          <span className="mr-auto flex items-center gap-2 sm:mr-0">
+            <span
+              aria-hidden
+              className="h-[7px] w-[7px] rounded-full bg-[color:var(--app-destructive)]"
+            />
+            <span className="text-[15px] font-medium tracking-[-0.2px] text-[color:var(--app-destructive)]">
+              Live
+            </span>
+          </span>
+        ) : null}
         <button
           type="button"
           onClick={onEditContacts}
-          // No separate aria-label: the visible text ("N people will be
-          // alerted" / "No contacts added", plus "Edit"/"Add") already reads
-          // as a complete, correctly-pluralized accessible name.
-          className="press-scale flex min-h-[60px] w-full items-center gap-3 rounded-xl bg-[color:var(--sos-control-surface)] px-4 py-3 text-left transition-colors hover:bg-[color:var(--sos-control-surface-hover)]"
+          aria-label="Edit SMS contacts"
+          className="press-scale flex items-center gap-[7px] text-[15px] tracking-[-0.2px] text-[color:var(--sos-label)] transition-colors hover:text-foreground"
         >
-          <span
-            aria-hidden
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color:var(--sos-control-surface-active)] text-[color:var(--sos-label)]"
-          >
-            <UsersRound className="h-[18px] w-[18px]" />
-          </span>
-          <span className="min-w-0 flex-1 truncate text-[15px] tracking-[-0.2px] text-foreground">
-            {readyRecipients.length
-              ? `${readyRecipients.length} ${
-                  readyRecipients.length === 1 ? "person" : "people"
-                } will be alerted`
-              : "No contacts added"}
-          </span>
-          <span className="shrink-0 text-[15px] font-medium tracking-[-0.2px] text-[color:var(--app-accent)]">
-            {readyRecipients.length ? "Edit" : "Add"}
-          </span>
+          <Plus className="h-[15px] w-[15px]" strokeWidth={1.8} aria-hidden />
+          <span>Contacts</span>
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="press-scale text-[15px] tracking-[-0.2px] text-[color:var(--sos-label)] transition-colors hover:text-foreground"
+        >
+          Cancel
         </button>
       </div>
 
@@ -733,14 +737,12 @@ export function SosPanel({
                     : "0 0 64px 4px rgb(var(--sos-glow-rgb) / 0.2), inset 0 1px 0 rgba(255,255,255,0.24)",
               }}
             >
-              {/* "SMS" is the name this feature carries everywhere a person
-                  meets it — the Home hub quick action, the onboarding card,
-                  the contacts screen it sends to, and the message that
-                  actually goes out. It read "SOS" for one day (bc3dd4694,
-                  reverted here); the glyph is back in step with the rest.
-                  Identifiers are untouched either way: data-testid, event
-                  name, scope handle and backend enum all still say sos,
-                  because those are contracts, not copy. */}
+              {/* "SMS", the name this feature carries everywhere else in the
+                  product — the Location menu tile is "SMS / Save my soul", and
+                  the outgoing message is an SMS. Only the visible glyph
+                  changes: every identifier (data-testid, event name, scope
+                  handle, backend enum) still says sos, because those are
+                  contracts, not copy. */}
               <span className="text-[44px] font-semibold tracking-[1.5px] lg:text-[64px] lg:tracking-[2px]">
                 SMS
               </span>
@@ -753,6 +755,13 @@ export function SosPanel({
           className="mt-[26px] text-center text-[15px] tracking-[-0.2px] text-[color:var(--sos-label)] lg:mt-[34px] lg:text-[17px] lg:tracking-[-0.37px]"
         >
           {statusLabel}
+        </p>
+
+        {/* Who the SMS reaches. The design has no equivalent, but sending an
+            emergency message to an audience you cannot see is not a thing to
+            ask anyone to do. */}
+        <p className="mt-2 max-w-full truncate px-2 text-center text-[13px] text-[color:var(--sos-label)]">
+          {names ? `Alerts ${names}` : "No emergency contacts selected"}
         </p>
 
         <div className="mt-9 flex w-full max-w-[520px] flex-col gap-2.5 lg:mt-[52px] lg:gap-3">
@@ -780,10 +789,6 @@ export function SosPanel({
               </p>
             </div>
           ) : null}
-
-          <p className="text-[13px] font-semibold tracking-[-0.1px] text-[color:var(--sos-label)]">
-            Message — optional
-          </p>
 
           <div className="flex gap-2.5 lg:gap-3">
             {QUICK_MESSAGES.map((option) => {
@@ -958,10 +963,6 @@ export function SosPanel({
             ) : (
               <span />
             )}
-            {/* Hidden while the field is empty — a "0/140" nobody has typed
-                into yet is a number to parse, not information. The id stays
-                on the DOM node regardless so the input's aria-describedby
-                always resolves, even before there is a count to announce. */}
             <div
               id="sos-short-message-count"
               className={cn(
@@ -971,9 +972,7 @@ export function SosPanel({
                   : "text-[color:var(--sos-label)]",
               )}
             >
-              {customMessageLength > 0
-                ? `${customMessageLength}/${ONE_LOCATION_SHARE_NOTE_MAX_LENGTH}`
-                : null}
+              {customMessageLength}/{ONE_LOCATION_SHARE_NOTE_MAX_LENGTH}
             </div>
           </div>
 

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -72,9 +72,9 @@ function oneLocationActionLabel(action: string): string {
     "shared-with-me": "Shared with me",
     "needs-review": "Needs my review",
     // The crumb must match the on-screen title of the flow it names. The SOS
-    // screen's TaskFlowHeader reads "Emergency help", so the crumb does too —
-    // a crumb saying "Safety" for a screen titled otherwise breaks the trail.
-    sos: "Emergency help",
+    // screen's TaskFlowHeader reads "Save my Soul", so the crumb does too — a
+    // crumb saying "Safety" for a screen titled otherwise breaks the trail.
+    sos: "Save my Soul",
     "sms-contacts": "SMS contacts",
     settings: "Settings",
     privacy: "Settings",


### PR DESCRIPTION
Reverts the screen changes in `bc3dd4694` ("calm the emergency screen down to hold-and-send", 2026-08-18). The owner asked for the original screen back from a screenshot of it.

| | Now on main | This PR |
|---|---|---|
| Title + breadcrumb | Emergency help | **Save my Soul** |
| Description | "Hold SMS to alert your people and share your location." | **"Alerts your emergency contacts with your live location."** |
| Contacts / Cancel | an "Emergency contacts" card above the ring | **top-right row, with the red "Live" dot while an alert runs** |
| Under the ring | (nothing) | **"Alerts Carol" / "No emergency contacts selected"** |
| 0/140 counter | hidden until you type | **visible from empty** |
| "Message — optional" label | present | **gone** |

## Why this is a 3-way revert, not a file restore

Four commits landed on this panel **after** `bc3dd4694`. Checking out the old file would have silently dropped every one — the exact failure `merge-regression-guard` exists for. Each is verified still present after conflict resolution:

- **`2b27524a1`** — `useHoldToConfirm`, the press-and-hold on the custom-message send button. This was the one real conflict: `ours` had the hook where `theirs` wanted `firstNameOf`/`formatNames` back. **Kept both**, rather than letting either side win.
- **`8b8cd9663`** — clears the send button's stuck "Hold to send…" label once the alert goes live, plus its regression test
- **`5ad213f46`** — emergency number and Stop sharing in one row, number left, plus both of its layout tests
- **`c726237d8`** — one grant is not one person

## Two lines the blunt revert got wrong

`5ad213f46` renamed the stop control `Cancel` → `Stop sharing` *after* `bc3dd4694`. The reverted hint text and the `stopBusy` doc comment would therefore have named a button that no longer says Cancel. Both keep the later naming.

The top-right **Cancel** is a different control — it closes the screen — and is the one the design has always had there. Two distinct actions, two distinct labels.

## Verification

- `verify:one-location` — **263 passed**, 9 files
- `verify:top-shell-navigation` — **51 passed** (the breadcrumb changed, so this lane matters)
- `tsc --noEmit` clean · `eslint --max-warnings=0` clean
- `verify:surface-map` — "Surface map is current"
- `verify-protected-behavior-tests.py` — 13 behaviours, 26 files, intact
- Repo-wide grep for "Emergency help" returns nothing

The SMS glyph from #5587 is unaffected — it was already the pre-`bc3dd4694` value, so the revert agrees with it.

Merge-Regression-Ack: Deliberate revert of bc3dd4694's screen layout, requested by the owner. The Merge Fidelity Gate is expected to flag resurrected pre-bc3dd4694 lines; that is the intent. The four post-bc3dd4694 fixes it might also flag are enumerated above and were each confirmed present after resolution.

Closes #5588