### PR TITLE
fix(one-location): emit the Circle trace on a level the web build keeps

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/circle-create-diagnostics.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/circle-create-diagnostics.test.ts
@@ -10,7 +10,7 @@ async function loadDiagnostics(appEnv: string) {
 
 describe("circle create diagnostics", () => {
   beforeEach(() => {
-    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -24,11 +24,11 @@ describe("circle create diagnostics", () => {
       const mod = await loadDiagnostics(env);
       expect(mod.isCircleCreateDiagnosticsEnabled(), env).toBe(true);
       mod.logCircleCreate("Click", { attemptId: "cc_1", circleKind: "family" });
-      expect(console.info, env).toHaveBeenCalledWith("[CircleCreate:Click]", {
+      expect(console.warn, env).toHaveBeenCalledWith("[CircleCreate:Click]", {
         attemptId: "cc_1",
         circleKind: "family",
       });
-      vi.mocked(console.info).mockClear();
+      vi.mocked(console.warn).mockClear();
     }
   });
 
@@ -40,7 +40,7 @@ describe("circle create diagnostics", () => {
     mod.logCircleCreate("Click", { attemptId: "cc_1" });
     mod.logCircleCreateLockCheck("cc_1", "locked");
     mod.logCircleCreateLockGuard("cc_1", "unlock_required", "no_owner_token");
-    expect(console.info).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("is silent inside a packaged store app, which is also stamped uat", async () => {
@@ -57,7 +57,7 @@ describe("circle create diagnostics", () => {
     const mod = await loadDiagnostics("uat");
     expect(mod.isCircleCreateDiagnosticsEnabled()).toBe(false);
     mod.logCircleCreate("Click", { attemptId: "cc_1" });
-    expect(console.info).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
     vi.doUnmock("@capacitor/core");
     vi.doUnmock("@/lib/testing/native-test");
   });
@@ -84,7 +84,7 @@ describe("circle create diagnostics", () => {
       stray:
         "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghijklmnop qrst@example.com",
     });
-    const [, detail] = vi.mocked(console.info).mock.calls[0] as [
+    const [, detail] = vi.mocked(console.warn).mock.calls[0] as [
       string,
       Record<string, unknown>,
     ];
@@ -119,7 +119,7 @@ describe("circle create diagnostics", () => {
     const mod = await loadDiagnostics("uat");
     const attemptId = mod.createCircleCreateAttemptId();
     mod.logCircleCreateLockCheck(attemptId, "locked");
-    const [, detail] = vi.mocked(console.info).mock.calls[0] as [
+    const [, detail] = vi.mocked(console.warn).mock.calls[0] as [
       string,
       Record<string, unknown>,
     ];
@@ -132,8 +132,42 @@ describe("circle create diagnostics", () => {
   it("drops undefined keys rather than printing them", async () => {
     const mod = await loadDiagnostics("uat");
     mod.logCircleCreate("Success", { attemptId: "cc_1", circleIdPrefix: undefined });
-    expect(console.info).toHaveBeenCalledWith("[CircleCreate:Success]", {
+    expect(console.warn).toHaveBeenCalledWith("[CircleCreate:Success]", {
       attemptId: "cc_1",
     });
+  });
+});
+
+describe("the trace survives the build it is meant to be read in", () => {
+  it("emits only on levels next.config.ts keeps", async () => {
+    // `removeConsole: isCapacitorBuild ? false : { exclude: ["error", "warn"] }`
+    // strips every other console level from a web build at compile time. The
+    // first version of this module used `console.info` -- correct by the repo's
+    // own convention, and verified ABSENT from every chunk served by
+    // uat.one.hushh.ai. A unit test cannot see that, so pin the two facts that
+    // together make the trace readable: the level this module uses, and the
+    // levels the build keeps.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const root = path.resolve(__dirname, "../../..");
+
+    const nextConfig = fs.readFileSync(path.join(root, "next.config.ts"), "utf8");
+    const match = nextConfig.match(/removeConsole:[^\n]*exclude:\s*\[([^\]]*)\]/);
+    expect(match, "next.config.ts no longer declares removeConsole.exclude").toBeTruthy();
+    const kept = String(match?.[1] ?? "")
+      .split(",")
+      .map((entry) => entry.trim().replace(/["']/g, ""))
+      .filter(Boolean);
+    expect(kept).toContain("warn");
+
+    const source = fs.readFileSync(
+      path.join(root, "lib/one-location/circle-create-diagnostics.ts"),
+      "utf8",
+    );
+    const levels = Array.from(source.matchAll(/console\.(\w+)\(/g)).map((m) => m[1]);
+    expect(levels.length).toBeGreaterThan(0);
+    for (const level of levels) {
+      expect(kept, `console.${level} is stripped from a web build`).toContain(level);
+    }
   });
 });

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -898,7 +898,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Neel Shah Connected on One/i }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 2 people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 2 people" }));
 
     await waitFor(() =>
       expect(onInviteConnections).toHaveBeenCalledWith("circle-1", [
@@ -982,7 +982,7 @@ describe("named Circle flows", () => {
         name: /Friend User Connected on One/i,
       }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
     await waitFor(() =>
       expect(onInviteConnections).toHaveBeenCalledWith("circle-1", [
         "friend-user",
@@ -1085,7 +1085,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Add people" }),
     );
-    expect(await screen.findByText(/invite 1 more person right now/i)).toBeTruthy();
+    expect(await screen.findByText(/add 1 more person right now/i)).toBeTruthy();
 
     const asha = screen.getByRole("button", {
       name: /Asha Meena Connected on One/i,
@@ -1098,7 +1098,7 @@ describe("named Circle flows", () => {
     expect(asha).toHaveAttribute("aria-pressed", "true");
     expect(neel).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "Invite 1 person" }),
+      screen.getByRole("button", { name: "Add 1 person" }),
     ).toBeEnabled();
   });
 
@@ -1124,7 +1124,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Add people" }),
     );
-    expect(await screen.findByText("No invitation slots available")).toBeTruthy();
+    expect(await screen.findByText("No room left in this Circle")).toBeTruthy();
     expect(screen.queryByText("Stale Candidate")).toBeNull();
   });
 
@@ -1172,7 +1172,7 @@ describe("named Circle flows", () => {
       name: /Asha Meena Connected on One/i,
     });
     fireEvent.click(asha);
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
     await waitFor(() =>
       expect(onLoadEligibleConnections).toHaveBeenCalledTimes(2),
@@ -1548,7 +1548,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: /Asha Meena Connected on One/i }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
     await waitFor(() =>
       expect(onInviteConnections).toHaveBeenCalledWith("circle-1", [
@@ -1567,7 +1567,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Neel Shah Connected on One/i }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 2 people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 2 people" }));
 
     await waitFor(() =>
       expect(onInviteConnections).toHaveBeenLastCalledWith("circle-1", [
@@ -1608,7 +1608,7 @@ describe("named Circle flows", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: /Asha Meena Connected on One/i }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith("Circle capacity changed."),
@@ -1671,7 +1671,7 @@ describe("named Circle flows", () => {
         name: /Friend User Connected on One/i,
       }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Invite 1 person" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Add people" })).toBeNull(),

--- a/hushh-webapp/lib/one-location/circle-create-diagnostics.ts
+++ b/hushh-webapp/lib/one-location/circle-create-diagnostics.ts
@@ -23,7 +23,8 @@
  * Local development, the UAT website, and an injected native UI-test session.
  * Never a production build, and never a packaged store build.
  *
- * Two traps decide that gate, and both are documented elsewhere in this repo:
+ * Three traps decide how this is written. The third was found by reading the
+ * deployed bundle rather than trusting the gate.
  *
  * 1. `isObservabilityDebugEnabled()` is unusable. `deploy/frontend.cloudbuild.yaml`
  *    hardcodes `--build-arg NEXT_PUBLIC_OBSERVABILITY_DEBUG=false`, and
@@ -32,12 +33,26 @@
  *    could never be read where it is needed.
  * 2. An environment check alone is not enough either. The App Store and Play
  *    Store lanes stamp `NEXT_PUBLIC_APP_ENV=uat` because they ship against the
- *    UAT backend (`.github/workflows/release-ios-appstore.yml:234`,
- *    `ship-android-playstore-v1.yml:145`), so `!== "production"` reads every
- *    store install as non-production. Distribution and backend environment are
+ *    UAT backend (`.github/workflows/release-ios-appstore.yml`,
+ *    `ship-android-playstore-v1.yml`), so `!== "production"` reads every store
+ *    install as non-production. Distribution and backend environment are
  *    separate facts — the same reasoning `lib/testing/location-map-demo.ts`
  *    spells out. A packaged app is therefore excluded unless it is running an
  *    injected UI-test session.
+ * 3. **`console.info` does not exist on the UAT website.** `next.config.ts` sets
+ *    `removeConsole: isCapacitorBuild ? false : { exclude: ["error", "warn"] }`,
+ *    so every `console.*` call except `error` and `warn` is stripped from the
+ *    bundle at compile time. The first version of this file used
+ *    `console.info`, matching `lib/cache/request-audit-log.ts` and
+ *    `lib/observability/client.ts` — and the tags were verified absent from
+ *    every chunk served by uat.one.hushh.ai. Both of those existing helpers are
+ *    dead on the deployed website for the same reason; they only survive in the
+ *    Capacitor build, where `removeConsole` is off.
+ *
+ *    So these lines go out on `console.warn`, the only channel that survives a
+ *    web build. The gate above is what keeps them off a real person's phone —
+ *    on iOS nothing strips them, which makes that check load-bearing rather
+ *    than defence in depth.
  *
  * ## What never goes in
  *
@@ -125,10 +140,12 @@ export function logCircleCreate(
   detail: Record<string, unknown>,
 ): void {
   if (!isCircleCreateDiagnosticsEnabled()) return;
-  // console.info, not console.log: matches `[RequestAudit:…]` and
-  // `[observability]`, and keeps these out of the default error/warn channels
-  // an operator scans for real faults.
-  console.info(`[CircleCreate:${stage}]`, redactDetail(detail));
+  // console.warn, not console.info: `removeConsole` in next.config.ts strips
+  // every level except error and warn from a web build, so info never reaches
+  // UAT at all. Verified against the served bundle, not assumed. Not `error` —
+  // these are a trace, and an operator scanning for real faults should not have
+  // to wade through them.
+  console.warn(`[CircleCreate:${stage}]`, redactDetail(detail));
 }
 
 export function logCircleCreateLockCheck(


### PR DESCRIPTION
Follow-up to #5596, found by reading the deployed bundle instead of trusting the gate.

## What was wrong

The behaviour fix works on UAT — verified against the live surface with the reviewer identity (the affected class, `bootstrapState: vault_error`):

| | before #5596 | after #5596 |
|---|---|---|
| `CTA data-lock-state` | `null` | `locked` |
| dead-end toast | **visible** | gone |
| unlock sheet | — | **opens** |

But the `[CircleCreate:*]` trace emitted nothing, and the tag string was absent from **every chunk** served by `uat.one.hushh.ai`.

`next.config.ts`:

```ts
removeConsole: isCapacitorBuild ? false : { exclude: ["error", "warn"] },
```

Every `console.*` level except `error` and `warn` is stripped from a web build at compile time. The tags used `console.info` — which is the repo's own convention, matching `lib/cache/request-audit-log.ts` and `lib/observability/client.ts`. **Both of those are equally dead on the deployed website**, and survive only in the Capacitor build where `removeConsole` is off.

## The fix

`console.warn` — the only level that reaches UAT. Not `error`: this is a trace, and an operator scanning for real faults shouldn't wade through it.

One consequence worth stating: on iOS nothing strips these, so the store-build gate (`!Capacitor.isNativePlatform()` unless it's a driven UI-test session) is now load-bearing rather than belt-and-braces. Noted in the file.

Pinned by a contract test that reads **both** facts — the level this module emits on, and the `exclude` list `next.config.ts` declares — so a future edit to either cannot silently kill the trace again. Reverting to `console.info` fails it.

## Also: 8 stale tests in the same suite

`named-circle-flows.test.tsx` was asserting copy a plain-language sweep had already renamed:

- `Invite N people` → `Add N people`
- `invite 1 more person right now` → `add 1 more person right now`
- `No invitation slots available` → `No room left in this Circle`

Nothing noticed because the file was in **no targeted pack**, so it had never run on a pull request. Registering it in `verify:one-location` in #5596 is what surfaced them — so they're mine to fix rather than leave `main` red for the next person in that pack.

## Verification

- `verify:one-location` — 12 files, **321 tests**, green
- `tsc --noEmit`, `eslint --max-warnings=0` — clean
- Mutation-checked: reverting to `console.info` fails 5 tests, including the new contract