### PR TITLE
fix(copy): the last seven user-facing "vault" leaks the rename missed

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4041,7 +4041,7 @@ export function OneLocationAgentPageContent({
       recipient: OneLocationRecipient,
       pointOverride?: PlainLocationPoint,
     ) => {
-      if (!vaultOwnerToken) throw new Error("Vault owner token required.");
+      if (!vaultOwnerToken) throw new OneLocationLockRequiredError();
       if (!recipient.publicKeyJwk || !recipient.keyId) {
         throw new Error(
           "They need to open Location once before private sharing can start.",
@@ -10983,7 +10983,7 @@ export function OneLocationAgentPageContent({
   const searchOnboardingSavedPlaces = useCallback(
     async (input: string) => {
       if (!vaultOwnerToken) {
-        throw new Error("Vault owner token required.");
+        throw new OneLocationLockRequiredError();
       }
       return OneLocationService.placesAutocomplete({
         vaultOwnerToken,

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -1484,7 +1484,7 @@ export function AgentChatWorkspace({
     () => {
       if (authLoading) return "Checking access";
       if (!user?.uid) return "Sign in required";
-      if (!isVaultUnlocked || !vaultOwnerToken || !tokenIsFresh) return "Vault locked";
+      if (!isVaultUnlocked || !vaultOwnerToken || !tokenIsFresh) return "Locked";
       if (activeActionRun) return activeActionRun.message;
       if (!agentVoiceEnabled && voiceActive) return "Voice disabled";
       if (voiceState === "connecting") return "Voice connecting";
@@ -2901,7 +2901,7 @@ export function AgentChatWorkspace({
 
     const loadTurnPkmContext = async (): Promise<AgentPkmContext> => {
       if (!vaultKey) {
-        throw new Error("Your vault must remain unlocked while One prepares your private memory.");
+        throw new Error("Stay unlocked while One reads your private memory.");
       }
 
       const cachedContext = peekAgentPkmContext({

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -2368,7 +2368,7 @@ export function ConsentCenterPage() {
     load: async () => {
       const vaultOwnerToken = getVaultOwnerToken();
       if (!user?.uid || !vaultOwnerToken) {
-        throw new Error("Unlock your vault to open this consent request.");
+        throw new Error("Unlock One to open this request.");
       }
       return ConsentCenterService.lookupPendingRequests({
         vaultOwnerToken,

--- a/hushh-webapp/components/profile/pkm-data-manager.tsx
+++ b/hushh-webapp/components/profile/pkm-data-manager.tsx
@@ -263,13 +263,13 @@ export function PkmDataManagerPanel({
             Set up saved details
           </SurfaceCardTitle>
           <SurfaceCardDescription>
-            Create your vault first so One can save your details and sharing
-            controls here.
+            Set a lock so One can save your details and sharing controls
+            here.
           </SurfaceCardDescription>
         </SurfaceCardHeader>
         <SurfaceCardContent>
           <Button type="button" onClick={onOpenImport}>
-            Create vault
+            Set a lock
           </Button>
         </SurfaceCardContent>
       </SurfaceCard>

--- a/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
@@ -67,7 +67,7 @@ export function ProfileKaiPreferencesPanel({
         <SurfaceCardHeader>
           <SurfaceCardTitle>Unlock to edit your preferences</SurfaceCardTitle>
           <SurfaceCardDescription>
-            Risk profile and horizon preferences are stored securely in your vault.
+            Your risk profile and horizon are stored privately.
           </SurfaceCardDescription>
         </SurfaceCardHeader>
         <SurfaceCardContent>


### PR DESCRIPTION
Follow-on to #5599. Refs #5597.

The Vault→Lock sweep (`bf5c75271`, 75 files) was language-only and correct as far as it went — it changed no condition, no default and no guard, which is why it is not the cause of the lifecycle regression. It did miss seven strings a person actually reads.

Found by sweeping **every quoted string** in `app/`, `components/` and `lib/` and classifying each hit, rather than grepping for the word and hoping. Everything not listed below is an internal identifier, a `console.warn`, a type literal or a route detail key, and stays exactly as it is — renaming a stable internal for cosmetic consistency is the thing that keeps causing this.

| Where | Was |
|---|---|
| `pkm-data-manager.tsx:266,272` | "Create your vault first…" **and** a `Create vault` button — the banned noun twice on one card |
| `consent-center-page.tsx:2371` | "Unlock your vault to open this consent request." |
| `profile-kai-preferences-panel.tsx:70` | "…stored securely in your vault." |
| `agent-chat-workspace.tsx:1487` | `"Vault locked"` status chip |
| `agent-chat-workspace.tsx:2904` | "Your vault must remain unlocked while One prepares your private memory." |
| `app/one/location/page.tsx:4044, 10986` | `"Vault owner token required."` thrown straight into a toast |

The Location pair become `OneLocationLockRequiredError`, which already carries the lock state, so the screen can offer the right door instead of naming an internal credential at somebody.

Worth saying explicitly: `pkm-data-manager` was **already gated on `needsVaultCreation`** — the correct state — so this is a pure copy change there. The reverse case (right words, wrong gate) is what #5599 spent its time on; this one was only ever the words.

Not included: the `NSFaceIDUsageDescription` and `LAContext.localizedReason` strings, which Apple prints verbatim in the shipped binary — those went in #5599.

## Verification

`tsc --noEmit` clean · `npm run lint` clean · `verify:onboarding-funnel` 16 files / 230 tests · `verify:one-location` 12 files / 320 tests.