### PR TITLE
fix(connect): live-refresh Connect list on real consent state changes

### DIFF
--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -36,6 +36,7 @@ import {
 import { useRequireAuth } from "@/hooks/use-auth";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
+import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { Button } from "@/lib/morphy-ux/button";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
@@ -397,6 +398,27 @@ export default function ConnectPageClient() {
   useEffect(() => {
     void loadOutgoingRequestIds();
   }, [loadOutgoingRequestIds]);
+
+  useEffect(() => {
+    const handleStateChanged = (event: Event) => {
+      const detail =
+        (event as CustomEvent<{ action?: unknown; reconcile?: unknown }>)
+          .detail || {};
+      // Only re-fetch for real mutations (`action`) or explicit reconcile
+      // requests, not bookkeeping echoes like "fcm_opened" that would
+      // otherwise flash the list on every notification read.
+      if (!detail.action && !detail.reconcile) return;
+      void loadConnections().then((rows) => setConnections(rows));
+      void loadOutgoingRequestIds();
+    };
+    window.addEventListener(CONSENT_STATE_CHANGED_EVENT, handleStateChanged);
+    return () => {
+      window.removeEventListener(
+        CONSENT_STATE_CHANGED_EVENT,
+        handleStateChanged,
+      );
+    };
+  }, [loadConnections, loadOutgoingRequestIds]);
 
   // The directory is every account on Hussh, so listing all of it unprompted
   // stops being useful as soon as sign-ups outgrow a screen or two: the person


### PR DESCRIPTION
## Summary
- Connect (`app/connect/page-client.tsx`) only loaded connections and outgoing requests once on mount — any external change (e.g. someone sending you a new connection request while the page is open) required a manual reload to show up.
- Adds a listener for the existing `CONSENT_STATE_CHANGED_EVENT` (already dispatched app-wide by `notification-provider.tsx` on real pushes, and already consumed the same way by `consent-center-page.tsx`), re-fetching connections/outgoing requests when a real mutation or explicit reconcile fires.
- Mirrors `consent-center-page.tsx`'s self-echo filter (`detail.action` / `detail.reconcile`) so bookkeeping-only events (e.g. `fcm_opened`) don't cause a visible refresh flicker.
- This is the first step of a broader "app needs a reload to update" fix — wiring existing real-time infra to more screens rather than building new infra. Location and other surfaces are tracked separately.

## Known gap (explicitly out of scope here)
- The accept side (someone accepting your outgoing request) does not currently dispatch any event on this baseline, so that specific case still needs a manual reload. Closing that gap requires backend work that is intentionally not part of this PR.

## Test plan
- [x] `tsc --noEmit -p .` clean
- [x] `eslint app/connect/page-client.tsx` clean
- [x] `vitest run __tests__/components/connect-page-layout.contract.test.ts` — 3 passed
- [ ] Manual: open Connect on two accounts, send a connection request from one, confirm the other's Connect list updates without a reload