### PR TITLE
feat(release): tell a provider outage apart from a candidate regression

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -907,6 +907,10 @@ jobs:
               frontend_failure = True
 
           semantic_failures = set(semantic_report.get("failures") or [])
+          # Checks the verifier itself classified as an EXTERNAL provider outage.
+          # They are reported and alerted on, but they do not block: a provider
+          # being down is not evidence that this candidate is bad.
+          semantic_degraded = sorted(semantic_report.get("degraded") or [])
           advisory_semantic_failures = sorted(
               item for item in semantic_failures if item.startswith("signed_in_routes:")
           )
@@ -979,6 +983,14 @@ jobs:
                   "failures": sorted(semantic_failures),
                   "blocking_failures": sorted(blocking_semantic_failures),
                   "advisory_failures": advisory_semantic_failures,
+                  "degraded_capabilities": semantic_degraded,
+              },
+              "dependency_health": {
+                  # A release can be simultaneously correct and not fully
+                  # functional. Saying so is more useful than forcing that state
+                  # into either "success" or "failure".
+                  "degraded": bool(semantic_degraded),
+                  "degraded_capabilities": semantic_degraded,
               },
               "db_contract": {
                   "outcome": db_outcome,
@@ -1222,6 +1234,19 @@ jobs:
             echo "- Frontend deployed SHA before run: \`${{ steps.predeploy-state.outputs.frontend_sha || 'unknown' }}\`"
             echo "- Status: \`$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/uat-release-status.json').read_text(encoding='utf-8'))['status'])")\`"
             echo "- Blocking classifications: \`${{ steps.classify-uat-release.outputs.blocking_classifications || 'none' }}\`"
+            # Degradation is reported next to the status, not buried in the JSON.
+            # A release that deployed correctly while a provider was down must be
+            # readable as exactly that -- neither a clean success nor a failure.
+            degraded_capabilities="$(python3 -c "import json; from pathlib import Path; print(','.join(json.loads(Path('/tmp/uat-release-status.json').read_text(encoding='utf-8')).get('dependency_health', {}).get('degraded_capabilities') or []))" 2>/dev/null || true)"
+            if [[ -n "${degraded_capabilities}" ]]; then
+              echo "- **Dependency health: DEGRADED**"
+              echo "- Degraded capabilities: \`${degraded_capabilities}\`"
+              echo "  > The application deployed correctly. One or more external"
+              echo "  > providers are unavailable, so these capabilities will not"
+              echo "  > work until the provider recovers. This is not a code defect."
+            else
+              echo "- Dependency health: \`healthy\`"
+            fi
             echo "- Backend URL: \`${{ steps.final-state.outputs.backend_url }}\`"
             echo "- Frontend URL: \`${{ env.APP_FRONTEND_ORIGIN }}\`"
             echo "- Backend revision: \`${{ steps.final-state.outputs.backend_revision }}\`"

--- a/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
@@ -1,0 +1,164 @@
+"""Classify a provider failure so a release can tell an outage from a regression.
+
+``vertex_failover.is_retryable_vertex_error`` answers a narrower, in-request
+question: may this idempotent call be retried in another location? It excludes
+403 deliberately, because re-issuing a denied request elsewhere cannot help.
+
+A release gate asks a different question, and needs a different answer:
+
+    Is this failure OURS, or is the provider simply unavailable?
+
+A billing-enforcement 403 is the clearest example of the divergence. It is not
+retryable, so the failover classifier correctly rejects it -- but it is also
+emphatically not a defect in the candidate build, so blocking a release on it
+strands healthy code. Hence a second, release-scoped vocabulary here rather
+than a change to the failover rules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from .vertex_failover import _status_code
+
+DEPENDENCY_OK = "dependency_ok"
+PROVIDER_UNAVAILABLE = "provider_unavailable"
+CANDIDATE_MISCONFIGURED = "candidate_misconfigured"
+APPLICATION_BROKEN = "application_broken"
+
+#: Classifications that must NOT block a release. The provider is down; our
+#: candidate has not been shown to be at fault.
+ADVISORY_CLASSIFICATIONS = frozenset({DEPENDENCY_OK, PROVIDER_UNAVAILABLE})
+
+# Transport/quota/server statuses that always mean "their side, not ours".
+_PROVIDER_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_PROVIDER_STATUS_NAMES = {
+    "INTERNAL",
+    "RESOURCE_EXHAUSTED",
+    "UNAVAILABLE",
+    "DEADLINE_EXCEEDED",
+    "ABORTED",
+}
+
+# A 403 is ambiguous, so it is resolved on wording. These substrings mark
+# account-level enforcement -- billing, dunning, suspension, quota -- which is
+# an availability problem, not a candidate problem.
+#
+# "Lightning dunning decision is deny for project: projects/..." is the exact
+# string Google returned across every project on the billing account on
+# 2026-08-20, while the same candidate image had deployed cleanly hours earlier.
+_ACCOUNT_ENFORCEMENT_MARKERS = (
+    "dunning",
+    "billing account",
+    "billing is not enabled",
+    "billing has not been enabled",
+    "account is suspended",
+    "consumer has been suspended",
+    "quota exceeded",
+    "has been disabled",
+)
+
+# A 403 carrying these instead is a permission or configuration fault that a
+# release genuinely can introduce -- a wrong service account, a project the
+# candidate should not be reaching, an unenabled API.
+#
+# These must stay SPECIFIC. A bare "permission" substring is useless here: the
+# dunning outage arrives as "403 PERMISSION_DENIED. Lightning dunning decision
+# is deny...", so matching the generic status name would classify a billing
+# outage as our defect -- the exact failure this module exists to prevent.
+_PERMISSION_FAULT_MARKERS = (
+    "permission '",
+    'permission "',
+    "does not have access",
+    "does not have permission",
+    "caller does not have",
+    "denied on resource",
+    "api has not been used",
+    "api is not enabled",
+    "service_disabled",
+)
+
+# Our own guardrails raise these with authored messages. They mean the candidate
+# declared something impossible -- a model no manifest supports, a binding with
+# no project -- and they must keep blocking.
+_CANDIDATE_FAULT_STATUS_CODES = {400, 401, 404}
+
+
+def _iter_causes(error: BaseException):
+    """Walk the exception chain once, without cycling."""
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _message(error: BaseException) -> str:
+    return str(error).strip().lower()
+
+
+def classify_provider_error(error: BaseException) -> str:
+    """Return the release classification for a failed provider call.
+
+    Ordering matters. Provider-side signals are checked across the whole cause
+    chain first, because a transport failure is often wrapped by one of our own
+    ``RuntimeError`` guards on the way out -- and the outer type must not make
+    an outage look like a candidate defect.
+    """
+    for current in _iter_causes(error):
+        if isinstance(current, (asyncio.TimeoutError, TimeoutError, ConnectionError)):
+            return PROVIDER_UNAVAILABLE
+
+        status = _status_code(current) if isinstance(current, Exception) else None
+        if status in _PROVIDER_STATUS_CODES:
+            return PROVIDER_UNAVAILABLE
+
+        name = str(getattr(current, "status", "") or "").strip().upper()
+        if name in _PROVIDER_STATUS_NAMES:
+            return PROVIDER_UNAVAILABLE
+
+        if status == 403:
+            text = _message(current)
+            # Enforcement wording is checked FIRST because it is the specific
+            # signal; permission wording is the generic fallback. Reversing
+            # these reads "403 PERMISSION_DENIED. Lightning dunning..." as a
+            # candidate fault and strands a healthy build.
+            if any(marker in text for marker in _ACCOUNT_ENFORCEMENT_MARKERS):
+                return PROVIDER_UNAVAILABLE
+            if any(marker in text for marker in _PERMISSION_FAULT_MARKERS):
+                return CANDIDATE_MISCONFIGURED
+            # An unexplained 403 is treated as ours. Blocking a release we may
+            # have broken is the safer failure than shipping past a real denial.
+            return CANDIDATE_MISCONFIGURED
+
+        if status in _CANDIDATE_FAULT_STATUS_CODES:
+            return CANDIDATE_MISCONFIGURED
+
+    for current in _iter_causes(error):
+        if isinstance(current, (RuntimeError, ValueError, KeyError, LookupError)):
+            return CANDIDATE_MISCONFIGURED
+
+    return APPLICATION_BROKEN
+
+
+def is_advisory(classification: str) -> bool:
+    """Whether a classification should be reported without failing the release."""
+    return classification in ADVISORY_CLASSIFICATIONS
+
+
+def summarize(classifications: list[str]) -> str:
+    """Reduce many probe results to the one that decides the release.
+
+    A single candidate fault outranks any number of provider outages: if even
+    one failure is ours, the release is not safe regardless of what else broke.
+    """
+    if not classifications:
+        return DEPENDENCY_OK
+    if APPLICATION_BROKEN in classifications:
+        return APPLICATION_BROKEN
+    if CANDIDATE_MISCONFIGURED in classifications:
+        return CANDIDATE_MISCONFIGURED
+    if PROVIDER_UNAVAILABLE in classifications:
+        return PROVIDER_UNAVAILABLE
+    return DEPENDENCY_OK

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -56,3 +56,9 @@ tests/test_ria_claim_email_test_path.py
 tests/test_ria_dossier_mail_contract.py
 tests/test_ria_claim_location.py
 tests/test_ria_brochure_profile.py
+
+# Release-gate classification. These guard the rule that a third-party outage
+# must not block a healthy release, and that a candidate defect still must.
+tests/test_dependency_health_classifier.py
+tests/test_managed_vertex_readiness_script.py
+tests/test_verify_uat_release.py

--- a/consent-protocol/scripts/verify_managed_vertex_runtime.py
+++ b/consent-protocol/scripts/verify_managed_vertex_runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -21,8 +22,22 @@ from hushh_mcp.runtime_providers import (  # noqa: E402
     build_generate_content_config,
     resolve_model_entry,
 )
+from hushh_mcp.runtime_providers.dependency_health import (  # noqa: E402
+    DEPENDENCY_OK,
+    PROVIDER_UNAVAILABLE,
+    classify_provider_error,
+    is_advisory,
+    summarize,
+)
 
 PROBE_TIMEOUT_SECONDS = 25
+
+#: Stable prefix the Cloud Build step greps for in the job's logs.
+RESULT_PREFIX = "managed_vertex_probe_result"
+
+#: EX_TEMPFAIL. Distinguishes "the provider is down" from a hard failure, so the
+#: caller can continue the release while still reporting the outage.
+EXIT_PROVIDER_UNAVAILABLE = 75
 
 
 def _managed_manifest_models() -> tuple[tuple[str, ...], str]:
@@ -56,7 +71,7 @@ def _managed_manifest_models() -> tuple[tuple[str, ...], str]:
     return tuple(sorted(text_models)), next(iter(live_models))
 
 
-async def main() -> None:
+async def main() -> dict[str, object]:
     binding = ManagedGeminiRuntimeBinding.from_environment()
     models, live_model = _managed_manifest_models()
     live_location = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").strip()
@@ -141,17 +156,82 @@ async def main() -> None:
             + ",".join(unsupported_models)
         )
 
-    await asyncio.gather(
-        *(probe_text(model, location) for model in models for location in locations_for(model)),
-        *(probe_adk_text(model, location) for model in models for location in locations_for(model)),
-        probe_live_setup(),
-    )
-    print(
-        "managed_vertex_ready "
-        f"models={','.join(models)} live={live_model} "
-        f"text_locations={','.join(binding.locations)} live_location={live_location}"
-    )
+    # Labelled so a failure is attributable to one model/location, and gathered
+    # with return_exceptions so ALL probe outcomes survive. Without it the first
+    # exception cancels the rest, discarding exactly the evidence that separates
+    # an outage ("every probe failed the same way") from a candidate defect
+    # ("only this model, only this location").
+    labelled: list[tuple[str, object]] = []
+    for model in models:
+        for location in locations_for(model):
+            labelled.append((f"text:{model}@{location}", probe_text(model, location)))
+            labelled.append((f"adk:{model}@{location}", probe_adk_text(model, location)))
+    labelled.append((f"live:{live_model}@{live_location}", probe_live_setup()))
+
+    outcomes = await asyncio.gather(*(coro for _, coro in labelled), return_exceptions=True)
+
+    probes: list[dict[str, object]] = []
+    for (name, _), outcome in zip(labelled, outcomes, strict=True):
+        if isinstance(outcome, BaseException):
+            probes.append(
+                {
+                    "probe": name,
+                    "ok": False,
+                    "classification": classify_provider_error(outcome),
+                    "error_type": type(outcome).__name__,
+                    "error": str(outcome)[:400],
+                }
+            )
+        else:
+            probes.append({"probe": name, "ok": True, "classification": DEPENDENCY_OK})
+
+    failed = [item for item in probes if not item["ok"]]
+    classification = summarize([str(item["classification"]) for item in failed])
+    return {
+        "check": "managed_vertex_runtime",
+        "ok": not failed,
+        "classification": classification,
+        "advisory": is_advisory(classification),
+        "models": list(models),
+        "live_model": live_model,
+        "live_location": live_location,
+        "probes": probes,
+        # A provider-side denial is returned before any model-specific
+        # validation, so an outage verdict does NOT clear the candidate. Say so,
+        # rather than letting a green-ish release imply the models were checked.
+        "candidate_models_exercised": classification != PROVIDER_UNAVAILABLE,
+    }
+
+
+def _run() -> int:
+    """Emit one machine-readable line and map the verdict onto an exit code."""
+    try:
+        report = asyncio.run(main())
+    except BaseException as exc:  # noqa: BLE001 - setup failures classify too
+        classification = classify_provider_error(exc)
+        report = {
+            "check": "managed_vertex_runtime",
+            "ok": False,
+            "classification": classification,
+            "advisory": is_advisory(classification),
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:400],
+            "probes": [],
+            "candidate_models_exercised": False,
+        }
+
+    # Single-line, greppable, and printed on BOTH paths. The caller runs this as
+    # a Cloud Run job via `gcloud run jobs execute --wait`, which surfaces exit
+    # status only -- so the classification has to be recoverable from the job's
+    # logs, which means one stable prefix and valid JSON after it.
+    print(f"{RESULT_PREFIX} {json.dumps(report, separators=(',', ':'), sort_keys=True)}")
+
+    if report["ok"]:
+        return 0
+    if report["advisory"]:
+        return EXIT_PROVIDER_UNAVAILABLE
+    return 1
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(_run())

--- a/consent-protocol/tests/test_dependency_health_classifier.py
+++ b/consent-protocol/tests/test_dependency_health_classifier.py
@@ -1,0 +1,136 @@
+"""A provider outage must not read as a candidate defect, and vice versa.
+
+Written after 2026-08-20, when a Google billing hold returned 403 for every
+project on the account. The Vertex release probe had no way to say "their side",
+so a healthy backend revision was built and then stranded at 0% traffic.
+
+The single most important case here is `test_dunning_403_is_a_provider_outage`.
+The real message is "403 PERMISSION_DENIED. Lightning dunning decision is deny
+for project: projects/745506018753" -- it contains the word PERMISSION, so a
+naive substring rule classifies an account-level billing outage as our own
+misconfiguration and blocks the release. That is the exact regression this file
+exists to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hushh_mcp.runtime_providers.dependency_health import (
+    APPLICATION_BROKEN,
+    CANDIDATE_MISCONFIGURED,
+    DEPENDENCY_OK,
+    PROVIDER_UNAVAILABLE,
+    classify_provider_error,
+    is_advisory,
+    summarize,
+)
+
+DUNNING_403 = (
+    "403 PERMISSION_DENIED. {'error': {'code': 403, 'message': "
+    "'Lightning dunning decision is deny for project: projects/745506018753', "
+    "'status': 'PERMISSION_DENIED'}}"
+)
+
+
+class _ProviderError(Exception):
+    """Shaped like google.genai errors: a message plus status_code/status."""
+
+    def __init__(self, message: str, status_code: int | None = None, status: str = "") -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.status = status
+
+
+def test_dunning_403_is_a_provider_outage() -> None:
+    assert classify_provider_error(_ProviderError(DUNNING_403, 403)) == PROVIDER_UNAVAILABLE
+
+
+def test_dunning_403_is_advisory_so_a_release_may_continue() -> None:
+    assert is_advisory(classify_provider_error(_ProviderError(DUNNING_403, 403))) is True
+
+
+def test_permission_denial_on_a_resource_still_blocks() -> None:
+    """A wrong service account is ours to fix, and must keep blocking."""
+    error = _ProviderError(
+        "Permission 'aiplatform.endpoints.predict' denied on resource //aiplatform...", 403
+    )
+    assert classify_provider_error(error) == CANDIDATE_MISCONFIGURED
+    assert is_advisory(CANDIDATE_MISCONFIGURED) is False
+
+
+def test_unenabled_api_blocks_because_a_release_can_cause_it() -> None:
+    error = _ProviderError("Cloud AI Platform API has not been used in project 123 before", 403)
+    assert classify_provider_error(error) == CANDIDATE_MISCONFIGURED
+
+
+def test_unexplained_403_defaults_to_blocking() -> None:
+    """Ambiguity resolves toward blocking: never ship past an unexplained denial."""
+    assert classify_provider_error(_ProviderError("forbidden", 403)) == CANDIDATE_MISCONFIGURED
+
+
+@pytest.mark.parametrize("status_code", [408, 429, 500, 502, 503, 504])
+def test_transport_and_quota_statuses_are_provider_outages(status_code: int) -> None:
+    assert classify_provider_error(_ProviderError("upstream", status_code)) == PROVIDER_UNAVAILABLE
+
+
+@pytest.mark.parametrize("status_name", ["UNAVAILABLE", "RESOURCE_EXHAUSTED", "INTERNAL"])
+def test_provider_status_names_are_outages_even_without_a_code(status_name: str) -> None:
+    assert classify_provider_error(_ProviderError("x", None, status_name)) == PROVIDER_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    "error", [asyncio.TimeoutError(), TimeoutError(), ConnectionError("refused")]
+)
+def test_timeouts_and_connection_failures_are_provider_outages(error: BaseException) -> None:
+    assert classify_provider_error(error) == PROVIDER_UNAVAILABLE
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 404])
+def test_client_faults_block(status_code: int) -> None:
+    assert classify_provider_error(_ProviderError("bad", status_code)) == CANDIDATE_MISCONFIGURED
+
+
+def test_our_own_manifest_guard_blocks() -> None:
+    error = RuntimeError("No managed Gemini text model is declared by a product manifest")
+    assert classify_provider_error(error) == CANDIDATE_MISCONFIGURED
+
+
+def test_an_outage_wrapped_in_our_own_error_is_still_an_outage() -> None:
+    """The outer type must not decide the verdict.
+
+    Our binding code wraps provider failures in RuntimeError on the way out. If
+    the classifier stopped at the outermost exception it would read every
+    wrapped outage as a candidate defect.
+    """
+    wrapped = RuntimeError("managed vertex probe failed")
+    wrapped.__cause__ = _ProviderError(DUNNING_403, 403)
+    assert classify_provider_error(wrapped) == PROVIDER_UNAVAILABLE
+
+
+def test_unexpected_exception_is_an_application_bug() -> None:
+    assert classify_provider_error(AttributeError("NoneType")) == APPLICATION_BROKEN
+
+
+def test_summarize_lets_one_candidate_fault_outrank_many_outages() -> None:
+    """If even one failure is ours, the release is unsafe regardless."""
+    assert (
+        summarize([PROVIDER_UNAVAILABLE, PROVIDER_UNAVAILABLE, CANDIDATE_MISCONFIGURED])
+        == CANDIDATE_MISCONFIGURED
+    )
+
+
+def test_summarize_reports_an_outage_when_every_failure_is_theirs() -> None:
+    assert summarize([PROVIDER_UNAVAILABLE, PROVIDER_UNAVAILABLE]) == PROVIDER_UNAVAILABLE
+
+
+def test_summarize_of_nothing_is_ok() -> None:
+    assert summarize([]) == DEPENDENCY_OK
+    assert is_advisory(DEPENDENCY_OK) is True
+
+
+def test_application_broken_outranks_everything() -> None:
+    assert summarize([PROVIDER_UNAVAILABLE, APPLICATION_BROKEN]) == APPLICATION_BROKEN
+    assert is_advisory(APPLICATION_BROKEN) is False

--- a/consent-protocol/tests/test_verify_uat_release.py
+++ b/consent-protocol/tests/test_verify_uat_release.py
@@ -104,3 +104,104 @@ def test_semantic_verifier_probes_the_canonical_one_adk_relay(monkeypatch, tmp_p
     assert all("/api/kai/voice/" not in path for path in request_paths)
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert {check["name"] for check in report["checks"]} >= {"voice_relay_session"}
+
+
+def _run_verifier_with_ria(
+    monkeypatch, tmp_path, ria_payload: dict[str, object]
+) -> tuple[int, dict]:
+    """Drive the verifier end to end with one configurable RIA Stage-1 answer."""
+    verifier = _load_verifier()
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _Smoke:
+        user_id = "uat-user"
+
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def authenticate(self) -> None:
+            pass
+
+        def _firebase_auth_headers(self) -> dict[str, str]:
+            return {"Authorization": "Bearer test-token"}
+
+        def _request(self, method: str, path: str, **_kwargs) -> _Response:
+            if path == "/api/kai/gmail/status/uat-user":
+                return _Response({"configured": True, "connected": False})
+            if path == "/api/one/adk/relay-session":
+                return _Response(
+                    {"relay_ticket": "t", "expires_at": 1, "model": "adk", "tier": "full"}
+                )
+            if path == "/api/ria/onboarding/verify-name":
+                return _Response(ria_payload)
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr(verifier, "UatKaiSmoke", _Smoke)
+    monkeypatch.setattr(
+        verifier, "_http_probe", lambda url: {"url": url, "status_code": 200, "ok": True}
+    )
+    report_path = tmp_path / "uat-release.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_uat_release.py",
+            "--backend-url",
+            "https://backend.example",
+            "--frontend-url",
+            "https://frontend.example",
+            "--report-path",
+            str(report_path),
+        ],
+    )
+    code = verifier.main()
+    return code, json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def test_provider_outage_degrades_the_release_instead_of_blocking_it(monkeypatch, tmp_path) -> None:
+    """An upstream Gemini outage must not withhold a healthy build.
+
+    This is the 2026-08-20 case: RIA Stage-1 returned provider_unavailable
+    because its Gemini calls were denied by a billing hold. The release was
+    marked blocked, even though the candidate was fine.
+    """
+    code, report = _run_verifier_with_ria(
+        monkeypatch, tmp_path, {"status": "provider_unavailable", "provider": "ria_stage1"}
+    )
+
+    assert code == 0, "a provider outage must not fail the release"
+    assert report["status"] == "degraded"
+    assert report["degraded"] == ["ria_stage1_query_only"]
+    assert report["failures"] == []
+
+
+def test_a_real_negative_result_still_blocks(monkeypatch, tmp_path) -> None:
+    """not_verified means the provider answered and the answer was wrong.
+
+    That is a genuine regression signal and must keep blocking, otherwise this
+    change would trade one broken gate for a useless one.
+    """
+    code, report = _run_verifier_with_ria(
+        monkeypatch, tmp_path, {"status": "not_verified", "crd_number": None}
+    )
+
+    assert code == 1, "a genuine verification failure must still block"
+    assert report["status"] == "blocked"
+    assert "ria_stage1_query_only" in report["failures"]
+    assert report["degraded"] == []
+
+
+def test_healthy_release_reports_no_degradation(monkeypatch, tmp_path) -> None:
+    code, report = _run_verifier_with_ria(
+        monkeypatch, tmp_path, {"status": "verified", "crd_number": "5838118"}
+    )
+
+    assert code == 0
+    assert report["status"] == "healthy"
+    assert report["degraded"] == []

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -372,11 +372,54 @@ steps:
           --max-retries=0 \
           --task-timeout=90s \
           --quiet
+        set +e
         gcloud run jobs execute "${job_name}" \
           --project="$PROJECT_ID" \
           --region="${_REGION}" \
           --wait \
           --quiet
+        execute_status=$?
+        set -e
+        if [[ "${execute_status}" -eq 0 ]]; then
+          echo "Managed Vertex candidate probe passed."
+          exit 0
+        fi
+
+        # `gcloud run jobs execute` surfaces the execution's exit STATUS only --
+        # the probe's stdout lands in Cloud Logging, not in this build log. So
+        # the verdict has to be read back from the job's logs before we can tell
+        # a provider outage from a candidate defect.
+        probe_line="$(gcloud logging read \
+          "resource.type=cloud_run_job AND resource.labels.job_name=${job_name} AND textPayload:managed_vertex_probe_result" \
+          --project="$PROJECT_ID" \
+          --limit=1 \
+          --format='value(textPayload)' \
+          --freshness=30m 2>/dev/null || true)"
+        classification="$(printf '%s' "${probe_line}" \
+          | sed -n 's/.*"classification":"\([a-z_]*\)".*/\1/p' | head -1)"
+
+        if [[ "${classification}" == "provider_unavailable" ]]; then
+          echo "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+          echo "WARNING  Managed Vertex is UNAVAILABLE (provider-side)."
+          echo "         The candidate image built and deployed correctly; the"
+          echo "         provider refused every probe. Release CONTINUES in"
+          echo "         degraded mode. Vertex-backed capabilities will not work"
+          echo "         until the provider recovers."
+          echo "         Probe verdict: ${probe_line}"
+          echo "         NOTE: a provider denial is returned before model"
+          echo "         validation, so this run did NOT clear the candidate's"
+          echo "         model configuration. Re-probe once the provider is back."
+          echo "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+          exit 0
+        fi
+
+        echo "Managed Vertex candidate probe FAILED and the cause is not a provider outage." >&2
+        if [[ -n "${probe_line}" ]]; then
+          echo "Probe verdict: ${probe_line}" >&2
+        else
+          echo "No probe verdict was recoverable from the job logs; treating as blocking." >&2
+        fi
+        exit 1
     id: "verify-managed-vertex-runtime"
 
 # NOTE: no top-level `images:` block — `docker buildx build --push` (Step 1) already

--- a/scripts/ops/verify_uat_release.py
+++ b/scripts/ops/verify_uat_release.py
@@ -118,6 +118,10 @@ def main() -> int:
     }
 
     failures: list[str] = []
+    # Checks that failed because an EXTERNAL provider is unavailable, not because
+    # this release is bad. They are reported, never hidden, but they must not
+    # block: a Google billing hold is not a reason to withhold healthy code.
+    degraded: list[str] = []
 
     backend_probe = _http_probe(f"{args.backend_url.rstrip('/')}/health")
     report["checks"].append({"name": "backend_health", **backend_probe})
@@ -216,7 +220,16 @@ def main() -> int:
                 }
             )
             if not ria_stage1_ok:
-                failures.append("ria_stage1_query_only")
+                # The backend already distinguishes "the provider is down" from
+                # "this advisor is not verified" -- ria_verification.py emits
+                # provider_unavailable for a 5xx/denied upstream and not_verified
+                # for a genuine negative. Until now that distinction was recorded
+                # in the check and then thrown away here, so an upstream Gemini
+                # outage read as a release regression.
+                if str(ria_stage1.get("status") or "") == "provider_unavailable":
+                    degraded.append("ria_stage1_query_only")
+                else:
+                    failures.append("ria_stage1_query_only")
         except Exception as exc:  # pragma: no cover - exercised in live verification
             _record_exception(report, failures, name="ria_stage1_query_only", exc=exc)
 
@@ -244,9 +257,16 @@ def main() -> int:
             }
         )
 
+    # Three states, not two. A release whose own code is healthy but whose
+    # provider is down is neither "healthy" (AI does not work) nor "blocked"
+    # (nothing is wrong with the build) -- reporting either one is a lie.
+    report["degraded"] = degraded
     if failures:
         report["status"] = "blocked"
         report["failures"] = failures
+    elif degraded:
+        report["status"] = "degraded"
+        report["failures"] = []
 
     report_path = Path(args.report_path)
     report_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## The problem this fixes

On 2026-08-20 a Google billing hold returned 403 for **every project on the billing account**. Two release gates call Vertex, neither could say *"their side, not ours"*, and a correctly-built backend revision (`consent-protocol-00497-pdq`) was created and then **stranded at 0% traffic**.

The same gates failed the earlier deploy of `7c1cbc3b8` for the same reason, before this branch existed. Third-party availability was deciding whether our code could ship.

## What blocks and what does not

| classification | verdict | examples |
|---|---|---|
| `candidate_misconfigured` | **BLOCKS** | wrong service account, unenabled API, model no manifest supports, 400/401/404 |
| `application_broken` | **BLOCKS** | unexpected exception in our own code |
| `provider_unavailable` | warns, release continues | 403 account enforcement (dunning/billing/suspension), 429, 5xx, timeout, connection loss |

An **unexplained 403 classifies as ours on purpose** — blocking a release we may have broken is the safer error than shipping past a real denial.

## Why not baseline-vs-candidate

The brief proposed comparing the serving revision against the candidate. It does not work for this probe: it runs as a Cloud Run **job** whose credentials, project, billing state and quota are identical for both, so only image content differs — and a dunning 403 is returned **before any model-specific validation**, so it would *mask* a real candidate defect rather than reveal one.

Classification therefore comes from **error shape**, which is decidable. Where an outage is declared the report records `candidate_models_exercised: false`, so a degraded release never implies the models were actually checked.

## Two bugs found along the way

- **`asyncio.gather` without `return_exceptions`** — the first failure cancelled the other 8 probes, discarding exactly the evidence that separates *"every probe failed identically"* (outage) from *"only this model, only this location"* (defect).
- **The verdict never reached the build.** `gcloud run jobs execute --wait` surfaces exit status only; the probe's stdout goes to Cloud Logging. So even a perfect classifier was unreadable by its caller. The step now reads it back from the job's logs, and **fails closed** when no verdict is recoverable.

## This is not advisory-by-default

Only *proven* external outages are downgraded. A genuine negative from a provider that answered still blocks — `test_a_real_negative_result_still_blocks` exists specifically to stop this becoming a blanket `allowFailure`.

## Tests

**32 new, all passing.** Also registered three release-gate test files in `scripts/test-ci.manifest.txt`: `test_verify_uat_release.py` and `test_managed_vertex_readiness_script.py` already existed but were **not in the allowlist, so they had never run on a PR**. Both pass.

## Scope

Release pipeline only. Runtime capability health and per-surface degraded UI are deliberately **not** here — the frontend already has a solid reference pattern for Maps (three-state loader, keyless fallback, 5s timeout), and that work is scoped separately.

## Verification note

The degraded path can be tested against reality right now, because Vertex is genuinely denied. The **healthy** path cannot be re-verified until the billing hold on account `014D7F-FD970D-D2459E` clears.