### PR TITLE
Polish location onboarding copy

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -627,7 +627,7 @@ async function openLocationFeatureStep() {
   fireEvent.click(screen.getByRole("button", { name: "Get started" }));
   expect(
     await screen.findByRole("heading", {
-      name: "Need to keep people updated?",
+      name: "Keep your people updated.",
     }),
   ).toBeTruthy();
 }
@@ -650,7 +650,7 @@ async function reachLocationOnboardingFinalStep() {
   await waitFor(() => {
     const savePrompt = screen.queryByTestId("save-location-modal");
     const continueButton = screen.queryByRole("button", {
-      name: /Find my people|Allow location/,
+      name: /Continue|Allow location/,
     });
     expect(savePrompt || continueButton).toBeTruthy();
   });
@@ -661,7 +661,7 @@ async function reachLocationOnboardingFinalStep() {
     );
   }
   const continueButton = await screen.findByRole("button", {
-    name: /Find my people|Allow location/,
+    name: /Continue|Allow location/,
   });
   await waitFor(() => expect(continueButton).toBeEnabled());
   fireEvent.click(continueButton);
@@ -683,7 +683,7 @@ async function leaveLocationFeatureStep() {
   await waitFor(() => {
     const savePrompt = screen.queryByTestId("save-location-modal");
     const continueButton = screen.queryByRole("button", {
-      name: /Find my people|Allow location/,
+      name: /Continue|Allow location/,
     });
     expect(savePrompt || continueButton).toBeTruthy();
   });
@@ -694,7 +694,7 @@ async function leaveLocationFeatureStep() {
     );
   }
   const continueButton = await screen.findByRole("button", {
-    name: /Find my people|Allow location/,
+    name: /Continue|Allow location/,
   });
   await waitFor(() => expect(continueButton).toBeEnabled());
   fireEvent.click(continueButton);
@@ -2380,7 +2380,7 @@ describe("OneLocationAgentPage", () => {
     await openLocationPermissionsStep();
     expect(screen.getByTestId("one-location-onboarding-features")).toBeTruthy();
     await waitFor(() => expect(mockOpenAppSettings).toHaveBeenCalled());
-    expect(screen.getByRole("button", { name: "Find my people" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
     expect(onSetupComplete).not.toHaveBeenCalled();
   });
 
@@ -2695,7 +2695,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeLessThan(mockCaptureCurrentPosition.mock.invocationCallOrder[0]!);
     expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await expectLocationInviteStep();
     fireEvent.click(await locationFinishButton());
     expect(
@@ -2790,7 +2790,7 @@ describe("OneLocationAgentPage", () => {
       ),
     ).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await expectLocationInviteStep();
   });
 
@@ -2914,7 +2914,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockRequestLocationPermission).not.toHaveBeenCalled();
     expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await expectLocationInviteStep();
     fireEvent.click(await locationFinishButton());
     expect(
@@ -2958,7 +2958,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save location" }));
     await waitFor(() => expect(mockAddSavedLocation).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await expectLocationInviteStep();
     fireEvent.click(await locationFinishButton());
     expect(
@@ -3054,7 +3054,7 @@ describe("OneLocationAgentPage", () => {
       ).toBeTruthy();
       expect(
         screen.queryByRole("heading", {
-          name: "Need to keep people updated?",
+          name: "Keep your people updated.",
         }),
       ).toBeNull();
       expect(

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -72,7 +72,7 @@ function renderFlow(
 /** welcome -> features -> contacts. */
 function openContactsScreen() {
   fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-  fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 }
 
 /** ...and on to the invite screen, declining the contacts step. */
@@ -139,7 +139,7 @@ describe("OneLocationOnboardingFlow", () => {
 
     const advance = [
       ["one-location-onboarding-welcome", "Get started"],
-      ["one-location-onboarding-features", "Find my people"],
+      ["one-location-onboarding-features", "Continue"],
       ["one-location-onboarding-contacts", "Not now"],
       ["one-location-onboarding-invite", null],
     ] as const;
@@ -172,7 +172,7 @@ describe("OneLocationOnboardingFlow", () => {
     record("one-location-onboarding-welcome");
     fireEvent.click(screen.getByRole("button", { name: "Get started" }));
     record("one-location-onboarding-features");
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     record("one-location-onboarding-contacts");
     fireEvent.click(screen.getByRole("button", { name: "Not now" }));
     record("one-location-onboarding-invite");
@@ -309,20 +309,17 @@ describe("OneLocationOnboardingFlow", () => {
           .getByTestId("location-use-case-checkin")
           .querySelectorAll("[data-one-feature-title-line]"),
       ).map((line) => line.textContent),
-    ).toEqual(["At the venue, but", "can\u2019t find each other?"]);
+    ).toEqual(["Stuck in the", "check-in line?"]);
     expect(
       Array.from(
         screen
           .getByTestId("location-use-case-sos")
           .querySelectorAll("[data-one-feature-title-line]"),
       ).map((line) => line.textContent),
-    ).toEqual(["Need help but can\u2019t", "call or speak?"]);
+    ).toEqual(["Need help but", "can\u2019t talk?"]);
 
     expect(
-      screen.getByRole("heading", { name: "Need to keep people updated?" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByText("Share location, check in, or send help in seconds."),
+      screen.getByRole("heading", { name: "Keep your people updated." }),
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
@@ -330,17 +327,25 @@ describe("OneLocationOnboardingFlow", () => {
       }),
     ).toBeTruthy();
     expect(
-      screen.getByText("Share once. Your Circle can find you safely."),
+      screen.getByText("Share your live location with your Circle in one tap."),
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: "At the venue, but can\u2019t find each other?",
+        name: "Stuck in the check-in line?",
       }),
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: "Need help but can\u2019t call or speak?",
+        name: "Need help but can\u2019t talk?",
       }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Check in early, pick up your key, and skip the front desk.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Send an SOS with your location in seconds."),
     ).toBeTruthy();
 
     expect(screen.getByText("Share location")).toBeTruthy();
@@ -410,7 +415,7 @@ describe("OneLocationOnboardingFlow", () => {
     }
     expect(shareCard.querySelector('img[src*="/orbit-person-"]')).toBeNull();
 
-    expect(screen.getByRole("button", { name: "Find my people" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Go back" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
     expect(screen.queryByText("Connected Person")).toBeNull();
@@ -424,7 +429,7 @@ describe("OneLocationOnboardingFlow", () => {
     expect(props.onLocationReady).not.toHaveBeenCalled();
     expect(props.onRequestNotifications).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     fireEvent.click(screen.getByRole("button", { name: "Go back" }));
     expect(props.onRequestLocation).toHaveBeenCalledTimes(1);
     expect(props.onRequestNotifications).toHaveBeenCalledTimes(1);
@@ -447,11 +452,11 @@ describe("OneLocationOnboardingFlow", () => {
     expect(props.onRequestNotifications).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Find my people" }),
+        screen.getByRole("button", { name: "Continue" }),
       ).toBeEnabled(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     fireEvent.click(screen.getByRole("button", { name: "Go back" }));
     expect(props.onLocationReady).toHaveBeenCalledTimes(1);
   });
@@ -484,7 +489,7 @@ describe("OneLocationOnboardingFlow", () => {
     expect(props.onRequestLocation).toHaveBeenCalledTimes(1);
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Find my people" }),
+        screen.getByRole("button", { name: "Continue" }),
       ).toBeEnabled(),
     );
   });
@@ -512,7 +517,7 @@ describe("OneLocationOnboardingFlow", () => {
 
     await waitFor(() => expect(onLocationReady).toHaveBeenCalledTimes(1));
     expect(
-      screen.getByRole("button", { name: "Find my people" }),
+      screen.getByRole("button", { name: "Continue" }),
     ).toBeDisabled();
     expect(screen.queryByTestId("one-location-onboarding-people")).toBeNull();
 
@@ -522,7 +527,7 @@ describe("OneLocationOnboardingFlow", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Find my people" }),
+        screen.getByRole("button", { name: "Continue" }),
       ).toBeEnabled(),
     );
   });
@@ -531,8 +536,8 @@ describe("OneLocationOnboardingFlow", () => {
     const props = renderFlow({ requireLocationToComplete: true });
 
     fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-    expect(screen.getByRole("button", { name: "Find my people" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(props.onRequestLocation).toHaveBeenCalledTimes(2);
     expect(screen.getByTestId("one-location-onboarding-features")).toBeTruthy();
@@ -613,7 +618,7 @@ describe("OneLocationOnboardingFlow", () => {
 
     expect(screen.getByRole("button", { name: "Go back" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(screen.getByRole("button", { name: "Go back" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
@@ -733,7 +738,7 @@ describe("OneLocationOnboardingFlow", () => {
       "bg-[color:var(--app-grouped-background)]",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     const contactsScreen = screen.getByTestId(
       "one-location-onboarding-contacts",
     );
@@ -1151,7 +1156,7 @@ describe("OneLocationOnboardingFlow", () => {
       renderFlow({ contactsStepAvailable: false, onSyncOnboardingContacts });
 
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-      fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
       expect(screen.getByTestId("one-location-onboarding-invite")).toBeTruthy();
       expect(
@@ -1164,7 +1169,7 @@ describe("OneLocationOnboardingFlow", () => {
       renderFlow({ contactsStepAvailable: false });
 
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-      fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
       fireEvent.click(screen.getByRole("button", { name: "Go back" }));
 
       // Back must not land on a screen that was never shown.
@@ -1177,7 +1182,7 @@ describe("OneLocationOnboardingFlow", () => {
       const props = renderFlow({ contactsStepAvailable: false });
 
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-      fireEvent.click(screen.getByRole("button", { name: "Find my people" }));
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
       fireEvent.click(finishButton());
 
       expect(props.onComplete).toHaveBeenCalledTimes(1);

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -651,7 +651,7 @@ function ShareLocationFeatureCard() {
           className="text-[15px] leading-[1.4] text-[#747b86] dark:text-[#aeb8c7]"
           data-one-feature-body
         >
-          Share once. Your Circle can find you safely.
+          Share your live location with your Circle in one tap.
         </p>
       </div>
       <div
@@ -720,14 +720,14 @@ function CheckInFeatureCard() {
           Check in
         </span>
         <TwoLineFeatureTitle
-          lines={["At the venue, but", "can\u2019t find each other?"]}
+          lines={["Stuck in the", "check-in line?"]}
           className="text-[19px]"
         />
         <p
           className="text-[14px] leading-[1.4] text-[#747b86] dark:text-[#aeb8c7]"
           data-one-feature-body
         >
-          Check in anywhere. Your Circle knows you arrived.
+          Check in early, pick up your key, and skip the front desk.
         </p>
       </div>
       <div
@@ -781,14 +781,14 @@ function SaveMySoulFeatureCard() {
           SMS &middot; Save My Soul
         </span>
         <TwoLineFeatureTitle
-          lines={["Need help but can\u2019t", "call or speak?"]}
+          lines={["Need help but", "can\u2019t talk?"]}
           className="text-[19px]"
         />
         <p
           className="text-[14px] leading-[1.4] text-[#747b86] dark:text-[#c2aeb2]"
           data-one-feature-body
         >
-          Send your location when you need help fast.
+          Send an SOS with your location in seconds.
         </p>
       </div>
       <div
@@ -907,14 +907,8 @@ function FeaturesScreen({
             className="ui-text-agent-title text-[#111823] dark:!text-[#f6f8fc]"
             data-one-feature-heading
           >
-            Need to keep people updated?
+            Keep your people updated.
           </h1>
-          <p
-            className="mt-3 text-[15px] font-normal leading-[20px] text-[#737a84] dark:text-[#aeb8c7]"
-            data-one-feature-subtitle
-          >
-            Share location, check in, or send help in seconds.
-          </p>
         </header>
         <div className="mx-auto mt-6 grid w-full max-w-[700px] shrink-0 gap-4" data-one-feature-grid>
           <ShareLocationFeatureCard />
@@ -943,10 +937,7 @@ function FeaturesScreen({
           disabled={permissionBusy}
           className="h-[58px] min-h-[58px]"
         >
-          {/* Names the next screen, which is finding people you already know.
-              A deliberately distinct string also keeps the reviewer flow's
-              exact button match from colliding with a generic "Continue". */}
-          {locationPreparationRetry ? "Try again" : "Find my people"}
+          {locationPreparationRetry ? "Try again" : "Continue"}
         </PrimaryButton>
       </div>
       <style>{`

--- a/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
@@ -83,8 +83,8 @@ const CARD = `
          line once the fixture stopped using the machine's fallback font and
          started using the InterVariable the product ships. That reported a 22px
          overlap with the artwork at every width, on a card that is fine. -->
-    <div class="text-[19px] font-bold leading-[1.13] tracking-[-0.015em]" role="heading" aria-level="2" data-one-feature-title><span class="block whitespace-nowrap" data-one-feature-title-line>At the venue, but</span><span class="block whitespace-nowrap" data-one-feature-title-line>can&rsquo;t find each other?</span></div>
-    <p class="text-[14px] leading-[1.4] text-[#747b86]" data-one-feature-body>Check in anywhere. Your Circle knows you arrived.</p>
+    <div class="text-[19px] font-bold leading-[1.13] tracking-[-0.015em]" role="heading" aria-level="2" data-one-feature-title><span class="block whitespace-nowrap" data-one-feature-title-line>Stuck in the</span><span class="block whitespace-nowrap" data-one-feature-title-line>check-in line?</span></div>
+    <p class="text-[14px] leading-[1.4] text-[#747b86]" data-one-feature-body>Check in early, pick up your key, and skip the front desk.</p>
   </div>
   <div class="absolute inset-x-0 bottom-0 h-[47%]" data-one-use-case-art aria-hidden="true">
     <span class="absolute bottom-[48%] left-1/2 w-[54%] -translate-x-1/2" data-one-checkin-art>

--- a/hushh-webapp/e2e/one-location-picker-layering.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-picker-layering.layout.spec.ts
@@ -40,7 +40,7 @@ function builtStylesheet(): string {
 
 const PAGE = `
   <div data-app-scroll-root="true"><p>saved places behind</p></div>
-  <div data-testid="one-location-onboarding"><h1>Need to keep people updated?</h1></div>
+  <div data-testid="one-location-onboarding"><h1>Keep your people updated.</h1></div>
   <div id="dialog-portal"></div>
 `;
 

--- a/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
+++ b/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
@@ -76,7 +76,7 @@ export const UI_FLOWS = [
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[0] },
       { type: "click_button", name: "Get started" },
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[1] },
-      { type: "click_button", name: "Find my people" },
+      { type: "click_button", name: "Continue" },
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[2] },
       // "Not now" rather than "Check my contacts": the reviewer run must not
       // trigger an OS contacts prompt, and declining is the path every person


### PR DESCRIPTION
## Summary
- update the Location onboarding feature screen headline to `Keep your people updated.`
- remove the supporting line under that headline
- update the three feature-card titles/body lines for Share location, Check in, and SMS
- change the primary CTA from `Find my people` to `Continue`

## Verification
- `npm run verify:design-system`
- `npm run typecheck`