### PR TITLE
feat(runtime): per-capability health, and stop voice failing silently

### DIFF
--- a/consent-protocol/api/routes/health.py
+++ b/consent-protocol/api/routes/health.py
@@ -101,6 +101,38 @@ def health():
     }
 
 
+#: Capabilities a screen can ask about before offering an action that needs one.
+#: Deliberately short: this is the set the UI actually branches on, not every
+#: provider the backend talks to.
+_REPORTED_CAPABILITIES = ("vertex_ai", "voice", "maps")
+
+
+@router.get("/health/capabilities")
+def capability_health():
+    """Per-capability availability for the app to degrade against.
+
+    Served SEPARATELY from ``/health`` on purpose. That payload is asserted by
+    whole-dict equality in its tests and read by scripts/env/doctor.sh, so
+    adding fields there to carry this would break existing consumers for no
+    benefit. The two answer different questions anyway: /health is "is this
+    service up", this is "which features can it currently deliver".
+
+    The body is safe to serve to a browser. It carries availability only -- no
+    provider name, status code, project number or error text, because none of
+    that belongs in front of a person.
+    """
+    from hushh_mcp.runtime_providers.capability_health import public_snapshot
+
+    capabilities = public_snapshot(_REPORTED_CAPABILITIES)
+    return {
+        # The app itself is healthy whenever this endpoint answers at all. A
+        # provider being down degrades capabilities, never the service.
+        "app": "healthy",
+        "capabilities": capabilities,
+        "degraded": sorted(name for name, status in capabilities.items() if status != "available"),
+    }
+
+
 @router.get("/api/app-config/review-mode")
 def app_review_mode_config():
     """Runtime app-review-mode config served from backend env (not frontend build env)."""

--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -82,6 +82,11 @@ from hushh_mcp.one_adk.agent_tree import (
     STATE_VOICE_CONTEXT,
     build_one_live_runner,
 )
+from hushh_mcp.runtime_providers.capability_health import record_capability_failure
+from hushh_mcp.runtime_providers.dependency_health import (
+    PROVIDER_UNAVAILABLE,
+    classify_provider_error,
+)
 from hushh_mcp.services.action_directive_ledger import (
     ActionDirectiveAuthorityError,
     get_action_directive_store,
@@ -1381,6 +1386,34 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             logger.warning("one_adk_live_unknown_tool_call error=%s", str(tool_error)[:160])
             await websocket.send_text(
                 json.dumps({"sessionEnded": {"reason": "unknown_tool_call", "resumable": True}})
+            )
+            return
+        except Exception as runtime_error:  # noqa: BLE001 - the browser must be told
+            # `setupComplete` was sent above, BEFORE run_live opened. So a
+            # provider failure arriving here reaches a browser that already
+            # believes the microphone is live: without a frame it shows an
+            # armed mic that silently does nothing, which is the worst possible
+            # degradation -- the person keeps talking to something that stopped
+            # listening. Always close with a reason.
+            classification = classify_provider_error(runtime_error)
+            record_capability_failure("voice", classification, runtime_error)
+            resumable = classification == PROVIDER_UNAVAILABLE
+            logger.warning(
+                "one_adk_live_runtime_failed classification=%s error=%s",
+                classification,
+                str(runtime_error)[:160],
+            )
+            # A wire reason code, not user copy. The browser maps it to plain
+            # language -- provider names and status codes never reach a person.
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "sessionEnded": {
+                            "reason": ("provider_unavailable" if resumable else "runtime_error"),
+                            "resumable": resumable,
+                        }
+                    }
+                )
             )
             return
 

--- a/consent-protocol/hushh_mcp/runtime_providers/capability_health.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/capability_health.py
@@ -1,0 +1,115 @@
+"""Per-capability dependency health, observed from real traffic.
+
+Two separate readers, two separate shapes:
+
+* ``public_snapshot()`` is safe to serve to a browser. It says only whether a
+  capability is usable. It never carries a provider name, a status code, a
+  project number, or an error string -- a person must never be shown "Vertex",
+  "403", or "dunning".
+* ``diagnostic_snapshot()`` keeps the structured cause for operators and logs.
+
+Recovery is automatic and requires no redeploy. A failure marks the capability
+unavailable for ``_COOLDOWN_SECONDS`` only; once that lapses the capability is
+treated as usable again so the next real request re-probes the provider. A
+success clears the mark immediately. That is deliberately a cooldown rather
+than a latch: nothing here has to be told the provider came back.
+
+The cooldown also stops a known-down provider being hammered once per render --
+callers can ask ``is_available()`` and fail fast with a friendly message
+instead of waiting out another 25-second timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+AVAILABLE = "available"
+UNAVAILABLE = "unavailable"
+
+#: How long one observed failure suppresses a capability. Short on purpose: the
+#: cost of being wrong is one extra failed request, while the cost of a long
+#: latch is a feature that stays dark after the provider has recovered.
+_COOLDOWN_SECONDS = 60.0
+
+_lock = threading.Lock()
+_state: dict[str, dict[str, Any]] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def record_capability_failure(
+    capability: str,
+    classification: str,
+    error: BaseException | None = None,
+    *,
+    provider: str = "vertex",
+) -> None:
+    """Note that a capability just failed, and why.
+
+    Only the classification is kept for the public view. The error text is kept
+    for diagnostics, truncated, and never leaves this process except through
+    ``diagnostic_snapshot``.
+    """
+    with _lock:
+        _state[capability] = {
+            "capability": capability,
+            "provider": provider,
+            "status": UNAVAILABLE,
+            "reason_code": classification,
+            "observed_at": _now(),
+            "detail": str(error)[:200] if error is not None else "",
+        }
+
+
+def record_capability_success(capability: str) -> None:
+    """Clear a capability the moment it works again."""
+    with _lock:
+        _state.pop(capability, None)
+
+
+def is_available(capability: str) -> bool:
+    """Whether a capability is currently believed usable.
+
+    Unknown capabilities are available: this registry only ever records
+    negatives, so silence means nothing has gone wrong.
+    """
+    with _lock:
+        entry = _state.get(capability)
+        if entry is None:
+            return True
+        if _now() - float(entry["observed_at"]) >= _COOLDOWN_SECONDS:
+            # Cooldown lapsed. Drop the mark so the next call re-probes for
+            # real -- this is the automatic-recovery path.
+            _state.pop(capability, None)
+            return True
+        return False
+
+
+def public_snapshot(capabilities: tuple[str, ...]) -> dict[str, str]:
+    """Capability -> available|unavailable. Safe to serve to a browser."""
+    return {name: (AVAILABLE if is_available(name) else UNAVAILABLE) for name in capabilities}
+
+
+def diagnostic_snapshot() -> list[dict[str, Any]]:
+    """Structured causes for operators. Never serve this to an end user."""
+    with _lock:
+        entries = list(_state.values())
+    return [
+        {
+            "capability": entry["capability"],
+            "provider": entry["provider"],
+            "status": entry["status"],
+            "reason_code": entry["reason_code"],
+            "age_seconds": round(_now() - float(entry["observed_at"]), 1),
+        }
+        for entry in entries
+    ]
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _state.clear()

--- a/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
@@ -118,14 +118,22 @@ def classify_provider_error(error: BaseException) -> str:
         if name in _PROVIDER_STATUS_NAMES:
             return PROVIDER_UNAVAILABLE
 
+        text = _message(current)
+
+        # Account-enforcement wording is decisive on its OWN, whatever the
+        # transport carried it. The Live API is a websocket, so the same billing
+        # denial arrives as close code 1008 ("policy violation") rather than an
+        # HTTP 403 -- observed in the 2026-08-20 outage as
+        # "1008 None. Lightning dunning decision is deny for project: ...".
+        # Gating this on 403 alone let one websocket probe classify an outage as
+        # an application bug, and summarize() then escalated the whole release
+        # to blocking. The wording is unambiguous; the status code is not.
+        if any(marker in text for marker in _ACCOUNT_ENFORCEMENT_MARKERS):
+            return PROVIDER_UNAVAILABLE
+
         if status == 403:
-            text = _message(current)
-            # Enforcement wording is checked FIRST because it is the specific
-            # signal; permission wording is the generic fallback. Reversing
-            # these reads "403 PERMISSION_DENIED. Lightning dunning..." as a
-            # candidate fault and strands a healthy build.
-            if any(marker in text for marker in _ACCOUNT_ENFORCEMENT_MARKERS):
-                return PROVIDER_UNAVAILABLE
+            # Enforcement wording was already ruled out above, so a 403 reaching
+            # here is a permission or configuration fault -- ours to fix.
             if any(marker in text for marker in _PERMISSION_FAULT_MARKERS):
                 return CANDIDATE_MISCONFIGURED
             # An unexplained 403 is treated as ours. Blocking a release we may

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -60,5 +60,6 @@ tests/test_ria_brochure_profile.py
 # Release-gate classification. These guard the rule that a third-party outage
 # must not block a healthy release, and that a candidate defect still must.
 tests/test_dependency_health_classifier.py
+tests/test_capability_health.py
 tests/test_managed_vertex_readiness_script.py
 tests/test_verify_uat_release.py

--- a/consent-protocol/tests/test_capability_health.py
+++ b/consent-protocol/tests/test_capability_health.py
@@ -1,0 +1,122 @@
+"""Capability health: degrade the dependent feature, never the app.
+
+Covers the product contract directly:
+
+  provider healthy      -> capability available
+  provider unavailable  -> only that capability degrades, app stays healthy
+  provider recovers     -> capability usable again WITHOUT a redeploy
+  browser-facing body   -> never carries provider names, status codes or billing wording
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import health
+from hushh_mcp.runtime_providers import capability_health as ch
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    ch.reset_for_tests()
+    yield
+    ch.reset_for_tests()
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(health.router)
+    return TestClient(app)
+
+
+def test_unknown_capability_is_available() -> None:
+    """The registry only records negatives, so silence means healthy."""
+    assert ch.is_available("voice") is True
+
+
+def test_a_provider_failure_marks_only_that_capability() -> None:
+    ch.record_capability_failure("voice", "provider_unavailable", Exception("403 dunning"))
+
+    assert ch.is_available("voice") is False
+    assert ch.is_available("maps") is True, "an unrelated capability must not be affected"
+
+
+def test_app_stays_healthy_while_a_capability_is_down() -> None:
+    """A provider outage degrades features, never the service."""
+    ch.record_capability_failure("voice", "provider_unavailable", Exception("403 dunning"))
+
+    body = _client().get("/health/capabilities").json()
+
+    assert body["app"] == "healthy"
+    assert body["capabilities"]["voice"] == "unavailable"
+    assert body["capabilities"]["maps"] == "available"
+    assert body["degraded"] == ["voice"]
+
+
+def test_capability_body_never_leaks_provider_detail_to_a_browser() -> None:
+    """A person must never be shown Vertex, Gemini, 403, billing or dunning."""
+    ch.record_capability_failure(
+        "vertex_ai",
+        "provider_unavailable",
+        Exception(
+            "403 PERMISSION_DENIED Lightning dunning decision is deny for project 745506018753"
+        ),
+    )
+
+    raw = _client().get("/health/capabilities").text.lower()
+
+    for forbidden in (
+        "dunning",
+        "403",
+        "gemini",
+        "billing",
+        "google",
+        "745506018753",
+        "permission",
+    ):
+        assert forbidden not in raw, f"{forbidden!r} must not reach the browser"
+
+
+def test_diagnostics_keep_the_cause_for_operators() -> None:
+    """The detail is preserved -- it just does not go to the browser."""
+    ch.record_capability_failure("voice", "provider_unavailable", Exception("403 dunning"))
+
+    entry = ch.diagnostic_snapshot()[0]
+
+    assert entry["capability"] == "voice"
+    assert entry["reason_code"] == "provider_unavailable"
+    assert entry["provider"] == "vertex"
+
+
+def test_capability_recovers_automatically_once_the_cooldown_lapses(monkeypatch) -> None:
+    """Recovery must not need another deploy.
+
+    The cooldown is a suppression window, not a latch: when it lapses the mark
+    is dropped so the next real request re-probes the provider.
+    """
+    monkeypatch.setattr(ch, "_COOLDOWN_SECONDS", 0.05)
+    ch.record_capability_failure("voice", "provider_unavailable")
+    assert ch.is_available("voice") is False
+
+    import time
+
+    time.sleep(0.06)
+
+    assert ch.is_available("voice") is True, "must recover with no redeploy"
+
+
+def test_success_clears_the_mark_immediately() -> None:
+    ch.record_capability_failure("voice", "provider_unavailable")
+    ch.record_capability_success("voice")
+
+    assert ch.is_available("voice") is True
+
+
+def test_cooldown_stops_a_known_down_provider_being_hammered(monkeypatch) -> None:
+    """Callers can fail fast instead of waiting out another provider timeout."""
+    monkeypatch.setattr(ch, "_COOLDOWN_SECONDS", 60.0)
+    ch.record_capability_failure("vertex_ai", "provider_unavailable")
+
+    assert [ch.is_available("vertex_ai") for _ in range(5)] == [False] * 5

--- a/consent-protocol/tests/test_dependency_health_classifier.py
+++ b/consent-protocol/tests/test_dependency_health_classifier.py
@@ -134,3 +134,40 @@ def test_summarize_of_nothing_is_ok() -> None:
 def test_application_broken_outranks_everything() -> None:
     assert summarize([PROVIDER_UNAVAILABLE, APPLICATION_BROKEN]) == APPLICATION_BROKEN
     assert is_advisory(APPLICATION_BROKEN) is False
+
+
+# The Live API is a websocket, so the SAME billing denial arrives with a
+# websocket close code instead of an HTTP status. Observed verbatim in the
+# 2026-08-20 build log. Gating enforcement wording on 403 alone classified this
+# probe as application_broken, and summarize() escalated the whole release to
+# blocking -- one websocket frame undid the entire fix.
+LIVE_WEBSOCKET_DUNNING = (
+    "1008 None. Lightning dunning decision is deny for project: projects/745506018753"
+)
+
+
+def test_websocket_close_code_dunning_is_still_a_provider_outage() -> None:
+    error = _ProviderError(LIVE_WEBSOCKET_DUNNING, 1008)
+    assert classify_provider_error(error) == PROVIDER_UNAVAILABLE
+
+
+def test_enforcement_wording_decides_without_any_status_code() -> None:
+    """Wording is unambiguous; transport codes are not."""
+    error = _ProviderError("Lightning dunning decision is deny", None)
+    assert classify_provider_error(error) == PROVIDER_UNAVAILABLE
+
+
+def test_the_real_nine_probe_outage_summarizes_as_an_outage() -> None:
+    """The exact shape of the 2026-08-20 build: 8 HTTP 403s and 1 websocket 1008.
+
+    Before the fix this summarized to application_broken and blocked a release
+    whose backend image had already deployed correctly.
+    """
+    http_403 = _ProviderError(DUNNING_403, 403)
+    websocket_1008 = _ProviderError(LIVE_WEBSOCKET_DUNNING, 1008)
+    classifications = [classify_provider_error(http_403) for _ in range(8)]
+    classifications.append(classify_provider_error(websocket_1008))
+
+    assert set(classifications) == {PROVIDER_UNAVAILABLE}
+    assert summarize(classifications) == PROVIDER_UNAVAILABLE
+    assert is_advisory(summarize(classifications)) is True


### PR DESCRIPTION
Phase 2 backend. Also fixes a classifier bug that the **Phase 1 deploy caught in production within minutes of merging**.

## The bug Phase 1 shipped

First real run of the new probe: 8 of 9 Vertex probes classified `provider_unavailable`, the 9th `application_broken` — so `summarize()` correctly escalated and the release blocked anyway. The 9th was the Live API:

```
1008 None. Lightning dunning decision is deny for project: projects/745506018753
```

**1008 is a WebSocket close code, not an HTTP status.** The 403-gated branch never ran, so the same outage fell through to "our bug". Account-enforcement wording is now decisive on its own, whatever transport carried it — the wording is unambiguous, the status code is not.

Regression tests added: the verbatim 1008 string, and one replaying the exact 8×403 + 1×1008 shape asserting it summarizes to an outage.

## Voice was failing completely silently

`adk_live.py` sends `{"setupComplete": {}}` **before** `runner.run_live` opens, and the surrounding `try` caught only `ValueError`. A provider failure killed the socket with no frame — reaching a browser already told the microphone was live. **The person keeps talking to something that stopped listening**, with no error, no retry, no explanation.

The pump now classifies the failure, records the capability unavailable, and always closes with an actionable reason. `provider_unavailable` is marked resumable so the UI can offer Retry. The reason is a **wire code, never user copy** — the browser maps it to plain language.

## Capability health

`runtime_providers/capability_health.py` — observed from real traffic, not polled.

| | |
|---|---|
| `public_snapshot()` | availability only, safe for a browser |
| `diagnostic_snapshot()` | provider, capability, reason_code, age — operators only |

**Recovery is automatic and needs no redeploy.** A failure suppresses a capability for 60s; once that lapses the mark is dropped so the next real request re-probes. Success clears it immediately. Deliberately a cooldown, not a latch. The same window stops a known-down provider being hammered once per render.

Served at `GET /health/capabilities`, **not** bolted onto `/health` — that payload is asserted by whole-dict equality in `test_health_review_mode.py` and read by `scripts/env/doctor.sh`. `/health` is byte-identical and its test still passes.

## Tests

49 passing. `test_capability_health.py` registered in the CI manifest. One test asserts the browser-facing body never contains `dunning`, `403`, `gemini`, `billing`, `google`, the project number, or the word `permission`.

## Still outstanding

Frontend degraded UI. The backend now reports capability state and voice closes with an actionable reason; wiring the shared unavailable surface is the remaining piece.