### PR TITLE
Polish Location home action hierarchy

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1198,10 +1198,10 @@ describe("OneLocationAgentPage", () => {
     expect(await toneOf("Needs my review")).toBe("gray");
   });
 
-  it("colours each counted Now-hub row by its own state once it is non-zero", async () => {
-    // Green = sharing is live (same family as the header switch and Check-In),
-    // indigo = other people, orange = something is waiting on you. Each row
-    // reads its OWN count, so one being populated must not colour the others.
+  it("keeps Activity rows visually quiet even when counts are non-zero", async () => {
+    // Activity is a status list, not an action palette. Colour belongs to the
+    // Actions grid and real alerts; counts alone should not make these rows
+    // compete with the primary tasks on the screen.
     mockGetState.mockResolvedValue({
       ...locationState(),
       receivedGrants: [
@@ -1241,41 +1241,39 @@ describe("OneLocationAgentPage", () => {
         ?.getAttribute("data-icon-tone");
     };
 
-    // locationState() already carries one active ownerGrant.
-    expect(await toneOf("Active shares")).toBe("green");
-    expect(await toneOf("Shared with me")).toBe("indigo");
-    expect(await toneOf("Needs my review")).toBe("orange");
+    expect(await toneOf("Active shares")).toBe("gray");
+    expect(await toneOf("Shared with me")).toBe("gray");
+    expect(await toneOf("Needs my review")).toBe("gray");
   });
 
-  it("groups the two things you do apart from the things that are happening", async () => {
-    // Reported: "share location / request location ek sath hona chahiye kyuki
-    // yeh user ke action items hain" — sharing your location and asking for
-    // someone else's are the same kind of decision pointed in opposite
-    // directions, and they sat two groups apart: one alone at the top, the
-    // other buried under three status rows.
-    //
-    // Everything else on this tab is either what is already happening (active
-    // shares, shared with me, needs my review) or where to look at it (Your
-    // Map) or how to change it (Settings). Two groups, not three.
+  it("uses one Actions grid, then quiet Activity and More lists", async () => {
+    // Now has one action home: Share, Request, Check-In, and SOS are peer
+    // choices in a 2x2 panel. Generated state and utility destinations stay in
+    // list groups, which keeps the tab from reading like a dashboard.
     mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
 
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    const actions = await screen.findByTestId("one-location-now-share");
+    const actions = await screen.findByTestId("one-location-now-actions");
     expect(within(actions).getByText("Share location")).toBeTruthy();
     expect(within(actions).getByText("Request location")).toBeTruthy();
+    expect(within(actions).getByText("Check-In")).toBeTruthy();
+    expect(within(actions).getByText("Send SOS")).toBeTruthy();
 
-    const rest = screen.getByTestId("one-location-now-status");
-    expect(within(rest).getByText("Your Map")).toBeTruthy();
-    expect(within(rest).getByText("Active shares")).toBeTruthy();
-    expect(within(rest).getByText("Settings")).toBeTruthy();
+    const activity = screen.getByTestId("one-location-now-activity");
+    expect(within(activity).getByText("Active shares")).toBeTruthy();
+    expect(within(activity).getByText("Shared with me")).toBeTruthy();
+    expect(within(activity).getByText("Needs my review")).toBeTruthy();
 
-    // The two must not drift back apart.
-    expect(within(rest).queryByText("Share location")).toBeNull();
-    expect(within(rest).queryByText("Request location")).toBeNull();
-    // And the standalone map group is gone, so the tab is two groups.
+    const more = screen.getByTestId("one-location-now-more");
+    expect(within(more).getByText("Your Map")).toBeTruthy();
+    expect(within(more).getByText("Settings")).toBeTruthy();
+
+    expect(within(activity).queryByText("Share location")).toBeNull();
+    expect(within(more).queryByText("Check-In")).toBeNull();
+    expect(screen.queryByText("Quick actions")).toBeNull();
     expect(screen.queryByTestId("one-location-now-primary")).toBeNull();
   });
 
@@ -2078,7 +2076,7 @@ describe("OneLocationAgentPage", () => {
     mockCaptureCurrentPosition.mockClear();
     const envelopeWritesBeforeOpen = mockStoreEnvelope.mock.calls.length;
 
-    fireEvent.click(screen.getByRole("button", { name: /SMS.*Save my soul/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Send SOS/i }));
 
     expect(
       await screen.findByRole("heading", { name: "Save my Soul", level: 1 }),
@@ -2120,7 +2118,7 @@ describe("OneLocationAgentPage", () => {
         }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /SMS.*Save my soul/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Send SOS/i }));
 
     expect(
       await screen.findByRole("button", {

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -26,43 +26,49 @@ describe("One Location settings placement", () => {
     expect(nowSource).not.toContain('title="Privacy"');
   });
 
-  it("offers Request Location directly above Settings in the Now hub", () => {
-    // The Now hub listed every way to give a location out -- Share, Map, Active
-    // shares, Shared with me -- and no way to ask for one; asking was reachable
-    // only from the People tab. Placement matters: it belongs with the other
-    // list entries, immediately above Settings, not buried in Quick actions.
+  it("offers Request Location inside the unified Actions grid", () => {
+    // Request location is an action, not status or utility. It belongs beside
+    // Share location, Check-In, and Send SOS in the Actions grid, while
+    // Settings stays quiet in More.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
-    expect(nowSource).toContain('testId="one-location-request-row"');
-    expect(nowSource).toContain('title="Request location"');
+    expect(nowSource).toContain('data-testid="one-location-now-actions"');
+    expect(nowSource).toContain('testId: "one-location-request-row"');
+    expect(nowSource).toContain('title: "Request location"');
+    expect(nowSource).toContain('title: "Send SOS"');
 
-    const requestIndex = nowSource.indexOf('title="Request location"');
+    const actionsIndex = nowSource.indexOf("LocationActionGrid");
+    const requestIndex = nowSource.indexOf('title: "Request location"');
+    const activityIndex = nowSource.indexOf("one-location-now-activity");
+    const moreIndex = nowSource.indexOf("one-location-now-more");
     const settingsIndex = nowSource.indexOf('title="Settings"');
-    expect(requestIndex).toBeGreaterThan(-1);
-    expect(settingsIndex).toBeGreaterThan(requestIndex);
+    expect(actionsIndex).toBeGreaterThan(-1);
+    expect(requestIndex).toBeGreaterThan(actionsIndex);
+    expect(activityIndex).toBeGreaterThan(requestIndex);
+    expect(moreIndex).toBeGreaterThan(activityIndex);
+    expect(settingsIndex).toBeGreaterThan(moreIndex);
 
     // Reuses the existing ask flow rather than introducing a second one, so
     // voice and the search bar keep naming a single control.
-    expect(nowSource).toContain('voiceControlId="one-location-action-ask"');
+    expect(nowSource).toContain('controlId: "one-location-action-ask"');
     expect(HUB_SOURCE).toContain('onRequestLocation={() => openFlow("ask")}');
   });
 
   it("gives Request Location an icon distinct from Share location", () => {
-    // These two rows are opposites -- give a location out, ask for one in --
-    // and sit three apart in the same list. `Send` was used first and reads as
-    // the same paper-plane silhouette as `Navigation` at row size, so the pair
-    // looked like one repeated icon.
+    // These two actions are opposites -- give a location out, ask for one in.
+    // They sit in one grid now, so the glyphs must be distinct at a glance.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
     const iconFor = (title: string) => {
-      const titleIndex = nowSource.indexOf(`title="${title}"`);
+      const titleIndex = nowSource.indexOf(`title: "${title}"`);
       expect(titleIndex).toBeGreaterThan(-1);
-      const rowStart = nowSource.lastIndexOf("<SettingsRow", titleIndex);
-      return /icon=\{(\w+)\}/.exec(nowSource.slice(rowStart, titleIndex))?.[1];
+      return /icon: <(\w+) \/>/.exec(
+        nowSource.slice(titleIndex, titleIndex + 180),
+      )?.[1];
     };
 
     const requestIcon = iconFor("Request location");

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -529,7 +529,7 @@ const LOCATION_HUB_TAB_LABELS: Readonly<Record<string, string>> = {
 };
 
 const LOCATION_TAB_MODULES: Readonly<Record<string, string[]>> = {
-  now: ["Sharing status", "Active shares", "Shared with me", "Quick actions"],
+  now: ["Sharing status", "Actions", "Activity", "More"],
   people: ["Circles", "Connections"],
   links: ["Temporary links"],
 };
@@ -615,7 +615,7 @@ const LOCATION_VOICE_CONTROLS = [
   { id: "one-location-action-needs-review", label: "Needs my review", purpose: "Approve or decline requests.", actionId: "location.open_needs_review", role: "button" },
   { id: "one-location-action-settings", label: "Settings", purpose: "Open privacy controls.", actionId: "location.open_settings", role: "button" },
   { id: "one-location-action-check-in", label: "Check-In", purpose: "Send a one-off check in.", actionId: "location.open_check_in", role: "button" },
-  { id: "one-location-action-sos", label: "SMS", purpose: "Open emergency SOS.", actionId: "location.open_sos", role: "button" },
+  { id: "one-location-action-sos", label: "Send SOS", purpose: "Open emergency SOS.", actionId: "location.open_sos", role: "button" },
   { id: "one-location-action-ask", label: "Request location", purpose: "Ask for location access.", actionId: "location.open_ask", role: "button" },
   { id: "one-location-action-invite", label: "Invite", purpose: "Invite someone to One.", actionId: "location.open_invite", role: "button" },
   { id: "one-location-action-create-circle", label: "Create", purpose: "Create a circle.", actionId: "location.open_create_circle", role: "button" },

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -114,10 +114,6 @@ import {
 } from "@/components/one-location/redesign/live-share-status-card";
 import { SosPanel } from "@/components/one-location/redesign/sos-panel";
 import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts-flow";
-import {
-  QuickActionCard,
-  QuickActionsSection,
-} from "@/components/one-location/redesign/quick-actions";
 import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
@@ -1276,9 +1272,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                   ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)
                   : openFlow("check-in")
               }
-              checkInSubtitle={
-                nearbyCheckInAvailable ? "See people nearby" : "Share now"
-              }
               onSos={() => openFlow("sos")}
               onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
               onOpenActiveShares={() => openFlow("active-shares")}
@@ -1336,7 +1329,6 @@ function NowHub({
   vm,
   onStartShare,
   onCheckIn,
-  checkInSubtitle,
   onSos,
   onOpenMap,
   onOpenActiveShares,
@@ -1348,7 +1340,6 @@ function NowHub({
   vm: LocationHubViewModel;
   onStartShare: () => void;
   onCheckIn: () => void;
-  checkInSubtitle: string;
   onSos: () => void;
   onOpenMap: () => void;
   onOpenActiveShares: () => void;
@@ -1359,27 +1350,12 @@ function NowHub({
 }) {
   const groupedShellClassName =
     "[--settings-group-radius:16px] bg-white shadow-none dark:bg-[#1C1C1E]";
-  // State beats category on every counted row: colour here means "there is
-  // something here", never "this row exists". A zero count is a neutral row.
-  // "Needs my review" already worked this way; "Active shares" and "Shared with
-  // me" were pinned to action blue, so an empty Location screen showed three
-  // saturated blue tiles reporting 0, 0, 0 — colour that carried no information
-  // and left nothing for the rows that did.
-  const reviewIconTone =
-    vm.pendingOwnerRequests.length > 0 ? "orange" : "gray";
   // The device record keeps counting while the server state reloads, so the row
   // no longer drops to 0 for the second or two after you re-enter the screen.
   const activeShareCount = Math.max(
     vm.activeOwnerGrants.length,
     vm.liveShare?.count ?? 0,
   );
-  // Green = sharing is live right now (the same meaning the header switch and
-  // Check-In carry).
-  const activeSharesIconTone = activeShareCount > 0 ? "green" : "gray";
-  // Indigo = other people, matching the People tab's circles and trusted
-  // contacts, rather than the blue reserved for actions you initiate.
-  const sharedWithMeIconTone =
-    vm.receivedGrants.length > 0 ? "indigo" : "gray";
 
   return (
     <div className="space-y-4" data-testid="one-location-now-hub">
@@ -1417,62 +1393,102 @@ function NowHub({
           saving={vm.liveShareDurationSaving}
         />
       ) : null}
-      {/* Every row and tile below carries the `control_ids` / `action_id` pair
+      {/* Every row and cell below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
           rather than only the screen it lives on. */}
-      {/* The two things a person DOES on this screen, together. Sharing your
-          location and asking for someone else's are the same kind of decision
-          pointed in opposite directions, and they were two groups apart — one
-          alone at the top, the other buried under three status rows. Everything
-          below is what is already happening, or where to look at it. */}
-      <SettingsGroup
-        separatorInset
-        testId="one-location-now-share"
-        shellClassName={groupedShellClassName}
-      >
-        <SettingsRow
-          icon={Navigation}
-          iconTone="blue"
-          title="Share location"
-          density="compact"
-          chevron
-          onClick={onStartShare}
-          testId="one-location-share-row"
-          voiceControlId="one-location-action-share"
-          voiceActionId="location.open_share"
-        />
-        {/* Asking someone to share was reachable only from the People tab, so
-            the Now tab listed every way to give a location out and none to ask
-            for one. Same flow and same voice control id as that entry -- this
-            is an additional way in, not a second implementation. */}
-        {/* Not `Send`: that is the same paper-plane silhouette as `Navigation`
-            on "Share location" two rows up, so at row size the two entries read
-            as the same icon -- and they are opposites. A speech bubble asking a
-            question is distinct at a glance and matches what the flow does:
-            "Requests should explain why. The other person chooses whether to
-            share." Radar and Crosshair were rejected for implying tracking on a
-            surface built around consent. */}
-        <SettingsRow
-          icon={MessageCircleQuestionMark}
-          iconTone="blue"
-          title="Request location"
-          density="compact"
-          chevron
-          onClick={onRequestLocation}
-          testId="one-location-request-row"
-          voiceControlId="one-location-action-ask"
-          voiceActionId="location.open_ask"
-        />
-      </SettingsGroup>
-      <SettingsGroup
-        separatorInset
-        testId="one-location-now-status"
-        shellClassName={groupedShellClassName}
-      >
+      <LocationActionGrid
+        items={[
+          {
+            title: "Share location",
+            icon: <Navigation />,
+            tone: "blue",
+            onClick: onStartShare,
+            controlId: "one-location-action-share",
+            actionId: "location.open_share",
+            testId: "one-location-share-row",
+          },
+          {
+            title: "Request location",
+            icon: <MessageCircleQuestionMark />,
+            tone: "blue",
+            onClick: onRequestLocation,
+            controlId: "one-location-action-ask",
+            actionId: "location.open_ask",
+            testId: "one-location-request-row",
+          },
+          {
+            title: "Check-In",
+            icon: <ShieldCheck />,
+            tone: "blue",
+            onClick: onCheckIn,
+            controlId: "one-location-action-check-in",
+            actionId: "location.open_check_in",
+          },
+          {
+            title: "Send SOS",
+            icon: <Shield />,
+            tone: "red",
+            onClick: onSos,
+            controlId: "one-location-action-sos",
+            actionId: "location.open_sos",
+          },
+        ]}
+      />
+
+      <div className="space-y-2">
+        <LocationNowGroupLabel>Activity</LocationNowGroupLabel>
+        <SettingsGroup
+          separatorInset
+          testId="one-location-now-activity"
+          shellClassName={groupedShellClassName}
+        >
+          <SettingsRow
+            icon={UsersRound}
+            iconTone="gray"
+            title="Active shares"
+            density="compact"
+            trailing={activeShareCount}
+            chevron
+            onClick={onOpenActiveShares}
+            voiceControlId="one-location-action-active-shares"
+            voiceActionId="location.open_active_shares"
+          />
+          <SettingsRow
+            icon={MapPin}
+            iconTone="gray"
+            title="Shared with me"
+            density="compact"
+            trailing={vm.receivedGrants.length}
+            chevron
+            onClick={onOpenSharedWithMe}
+            voiceControlId="one-location-action-shared-with-me"
+            voiceActionId="location.open_shared_with_me"
+          />
+          <SettingsRow
+            icon={ShieldCheck}
+            iconTone="gray"
+            title="Needs my review"
+            density="compact"
+            trailing={vm.pendingOwnerRequests.length}
+            chevron
+            onClick={onOpenNeedsReview}
+            voiceControlId="one-location-action-needs-review"
+            voiceActionId="location.open_needs_review"
+          />
+        </SettingsGroup>
+      </div>
+
+      <div className="space-y-2">
+        <LocationNowGroupLabel>More</LocationNowGroupLabel>
+        <SettingsGroup
+          separatorInset
+          testId="one-location-now-more"
+          shellClassName={groupedShellClassName}
+        >
         <SettingsRow
           icon={Map}
-          iconTone="blue"
+          iconTone="gray"
           title="Your Map"
           density="compact"
           chevron
@@ -1480,39 +1496,6 @@ function NowHub({
           testId="one-location-map-row"
           voiceControlId="one-location-open-map"
           voiceActionId="location.open_map"
-        />
-        <SettingsRow
-          icon={UsersRound}
-          iconTone={activeSharesIconTone}
-          title="Active shares"
-          density="compact"
-          trailing={activeShareCount}
-          chevron
-          onClick={onOpenActiveShares}
-          voiceControlId="one-location-action-active-shares"
-          voiceActionId="location.open_active_shares"
-        />
-        <SettingsRow
-          icon={MapPin}
-          iconTone={sharedWithMeIconTone}
-          title="Shared with me"
-          density="compact"
-          trailing={vm.receivedGrants.length}
-          chevron
-          onClick={onOpenSharedWithMe}
-          voiceControlId="one-location-action-shared-with-me"
-          voiceActionId="location.open_shared_with_me"
-        />
-        <SettingsRow
-          icon={ShieldCheck}
-          iconTone={reviewIconTone}
-          title="Needs my review"
-          density="compact"
-          trailing={vm.pendingOwnerRequests.length}
-          chevron
-          onClick={onOpenNeedsReview}
-          voiceControlId="one-location-action-needs-review"
-          voiceActionId="location.open_needs_review"
         />
         <SettingsRow
           icon={Lock}
@@ -1525,32 +1508,82 @@ function NowHub({
           voiceControlId="one-location-action-settings"
           voiceActionId="location.open_settings"
         />
-      </SettingsGroup>
-
-      <QuickActionsSection title="Quick actions" columns={2}>
-        {/* Green, not blue: Check-In is a presence state you enter, the same
-            family as the header switch being on — and it is the one tile that
-            sits beside the red SMS tile, where "safe / emergency" has to read
-            at a glance. Blue here made the two tiles differ only in the second
-            colour, not the first. */}
-        <QuickActionCard
-          tone="green"
-          icon={<ShieldCheck />}
-          title="Check-In"
-          subtitle={checkInSubtitle}
-          onClick={onCheckIn}
-          controlId="one-location-action-check-in"
-        />
-        <QuickActionCard
-          tone="red"
-          icon={<Shield />}
-          title="SMS"
-          subtitle={vm.sosActive ? "Live now" : "Save my soul"}
-          onClick={onSos}
-          controlId="one-location-action-sos"
-        />
-      </QuickActionsSection>
+        </SettingsGroup>
+      </div>
     </div>
+  );
+}
+
+function LocationNowGroupLabel({ children }: { children: ReactNode }) {
+  return (
+    <AppSectionLabel
+      as="h2"
+      className="px-[6px] text-[15px] font-medium leading-5 text-[color:var(--app-secondary-label)]"
+    >
+      {children}
+    </AppSectionLabel>
+  );
+}
+
+type LocationActionGridItem = {
+  title: string;
+  icon: ReactNode;
+  tone: "blue" | "red";
+  onClick: () => void;
+  controlId: string;
+  actionId: string;
+  testId?: string;
+};
+
+function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
+  return (
+    <section className="space-y-2" data-testid="one-location-now-actions">
+      <LocationNowGroupLabel>Actions</LocationNowGroupLabel>
+      <div
+        data-ui-role="grouped-card"
+        className="grid grid-cols-2 overflow-hidden rounded-[20px] bg-[color:var(--app-card-surface-default-solid)] shadow-none"
+      >
+        {items.map((item, index) => (
+          <button
+            key={item.controlId}
+            type="button"
+            data-testid={item.testId}
+            data-voice-control-id={item.controlId}
+            data-voice-action-id={item.actionId}
+            data-voice-label={item.title}
+            onClick={item.onClick}
+            className={cn(
+              "group flex min-h-[76px] min-w-0 items-center gap-3 bg-transparent px-4 py-3 text-left transition-colors [-webkit-tap-highlight-color:transparent] active:bg-[rgba(120,120,128,0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]",
+              index % 2 === 0 &&
+                "border-r border-[color:var(--app-separator)]",
+              index < 2 &&
+                "border-b border-[color:var(--app-separator)]",
+            )}
+          >
+            <span
+              aria-hidden
+              className={cn(
+                "inline-flex h-8 w-8 shrink-0 items-center justify-center [&_svg]:h-6 [&_svg]:w-6 [&_svg]:stroke-[1.9]",
+                item.tone === "red"
+                  ? "text-[color:var(--app-destructive)]"
+                  : "text-[color:var(--app-accent)]",
+              )}
+            >
+              {item.icon}
+            </span>
+            <RowLabel
+              as="span"
+              className={cn(
+                "min-w-0 text-[15px] font-medium leading-5",
+                item.tone === "red" && "text-[color:var(--app-destructive)]",
+              )}
+            >
+              {item.title}
+            </RowLabel>
+          </button>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/hushh-webapp/e2e/location-agent-now-ui.spec.ts
+++ b/hushh-webapp/e2e/location-agent-now-ui.spec.ts
@@ -87,18 +87,18 @@ test.describe("Location Agent Now visual contract", () => {
       },
     );
 
-    await expectTypography(page.getByRole("heading", { name: "Quick actions" }), {
-      fontSize: "22px",
-      fontWeight: "600",
-      lineHeight: "27px",
-      color: "rgb(29, 29, 31)",
+    await expectTypography(page.getByRole("heading", { name: "Actions" }), {
+      fontSize: "15px",
+      fontWeight: "500",
+      lineHeight: "20px",
+      color: "rgb(110, 110, 115)",
     });
 
     const rowLabels = page.locator(
-      '[data-testid^="one-location-now"] [data-slot="settings-row-title"]',
+      '[data-testid="one-location-now-activity"] [data-slot="settings-row-title"], [data-testid="one-location-now-more"] [data-slot="settings-row-title"]',
     );
     const rowCount = await rowLabels.count();
-    expect(rowCount).toBeGreaterThanOrEqual(7);
+    expect(rowCount).toBe(5);
     for (let index = 0; index < rowCount; index += 1) {
       await expectTypography(rowLabels.nth(index), {
         fontSize: "17px",
@@ -108,35 +108,21 @@ test.describe("Location Agent Now visual contract", () => {
       });
     }
 
-    const cardTitles = page.locator(
-      '[data-voice-control-id^="one-location-action-"] .ui-text-card-title',
+    const actionTitles = page.locator(
+      '[data-testid="one-location-now-actions"] .ui-text-row-label',
     );
-    await expectTypography(cardTitles.filter({ hasText: "Check-In" }), {
-      fontSize: "17px",
-      fontWeight: "600",
-      lineHeight: "22px",
+    await expectTypography(actionTitles.filter({ hasText: "Check-In" }), {
+      fontSize: "15px",
+      fontWeight: "500",
+      lineHeight: "20px",
       color: "rgb(29, 29, 31)",
     });
-    await expectTypography(cardTitles.filter({ hasText: "SMS" }), {
-      fontSize: "17px",
-      fontWeight: "600",
-      lineHeight: "22px",
-      color: "rgb(29, 29, 31)",
+    await expectTypography(actionTitles.filter({ hasText: "Send SOS" }), {
+      fontSize: "15px",
+      fontWeight: "500",
+      lineHeight: "20px",
+      color: "rgb(255, 59, 48)",
     });
-
-    const cardDescriptions = page.locator(
-      '[data-voice-control-id^="one-location-action-"] .ui-text-row-description',
-    );
-    const descriptionCount = await cardDescriptions.count();
-    expect(descriptionCount).toBeGreaterThanOrEqual(2);
-    for (let index = 0; index < descriptionCount; index += 1) {
-      await expectTypography(cardDescriptions.nth(index), {
-        fontSize: "13px",
-        fontWeight: "400",
-        lineHeight: "18px",
-        color: "rgb(142, 142, 147)",
-      });
-    }
 
     await expect(page.locator("body")).toHaveCSS(
       "background-color",


### PR DESCRIPTION
## Summary
- restructure Location Now into one Actions grid with Share location, Request location, Check-In, and Send SOS
- move generated state into a quiet Activity list and utilities into More
- update Location UI contracts so Activity icons stay neutral and the action grid remains labels-only

## Verification
- npm run verify:one-location
- npx vitest run __tests__/components/one-location-settings-placement.contract.test.ts
- npm run typecheck
- npm run verify:design-system
- npm run verify:voice-gateway
- npm run lint
- npm run build