### PR TITLE
feat(one): restore compact Ask One capsule

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
-  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+  return fs
+    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
+    .replace(/\r\n/g, "\n");
 }
 
 describe("Navbar bottom chrome contract", () => {
@@ -47,7 +49,15 @@ describe("Navbar bottom chrome contract", () => {
     expect(agentBar).toContain("aria-label={`Open Agent Chat. ${hint}`}");
     expect(agentBar).not.toContain("openSearchAndChat");
     expect(agentBar).not.toContain("openKaiCommandBar");
-    expect(agentBar).toContain("Talk to One");
+    expect(agentBar).toContain("Ask One");
+    expect(agentBar).toContain("one-bar-aurora--active");
+    expect(agentBar).not.toContain("one-capsule");
+    expect(agentBar).not.toContain("capsuleShowPermission");
+    expect(agentBar).not.toContain("capsuleShowSuccess");
+    expect(agentBar).toContain("AudioLines");
+    expect(agentBar).not.toContain("OneVoiceOrb");
+    expect(agentBar).not.toContain("HushhWordmark");
+    expect(agentBar).not.toContain("translate-y-[calc(100%+0.375rem)]");
     expect(agentBar).toContain(
       'data-native-voice-control-id="one_voice_agent_bar_start"',
     );
@@ -58,7 +68,7 @@ describe("Navbar bottom chrome contract", () => {
     // The native control is the complete visible voice pill. The separate
     // Agent Chat button remains its own action, but no whitespace or icon-only
     // target is allowed inside the voice launcher.
-    expect(agentBar).toContain("agent-bar-voice-launcher press-scale");
+    expect(agentBar).toContain("agent-bar-voice-launcher press-scale relative");
     expect(agentBar).toContain("flex-1 self-stretch items-center");
     expect(agentBar).toContain("hover:bg-current/[0.09]");
     expect(agentBar).toContain("focus-visible:ring-inset");
@@ -120,8 +130,16 @@ describe("Navbar bottom chrome contract", () => {
     );
     expect(bottomShell).toContain('<AgentBar layout="slot" />');
     expect(bottomShell).toContain("items-center gap-1.5");
-    expect(agentBar).toContain('? "h-10 rounded-[1.25rem] px-2"');
-    expect(agentBar).toContain("var(--app-agent-bar-max-width)");
+    expect(agentBar).toContain("layout");
+    expect(agentBar).toContain("AnimatePresence");
+    expect(agentBar).toContain("stiffness: 292");
+    expect(agentBar).toContain("will-change-[width,transform,opacity]");
+    expect(agentBar).toContain("w-[min(calc(100vw-2rem),14rem)]");
+    expect(agentBar).toContain("w-[min(calc(100vw-2rem),21rem)]");
+    expect(agentBar).toContain('title="Start a voice conversation with One"');
+    expect(agentBar).not.toContain("Couldn&apos;t connect · Try again");
+    expect(agentBar).not.toContain("useFeedUnreadCount");
+    expect(agentBar).not.toContain("useConsentPendingSummaryCount");
     expect(bottomShell).toContain("var(--bottom-chrome-full-height)");
     expect(bottomShell).toContain("--app-bottom-shell-height");
     expect(bottomShell).not.toContain("xl:hidden");
@@ -137,8 +155,8 @@ describe("Navbar bottom chrome contract", () => {
     expect(providers).toContain(
       "const foundationVoiceOnlyChrome = isFoundationRoute;",
     );
-    expect(providers).toContain(
-      "const pinnedBottomChrome =\n    isRiaRoute(pathname) || foundationVoiceOnlyChrome;",
+    expect(providers).toMatch(
+      /const pinnedBottomChrome\s*=\s*isRiaRoute\(pathname\) \|\| foundationVoiceOnlyChrome;/,
     );
     expect(providers).toContain(
       "navigationHidden:\n      chromeState.hideCommandBar || foundationVoiceOnlyChrome,",

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2885,56 +2885,6 @@ html.native-ios [data-testid="one-location-onboarding"] {
   }
 }
 
-/* Agent bar edge glow: a STILL soft gold gradient rim (no idle spin). It only
-   comes alive (a gentle breathing brighten) while a live voice conversation is
-   active, so motion always MEANS something. */
-.one-bar-aurora {
-  position: absolute;
-  inset: -6px;
-  border-radius: 9999px;
-  background: radial-gradient(
-    120% 160% at 50% 120%,
-    rgba(212, 175, 106, 0.5),
-    rgba(212, 175, 106, 0.12) 55%,
-    transparent 72%
-  );
-  filter: blur(12px);
-  opacity: 0.5;
-}
-.one-bar-aurora--active {
-  background: linear-gradient(
-    120deg,
-    rgba(212, 175, 106, 0.7),
-    rgba(129, 140, 248, 0.55),
-    rgba(236, 72, 153, 0.5),
-    rgba(212, 175, 106, 0.7)
-  );
-  animation: one-bar-breathe 3.4s ease-in-out infinite;
-}
-.one-bar-aurora--onboarding {
-  background: radial-gradient(
-    120% 160% at 50% 120%,
-    rgba(212, 175, 106, 0.42),
-    rgba(212, 175, 106, 0.08) 58%,
-    transparent 74%
-  );
-  animation: none;
-}
-@keyframes one-bar-breathe {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
-  50% {
-    opacity: 0.9;
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .one-bar-aurora--active {
-    animation: none;
-  }
-}
-
 /* ── Cinematic launch sequence (welcome hero) ── */
 /* The quiet-mark IGNITES: a light bloom scales up behind it while the mark
    fades/scales into focus, then a soft ring pulses out once. */
@@ -4475,7 +4425,7 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
   --agent-approval-rim: rgba(255, 255, 255, 0.55);
   --agent-approval-edge: rgba(0, 0, 0, 0.1);
   --agent-approval-cast: rgba(0, 0, 0, 0.18);
-  /* The colour the glass carries, taken from .one-bar-aurora--active -- the
+  /* The colour the glass carries, taken from the live voice bar's aurora -- the
      gold/indigo/pink the voice bar already wears while a conversation is
      live. The card belongs to that same moment, so it should read as the same
      material rather than as a generic accent panel that happened to appear. */
@@ -4691,6 +4641,71 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 .dark .kai-bottom-nav-pill {
   border-color: rgba(84, 84, 88, 0.58) !important;
   background: rgba(28, 28, 30, 0.78) !important;
+}
+
+/* Live voice feedback: a restrained rainbow rim around the same glass bar.
+   It is present only while the real voice conversation is active. */
+.one-bar-aurora {
+  position: absolute;
+  inset: -6px;
+  border-radius: 9999px;
+  background: radial-gradient(
+    120% 160% at 50% 120%,
+    rgba(212, 175, 106, 0.5),
+    rgba(212, 175, 106, 0.12) 55%,
+    transparent 72%
+  );
+  filter: blur(12px);
+  opacity: 0.5;
+}
+
+.one-bar-aurora--active {
+  background: linear-gradient(
+    120deg,
+    rgba(212, 175, 106, 0.7),
+    rgba(129, 140, 248, 0.55),
+    rgba(236, 72, 153, 0.5),
+    rgba(212, 175, 106, 0.7)
+  );
+  background-size: 220% 100%;
+  animation: one-bar-rainbow 4.8s ease-in-out infinite;
+}
+
+@keyframes one-bar-rainbow {
+  0%,
+  100% {
+    background-position: 0% 50%;
+    opacity: 0.55;
+  }
+
+  50% {
+    background-position: 100% 50%;
+    opacity: 0.82;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .one-bar-aurora--active {
+    animation: none;
+  }
+}
+
+/* Sign-in (/login) keeps the Talk to One bar and every control inside it, but
+   drops the bar to a quieter material so the two sign-in buttons are clearly
+   the first thing to touch. Scoped to the AuthStep cluster attribute, which
+   only the sign-in screen renders, so no other route moves. The signed-in
+   bottom nav (.kai-bottom-nav-pill) is deliberately excluded — it does not
+   render here, and matching it would reach every signed-in route.
+   !important is required: the base rule above is itself !important. */
+body:has([data-auth-signin-clusters]) .bottom-chrome-surface {
+  border: 0.5px solid rgba(60, 60, 67, 0.1) !important;
+  background: rgba(255, 255, 255, 0.55) !important;
+  box-shadow: none !important;
+}
+
+.dark body:has([data-auth-signin-clusters]) .bottom-chrome-surface {
+  border-color: rgba(84, 84, 88, 0.32) !important;
+  background: rgba(28, 28, 30, 0.55) !important;
 }
 
 .kai-bottom-nav-pill [data-segment-indicator] {

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -19,8 +19,16 @@ import React, {
   type MouseEvent,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { AudioLines, MessageCircle, Monitor, Moon, Sun, X } from "lucide-react";
+import {
+  AudioLines,
+  MessageCircle,
+  Monitor,
+  Moon,
+  Sun,
+  X,
+} from "lucide-react";
 import { useTheme } from "next-themes";
+import { AnimatePresence, motion } from "framer-motion";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { AgentVoiceWaveform } from "@/components/agent/agent-voice-waveform";
@@ -1271,7 +1279,11 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       // request, not a toggle. Coalesce it so one mic/socket survives.
       return;
     }
-    if (liveClientRef.current || erroredRef.current || conversationActive) {
+    if (erroredRef.current) {
+      // Failure remains visible until an intentional retry. Reuse the same
+      // teardown/start path so retry never becomes a second voice client.
+      stopConversation();
+    } else if (liveClientRef.current || conversationActive) {
       stopConversation();
       return;
     }
@@ -1280,11 +1292,24 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       onRevoked: () => stopConversationRef.current(),
     });
     voiceLeaseRef.current = lease;
-    const runtimeConnection = await resolveGeminiRuntimeConnection({
-      userId: user?.uid,
-      vaultKey,
-      vaultOwnerToken,
-    });
+    erroredRef.current = false;
+    setVoiceStatus("connecting", "Connecting…");
+    let runtimeConnection;
+    try {
+      runtimeConnection = await resolveGeminiRuntimeConnection({
+        userId: user?.uid,
+        vaultKey,
+        vaultOwnerToken,
+      });
+    } catch {
+      if (lease.isCurrent() && voiceLeaseRef.current?.id === lease.id) {
+        erroredRef.current = true;
+        setVoiceStatus("error", "Couldn't connect");
+        lease.release("runtime_connection_failed");
+        voiceLeaseRef.current = null;
+      }
+      return;
+    }
     if (!lease.isCurrent() || voiceLeaseRef.current?.id !== lease.id) {
       return;
     }
@@ -1305,7 +1330,6 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       voiceLeaseRef.current = null;
       return;
     }
-    erroredRef.current = false;
     setConversationActive(true);
     scheduleVoiceIdleTimer();
     const context = runtime?.oneVoiceContextSnapshot ?? null;
@@ -1333,19 +1357,25 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     lastPushedContextRef.current = context
       ? actionableContextKey(context)
       : null;
-    void client.start({
-      context,
-      accessTier: runtime?.tier ?? null,
-      relayUrl,
-      sessionMirrorId: mirrorSessionId,
-      allowedActionIds: context?.available_action_ids ?? null,
-      consentToken: vaultOwnerToken ?? null,
-      runtimeCredentialMode: runtimeConnection.mode,
-      runtimeCredential: runtimeConnection.credential,
-      runtimeCredentialTransport: runtimeConnection.transport,
-      runtimeVertexProject: runtimeConnection.vertexProject,
-      runtimeVertexLocation: runtimeConnection.vertexLocation,
-    });
+    void client
+      .start({
+        context,
+        accessTier: runtime?.tier ?? null,
+        relayUrl,
+        sessionMirrorId: mirrorSessionId,
+        allowedActionIds: context?.available_action_ids ?? null,
+        consentToken: vaultOwnerToken ?? null,
+        runtimeCredentialMode: runtimeConnection.mode,
+        runtimeCredential: runtimeConnection.credential,
+        runtimeCredentialTransport: runtimeConnection.transport,
+        runtimeVertexProject: runtimeConnection.vertexProject,
+        runtimeVertexLocation: runtimeConnection.vertexLocation,
+      })
+      .catch(() => {
+        if (!lease.isCurrent() || voiceLeaseRef.current?.id !== lease.id) return;
+        erroredRef.current = true;
+        setVoiceStatus("error", "Couldn't connect");
+      });
   }, [
     conversationActive,
     runtime?.oneVoiceContextSnapshot,
@@ -1564,14 +1594,6 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const isLoginRoute = (pathname ?? "").startsWith(ROUTES.LOGIN);
   const isFoundationPublic = isFoundationPublicRoute(pathname ?? "");
   
-  // The visual styling of the bar (width, aurora, etc.) aligns with the chat
-  // workspace's concept of onboarding.
-  const visualOnboardingChrome =
-    (runtime?.onboardingActive ?? chromeState.useOnboardingChrome) ||
-    isHomeRoute ||
-    isLoginRoute ||
-    isFoundationPublic;
-
   // The physical navbar rendering strictly follows path and auth state. We use
   // this strictly for positioning to avoid overlapping the navbar if the cloud
   // state (runtime.onboardingActive) lags behind the local pathname.
@@ -1700,6 +1722,11 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
             : voiceStatus === "error"
               ? "error"
               : "opening";
+  // The rainbow begins at the tap boundary, while the transport is opening,
+  // so the control feels immediately alive instead of waiting for the socket
+  // to finish connecting. It is still tied only to the real voice lifecycle.
+  const voiceSurfaceActive =
+    conversationActive || voiceStatus === "connecting";
 
   const currentThemePreference = resolveThemePreference(theme) ?? "system";
   const nextTheme = nextThemePreference(currentThemePreference);
@@ -1764,10 +1791,12 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   );
   // Pill contents for the frosted bar, one JSX source across all modes so
   // the voice/theme controls and test ids never fork.
-  const pillContents = conversationActive ? (
+  const activeVoiceLabel =
+    voiceStatus === "connecting" ? "Listening…" : voiceStatusLabel;
+  const pillContents = voiceSurfaceActive ? (
     // The ENTIRE bar is the tap target to end the conversation: tapping
-    // anywhere stops it. The X icon on the left is a bare marker (no chip
-    // background) showing this is the "tap to end" affordance. On the
+    // anywhere stops it. The X icon on the left is a bare marker showing this
+    // is the "tap to end" affordance. On the
     // pre-auth greeter (home route auto-greet) the theme toggle stays
     // docked alongside it so it never disappears mid-connect.
     <>
@@ -1793,7 +1822,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           className="flex min-w-0 flex-1 items-center gap-3"
           role="status"
           aria-live="polite"
-          aria-label={voiceStatusLabel}
+          aria-label={activeVoiceLabel}
         >
           <AgentVoiceWaveform
             level={voiceLevel}
@@ -1808,9 +1837,9 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
                 ? "min-w-0 max-w-[60%] flex-1 truncate text-right text-destructive/80"
                 : "tabular-nums text-current/60",
             )}
-            title={voiceStatus === "error" ? voiceStatusLabel : undefined}
+            title={voiceStatus === "error" ? activeVoiceLabel : undefined}
           >
-            {voiceStatusLabel}
+            {activeVoiceLabel}
           </span>
         </span>
       </button>
@@ -1842,7 +1871,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           <AudioLines className="h-[19px] w-[19px]" />
         </span>
         <span className="relative z-10 min-w-0 flex-1 truncate text-[13px] font-medium text-current/70">
-          Talk to One
+          Ask One
         </span>
         <span
           aria-hidden
@@ -1979,33 +2008,26 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           ) : null}
         </div>
       ) : null}
-      <div
+      <motion.div
+        layout
+        transition={{
+          layout: { type: "spring", stiffness: 292, damping: 32, mass: 0.98 },
+          opacity: { duration: 0.22, ease: [0.2, 0.8, 0.2, 1] },
+        }}
         data-testid="one-voice-agent-bar"
         data-voice-mode={nativeVoiceMode}
         data-morphy-ax-presentation={runtime?.morphyAxPresentation ?? "idle"}
         className={cn(
-          // z-0 (not just `relative`) is required so this pill forms its own
-          // local stacking context: the `.one-bar-aurora -z-10` glow span
-          // below then resolves ONE level behind THIS element, not behind
-          // the whole `z-[118]` fixed wrapper it's nested in. Without z-0 the
-          // active Gemini Live glow renders invisible/clipped behind other
-          // page content instead of hugging the pill.
-          "pointer-events-auto relative z-0 flex w-full items-center gap-2",
-          // The root, public, and signed-in variants share one bar chassis.
-          // Route state may add toggles, but cannot fork width or geometry.
+          "pointer-events-auto relative z-0 flex items-center gap-2",
           layout === "slot"
-            ? "max-w-[min(calc(100vw-1.5rem),var(--app-agent-bar-max-width))]"
-            : "max-w-[min(calc(100vw-2rem),34rem)]",
-          layout === "slot"
-            ? "h-11 rounded-[22px] px-2.5"
-            : "h-11 rounded-full pl-3 pr-1.5",
-          // Single, consolidated transition covering surface color plus the
-          // open/close fade+lift. Smoothly eases the bar in/out with the agent
-          // window lifecycle so it never snaps back into place after closing.
-          "transition-[opacity,transform,background-color,box-shadow] duration-300 ease-[cubic-bezier(0.16,0.84,0.28,1)] will-change-[opacity,transform]",
-          // Bottom-shell material: read the same live ambient token as the
-          // shared bottom mask so the Agent Bar never becomes a white pill on
-          // a dark/gradient route surface.
+            ? voiceSurfaceActive
+              ? "w-[min(calc(100vw-1.5rem),21rem)]"
+              : "w-[min(calc(100vw-1.5rem),14rem)] sm:w-[min(calc(100vw-1.5rem),16.5rem)]"
+            : voiceSurfaceActive
+              ? "w-[min(calc(100vw-2rem),21rem)]"
+              : "w-[min(calc(100vw-2rem),14rem)] sm:w-[min(calc(100vw-2rem),16.5rem)]",
+          layout === "slot" ? "h-11 rounded-[22px] px-2.5" : "h-11 rounded-full pl-3 pr-1.5",
+          "will-change-[width,transform,opacity]",
           "backdrop-blur-[24px] backdrop-saturate-[1.6]",
           "bottom-chrome-surface",
           barHidden
@@ -2014,22 +2036,25 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           barAmbient && "pointer-events-none opacity-70",
         )}
       >
-        {/* Aurora rim only while a live conversation is active, so motion
-            always means something. Pre-auth keeps the same Foundation tone as
-            the onboarding surface; no rainbow competes with One. */}
-        {conversationActive ? (
+        <AnimatePresence initial={false} mode="wait">
+          <motion.div
+            key={voiceSurfaceActive ? "voice-active" : "voice-idle"}
+            initial={{ opacity: 0, y: 2 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -2 }}
+            transition={{ duration: 0.14, ease: [0.2, 0.8, 0.2, 1] }}
+            className="flex min-w-0 flex-1 items-center gap-2"
+          >
+            {pillContents}
+          </motion.div>
+        </AnimatePresence>
+        {voiceSurfaceActive ? (
           <span
             aria-hidden
-            className={cn(
-              "one-bar-aurora -z-10 transition-opacity duration-500",
-              visualOnboardingChrome
-                ? "one-bar-aurora--onboarding"
-                : "one-bar-aurora--active",
-            )}
+            className="one-bar-aurora one-bar-aurora--active -z-10"
           />
         ) : null}
-        {pillContents}
-      </div>
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restore the compact centered Ask One capsule above the bottom navigation
- animate idle → active width changes from the center with a shared Framer Motion spring
- restore restrained rainbow motion during connection/listening
- keep the context-aware/live-state capsule layer removed

## Impact Map
- Routes touched: shared Agent Bar used by One shell; no route-local redesign
- API/schema/type changes: none
- Runtime DB/cache/PKM changes: none
- Mobile parity: web shell only; no native plugin changes
- Trust boundary: voice presentation only; existing transport and consent controls preserved
- Rollback: revert this PR; the prior Agent Bar shell is the only affected surface
- UI proof: /one returns HTTP 200; mobile compact widths are contract-tested
- Verification: 
pm run typecheck, ESLint, Agent Bar contract tests, 
pm run verify:design-system

Closes #5617