### PR TITLE
fix(one-location): put a real map on the onboarding finale, and take the words off it

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2349,6 +2349,27 @@ describe("OneLocationAgentPage", () => {
     vi.useRealTimers();
   });
 
+  it("still knows where you are on the finale after the save-place prompt closes", async () => {
+    // THE REGRESSION. The last onboarding screen -- "You're on the map." -- took
+    // its camera from the save-place modal's DRAFT point, and both of that
+    // modal's exits null it. The modal runs two screens earlier, so the finale
+    // was handed null on every single run, `useGoogleMaps` was never enabled,
+    // and the screen always drew its stylised fallback. The map feature shipped
+    // and nobody, on any platform or in any environment, ever saw it.
+    //
+    // `reachLocationOnboardingFinalStep` dismisses that prompt with
+    // "Skip for now" -- precisely the exit that used to destroy the point.
+    render(<OneLocationAgentPage mode="setup" onSetupComplete={vi.fn()} />);
+
+    await reachLocationOnboardingFinalStep();
+
+    const map = screen.getByTestId("onboarding-live-map");
+    // `data-map-state` cannot answer this: jsdom has no Google Maps, so it
+    // reads "stylised" whether or not a point survived. That ambiguity is what
+    // hid the bug, which is why the component reports the two separately.
+    expect(map.getAttribute("data-map-point")).toBe("ready");
+  });
+
   it("does not finish web Location setup while permission is denied", async () => {
     const onSetupComplete = vi.fn();
     mockGetPermissionState.mockResolvedValue({

--- a/hushh-webapp/__tests__/components/one-location-onboarding-finale.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-finale.contract.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OneLocationOnboardingFlow } from "@/components/one-location/onboarding/one-location-onboarding-flow";
+
+/**
+ * The last onboarding screen, locked as a contract.
+ *
+ * It lives in its own file, and in the CI-registered `verify:one-location`
+ * pack, for one reason: the sibling suite
+ * `__tests__/components/one-location-onboarding-flow.test.tsx` is not in any
+ * pack, so nothing it asserts has ever gated a pull request. That is how a
+ * screen shipped for months drawing a decorative grid under a headline that
+ * said "You're on the map." -- there were tests, and none of them ran, and the
+ * one that could have caught it modelled the bug (its default `mapPoint` was
+ * null) rather than the product.
+ *
+ * Two claims are worth more than the rest here:
+ *
+ *   1. What the screen SAYS matches what it SHOWS. A headline promising a map
+ *      only appears when a map is on screen.
+ *   2. Nothing on this screen is a decoration standing in for a fact. No pin
+ *      over an unknown place, no grid pretending to be streets.
+ */
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const INVITE = {
+  circleId: "circle-1",
+  circleName: "Meena Family",
+  code: "ABCDEFGHJKLM",
+};
+
+const MUMBAI = { lat: 19.076, lng: 72.8777 };
+
+function renderFinale(
+  overrides: Partial<
+    React.ComponentProps<typeof OneLocationOnboardingFlow>
+  > = {},
+) {
+  const props: React.ComponentProps<typeof OneLocationOnboardingFlow> = {
+    startAt: "welcome",
+    currentUserName: "Ankit",
+    // "prompt", not "granted": granting sends the features screen into its
+    // save-place preparation, which holds Continue busy and never reaches the
+    // finale here. The coordinate this file cares about is injected directly
+    // as `mapPoint`, which is what the page hands the flow in production.
+    locationPermission: {
+      state: "prompt",
+      precise: null,
+      background: "foreground-only",
+      locationServicesEnabled: true,
+    },
+    notificationDeliveryMode: "inbox_only",
+    notificationBusy: false,
+    locationBusy: false,
+    nativeTest: {
+      routeId: "/one/location",
+      marker: "native-route-one-location",
+      authState: "authenticated",
+      dataState: "loaded",
+    },
+    onRequestLocation: vi.fn().mockResolvedValue(undefined),
+    onLocationReady: vi.fn().mockResolvedValue(true),
+    onRequestNotifications: vi.fn().mockResolvedValue(undefined),
+    onBack: vi.fn(),
+    onComplete: vi.fn(),
+    onSkip: vi.fn(),
+    mapPoint: MUMBAI,
+    onPrepareOnboardingCircleInvite: vi.fn().mockResolvedValue(INVITE),
+    onCopyOnboardingCircleCode: vi.fn(),
+    onShareOnboardingCircleCode: vi.fn(),
+    onPreviewCircleCode: vi.fn(),
+    onAcceptCircleCode: vi.fn(),
+    ...overrides,
+  };
+
+  render(<OneLocationOnboardingFlow {...props} />);
+
+  // welcome -> features -> contacts -> invite
+  fireEvent.click(screen.getByRole("button", { name: "Get started" }));
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+
+  return props;
+}
+
+const map = () => screen.getByTestId("onboarding-live-map");
+const finishButton = () =>
+  screen.getByRole("button", { name: "Open One Location" });
+
+describe("One Location onboarding finale — the map is real", () => {
+  it("draws a map of where the person actually is", () => {
+    renderFinale();
+
+    // jsdom has no Google Maps script, which is exactly the state a
+    // referrer-blocked key or the iOS `App://` origin produces in production.
+    // The answer is the keyless embed every other Location surface degrades to
+    // -- a real map, of the real coordinate, not an illustration of one.
+    expect(map().getAttribute("data-map-point")).toBe("ready");
+    expect(map().getAttribute("data-map-state")).toBe("embed");
+
+    const embed = screen.getByTestId(
+      "onboarding-live-map-embed",
+    ) as HTMLIFrameElement;
+    expect(embed.src).toContain(encodeURIComponent("19.076000,72.877700"));
+    expect(embed.src).toContain("output=embed");
+    // A backdrop, not a maps app. Panning away from yourself on the one screen
+    // whose entire point is that you are here would be a strange affordance.
+    expect(embed.className).toContain("pointer-events-none");
+  });
+
+  it("keeps the headline honest when there is nothing to draw", () => {
+    renderFinale({ mapPoint: null });
+
+    expect(map().getAttribute("data-map-state")).toBe("unavailable");
+    // No pin. The old screen drew a pulsing blue dot in the middle of a grid,
+    // which is a claim about a place nothing knew.
+    expect(map().querySelector("[data-onboarding-map-pulse]")).toBeNull();
+    expect(screen.queryByTestId("onboarding-live-map-embed")).toBeNull();
+    expect(screen.getByText("Map unavailable")).toBeTruthy();
+
+    // And the headline stops promising a map.
+    expect(screen.getByRole("heading", { name: "You're all set." })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: /on the map/ })).toBeNull();
+  });
+
+  it("names Location, not Maps, when Location is the thing that is off", () => {
+    renderFinale({
+      mapPoint: null,
+      locationPermission: {
+        state: "denied",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      },
+    });
+
+    expect(screen.getByText("Location is off")).toBeTruthy();
+    expect(screen.queryByText("Map unavailable")).toBeNull();
+  });
+
+  it("stays fully usable when no map can be drawn at all", async () => {
+    // A Maps outage, or a refused permission, must not strand anyone at the end
+    // of setup. Everything this screen exists to do still works.
+    const props = renderFinale({ mapPoint: null });
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("one-location-onboarding-invite-code").textContent,
+      ).toContain("ABCD-EFGH-JKLM"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy/ }));
+    expect(props.onCopyOnboardingCircleCode).toHaveBeenCalledWith(
+      "ABCDEFGHJKLM",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Share/ }));
+    expect(props.onShareOnboardingCircleCode).toHaveBeenCalledWith(INVITE);
+
+    fireEvent.click(screen.getByText("Join with a code"));
+    expect(screen.getByLabelText("Circle code")).toBeTruthy();
+
+    fireEvent.click(finishButton());
+    expect(props.onComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("One Location onboarding finale — the copy", () => {
+  it("says each thing once, and says nothing the layout already shows", async () => {
+    renderFinale();
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("one-location-onboarding-invite-code").textContent,
+      ).toContain("ABCD-EFGH-JKLM"),
+    );
+
+    // What survives: state, the privacy fact, the circle's name, the code, its
+    // expiry, the two invite actions, the way in, the way on.
+    expect(
+      screen.getByRole("heading", { name: "You're on the map." }),
+    ).toBeTruthy();
+    expect(screen.getByText("Private until you share.")).toBeTruthy();
+    expect(screen.getByText("Meena Family")).toBeTruthy();
+    expect(screen.getByText("Expires in 72 hours")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Copy/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Share/ })).toBeTruthy();
+    expect(screen.getByText("Join with a code")).toBeTruthy();
+    expect(finishButton()).toBeTruthy();
+
+    // What does not, and must not come back. Each of these either restated the
+    // layout, explained a screen the person had not reached, or asked a
+    // question where an action belonged.
+    for (const gone of [
+      /show up here once they join/i,
+      /Bring your people/i,
+      /fresh one any time/i,
+      /Someone sent you a code/i,
+      /finishes setting up/i,
+    ]) {
+      expect(screen.queryByText(gone)).toBeNull();
+    }
+  });
+
+  it("gives the invite code room it can never be denied", async () => {
+    renderFinale();
+
+    const code = await screen.findByTestId(
+      "one-location-onboarding-invite-code",
+    );
+    // Twelve characters of fixed-width type with two separators cannot reflow:
+    // it either fits or it clips, and a clipped code is useless. The class
+    // string is the shared contract; `e2e/one-location-ready-panel.layout.spec.ts`
+    // measures what it actually does at 320px.
+    expect(code.className).toContain("whitespace-nowrap");
+    expect(code.className).toContain("text-[clamp(20px,6vw,28px)]");
+    expect(code.className).not.toMatch(/truncate|text-ellipsis|line-clamp/u);
+    expect(code.getAttribute("data-ui-truncation")).toBe("forbid");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -52,6 +52,13 @@ function renderFlow(
     onBack: vi.fn(),
     onComplete: vi.fn(),
     onSkip: vi.fn(),
+    // The finale HAS a coordinate on an ordinary run -- Location is granted on
+    // the features screen and the save-place step captures a fix two screens
+    // before this one. Defaulting to null here modelled the bug rather than the
+    // product, and it is the reason a screen that always drew its fallback had
+    // a suite that never noticed. Cases about the empty band pass `null`
+    // explicitly.
+    mapPoint: { lat: 19.076, lng: 72.8777 },
     ...overrides,
   };
 
@@ -778,7 +785,7 @@ describe("OneLocationOnboardingFlow", () => {
     it("shows who is behind a code before asking anyone to join", async () => {
       const props = openJoin();
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "abcd-efgh-jklm" },
       });
@@ -802,7 +809,7 @@ describe("OneLocationOnboardingFlow", () => {
     it("accepts the circle and says when it will take effect", async () => {
       const props = openJoin();
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "ABCDEFGHJKLM" },
       });
@@ -817,7 +824,7 @@ describe("OneLocationOnboardingFlow", () => {
       // Honest about the delay rather than claiming a join that has not
       // happened: the redeem waits for the vault the wizard has yet to create.
       expect(
-        await screen.findByText(/join Meena Family as soon as One finishes/i),
+        await screen.findByText(/join Meena Family after setup/i),
       ).toBeTruthy();
     });
 
@@ -826,7 +833,7 @@ describe("OneLocationOnboardingFlow", () => {
         onPrepareOnboardingCircleInvite: vi.fn().mockResolvedValue(invite),
       });
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "ABCDEFGHJKLM" },
       });
@@ -853,7 +860,7 @@ describe("OneLocationOnboardingFlow", () => {
         onPrepareOnboardingCircleInvite: vi.fn().mockResolvedValue(invite),
       });
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "ABCDEFGHJKLM" },
       });
@@ -876,14 +883,14 @@ describe("OneLocationOnboardingFlow", () => {
           .mockResolvedValue({ ...preview, alreadyMember: true }),
       });
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "ABCDEFGHJKLM" },
       });
       fireEvent.click(screen.getByRole("button", { name: /Look up/ }));
 
       expect(
-        await screen.findByText("You're already in this circle."),
+        await screen.findByText("Already in this circle."),
       ).toBeTruthy();
       expect(
         screen.queryByRole("button", { name: /Join Meena Family/ }),
@@ -898,7 +905,7 @@ describe("OneLocationOnboardingFlow", () => {
           .mockRejectedValue(new Error("That code has expired.")),
       });
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "NOPENOPENOPE" },
       });
@@ -925,7 +932,7 @@ describe("OneLocationOnboardingFlow", () => {
         ).toContain("ABCD-EFGH-JKLM"),
       );
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       // Typed the way it is displayed, dashes and all.
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "abcd-efgh-jklm" },
@@ -943,7 +950,7 @@ describe("OneLocationOnboardingFlow", () => {
     it("lets the person back out of a preview to try another code", async () => {
       const props = openJoin();
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "ABCDEFGHJKLM" },
       });
@@ -978,7 +985,7 @@ describe("OneLocationOnboardingFlow", () => {
           .mockRejectedValue(new Error("That code has expired.")),
       });
 
-      fireEvent.click(screen.getByText("Someone sent you a code?"));
+      fireEvent.click(screen.getByText("Join with a code"));
       fireEvent.change(screen.getByLabelText("Circle code"), {
         target: { value: "NOPENOPENOPE" },
       });
@@ -1222,9 +1229,15 @@ describe("OneLocationOnboardingFlow", () => {
           screen.getByTestId("one-location-onboarding-invite-code").textContent,
         ).toContain("ABCD-EFGH-JKLM"),
       );
-      expect(
-        screen.getByText(/Bring your people to Meena Family/),
-      ).toBeTruthy();
+      // The circle's name, and nothing wrapped around it. "Bring your people
+      // to Meena Family" spent five words introducing the code and the Share
+      // button directly beneath it.
+      expect(screen.getByText("Meena Family")).toBeTruthy();
+      expect(screen.queryByText(/Bring your people/i)).toBeNull();
+      // Expiry changes what the person does with the code, so it stays. The
+      // reassurance that followed it did not.
+      expect(screen.getByText("Expires in 72 hours")).toBeTruthy();
+      expect(screen.queryByText(/fresh one any time/i)).toBeNull();
 
       fireEvent.click(screen.getByRole("button", { name: /Copy/ }));
       expect(onCopyOnboardingCircleCode).toHaveBeenCalledWith("ABCDEFGHJKLM");
@@ -1270,7 +1283,7 @@ describe("OneLocationOnboardingFlow", () => {
       openInviteScreen();
 
       expect(screen.getByTestId("one-location-onboarding-invite")).toBeTruthy();
-      expect(screen.getByText(/circle code will be ready/i)).toBeTruthy();
+      expect(screen.getByText(/code isn't ready yet/i)).toBeTruthy();
 
       fireEvent.click(finishButton());
       expect(props.onComplete).toHaveBeenCalledTimes(1);
@@ -1287,11 +1300,18 @@ describe("OneLocationOnboardingFlow", () => {
       expect(
         screen.getByRole("heading", { name: /You're on the map/ }),
       ).toBeTruthy();
-      expect(screen.getByTestId("onboarding-live-map")).toBeTruthy();
+      const map = screen.getByTestId("onboarding-live-map");
+      expect(map).toBeTruthy();
+      // A real coordinate reached the map. `data-map-state` cannot prove this
+      // in jsdom -- there is no Google Maps there, so it never says "live" --
+      // but the point either arrived or it did not.
+      expect(map.getAttribute("data-map-point")).toBe("ready");
 
-      // The empty seat, which is the only thing here the map cannot show by
-      // itself and the reason the code below matters.
-      expect(screen.getByTestId("onboarding-ready-empty-seat")).toBeTruthy();
+      // "Your people show up here once they join." is gone, and so is the
+      // dashed empty-seat avatar beside it. The map above and the invite card
+      // below already carry that between them.
+      expect(screen.queryByTestId("onboarding-ready-empty-seat")).toBeNull();
+      expect(screen.queryByText(/show up here once they join/i)).toBeNull();
 
       // And explicitly NOT a second telling of Share / Check in / SOS: the
       // features screen already introduces those, and repeating them turns the
@@ -1311,7 +1331,7 @@ describe("OneLocationOnboardingFlow", () => {
       openInviteScreen();
 
       const map = screen.getByTestId("onboarding-live-map");
-      const seat = screen.getByTestId("onboarding-ready-empty-seat");
+      const title = screen.getByRole("heading", { name: /You're on the map/ });
       const sheet = screen.getByTestId("one-location-onboarding-ready-panel");
 
       // The map owns a band of its own; the words sit on an opaque sheet below
@@ -1324,7 +1344,9 @@ describe("OneLocationOnboardingFlow", () => {
         "bg-[color:var(--app-primary-surface)]",
       );
       expect(sheet?.className).not.toMatch(/bg-white\/\d/u);
-      expect(map.contains(seat)).toBe(false);
+      // Nothing readable lives inside the map band.
+      expect(map.contains(title)).toBe(false);
+      expect(map.contains(sheet)).toBe(false);
     });
 
     it("centers the invite panel on wide viewports instead of pinning it right", () => {
@@ -1364,26 +1386,89 @@ describe("OneLocationOnboardingFlow", () => {
         .map((n) => n.textContent ?? "")
         .join(" ");
 
-      // 34dvh of map is right on a phone, which is tall. A 1366x768 laptop is
-      // shorter than an iPhone, and there the same fraction pushed "Someone
-      // sent you a code?" below the fold -- the last thing on the screen took
-      // a scroll to discover it existed. The map yields, not the content.
+      // 42dvh of map is right on a phone, which is tall. A 1366x768 laptop is
+      // shorter than an iPhone, and there the same fraction pushed "Join with
+      // a code" below the fold -- the last thing on the screen took a scroll
+      // to discover it existed. The map yields, not the content.
       expect(styles).toContain("max-height: 820px");
-      expect(styles).toContain("24dvh");
+      expect(styles).toContain("30dvh");
     });
 
-    it("renders a composed map even with no point and no Maps key", () => {
+    it("still shows a real map when the Maps script never becomes usable", () => {
       // A missing or referrer-blocked browser key is common enough that it is
-      // the entire local-dev story. The last screen must still look finished:
-      // onboarding cannot end on an error panel.
-      renderFlow({ mapPoint: null });
+      // the entire local-dev story, and it is the whole iOS `App://` story.
+      // jsdom has no Google Maps at all, so this is exactly that state: a
+      // coordinate in hand and no script to draw it with. The answer is the
+      // same keyless embed every other Location surface degrades to -- still a
+      // map of where the person actually is.
+      renderFlow({ mapPoint: { lat: 19.076, lng: 72.8777 } });
       openInviteScreen();
 
       const map = screen.getByTestId("onboarding-live-map");
-      expect(map.getAttribute("data-map-state")).toBe("stylised");
+      expect(map.getAttribute("data-map-state")).toBe("embed");
+      expect(map.getAttribute("data-map-point")).toBe("ready");
+
+      const embed = screen.getByTestId(
+        "onboarding-live-map-embed",
+      ) as HTMLIFrameElement;
+      expect(embed.src).toContain("output=embed");
+      expect(embed.src).toContain(encodeURIComponent("19.076000,72.877700"));
+      // A backdrop, not a map app: panning away from yourself on the one screen
+      // whose point is that you are here would be a strange thing to allow.
+      expect(embed.className).toContain("pointer-events-none");
+
       expect(
         screen.getByRole("heading", { name: /You're on the map/ }),
       ).toBeTruthy();
+      expect(finishButton()).toBeEnabled();
+    });
+
+    it("says why, and drops the pin, when there is no coordinate at all", () => {
+      // The old screen drew a grid, two diagonal streaks and a pulsing blue dot
+      // for this case -- a picture of a map, under a headline claiming the
+      // person was on it, when nothing knew where they were. Both halves of
+      // that lie are gone: the headline stops claiming, and the band says what
+      // is actually true.
+      renderFlow({
+        mapPoint: null,
+        onPreviewCircleCode: vi.fn(),
+        onAcceptCircleCode: vi.fn(),
+      });
+      openInviteScreen();
+
+      const map = screen.getByTestId("onboarding-live-map");
+      expect(map.getAttribute("data-map-state")).toBe("unavailable");
+      expect(map.getAttribute("data-map-point")).toBe("none");
+      expect(map.querySelector("[data-onboarding-map-pulse]")).toBeNull();
+      expect(screen.getByText("Map unavailable")).toBeTruthy();
+      expect(
+        screen.getByRole("heading", { name: /You're all set/ }),
+      ).toBeTruthy();
+      expect(screen.queryByRole("heading", { name: /on the map/ })).toBeNull();
+
+      // Everything that matters still works. A Maps outage is not a reason to
+      // strand someone at the end of setup.
+      expect(screen.getByText("Private until you share.")).toBeTruthy();
+      expect(screen.getByText("Join with a code")).toBeTruthy();
+      expect(finishButton()).toBeEnabled();
+    });
+
+    it("blames Location, not Maps, when Location is the thing that is off", () => {
+      // "Map unavailable" in front of someone who refused Location points at
+      // the wrong thing and hides the only thing they could change.
+      renderFlow({
+        mapPoint: null,
+        locationPermission: {
+          state: "denied",
+          precise: null,
+          background: "foreground-only",
+          locationServicesEnabled: true,
+        },
+      });
+      openInviteScreen();
+
+      expect(screen.getByText("Location is off")).toBeTruthy();
+      expect(screen.queryByText("Map unavailable")).toBeNull();
       expect(finishButton()).toBeEnabled();
     });
 

--- a/hushh-webapp/__tests__/lib/one-location/onboarding-map-point.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/onboarding-map-point.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveOnboardingMapPoint } from "@/lib/one-location/onboarding-map-point";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+function point(
+  latitude: number,
+  longitude: number,
+): PlainLocationPoint {
+  return {
+    latitude,
+    longitude,
+    accuracyM: 12,
+    capturedAt: "2026-08-17T00:00:00.000Z",
+    sourcePlatform: "web",
+  };
+}
+
+describe("resolveOnboardingMapPoint", () => {
+  it("survives the save-place modal closing", () => {
+    // THE REGRESSION. The modal's draft is nulled by both of its exits, two
+    // screens before the finale renders. Reading the finale's camera from that
+    // draft is why "You're on the map." never showed anyone a map.
+    expect(
+      resolveOnboardingMapPoint({
+        draft: null,
+        confirmed: point(25.4358, 81.8463),
+        workspace: null,
+      }),
+    ).toEqual({ lat: 25.4358, lng: 81.8463 });
+  });
+
+  it("follows the point being edited right now", () => {
+    // Dragging the pin edits the draft. While that is on screen it is the
+    // freshest statement of where the person says they are.
+    expect(
+      resolveOnboardingMapPoint({
+        draft: point(19.076, 72.8777),
+        confirmed: point(25.4358, 81.8463),
+        workspace: point(28.6139, 77.209),
+      }),
+    ).toEqual({ lat: 19.076, lng: 72.8777 });
+  });
+
+  it("falls back to what the workspace already knows", () => {
+    // Reached the finale without the save-place step ever running: a returning
+    // account, or a workspace run where Location was already granted.
+    expect(
+      resolveOnboardingMapPoint({
+        draft: null,
+        confirmed: null,
+        workspace: point(28.6139, 77.209),
+      }),
+    ).toEqual({ lat: 28.6139, lng: 77.209 });
+  });
+
+  it("returns nothing when this account has never produced a fix", () => {
+    // The one case the stylised map is actually for.
+    expect(resolveOnboardingMapPoint({})).toBeNull();
+    expect(
+      resolveOnboardingMapPoint({
+        draft: null,
+        confirmed: null,
+        workspace: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("steps over a coordinate it cannot draw and keeps looking", () => {
+    // A broken fresher source must not blank the screen when a usable older
+    // one is sitting right behind it.
+    expect(
+      resolveOnboardingMapPoint({
+        draft: point(Number.NaN, 81.8463),
+        confirmed: point(25.4358, 81.8463),
+      }),
+    ).toEqual({ lat: 25.4358, lng: 81.8463 });
+
+    expect(
+      resolveOnboardingMapPoint({
+        draft: point(91, 0.5),
+        confirmed: point(25.4358, 81.8463),
+      }),
+    ).toEqual({ lat: 25.4358, lng: 81.8463 });
+
+    expect(
+      resolveOnboardingMapPoint({
+        draft: point(10, 181),
+        confirmed: point(25.4358, 81.8463),
+      }),
+    ).toEqual({ lat: 25.4358, lng: 81.8463 });
+  });
+
+  it("refuses Null Island", () => {
+    // 0,0 is the shape a dropped or default-initialised fix takes. Ending
+    // onboarding by flying the camera into the Gulf of Guinea is worse than the
+    // stylised map, which at least never claims to be anywhere.
+    expect(
+      resolveOnboardingMapPoint({ confirmed: point(0, 0) }),
+    ).toBeNull();
+    expect(
+      resolveOnboardingMapPoint({
+        draft: point(0, 0),
+        confirmed: point(25.4358, 81.8463),
+      }),
+    ).toEqual({ lat: 25.4358, lng: 81.8463 });
+  });
+
+  it("keeps a real coordinate that merely sits on one axis", () => {
+    // The equator and the prime meridian are places. Only the pair 0,0 is the
+    // sentinel, so neither axis alone may be rejected.
+    expect(resolveOnboardingMapPoint({ confirmed: point(0, 81.8463) })).toEqual({
+      lat: 0,
+      lng: 81.8463,
+    });
+    expect(resolveOnboardingMapPoint({ confirmed: point(51.4779, 0) })).toEqual({
+      lat: 51.4779,
+      lng: 0,
+    });
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -236,6 +236,7 @@ import {
   isOneLocationNearbyCheckInAvailable,
   ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS,
 } from "@/lib/one-location/nearby-check-in-availability";
+import { resolveOnboardingMapPoint } from "@/lib/one-location/onboarding-map-point";
 
 import {
   clearLiveShareEntries,
@@ -2390,6 +2391,22 @@ export function OneLocationAgentPageContent({
   const [saveLocationModalOpen, setSaveLocationModalOpen] = useState(false);
   const [saveLocationPoint, setSaveLocationPoint] =
     useState<PlainLocationPoint | null>(null);
+  /**
+   * The point onboarding confirmed, kept ALIVE past the save-place modal.
+   *
+   * `saveLocationPoint` above is that modal's draft, and both of its exits null
+   * it -- the save at `saveOnboardingLocation` and the skip at
+   * `handleSkipSaveOnboardingLocation`. That is right for a draft and was fatal
+   * for the finale: "You're on the map." renders two screens later, so it
+   * received null every single time and always drew its stylised fallback. The
+   * feature shipped and nobody could see it, in any environment.
+   *
+   * So the finale gets its own state. Written wherever a real fix is
+   * established, never cleared by the modal closing, cleared only when the
+   * account changes (below, with the rest of that reset).
+   */
+  const [onboardingConfirmedPoint, setOnboardingConfirmedPoint] =
+    useState<PlainLocationPoint | null>(null);
   const [saveLocationAddress, setSaveLocationAddress] = useState<string | null>(
     null,
   );
@@ -2574,6 +2591,9 @@ export function OneLocationAgentPageContent({
     savedLocationPointUserIdRef.current = null;
     setSaveLocationModalOpen(false);
     setSaveLocationPoint(null);
+    // The one place the finale's point IS cleared. A coordinate belongs to the
+    // account that produced it, and must never be inherited across a switch.
+    setOnboardingConfirmedPoint(null);
     setSaveLocationAddress(null);
     setSaveLocationAddressLoading(false);
     setSaveLocationSaving(false);
@@ -2605,6 +2625,24 @@ export function OneLocationAgentPageContent({
     [auth.userId],
   );
   const myLocationPoint = locationWorkspace.myLocationPoint;
+  /**
+   * Where the last onboarding screen puts its camera.
+   *
+   * Three sources, freshest first, resolved by a named function with its own
+   * tests rather than inline here -- see `resolveOnboardingMapPoint`. The
+   * workspace point at the end is what covers the person who reached the finale
+   * without the save-place step running at all: a returning account, or a
+   * workspace run where Location was already granted.
+   */
+  const onboardingFinaleMapPoint = useMemo(
+    () =>
+      resolveOnboardingMapPoint({
+        draft: saveLocationPoint,
+        confirmed: onboardingConfirmedPoint,
+        workspace: myLocationPoint,
+      }),
+    [myLocationPoint, onboardingConfirmedPoint, saveLocationPoint],
+  );
   const setMyLocationPoint = useCallback(
     (next: SetStateAction<PlainLocationPoint | null>) => {
       updateLocationWorkspace((current) => ({
@@ -10519,6 +10557,9 @@ export function OneLocationAgentPageContent({
           savedLocationAddressResolutionIdRef.current + 1;
         savedLocationAddressResolutionIdRef.current = addressResolutionId;
         setSaveLocationPoint(point);
+        // The finale's copy. Same value, different lifetime: this one has to
+        // outlive the modal below, because the map that uses it comes after it.
+        setOnboardingConfirmedPoint(point);
         setSaveLocationAddress(null);
         setSaveLocationAddressLoading(true);
         setSaveLocationModalOpen(true);
@@ -10805,13 +10846,17 @@ export function OneLocationAgentPageContent({
         throw new Error("The selected place did not return an address.");
       }
       savedLocationAddressResolutionIdRef.current += 1;
-      setSaveLocationPoint({
+      const selectedPoint: PlainLocationPoint = {
         ...saveLocationPoint,
         latitude: place.latitude,
         longitude: place.longitude,
         accuracyM: null,
         capturedAt: new Date().toISOString(),
-      });
+      };
+      setSaveLocationPoint(selectedPoint);
+      // Choosing a different address moves the finale's camera too: the point
+      // the person confirmed is the one the last screen should show.
+      setOnboardingConfirmedPoint(selectedPoint);
       setSaveLocationAddress(label);
       setSaveLocationAddressLoading(false);
     },
@@ -10834,13 +10879,27 @@ export function OneLocationAgentPageContent({
       ) {
         return;
       }
+      // Stamped once, outside the updater: a state updater has to be pure, and
+      // one that reads the clock hands back a different point each time React
+      // chooses to re-run it.
+      const pickedAt = new Date().toISOString();
       setSaveLocationPoint((current) => ({
         latitude: picked.latitude,
         longitude: picked.longitude,
         accuracyM: null,
-        capturedAt: new Date().toISOString(),
+        capturedAt: pickedAt,
         sourcePlatform: current?.sourcePlatform ?? "web",
       }));
+      // Dragging the pin is the most deliberate statement of "I am here" this
+      // flow ever gets, so the finale honours it. Only the coordinate is read
+      // there, which is why this copy does not need the platform above.
+      setOnboardingConfirmedPoint({
+        latitude: picked.latitude,
+        longitude: picked.longitude,
+        accuracyM: null,
+        capturedAt: pickedAt,
+        sourcePlatform: "web",
+      });
       savedLocationAddressResolutionIdRef.current += 1;
       setSaveLocationAddress(picked.address);
       setSaveLocationAddressLoading(false);
@@ -11181,14 +11240,13 @@ export function OneLocationAgentPageContent({
           // same fix costs a second permission round-trip and a visible delay
           // on the one screen that has to feel instant. Null renders the
           // stylised map, which is a composed screen rather than an error.
-          mapPoint={
-            saveLocationPoint
-              ? {
-                  lat: saveLocationPoint.latitude,
-                  lng: saveLocationPoint.longitude,
-                }
-              : null
-          }
+          //
+          // It reads `onboardingConfirmedPoint`, NOT `saveLocationPoint`. That
+          // is the whole fix: the modal's draft is nulled when the modal
+          // closes, two screens before this map exists, so feeding the finale
+          // from it meant the finale was fed null on every run. See the state
+          // declaration above for the full account.
+          mapPoint={onboardingFinaleMapPoint}
           contactsStepAvailable={contactsStepAvailable}
           onPreviewCircleCode={handlePreviewCircleCode}
           onAcceptCircleCode={handleAcceptCircleCode}

--- a/hushh-webapp/components/one-location/onboarding/onboarding-live-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/onboarding-live-map.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { MapPinOff } from "lucide-react";
 import { useTheme } from "next-themes";
 
+import { googleMapsLocationEmbedUrl } from "@/lib/one-location/maps-urls";
 import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
 import { cn } from "@/lib/utils";
 
@@ -14,26 +16,56 @@ import { cn } from "@/lib/utils";
  * it renders a single pin and nothing that can be interacted with or that could
  * fail loudly.
  *
- * The stylised fallback is not a degraded state to apologise for -- a missing
- * or referrer-blocked Maps key is common enough (it is the entire local-dev
- * story) that the final screen must look composed without one. Onboarding must
- * never end on an error panel.
+ * There are exactly three things it can draw, and they are not interchangeable:
+ *
+ *   live         a coordinate and a working Maps script -- the real thing
+ *   embed        a coordinate but no usable Maps script -- still a real map,
+ *                the same keyless Google embed `live-map.tsx` degrades to,
+ *                because a missing or referrer-blocked browser key is common
+ *                enough that it is the entire local-dev story
+ *   unavailable  no coordinate at all -- the only case with no map to show
+ *
+ * The screen used to draw one stylised picture for all three: a grid, two
+ * diagonal streaks and a pulsing blue dot floating over nothing. It looked
+ * composed, which is most of why nobody read it as broken -- and under a
+ * headline that says "You're on the map." it was a picture of a map the person
+ * was not on. A decorative grid is not a fallback; it is a claim.
  */
 export function OnboardingLiveMap({
   point,
+  emptyLabel = "Map unavailable",
   className,
 }: {
   point: { lat: number; lng: number } | null;
+  /**
+   * What to say when there is no coordinate to draw. The caller knows why --
+   * Location refused is a different sentence from Maps not loading -- and
+   * guessing here would put the wrong one on screen.
+   */
+  emptyLabel?: string;
   className?: string;
 }) {
   const { resolvedTheme } = useTheme();
   const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
   const { status } = useGoogleMaps({ enabled: Boolean(point) });
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
   const [rendered, setRendered] = useState(false);
+  /**
+   * Depend on the numbers, not the object.
+   *
+   * `point` is computed by the caller, so a render that changes nothing about
+   * where the person is still hands this component a fresh object. With that
+   * object in the effect below's dependencies, every such render tore the map
+   * down and built a new one -- and the cleanup's `setRendered(false)` flashes
+   * the fallback on the way through. That was invisible while this screen was
+   * never given a point at all; it is not invisible now.
+   */
+  const lat = point?.lat ?? null;
+  const lng = point?.lng ?? null;
 
   useEffect(() => {
-    if (status !== "ready" || !point) return;
+    if (status !== "ready" || lat === null || lng === null) return;
     const host = hostRef.current;
     if (!host) return;
 
@@ -45,7 +77,7 @@ export function OnboardingLiveMap({
     // light on a dark phone should not show a dark map here and a light one
     // there.
     const map = new google.maps.Map(host, {
-      center: point,
+      center: { lat, lng },
       zoom: 17,
       disableDefaultUI: true,
       clickableIcons: false,
@@ -55,59 +87,96 @@ export function OnboardingLiveMap({
       gestureHandling: "none",
       keyboardShortcuts: false,
     });
+    mapRef.current = map;
     setRendered(true);
 
     return () => {
       // Google keeps no dispose hook; dropping the node is the supported way to
       // release the instance, and the host is unmounted with this screen.
       google.maps.event.clearInstanceListeners(map);
+      mapRef.current = null;
       setRendered(false);
     };
-  }, [colorScheme, point, status]);
+    // `lat`/`lng` are read on construction but are deliberately NOT
+    // dependencies: the device keeps answering while this screen is open, and
+    // rebuilding a google.maps.Map on every fix would blink the finale several
+    // times in the few seconds it exists. The camera follows in the effect
+    // below instead. `colorScheme` stays, because Google accepts it only at
+    // construction, so a theme change genuinely is a rebuild.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [colorScheme, status]);
+
+  // The device is still reporting while this screen is open. Follow it with the
+  // camera rather than a rebuild -- the same reason `live-map.tsx` pans.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || lat === null || lng === null) return;
+    map.setCenter({ lat, lng });
+  }, [lat, lng]);
 
   const live = rendered && status === "ready";
+  const hasPoint = lat !== null && lng !== null;
+  // A coordinate with no usable Maps script still deserves a real map. This is
+  // the same keyless embed every other Location surface degrades to.
+  const embedded = hasPoint && !live;
+  const mapState = live ? "live" : embedded ? "embed" : "unavailable";
 
   return (
     <div
       className={cn("relative overflow-hidden", className)}
       data-testid="onboarding-live-map"
-      data-map-state={live ? "live" : "stylised"}
-      aria-hidden="true"
+      data-map-state={mapState}
+      // Two very different reasons used to produce the same stylised picture:
+      // nobody gave this screen a coordinate, or the Maps script never became
+      // usable. They were indistinguishable from the outside, which is most of
+      // why the first one went unnoticed -- the screen looked composed and said
+      // nothing. Saying which is which costs one attribute.
+      data-map-point={hasPoint ? "ready" : "none"}
+      // Decorative while it is a map: the headline already says what it shows.
+      // Not decorative when it cannot draw one -- then it is the only thing on
+      // the screen explaining why, and a screen reader must hear it.
+      aria-hidden={hasPoint ? true : undefined}
     >
       <div ref={hostRef} className="absolute inset-0" />
 
-      {/* Drawn under the real map too, so the transition from fallback to live
-          is a fade rather than a flash of empty tiles. */}
-      {!live ? (
-        <div className="absolute inset-0 bg-[#eef3f8] dark:bg-[#161b23]">
-          <div
-            className="absolute inset-0 opacity-70"
-            style={{
-              backgroundImage:
-                "linear-gradient(0deg, rgba(120,140,170,0.16) 1px, transparent 1px), linear-gradient(90deg, rgba(120,140,170,0.16) 1px, transparent 1px)",
-              backgroundSize: "38px 38px",
-            }}
-          />
-          <div
-            className="absolute -left-[12%] top-[18%] h-[36%] w-[150%] -rotate-[14deg] rounded-full bg-white/70 dark:bg-white/[0.05]"
-            aria-hidden="true"
-          />
-          <div
-            className="absolute -right-[22%] top-[58%] h-[26%] w-[120%] rotate-[9deg] rounded-full bg-white/60 dark:bg-white/[0.04]"
-            aria-hidden="true"
-          />
+      {embedded && lat !== null && lng !== null ? (
+        <iframe
+          title="Map of where you are"
+          src={googleMapsLocationEmbedUrl({ lat, lng })}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          // A backdrop, exactly like the live map above it. The keyless embed
+          // has no dark mode, so dark theme applies the same invert+hue-rotate
+          // filter live-map uses to stop the surface glowing white.
+          className="pointer-events-none absolute inset-0 h-full w-full border-0 dark:[filter:invert(0.9)_hue-rotate(180deg)_saturate(0.85)]"
+          data-testid="onboarding-live-map-embed"
+        />
+      ) : null}
+
+      {/* No coordinate, so no map and no pin. A pin here would point at a place
+          nobody knows, which is exactly what the old grid did. */}
+      {!hasPoint ? (
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-[#eef3f8] text-[#6b7280] dark:bg-[#161b23] dark:text-[#8d99a8]"
+          data-testid="onboarding-live-map-empty"
+        >
+          <MapPinOff className="h-6 w-6" strokeWidth={1.8} aria-hidden="true" />
+          <p className="text-[14px] font-medium leading-5">{emptyLabel}</p>
         </div>
       ) : null}
 
-      {/* The pin is ours in both cases: a Google marker cannot carry the pulse,
-          and keeping one renderer means the animation is identical either way. */}
-      <span className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-        <span
-          className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[color:var(--app-accent)]/20"
-          data-onboarding-map-pulse
-        />
-        <span className="relative flex h-5 w-5 items-center justify-center rounded-full border-[3px] border-white bg-[color:var(--app-accent)] shadow-[0_6px_18px_rgba(24,57,91,0.35)]" />
-      </span>
+      {/* The pin is ours on both real-map paths: a Google marker cannot carry
+          the pulse, and keeping one renderer means the animation is identical
+          whether the tiles came from the script or the embed. */}
+      {hasPoint ? (
+        <span className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+          <span
+            className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[color:var(--app-accent)]/20"
+            data-onboarding-map-pulse
+          />
+          <span className="relative flex h-5 w-5 items-center justify-center rounded-full border-[3px] border-white bg-[color:var(--app-accent)] shadow-[0_6px_18px_rgba(24,57,91,0.35)]" />
+        </span>
+      ) : null}
 
       <style>{`
         [data-onboarding-map-pulse] {

--- a/hushh-webapp/components/one-location/onboarding/onboarding-live-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/onboarding-live-map.tsx
@@ -145,6 +145,10 @@ export function OnboardingLiveMap({
           src={googleMapsLocationEmbedUrl({ lat, lng })}
           loading="lazy"
           referrerPolicy="no-referrer-when-downgrade"
+          // Out of the tab order. An iframe is focusable by default, and this
+          // one sits inside an `aria-hidden` container -- focusable content
+          // hidden from assistive technology is a trap, not a decoration.
+          tabIndex={-1}
           // A backdrop, exactly like the live map above it. The keyless embed
           // has no dark mode, so dark theme applies the same invert+hue-rotate
           // filter live-map uses to stop the surface glowing white.

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -20,11 +21,15 @@ import {
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { OnboardingLiveMap } from "@/components/one-location/onboarding/onboarding-live-map";
 import {
+  READY_CODE_CLASSNAME,
   READY_MAP_CLASSNAME,
+  READY_MAP_SHORT_WINDOW_CSS,
   READY_PANEL_CLASSNAME,
   READY_SURFACE_CLASSNAME,
 } from "@/components/one-location/onboarding/ready-panel-layout";
+import { resolveOnboardingFinaleMapPoint } from "@/lib/one-location/onboarding-map-point";
 import { normalizeCircleCode } from "@/lib/one-location/pending-circle-join";
+import { useCurrentLocation } from "@/lib/one-location/use-current-location";
 import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
 import type { ConsentNotificationDeliveryMode } from "@/components/consent/notification-provider";
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
@@ -1663,6 +1668,7 @@ function ContactsScreen({
 function ReadyScreen({
   currentUserName: _currentUserName,
   mapPoint,
+  mapEmptyLabel,
   invite,
   loading,
   error,
@@ -1690,6 +1696,8 @@ function ReadyScreen({
 }: {
   currentUserName: string;
   mapPoint: { lat: number; lng: number } | null;
+  /** What the map band says when there is no coordinate to draw. */
+  mapEmptyLabel: string;
   invite: OnboardingCircleInvite | null;
   loading: boolean;
   error: string | null;
@@ -1730,6 +1738,7 @@ function ReadyScreen({
           layout every map product converges on for the same reason. */}
       <OnboardingLiveMap
         point={mapPoint}
+        emptyLabel={mapEmptyLabel}
         className={READY_MAP_CLASSNAME}
       />
 
@@ -1757,39 +1766,34 @@ function ReadyScreen({
         data-testid="one-location-onboarding-ready-panel"
       >
         <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4 pt-6 md:px-7 md:pb-5 md:pt-7">
+          {/* The headline is the map's, so it only gets to make the claim when
+              there is a map. Reaching this screen with Location declined is an
+              ordinary outcome -- the features screen offers "Not now" -- and
+              telling that person they are on a map, over a panel that says the
+              map is unavailable, is the one thing this screen must not do. */}
           <h1
             className="ui-text-agent-title pb-1 leading-[1.15] text-[#151b26] dark:!text-[#f5f7fb]"
             data-one-ready-title
           >
-            You&apos;re on the map.
+            {mapPoint ? "You're on the map." : "You're all set."}
           </h1>
           <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[#b5bfcc]">
             Private until you share.
           </p>
 
-        <p
-          className="mt-6 flex items-center gap-2 text-[14px] font-medium leading-5 text-[#5c626c] dark:text-[#aeb8c7]"
-          data-testid="onboarding-ready-empty-seat"
-          data-one-ready-seat
-        >
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-[color:var(--app-accent)]/45">
-            <UserPlus
-              className="h-3.5 w-3.5 text-[color:var(--app-accent)]/70"
-              strokeWidth={2.2}
-            />
-          </span>
-          Your people show up here once they join.
-        </p>
-
+        {/* "Your people show up here once they join." used to sit here, with a
+            dashed empty-seat avatar beside it. The map above and the invite
+            card below already say it between them, and a screen a person reads
+            in three seconds cannot afford a sentence that only restates its own
+            layout. */}
         <div
-          className="mt-5 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-5 dark:border-white/[0.08] dark:bg-[#1c212a]"
+          className="mt-6 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-5 dark:border-white/[0.08] dark:bg-[#1c212a]"
           data-testid="one-location-onboarding-invite-card"
           data-one-ready-code
         >
           {loading ? (
             <div className="flex min-h-24 items-center justify-center gap-2 text-sm text-[#777d86] dark:text-[#8d99a8]">
-              <Loader2 className="h-5 w-5 animate-spin" /> Preparing your circle
-              code
+              <Loader2 className="h-5 w-5 animate-spin" /> Getting your code
             </div>
           ) : error ? (
             <div className="flex min-h-24 flex-col items-center justify-center gap-3 text-center">
@@ -1806,17 +1810,27 @@ function ReadyScreen({
             </div>
           ) : invite ? (
             <>
+              {/* The circle's name, not a sentence wrapped around it. "Bring
+                  your people to Ankit's Circle" spent five words introducing
+                  the two things directly under it -- a code and a Share
+                  button -- which the card's own shape already introduces. */}
               <p className="text-[13px] font-medium leading-[18px] text-[#6E6E73] dark:text-[#aeb8c7]">
-                Bring your people to {invite.circleName}
+                {invite.circleName}
               </p>
               <p
-                className="mt-2 select-all whitespace-nowrap font-mono text-[clamp(20px,6vw,28px)] font-bold uppercase leading-[1.15] tracking-[0.12em] text-[#151b26] dark:text-[#f5f7fb]"
+                className={READY_CODE_CLASSNAME}
                 data-testid="one-location-onboarding-invite-code"
+                data-ui-contract="required-copy"
+                data-ui-id="onboarding-invite-code"
+                data-ui-truncation="forbid"
               >
                 {formattedCode}
               </p>
+              {/* Kept, shortened. The expiry changes what the person does with
+                  the code, so it stays; "You can get a fresh one any time" is a
+                  reassurance about a screen they have not reached yet. */}
               <p className="mt-2 text-[12px] leading-[18px] text-[#96999e] dark:text-[#8d99a8]">
-                Expires in 72 hours. You can get a fresh one any time.
+                Expires in 72 hours
               </p>
               <div className="mt-4 grid grid-cols-2 gap-3">
                 <button
@@ -1843,8 +1857,10 @@ function ReadyScreen({
             </>
           ) : (
             <p className="flex min-h-24 items-center justify-center px-2 text-center text-sm leading-5 text-[#6f7580] dark:text-[#8d99a8]">
-              Your circle code will be ready in One. You can share it any time
-              from your circle.
+              {/* Where to get it is the button at the bottom of this screen,
+                  which already says "Open One Location". Saying it again here
+                  is the paragraph this card used to be. */}
+              Your code isn&apos;t ready yet.
             </p>
           )}
         </div>
@@ -1860,8 +1876,8 @@ function ReadyScreen({
                   className="h-4 w-4 shrink-0 text-[color:var(--app-accent)]"
                   strokeWidth={2.5}
                 />
-                You&apos;ll join {joinPreview?.name ?? "their circle"} as soon as
-                One finishes setting up.
+                You&apos;ll join {joinPreview?.name ?? "their circle"} after
+                setup.
               </p>
             ) : joinPreview ? (
               <div
@@ -1885,7 +1901,7 @@ function ReadyScreen({
                 </p>
                 {joinPreview.alreadyMember ? (
                   <p className="mt-3 text-[13px] leading-[18px] text-[#73777f] dark:text-[#aeb8c7]">
-                    You&apos;re already in this circle.
+                    Already in this circle.
                   </p>
                 ) : (
                   <button
@@ -1915,8 +1931,11 @@ function ReadyScreen({
               </div>
             ) : (
               <details className="group" data-testid="onboarding-join-circle-toggle" open={Boolean(joinCode)}>
+                {/* An action, not a question. "Someone sent you a code?" asks
+                    the person to confirm a situation before it offers to do
+                    anything about it; this names what tapping does. */}
                 <summary className="flex min-h-11 cursor-pointer list-none items-center justify-center text-[14px] font-bold text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]">
-                  Someone sent you a code?
+                  Join with a code
                 </summary>
                 <div className="mt-3 flex gap-2">
                   <input
@@ -1955,13 +1974,17 @@ function ReadyScreen({
         ) : null}
         </div>
 
-        <footer className="relative z-10 shrink-0 bg-white px-6 pb-[calc(env(safe-area-inset-bottom,0px)+18px)] pt-3 dark:bg-[#14171d] md:px-7 md:pb-7">
+        {/* The SAME surface as the panel it sits inside, by token rather than
+            by a second hand-picked hex. When the panel moved to the semantic
+            token and this did not, dark mode showed the panel at #1c1c1e and
+            its own footer at #14171d -- one card with a seam across it. */}
+        <footer className="relative z-10 shrink-0 bg-[color:var(--app-primary-surface)] px-6 pb-[calc(env(safe-area-inset-bottom,0px)+18px)] pt-3 md:px-7 md:pb-7">
           {settlementRetryCount > 0 ? (
             <p
               className="mb-3 text-center text-[13px] leading-5 text-[#96999e] dark:text-[#8d99a8]"
               role="status"
             >
-              That didn&apos;t save. Tap again to finish setting up Location.
+              That didn&apos;t save. Tap again.
             </p>
           ) : null}
           {/* Always the completion CTA. A code that failed to load is not a
@@ -1976,24 +1999,14 @@ function ReadyScreen({
 
       <style>{`
         [data-one-ready-title] { animation: oneReadyRise 520ms cubic-bezier(0.22, 1, 0.36, 1) both; }
-        [data-one-ready-seat] { animation: oneReadyRise 520ms cubic-bezier(0.22, 1, 0.36, 1) both; animation-delay: 80ms; }
         [data-one-ready-code] { animation: oneReadyRise 560ms cubic-bezier(0.22, 1, 0.36, 1) both; animation-delay: 140ms; }
-        /* 34dvh of map is right on a phone, which is tall. A 1366x768 laptop is
-           shorter than an iPhone, and there the same fraction pushed the join
-           link below the fold -- so the last thing on the screen needed a
-           scroll to discover it existed. The map yields the height instead,
-           since it is atmosphere and the link is a way in. Phones are past 820px
-           and keep the taller band. */
-        @media (max-width: 767px) and (max-height: 820px) {
-          [data-testid="onboarding-live-map"] { height: 24dvh; min-height: 150px; }
-        }
+        ${READY_MAP_SHORT_WINDOW_CSS}
         @keyframes oneReadyRise {
           from { opacity: 0; transform: translateY(14px); }
           to   { opacity: 1; transform: translateY(0); }
         }
         @media (prefers-reduced-motion: reduce) {
           [data-one-ready-title],
-          [data-one-ready-seat],
           [data-one-ready-code] {
             animation: none;
             opacity: 1;
@@ -2050,6 +2063,38 @@ export function OneLocationOnboardingFlow({
   preconnect("https://maps.googleapis.com");
   preconnect("https://maps.gstatic.com");
   useGoogleMaps({ enabled: true });
+
+  /**
+   * The account's position, from the one place the whole app already keeps it.
+   *
+   * `auto` resolves a fix on mount ONLY when the OS has already granted
+   * permission; it never triggers a first prompt, which matters more here than
+   * anywhere -- iOS grants exactly one Core Location alert per install, and
+   * this flow's entire second screen exists to spend it deliberately.
+   *
+   * Subscribed here rather than in the Location page because the bus updates
+   * as the device reports, and the page is a very large tree that has no reason
+   * to re-render for a coordinate only the finale reads. The onboarding overlay
+   * is mounted for a minute at most.
+   */
+  const { snapshot: deviceSnapshot } = useCurrentLocation({ auto: true });
+
+  /**
+   * Where the finale's camera actually goes.
+   *
+   * `mapPoint` is the page's answer from the three sources it owns. All three
+   * are empty on ordinary runs -- someone who skipped the save-place step, or
+   * granted Location and walked straight through -- and the screen then drew a
+   * picture of a map the person was not on. The bus is the last resort.
+   */
+  const finaleMapPoint = useMemo(
+    () =>
+      resolveOnboardingFinaleMapPoint({
+        onboarding: mapPoint,
+        device: deviceSnapshot,
+      }),
+    [deviceSnapshot, mapPoint],
+  );
 
   const [screen, setScreen] = useState<OnboardingScreen>(() =>
     initialScreen(startAt),
@@ -2112,6 +2157,18 @@ export function OneLocationOnboardingFlow({
   const locationGranted =
     locationPermission?.state === "granted" &&
     locationPermission.locationServicesEnabled !== false;
+  /**
+   * The states where asking again cannot help: refused, held by device policy,
+   * or the phone's Location Services switch is off. `prompt` and a null (not
+   * yet read) permission are deliberately NOT blocked -- those are the states
+   * where the answer is still coming.
+   *
+   * Read on the finale only, to name the right reason for an empty map band.
+   */
+  const locationBlocked =
+    locationPermission?.state === "denied" ||
+    locationPermission?.state === "restricted" ||
+    locationPermission?.locationServicesEnabled === false;
   const notificationsGranted = notificationDeliveryMode === "push_active";
 
   const requestMissingPermissions = useCallback(() => {
@@ -2190,7 +2247,9 @@ export function OneLocationOnboardingFlow({
       setCircleInviteError(
         error instanceof Error && error.message
           ? error.message
-          : "We couldn't prepare your circle code. Try again.",
+          // The state, not the apology. "Try again" is the button directly
+          // under this line, so the sentence does not have to say it too.
+          : "Couldn't get your code.",
       );
     } finally {
       circleInviteInFlightRef.current = false;
@@ -2555,9 +2614,9 @@ export function OneLocationOnboardingFlow({
             full-size instance renders here, invisibly, so the tiles are in the
             browser cache before the screen that shows them exists. It unmounts
             as the finale mounts, so there is never a second live map. */}
-        {screen === "contacts" && mapPoint ? (
+        {screen === "contacts" && finaleMapPoint ? (
           <OnboardingLiveMap
-            point={mapPoint}
+            point={finaleMapPoint}
             className="pointer-events-none absolute inset-0 -z-10 opacity-0"
           />
         ) : null}
@@ -2579,7 +2638,12 @@ export function OneLocationOnboardingFlow({
         {screen === "invite" ? (
           <ReadyScreen
             currentUserName={currentUserName}
-            mapPoint={mapPoint}
+            mapPoint={finaleMapPoint}
+            // Two different reasons produce an empty map band, and only the
+            // caller can tell them apart. "Map unavailable" in front of someone
+            // who refused Location blames the wrong thing and hides the one
+            // thing they could change.
+            mapEmptyLabel={locationBlocked ? "Location is off" : "Map unavailable"}
             invite={circleInvite}
             loading={circleInviteLoading}
             error={circleInviteError}

--- a/hushh-webapp/components/one-location/onboarding/ready-panel-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/ready-panel-layout.ts
@@ -22,17 +22,79 @@
 export const READY_SURFACE_CLASSNAME =
   "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#14171d] md:bg-[#eef3f8] md:dark:bg-[#070a0f]";
 
-/** A band of its own on phones; the full backdrop from `md:` up. */
+/**
+ * A band of its own on phones; the full backdrop from `md:` up.
+ *
+ * 42dvh, not the 34dvh it carried while it drew a decorative grid. The band was
+ * sized for a picture nobody was meant to look at, and the screen paid for that
+ * twice: too little map to read as a place, and a panel with a hand's width of
+ * empty white in the middle of it once the copy below it came down to what it
+ * needed to be. The 400px cap keeps a 932pt phone from turning the finale into
+ * a map with a strip of content, and `min-h` holds a usable band on a short
+ * landscape window.
+ */
 export const READY_MAP_CLASSNAME =
-  "h-[34dvh] max-h-[300px] min-h-[190px] w-full shrink-0 md:absolute md:inset-0 md:h-full md:max-h-none md:min-h-0";
+  "h-[42dvh] max-h-[400px] min-h-[190px] w-full shrink-0 md:absolute md:inset-0 md:h-full md:max-h-none md:min-h-0";
+
+/**
+ * Where the band yields.
+ *
+ * 42dvh is right on a phone, which is tall. A 1366x768 laptop is shorter than
+ * an iPhone, and there the same fraction pushed "Join with a code" below the
+ * fold -- so the last thing on the screen needed a scroll to discover it
+ * existed. The map yields the height, since it is atmosphere and the link is a
+ * way in. iPhone SE is 667pt and lands here too: 30dvh is 200px there, which
+ * still reads as a place rather than a texture.
+ *
+ * Exported rather than inlined for the same reason as the class strings above:
+ * `e2e/one-location-ready-panel.layout.spec.ts` measures the composition this
+ * produces, and it can only do that if it is reading the same source the
+ * component renders.
+ */
+export const READY_MAP_SHORT_WINDOW_CSS = `
+  @media (max-width: 767px) and (max-height: 820px) {
+    [data-testid="onboarding-live-map"] { height: 30dvh; min-height: 168px; }
+  }
+`;
+
+/**
+ * The invite code itself.
+ *
+ * Here rather than inline for the same reason as the panel: this string is the
+ * one thing on the screen that must survive every width intact. It is twelve
+ * characters plus two separators of fixed-width type, so it cannot reflow --
+ * it either fits or it clips, and clipping a code makes it useless. `clamp`
+ * with a `6vw` middle term is what keeps it inside a 320px phone;
+ * `e2e/one-location-ready-panel.layout.spec.ts` measures that rather than
+ * trusting the arithmetic.
+ */
+export const READY_CODE_CLASSNAME =
+  "mt-2 select-all whitespace-nowrap font-mono text-[clamp(20px,6vw,28px)] font-bold uppercase leading-[1.15] tracking-[0.12em] text-[#151b26] dark:text-[#f5f7fb]";
 
 /**
  * Phones keep the full-width sheet in normal flow -- that is also what the iOS
  * build renders, so the `md:` rules must never leak into phone widths. From
  * `md:` up the panel becomes a fixed-width dialog centred on both axes.
+ *
+ * Three things here are deliberate and were changed together once the map
+ * behind this panel actually started rendering (it never had -- see
+ * `resolveOnboardingMapPoint`, which is the state bug that kept this screen
+ * showing its stylised fallback on every run):
+ *
+ *  - The surface is the semantic token, not `bg-white` + a hand-picked dark
+ *    hex. Light is the same #ffffff it always was; dark now matches every other
+ *    sheet in the app instead of being one screen's private shade.
+ *  - The desktop cap is `min(760px, 100dvh-176px)` rather than `100dvh-96px`.
+ *    The old one let the dialog grow to within 48px of both edges on a laptop,
+ *    which reads as a slab with a hairline of map around it. 176px guarantees a
+ *    real band of map above and below, and 760px stops a tall monitor from
+ *    stretching a short panel into a column.
+ *  - The desktop chrome is the immersive map's: an accent hairline and its
+ *    accent-tinted shadow, so the dialog reads as the same family of surface as
+ *    the people tray on Your Map rather than a generic modal.
  */
 export const READY_PANEL_CLASSNAME =
-  "relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-white shadow-[0_-8px_24px_rgba(24,57,91,0.10)] dark:bg-[#14171d] md:absolute md:left-1/2 md:top-1/2 md:mt-0 md:h-auto md:max-h-[calc(100dvh-96px)] md:w-[430px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[30px] md:shadow-[0_24px_80px_rgba(24,57,91,0.22)]";
+  "relative z-10 -mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[28px] bg-[color:var(--app-primary-surface)] shadow-[0_-8px_24px_rgba(24,57,91,0.10)] md:absolute md:left-1/2 md:top-1/2 md:mt-0 md:h-auto md:max-h-[min(760px,calc(100dvh-176px))] md:w-[430px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[30px] md:border md:border-[var(--app-accent-border)] md:shadow-[0_18px_60px_color-mix(in_oklab,var(--app-accent)_18%,transparent)]";
 
 /** Tailwind's `md:` breakpoint -- where the sheet becomes a centred dialog. */
 export const READY_PANEL_DIALOG_MIN_WIDTH_PX = 768;

--- a/hushh-webapp/e2e/one-location-ready-panel.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-ready-panel.layout.spec.ts
@@ -7,7 +7,9 @@ import { awaitProductFont, productFontStyle } from "./fixtures/product-font";
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
 import {
+  READY_CODE_CLASSNAME,
   READY_MAP_CLASSNAME,
+  READY_MAP_SHORT_WINDOW_CSS,
   READY_PANEL_CLASSNAME,
   READY_PANEL_DIALOG_MIN_WIDTH_PX,
   READY_PANEL_DIALOG_WIDTH_PX,
@@ -57,7 +59,7 @@ async function buildFixture(): Promise<string> {
     },
   });
 
-  const classes = `${READY_SURFACE_CLASSNAME} ${READY_MAP_CLASSNAME} ${READY_PANEL_CLASSNAME} h-screen flex flex-col`;
+  const classes = `${READY_SURFACE_CLASSNAME} ${READY_MAP_CLASSNAME} ${READY_PANEL_CLASSNAME} ${READY_CODE_CLASSNAME} h-screen flex flex-col`;
   const css = compiler.build(classes.split(/\s+/).filter(Boolean));
 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ready-panel-layout-"));
@@ -66,14 +68,24 @@ async function buildFixture(): Promise<string> {
     path.join(dir, "fixture.html"),
     `<!doctype html><html><head><meta charset="utf-8">
 <style>${productFontStyle()}</style>
-<link rel="stylesheet" href="fixture.css"></head><body style="margin:0">
+<link rel="stylesheet" href="fixture.css">
+<!-- The component's own short-window rule, read from the module it renders
+     from rather than copied here, so the two cannot drift apart. -->
+<style>${READY_MAP_SHORT_WINDOW_CSS}</style></head><body style="margin:0">
 <div class="h-screen flex flex-col">
   <div class="${READY_SURFACE_CLASSNAME}" data-testid="one-location-onboarding-ready-surface">
     <div class="${READY_MAP_CLASSNAME}" data-testid="onboarding-live-map"></div>
     <div class="${READY_PANEL_CLASSNAME}" data-testid="one-location-onboarding-ready-panel">
       <div style="padding:24px">
         <h1>You&apos;re on the map.</h1><p>Private until you share.</p>
-        <p>SWDX-ENDP-B954</p><button>Copy</button><button>Share</button>
+        <!-- The invite card's real insets: the panel's px-6 (24px, above) plus
+             the card's own p-5. The code has to survive both at 320px. -->
+        <div style="padding:20px;border:1px solid #e4e6e9;border-radius:20px">
+          <p style="font-size:13px">Ankit&apos;s Circle</p>
+          <p class="${READY_CODE_CLASSNAME}" data-testid="one-location-onboarding-invite-code">SWDX-ENDP-B954</p>
+          <p style="font-size:12px">Expires in 72 hours</p>
+        </div>
+        <button>Copy</button><button>Share</button>
       </div>
     </div>
   </div>
@@ -125,6 +137,106 @@ test.describe("One Location ready panel layout", () => {
         expect(measured.position).not.toBe("absolute");
         expect(Math.abs(measured.width - width)).toBeLessThanOrEqual(1);
       }
+    });
+  }
+});
+
+/**
+ * The invite code, measured rather than reasoned about.
+ *
+ * Twelve characters of fixed-width type with two separators cannot reflow: at
+ * any width it either fits or it clips, and half a circle code is not a circle
+ * code. The arithmetic says it fits inside a 320px phone once the panel's 24px
+ * insets and the card's 20px insets are taken off; this is the check that the
+ * arithmetic is right, in a real engine, with the real class string.
+ */
+const PHONE_WIDTHS = [320, 360, 375, 390, 430] as const;
+
+test.describe("One Location invite code", () => {
+  for (const width of PHONE_WIDTHS) {
+    test(`is never clipped or ellipsized at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await buildFixture());
+      await awaitProductFont(page);
+
+      const code = page.getByTestId("one-location-onboarding-invite-code");
+      await expect(code).toBeVisible();
+
+      const measured = await code.evaluate((node) => {
+        const style = getComputedStyle(node);
+        const box = node.getBoundingClientRect();
+        return {
+          overflowX: node.scrollWidth - node.clientWidth,
+          overflowY: node.scrollHeight - node.clientHeight,
+          textOverflow: style.textOverflow,
+          webkitLineClamp: style.webkitLineClamp,
+          fontSizePx: Number.parseFloat(style.fontSize),
+          left: box.left,
+          right: box.right,
+          text: (node.textContent ?? "").trim(),
+        };
+      });
+
+      expect(measured.text).toBe("SWDX-ENDP-B954");
+      expect(measured.overflowX).toBeLessThanOrEqual(1);
+      expect(measured.overflowY).toBeLessThanOrEqual(1);
+      expect(measured.textOverflow).not.toBe("ellipsis");
+      expect(measured.webkitLineClamp).toBe("none");
+      // Small enough to fit is not the same as readable. The clamp floor is
+      // 20px and nothing may take it below that.
+      expect(measured.fontSizePx).toBeGreaterThanOrEqual(20);
+      expect(measured.left).toBeGreaterThanOrEqual(-1);
+      expect(measured.right).toBeLessThanOrEqual(width + 1);
+    });
+  }
+});
+
+/**
+ * The map band's share of the screen.
+ *
+ * It grew from 34dvh to 42dvh when it stopped being a decorative grid and
+ * started being a map of where the person is -- the ticket's "the map can
+ * occupy more useful visual area rather than leaving a giant blank white
+ * middle". The two failure modes that bound it are opposite, so both are
+ * measured: too small to read as a place, and so tall that the panel below it
+ * loses the invite code and the primary action.
+ */
+const PHONE_HEIGHTS = [
+  { name: "iPhone SE", width: 375, height: 667 },
+  { name: "iPhone 15", width: 390, height: 844 },
+  { name: "iPhone 15 Pro Max", width: 430, height: 932 },
+] as const;
+
+test.describe("One Location finale map band", () => {
+  for (const device of PHONE_HEIGHTS) {
+    test(`leaves room for the panel on ${device.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: device.width, height: device.height });
+      await page.goto(await buildFixture());
+      await awaitProductFont(page);
+
+      const measured = await page.evaluate(() => {
+        const map = document.querySelector<HTMLElement>(
+          '[data-testid="onboarding-live-map"]',
+        );
+        const panel = document.querySelector<HTMLElement>(
+          '[data-testid="one-location-onboarding-ready-panel"]',
+        );
+        if (!map || !panel) throw new Error("fixture missing a node");
+        return {
+          mapHeight: map.getBoundingClientRect().height,
+          panelHeight: panel.getBoundingClientRect().height,
+          viewport: window.innerHeight,
+        };
+      });
+
+      const share = measured.mapHeight / measured.viewport;
+      // Enough map to read as a place. The old band bottomed out near a fifth
+      // of the screen on a short phone.
+      expect(share).toBeGreaterThan(0.22);
+      // And never so much that the panel becomes a strip. The panel holds the
+      // code, both invite actions, the way in and the primary action.
+      expect(share).toBeLessThan(0.5);
+      expect(measured.panelHeight).toBeGreaterThan(measured.viewport * 0.45);
     });
   }
 });

--- a/hushh-webapp/lib/one-location/onboarding-map-point.ts
+++ b/hushh-webapp/lib/one-location/onboarding-map-point.ts
@@ -1,0 +1,112 @@
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+/**
+ * Where the last onboarding screen points its camera.
+ *
+ * This exists because the answer used to be "whatever the save-place modal is
+ * currently holding", and that is a DRAFT: both of the modal's exits -- saving
+ * the place and skipping it -- clear it, which is correct for a draft and fatal
+ * here. The modal runs two screens before the finale, so by the time "You're on
+ * the map." rendered, the point was always null and the screen always drew its
+ * stylised fallback. Nobody ever saw themselves on a real map at the end of
+ * onboarding, on any platform or in any environment.
+ *
+ * Keeping the choice in one small pure function is what makes that regression
+ * hard to reintroduce: the finale reads a named answer with its own test,
+ * rather than reaching into whichever piece of state happens to be nearby.
+ */
+
+/** Web Mercator, and the map itself, stop making sense outside these. */
+function isDrawableCoordinate(point: {
+  latitude: number;
+  longitude: number;
+}): boolean {
+  const { latitude, longitude } = point;
+  return (
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    latitude >= -90 &&
+    latitude <= 90 &&
+    longitude >= -180 &&
+    longitude <= 180 &&
+    // 0,0 is Null Island -- the shape a dropped or default-initialised fix
+    // takes. Flying the finale camera into the Gulf of Guinea is worse than
+    // the stylised map, which at least never claims to be anywhere.
+    !(latitude === 0 && longitude === 0)
+  );
+}
+
+export interface OnboardingMapPointSources {
+  /**
+   * The save-place modal's live working point, while that modal is open. It is
+   * the freshest thing on screen -- dragging the pin edits exactly this -- so
+   * it wins whenever it exists.
+   */
+  draft?: PlainLocationPoint | null;
+  /**
+   * What onboarding confirmed for this run. Deliberately outlives the modal:
+   * this is the value the finale is actually for.
+   */
+  confirmed?: PlainLocationPoint | null;
+  /**
+   * What the Location workspace already knows about this device. Covers the
+   * person who reached the finale without the save-place step ever running --
+   * a returning account, or a workspace run where location was already granted.
+   */
+  workspace?: PlainLocationPoint | null;
+}
+
+/**
+ * Freshest usable point first, or null when this account has genuinely never
+ * produced a fix -- the one case the stylised map is for.
+ */
+export function resolveOnboardingMapPoint(
+  sources: OnboardingMapPointSources,
+): { lat: number; lng: number } | null {
+  for (const point of [sources.draft, sources.confirmed, sources.workspace]) {
+    if (!point || !isDrawableCoordinate(point)) continue;
+    return { lat: point.latitude, lng: point.longitude };
+  }
+  return null;
+}
+
+/**
+ * One step further out than `resolveOnboardingMapPoint`, and the last word on
+ * where the finale's camera goes.
+ *
+ * All three sources above belong to the Location page, and all three are empty
+ * on a real and ordinary run: someone who declined the save-place step, or
+ * granted Location on the features screen and walked straight through, reaches
+ * "You're on the map." with nothing captured under any of those names. The
+ * screen then showed a picture of a map they were not on.
+ *
+ * The shared LocationBus is the account's position for the whole app -- one
+ * subscription, one device read, and a fix that survives a reload sealed to the
+ * owner's own key. It is the honest answer to "where is this person", and it is
+ * the reason the finale can now open on their own street when every
+ * onboarding-owned source is empty.
+ *
+ * Last, never first. A coordinate the person confirmed in this run is a
+ * statement of intent; the bus is whatever the device last managed to measure.
+ */
+export function resolveOnboardingFinaleMapPoint(sources: {
+  /** What the Location page resolved from the three sources it owns. */
+  onboarding: { lat: number; lng: number } | null;
+  /** The shared LocationBus snapshot, if this session is holding one. */
+  device?: { latitude: number; longitude: number } | null;
+}): { lat: number; lng: number } | null {
+  const { onboarding, device } = sources;
+  if (
+    onboarding &&
+    isDrawableCoordinate({
+      latitude: onboarding.lat,
+      longitude: onboarding.lng,
+    })
+  ) {
+    return onboarding;
+  }
+  if (device && isDrawableCoordinate(device)) {
+    return { lat: device.latitude, lng: device.longitude };
+  }
+  return null;
+}

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -52,7 +52,7 @@
     "ios:device:ui:test": "node ./scripts/native/assert-destructive-native-audit.mjs && bash ./scripts/native/ios-device-ui-test.sh",
     "verify:cache": "vitest run __tests__/services/cache-sync-mutation-cascade.test.ts __tests__/services/cache-service.test.ts __tests__/services/cache-hit-rate-contract.test.ts __tests__/services/use-stale-resource.test.tsx __tests__/services/use-stale-resource-lifecycle.test.tsx __tests__/services/pkm-cache.test.ts __tests__/services/pkm-domain-resource.test.ts",
     "verify:connect-search": "vitest run __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts",
-    "verify:one-location": "vitest run __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx components/one-location/redesign/__tests__/duration-presets.test.tsx",
+    "verify:one-location": "vitest run __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts components/one-location/redesign/__tests__/duration-wheel-picker.test.tsx components/one-location/redesign/__tests__/duration-presets.test.tsx __tests__/components/one-location-onboarding-finale.contract.test.tsx __tests__/lib/one-location/onboarding-map-point.test.ts",
     "report:contributor-impact:pdf": "node ../.codex/skills/pr-governance-review/scripts/export_contributor_impact_pdf.mjs",
     "report:markdown:pdf": "node ./scripts/reports/export-markdown-pdf.mjs",
     "audit:analytics-sandbox": "node ./scripts/testing/run-observability-sandbox-audit.mjs",

--- a/hushh-webapp/playwright.config.ts
+++ b/hushh-webapp/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       // radius defect it covers is INVISIBLE in Chromium. A Chromium-only run
       // passes the broken control.
       testMatch:
-        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout|one-location-tab-strip\.layout|app-shell-top-clearance\.layout|app-shell-bottom-clearance\.layout)\.spec\.ts/,
+        /(circle-join-responsive-contract|connect-circle-cta\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout|one-location-tab-strip\.layout|one-location-ready-panel\.layout|app-shell-top-clearance\.layout|app-shell-bottom-clearance\.layout)\.spec\.ts/,
     },
     {
       name: "firefox",


### PR DESCRIPTION
Closes #5620

## The bug

`main` today reads the finale's camera from `saveLocationPoint` — the save-a-place modal's **working draft** — and both of that modal's exits null it. The modal runs two screens before the finale, so the finale is handed `null` on every run, `useGoogleMaps` (gated on `enabled: Boolean(point)`) never starts, and the screen draws its stylised fallback: a grid, two diagonal streaks and a pulsing blue dot. Under a headline that says *"You're on the map."*

This was fixed once, in `25b8f974c` + `cb52a5455`, and the mass revert to Monday 2026-08-17 14:00 (`a60c51dfc`) rolled it back out. Those two commits are restored here unchanged, with the polish below on top.

## Map

| state | when | what you see |
|---|---|---|
| `live` | coordinate + working Maps script | the real Google map, chrome-free, gesture-free |
| `embed` | coordinate, no usable script | the same keyless Google embed `live-map.tsx` degrades to — still a real map (this is the whole iOS `App://` story) |
| `unavailable` | no coordinate at all | a calm band saying `Map unavailable`, or `Location is off` when that is the real reason. No pin, no grid. |

- `resolveOnboardingFinaleMapPoint` adds the shared **LocationBus** as a last resort behind the page's three sources. That is the position the app already holds — `auto` resolves only when the OS has *already* granted, so it never spends the one Core Location prompt iOS allows per install. No new location logic, no new endpoint, no second GPS subscription.
- The camera now `setCenter`s as the device reports instead of rebuilding the map on every fix.
- The headline stops claiming a map when there is none: `You're all set.`
- Band grew `34dvh → 42dvh` (capped 400px). It was sized for a picture nobody was meant to look at.

## Copy: 9 blocks → 6

| before | after |
|---|---|
| `Your people show up here once they join.` + dashed empty-seat avatar | *removed* — restated the layout |
| `Bring your people to Ankit's Circle` | `Ankit's Circle` |
| `Expires in 72 hours. You can get a fresh one any time.` | `Expires in 72 hours` |
| `Someone sent you a code?` | `Join with a code` |
| `Preparing your circle code` | `Getting your code` |
| `We couldn't prepare your circle code. Try again.` | `Couldn't get your code.` (the button below already says Try again) |
| `Your circle code will be ready in One. You can share it any time from your circle.` | `Your code isn't ready yet.` |
| `You'll join X as soon as One finishes setting up.` | `You'll join X after setup.` |
| `That didn't save. Tap again to finish setting up Location.` | `That didn't save. Tap again.` |
| `You're already in this circle.` | `Already in this circle.` |

Kept: state, privacy line, circle name, code, expiry, Copy, Share, primary action.

## Behaviour preserved

Copy, Share, Join with a code, Open One Location, Back, Skip and the in-card retry all call the same handlers as before. No route, guard, analytics event or permission path changed.

## Coverage

`one-location-onboarding-flow.test.tsx` is in **no CI pack**, so nothing it asserted had ever gated a PR — and its own `mapPoint` default was `null`, modelling the bug rather than the product. Both fixed:

- New `__tests__/components/one-location-onboarding-finale.contract.test.tsx`, **registered in `verify:one-location`** — map states, the embed fallback and its coordinate, the honest headline, the empty-band reason, the surviving copy set, and all four actions still firing with no map at all.
- `__tests__/lib/one-location/onboarding-map-point.test.ts` registered in the same pack.
- `e2e/one-location-ready-panel.layout.spec.ts` (already in `test:layout-contracts`) gains what JSDOM cannot see: the invite code measured at 320/360/375/390/430px — no clip, no ellipsis, never under 20px — and the map/panel split on iPhone SE, iPhone 15 and iPhone 15 Pro Max. The short-window rule moved into `ready-panel-layout.ts` so the component and the spec read one source.

Mutation-checked: forcing the embed off, pinning the headline to "You're on the map.", shrinking the band to 12dvh and adding `truncate` to the code each fail the assertion written for them (7 of 18 layout cases fail under mutation).

## Verification

- `npm run verify:one-location` — **155 passed / 6 files** (base `origin/main`: 141 / 4)
- `test:layout-contracts` for this spec, chromium — **18 passed**
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `verify:design-system`, `verify:accent-tokens`, `verify:surface-map` — all pass
- `one-location-onboarding-flow.test.tsx`: 52 passed / **2 failed, both pre-existing on `origin/main`** (`keeps the mobile feature screen readable…`, `uses one semantic light and dark surface contract…`). They assert a `location-agent-v2` design pass on the *welcome and features* screens that the same mass revert removed; restoring that is a different ticket. Base fails 3 of these — this branch fixes one of them (`never lays copy over live map tiles`).

## Scope

Frontend only. 11 files, all under `hushh-webapp/`. Zero deletions or renames. No backend, API, Circle route, invite-code generation or location-sharing semantic touched.