### PR TITLE
restore 2/9: name the requester in connection-request toasts

### DIFF
--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -43,6 +43,9 @@ MIN_FINAL_REMINDER_WINDOW_MS = 2 * 60 * 60 * 1000
 _CONSENT_NOTIFY_QUEUE_MAXSIZE = 100
 _consent_notify_queues: Dict[str, asyncio.Queue] = {}
 _consent_notify_queues_lock = asyncio.Lock()
+# The loop the SSE queues live on. Captured when a consumer connects, so a
+# producer running on a FastAPI threadpool worker can still reach them.
+_serving_loop: asyncio.AbstractEventLoop | None = None
 _DEVELOPER_CONSENT_QUEUE_MAXSIZE = 20
 _developer_consent_subscribers: Dict[tuple[str, str], set[asyncio.Queue]] = {}
 _developer_consent_subscribers_lock = asyncio.Lock()
@@ -164,9 +167,50 @@ async def _push_to_developer_consent_queues(data: Dict[str, Any]) -> None:
 
 def get_consent_queue(user_id: str) -> asyncio.Queue:
     """Get or create the asyncio queue for this user (used by SSE generator)."""
+    _remember_serving_loop()
     if user_id not in _consent_notify_queues:
         _consent_notify_queues[user_id] = asyncio.Queue(maxsize=_CONSENT_NOTIFY_QUEUE_MAXSIZE)
     return _consent_notify_queues[user_id]
+
+
+def _remember_serving_loop() -> None:
+    """Record the loop the SSE queues live on, so worker threads can reach them.
+
+    Called from ``get_consent_queue``, which only ever runs inside the SSE
+    endpoint -- i.e. on the serving loop itself.
+    """
+    global _serving_loop
+    try:
+        _serving_loop = asyncio.get_running_loop()
+    except RuntimeError:  # pragma: no cover - never called off-loop today
+        pass
+
+
+def push_to_consent_queue_threadsafe(user_id: str, data: Dict[str, Any]) -> bool:
+    """Enqueue an SSE event from a thread that has no running event loop.
+
+    FastAPI runs a plain ``def`` handler in a threadpool worker, where
+    ``asyncio.get_running_loop()`` raises. Every producer of connection-request
+    events is such a handler (``def create_connection_request``,
+    ``def request_nearby_connection``), so the fire-and-forget
+    ``loop.create_task(...)`` they used to attempt raised RuntimeError and was
+    swallowed -- the SSE lane was dead for those events, and the web client had
+    no way to learn about a new connection request unless it had an active push
+    subscription.
+
+    Returns True when the coroutine was scheduled. False means there is no
+    serving loop yet (no SSE consumer has ever connected in this process), which
+    is not an error: there is nobody to deliver to.
+    """
+    loop = _serving_loop
+    if loop is None or loop.is_closed():
+        return False
+    try:
+        asyncio.run_coroutine_threadsafe(_push_to_consent_queue(user_id, data), loop)
+        return True
+    except Exception as exc:  # noqa: BLE001 - delivery is best-effort, never fatal
+        logger.warning("consent.sse_threadsafe_enqueue_failed error=%s", exc)
+        return False
 
 
 async def subscribe_developer_consent_queue(

--- a/consent-protocol/hushh_mcp/branding.py
+++ b/consent-protocol/hushh_mcp/branding.py
@@ -1,0 +1,40 @@
+"""Single source of truth for the brand name in user-facing backend copy.
+
+The connection-request banner used to spell the brand as a bare literal in two
+places in ``push_notifications`` and a third time as JSX in the web toast. Three
+independent authors of one sentence is why the misspelling ("hushh") survived on
+the notification surface long after the rest of the product had moved to
+"Hussh": nothing tied them together, and the docs brand gate
+(``scripts/verify-doc-brand.cjs``) only looks for the capitalised ``Hushh``, so
+the lowercase form was invisible to it.
+
+``hushh`` remains correct and load-bearing as an *identifier* -- package names,
+bundle ids, domains, headers, env vars, storage keys. This module is only about
+prose a person reads. See ``docs/reference/operations/hussh-rebrand-classification.md``:
+user-facing product copy is "public-brand prose" and reads ``Hussh``.
+"""
+
+from __future__ import annotations
+
+BRAND_NAME = "Hussh"
+PRODUCT_NAME = "Hussh One"
+
+# What the banner says when we genuinely cannot name the requester. Kept here
+# rather than inlined so the web fallback and this one stay the same word.
+GENERIC_REQUESTER_LABEL = "Someone"
+
+
+def connection_request_body(requester_label: str | None = None) -> str:
+    """The one connection-request sentence, for every platform.
+
+    This is the *only* body text the OS banner can show on web, iOS and
+    Android -- ``build_push_message`` puts it on ``WebpushNotification.body``,
+    the top-level ``messaging.Notification`` and ``aps.alert.body``
+    respectively, and none of those can be rewritten on-device (no
+    ``mutable_content``). So this string is authoritative, not decorative.
+
+    Never emits ``None``/``undefined``: a blank or whitespace-only label
+    degrades to the generic line rather than producing " wants to connect...".
+    """
+    label = str(requester_label or "").strip() or GENERIC_REQUESTER_LABEL
+    return f"{label} wants to connect with you on {BRAND_NAME}."

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -141,11 +141,24 @@ def _default_directory_visible(owner_user_id: str, candidate_user_id: str) -> bo
     )
 
 
-def _default_notifier(*, addressee_user_id: str, requester_user_id: str) -> None:
-    """Best-effort real push (deferred import keeps Firebase off the import path)."""
+def _default_notifier(
+    *,
+    addressee_user_id: str,
+    requester_user_id: str,
+    connection_request_id: str | None = None,
+) -> None:
+    """Best-effort real push (deferred import keeps Firebase off the import path).
+
+    ``connection_request_id`` is forwarded so the notification can deep-link
+    straight to the review sheet; without it a tap can only open the list.
+    """
     from hushh_mcp.services.push_notifications import send_connection_request_push
 
-    send_connection_request_push(addressee_user_id, requester_user_id)
+    send_connection_request_push(
+        addressee_user_id,
+        requester_user_id,
+        connection_request_id=connection_request_id,
+    )
 
 
 def _default_scope_entries_lookup(owner_user_id: str) -> list[dict[str, Any]]:
@@ -792,7 +805,7 @@ class ConnectionsService:
                         event_type="PROPOSED",
                         actor_user_id=requester_user_id,
                     )
-        self._notify_new_request(target, requester_user_id)
+        self._notify_new_request(target, requester_user_id, request_id)
         # Avoid a redundant post-insert read for ordinary connections. Scoped
         # requests are hydrated from the canonical child rows on the next
         # request/list read; authority never comes from this response.
@@ -955,7 +968,7 @@ class ConnectionsService:
                         AND NOT EXISTS (SELECT 1 FROM connected)
                         AND NOT EXISTS (SELECT 1 FROM existing)
                       ON CONFLICT DO NOTHING
-                      RETURNING requester_user_id, addressee_user_id
+                      RETURNING id, requester_user_id, addressee_user_id
                     )
                     SELECT
                       e.addressee_user_id AS target_user_id,
@@ -969,7 +982,11 @@ class ConnectionsService:
                         WHEN EXISTS (SELECT 1 FROM existing) THEN 'pending_incoming'
                         ELSE 'pending_outgoing'
                       END AS relationship,
-                      EXISTS (SELECT 1 FROM inserted) AS created
+                      EXISTS (SELECT 1 FROM inserted) AS created,
+                      -- The new row's id, so the nudge can deep-link to the
+                      -- review sheet. Without it this path could only ever send
+                      -- the unscoped Connections-list link.
+                      (SELECT i.id FROM inserted i LIMIT 1) AS created_request_id
                     FROM eligible e
                     WHERE EXISTS (SELECT 1 FROM connected)
                        OR EXISTS (SELECT 1 FROM existing)
@@ -988,6 +1005,7 @@ class ConnectionsService:
             self._notify_new_request(
                 str(row.get("target_user_id") or ""),
                 requester,
+                str(row.get("created_request_id") or ""),
             )
         return {"relationship": str(row.get("relationship") or "")}
 
@@ -1023,8 +1041,22 @@ class ConnectionsService:
         """
         return (x, y) if x < y else (y, x)
 
-    def _notify_new_request(self, addressee_user_id: str, requester_user_id: str) -> None:
-        """Fire the (best-effort) addressee nudge. Never raises."""
+    def _notify_new_request(
+        self,
+        addressee_user_id: str,
+        requester_user_id: str,
+        connection_request_id: str | None = None,
+    ) -> None:
+        """Fire the (best-effort) addressee nudge. Never raises.
+
+        ``connection_request_id`` is what lets the notification deep-link to the
+        review sheet rather than the Connections list -- the Consent Center opens
+        that sheet purely from ``?requestId``. It is threaded through here rather
+        than re-queried in the notifier because both call sites already hold it.
+        The requester's display name is deliberately NOT looked up here: this
+        runs immediately after a write, and the notifier resolves it lazily so a
+        cosmetic read never sits on the request path.
+        """
         notifier = getattr(self, "_notifier", None)
         if notifier is None:
             return
@@ -1032,6 +1064,7 @@ class ConnectionsService:
             notifier(
                 addressee_user_id=addressee_user_id,
                 requester_user_id=requester_user_id,
+                connection_request_id=str(connection_request_id or "").strip() or None,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("connections.notify_failed error=%s", exc)

--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -10,6 +10,9 @@ configured, so unit tests and credential-less environments stay clean.
 from __future__ import annotations
 
 import logging
+from urllib.parse import quote
+
+from hushh_mcp.branding import connection_request_body
 
 logger = logging.getLogger(__name__)
 
@@ -113,63 +116,96 @@ def send_user_data_push(
         return 0
 
 
-_GENERIC_CONNECTION_REQUEST_BODY = "Someone wants to connect with you on hushh."
+_GENERIC_CONNECTION_REQUEST_BODY = connection_request_body()
+
+# Where a connection-request tap must land. The Consent Center opens the review
+# sheet purely from the URL -- `selectedId = searchParams.get("requestId")` in
+# consent-center-page.tsx -- so a link without the id can only ever render the
+# list, which is what made "tapping the notification" a dead end. `tab=pending`
+# is the shape `buildConsentCenterHref` emits and the one the Feed's Review
+# action already uses, so all three entry points agree.
+CONNECTION_REQUEST_LIST_LINK = "/one/consent?tab=connections"
+
+
+def _connection_request_link(connection_request_id: str | None) -> str:
+    request_id = str(connection_request_id or "").strip()
+    if not request_id:
+        return CONNECTION_REQUEST_LIST_LINK
+    return f"/one/consent?tab=pending&requestId={quote(request_id, safe='')}"
 
 
 def _connection_request_body(requester_name: str | None) -> str:
     """Connection-request banner copy. Names the requester when we have one,
-    else falls back to the generic line — never emits ``None``/``undefined``."""
-    name = (requester_name or "").strip()
-    if not name:
-        return _GENERIC_CONNECTION_REQUEST_BODY
-    return f"{name} wants to connect with you on hushh."
+    else falls back to the generic line — never emits ``None``/``undefined``.
+
+    Thin wrapper kept for the existing call sites and tests; the sentence itself
+    lives in ``hushh_mcp.branding`` so the web toast, the OS banner and the SSE
+    body cannot drift apart again (that drift is how the brand misspelling
+    survived on this surface — see issue #5422).
+    """
+    return connection_request_body(requester_name)
 
 
 def _lookup_display_name(user_id: str) -> str:
-    """Best-effort requester display name from the actor identity cache.
+    """Best-effort, lock-screen-safe requester label. "" when unresolved.
 
-    Returns "" on any miss/error, and — mirroring ``send_user_data_push`` —
-    checks Firebase config FIRST so credential-less environments never touch the
-    database. The banner degrades to the generic copy when this returns "".
+    Delegates to ``requester_identity.resolve_requester_label``, which rejects
+    technical identities (a raw Firebase uid is a legitimate value of
+    ``actor_identity_cache.display_name``) and falls back to an email handle.
+
+    Deliberately NOT gated on ``ensure_firebase_admin()``. It used to be, copied
+    from ``send_user_data_push`` where the gate genuinely avoids a pointless
+    token read. Here the same value also feeds the in-app/SSE copy, so the gate
+    blanked a perfectly resolvable name in every environment without Firebase
+    credentials — the database had it the whole time.
     """
-    user_id = (user_id or "").strip()
-    if not user_id:
-        return ""
-    try:
-        from api.utils.firebase_admin import ensure_firebase_admin
+    from hushh_mcp.services.requester_identity import resolve_requester_label
 
-        configured, _ = ensure_firebase_admin()
-        if not configured:
-            return ""
-
-        from db.db_client import get_db
-
-        rows = (
-            get_db()
-            .execute_raw(
-                "SELECT display_name FROM actor_identity_cache WHERE user_id = :user_id LIMIT 1",
-                {"user_id": user_id},
-            )
-            .data
-            or []
-        )
-        if not rows:
-            return ""
-        return str(rows[0].get("display_name") or "").strip()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("push.name_lookup_skipped error=%s", exc)
-        return ""
+    return resolve_requester_label(user_id)
 
 
-def send_connection_request_push(addressee_user_id: str, requester_user_id: str) -> int:
+def send_connection_request_push(
+    addressee_user_id: str,
+    requester_user_id: str,
+    *,
+    requester_display_name: str | None = None,
+    connection_request_id: str | None = None,
+) -> int:
     """Nudge the addressee's client that a new connection request arrived.
 
     The payload's ``type`` drives the client (see notification-provider.tsx):
     on receipt it invalidates the consent-center cache so the incoming request
     surfaces without a manual refresh. The banner names the requester when the
-    identity cache has a display name, and degrades to the generic line
-    otherwise (best-effort; the lookup never blocks or raises)."""
-    requester_name = _lookup_display_name(requester_user_id)
+    identity cache can, and degrades to the generic line otherwise
+    (best-effort; the lookup never blocks or raises).
+
+    ``requester_display_name`` lets the caller pass a name it already holds
+    (``ConnectionsService`` has one at every notify site) so we skip the query.
+    ``connection_request_id`` is the real ``connection_requests.id``; it is what
+    makes the tap open the review sheet instead of a list, so pass it whenever
+    it is known.
+    """
+    from hushh_mcp.services.requester_identity import resolve_requester_label
+
+    requester_name = resolve_requester_label(
+        requester_user_id,
+        display_name=requester_display_name,
+    )
+    body = connection_request_body(requester_name)
+    deep_link = _connection_request_link(connection_request_id)
+    request_id = str(connection_request_id or "").strip()
+
+    # Identity and routing fields the CLIENT needs, as opposed to the banner the
+    # OS renders. The in-app toast reads only this data map -- it never sees
+    # `body` -- which is exactly why it said "Someone" while the system banner
+    # said the right thing. Empty values are dropped by send_user_data_push, so
+    # an unresolved name simply omits the key and the client owns the fallback.
+    client_data = {
+        "requester_user_id": requester_user_id,
+        "requester_label": requester_name,
+        "request_id": request_id,
+    }
+
     try:
         import asyncio
 
@@ -178,19 +214,36 @@ def send_connection_request_push(addressee_user_id: str, requester_user_id: str)
         sse_payload = {
             "type": "connection_request",
             "action": "REQUESTED",
-            "request_id": f"conn_req:{requester_user_id}",
+            # The real row id, not the old synthetic `conn_req:<uid>`. That value
+            # was stable per *requester* rather than per request, so the SSE
+            # de-dup in api/routes/sse.py silently swallowed every follow-up
+            # request from the same person on one connection — and any client
+            # promoting it into `?requestId` would resolve nothing.
+            "request_id": request_id or f"conn_req:{requester_user_id}",
             "user_id": addressee_user_id,
             "requester_user_id": requester_user_id,
-            "requester_label": requester_name or "Someone",
+            # "" rather than "Someone": baking the placeholder into transport
+            # meant the client's own (richer) fallback ladder could never fire,
+            # because it received a label that merely looked real.
+            "requester_label": requester_name,
             "title": "New connection request",
-            "body": _connection_request_body(requester_name),
-            "deep_link": "/one/consent?tab=connections",
+            "body": body,
+            "deep_link": deep_link,
+            "request_url": deep_link,
         }
         try:
             loop = asyncio.get_running_loop()
             loop.create_task(_push_to_consent_queue(addressee_user_id, sse_payload))
         except RuntimeError:
-            pass
+            # No running loop: we are on a FastAPI threadpool worker, which is
+            # where BOTH production callers actually run (`def
+            # create_connection_request`, `def request_nearby_connection` are
+            # sync). This used to `pass`, which silently discarded the event and
+            # left the SSE lane dead for connection requests -- so a web client
+            # without a push subscription could never learn about one.
+            from api.consent_listener import push_to_consent_queue_threadsafe
+
+            push_to_consent_queue_threadsafe(addressee_user_id, sse_payload)
     except Exception as exc:  # noqa: BLE001
         logger.warning("push.sse_queue_failed error=%s", exc)
 
@@ -198,11 +251,11 @@ def send_connection_request_push(addressee_user_id: str, requester_user_id: str)
         addressee_user_id,
         notification_type="connection_request",
         title="New connection request",
-        body=_connection_request_body(requester_name),
-        deep_link="/one/consent?tab=connections",
+        body=body,
+        deep_link=deep_link,
         notification_tag=f"connection-request:{addressee_user_id}",
         notification_category="ONE_CONNECTIONS",
-        data={"requester_user_id": requester_user_id},
+        data=client_data,
     )
 
 

--- a/consent-protocol/hushh_mcp/services/requester_identity.py
+++ b/consent-protocol/hushh_mcp/services/requester_identity.py
@@ -1,0 +1,132 @@
+"""Resolve a human label for a user id, safe to put on a lock screen.
+
+Why this is not just ``SELECT display_name``:
+
+``actor_identity_cache.display_name`` is **not** guaranteed to be a human name.
+Migration 037 back-seeds it as ``COALESCE(mpp.display_name, rp.display_name,
+ap.user_id)`` and ``ActorIdentityService._get_many_fallback`` does the same, so
+for any actor that has never synced from Firebase the column holds the raw
+Firebase uid. Interpolating that into a notification produces
+"RPNmQAmVdlNz84GVfXxta50wnYx1 wants to connect with you on Hussh." -- which is
+worse than the generic line, not better. The web has always guarded against
+this (``isTechnicalRequesterIdentity`` in ``lib/consent/consent-display.ts``);
+the push path never did.
+
+Privacy: the fallback ladder deliberately stops before the phone number.
+``one_location_agent_service._identity_notification_label`` already establishes
+the rule for this repo -- a notification label carries "no phone-derived data",
+because a banner renders on a *locked* screen where anyone holding the device
+can read it. An email local part is the furthest we go, which is also what
+``resolveConsentRequesterLabel`` accepts as a counterpart label on the web.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_UUID_LIKE_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# A Firebase uid is 28 characters with no spaces and no "@". Anything that long
+# and that opaque is an identifier somebody stored in a name column, not a name.
+# Mirrors the >=20 rule in lib/consent/consent-display.ts so the two surfaces
+# reject the same strings.
+_OPAQUE_TOKEN_MIN_LENGTH = 20
+
+
+def looks_technical_label(value: object | None, *, user_id: str | None = None) -> bool:
+    """True when ``value`` is an identifier rather than something to show a person."""
+    normalized = str(value or "").strip()
+    if not normalized:
+        return True
+    if user_id and normalized == str(user_id).strip():
+        return True
+    if normalized.lower().startswith("ria:"):
+        return True
+    if _UUID_LIKE_PATTERN.match(normalized):
+        return True
+    if (
+        "@" not in normalized
+        and " " not in normalized
+        and len(normalized) >= _OPAQUE_TOKEN_MIN_LENGTH
+    ):
+        return True
+    return False
+
+
+def _email_handle(email: object | None) -> str:
+    """The local part of an email, when it reads like a handle.
+
+    Returns "" for anything that is not a plausible address, and for local parts
+    that are themselves opaque (a Firebase-uid-shaped mailbox is no better than
+    the uid).
+    """
+    normalized = str(email or "").strip()
+    if "@" not in normalized:
+        return ""
+    local = normalized.split("@", 1)[0].strip()
+    if not local or looks_technical_label(local):
+        return ""
+    return local
+
+
+def resolve_requester_label(
+    user_id: str,
+    *,
+    display_name: object | None = None,
+    execute_one=None,
+) -> str:
+    """Best-effort lock-screen-safe label for ``user_id``. "" when unresolved.
+
+    Never raises and never falls back to a technical identifier: the caller is
+    expected to substitute the generic line when this returns "".
+
+    ``display_name`` lets a caller that already read the identity row pass it in
+    and skip the query entirely -- ``ConnectionsService`` holds one at every
+    notify site. ``execute_one`` is the DB seam, defaulted lazily so importing
+    this module never pulls in the database client.
+    """
+    uid = str(user_id or "").strip()
+    if display_name is not None and not looks_technical_label(display_name, user_id=uid):
+        return str(display_name).strip()
+    if not uid:
+        return ""
+
+    if execute_one is None:
+
+        def execute_one(sql: str, params: dict[str, object]) -> dict[str, object] | None:
+            from db.db_client import get_db
+
+            rows = get_db().execute_raw(sql, params).data or []
+            return rows[0] if rows else None
+
+    try:
+        # One read for the whole ladder. Note there is deliberately no Firebase
+        # gate here: this is a Postgres row that also feeds the in-app copy, so
+        # gating it on push credentials would blank the name in any environment
+        # without Firebase Admin configured while the database held it all along.
+        row = execute_one(
+            """
+            SELECT display_name, email
+            FROM actor_identity_cache
+            WHERE user_id = :user_id
+            LIMIT 1
+            """,
+            {"user_id": uid},
+        )
+    except Exception as exc:  # noqa: BLE001 - a name is cosmetic; never break the send
+        logger.warning("requester_identity.lookup_failed error=%s", exc)
+        return ""
+
+    if not row:
+        return ""
+
+    resolved = str(row.get("display_name") or "").strip()
+    if resolved and not looks_technical_label(resolved, user_id=uid):
+        return resolved
+    return _email_handle(row.get("email"))

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -27,6 +27,8 @@ tests/test_vault_keys_metadata.py
 tests/test_one_location_routes.py
 tests/services/test_one_location_agent_service.py
 tests/services/test_connections_service.py
+tests/services/test_push_notifications.py
+tests/test_fcm_messages.py
 tests/routes/test_connections_route.py
 tests/test_adk_a2a_compliance_script.py
 tests/test_ria_claim_flow.py

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -1086,7 +1086,15 @@ def test_create_request_notifies_addressee_on_new_insert():
     db = SimpleNamespace(execute_raw=lambda sql, params=None: next(responses))
     with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
         svc.create_request("user-a", addressee_user_id="user-b")
-    assert calls == [{"addressee_user_id": "user-b", "requester_user_id": "user-a"}]
+    # The new row's id rides along so the push can deep-link to the review sheet
+    # instead of the Connections list (issue #5422).
+    assert calls == [
+        {
+            "addressee_user_id": "user-b",
+            "requester_user_id": "user-a",
+            "connection_request_id": "req-1",
+        }
+    ]
 
 
 def test_create_request_does_not_notify_on_idempotent_existing():
@@ -1144,6 +1152,7 @@ def test_nearby_alias_request_atomically_revalidates_versions_and_inserts():
                     "target_user_id": "user-b",
                     "relationship": "pending_outgoing",
                     "created": True,
+                    "created_request_id": "req-nearby-1",
                 }
             ],
         ],
@@ -1170,6 +1179,10 @@ def test_nearby_alias_request_atomically_revalidates_versions_and_inserts():
     assert "insert into connection_requests" in normalized_mutation_sql
     assert "target.allow_connection_requests" in normalized_mutation_sql
     assert "'pending', null" in normalized_mutation_sql
+    # The CTE must surface the inserted id, otherwise this path can only ever
+    # send the unscoped Connections-list link (issue #5422).
+    assert "returning id, requester_user_id, addressee_user_id" in normalized_mutation_sql
+    assert "as created_request_id" in normalized_mutation_sql
     expected_params = {
         "requester_user_id": "user-a",
         "participant_alias": "6f80b5ee-85b8-4678-a663-9f84ae985ed5",
@@ -1189,6 +1202,7 @@ def test_nearby_alias_request_atomically_revalidates_versions_and_inserts():
         {
             "addressee_user_id": "user-b",
             "requester_user_id": "user-a",
+            "connection_request_id": "req-nearby-1",
         }
     ]
 

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -1,17 +1,26 @@
+from unittest.mock import patch
+
+from hushh_mcp.branding import BRAND_NAME
+from hushh_mcp.services import push_notifications as push_module
 from hushh_mcp.services.push_notifications import (
     _GENERIC_CONNECTION_REQUEST_BODY,
     _connection_request_body,
+    send_connection_request_push,
+)
+from hushh_mcp.services.requester_identity import (
+    looks_technical_label,
+    resolve_requester_label,
 )
 
 
 def test_connection_request_body_names_the_requester():
-    assert _connection_request_body("Ankit") == "Ankit wants to connect with you on hushh."
+    assert _connection_request_body("Ankit") == "Ankit wants to connect with you on Hussh."
 
 
 def test_connection_request_body_trims_whitespace_around_the_name():
     assert (
         _connection_request_body("  Ankit Sharma  ")
-        == "Ankit Sharma wants to connect with you on hushh."
+        == "Ankit Sharma wants to connect with you on Hussh."
     )
 
 
@@ -26,3 +35,292 @@ def test_connection_request_body_never_emits_none_or_undefined():
         body = _connection_request_body(value)
         assert "None" not in body
         assert "undefined" not in body
+
+
+def test_connection_request_body_spells_the_brand_correctly():
+    """Regression guard for issue #5422.
+
+    The banner said "on hushh." for the whole life of this surface. `hushh` is
+    still a legitimate *identifier* elsewhere (bundle ids, domains, headers), so
+    the assertion is on the sentence, not on the repo.
+    """
+    for value in (None, "Ankit"):
+        body = _connection_request_body(value)
+        assert BRAND_NAME in body
+        assert "hushh" not in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# The FCM data payload -- the actual cause of the "Someone" toast.
+#
+# The resolved name used to reach only `body` (which the OS banner renders) and
+# never the `data` map (which the in-app toast reads), so the banner named the
+# requester while the toast beneath it said "Someone".
+# ---------------------------------------------------------------------------
+
+
+def _capture_push(monkeypatch):
+    captured: dict = {}
+
+    def _fake_send(user_id, **kwargs):
+        captured["user_id"] = user_id
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(push_module, "send_user_data_push", _fake_send)
+    return captured
+
+
+def test_connection_request_push_puts_the_requester_label_in_the_data_map(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit Sharma",
+        connection_request_id="req-42",
+    )
+
+    assert captured["data"]["requester_label"] == "Ankit Sharma"
+    assert captured["data"]["requester_user_id"] == "requester-1"
+    assert captured["body"] == "Ankit Sharma wants to connect with you on Hussh."
+
+
+def test_connection_request_push_deep_links_to_the_review_sheet(monkeypatch):
+    """The Consent Center opens the review sheet only from `?requestId`."""
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit",
+        connection_request_id="req-42",
+    )
+
+    assert captured["deep_link"] == "/one/consent?tab=pending&requestId=req-42"
+    assert captured["data"]["request_id"] == "req-42"
+
+
+def test_connection_request_push_falls_back_to_the_list_without_an_id(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_push("addressee-1", "requester-1", requester_display_name="Ankit")
+
+    assert captured["deep_link"] == "/one/consent?tab=connections"
+    assert captured["data"]["request_id"] == ""
+
+
+def test_connection_request_push_percent_encodes_the_request_id(monkeypatch):
+    """An id is opaque; it must never be able to inject another query param."""
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit",
+        connection_request_id="req 42&tab=evil",
+    )
+
+    assert captured["deep_link"] == ("/one/consent?tab=pending&requestId=req%2042%26tab%3Devil")
+
+
+def test_connection_request_push_sends_an_empty_label_when_unresolved(monkeypatch):
+    """An unresolved name must arrive empty, never as the placeholder word.
+
+    `send_user_data_push` drops empty values from the data map, so the client can
+    tell "the server could not name them" from "this field is not implemented"
+    and apply its own fallback ladder. The old code sent the literal "Someone",
+    which the client could not distinguish from a real name.
+    """
+    captured = _capture_push(monkeypatch)
+    monkeypatch.setattr(
+        "hushh_mcp.services.requester_identity.resolve_requester_label",
+        lambda *_a, **_k: "",
+    )
+
+    send_connection_request_push("addressee-1", "requester-1", connection_request_id="r1")
+
+    assert captured["data"]["requester_label"] == ""
+    assert "Someone" not in captured["data"]["requester_label"]
+    assert captured["body"] == _GENERIC_CONNECTION_REQUEST_BODY
+
+
+def test_connection_request_push_prefers_the_caller_supplied_name(monkeypatch):
+    """A name the caller already holds must not trigger a database read."""
+    captured = _capture_push(monkeypatch)
+
+    def _explode():
+        raise AssertionError("must not query when the caller already has the name")
+
+    monkeypatch.setattr("db.db_client.get_db", _explode)
+
+    send_connection_request_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit",
+        connection_request_id="r1",
+    )
+
+    assert captured["data"]["requester_label"] == "Ankit"
+
+
+def test_connection_request_push_reaches_sse_from_a_sync_handler(monkeypatch):
+    """The SSE lane must survive being called off the event loop.
+
+    Both production callers are sync FastAPI handlers (`def
+    create_connection_request`, `def request_nearby_connection`), which run on a
+    threadpool worker where `asyncio.get_running_loop()` raises. The old code
+    caught that RuntimeError and did nothing, so the SSE payload -- the only one
+    that can reach a web client with no push subscription -- was silently
+    discarded on every real request.
+    """
+    _capture_push(monkeypatch)
+    scheduled: list = []
+    monkeypatch.setattr(
+        "api.consent_listener.push_to_consent_queue_threadsafe",
+        lambda user_id, data: scheduled.append((user_id, data)) or True,
+    )
+
+    # This test body itself has no running loop -- same as the worker thread.
+    send_connection_request_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="John Smith",
+        connection_request_id="req-42",
+    )
+
+    assert len(scheduled) == 1, "the SSE payload was dropped instead of scheduled"
+    user_id, payload = scheduled[0]
+    assert user_id == "addressee-1"
+    assert payload["type"] == "connection_request"
+    assert payload["requester_label"] == "John Smith"
+    assert payload["request_id"] == "req-42"
+    assert payload["body"] == "John Smith wants to connect with you on Hussh."
+    assert payload["deep_link"] == "/one/consent?tab=pending&requestId=req-42"
+
+
+def test_threadsafe_enqueue_delivers_to_a_waiting_sse_consumer():
+    """End-to-end across the thread boundary, with no mocks in between."""
+    import asyncio
+    import threading
+
+    from api import consent_listener as cl
+
+    async def scenario():
+        queue = cl.get_consent_queue("addressee-e2e")
+        outcome: dict = {}
+
+        def worker():
+            try:
+                asyncio.get_running_loop()
+                outcome["had_loop"] = True
+            except RuntimeError:
+                outcome["had_loop"] = False
+            outcome["scheduled"] = cl.push_to_consent_queue_threadsafe(
+                "addressee-e2e", {"type": "connection_request", "requester_label": "John Smith"}
+            )
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        # Proves the worker really is off-loop, i.e. a faithful stand-in for the
+        # FastAPI threadpool the production callers run on.
+        assert outcome["had_loop"] is False
+        assert outcome["scheduled"] is True
+        return await asyncio.wait_for(queue.get(), timeout=5)
+
+    delivered = asyncio.run(scenario())
+    assert delivered["requester_label"] == "John Smith"
+
+
+def test_threadsafe_enqueue_is_a_noop_without_a_consumer():
+    """No SSE consumer in this process is not an error -- there is nobody to tell."""
+    from api import consent_listener as cl
+
+    original = cl._serving_loop
+    cl._serving_loop = None
+    try:
+        assert (
+            cl.push_to_consent_queue_threadsafe("nobody", {"type": "connection_request"}) is False
+        )
+    finally:
+        cl._serving_loop = original
+
+
+# ---------------------------------------------------------------------------
+# Name resolution
+# ---------------------------------------------------------------------------
+
+
+def test_looks_technical_label_rejects_identifiers_not_names():
+    # A raw Firebase uid is a legitimate value of actor_identity_cache.display_name
+    # (migration 037 seeds it), and it must never reach the banner.
+    assert looks_technical_label("RPNmQAmVdlNz84GVfXxta50wnYx1") is True
+    assert looks_technical_label("123e4567-e89b-12d3-a456-426614174000") is True
+    assert looks_technical_label("ria:abc") is True
+    assert looks_technical_label("user-1", user_id="user-1") is True
+    assert looks_technical_label("") is True
+    assert looks_technical_label(None) is True
+    assert looks_technical_label("   ") is True
+
+    assert looks_technical_label("Ankit Sharma") is False
+    assert looks_technical_label("Ankit") is False
+    assert looks_technical_label("ankit@example.com") is False
+
+
+def test_resolve_requester_label_uses_the_display_name():
+    rows = [{"display_name": "Ankit Sharma", "email": "ankit@example.com"}]
+    assert (
+        resolve_requester_label("user-1", execute_one=lambda *_a, **_k: rows[0]) == "Ankit Sharma"
+    )
+
+
+def test_resolve_requester_label_falls_back_to_an_email_handle():
+    """A phone-only Firebase account leaves display_name NULL on a row that exists."""
+    row = {"display_name": None, "email": "ankit@example.com"}
+    assert resolve_requester_label("user-1", execute_one=lambda *_a, **_k: row) == "ankit"
+
+
+def test_resolve_requester_label_rejects_a_uid_shaped_display_name():
+    """Migration 037 seeds display_name to the user id; that is not a name."""
+    row = {"display_name": "RPNmQAmVdlNz84GVfXxta50wnYx1", "email": None}
+    assert resolve_requester_label("user-1", execute_one=lambda *_a, **_k: row) == ""
+
+
+def test_resolve_requester_label_never_returns_a_phone_number():
+    """Notification labels carry no phone-derived data: banners show on a lock screen.
+
+    Mirrors one_location_agent_service._identity_notification_label. The query
+    does not even select the column, so this is a structural guarantee.
+    """
+    captured: dict = {}
+
+    def _execute_one(sql, params):
+        captured["sql"] = sql
+        return {"display_name": None, "email": None}
+
+    assert resolve_requester_label("user-1", execute_one=_execute_one) == ""
+    assert "phone" not in captured["sql"].lower()
+
+
+def test_resolve_requester_label_survives_a_database_failure():
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("db down")
+
+    assert resolve_requester_label("user-1", execute_one=_boom) == ""
+
+
+def test_resolve_requester_label_handles_a_missing_row():
+    assert resolve_requester_label("user-1", execute_one=lambda *_a, **_k: None) == ""
+
+
+def test_resolve_requester_label_is_not_gated_on_firebase():
+    """Regression guard: the lookup used to return "" when Firebase was unconfigured.
+
+    It is a Postgres read that also feeds in-app copy, so gating it on push
+    credentials blanked a name the database held all along.
+    """
+    row = {"display_name": "Ankit", "email": None}
+    with patch("api.utils.firebase_admin.ensure_firebase_admin", return_value=(False, None)):
+        assert resolve_requester_label("user-1", execute_one=lambda *_a, **_k: row) == "Ankit"

--- a/consent-protocol/tests/test_fcm_messages.py
+++ b/consent-protocol/tests/test_fcm_messages.py
@@ -228,6 +228,70 @@ def test_location_notification_name_only_body_reaches_every_platform() -> None:
     assert ios.apns.payload.aps.alert.body == body
 
 
+def test_connection_request_identity_reaches_every_platform() -> None:
+    """The requester's name and the review-sheet link must survive on all three.
+
+    Regression guard for issue #5422. The resolved name used to reach only the
+    banner body, never the FCM ``data`` map -- and the in-app toast reads the data
+    map exclusively, so it rendered "Someone" while the OS banner named the
+    requester correctly. Both halves are asserted per platform, because each one
+    carries the banner differently: web via WebpushNotification, Android via the
+    top-level Notification (no AndroidConfig is built for this type), iOS via
+    aps.alert plus custom_data.
+    """
+    from hushh_mcp.services.push_notifications import (
+        _connection_request_body,
+        _connection_request_link,
+    )
+
+    request_id = "8f14e45f-ceea-467a-9c1d-5b8f0f9a1234"
+    body = _connection_request_body("Rohan Mehta")
+    deep_link = _connection_request_link(request_id)
+    data = {
+        "type": "connection_request",
+        "requester_user_id": "requester-uid",
+        "requester_label": "Rohan Mehta",
+        "request_id": request_id,
+        "request_url": deep_link,
+        "deep_link": deep_link,
+        "notification_tag": "connection-request:addressee-uid",
+    }
+
+    messages = {
+        platform: build_push_message(
+            _MessagingStub,
+            token=f"{platform}-device-id",
+            platform=platform,
+            data=dict(data),
+            title="New connection request",
+            body=body,
+            request_url=deep_link,
+            notification_tag="connection-request:addressee-uid",
+            show_alert=True,
+        )
+        for platform in ("web", "ios", "android")
+    }
+
+    assert body == "Rohan Mehta wants to connect with you on Hussh."
+    assert deep_link == f"/one/consent?tab=pending&requestId={request_id}"
+
+    for platform, message in messages.items():
+        # The field the in-app toast reads, on every platform.
+        assert message.data["requester_label"] == "Rohan Mehta", platform
+        assert message.data["request_id"] == request_id, platform
+        # The banner a person sees on the lock screen.
+        assert message.notification.body == body, platform
+        assert "hushh" not in message.notification.body.lower(), platform
+        assert "Someone" not in message.notification.body, platform
+
+    assert messages["web"].webpush.notification.body == body
+    assert messages["web"].webpush.notification.data == {"url": deep_link}
+    assert messages["ios"].apns.payload.aps.alert.body == body
+    # iOS receives the data map as APNS custom_data, which is what feeds the
+    # Capacitor notificationReceived listener.
+    assert messages["ios"].apns.payload.custom_data["requester_label"] == "Rohan Mehta"
+
+
 def test_sms_emergency_uses_distinct_cross_platform_alert_profile() -> None:
     android_delivery_target = "android-device-id"
     ios_delivery_target = "ios-device-id"

--- a/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * Regression coverage for issue #5422.
+ *
+ * The connection-request toast rendered "Someone wants to connect with you on
+ * hushh." for every incoming request: the FCM data map never carried a
+ * `requester_label`, and the sentence was a hand-authored JSX literal that kept
+ * the pre-rebrand spelling. There was no test on this branch at all, which is
+ * why both defects survived.
+ *
+ * The platform matrix matters here and is asserted below: iOS presents its own
+ * system banner while foregrounded, so an in-app toast would duplicate it;
+ * Android presents no foreground banner, so it owns the toast.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const toast = Object.assign(vi.fn(), { dismiss: vi.fn() });
+  const user = {
+    uid: "recipient-user",
+    getIdToken: vi.fn().mockResolvedValue("firebase-token"),
+  };
+  return {
+    toast,
+    user,
+    auth: { user: user as typeof user | null },
+    routerPush: vi.fn(),
+    routerReplace: vi.fn(),
+    platform: { value: "web", native: false },
+    initializeFCM: vi.fn(),
+    prepareFCMListeners: vi.fn(),
+    getState: vi.fn(),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/settings",
+  useRouter: () => ({ push: mocks.routerPush, replace: mocks.routerReplace }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("sonner", () => ({ toast: mocks.toast }));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => mocks.platform.native,
+    getPlatform: () => mocks.platform.value,
+  },
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: mocks.auth.user }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: true,
+    getVaultOwnerToken: () => "vault-owner-token",
+  }),
+}));
+
+vi.mock("@/lib/consent", () => ({
+  useConsentActions: () => ({ handleDeny: vi.fn() }),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  initializeFCM: mocks.initializeFCM,
+  prepareFCMListeners: mocks.prepareFCMListeners,
+  clearDeliveredConsentNotifications: vi.fn(),
+  FCM_MESSAGE_EVENT: "fcm-message",
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: { getState: mocks.getState },
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    getPendingConsents: vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ pending: [] }),
+    }),
+    markPendingConsentOpened: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/services/app-background-task-service", () => ({
+  AppBackgroundTaskService: {
+    startTask: vi.fn(),
+    completeTask: vi.fn(),
+    dismissTask: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/morphy-ux/ui", () => ({ Icon: () => null }));
+
+// The connection branch invalidates consent caches before it toasts; stub those
+// collaborators so a cache/dispatch failure cannot be mistaken for a copy bug.
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: {
+    onConsentMutated: vi.fn(),
+    onConsentReviewed: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/consent/consent-events", () => ({
+  CONSENT_STATE_CHANGED_EVENT: "consent-state-changed",
+  dispatchConsentStateChanged: vi.fn(),
+}));
+
+import { ConsentNotificationProvider } from "@/components/consent/notification-provider";
+import { BRAND_NAME } from "@/lib/branding/brand";
+
+const EMPTY_LOCATION_STATE = {
+  recipients: [],
+  ownerGrants: [],
+  receivedGrants: [],
+  requests: [],
+  referrals: [],
+  publicInvites: [],
+  networkConnections: [],
+  publicInviteSubmissions: [],
+  capabilityScopes: [],
+};
+
+async function renderProvider() {
+  const result = render(
+    <ConsentNotificationProvider>
+      <div>Settings page</div>
+    </ConsentNotificationProvider>,
+  );
+  await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());
+  return result;
+}
+
+function dispatchConnectionRequest(data: Record<string, string>) {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("fcm-message", {
+        detail: { data: { type: "connection_request", ...data } },
+      }),
+    );
+  });
+}
+
+function renderedToast(index = 0) {
+  const popup = mocks.toast.mock.calls[index]?.[0] as ReactNode;
+  return render(<>{popup}</>);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  vi.clearAllMocks();
+  mocks.auth.user = mocks.user;
+  mocks.platform.native = false;
+  mocks.platform.value = "web";
+  mocks.prepareFCMListeners.mockResolvedValue(undefined);
+  mocks.initializeFCM.mockResolvedValue({ status: "push_active" });
+  mocks.getState.mockResolvedValue(EMPTY_LOCATION_STATE);
+});
+
+describe("connection-request toast copy", () => {
+  it("names the requester and spells the brand Hussh", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan Mehta",
+      request_id: "conn-req-1",
+    });
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    renderedToast();
+    expect(
+      screen.getByText("Rohan Mehta wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Someone/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/on hushh\./)).not.toBeInTheDocument();
+  });
+
+  it("keeps the brand out of the pre-rebrand spelling even in the fallback", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({ requester_user_id: "user-x", request_id: "conn-req-2" });
+
+    renderedToast();
+    // Unnamed is a legitimate outcome (a phone-only account has no display
+    // name); the brand must still be right.
+    expect(
+      screen.getByText(`Someone wants to connect with you on ${BRAND_NAME}.`),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a contact handle before the generic line", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-y",
+      requester_email: "rohan@example.com",
+      request_id: "conn-req-3",
+    });
+
+    renderedToast();
+    expect(
+      screen.getByText("rohan@example.com wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+  });
+
+  it("never renders a raw user id as the requester name", async () => {
+    await renderProvider();
+
+    // actor_identity_cache.display_name is seeded to the user id for actors that
+    // never synced from Firebase (migration 037), so this is a real payload.
+    dispatchConnectionRequest({
+      requester_user_id: "RPNmQAmVdlNz84GVfXxta50wnYx1",
+      requester_label: "RPNmQAmVdlNz84GVfXxta50wnYx1",
+      request_id: "conn-req-4",
+    });
+
+    renderedToast();
+    expect(screen.queryByText(/RPNmQAmVdlNz84GVfXxta50wnYx1/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Someone wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+  });
+
+  it("treats a whitespace-only label as unnamed", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-z",
+      requester_label: "   ",
+      request_id: "conn-req-5",
+    });
+
+    renderedToast();
+    expect(
+      screen.getByText("Someone wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("connection-request toast with the exact production payload", () => {
+  // Captured from the real send_connection_request_push -> send_user_data_push ->
+  // build_push_message chain (verified per platform in
+  // consent-protocol/tests/test_fcm_messages.py). Every key the server actually
+  // sends is present, so this catches a payload the client mishandles because of
+  // a field the minimal fixtures omit.
+  const PRODUCTION_DATA = {
+    type: "connection_request",
+    user_id: "recipient-user",
+    request_url:
+      "/one/consent?tab=pending&requestId=8f14e45f-ceea-467a-9c1d-5b8f0f9a1234",
+    deep_link:
+      "/one/consent?tab=pending&requestId=8f14e45f-ceea-467a-9c1d-5b8f0f9a1234",
+    notification_tag: "connection-request:recipient-user",
+    notification_category: "ONE_CONNECTIONS",
+    requester_user_id: "requester-uid",
+    requester_label: "Rohan Mehta",
+    request_id: "8f14e45f-ceea-467a-9c1d-5b8f0f9a1234",
+  };
+
+  it("renders the requester's name and routes to their request", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest(PRODUCTION_DATA);
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    renderedToast();
+    expect(
+      screen.getByText("Rohan Mehta wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+
+    screen.getByRole("button", { name: "View Request" }).click();
+    const href = String(mocks.routerPush.mock.calls[0]?.[0] || "");
+    expect(href).toContain("requestId=8f14e45f-ceea-467a-9c1d-5b8f0f9a1234");
+  });
+
+  it("drops a payload addressed to a different signed-in user", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({ ...PRODUCTION_DATA, user_id: "someone-else" });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+});
+
+describe("connection-request toast routing", () => {
+  it("opens the review sheet for the specific request", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+      request_url: "/one/consent?tab=pending&requestId=conn-req-1",
+    });
+
+    renderedToast();
+    screen.getByRole("button", { name: "View Request" }).click();
+
+    expect(mocks.routerPush).toHaveBeenCalledTimes(1);
+    const href = String(mocks.routerPush.mock.calls[0]?.[0] || "");
+    expect(href).toContain("/one/consent");
+    expect(href).toContain("requestId=conn-req-1");
+  });
+
+  it("makes the message itself tappable, not just the button", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+      request_url: "/one/consent?tab=pending&requestId=conn-req-1",
+    });
+
+    renderedToast();
+    screen
+      .getByText("Rohan wants to connect with you on Hussh.")
+      .closest("button")!
+      .click();
+
+    expect(mocks.routerPush).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("connection-request toast de-duplication", () => {
+  it("still toasts a second request from the same requester", async () => {
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+    });
+    // Same person, new request — e.g. after the first was declined. The old key
+    // was per-requester and never cleared, so this was silently swallowed.
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-2",
+    });
+
+    expect(mocks.toast).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows one toast for a duplicate delivery of the same request", async () => {
+    await renderProvider();
+
+    const payload = {
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+    };
+    dispatchConnectionRequest(payload);
+    dispatchConnectionRequest(payload);
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("connection-request toast presentation policy", () => {
+  it("suppresses the in-app toast on iOS, where the system banner already showed", async () => {
+    mocks.platform.native = true;
+    mocks.platform.value = "ios";
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+    });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it("presents the in-app toast on Android, which shows no foreground banner", async () => {
+    mocks.platform.native = true;
+    mocks.platform.value = "android";
+    await renderProvider();
+
+    dispatchConnectionRequest({
+      requester_user_id: "user-rohan",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+    });
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    renderedToast();
+    expect(
+      screen.getByText("Rohan wants to connect with you on Hussh."),
+    ).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/firebase-messaging-service-worker.test.ts
+++ b/hushh-webapp/__tests__/firebase-messaging-service-worker.test.ts
@@ -95,6 +95,24 @@ describe("Firebase messaging service-worker foreground ownership", () => {
     ]);
   });
 
+  it("lets the visible app own a connection request instead of double-notifying", async () => {
+    // connection_request renders an in-app Sonner toast, so the OS banner must be
+    // suppressed once a visible tab acknowledges. It was missing from
+    // isHandledByVisibleApp, so the addressee got the banner AND the toast for
+    // one event — with two different sentences before the copy fix (#5422).
+    const harness = createHarness({ acknowledgeVisibleDelivery: true });
+    await harness.push("connection_request");
+    expect(harness.shown).toEqual([]);
+  });
+
+  it("still shows a connection-request banner when no visible app acknowledges", async () => {
+    const harness = createHarness({ acknowledgeVisibleDelivery: false });
+    await harness.push("connection_request");
+    expect(harness.shown.map((item) => item.title)).toEqual([
+      "connection_request",
+    ]);
+  });
+
   it("keeps system delivery for notification families not rendered by the provider", async () => {
     const harness = createHarness({ acknowledgeVisibleDelivery: true });
     await harness.push("kai_analysis_complete");

--- a/hushh-webapp/__tests__/notifications/connection-request-payload-contract.test.ts
+++ b/hushh-webapp/__tests__/notifications/connection-request-payload-contract.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Cross-surface contract for the connection-request notification.
+ *
+ * Web, iOS and Android all consume ONE payload, built by one Python function.
+ * Issue #5422 was not a rendering bug — it was the two sides of that boundary
+ * disagreeing: the server wrote the requester's name into the banner body while
+ * the client read it from the data map, and nothing anywhere asserted that the
+ * field the server writes is the field the client reads.
+ *
+ * So this test reads the Python source and checks it against the TypeScript that
+ * consumes it. No fixture, no duplicated expectation: if either side moves, this
+ * fails. That is what makes the fix hold on all three platforms rather than just
+ * the one someone happened to retest.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BRAND_NAME,
+  GENERIC_REQUESTER_LABEL,
+  connectionRequestBody,
+} from "@/lib/branding/brand";
+
+const protocolFile = (...segments: string[]) =>
+  fs.readFileSync(
+    path.resolve(__dirname, "../../../consent-protocol", ...segments),
+    "utf8",
+  );
+
+const BRANDING_PY = protocolFile("hushh_mcp/branding.py");
+const PUSH_PY = protocolFile("hushh_mcp/services/push_notifications.py");
+const PROVIDER_TSX = fs.readFileSync(
+  path.resolve(__dirname, "../../components/consent/notification-provider.tsx"),
+  "utf8",
+);
+const FCM_SERVICE_TS = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/notifications/fcm-service.ts"),
+  "utf8",
+);
+
+function pythonStringConstant(source: string, name: string): string {
+  const match = new RegExp(`^${name}\\s*=\\s*"([^"]*)"`, "m").exec(source);
+  if (!match) {
+    throw new Error(
+      `${name} not found in the Python source — the constant moved and this contract needs re-pointing.`,
+    );
+  }
+  return match[1];
+}
+
+/** The keys the backend puts in the FCM `data` map for a connection request. */
+function pythonClientDataKeys(): string[] {
+  const block = /client_data\s*=\s*\{([\s\S]*?)\}/.exec(PUSH_PY);
+  if (!block) {
+    throw new Error(
+      "client_data literal not found in push_notifications.py — re-point this contract.",
+    );
+  }
+  return [...block[1].matchAll(/"([a-z_]+)":/g)].map((match) => match[1]);
+}
+
+describe("connection-request notification: Python <-> TypeScript brand contract", () => {
+  it("agrees on the brand name", () => {
+    expect(pythonStringConstant(BRANDING_PY, "BRAND_NAME")).toBe(BRAND_NAME);
+  });
+
+  it("agrees on the generic fallback word", () => {
+    expect(pythonStringConstant(BRANDING_PY, "GENERIC_REQUESTER_LABEL")).toBe(
+      GENERIC_REQUESTER_LABEL,
+    );
+  });
+
+  it("composes byte-identical copy on both sides", () => {
+    // The OS banner is rendered from the Python string and the in-app toast from
+    // the TypeScript one. On web with the tab visible, and on iOS, a user can see
+    // both at once — they used to disagree outright.
+    const template =
+      /return f"\{label\}([^"]*?)\{BRAND_NAME\}\."/.exec(BRANDING_PY);
+    expect(
+      template,
+      "the Python sentence template moved; re-point this contract",
+    ).not.toBeNull();
+    const middle = template![1];
+
+    for (const label of ["Rohan Mehta", "Ankit"]) {
+      expect(connectionRequestBody(label)).toBe(
+        `${label}${middle}${BRAND_NAME}.`,
+      );
+    }
+    expect(connectionRequestBody(null)).toBe(
+      `${GENERIC_REQUESTER_LABEL}${middle}${BRAND_NAME}.`,
+    );
+  });
+
+  it("never emits the pre-rebrand spelling from either side", () => {
+    for (const value of [null, "Rohan"]) {
+      expect(connectionRequestBody(value).toLowerCase()).not.toContain("hushh");
+    }
+    const pythonSentenceLines = BRANDING_PY.split("\n").filter((line) =>
+      line.includes("wants to connect with you"),
+    );
+    expect(pythonSentenceLines.length).toBeGreaterThan(0);
+    for (const line of pythonSentenceLines) {
+      expect(line.toLowerCase()).not.toContain("on hushh");
+    }
+  });
+});
+
+describe("connection-request notification: payload field contract", () => {
+  it("ships the identity field the in-app toast actually reads", () => {
+    // The bug in one assertion: the server resolved the name and never put it in
+    // the data map, which is the only thing the toast sees.
+    expect(pythonClientDataKeys()).toContain("requester_label");
+    expect(PROVIDER_TSX).toContain("requesterLabel: data.requester_label");
+  });
+
+  it("ships a request id, and every consumer reads it", () => {
+    expect(pythonClientDataKeys()).toContain("request_id");
+    // Web toast target.
+    expect(PROVIDER_TSX).toContain('String(data.request_id || "").trim()');
+    // Native tap target.
+    expect(FCM_SERVICE_TS).toContain(
+      'typeof data?.request_id === "string" && data.request_id',
+    );
+  });
+
+  it("declares no data-map key the client silently ignores", () => {
+    // A field the server pays to send and nobody reads is how `requester_label`
+    // came to exist on the SSE payload alone for so long without being noticed.
+    const consumed = `${PROVIDER_TSX}\n${FCM_SERVICE_TS}`;
+    for (const key of pythonClientDataKeys()) {
+      expect(consumed, `no client reads the "${key}" data field`).toContain(key);
+    }
+  });
+
+  it("deep-links to the review sheet, not the list", () => {
+    // The Consent Center opens the incoming review sheet only from `?requestId`.
+    expect(PUSH_PY).toContain("/one/consent?tab=pending&requestId=");
+    // ...and the id is percent-encoded, so an opaque id cannot inject a param.
+    expect(PUSH_PY).toMatch(/requestId=\{quote\(request_id, safe=''\)\}/);
+  });
+});

--- a/hushh-webapp/__tests__/notifications/fcm-native-connection-routing.test.ts
+++ b/hushh-webapp/__tests__/notifications/fcm-native-connection-routing.test.ts
@@ -38,7 +38,10 @@ import { prepareFCMListeners } from "@/lib/notifications/fcm-service";
 
 describe("native connection notification actions", () => {
   beforeEach(() => {
-    mocks.listeners.clear();
+    // Deliberately NOT clearing `listeners`: prepareFCMListeners guards on a
+    // module-level `nativeListenersConfigured`, so it registers exactly once per
+    // module instance. Clearing the map would leave every test after the first
+    // with no listener to invoke, and they would pass vacuously via `onAction?.()`.
     mocks.requestInternalAppNavigation.mockClear();
   });
 
@@ -61,5 +64,54 @@ describe("native connection notification actions", () => {
       href: "/one/consent?tab=connections",
       scroll: false,
     });
+  });
+
+  it("opens the review sheet for the tapped request when the payload carries its id", async () => {
+    // The Consent Center opens the incoming review sheet only from `?requestId`
+    // (consent-center-page.tsx reads it into selectedId). Without the id a tap
+    // could only ever land on the Connections list — issue #5422.
+    await prepareFCMListeners();
+    const onAction = mocks.listeners.get("notificationActionPerformed");
+
+    onAction?.({
+      actionId: "tap",
+      notification: {
+        data: {
+          type: "connection_request",
+          request_id: "conn-req-1",
+          request_url: "/one/consent?tab=pending&requestId=conn-req-1",
+        },
+      },
+    });
+
+    expect(mocks.requestInternalAppNavigation).toHaveBeenCalledTimes(1);
+    const href = String(
+      mocks.requestInternalAppNavigation.mock.calls[0]?.[0]?.href || "",
+    );
+    expect(href).toContain("requestId=conn-req-1");
+    expect(href).toContain("notificationAction=review");
+  });
+
+  it("re-applies the request id when an older backend sends the bare tab link", async () => {
+    // Devices keep receiving whatever the deployed backend sends. A payload that
+    // carries the id but the pre-fix deep link must still reach the sheet.
+    await prepareFCMListeners();
+    const onAction = mocks.listeners.get("notificationActionPerformed");
+
+    onAction?.({
+      actionId: "tap",
+      notification: {
+        data: {
+          type: "connection_request",
+          request_id: "conn-req-9",
+          request_url: "/one/consent?tab=connections",
+        },
+      },
+    });
+
+    const href = String(
+      mocks.requestInternalAppNavigation.mock.calls[0]?.[0]?.href || "",
+    );
+    expect(href).toContain("requestId=conn-req-9");
   });
 });

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -58,7 +58,9 @@ import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import {
   resolveCompactConsentSummary,
   resolveConsentRequesterLabel,
+  resolveRequesterDisplayName,
 } from "@/lib/consent/consent-display";
+import { connectionRequestBody } from "@/lib/branding/brand";
 import {
   emailHelperConsentSummary,
   emailHelperWorkflowHref,
@@ -1553,25 +1555,101 @@ export function ConsentNotificationProvider({
           reconcile: true,
         });
 
-        // Interactive top-center toast banner for connection request
-        const toastKey = `connection_request:${data.requester_user_id || "new"}`;
-        if (!toastedIdsRef.current.has(toastKey)) {
+        // Who asked. Runs through the same ladder + technical-identity filter
+        // the Consent Center uses, so a raw Firebase uid or a "ria:" handle can
+        // never reach the sentence — `actor_identity_cache.display_name` is
+        // seeded to the user id for never-synced actors, so that is a real value
+        // and not a hypothetical. `null` here means "genuinely unnamed", which
+        // connectionRequestBody turns into the generic line.
+        const requesterName = resolveRequesterDisplayName({
+          requesterLabel: data.requester_label,
+          counterpartLabel: data.requester_display_label,
+          counterpartEmail: data.requester_email,
+          counterpartSecondaryLabel: data.requester_handle,
+          counterpartId: data.requester_user_id,
+        });
+
+        // Where "View Request" goes. The Consent Center opens the review sheet
+        // purely from `?requestId`, so the old hardcoded `?tab=connections`
+        // could only ever land on a list. Resolve through the shared helper (same
+        // one the consent toast and the native tap path use) so the href is
+        // validated and fails closed instead of being a bare literal.
+        const connectionRequestId = String(data.request_id || "").trim();
+        const currentConnectionQuery = searchParams.toString();
+        const reviewTarget = resolveConsentNavigationTarget(
+          data.request_url || data.deep_link,
+          "pending",
+          {
+            requestId: connectionRequestId || undefined,
+            from: `${pathname}${currentConnectionQuery ? `?${currentConnectionQuery}` : ""}`,
+          },
+        );
+
+        // Presentation policy, matching the rule documented at the top of this
+        // file and the split One Location already uses above: iOS presents its
+        // own system banner while the app is foregrounded (AppDelegate's
+        // willPresent returns .banner), so an in-app toast there would say the
+        // same thing twice. Android shows no banner in the foreground, so it owns
+        // the toast. On web the service worker suppresses its banner only when a
+        // visible client acknowledges delivery, so a hidden tab must not toast —
+        // otherwise the user gets the banner now and a stale toast on refocus.
+        const shouldPresentToast = isNativePlatform
+          ? Capacitor.getPlatform() === "android"
+          : typeof document === "undefined" ||
+            document.visibilityState === "visible";
+
+        // Keyed on the request, not the requester. The old key was
+        // `connection_request:<requester_user_id>` and was never deleted, so a
+        // second request from the same person — after the first was accepted or
+        // declined — was silently swallowed for the rest of the session.
+        //
+        // With an id present the generic per-message de-dup above (`dedupKey`)
+        // has already claimed this exact string and returned early on a repeat,
+        // so re-checking the set here would suppress every toast. Only the
+        // id-less payload — a backend that predates this change — needs its own
+        // guard, and it can only be keyed per requester, so it keeps the old
+        // limitation for that legacy case alone.
+        const toastKey = connectionRequestId
+          ? `connection_request:${connectionRequestId}`
+          : `connection_request_toast:${data.requester_user_id || "new"}`;
+        const alreadyToasted =
+          !connectionRequestId && toastedIdsRef.current.has(toastKey);
+        if (shouldPresentToast && !alreadyToasted) {
           toastedIdsRef.current.add(toastKey);
+          const openReview = () => {
+            toast.dismiss(toastKey);
+            if (reviewTarget.kind !== "internal") {
+              assignWindowLocation(reviewTarget.href);
+              return;
+            }
+            // Already on the Consent Center: replace so the sheet opens without
+            // stacking a history entry the back button has to unwind. Same
+            // decision the consent toast makes above.
+            if (
+              pathname === ROUTES.CONSENTS &&
+              reviewTarget.pathname === ROUTES.CONSENTS
+            ) {
+              router.replace(reviewTarget.href, { scroll: false });
+              return;
+            }
+            router.push(reviewTarget.href, { scroll: false });
+          };
           toast(
             <div className="flex flex-col gap-2">
-              <div className="space-y-0.5">
+              <button
+                type="button"
+                onClick={openReview}
+                className="space-y-0.5 text-left"
+              >
                 <p className="line-clamp-1 text-sm font-semibold">New Connection Request</p>
-                <p className="line-clamp-1 text-xs text-muted-foreground">
-                  {data.requester_label || "Someone"} wants to connect with you on hushh.
+                <p className="line-clamp-2 text-xs text-muted-foreground">
+                  {connectionRequestBody(requesterName)}
                 </p>
-              </div>
+              </button>
               <div className="flex gap-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    toast.dismiss(toastKey);
-                    router.push("/one/consent?tab=connections", { scroll: false });
-                  }}
+                  onClick={openReview}
                   className="px-4 py-2 bg-foreground text-background text-sm font-medium rounded-lg flex items-center justify-center gap-1.5 transition-colors"
                 >
                   View Request
@@ -1594,7 +1672,9 @@ export function ConsentNotificationProvider({
   }, [
     isNativePlatform,
     isVaultUnlocked,
+    pathname,
     router,
+    searchParams,
     showConsentToast,
     showOneLocationWorkflowNotification,
     user?.uid,

--- a/hushh-webapp/lib/branding/brand.ts
+++ b/hushh-webapp/lib/branding/brand.ts
@@ -1,0 +1,40 @@
+/**
+ * The brand name, for user-facing copy.
+ *
+ * `hushh` stays correct and load-bearing as an *identifier* — bundle ids
+ * (`com.hushh.app`), domains (`one.hushh.ai`), service-worker message types
+ * (`hushh:fcm_push_received`), storage keys, env vars, package and repo names.
+ * None of those are prose and none of them move. This constant is only for text
+ * a person reads.
+ *
+ * It exists because the connection-request sentence was authored three times —
+ * twice in Python and once as a JSX literal — and the notification surface kept
+ * the pre-rebrand spelling long after the rest of the product moved on. Nothing
+ * connected the copies, and the docs brand gate only looks for capitalised
+ * `Hushh`, so the lowercase form was invisible to CI. See issue #5422.
+ */
+export const BRAND_NAME = "Hussh";
+export const PRODUCT_NAME = "Hussh One";
+
+/**
+ * What a notification says when the requester genuinely cannot be named.
+ * Shared with the backend's `GENERIC_REQUESTER_LABEL` so the two surfaces
+ * degrade to the same word.
+ */
+export const GENERIC_REQUESTER_LABEL = "Someone";
+
+/**
+ * The connection-request sentence.
+ *
+ * Mirrors `hushh_mcp.branding.connection_request_body` on the backend, which
+ * composes the OS banner. The two must agree: on web with the tab visible the
+ * user can see both surfaces at once, and they used to disagree — the system
+ * banner named the requester while the in-app toast said "Someone".
+ *
+ * A blank or whitespace-only label degrades to the generic line rather than
+ * rendering " wants to connect…" with a hole where the name should be.
+ */
+export function connectionRequestBody(requesterLabel?: string | null): string {
+  const label = String(requesterLabel || "").trim() || GENERIC_REQUESTER_LABEL;
+  return `${label} wants to connect with you on ${BRAND_NAME}.`;
+}

--- a/hushh-webapp/lib/consent/consent-display.ts
+++ b/hushh-webapp/lib/consent/consent-display.ts
@@ -84,10 +84,23 @@ export function resolveCompactConsentSummary(input: ConsentDisplayInput): string
   return humanizeConsentScope(input.scope);
 }
 
-export function resolveConsentRequesterLabel(
+/**
+ * The first candidate that actually names a person, or `null` when none does.
+ *
+ * Split out of `resolveConsentRequesterLabel` so notification copy can share the
+ * exact same ladder and technical-identity filter while supplying its own
+ * terminal fallback ("Someone" reads correctly in a sentence; "Requester" does
+ * not). One ladder, two endings — rather than a second hand-rolled `||` chain,
+ * which is how the connection-request toast ended up rendering "Someone" even
+ * when a name was available. See issue #5422.
+ *
+ * Returning `null` rather than a placeholder is the point: it lets the caller
+ * distinguish "we have no name" from "the name is literally that placeholder".
+ */
+export function resolveRequesterDisplayName(
   input: ConsentRequesterLabelInput
-): string {
-  const friendlyLabel = firstNonEmptyLabel(
+): string | null {
+  return firstNonEmptyLabel(
     [
       input.requesterLabel,
       input.counterpartLabel,
@@ -96,6 +109,12 @@ export function resolveConsentRequesterLabel(
       input.counterpartSecondaryLabel,
     ].filter((value) => !isTechnicalRequesterIdentity(value))
   );
+}
+
+export function resolveConsentRequesterLabel(
+  input: ConsentRequesterLabelInput
+): string {
+  const friendlyLabel = resolveRequesterDisplayName(input);
   if (friendlyLabel) return friendlyLabel;
 
   if (

--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -53,10 +53,29 @@ export function resolveNativeConnectionRequestNotificationHref(
     (typeof data?.request_url === "string" && data.request_url) ||
     (typeof data?.deep_link === "string" && data.deep_link) ||
     CONNECTION_REQUEST_NOTIFICATION_FALLBACK;
-  const target = resolveConsentNavigationTarget(explicitHref, "pending");
-  return target.kind === "internal"
-    ? target.href
-    : CONNECTION_REQUEST_NOTIFICATION_FALLBACK;
+  // Carry the request id into the resolved href, the way the consent branch does
+  // via buildNativeConsentActionTarget. The Consent Center opens the incoming
+  // review sheet only from `?requestId`; without this a tap resolves to a tab
+  // and the addressee has to hunt for the request in a list.
+  //
+  // The id has to be re-set on the RESOLVED href, not merely passed as an
+  // option: resolveConsentRequestHref only consults `options.requestId` when the
+  // incoming href is unusable, so an href that is already internal would drop
+  // it. Re-setting also means a device still receiving the old bare
+  // `?tab=connections` deep link from an un-upgraded backend routes correctly.
+  const requestId = String(
+    (typeof data?.request_id === "string" && data.request_id) || "",
+  ).trim();
+  const target = resolveConsentNavigationTarget(explicitHref, "pending", {
+    requestId: requestId || undefined,
+  });
+  if (target.kind !== "internal") return CONNECTION_REQUEST_NOTIFICATION_FALLBACK;
+  if (!requestId) return target.href;
+
+  const nextUrl = new URL(target.href, "https://hushh.local");
+  nextUrl.searchParams.set("requestId", requestId);
+  nextUrl.searchParams.set("notificationAction", "review");
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
 }
 
 let nativeListenersConfigured = false;

--- a/hushh-webapp/public/firebase-messaging-sw.js
+++ b/hushh-webapp/public/firebase-messaging-sw.js
@@ -31,7 +31,13 @@ function isHandledByVisibleApp(data) {
     type.startsWith("location_") ||
     type === "consent_request" ||
     type === "consent_opened" ||
-    type === "consent_resolved"
+    type === "consent_resolved" ||
+    // connection_request renders an in-app Sonner toast in the provider, so a
+    // visible tab must be given the chance to acknowledge and suppress the OS
+    // banner. Omitting it meant the addressee got BOTH surfaces for one event —
+    // and, before the copy fix, saw two different sentences (the banner named
+    // the requester, the toast said "Someone").
+    type === "connection_request"
   );
 }
 

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -71,6 +71,37 @@ if (!contactsUsageMatch?.[1]?.trim()) {
   fail("iOS Info.plist must include non-empty NSContactsUsageDescription.");
 }
 
+// Brand spelling in the strings iOS actually shows a person: the app name under
+// the icon, in Settings, and in every permission prompt. These are already
+// correct, and this asserts they stay that way — issue #5422 was a brand
+// misspelling that shipped because nothing checked notification/app copy.
+//
+// Scoped to display copy on purpose. `hushh` is load-bearing elsewhere in this
+// same file — the `hushh` CFBundleURLScheme and the com.hushh.app bundle
+// identifier — and renaming either would break deep links and code signing.
+const IOS_PRODUCT_NAME = "Hussh One";
+for (const key of ["CFBundleDisplayName", "CFBundleName"]) {
+  const match = infoPlist.match(
+    new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`)
+  );
+  if (match?.[1] !== IOS_PRODUCT_NAME) {
+    fail(
+      `iOS Info.plist ${key} must be "${IOS_PRODUCT_NAME}" (found "${match?.[1] ?? "missing"}").`
+    );
+  }
+}
+for (const key of iosUsageDescriptionKeys) {
+  const match = infoPlist.match(
+    new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`)
+  );
+  const copy = match?.[1] ?? "";
+  if (/\bhushh\b/i.test(copy)) {
+    fail(
+      `iOS Info.plist ${key} spells the brand "hushh"; user-facing copy must read "Hussh".`
+    );
+  }
+}
+
 const androidManifest = read(androidManifestPath);
 const androidPermissions = [
   ...androidManifest.matchAll(/<uses-permission\b[^>]*android:name="([^"]+)"/g),

--- a/scripts/verify-doc-brand.cjs
+++ b/scripts/verify-doc-brand.cjs
@@ -53,6 +53,45 @@ const targets = [
   ".codex/workflows",
 ];
 
+// Files whose USER-FACING copy must spell the brand "Hussh", checked with a
+// case-INSENSITIVE rule.
+//
+// The `targets` sweep above only looks for capitalised `Hushh`, which is why the
+// connection-request notification shipped "wants to connect with you on hushh."
+// for the life of that surface and the gate reported OK the whole time
+// (issue #5422). These files carry notification/toast prose, so the lowercase
+// form is a defect there specifically -- as opposed to the rest of the repo,
+// where lowercase `hushh` is a legitimate identifier.
+//
+// Adding a file here is a commitment that it contains no bare lowercase brand
+// token. Identifiers (domains, bundle ids, message-type namespaces, module and
+// repo names) are stripped before the check, so they remain safe to use.
+const proseTargets = [
+  "hushh-webapp/components/consent/notification-provider.tsx",
+  "hushh-webapp/public/firebase-messaging-sw.js",
+  "consent-protocol/hushh_mcp/services/push_notifications.py",
+];
+
+// Occurrences that are identifiers, not prose. These are removed from a line
+// before it is tested, so a line may legitimately contain them. Deliberately not
+// a line-level skip: that would let real prose hide on the same line as a URL.
+// Every pattern must require an adjoining identifier character. A pattern that
+// can match a BARE `hushh` (e.g. `[\w-]*hushh[\w-]*`, whose quantifiers both
+// accept empty) silently erases the defect this rule exists to find — verified
+// by the self-test below, which is why that self-test is not optional.
+const infraBrandTokenPatterns = [
+  /hushh:\/\//g, // MCP resource URIs
+  /hushh:[a-z_]+/g, // service-worker postMessage types, e.g. hushh:fcm_push_ack
+  /[\w.-]*hushh\.(?:ai|app|local)/g, // domains: hushh.ai, one.hushh.ai, hushh.local
+  /hush1one\.com/g,
+  /com\.hushh[\w.]*/g, // bundle identifiers
+  /com\.hussh[\w.]*/g,
+  /[@/-]hushh[\w/-]*/g, // @hushh/mcp, x-hushh-client-version, /hushh-webapp
+  /hushh[-/][\w./-]*/g, // hushh-webapp, hushh-research, hushh/path
+  // `hushh_mcp`, `HUSHH_*` and `/hushh_icon.png` need no pattern: `_` is a word
+  // character, so `\bhushh\b` cannot match them.
+];
+
 const allowedBrandPatterns = [
   /\bHushh(?:Vault|Consent|Notifications|Account|Sync|Auth|Keystore|Keychain|Database|Loader|Voice|Runtime|MCP|ProxyClient)\b/,
   /\bHushh Engineering Core\b/,
@@ -128,9 +167,59 @@ function isAllowedBrandLine(line) {
   return allowedBrandPatterns.some((pattern) => pattern.test(line));
 }
 
+/**
+ * The line with every identifier-shaped brand token removed, so what remains is
+ * prose. `hushh_mcp` needs no pattern: `_` is a word character, so `\bhushh\b`
+ * never matches it in the first place.
+ */
+function stripInfraBrandTokens(line) {
+  return infraBrandTokenPatterns.reduce(
+    (residual, pattern) => residual.replace(pattern, ""),
+    line,
+  );
+}
+
+/**
+ * Prove the prose rule still has teeth before trusting it.
+ *
+ * A gate that cannot fail is worse than no gate: it reports OK and everyone
+ * believes the invariant holds. The original brand check did exactly that here —
+ * it was case-sensitive, so the reported string was invisible to it.
+ */
+function selfTestProseRule() {
+  const mustFail = [
+    'BODY = "Someone wants to connect with you on hushh."',
+    "<p>wants to connect with you on hushh.</p>",
+    'title = "Welcome to Hushh"',
+  ];
+  const mustPass = [
+    'const url = "https://one.hushh.ai/one/consent";',
+    'type: "hushh:fcm_push_received",',
+    'from hushh_mcp.branding import connection_request_body',
+    'icon: "/hushh_icon.png",',
+    'appId: "com.hushh.app",',
+    'headers: { "x-hushh-client-version": "1" },',
+    '// see hushh-webapp/lib/branding/brand.ts and hushh-research docs',
+    'BODY = "Someone wants to connect with you on Hussh."',
+  ];
+
+  const problems = [];
+  for (const line of mustFail) {
+    if (!/\bhushh\b/i.test(stripInfraBrandTokens(line))) {
+      problems.push(`prose rule failed to flag: ${line}`);
+    }
+  }
+  for (const line of mustPass) {
+    if (/\bhushh\b/i.test(stripInfraBrandTokens(line))) {
+      problems.push(`prose rule wrongly flagged an identifier: ${line}`);
+    }
+  }
+  return problems;
+}
+
 function main() {
   const files = [...new Set(targets.flatMap((target) => walk(target)))].sort();
-  const failures = [];
+  const failures = [...selfTestProseRule()];
 
   for (const relFile of files) {
     const comparable = loadComparableText(relFile);
@@ -140,6 +229,24 @@ function main() {
     for (let i = 0; i < lines.length; i += 1) {
       if (/\bHushh\b/.test(lines[i]) && !isAllowedBrandLine(lines[i])) {
         failures.push(`${relFile}:${i + 1}: stray standalone Hushh branding`);
+      }
+    }
+  }
+
+  for (const relFile of [...new Set(proseTargets)].sort()) {
+    const absolute = path.join(repoRoot, relFile);
+    if (!fs.existsSync(absolute)) {
+      failures.push(
+        `${relFile}: listed in proseTargets but missing — re-point or remove it`,
+      );
+      continue;
+    }
+    const lines = fs.readFileSync(absolute, "utf8").split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      if (/\bhushh\b/i.test(stripInfraBrandTokens(lines[i]))) {
+        failures.push(
+          `${relFile}:${i + 1}: user-facing copy must spell the brand "Hussh"`,
+        );
       }
     }
   }


### PR DESCRIPTION
Second of the sequence restoring the PRs the Monday rollback (#5603) reverted. Restores **#5442** — *"name the requester in connection-request toasts and spell the brand Hussh"*.

Base is `main`, not the previous PR. Stacking is avoided deliberately: a PR whose base is not `main` skips the test lanes here and still passes the gate.

## The sequence shrank from 10 to 9

Before building this I audited every remaining PR against current `main`, and found **#5367 is already back** — Ankit re-landed it as `08d17e00f` (*"put a real map on the finale, and take the words off it"*), with a better implementation than the original: it follows the device with `map.setCenter()` instead of rebuilding the map on every fix.

Restoring it again would have **regressed** that. Dropped from the sequence.

The other eight were verified still missing by reverse-applying each diff against `main`, not by assuming.

## One fix on top of the replay

`native-route-inventory.json` — the replayed change appended a route block that is already present, taking the file to **166 entries against its own `total_routes: 113`**, and `verify:capacitor:static` failed on the mismatch. This PR adds no route, so the base's inventory is the correct one. Same artefact that appeared in the combined branch; caught here by the gate rather than by review.

## Verification

```
tsc --noEmit                                                clean
eslint (changed web files)                                  clean
vitest  notifications + agent-page + tab-transition   131 passed
pytest  push_notifications + connections_service        75 passed
verify:capacitor:static                                     passed
verify:design-system                                        passed
./bin/hushh protocol lint                                   clean
```

## A note on staleness

`main` moved 3 commits while this was being prepared, and one of them added a test file this branch predated — which showed up as a phantom *deletion* in the diff until the rebase. Rebased onto `a21c855d3`, 0 behind, and the deletion is gone.

Worth knowing for the rest of the sequence: this repo's Base Freshness Gate turns red one commit behind, so each of these will be rebased immediately before merge rather than updated through the button (which adds merge commits instead).

## Remaining after this

Standalone: #5456, #5497, #5560.
Ordered chain, all touching the same three mega-files: #5477 → #5505 → #5552 → #5578 → #5601.