### PR TITLE
fix(one-location): report a Reduce Motion tab switch on a timer, not a frame

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
@@ -490,10 +490,17 @@ describe("Location tab transition — Reduce Motion", () => {
 
     pressTab("people");
 
-    // Reported one frame later, where Embla's own `select` would have landed.
-    // Reporting inside the tap's own dispatch put a second navigation request
-    // ahead of the strip's in the same tick, and the tap then produced no
-    // history write at all.
+    // Nothing reported yet: the report deliberately leaves the tap's own tick.
+    expect(onSelectionChange).not.toHaveBeenCalled();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Reported after the current task, not inside the tap's own dispatch:
+    // reporting synchronously put a second navigation request ahead of the
+    // strip's in the same tick and the tap produced no history write at all.
+    // A timer rather than an animation frame, because a page that is not
+    // being painted never delivers a frame and the report would never run.
     expect(onSelectionChange).toHaveBeenCalledWith("people");
     expect(onSelectionCommit).toHaveBeenCalledWith("people");
   });

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -265,7 +265,7 @@ export function SwipeViews({
   const renderedHeightRef = useRef<number | null>(null);
   const heightFloorRef = useRef<number | null>(null);
   const measuredValueRef = useRef<string | null>(null);
-  const jumpReportFrameRef = useRef<number | null>(null);
+  const jumpReportTimerRef = useRef<number | null>(null);
   /**
    * A pane we moved to on purpose and told the consumer about, while its
    * `activeValue` still names the pane we came from.
@@ -293,9 +293,9 @@ export function SwipeViews({
 
   useEffect(
     () => () => {
-      if (jumpReportFrameRef.current !== null) {
-        window.cancelAnimationFrame(jumpReportFrameRef.current);
-        jumpReportFrameRef.current = null;
+      if (jumpReportTimerRef.current !== null) {
+        window.clearTimeout(jumpReportTimerRef.current);
+        jumpReportTimerRef.current = null;
       }
     },
     [],
@@ -545,16 +545,20 @@ export function SwipeViews({
    * disagreed with what was on screen until an unrelated navigation caught up
    * (measured on WebKit: ~700ms before, ~6s after).
    *
-   * It is reported on the NEXT FRAME, which is where Embla's own `select`
-   * lands, and that timing is load-bearing rather than incidental. A shell tab
-   * press dispatches its selection synchronously and then opens its own
-   * navigation; reporting from inside that dispatch put a second
-   * `requestNavigation` for the same destination ahead of it in the same tick,
-   * and the coordinator supersedes rather than coalesces an intent that has
-   * already committed. Measured: the tap then produced no history write at all
-   * on Chromium. One frame later the tick is over and the report is either a
-   * no-op or the only navigation, which is the same shape the animated path
-   * has always had.
+   * It is reported after the current task, and that timing is load-bearing
+   * rather than incidental. A shell tab press dispatches its selection
+   * synchronously and then opens its own navigation; reporting from inside
+   * that dispatch put a second `requestNavigation` for the same destination
+   * ahead of it in the same tick, and the coordinator supersedes rather than
+   * coalesces an intent that has already committed. Measured: the tap then
+   * produced no history write at all on Chromium.
+   *
+   * A timer, not an animation frame. The only requirement is to be out of the
+   * current tick -- but `requestAnimationFrame` also waits for a paint, and a
+   * page that is not being painted never delivers one. Measured against the
+   * deployed build: in a throttled context rAF never fired, so the report
+   * never ran and the tab press did not commit at all. A macrotask still runs
+   * when frames are not being produced.
    */
   const scrollToSelection = useCallback(
     (api: EmblaCarouselType, index: number) => {
@@ -570,14 +574,14 @@ export function SwipeViews({
             value: nextValue,
             awaitedFrom: activeValueRef.current,
           };
-          if (jumpReportFrameRef.current !== null) {
-            window.cancelAnimationFrame(jumpReportFrameRef.current);
+          if (jumpReportTimerRef.current !== null) {
+            window.clearTimeout(jumpReportTimerRef.current);
           }
-          jumpReportFrameRef.current = window.requestAnimationFrame(() => {
-            jumpReportFrameRef.current = null;
+          jumpReportTimerRef.current = window.setTimeout(() => {
+            jumpReportTimerRef.current = null;
             onSelectionChange?.(nextValue);
             onSelectionCommit?.(nextValue);
-          });
+          }, 0);
         }
         return;
       }


### PR DESCRIPTION
Follow-up to #5633, caught by verifying on the deployed UAT build rather than locally.

The Reduce Motion path places the panel instead of travelling it. Embla emits neither `select` nor `settle` for a jump, so that path has to report the selection itself — and that report is deliberately deferred out of the tap's own tick, because reporting synchronously puts a second `requestNavigation` for the same destination ahead of the strip's and the coordinator supersedes rather than coalesces an already-committing intent.

The deferral used `requestAnimationFrame`. A frame is a stronger promise than the job needs: **a page that is not being painted never delivers one.**

Measured against UAT: in a throttled Chromium context rAF never fired at all — 0 frames sampled over 3 seconds — so the report never ran, the consumer never navigated, and a tab press under Reduce Motion did not commit. Panes moved while the query string, `aria-hidden` and `inert` all stayed on the previous tab. WebKit, whose frames kept coming, passed the identical check, which is why only the real deployment surfaced it.

`setTimeout(0)` gives the one guarantee actually required — run after this task — and still runs when frames are not being produced.

## Verification

- Contract suite 12/12, and it now asserts the deferral itself: nothing is reported synchronously, and the flush is a macrotask.
- All 7 mutations still caught (each reverts one piece of #5633 and each fails the suite).
- Browser harness green in Chromium and WebKit at 320/375/390/430/1280: selection, panel activation, rapid switching, state preservation, Reduce Motion, keyboard reachability, overflow, indicator bounds.
- `tsc --noEmit` and `eslint --max-warnings=0` clean.

2 files, frontend only.