### PR TITLE
fix(db): make migrations 158 and 159 replay-safe

### DIFF
--- a/consent-protocol/db/migrations/158_one_location_circle_member_limit_100.sql
+++ b/consent-protocol/db/migrations/158_one_location_circle_member_limit_100.sql
@@ -57,6 +57,18 @@ BEGIN
 END
 $$;
 
+-- Replay-safe: the DO block above deliberately spares this constraint so it
+-- does not drop the one it is about to create, which is right on a first run
+-- and fatal on a replay -- `ALTER TABLE ... ADD CONSTRAINT` has no
+-- IF NOT EXISTS in Postgres, so a second pass raised DuplicateObjectError and
+-- aborted the whole transaction. The UAT lane runs
+-- `db/migrate.py --release --migration-mode replay`, so re-running this file
+-- against a database that already has it is the normal case, not the
+-- exception. Dropping first makes the pair idempotent; re-adding revalidates
+-- the same widened bound inside this transaction.
+ALTER TABLE one_location_circles
+  DROP CONSTRAINT IF EXISTS one_location_circles_member_limit_bounds;
+
 ALTER TABLE one_location_circles
   ADD CONSTRAINT one_location_circles_member_limit_bounds
     CHECK (member_limit BETWEEN 2 AND 100);

--- a/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
+++ b/consent-protocol/db/migrations/159_one_location_circle_invite_max_uses_100.sql
@@ -47,6 +47,18 @@ BEGIN
 END
 $$;
 
+-- Replay-safe: the DO block above deliberately spares this constraint so it
+-- does not drop the one it is about to create, which is right on a first run
+-- and fatal on a replay -- `ALTER TABLE ... ADD CONSTRAINT` has no
+-- IF NOT EXISTS in Postgres, so a second pass raised DuplicateObjectError and
+-- aborted the whole transaction. The UAT lane runs
+-- `db/migrate.py --release --migration-mode replay`, so re-running this file
+-- against a database that already has it is the normal case, not the
+-- exception. Dropping first makes the pair idempotent; re-adding revalidates
+-- the same widened bound inside this transaction.
+ALTER TABLE one_location_circle_invite_codes
+  DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_bounds;
+
 ALTER TABLE one_location_circle_invite_codes
   ADD CONSTRAINT one_location_circle_invite_codes_max_uses_bounds
     CHECK (max_uses BETWEEN 1 AND 100);


### PR DESCRIPTION
The UAT deploy of `a21c855d3` failed applying migration 158:

```
asyncpg.exceptions.DuplicateObjectError: constraint
"one_location_circles_member_limit_bounds" for relation
"one_location_circles" already exists
```

The aborted transaction then took 159 and 160 with it — `InFailedSQLTransactionError` — so **no part of the release reached the database**. Backend deploy was skipped and rolled back automatically, so UAT is intact; it simply has none of the three migrations.

## Why it happened

Both 158 and 159 drop every stale `member_limit` / `max_uses` CHECK constraint through a `DO` block, and both deliberately exempt the constraint they are about to create:

```sql
AND con.conname <> 'one_location_circles_member_limit_bounds'
```

That is right on a first run — dropping it would undo the work — and fatal on a replay, because Postgres has no `ALTER TABLE ... ADD CONSTRAINT IF NOT EXISTS`.

And a replay is not the rare case here. The UAT lane runs:

```
db/migrate.py --release --migration-mode replay
```

UAT still carried these constraints from the deploy that preceded the Monday rollback. **The rollback removed the migration files from the repo; the database kept the objects they had already created.** So the first replay after re-landing them was always going to collide.

## The fix

Drop immediately before adding, in both files. Both statements are inside the file's existing transaction, and re-adding revalidates the same widened bound (`2..100`, `1..100`) against rows that already satisfy it — no window where the old ceiling is unenforced, no new table scan.

**160 needed nothing.** It was already idempotent: `ADD COLUMN IF NOT EXISTS`, `CREATE UNIQUE INDEX IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, and `DROP TRIGGER IF EXISTS` before `CREATE TRIGGER`.

## Verification

```
./bin/hushh protocol lint                                  clean
tests/services/test_account_service_cleanup_tables.py      14 passed
```

Every `ADD CONSTRAINT` in 158 and 159 is now preceded by a `DROP CONSTRAINT IF EXISTS` of the same name.

Once this lands, the UAT deploy can be re-dispatched with `scope=auto` and it should apply 158, 159 and 160 cleanly.