### PR TITLE
fix(ci): restore the rollback lane the mass revert deleted

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,7 +39,11 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # write: this workflow tags a healthy release as "last known good"
+  # (scripts/ci/tag-last-known-good.sh) so a future revert check and a
+  # future rollback both have a durable anchor. Scoped to pushing tags only
+  # — the workflow never touches a branch.
+  contents: write
   checks: read
   id-token: write
 
@@ -896,6 +900,33 @@ jobs:
             echo "- Connected Systems Omni Gateway: \`${{ steps.verify-connected-systems.outcome }}\`"
             echo "- Native passkey domain associations: \`${{ steps.verify-passkey-associations.outcome }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Tag this release as last known good
+        id: tag-last-known-good
+        if: always()
+        # Advisory annotation, not a release-health signal: the deploy above
+        # already succeeded and classified healthy by this point. A tagging
+        # failure (e.g. a transient push conflict) must never turn a healthy
+        # release red or trigger the rollback investigation that implies.
+        continue-on-error: true
+        shell: bash
+        env:
+          ENVIRONMENT: production
+          SHA: ${{ github.event.inputs.sha }}
+          BACKEND_REVISION: ${{ steps.final-state.outputs.backend_serving }}
+          BACKEND_SERVICE_URL: ${{ steps.backend-url.outputs.url }}
+          FRONTEND_REVISION: ${{ steps.final-state.outputs.frontend_serving }}
+          FRONTEND_SERVICE_URL: ${{ steps.frontend-url.outputs.url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          STATUS="$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/prod-release-status.json').read_text(encoding='utf-8'))['status'])")"
+          if [ "$STATUS" != "healthy" ]; then
+            echo "[tag-last-known-good] Release status is '$STATUS', not 'healthy' — not tagging."
+            exit 0
+          fi
+          bash scripts/ci/tag-last-known-good.sh
 
       - name: Fail workflow when production release did not end healthy
         if: always()

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -127,6 +127,10 @@ jobs:
         id: rollback-backend
         if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
         shell: bash
+        env:
+          ROLLBACK_VERIFY_SERVICE: ${{ env.BACKEND_SERVICE }}
+          ROLLBACK_VERIFY_REGION: ${{ env.GCP_REGION }}
+          ROLLBACK_VERIFY_PROJECT: ${{ env.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
           REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat backend "${{ github.event.inputs.backend_revision }}")"
@@ -145,6 +149,10 @@ jobs:
         id: rollback-frontend
         if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
         shell: bash
+        env:
+          ROLLBACK_VERIFY_SERVICE: ${{ env.FRONTEND_SERVICE }}
+          ROLLBACK_VERIFY_REGION: ${{ env.GCP_REGION }}
+          ROLLBACK_VERIFY_PROJECT: ${{ env.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
           REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat frontend "${{ github.event.inputs.frontend_revision }}")"
@@ -243,6 +251,10 @@ jobs:
         id: rollback-backend
         if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
         shell: bash
+        env:
+          ROLLBACK_VERIFY_SERVICE: ${{ env.BACKEND_SERVICE }}
+          ROLLBACK_VERIFY_REGION: ${{ env.GCP_REGION }}
+          ROLLBACK_VERIFY_PROJECT: ${{ env.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
           REVISION="$(bash scripts/ci/resolve-rollback-target.sh production backend "${{ github.event.inputs.backend_revision }}")"
@@ -261,6 +273,10 @@ jobs:
         id: rollback-frontend
         if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
         shell: bash
+        env:
+          ROLLBACK_VERIFY_SERVICE: ${{ env.FRONTEND_SERVICE }}
+          ROLLBACK_VERIFY_REGION: ${{ env.GCP_REGION }}
+          ROLLBACK_VERIFY_PROJECT: ${{ env.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
           REVISION="$(bash scripts/ci/resolve-rollback-target.sh production frontend "${{ github.event.inputs.frontend_revision }}")"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,290 @@
+name: "Rollback"
+
+# Standalone, manually-dispatchable rollback: repoints UAT/production Cloud
+# Run traffic to a known-good revision without going through a git revert
+# PR first. Before this workflow existed, rollback only happened as an
+# automatic side effect inside deploy-uat.yml / deploy-production.yml, and
+# only when the post-deploy health classifier failed — a revert to code that
+# was itself previously shipped and working passes those health checks
+# cleanly, so it would never trigger. This closes that gap.
+#
+# This IS the governed mechanism the "no ad hoc gcloud run deploy /
+# update-traffic" rule in admin-release-sop.md refers to — see the doc
+# update landed alongside this file. It is not the ad hoc command that rule
+# prohibits: it is actor-gated by the same allowlist that already gates
+# deploy dispatch, authenticates the same way (Workload Identity
+# Federation), and calls the same, unmodified scripts/ci/cloudrun-rollback.sh
+# the automatic path already uses.
+#
+# Two separate jobs, not one dynamic `environment:`, deliberately — this
+# mirrors deploy-uat.yml (no environment: key, repo-level vars) and
+# deploy-production.yml (environment: production, environment-scoped vars)
+# exactly, rather than introducing an unproven dynamic-environment pattern.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment to roll back"
+        required: true
+        type: choice
+        options:
+          - uat
+          - production
+      scope:
+        description: "Which service(s) to roll back"
+        required: true
+        type: choice
+        default: all
+        options:
+          - backend
+          - frontend
+          - all
+      backend_revision:
+        description: "Backend revision to restore (blank = last known-good tag)"
+        required: false
+        type: string
+      frontend_revision:
+        description: "Frontend revision to restore (blank = last known-good tag)"
+        required: false
+        type: string
+      reason:
+        description: "Why this rollback is needed (audit trail)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  rollback-uat:
+    name: "Rollback — UAT"
+    if: github.event.inputs.environment == 'uat'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: deploy-uat
+      cancel-in-progress: false
+    env:
+      GCP_PROJECT_ID: hushh-pda-uat
+      GCP_REGION: us-central1
+      BACKEND_SERVICE: consent-protocol
+      FRONTEND_SERVICE: hushh-webapp
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing UAT rollback from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: main
+
+      - name: Assert manual UAT dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface uat --actor "${GITHUB_ACTOR}"
+
+      - name: Fetch last-known-good deploy tags
+        run: git fetch origin 'refs/tags/deployed/*:refs/tags/deployed/*' 2>&1 || true
+
+      - name: Validate Google Cloud workload identity configuration
+        shell: bash
+        env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Roll back backend
+        id: rollback-backend
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat backend "${{ github.event.inputs.backend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback backend health check
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/health" 5 30 5 200
+
+      - name: Roll back frontend
+        id: rollback-frontend
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh uat frontend "${{ github.event.inputs.frontend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback frontend health check
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/" 3 30 5 200
+
+      - name: Rollback summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## UAT Rollback"
+            echo ""
+            echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Backend target revision: \`${{ steps.rollback-backend.outputs.revision || 'n/a (not in scope)' }}\`"
+            echo "- Frontend target revision: \`${{ steps.rollback-frontend.outputs.revision || 'n/a (not in scope)' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  rollback-production:
+    name: "Rollback — Production"
+    if: github.event.inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    concurrency:
+      group: deploy-production-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      GCP_PROJECT_ID: hushh-pda
+      GCP_REGION: us-central1
+      BACKEND_SERVICE: consent-protocol
+      FRONTEND_SERVICE: hushh-webapp
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing production rollback from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: main
+
+      - name: Assert production dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface production --actor "${GITHUB_ACTOR}"
+
+      - name: Fetch last-known-good deploy tags
+        run: git fetch origin 'refs/tags/deployed/*:refs/tags/deployed/*' 2>&1 || true
+
+      - name: Validate Google Cloud workload identity configuration
+        shell: bash
+        env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Roll back backend
+        id: rollback-backend
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh production backend "${{ github.event.inputs.backend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback backend health check
+        if: github.event.inputs.scope == 'backend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/health" 5 30 5 200
+
+      - name: Roll back frontend
+        id: rollback-frontend
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          REVISION="$(bash scripts/ci/resolve-rollback-target.sh production frontend "${{ github.event.inputs.frontend_revision }}")"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${REVISION}"
+
+      - name: Post-rollback frontend health check
+        if: github.event.inputs.scope == 'frontend' || github.event.inputs.scope == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" --project="${{ env.GCP_PROJECT_ID }}" --region="${{ env.GCP_REGION }}" --format='value(status.url)')"
+          bash scripts/ci/cloudrun-http-health.sh "$URL" "/" 3 30 5 200
+
+      - name: Rollback summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Production Rollback"
+            echo ""
+            echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Backend target revision: \`${{ steps.rollback-backend.outputs.revision || 'n/a (not in scope)' }}\`"
+            echo "- Frontend target revision: \`${{ steps.rollback-frontend.outputs.revision || 'n/a (not in scope)' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/hushh
+++ b/bin/hushh
@@ -46,11 +46,13 @@ Operational commands:
   compose <subcommand>
   protocol <subcommand>
   sync <main|verify-merge|check-main>
+  rollback <uat|production> [backend|frontend|all] --reason "<reason>"
 
 Run:
   ./bin/hushh compose --help
   ./bin/hushh protocol --help
   ./bin/hushh sync --help
+  ./bin/hushh rollback --help
   ./bin/hushh codex --help
 EOF
 }
@@ -417,6 +419,38 @@ run_sync() {
     *)
       sync_usage
       exit 1
+      ;;
+  esac
+}
+
+rollback_usage() {
+  cat <<'EOF'
+Usage:
+  ./bin/hushh rollback <uat|production> [backend|frontend|all] --reason "<reason>" \
+      [--backend-revision <revision>] [--frontend-revision <revision>]
+
+Dispatches .github/workflows/rollback.yml and watches it to completion. Moves
+Cloud Run traffic straight to a known-good revision, without a git revert PR
+first. Blank revision flags fall back to the deployed/<env>-latest tag.
+
+Requires `gh` authenticated as an actor already allowed to dispatch a deploy
+to that environment (config/ci-governance.json manual_dispatch_users) — this
+reuses that allowlist, it does not grant anything new.
+EOF
+}
+
+run_rollback() {
+  [ "$#" -ge 1 ] || {
+    rollback_usage
+    exit 1
+  }
+  case "${1:-}" in
+    -h|--help)
+      rollback_usage
+      exit 0
+      ;;
+    *)
+      exec bash "$REPO_ROOT/scripts/ci/dispatch-rollback.sh" "$@"
       ;;
   esac
 }
@@ -882,6 +916,9 @@ EOF
     ;;
   sync)
     run_sync "$@"
+    ;;
+  rollback)
+    run_rollback "$@"
     ;;
   *)
     main_usage

--- a/scripts/ci/dispatch-rollback.sh
+++ b/scripts/ci/dispatch-rollback.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# scripts/ci/dispatch-rollback.sh
+#
+# Dispatches .github/workflows/rollback.yml and watches it to completion.
+# The actual mutation (moving Cloud Run traffic) happens entirely inside the
+# governed workflow — this is convenience only, mirroring the pattern
+# scripts/release/dispatch-ios-appstore.mjs already uses for a different
+# release lane ("gh workflow run does not return the run id; grab the
+# newest run for this workflow").
+#
+# Requires `gh` authenticated as an actor in the target environment's
+# manual_dispatch_users allowlist (config/ci-governance.json) — the same
+# allowlist that already gates deploy-uat.yml / deploy-production.yml
+# dispatch. Nobody's permissions change to use this.
+set -euo pipefail
+
+REPO="hushh-labs/hushh-research"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  dispatch-rollback.sh <uat|production> [backend|frontend|all] --reason "<reason>" \
+      [--backend-revision <revision>] [--frontend-revision <revision>]
+
+Blank --backend-revision/--frontend-revision fall back to the revision
+recorded in the deployed/<environment>-latest tag (scripts/ci/tag-last-known-good.sh).
+EOF
+}
+
+ENVIRONMENT="${1:-}"
+case "${ENVIRONMENT}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  uat|production)
+    shift
+    ;;
+  *)
+    echo "Error: first argument must be 'uat' or 'production'." >&2
+    usage
+    exit 1
+    ;;
+esac
+
+SCOPE="all"
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    backend|frontend|all)
+      SCOPE="$1"
+      shift
+      ;;
+  esac
+fi
+
+REASON=""
+BACKEND_REVISION=""
+FRONTEND_REVISION=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --backend-revision)
+      BACKEND_REVISION="${2:-}"
+      shift 2
+      ;;
+    --frontend-revision)
+      FRONTEND_REVISION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+[ -n "$REASON" ] || {
+  echo "Error: --reason is required (audit trail for the rollback)." >&2
+  usage
+  exit 1
+}
+
+command -v gh >/dev/null 2>&1 || {
+  echo "Error: the 'gh' CLI is required." >&2
+  exit 1
+}
+
+echo "Dispatching rollback: environment=${ENVIRONMENT} scope=${SCOPE} reason=\"${REASON}\""
+
+BEFORE_RUN_ID="$(gh run list --repo "$REPO" --workflow rollback.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+
+gh workflow run rollback.yml --repo "$REPO" --ref main \
+  -f "environment=${ENVIRONMENT}" \
+  -f "scope=${SCOPE}" \
+  -f "reason=${REASON}" \
+  -f "backend_revision=${BACKEND_REVISION}" \
+  -f "frontend_revision=${FRONTEND_REVISION}"
+
+echo "Dispatched. Locating the run..."
+
+RUN_ID=""
+for _ in $(seq 1 10); do
+  sleep 3
+  RUN_ID="$(gh run list --repo "$REPO" --workflow rollback.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+  if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$BEFORE_RUN_ID" ]; then
+    break
+  fi
+  RUN_ID=""
+done
+
+if [ -z "$RUN_ID" ]; then
+  echo "Could not locate the dispatched run automatically. Check:" >&2
+  echo "  gh run list --repo $REPO --workflow rollback.yml --limit 5" >&2
+  exit 1
+fi
+
+echo "Watching run ${RUN_ID}..."
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status

--- a/scripts/ci/resolve-rollback-target.sh
+++ b/scripts/ci/resolve-rollback-target.sh
@@ -40,4 +40,45 @@ if [ -z "$REVISION" ]; then
   exit 1
 fi
 
+# A tag is a record of what WAS live, not a promise it still exists. Cloud Run
+# revisions are pruned (scripts/ci/cloudrun-retention.sh), so a tag that has
+# stopped moving — because the deploy step that writes it broke, which is
+# exactly what happened between 2026-08-19 and this restore — ages into
+# naming a revision that has since been deleted. Resolving it anyway hands
+# cloudrun-rollback.sh a dead name and produces a gcloud error in the middle
+# of an incident, at the one moment nobody has attention to spare for it.
+# Check here instead, and say what IS still available.
+VERIFY_SERVICE="${ROLLBACK_VERIFY_SERVICE:-}"
+VERIFY_REGION="${ROLLBACK_VERIFY_REGION:-}"
+VERIFY_PROJECT="${ROLLBACK_VERIFY_PROJECT:-}"
+
+if [ -n "$VERIFY_SERVICE" ] && [ -n "$VERIFY_REGION" ] && command -v gcloud >/dev/null 2>&1; then
+  # --project explicitly rather than leaning on ambient `gcloud config` state:
+  # the wrong project answers with an empty list, which this code reads as
+  # "lookup failed, stay quiet" — a silent skip of the very check being added.
+  set -- --service="$VERIFY_SERVICE" --region="$VERIFY_REGION" \
+         --format='value(metadata.name)' --limit=200
+  [ -n "$VERIFY_PROJECT" ] && set -- "$@" --project="$VERIFY_PROJECT"
+
+  SURVIVING="$(gcloud run revisions list "$@" 2>/dev/null || true)"
+
+  # An empty list means the lookup itself failed (no credentials, wrong
+  # project, API hiccup). That is not evidence the revision is gone, so fall
+  # through and let the rollback step surface the real error.
+  if [ -n "$SURVIVING" ] && ! printf '%s\n' "$SURVIVING" | grep -qxF "$REVISION"; then
+    TAGGED_AT="$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | grep -E '^tagged_at:' | sed -E 's/^tagged_at:[[:space:]]*//')"
+    {
+      echo "[resolve-rollback-target] refs/tags/${TAG} names ${LANE} revision '${REVISION}',"
+      echo "but that revision no longer exists on ${VERIFY_SERVICE} in ${VERIFY_REGION}."
+      echo ""
+      echo "  tag last written: ${TAGGED_AT:-unknown}"
+      echo ""
+      echo "The tag is stale — it has not been updated since the revision it names was"
+      echo "pruned. Re-dispatch with an explicit revision from the ones still available:"
+      printf '%s\n' "$SURVIVING" | head -10 | sed 's/^/  /'
+    } >&2
+    exit 1
+  fi
+fi
+
 echo "$REVISION"

--- a/scripts/ci/resolve-rollback-target.sh
+++ b/scripts/ci/resolve-rollback-target.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/ci/resolve-rollback-target.sh
+#
+# Resolves which Cloud Run revision rollback.yml should restore traffic to,
+# for one service lane. An explicit revision always wins. Otherwise, falls
+# back to the revision recorded in the "last known good" tag written by
+# scripts/ci/tag-last-known-good.sh — so an operator dispatching a rollback
+# doesn't need to already know the revision name.
+#
+# Usage:
+#   resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]
+#
+# Prints the resolved revision name to stdout. Exits non-zero with a clear
+# message if nothing can be resolved (no explicit input AND no
+# deployed/<environment>-latest tag exists yet).
+set -euo pipefail
+
+ENVIRONMENT="${1:?usage: resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]}"
+LANE="${2:?usage: resolve-rollback-target.sh <environment> <backend|frontend> [explicit-revision]}"
+EXPLICIT="${3:-}"
+
+if [ -n "$EXPLICIT" ]; then
+  echo "$EXPLICIT"
+  exit 0
+fi
+
+TAG="deployed/${ENVIRONMENT}-latest"
+
+if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "[resolve-rollback-target] No explicit ${LANE} revision given and refs/tags/${TAG} does not exist yet (no healthy deploy has been tagged for ${ENVIRONMENT})." >&2
+  echo "[resolve-rollback-target] Pass the revision explicitly — read it with:" >&2
+  echo "  gcloud run services describe <service> --project=<project> --region=us-central1 --format='value(status.traffic[0].revisionName)'" >&2
+  exit 1
+fi
+
+REVISION="$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | grep -E "^${LANE}_revision:" | head -1 | sed -E "s/^${LANE}_revision:[[:space:]]*//")"
+
+if [ -z "$REVISION" ]; then
+  echo "[resolve-rollback-target] refs/tags/${TAG} exists but has no ${LANE}_revision line — pass the revision explicitly." >&2
+  exit 1
+fi
+
+echo "$REVISION"

--- a/scripts/ci/tag-last-known-good.sh
+++ b/scripts/ci/tag-last-known-good.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/ci/tag-last-known-good.sh
+#
+# Marks a successful, healthy deploy as "last known good" so a future revert
+# check (scripts/git/check-merge-regression.sh, via the wider comparison pass
+# in the Merge Fidelity Gate) and a future rollback (rollback.yml) both have
+# a durable anchor to work from. Nothing in this repo tagged a deploy before
+# this script existed — only 2 git tags existed in the whole repo, neither
+# part of the deploy pipeline.
+#
+# Writes two refs:
+#   - one immutable annotated tag per successful run:
+#       deployed/<env>/<sha8>-<UTC-timestamp>
+#   - one moving convenience ref, force-updated each time:
+#       deployed/<env>-latest
+# One combined tag for both lanes (backend+frontend) rather than four
+# separate per-lane tags — deliberately lightweight, since backend/frontend
+# can deploy independently via the existing scope mechanism and a maintained
+# per-lane changelog is not what this needs to be. If lane drift becomes a
+# real operational problem, split into deployed/<env>-backend-latest /
+# deployed/<env>-frontend-latest — the mechanism doesn't change, just the ref
+# names.
+#
+# Called from deploy-uat.yml / deploy-production.yml only after the release
+# classified healthy (no rollback fired). Requires `contents: write` on the
+# calling workflow and a checkout with push credentials persisted (the
+# actions/checkout default — do not add persist-credentials: false upstream
+# of this step).
+#
+# Env (all required except RUN_URL/ACTOR):
+#   ENVIRONMENT        uat | production
+#   SHA                the commit that was deployed
+#   BACKEND_REVISION, BACKEND_SERVICE_URL, FRONTEND_REVISION, FRONTEND_SERVICE_URL
+#   RUN_URL            the GitHub Actions run URL, for the annotation
+#   ACTOR              who dispatched the deploy
+#
+# Named *_SERVICE_URL, not *_URL — this repo's runtime config contract
+# (scripts/ci/verify-runtime-config-contract.py) retired one specific bare
+# frontend-URL env-var name repo-wide (its canonical replacement is
+# APP_FRONTEND_ORIGIN). These are unrelated Cloud Run service URLs, but the
+# check matches on the literal name anywhere, so a different name avoids a
+# false collision.
+set -euo pipefail
+
+ENVIRONMENT="${ENVIRONMENT:?ENVIRONMENT is required (uat|production)}"
+SHA="${SHA:?SHA is required}"
+BACKEND_REVISION="${BACKEND_REVISION:-}"
+BACKEND_SERVICE_URL="${BACKEND_SERVICE_URL:-}"
+FRONTEND_REVISION="${FRONTEND_REVISION:-}"
+FRONTEND_SERVICE_URL="${FRONTEND_SERVICE_URL:-}"
+RUN_URL="${RUN_URL:-}"
+ACTOR="${ACTOR:-unknown}"
+
+SHA8="${SHA:0:8}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+TAG="deployed/${ENVIRONMENT}/${SHA8}-${TIMESTAMP}"
+LATEST_REF="deployed/${ENVIRONMENT}-latest"
+
+MESSAGE="$(cat <<EOF
+Last known good — ${ENVIRONMENT}
+sha: ${SHA}
+backend_revision: ${BACKEND_REVISION}
+backend_url: ${BACKEND_SERVICE_URL}
+frontend_revision: ${FRONTEND_REVISION}
+frontend_url: ${FRONTEND_SERVICE_URL}
+run: ${RUN_URL}
+actor: ${ACTOR}
+tagged_at: ${TIMESTAMP}
+EOF
+)"
+
+# A fresh actions/checkout has no committer identity configured, and an
+# annotated tag needs one (2026-08-19: first real run failed here with
+# "empty ident name"). Scoped to this repo checkout only, never --global.
+if [ -z "$(git config user.email || true)" ]; then
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+fi
+if [ -z "$(git config user.name || true)" ]; then
+  git config user.name "github-actions[bot]"
+fi
+
+git tag -a "$TAG" "$SHA" -m "$MESSAGE"
+git push origin "refs/tags/${TAG}"
+
+# Force-move only this one ref, not a general force-push — deliberately
+# scoped so it can never touch a branch or another tag.
+git tag -fa "$LATEST_REF" "$SHA" -m "$MESSAGE"
+git push origin "refs/tags/${LATEST_REF}" --force
+
+echo "[tag-last-known-good] Tagged ${SHA8} as ${TAG} and moved ${LATEST_REF} to it."


### PR DESCRIPTION
`deploy-uat.yml` on main still runs its "Tag this release as last known good" step, which calls `bash scripts/ci/tag-last-known-good.sh`. That file has not existed since the mass revert `a60c51dfc` deleted it on 2026-08-20. The step is `continue-on-error: true`, so every UAT deploy since then has reported success and recorded nothing.

Closes #5642

## Evidence

```
newest tag         deployed/uat/87f731cd-20260819T224835Z
deployed/uat-latest dfc7d45d1   (2026-08-19 06:18)

UAT deploys today
  2026-08-20T16:17:50Z  success  a21c855d3   → no tag
  2026-08-20T15:54:53Z  success  26fbbbf08   → no tag
```

There is currently no recorded "this was live and healthy" anchor in the repo, and no rollback workflow to move traffic back to one.

## What the revert actually took

| | |
|---|---|
| `.github/workflows/rollback.yml` | deleted |
| `scripts/ci/tag-last-known-good.sh` | deleted |
| `scripts/ci/dispatch-rollback.sh` | deleted |
| `scripts/ci/resolve-rollback-target.sh` | deleted |
| `rollback` subcommand in `bin/hushh` | deleted |
| `deploy-production.yml` tagging step + `contents: write` | removed |
| `deploy-uat.yml` tagging step + `contents: write` | **kept** — only the script it calls went |

That last row is why this was invisible: the two deploy workflows disagree, and the surviving half fails quietly by design.

## Restored, not rewritten

This code shipped, ran, and produced the tags still in the repo, so it comes back from `a60c51dfc^` rather than being reimplemented.

- `deploy-production.yml` has not been touched since the revert, so its half reverse-applies exactly.
- `bin/hushh` restores as **37 insertions, 0 deletions** — nothing that landed after the revert is disturbed.

**Not** restored here: the migration `rollback/*.sql` files (158, 159, 160) the same commit deleted. Other work already put those back; they are a different concern from this lane.

## Verified

- `bash -n` passes on all three scripts
- `rollback.yml`, `deploy-uat.yml`, `deploy-production.yml` all parse as YAML
- `./bin/hushh rollback --help` prints its usage
- `scripts/ci/repo-governance-check.sh` passes locally; migration contracts aligned at 160
- the Merge Fidelity Gate merged this morning reports this branch clean

No application code.