### PR TITLE
fix(one-location): let the route report a Reduce Motion tab switch, not the pager

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
@@ -58,12 +58,18 @@ const embla = vi.hoisted(() => ({
   ref: vi.fn(),
   root: null as HTMLElement | null,
   container: null as HTMLElement | null,
+  api: null as Record<string, unknown> | null,
   options: null as Record<string, unknown> | null,
 }));
 
 vi.mock("embla-carousel-react", () => ({
+  // The api object is cached, because the real hook returns a STABLE instance.
+  // Handing back a fresh object each render makes every effect keyed on
+  // `emblaApi` re-run on every render, which fires the self-healing
+  // reconciliation pass continuously and drowns the behaviour under test.
   default: (options: Record<string, unknown>) => {
     embla.options = options;
+    if (embla.api) return [embla.ref, embla.api];
     const engine = {
       slideRects: Array.from({ length: embla.slideCount }, () => ({
         width: SLIDE_WIDTH,
@@ -84,9 +90,7 @@ vi.mock("embla-carousel-react", () => ({
       previousLocation: { set: () => undefined },
       translate: { to: () => undefined },
     };
-    return [
-      embla.ref,
-      {
+    embla.api = {
         selectedScrollSnap: () => Math.round(-embla.offset / SLIDE_WIDTH),
         // Derived from position, exactly as Embla derives it. A mock that
         // stored progress separately let the two disagree, which is a state
@@ -104,8 +108,8 @@ vi.mock("embla-carousel-react", () => ({
         off: (event: string) => {
           embla.listeners.delete(event);
         },
-      },
-    ];
+    };
+    return [embla.ref, embla.api];
   },
 }));
 
@@ -266,6 +270,7 @@ beforeEach(() => {
   embla.scrollTo.mockClear();
   embla.reInit.mockClear();
   embla.listeners.clear();
+  embla.api = null;
   embla.root = document.createElement("div");
   embla.root.getBoundingClientRect = () =>
     ({ width: SLIDE_WIDTH, height: 800 }) as DOMRect;
@@ -468,15 +473,30 @@ describe("Location tab transition — one writer owns the indicator", () => {
 describe("Location tab transition — Reduce Motion", () => {
   it("places the panel instead of travelling a full screen width", () => {
     reduceMotion = true;
-    render(<LocationPager activeValue="now" />);
+    const view = render(<LocationPager activeValue="now" />);
 
+    // The press itself defers to the route, so nothing moves yet.
     pressTab("people");
+    expect(embla.scrollTo).not.toHaveBeenCalled();
 
+    // The route lands, and the panel is placed rather than travelled.
+    act(() => {
+      view.rerender(<LocationPager activeValue="people" />);
+    });
     expect(embla.scrollTo).toHaveBeenCalledWith(1, true);
     expect(swipeVariable("location")).toBe("1");
   });
 
-  it("still reports the selection, because a jump emits no select or settle", async () => {
+  it("still travels the panel when Reduce Motion is off", () => {
+    const view = render(<LocationPager activeValue="now" />);
+    act(() => {
+      view.rerender(<LocationPager activeValue="people" />);
+    });
+    // No `jump` argument: this one animates.
+    expect(embla.scrollTo).toHaveBeenCalledWith(1);
+  });
+
+  it("leaves the consumer as the only reporter, so a press cannot race its own navigation", () => {
     reduceMotion = true;
     const onSelectionChange = vi.fn();
     const onSelectionCommit = vi.fn();
@@ -489,45 +509,11 @@ describe("Location tab transition — Reduce Motion", () => {
     );
 
     pressTab("people");
-
-    // Nothing reported yet: the report deliberately leaves the tap's own tick.
+    // Reporting from here was tried three ways and every one of them raced
+    // the strip's own navigation, because a tab press takes the whole
+    // document with it on the deployed build.
     expect(onSelectionChange).not.toHaveBeenCalled();
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    // Reported after the current task, not inside the tap's own dispatch:
-    // reporting synchronously put a second navigation request ahead of the
-    // strip's in the same tick and the tap produced no history write at all.
-    // A timer rather than an animation frame, because a page that is not
-    // being painted never delivers a frame and the report would never run.
-    expect(onSelectionChange).toHaveBeenCalledWith("people");
-    expect(onSelectionCommit).toHaveBeenCalledWith("people");
-  });
-
-  it("does not drag the panel back before the consumer's value catches up", () => {
-    reduceMotion = true;
-    const view = render(<LocationPager activeValue="now" />);
-
-    pressTab("people");
-    expect(embla.scrollTo).toHaveBeenLastCalledWith(1, true);
-    embla.scrollTo.mockClear();
-
-    // The route has not committed yet, so the pager still receives "now".
-    // Repairing that disagreement here would undo the person's own tap.
-    act(() => {
-      view.rerender(<LocationPager activeValue="now" />);
-    });
-    // It may re-assert where it already is; it must never go back to the tab
-    // the person just left.
-    for (const call of embla.scrollTo.mock.calls) expect(call[0]).toBe(1);
-    embla.scrollTo.mockClear();
-
-    // A value that is neither where we were nor where we went still wins.
-    act(() => {
-      view.rerender(<LocationPager activeValue="links" />);
-    });
-    expect(embla.scrollTo).toHaveBeenCalledWith(2, true);
+    expect(onSelectionCommit).not.toHaveBeenCalled();
   });
 });
 

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -265,23 +265,6 @@ export function SwipeViews({
   const renderedHeightRef = useRef<number | null>(null);
   const heightFloorRef = useRef<number | null>(null);
   const measuredValueRef = useRef<string | null>(null);
-  const jumpReportTimerRef = useRef<number | null>(null);
-  /**
-   * A pane we moved to on purpose and told the consumer about, while its
-   * `activeValue` still names the pane we came from.
-   *
-   * The reconcile effect below treats any disagreement between the selected
-   * value and the rendered pane as drift to be repaired. Under Reduce Motion
-   * that repair fires against our own tap: the jump puts the pane on the new
-   * index in the same frame, the consumer's route has not committed yet, and
-   * the effect immediately drags it back -- so the person's tap visibly undoes
-   * itself and only sticks once the query string lands (measured: 700ms to 6s
-   * in dev). Holding until the prop moves is what makes the tap authoritative.
-   */
-  const pendingSelectionRef = useRef<{
-    value: string;
-    awaitedFrom: string;
-  } | null>(null);
   const [heightSettling, setHeightSettling] = useState(false);
   // Bumped on settle so the measurement effect re-runs and releases the floor.
   const [heightSettleTick, setHeightSettleTick] = useState(0);
@@ -291,15 +274,6 @@ export function SwipeViews({
   // `registerTopShellTabPager`.
   useEffect(() => registerTopShellTabPager(tabSetId), [tabSetId]);
 
-  useEffect(
-    () => () => {
-      if (jumpReportTimerRef.current !== null) {
-        window.clearTimeout(jumpReportTimerRef.current);
-        jumpReportTimerRef.current = null;
-      }
-    },
-    [],
-  );
   // Read by the measurement-reconciliation effect below, which must not itself
   // re-run on every selection change (re-subscribing its observer each time),
   // but still needs the CURRENT selection whenever it does fire.
@@ -445,23 +419,9 @@ export function SwipeViews({
         typeof engineSnapCount === "number" &&
         containerChildCount !== engineSnapCount;
 
-      // A pane we moved to on purpose and have already reported upward is the
-      // truth until the consumer's own value moves, exactly as in the
-      // selection effect below. Without this, a resize landing inside that
-      // window repairs the pane back to the tab the person just left -- the
-      // same undo, arriving through the other door.
-      const pending = pendingSelectionRef.current;
-      const pendingIdx =
-        pending !== null && pending.awaitedFrom === activeValueRef.current
-          ? optionsRef.current.findIndex((opt) => opt.value === pending.value)
-          : -1;
-
-      const targetIdx =
-        pendingIdx !== -1
-          ? pendingIdx
-          : optionsRef.current.findIndex(
-              (opt) => opt.value === activeValueRef.current,
-            );
+      const targetIdx = optionsRef.current.findIndex(
+        (opt) => opt.value === activeValueRef.current,
+      );
 
       // Where the pane is trying to go, against where the selected pane belongs.
       // Checking `target` instead of `offsetLocation` allows normal animations
@@ -560,43 +520,44 @@ export function SwipeViews({
    * never ran and the tab press did not commit at all. A macrotask still runs
    * when frames are not being produced.
    */
+  /**
+   * Moves the pager to a selection made somewhere else -- a shell tab tap, a
+   * deep link, a voice action -- and claims the shared indicator variable for
+   * the whole flight, so the pill is that same motion rather than a second
+   * animation racing it.
+   *
+   * `viaRoute` is the press path, where the consumer's own navigation is
+   * already in flight. Under Reduce Motion that path does NOT move the pane
+   * here: it lets the route land and the effect below place the pane the
+   * instant `activeValue` arrives.
+   *
+   * Reporting the selection from here instead was tried and abandoned. Embla
+   * emits neither `select` nor `settle` for a jump, so the jump had to report
+   * upward itself -- and every version of that raced the consumer's own
+   * navigation, because a tab press on the deployed build takes the whole
+   * document with it. Synchronously it put a second `requestNavigation` ahead
+   * of the strip's in the same tick and the press produced no history write at
+   * all; on an animation frame it never ran in a context that was not being
+   * painted; on a timer it still intermittently lost to the navigation.
+   * Letting the route stay the only reporter removes the race rather than
+   * re-timing it, and Reduce Motion still gets a placed pane rather than a
+   * travelled one.
+   */
   const scrollToSelection = useCallback(
-    (api: EmblaCarouselType, index: number) => {
+    (api: EmblaCarouselType, index: number, viaRoute = false) => {
       if (prefersReducedMotion()) {
+        if (viaRoute) return;
         isAnimatingRef.current = false;
         scrollToIndexSafely(api, index, true);
         setTopShellTabSwipeState(tabSetId, Math.max(0, index), false);
         releaseHeightFloor();
-        const nextValue = options[index]?.value;
-        if (nextValue && nextValue !== lastReportedValueRef.current) {
-          lastReportedValueRef.current = nextValue;
-          pendingSelectionRef.current = {
-            value: nextValue,
-            awaitedFrom: activeValueRef.current,
-          };
-          if (jumpReportTimerRef.current !== null) {
-            window.clearTimeout(jumpReportTimerRef.current);
-          }
-          jumpReportTimerRef.current = window.setTimeout(() => {
-            jumpReportTimerRef.current = null;
-            onSelectionChange?.(nextValue);
-            onSelectionCommit?.(nextValue);
-          }, 0);
-        }
         return;
       }
       isAnimatingRef.current = true;
       scrollToIndexSafely(api, index);
       syncTabIndicator(true);
     },
-    [
-      onSelectionChange,
-      onSelectionCommit,
-      options,
-      releaseHeightFloor,
-      syncTabIndicator,
-      tabSetId,
-    ],
+    [releaseHeightFloor, syncTabIndicator, tabSetId],
   );
 
   // The route is the selection authority. Page swipes report their new value
@@ -605,19 +566,6 @@ export function SwipeViews({
     if (!emblaApi) return;
     const targetIdx = options.findIndex((opt) => opt.value === activeValue);
     const visualIdx = resolveVisualIndex(emblaApi, options.length);
-
-    // Never undo a selection we made and have already reported upward. It is
-    // released the moment the consumer's own value moves -- to our pane or to
-    // any other -- so a redirect still wins and this can never latch.
-    const pending = pendingSelectionRef.current;
-    if (pending) {
-      if (pending.awaitedFrom !== activeValue) {
-        pendingSelectionRef.current = null;
-      } else if (options[visualIdx]?.value === pending.value) {
-        lastReportedValueRef.current = pending.value;
-        return;
-      }
-    }
 
     if (targetIdx !== -1 && targetIdx !== visualIdx) {
       scrollToSelection(emblaApi, targetIdx);
@@ -650,8 +598,6 @@ export function SwipeViews({
     isDraggingRef.current = false;
     isAnimatingRef.current = false;
     hasMovedSincePointerDownRef.current = false;
-    // Where the pager physically rests is now the truth; nothing is pending.
-    pendingSelectionRef.current = null;
     setTopShellTabSwipeState(tabSetId, currentIdx, false);
     releaseHeightFloor();
     const newValue = options[currentIdx]?.value;
@@ -739,7 +685,7 @@ export function SwipeViews({
         return;
       // A top-tab press starts the compositor motion immediately. Waiting for
       // Next searchParams made the tab ink update first and the pane lag behind.
-      scrollToSelection(emblaApi, targetIndex);
+      scrollToSelection(emblaApi, targetIndex, true);
     });
   }, [emblaApi, options, scrollToSelection, tabSetId]);
 
@@ -783,7 +729,6 @@ export function SwipeViews({
       isDraggingRef.current = true;
       // A finger landing mid-flight takes over from the tap that started it.
       isAnimatingRef.current = false;
-      pendingSelectionRef.current = null;
       hasMovedSincePointerDownRef.current = false;
       syncTabIndicator(true);
     };


### PR DESCRIPTION
Follow-up to #5633 and #5639. Net **−69 lines**.

A jump emits neither `select` nor `settle`, so the Reduce Motion path was reporting its own selection upward. Every timing for that report raced the consumer's own navigation, because a tab press takes the whole document with it on a production build:

| Timing | What happened |
|---|---|
| synchronous | put a second `requestNavigation` ahead of the strip's in the same tick — the press produced **no history write at all** |
| `requestAnimationFrame` | never ran in a context that was not being painted — **0 frames** sampled over 3s on the deployed build |
| `setTimeout(0)` | still lost intermittently — **2 of 2** presses 8 seconds after load navigated to the tab *already selected* instead of the one pressed |

That last one only ever appeared in a production build. The same code passed every time in dev, which is why it reached UAT. Production (`one.hushh.ai`), which predates this work, passed 3 of 3 on the identical probe — so the race was ours, not the platform's.

## The change

The press path no longer moves the pane at all under Reduce Motion. The route stays the only reporter, exactly as it always was, and the pane is placed the instant `activeValue` arrives.

Reduce Motion still never travels a panel a full screen width, and the strip's own optimistic selected state still answers the press immediately — so the press feels no different.

Removing the report also removes its timer and the pending-selection bookkeeping that existed only to stop those reports fighting the two reconcile passes. That is the whole class of race, not a re-timing of it.

## Verification

On a **local production build** — the configuration that reproduced the failure:

- 12 of 12 presses correct across three runs at 3s and 8s, Reduce Motion on and off (was 2 of 2 wrong at 8s).
- Both browser harnesses green in Chromium and WebKit at 320/375/390/430/1280: selection, panel activation, rapid switching, state preservation, Reduce Motion, keyboard reachability, overflow, indicator bounds.

Unit: 12 contract tests, all 7 mutations caught (each reverts one piece of this work). `verify:one-location` 12 files / 306 tests, shared pager suites 5 files / 44 tests, `verify:surface-map`, `verify:design-system`, `tsc --noEmit`, `eslint --max-warnings=0` all green.

The mock's Embla api is now cached, matching the real hook's stable instance — handing back a fresh object each render re-ran every `emblaApi`-keyed effect and fired the self-healing pass continuously.

2 files, frontend only.