### PR TITLE
restore 3/8: 100-member Circles and a contact picker built for them

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -37,7 +37,12 @@ CIRCLE_MEMBER_INVITE_TTL_HOURS = 72
 CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS = 12
 CIRCLE_NON_OWNER_PENDING_INVITE_LIMIT = 5
 CIRCLE_MAX_PER_USER = 10
-CIRCLE_DEFAULT_MEMBER_LIMIT = 20
+# Raised from 20 in migration 158. This constant is stamped onto a Circle at
+# INSERT and never edited afterwards, so it governs new Circles only -- the
+# migration lifts the stored ceiling on Circles that already carry the old
+# default, which is what makes the higher limit real for accounts that
+# already have Circles rather than only for ones created from here on.
+CIRCLE_DEFAULT_MEMBER_LIMIT = 100
 CIRCLE_CODE_LENGTH = 12
 CIRCLE_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
 _CIRCLE_CODE_DOMAIN = b"one-location-circle-code:v1:"

--- a/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_member_limit_migration.py
@@ -1,0 +1,142 @@
+"""Migration 158 raises the per-Circle member ceiling from 20 to 100.
+
+The number lived in two places in 134 -- the column default and an inline
+`CHECK (member_limit BETWEEN 2 AND 20)` -- and a third, implicit one: the
+value already frozen onto every Circle row. Raising only the first two would
+ship "Circles hold 100" to accounts whose existing Circles all still stop at
+20, so the backfill is part of the contract, not an optimisation.
+
+These assertions are deliberately about SHAPE rather than a live database:
+the release-migration gate reads these same files, and a migration that
+silently stops widening the bound, stops raising the default, or starts
+rewriting Circles whose ceiling was set deliberately is exactly the drift
+worth failing on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+CONTRACTS_DIR = REPO_ROOT / "db" / "contracts"
+SERVICE_PATH = REPO_ROOT / "hushh_mcp" / "services" / "one_location_circle_service.py"
+
+MIGRATION = "158_one_location_circle_member_limit_100.sql"
+ROLLBACK = "158_one_location_circle_member_limit_100.rollback.sql"
+
+
+def _migration() -> str:
+    return (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+
+def _rollback() -> str:
+    return (MIGRATIONS_DIR / "rollback" / ROLLBACK).read_text(encoding="utf-8")
+
+
+def _statements(sql: str) -> str:
+    """The executable half of a migration, with `--` commentary stripped.
+
+    These files explain themselves at length, and the commentary necessarily
+    quotes the old shape it is replacing. Asserting "the old bound is gone"
+    against the raw text would therefore fail on the sentence describing why
+    it went.
+    """
+    lines = [
+        line.split("--", 1)[0] for line in sql.splitlines() if not line.lstrip().startswith("--")
+    ]
+    return chr(10).join(lines)
+
+
+def test_member_limit_migration_is_registered_in_release_order() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert (MIGRATIONS_DIR / MIGRATION).exists()
+    assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
+    # Registered, and after the migration it builds on. NOT "last": this file
+    # was written while 158 was the head, and 159 and 160 have since landed on
+    # top of it. Pinning to the tail asserts nothing about THIS migration and
+    # breaks every time another one is added, which is how it failed here.
+    ordered = manifest["ordered_migrations"]
+    assert MIGRATION in ordered
+    assert ordered.index(MIGRATION) > ordered.index("157_hussh_crm_delete_operation.sql")
+    # Structural One Location migrations belong to the iam group, as 155 does.
+    assert MIGRATION in manifest["groups"]["iam"]
+
+
+def test_schema_contracts_advance_to_the_new_migration_head() -> None:
+    for name in (
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+        "dev_minimum_schema.json",
+    ):
+        contract = json.loads((CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] >= 158, name
+
+    # No new table or column, so the required-table shape must be untouched:
+    # this migration only moves a bound, a default and the rows carrying it.
+    prod = json.loads((CONTRACTS_DIR / "prod_core_schema.json").read_text(encoding="utf-8"))
+    assert "member_limit" in prod["required_tables"]["one_location_circles"]
+
+
+def test_migration_widens_the_bound_and_the_default_together() -> None:
+    migration = _migration()
+
+    # Both halves of 134's cap, or the ceiling only appears to move.
+    assert "DROP CONSTRAINT IF EXISTS one_location_circles_member_limit_check" in migration
+    assert "one_location_circles_member_limit_bounds" in migration
+    assert "CHECK (member_limit BETWEEN 2 AND 100)" in migration
+    assert "ALTER COLUMN member_limit SET DEFAULT 100" in migration
+    assert "BETWEEN 2 AND 20" not in _statements(migration)
+
+
+def test_migration_lifts_only_circles_still_on_the_old_default() -> None:
+    migration = _migration()
+
+    assert "SET member_limit = 100" in migration
+    # A hand-set ceiling is the one case where the stored number carries
+    # intent; a blanket UPDATE would erase it.
+    assert "WHERE member_limit = 20" in migration
+    statements = _statements(migration)
+    assert "WHERE member_limit <" not in statements
+    assert "WHERE TRUE" not in statements
+
+
+def test_migration_grants_no_access_of_its_own() -> None:
+    migration = _migration()
+
+    # Raising a ceiling must not add a member, a connection, a grant or an SMS
+    # selection. Membership is still something a person does.
+    assert "INSERT INTO one_location_circle_memberships" not in migration
+    assert "INSERT INTO connections" not in migration
+    assert "INSERT INTO trusted_connections" not in migration
+    assert "INSERT INTO one_location_share_grants" not in migration
+    assert "INSERT INTO one_location_sms_contacts" not in migration
+
+
+def test_rollback_restores_the_ceiling_without_stranding_grown_circles() -> None:
+    rollback = _rollback()
+
+    assert "ALTER COLUMN member_limit SET DEFAULT 20" in rollback
+    # NOT VALID is the load-bearing word: it still governs every future INSERT
+    # and UPDATE while declining to re-scan the Circles that legitimately grew
+    # past 20 while the higher ceiling was live.
+    assert "CHECK (member_limit BETWEEN 2 AND 20) NOT VALID" in rollback
+    # Only Circles that can actually live inside the restored ceiling are
+    # lowered; the rest keep theirs rather than becoming rows that violate
+    # their own invariant.
+    assert "FROM one_location_circle_memberships m" in rollback
+    assert "<= 20" in rollback
+    assert "DELETE FROM one_location_circle_memberships" not in rollback
+
+
+def test_service_default_matches_the_migrated_ceiling() -> None:
+    service = SERVICE_PATH.read_text(encoding="utf-8")
+
+    # The constant is stamped onto a Circle at INSERT, so a service still
+    # saying 20 would keep writing the old ceiling onto every new Circle no
+    # matter what the column default says.
+    assert "CIRCLE_DEFAULT_MEMBER_LIMIT = 100" in service
+    assert "CIRCLE_DEFAULT_MEMBER_LIMIT = 20" not in service

--- a/hushh-webapp/__tests__/lib/one-location/contact-picker-controls.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-picker-controls.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTACT_LIST_CONTROLS_THRESHOLD,
+  contactQueryIsActive,
+  filterByContactQuery,
+  matchesContactQuery,
+  normalizeSearchText,
+  peoplePillLabel,
+  shouldRevealListControls,
+  shouldVirtualizeList,
+  sortByContactMode,
+} from "@/lib/one-location/contact-picker-controls";
+
+describe("conditional list controls", () => {
+  it("stays hidden for a list that fits on one screen", () => {
+    expect(shouldRevealListControls(0)).toBe(false);
+    expect(shouldRevealListControls(4)).toBe(false);
+    expect(shouldRevealListControls(CONTACT_LIST_CONTROLS_THRESHOLD)).toBe(false);
+  });
+
+  it("appears once the list outgrows a screenful", () => {
+    expect(shouldRevealListControls(CONTACT_LIST_CONTROLS_THRESHOLD + 1)).toBe(true);
+    expect(shouldRevealListControls(100)).toBe(true);
+  });
+
+  it("stays put once revealed, however far the list shrinks", () => {
+    // The defect this guards: removing people one at a time from a 12-person
+    // list must not yank the search field out from under a half-typed query
+    // the moment the eleventh goes.
+    expect(shouldRevealListControls(3, true)).toBe(true);
+    expect(shouldRevealListControls(0, true)).toBe(true);
+  });
+
+  it("virtualizes on the same boundary it reveals controls on", () => {
+    expect(shouldVirtualizeList(CONTACT_LIST_CONTROLS_THRESHOLD)).toBe(false);
+    expect(shouldVirtualizeList(CONTACT_LIST_CONTROLS_THRESHOLD + 1)).toBe(true);
+  });
+});
+
+describe("search", () => {
+  it("finds a name through case and accents", () => {
+    expect(normalizeSearchText("  RenÉe  ")).toBe("renee");
+    expect(matchesContactQuery("Renée Dubois", "renee")).toBe(true);
+    expect(matchesContactQuery("Renée Dubois", "DUBOIS")).toBe(true);
+  });
+
+  it("matches terms in any order, so a remembered first and last name works", () => {
+    // The real shape of a query: people type the names they remember, not the
+    // middle one they do not.
+    expect(matchesContactQuery("Ankit Kumar Singh", "ankit singh")).toBe(true);
+    expect(matchesContactQuery("Ankit Kumar Singh", "singh ankit")).toBe(true);
+    expect(matchesContactQuery("Ankit Kumar Singh", "ankit gupta")).toBe(false);
+  });
+
+  it("treats an empty or whitespace query as no filter at all", () => {
+    expect(contactQueryIsActive("   ")).toBe(false);
+    const people = [{ name: "Aarav" }, { name: "Maya" }];
+    expect(filterByContactQuery(people, "  ", (p) => p.name)).toHaveLength(2);
+  });
+
+  it("filters a roster down to the matching people", () => {
+    const people = [
+      { name: "Aarav Shah" },
+      { name: "Maya Chen" },
+      { name: "Neelesh Meena" },
+    ];
+    expect(
+      filterByContactQuery(people, "ee", (p) => p.name).map((p) => p.name),
+    ).toEqual(["Neelesh Meena"]);
+  });
+
+  it("returns a copy rather than the original array", () => {
+    const people = [{ name: "Aarav" }];
+    expect(filterByContactQuery(people, "", (p) => p.name)).not.toBe(people);
+  });
+});
+
+describe("sort", () => {
+  const people = [
+    { name: "Maya Chen" },
+    { name: "aarav shah" },
+    { name: "Neelesh Meena" },
+  ];
+
+  it("leaves the caller's own order alone by default", () => {
+    // "Suggested" is the directory's recommendation ranking; offering sorting
+    // must not silently discard it.
+    expect(sortByContactMode(people, "default", (p) => p.name).map((p) => p.name)).toEqual([
+      "Maya Chen",
+      "aarav shah",
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("sorts case-insensitively in both directions", () => {
+    expect(sortByContactMode(people, "name-asc", (p) => p.name).map((p) => p.name)).toEqual([
+      "aarav shah",
+      "Maya Chen",
+      "Neelesh Meena",
+    ]);
+    expect(sortByContactMode(people, "name-desc", (p) => p.name).map((p) => p.name)).toEqual([
+      "Neelesh Meena",
+      "Maya Chen",
+      "aarav shah",
+    ]);
+  });
+
+  it("never mutates the input", () => {
+    const original = [...people];
+    sortByContactMode(people, "name-asc", (p) => p.name);
+    expect(people).toEqual(original);
+  });
+});
+
+describe("pill label", () => {
+  it("counts people the way a person would say it", () => {
+    expect(peoplePillLabel(0)).toBe("0 people added");
+    expect(peoplePillLabel(1)).toBe("1 person added");
+    expect(peoplePillLabel(12)).toBe("12 people added");
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4797,8 +4797,17 @@ export function OneLocationAgentPageContent({
     [auth.userId, busy, refresh, vaultOwnerToken],
   );
 
+  /**
+   * Add some or all of a Circle's SMS-ready members in one pass.
+   *
+   * `memberUserIds` is the picker's hand-picked subset; omitting it keeps the
+   * original whole-Circle behaviour for any caller that still wants it (voice
+   * actions, deep links). Either way the roster is re-resolved here rather than
+   * trusted from the client, so a stale picker cannot smuggle in someone who
+   * has since left the Circle or lost phone verification.
+   */
   const handleAddSmsCircle = useCallback(
-    async (circleId: string) => {
+    async (circleId: string, memberUserIds?: readonly string[]) => {
       if (!auth.userId || !vaultOwnerToken || busy) return;
       setBusy(`sms-circle:${circleId}`);
       try {
@@ -4812,14 +4821,19 @@ export function OneLocationAgentPageContent({
           requirePhoneVerified: true,
         });
         const alreadySelected = new Set(smsContactUserIds);
+        const requested = memberUserIds ? new Set(memberUserIds) : null;
         const targets = selection.ready.filter(
-          (target) => !alreadySelected.has(target.recipient.userId),
+          (target) =>
+            !alreadySelected.has(target.recipient.userId) &&
+            (!requested || requested.has(target.recipient.userId)),
         );
         if (!targets.length) {
           toast.message(
-            selection.ready.length
-              ? `${selection.circle.name} is already in your SMS contacts.`
-              : `${selection.circle.name} has no members ready for SMS yet.`,
+            !selection.ready.length
+              ? `${selection.circle.name} has no members ready for SMS yet.`
+              : requested
+                ? "Those people are already in your SMS contacts."
+                : `${selection.circle.name} is already in your SMS contacts.`,
           );
           return;
         }

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -4,12 +4,17 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 
 import { describe, expect, it, vi } from "vitest";
 
 import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts-flow";
-import type { OneLocationRecipient } from "@/lib/one-location/types";
+import type { CircleRecipientSelection } from "@/lib/one-location/circle-recipient-selection";
+import type {
+  OneLocationCircleMember,
+  OneLocationRecipient,
+} from "@/lib/one-location/types";
 
 const recipients: OneLocationRecipient[] = [
   {
@@ -34,6 +39,58 @@ const recipients: OneLocationRecipient[] = [
   },
 ];
 
+function member(
+  userId: string,
+  displayName: string,
+): OneLocationCircleMember {
+  return {
+    userId,
+    displayName,
+    role: "member",
+    status: "active",
+    phoneVerified: true,
+    canReceiveLocation: true,
+    keyId: `key-${userId}`,
+    publicKeyJwk: { kty: "EC" },
+  } as OneLocationCircleMember;
+}
+
+/** A resolved Circle roster: two people ready, one held back with a reason. */
+function circleSelection(
+  ready: Array<{ userId: string; displayName: string }>,
+): CircleRecipientSelection {
+  return {
+    circle: {
+      id: "circle-1",
+      name: "Family",
+      kind: "family",
+      role: "owner",
+      memberCount: ready.length + 1,
+      memberLimit: 100,
+      members: ready.map((person) => member(person.userId, person.displayName)),
+    },
+    ready: ready.map((person) => ({
+      sourceCircleId: "circle-1",
+      recipient: {
+        userId: person.userId,
+        displayName: person.displayName,
+        phoneVerified: true,
+        keyId: `key-${person.userId}`,
+        publicKeyJwk: { kty: "EC" },
+        keyAlgorithm: "fixture",
+        canReceiveLocation: true,
+      },
+    })),
+    excluded: [
+      {
+        member: member("not-ready", "Priya"),
+        reason: "location_setup_needed",
+        label: "Location setup is not complete",
+      },
+    ],
+  } as CircleRecipientSelection;
+}
+
 const baseProps = {
   recipients,
   circles: [
@@ -43,30 +100,33 @@ const baseProps = {
       kind: "family" as const,
       role: "owner" as const,
       memberCount: 3,
-      memberLimit: 20,
+      memberLimit: 100,
     },
   ],
   selectedUserIds: ["selected"],
   busyKey: null,
-  onBack: vi.fn(),
   onAdd: vi.fn(),
-  onAddCircle: vi.fn().mockResolvedValue(undefined),
+  onAddCircleMembers: vi.fn().mockResolvedValue(undefined),
+  onLoadCircleMembers: vi
+    .fn()
+    .mockResolvedValue(
+      circleSelection([
+        { userId: "aarav", displayName: "Aarav Shah" },
+        { userId: "maya", displayName: "Maya Chen" },
+      ]),
+    ),
   onRemove: vi.fn(),
   recipientLabel: (recipient: OneLocationRecipient) => recipient.displayName,
   recipientSubtitle: (recipient: OneLocationRecipient) =>
     recipient.maskedPhone || "Connected",
   isRecipientShareReady: (recipient: OneLocationRecipient) =>
     recipient.canReceiveLocation,
-  onShareCircleCode: vi.fn().mockResolvedValue(undefined),
-  onLoadCircleEligibleConnections: vi.fn().mockResolvedValue({
-    eligibleConnections: [],
-    pendingInvites: [],
-    remainingCapacity: 0,
-  }),
-  onInviteCircleConnections: vi.fn().mockResolvedValue(undefined),
-  onCancelCircleMemberInvite: vi.fn().mockResolvedValue(undefined),
 };
 
+/** The flat directory lives behind the second tab now. */
+function openAllContacts() {
+  fireEvent.click(screen.getByRole("tab", { name: "All Contacts" }));
+}
 
 describe("SmsContactsFlow", () => {
   it("grows past phone width and keeps contacts in one calm column", () => {
@@ -80,49 +140,230 @@ describe("SmsContactsFlow", () => {
       .firstElementChild as HTMLElement;
     expect(column).toHaveClass("max-w-[430px]");
     expect(column).toHaveClass("md:max-w-[680px]", "xl:max-w-[720px]");
-
-    // SMS contacts are a simple contact-management task. A forced two-column
-    // desktop split made the page feel scattered.
-    const lists = screen.getByText("Contacts").closest("div")
-      ?.parentElement as HTMLElement;
-    expect(lists).toHaveClass("grid", "gap-6");
-    expect(lists).not.toHaveClass("md:grid-cols-2");
   });
 
-  it("separates selected and available circle members", () => {
+  it("presents exactly two sections: Circles and All Contacts", () => {
     render(<SmsContactsFlow {...baseProps} />);
 
-    expect(screen.getByText("Contacts")).toBeInTheDocument();
-    expect(screen.getByText("Add contacts")).toBeInTheDocument();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.textContent)).toEqual([
+      "Circles",
+      "All Contacts",
+    ]);
+    // "Add contacts" named the button on each row rather than the list, which
+    // left the screen holding a "Contacts" list and an "Add contacts" list that
+    // were the same people in two states.
+    expect(screen.queryByText("Add contacts")).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("sms-circles-panel")).toBeInTheDocument();
+    openAllContacts();
+    expect(screen.getByTestId("sms-all-contacts-panel")).toBeInTheDocument();
     expect(screen.getByText("Kushal")).toBeInTheDocument();
     expect(screen.getByText("Neelesh")).toBeInTheDocument();
+  });
+
+  it("opens on All Contacts when the account has no Circles", () => {
+    // Landing on an empty tab makes the screen look broken before the person
+    // has done anything.
+    render(<SmsContactsFlow {...baseProps} circles={[]} />);
+
+    expect(screen.getByTestId("sms-all-contacts-panel")).toBeInTheDocument();
   });
 
   it("adds an available recipient", () => {
     const onAdd = vi.fn();
     render(<SmsContactsFlow {...baseProps} onAdd={onAdd} />);
 
+    openAllContacts();
     fireEvent.click(screen.getByRole("button", { name: "Add Neelesh" }));
     expect(onAdd).toHaveBeenCalledWith("available");
   });
 
-  it("adds the current ready members from an explicitly selected Circle", () => {
-    const onAddCircle = vi.fn().mockResolvedValue(undefined);
-    render(
-      <SmsContactsFlow {...baseProps} onAddCircle={onAddCircle} />,
-    );
+  describe("per-Circle person picker", () => {
+    it("picks individual members instead of taking the whole Circle", async () => {
+      // The reported gap: a Circle offered one "Add" that took every member.
+      // Tolerable at 20; not at 100.
+      const onAddCircleMembers = vi.fn().mockResolvedValue(undefined);
+      render(
+        <SmsContactsFlow
+          {...baseProps}
+          onAddCircleMembers={onAddCircleMembers}
+        />,
+      );
 
-    fireEvent.click(screen.getByRole("button", { name: "Add Family" }));
+      // Collapsed, the row is an expander -- not an all-or-nothing Add.
+      expect(
+        screen.queryByRole("button", { name: "Add Family" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("3 members")).toBeInTheDocument();
 
-    expect(onAddCircle).toHaveBeenCalledWith("circle-1");
-    expect(screen.getByText("3 members")).toBeInTheDocument();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Choose people from Family" }),
+      );
+
+      const list = await screen.findByTestId("circle-members-circle-1");
+      fireEvent.click(
+        within(list).getByRole("checkbox", { name: "Aarav Shah" }),
+      );
+
+      fireEvent.click(screen.getByTestId("circle-add-selected-circle-1"));
+      await waitFor(() => {
+        expect(onAddCircleMembers).toHaveBeenCalledWith("circle-1", ["aarav"]);
+      });
+      // Only the ticked person, never the roster.
+      expect(onAddCircleMembers).not.toHaveBeenCalledWith("circle-1", [
+        "aarav",
+        "maya",
+      ]);
+    });
+
+    it("resolves the roster only when the Circle is opened", async () => {
+      // Ten collapsed Circles must not cost ten roster requests.
+      const onLoadCircleMembers = baseProps.onLoadCircleMembers;
+      onLoadCircleMembers.mockClear();
+      render(<SmsContactsFlow {...baseProps} />);
+
+      expect(onLoadCircleMembers).not.toHaveBeenCalled();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Choose people from Family" }),
+      );
+      await waitFor(() =>
+        expect(onLoadCircleMembers).toHaveBeenCalledWith("circle-1"),
+      );
+    });
+
+    it("names members it cannot add rather than dropping them silently", async () => {
+      render(<SmsContactsFlow {...baseProps} />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Choose people from Family" }),
+      );
+
+      // Someone hunting for a person who is not there needs to know they were
+      // found and skipped, not silently absent.
+      expect(await screen.findByText("Priya")).toBeInTheDocument();
+      expect(
+        screen.getByText("Location setup is not complete"),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Priya" })).toBeDisabled();
+    });
+
+    it("selects and clears every addable member at once", async () => {
+      const onAddCircleMembers = vi.fn().mockResolvedValue(undefined);
+      render(
+        <SmsContactsFlow
+          {...baseProps}
+          onAddCircleMembers={onAddCircleMembers}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Choose people from Family" }),
+      );
+      fireEvent.click(await screen.findByRole("button", { name: "Select all 2" }));
+      fireEvent.click(screen.getByTestId("circle-add-selected-circle-1"));
+
+      await waitFor(() => {
+        expect(onAddCircleMembers).toHaveBeenCalledWith("circle-1", [
+          "aarav",
+          "maya",
+        ]);
+      });
+    });
+  });
+
+  describe("conditional list controls", () => {
+    it("hides search and sort while a list still fits on one screen", () => {
+      render(<SmsContactsFlow {...baseProps} />);
+
+      openAllContacts();
+      // Two contacts. A search field here is furniture, not help.
+      expect(
+        screen.queryByTestId("contact-list-controls"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("reveals them once the list outgrows a screenful, and filters on it", () => {
+      const many: OneLocationRecipient[] = Array.from({ length: 24 }, (_, i) => ({
+        ...recipients[1]!,
+        userId: `person-${i}`,
+        displayName: i === 7 ? "Zubin Mehta" : `Person ${i}`,
+      }));
+      render(
+        <SmsContactsFlow {...baseProps} recipients={many} selectedUserIds={[]} />,
+      );
+
+      openAllContacts();
+      expect(screen.getByTestId("contact-list-controls")).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText("Search contacts"), {
+        target: { value: "zubin" },
+      });
+      expect(screen.getByText("Zubin Mehta")).toBeInTheDocument();
+      expect(screen.queryByText("Person 3")).not.toBeInTheDocument();
+
+      // The defect this guards: measuring the FILTERED list would unmount the
+      // field the moment it narrowed below the threshold, which clears the
+      // query, which regrows the list, which remounts the field.
+      expect(screen.getByTestId("contact-list-controls")).toBeInTheDocument();
+    });
+  });
+
+  describe("sticky review pill and sheet", () => {
+    it("counts the added people and opens a sheet listing them", async () => {
+      render(<SmsContactsFlow {...baseProps} />);
+
+      const pill = screen.getByTestId("sms-selected-pill");
+      expect(pill).toHaveTextContent("1 person added");
+
+      fireEvent.click(pill);
+      const sheet = await screen.findByTestId("sms-selected-sheet");
+      // Only the people actually added, from either tab.
+      expect(within(sheet).getByText("Kushal")).toBeInTheDocument();
+      expect(within(sheet).queryByText("Neelesh")).not.toBeInTheDocument();
+    });
+
+    it("sits above the app's own bottom chrome rather than a guessed offset", () => {
+      render(<SmsContactsFlow {...baseProps} />);
+
+      const anchor = screen.getByTestId("sms-selected-pill").parentElement!;
+      // The shell publishes its height; hard-coding one breaks the moment the
+      // nav changes size or the keyboard opens.
+      expect(anchor.style.bottom).toContain("--bottom-chrome-full-height");
+      expect(anchor.style.bottom).toContain("--kb-height");
+      expect(anchor.style.bottom).toContain("safe-area-inset-bottom");
+    });
+
+    it("shows no pill at all when nobody is added", () => {
+      render(<SmsContactsFlow {...baseProps} selectedUserIds={[]} />);
+
+      // A permanent "0 people added" hovering over a screen whose whole job is
+      // to stop being 0.
+      expect(screen.queryByTestId("sms-selected-pill")).not.toBeInTheDocument();
+    });
+
+    it("removes from the sheet through the same confirmation", async () => {
+      const onRemove = vi.fn().mockResolvedValue(true);
+      render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
+
+      fireEvent.click(screen.getByTestId("sms-selected-pill"));
+      const sheet = await screen.findByTestId("sms-selected-sheet");
+      fireEvent.click(
+        within(sheet).getByRole("button", { name: "Remove Kushal" }),
+      );
+
+      // Never a silent delete, wherever it is triggered from.
+      expect(onRemove).not.toHaveBeenCalled();
+      expect(await screen.findByText("Remove Kushal?")).toBeInTheDocument();
+    });
   });
 
   it("requires confirmation and waits for successful removal", async () => {
     const onRemove = vi.fn().mockResolvedValue(true);
     render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
 
-    const removeButton = screen.getByRole("button", { name: "Remove" });
+    openAllContacts();
+    const removeButton = screen.getByRole("button", { name: "Remove Kushal" });
     // The ground is the semantic `-tint` partner, not a one-off alpha on the
     // flat token. Hand-rolled alphas are what made the same destructive ground
     // render a slightly different colour on every screen that spelled it out.
@@ -136,9 +377,9 @@ describe("SmsContactsFlow", () => {
 
     const title = screen.getByRole("heading", { name: /Remove Kushal\?/i });
     expect(title.querySelector("span")).toHaveClass("text-foreground");
-    expect(
-      screen.getByText("They won't receive SMS alerts."),
-    ).toHaveClass("!text-muted-foreground");
+    expect(screen.getByText("They won't receive SMS alerts.")).toHaveClass(
+      "!text-muted-foreground",
+    );
 
     const removeButtons = screen.getAllByRole("button", {
       name: "Remove",
@@ -155,7 +396,8 @@ describe("SmsContactsFlow", () => {
     const onRemove = vi.fn().mockResolvedValue(false);
     render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    openAllContacts();
+    fireEvent.click(screen.getByRole("button", { name: "Remove Kushal" }));
     const removeButtons = screen.getAllByRole("button", {
       name: "Remove",
       hidden: true,
@@ -191,7 +433,8 @@ describe("SmsContactsFlow", () => {
       screen.getByRole("heading", { level: 1, name: "SMS contacts" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    openAllContacts();
+    fireEvent.click(screen.getByRole("button", { name: "Remove Kushal" }));
     expect(screen.getByRole("alertdialog")).toHaveClass(
       "!bottom-0",
       "!top-auto",
@@ -214,11 +457,5 @@ describe("SmsContactsFlow", () => {
     expect(
       screen.queryByRole("button", { name: /Invite people/i }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /Share code/i }),
-    ).not.toBeInTheDocument();
-
-    // The contact lists it exists for are untouched.
-    expect(screen.getByText("Circles")).toBeInTheDocument();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/contact-picker/__tests__/virtual-list.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/__tests__/virtual-list.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import { CONTACT_LIST_CONTROLS_THRESHOLD } from "@/lib/one-location/contact-picker-controls";
+
+/**
+ * jsdom gives every element a zero-sized box, so a windowing virtualizer sees
+ * a viewport it can fit nothing in and renders no rows at all. That is a
+ * property of the test environment, not of the component -- but it means the
+ * virtualized branch is invisible to a plain render, which is exactly how a
+ * broken one would ship unnoticed.
+ *
+ * So the scroll container is given a real height here, the way the browser
+ * gives it one from `max-h-[52vh]`, and the window is asserted against it.
+ */
+function withMeasuredViewport(heightPx: number) {
+  const rect = vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function measured(this: HTMLElement) {
+      const height = this.dataset.virtualized === "true" ? heightPx : 58;
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 320,
+        bottom: height,
+        width: 320,
+        height,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+  const clientHeight = vi
+    .spyOn(HTMLElement.prototype, "clientHeight", "get")
+    .mockReturnValue(heightPx);
+  return () => {
+    rect.mockRestore();
+    clientHeight.mockRestore();
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+const rows = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({ id: String(index) }));
+
+function renderList(count: number) {
+  return render(
+    <VirtualContactList
+      items={rows(count)}
+      getKey={(row) => row.id}
+      testId="probe-list"
+      ariaLabel="Probe"
+      renderItem={(row) => <div data-testid="probe-row">row {row.id}</div>}
+    />,
+  );
+}
+
+describe("VirtualContactList", () => {
+  it("renders a short list as plain rows, with no windowing at all", () => {
+    renderList(CONTACT_LIST_CONTROLS_THRESHOLD);
+
+    const list = screen.getByTestId("probe-list");
+    expect(list).not.toHaveAttribute("data-virtualized");
+    // Every row present: a virtualizer measuring ten rows costs more than it
+    // saves, and keeping them plain is what leaves small fixtures directly
+    // assertable in every other test in this feature.
+    expect(screen.getAllByTestId("probe-row")).toHaveLength(
+      CONTACT_LIST_CONTROLS_THRESHOLD,
+    );
+  });
+
+  it("windows a long roster instead of mounting all of it", () => {
+    const restore = withMeasuredViewport(400);
+    try {
+      renderList(120);
+
+      const list = screen.getByTestId("probe-list");
+      expect(list).toHaveAttribute("data-virtualized", "true");
+
+      // The scalability claim, stated as a bound rather than a feeling: a
+      // 120-person Circle must not put 120 rows in the document.
+      const mounted = screen.queryAllByTestId("probe-row");
+      expect(mounted.length).toBeLessThan(30);
+
+      // ...while the scroller still reserves the full height, so the scrollbar
+      // tells the truth about how much list there is. The two together are
+      // what "windowed" means, and together they fail loudly if this ever
+      // regresses to rendering the whole roster.
+      const sizer = list.firstElementChild as HTMLElement;
+      expect(parseInt(sizer.style.height, 10)).toBeGreaterThanOrEqual(120 * 58);
+
+      // Deliberately NOT asserted here: that at least one row is mounted.
+      // jsdom's ResizeObserver is a no-op stub (see __tests__/setup.ts), so the
+      // virtualizer is never handed a viewport and computes an empty visible
+      // range no matter what the element's rect claims. Proving the window is
+      // non-empty needs a real layout engine, which is a browser-level layout
+      // spec's job, not this file's.
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps its own scroll surface bounded so the page does not nest scrollers", () => {
+    const restore = withMeasuredViewport(400);
+    try {
+      renderList(120);
+      const list = screen.getByTestId("probe-list");
+      expect(list.className).toContain("overflow-y-auto");
+      expect(list.className).toContain("max-h-[52vh]");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
+
+/**
+ * Shared row furniture for the SMS contact picker.
+ *
+ * Extracted from `sms-contacts-flow` when the picker grew a second list (the
+ * per-Circle member picker) and a third (the review sheet). Three copies of a
+ * 58px person row is how they drift apart.
+ */
+
+/**
+ * A person avatar reports no state of its own — the initials identify, the
+ * trailing control acts. Keeping it neutral leaves exactly one accent per row
+ * instead of two competing across the same 58px.
+ */
+export const CONTACT_AVATAR_TONE = cn(
+  roleClasses("neutral").tile,
+  roleClasses("neutral").glyph,
+);
+
+/** The row height every list here is measured and virtualized against. */
+export const CONTACT_ROW_HEIGHT_PX = 58;
+
+export function initials(value: string): string {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  return ((parts[0]?.[0] ?? "?") + (parts[1]?.[0] ?? ""))
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function ContactAvatar({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[15px] font-semibold",
+        CONTACT_AVATAR_TONE,
+        className,
+      )}
+      aria-hidden
+    >
+      {initials(label)}
+    </span>
+  );
+}
+
+export function ContactGroup({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "divide-y divide-[color:var(--app-separator)] overflow-hidden rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] shadow-none",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function EmptyStateCard({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-[72px] w-full items-center justify-center rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-5 py-4 text-center text-[15px] font-normal leading-5 text-muted-foreground shadow-none transition-all duration-200 ease-out">
+      <p className="max-w-[280px]">{message}</p>
+    </div>
+  );
+}
+
+/**
+ * The Add / Remove control that ends a person row.
+ *
+ * `ready === false` means the person has not finished Location or phone setup,
+ * so adding them would silently produce a contact who receives nothing. The
+ * button says "Setup" rather than going disabled-and-silent, because the row
+ * still has to explain why it will not act.
+ */
+export function ContactRowAction({
+  selected,
+  busy,
+  ready,
+  label,
+  onAdd,
+  onRemove,
+}: {
+  selected: boolean;
+  busy: boolean;
+  ready: boolean;
+  label: string;
+  onAdd: () => void;
+  onRemove: () => void;
+}) {
+  if (selected) {
+    return (
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={busy}
+        aria-label={`Remove ${label}`}
+        className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full bg-[color:var(--app-destructive-tint)] px-3 text-[13px] font-semibold text-[color:var(--app-destructive)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:opacity-45"
+      >
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onAdd}
+      disabled={busy || !ready}
+      aria-label={`Add ${label}`}
+      className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-muted-foreground"
+    >
+      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : ready ? "Add" : "Setup"}
+    </button>
+  );
+}
+
+export function ContactRow({
+  label,
+  subtitle,
+  selected,
+  busy,
+  ready,
+  onAdd,
+  onRemove,
+}: {
+  label: string;
+  subtitle?: string | null;
+  selected: boolean;
+  busy: boolean;
+  ready: boolean;
+  onAdd: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      className="flex min-h-[58px] items-center gap-3 px-3.5 py-2"
+      data-testid="contact-picker-row"
+    >
+      <ContactAvatar label={label} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+          {label}
+        </span>
+        {subtitle ? (
+          <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+      <ContactRowAction
+        selected={selected}
+        busy={busy}
+        ready={ready}
+        label={label}
+        onAdd={onAdd}
+        onRemove={onRemove}
+      />
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, ChevronDown, Loader2, UsersRound } from "lucide-react";
+
+import { ContactAvatar } from "@/components/one-location/redesign/contact-picker/atoms";
+import { ContactListControls } from "@/components/one-location/redesign/contact-picker/list-controls";
+import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import {
+  filterByContactQuery,
+  sortByContactMode,
+  type ContactSortMode,
+} from "@/lib/one-location/contact-picker-controls";
+import type { CircleRecipientSelection } from "@/lib/one-location/circle-recipient-selection";
+import type { OneLocationCircleSummary } from "@/lib/one-location/types";
+import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
+import { cn } from "@/lib/utils";
+
+type MemberRow = {
+  userId: string;
+  label: string;
+  /** Set when the member cannot receive SMS yet; explains why, inline. */
+  blockedReason: string | null;
+};
+
+/**
+ * One Circle, expandable into its own member picker.
+ *
+ * The old row offered a single "Add" that took the whole roster. That was
+ * tolerable at 20 members and is not at 100 (migration 158): adding a
+ * hundred-person Circle to emergency SMS because you wanted four of them is
+ * not a mistake the UI should make easy to make.
+ *
+ * Expanding resolves the roster through the same
+ * `resolveCircleRecipientSelection` the Share flow uses, so "who in this Circle
+ * can actually receive an SMS" is answered once, in one place, for both
+ * features. Members it excludes are still listed -- with the reason -- because
+ * someone hunting for a person who is not there needs to know they were found
+ * and skipped, not silently absent.
+ */
+export function CircleMemberPicker({
+  circle,
+  expanded,
+  onToggle,
+  selectedUserIds,
+  busy,
+  onLoadMembers,
+  onAddMembers,
+  recipientLabel,
+}: {
+  circle: OneLocationCircleSummary;
+  expanded: boolean;
+  onToggle: () => void;
+  selectedUserIds: ReadonlySet<string>;
+  busy: boolean;
+  onLoadMembers: (circleId: string) => Promise<CircleRecipientSelection>;
+  onAddMembers: (circleId: string, userIds: string[]) => Promise<void>;
+  recipientLabel: (person: {
+    userId: string;
+    displayName?: string | null;
+  }) => string;
+}) {
+  const [selection, setSelection] = useState<CircleRecipientSelection | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [ticked, setTicked] = useState<ReadonlySet<string>>(() => new Set());
+  const [query, setQuery] = useState("");
+  const [sortMode, setSortMode] = useState<ContactSortMode>("default");
+  const [adding, setAdding] = useState(false);
+
+  // STATE BEATS CATEGORY: a Circle is the people role, but one holding nobody
+  // except the viewer has nothing to report and stays neutral. `memberCount`
+  // includes the viewer, so the count that decides this is `memberCount - 1` --
+  // the same test the Circles list and the check-in flow apply.
+  const circleRole = roleClasses("people", {
+    inactive: Math.max(0, circle.memberCount - 1) === 0,
+  });
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      setSelection(await onLoadMembers(circle.id));
+    } catch {
+      setSelection(null);
+      setLoadError("This Circle's members could not be loaded. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [circle.id, onLoadMembers]);
+
+  // Resolved on expand, not on mount. A hub with ten Circles would otherwise
+  // fire ten roster requests just to draw ten collapsed rows.
+  useEffect(() => {
+    if (!expanded || selection || loading || loadError) return;
+    void load();
+  }, [expanded, load, loadError, loading, selection]);
+
+  const readyRows = useMemo<MemberRow[]>(() => {
+    if (!selection) return [];
+    return selection.ready.map((target) => ({
+      userId: target.recipient.userId,
+      label: recipientLabel(target.recipient),
+      blockedReason: null,
+    }));
+  }, [recipientLabel, selection]);
+
+  const blockedRows = useMemo<MemberRow[]>(() => {
+    if (!selection) return [];
+    return (
+      selection.excluded
+        // "You are not a recipient of your own alert" is not news, and listing
+        // the viewer in their own Circle's picker is noise in every roster.
+        .filter((item) => item.reason !== "self")
+        .map((item) => ({
+          userId: item.member.userId,
+          label: recipientLabel(item.member),
+          blockedReason: item.label,
+        }))
+    );
+  }, [recipientLabel, selection]);
+
+  const allRows = useMemo(
+    () => [...readyRows, ...blockedRows],
+    [blockedRows, readyRows],
+  );
+
+  const visibleRows = useMemo(
+    () =>
+      sortByContactMode(
+        filterByContactQuery(allRows, query, (row) => row.label),
+        sortMode,
+        (row) => row.label,
+      ),
+    [allRows, query, sortMode],
+  );
+
+  const addableIds = useMemo(
+    () =>
+      readyRows
+        .filter((row) => !selectedUserIds.has(row.userId))
+        .map((row) => row.userId),
+    [readyRows, selectedUserIds],
+  );
+  const tickedAddable = useMemo(
+    () => addableIds.filter((id) => ticked.has(id)),
+    [addableIds, ticked],
+  );
+  const allAddableTicked =
+    addableIds.length > 0 && tickedAddable.length === addableIds.length;
+
+  const toggleMember = (userId: string) => {
+    setTicked((current) => {
+      const next = new Set(current);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const commit = async () => {
+    if (!tickedAddable.length || adding) return;
+    setAdding(true);
+    try {
+      await onAddMembers(circle.id, tickedAddable);
+      setTicked(new Set());
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const alreadyAddedCount = readyRows.filter((row) =>
+    selectedUserIds.has(row.userId),
+  ).length;
+
+  const toggleAll = () =>
+    setTicked((current) => {
+      const next = new Set(current);
+      if (allAddableTicked) {
+        for (const id of addableIds) next.delete(id);
+      } else {
+        for (const id of addableIds) next.add(id);
+      }
+      return next;
+    });
+
+  return (
+    <div data-testid={"circle-picker-" + circle.id}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-label={
+          (expanded ? "Collapse " : "Choose people from ") + circle.name
+        }
+        className="flex min-h-[58px] w-full items-center gap-3 px-3.5 py-2 text-left"
+      >
+        <span
+          className={cn(
+            "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
+            circleRole.tile,
+            circleRole.glyph,
+          )}
+        >
+          <UsersRound className="h-[17px] w-[17px]" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+            {circle.name}
+          </span>
+          <span className="mt-0.5 block text-[15px] leading-5 text-muted-foreground">
+            {circle.memberCount} members
+            {alreadyAddedCount ? " · " + alreadyAddedCount + " added" : ""}
+          </span>
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 motion-reduce:transition-none",
+            expanded && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-[color:var(--app-separator)] bg-[color:var(--app-neutral-fill)] px-3.5 py-3">
+          {loading ? (
+            <p className="flex items-center gap-2 py-2 text-[15px] text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading members…
+            </p>
+          ) : loadError ? (
+            <div role="status" className="py-1">
+              <p className="text-[15px] text-muted-foreground">{loadError}</p>
+              <button
+                type="button"
+                onClick={() => void load()}
+                className="mt-2 h-9 rounded-full bg-[color:var(--app-neutral-fill-strong)] px-4 text-[13px] font-semibold text-foreground"
+              >
+                Try again
+              </button>
+            </div>
+          ) : !allRows.length ? (
+            <p className="py-2 text-[15px] text-muted-foreground">
+              No one in this Circle is ready for SMS yet.
+            </p>
+          ) : (
+            <>
+              <ContactListControls
+                sourceCount={allRows.length}
+                query={query}
+                onQueryChange={setQuery}
+                sortMode={sortMode}
+                onSortModeChange={setSortMode}
+                placeholder={"Search " + circle.name}
+                resultCount={visibleRows.length}
+              />
+
+              {addableIds.length ? (
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    onClick={toggleAll}
+                    className="h-8 rounded-full px-3 text-[13px] font-semibold text-[color:var(--app-accent)]"
+                  >
+                    {allAddableTicked
+                      ? "Clear all"
+                      : "Select all " + addableIds.length}
+                  </button>
+                  <span className="text-[13px] text-muted-foreground">
+                    {tickedAddable.length} selected
+                  </span>
+                </div>
+              ) : null}
+
+              <VirtualContactList
+                items={visibleRows}
+                getKey={(row) => row.userId}
+                testId={"circle-members-" + circle.id}
+                ariaLabel={circle.name + " members"}
+                maxHeightClassName="max-h-[44vh]"
+                renderItem={(row) => {
+                  const added = selectedUserIds.has(row.userId);
+                  const blocked = Boolean(row.blockedReason);
+                  const checked = added || ticked.has(row.userId);
+                  return (
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={checked}
+                      aria-label={row.label}
+                      disabled={added || blocked || adding || busy}
+                      onClick={() => toggleMember(row.userId)}
+                      className={cn(
+                        "flex min-h-[58px] w-full items-center gap-3 px-3.5 py-2 text-left",
+                        (added || blocked) && "opacity-60",
+                      )}
+                    >
+                      <ContactAvatar label={row.label} />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+                          {row.label}
+                        </span>
+                        {row.blockedReason ? (
+                          <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+                            {row.blockedReason}
+                          </span>
+                        ) : added ? (
+                          <span className="mt-0.5 block text-[13px] leading-4 text-muted-foreground">
+                            Already added
+                          </span>
+                        ) : null}
+                      </span>
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border-2",
+                          checked
+                            ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)]"
+                            : "border-[color:var(--app-separator)]",
+                          blocked && "opacity-40",
+                        )}
+                      >
+                        {checked ? (
+                          <Check className="h-3.5 w-3.5 text-[color:var(--app-accent-fg)]" />
+                        ) : null}
+                      </span>
+                    </button>
+                  );
+                }}
+              />
+
+              <button
+                type="button"
+                disabled={!tickedAddable.length || adding || busy}
+                onClick={() => void commit()}
+                data-testid={"circle-add-selected-" + circle.id}
+                className="press-scale mt-3 flex h-11 w-full items-center justify-center gap-2 rounded-full bg-[color:var(--app-accent)] text-[15px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-muted-foreground"
+              >
+                {adding ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {tickedAddable.length
+                  ? "Add " +
+                    tickedAddable.length +
+                    (tickedAddable.length === 1 ? " person" : " people")
+                  : "Select people to add"}
+              </button>
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/list-controls.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/list-controls.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { PersonSearchInput } from "@/components/one-location/redesign/selectors";
+import {
+  CONTACT_SORT_MODES,
+  shouldRevealListControls,
+  type ContactSortMode,
+} from "@/lib/one-location/contact-picker-controls";
+import { cn } from "@/lib/utils";
+
+/**
+ * Search and sort for one list — present only while that list is long enough
+ * to need them.
+ *
+ * The reveal decision lives in `shouldRevealListControls`, and the two
+ * properties it protects are worth restating where the component uses it:
+ *
+ *   * `sourceCount` is the section's FULL length, never the filtered result.
+ *     Measuring the filtered list would make this control delete itself: type
+ *     a query, 40 rows become 4, the field unmounts, the query dies with it,
+ *     the list returns to 40, the field remounts.
+ *   * Once revealed it stays revealed for as long as the section is mounted,
+ *     so removing people one at a time cannot pull the field out from under a
+ *     half-typed query.
+ */
+export function ContactListControls({
+  sourceCount,
+  query,
+  onQueryChange,
+  sortMode,
+  onSortModeChange,
+  placeholder,
+  voiceControlId,
+  resultCount,
+}: {
+  sourceCount: number;
+  query: string;
+  onQueryChange: (next: string) => void;
+  sortMode: ContactSortMode;
+  onSortModeChange: (next: ContactSortMode) => void;
+  placeholder: string;
+  voiceControlId?: string;
+  /** Rows currently on screen, announced politely while a query is active. */
+  resultCount: number;
+}) {
+  // State, not a ref: the latch has to survive re-renders AND be allowed to
+  // cause one. It only ever moves false -> true, which is the whole point --
+  // `shouldRevealListControls` is handed the current value so the rule itself
+  // stays in one tested place rather than being re-implemented here.
+  const [revealed, setRevealed] = useState(() =>
+    shouldRevealListControls(sourceCount),
+  );
+  useEffect(() => {
+    setRevealed((current) => shouldRevealListControls(sourceCount, current));
+  }, [sourceCount]);
+
+  // A list that was already long on first render has always had its controls;
+  // animating them in on load would be a glitch, not a reveal. Only a list
+  // that GROWS past the threshold gets the transition.
+  const [entered, setEntered] = useState(() =>
+    shouldRevealListControls(sourceCount),
+  );
+  useEffect(() => {
+    if (!revealed || entered) return;
+    const frame = window.requestAnimationFrame(() => setEntered(true));
+    return () => window.cancelAnimationFrame(frame);
+  }, [entered, revealed]);
+
+  if (!revealed) return null;
+
+  const queryActive = query.trim().length > 0;
+
+  return (
+    <div
+      data-testid="contact-list-controls"
+      className={cn(
+        "grid gap-2 overflow-hidden transition-all duration-200 ease-out motion-reduce:transition-none",
+        entered ? "mb-3 max-h-40 opacity-100" : "mb-0 max-h-0 opacity-0",
+      )}
+    >
+      <PersonSearchInput
+        value={query}
+        onChange={onQueryChange}
+        placeholder={placeholder}
+        voiceControlId={voiceControlId}
+      />
+      <div
+        className="flex items-center gap-1.5 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="group"
+        aria-label="Sort contacts"
+      >
+        {CONTACT_SORT_MODES.map((mode) => {
+          const active = mode.value === sortMode;
+          return (
+            <button
+              key={mode.value}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onSortModeChange(mode.value)}
+              className={cn(
+                "press-scale h-8 shrink-0 rounded-full px-3 text-[13px] font-semibold transition-colors",
+                active
+                  ? "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
+                  : "bg-[color:var(--app-neutral-fill-strong)] text-foreground",
+              )}
+            >
+              {mode.label}
+            </button>
+          );
+        })}
+      </div>
+      {/* A filtered list that comes back empty has to say so out loud, or the
+          only feedback for a typo is rows silently vanishing. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {queryActive
+          ? `${resultCount} ${resultCount === 1 ? "result" : "results"}`
+          : ""}
+      </p>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Loader2, UsersRound } from "lucide-react";
+
+import {
+  ContactAvatar,
+  EmptyStateCard,
+} from "@/components/one-location/redesign/contact-picker/atoms";
+import { ContactListControls } from "@/components/one-location/redesign/contact-picker/list-controls";
+import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import {
+  filterByContactQuery,
+  peoplePillLabel,
+  sortByContactMode,
+  type ContactSortMode,
+} from "@/lib/one-location/contact-picker-controls";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * The sticky counter, and the sheet it opens.
+ *
+ * Selection used to be readable only by scrolling the whole screen and
+ * counting the rows wearing a Remove button -- across two sections, and soon
+ * across two tabs. The pill answers "who is on this list" from anywhere in the
+ * flow, and the sheet is where that answer gets edited.
+ *
+ * Vaul's drawer rather than a dialog, because this is a review surface a thumb
+ * should be able to drag away: it is not a decision, and dismissing it must
+ * cost nothing.
+ */
+
+export function SelectedContactsPill({
+  count,
+  onOpen,
+}: {
+  count: number;
+  onOpen: () => void;
+}) {
+  // Nothing selected, nothing to review. An empty pill would be a permanent
+  // "0 people added" hovering over a screen whose whole job is to stop being 0.
+  if (count <= 0) return null;
+  return (
+    // Sits above the app's own bottom chrome by reading the height the shell
+    // publishes (`--bottom-chrome-full-height`, set in app-bottom-shell) rather
+    // than guessing an offset that breaks the moment the nav changes height or
+    // the keyboard opens.
+    <div
+      className="pointer-events-none sticky z-40 flex justify-center px-4"
+      style={{
+        bottom:
+          "calc(var(--bottom-chrome-full-height, 0px) + var(--kb-height, 0px) + max(12px, env(safe-area-inset-bottom)))",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onOpen}
+        data-testid="sms-selected-pill"
+        aria-label={"Review " + peoplePillLabel(count)}
+        className="press-scale pointer-events-auto flex h-11 max-w-full items-center gap-2 rounded-full bg-[color:var(--app-accent)] px-5 text-[15px] font-semibold text-[color:var(--app-accent-fg)] shadow-lg"
+      >
+        <UsersRound className="h-4 w-4 shrink-0" aria-hidden />
+        <span className="truncate">{peoplePillLabel(count)}</span>
+      </button>
+    </div>
+  );
+}
+
+export function SelectedContactsSheet({
+  open,
+  onOpenChange,
+  recipients,
+  busyUserId,
+  onRemove,
+  recipientLabel,
+  recipientSubtitle,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  recipients: OneLocationRecipient[];
+  busyUserId: string | null;
+  onRemove: (recipientUserId: string) => void;
+  recipientLabel: (recipient: OneLocationRecipient) => string;
+  recipientSubtitle?: (recipient: OneLocationRecipient) => string;
+}) {
+  const [query, setQuery] = useState("");
+  const [sortMode, setSortMode] = useState<ContactSortMode>("default");
+
+  const visible = useMemo(
+    () =>
+      sortByContactMode(
+        filterByContactQuery(recipients, query, recipientLabel),
+        sortMode,
+        recipientLabel,
+      ),
+    [query, recipientLabel, recipients, sortMode],
+  );
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent
+        className="max-h-[80vh]"
+        data-testid="sms-selected-sheet"
+        aria-describedby={undefined}
+      >
+        <DrawerHeader className="pb-2 text-left">
+          <DrawerTitle className="text-[20px] font-semibold leading-[25px]">
+            {peoplePillLabel(recipients.length)}
+          </DrawerTitle>
+          <DrawerDescription className="text-[15px] leading-5 text-muted-foreground">
+            They receive your SMS alerts. Remove anyone who should not.
+          </DrawerDescription>
+        </DrawerHeader>
+
+        <div
+          className={cn(
+            "min-h-0 flex-1 overflow-y-auto px-4",
+            "pb-[max(16px,env(safe-area-inset-bottom))]",
+          )}
+        >
+          <ContactListControls
+            sourceCount={recipients.length}
+            query={query}
+            onQueryChange={setQuery}
+            sortMode={sortMode}
+            onSortModeChange={setSortMode}
+            placeholder="Search added people"
+            resultCount={visible.length}
+          />
+
+          {visible.length ? (
+            <VirtualContactList
+              items={visible}
+              getKey={(recipient) => recipient.userId}
+              testId="sms-selected-sheet-list"
+              ariaLabel="People added to SMS alerts"
+              maxHeightClassName="max-h-[52vh]"
+              renderItem={(recipient) => {
+                const label = recipientLabel(recipient);
+                const subtitle = recipientSubtitle?.(recipient);
+                const busy = busyUserId === recipient.userId;
+                return (
+                  <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
+                    <ContactAvatar label={label} />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+                        {label}
+                      </span>
+                      {subtitle ? (
+                        <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+                          {subtitle}
+                        </span>
+                      ) : null}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(recipient.userId)}
+                      disabled={busy}
+                      aria-label={"Remove " + label}
+                      className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full bg-[color:var(--app-destructive-tint)] px-3 text-[13px] font-semibold text-[color:var(--app-destructive)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:opacity-45"
+                    >
+                      {busy ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        "Remove"
+                      )}
+                    </button>
+                  </div>
+                );
+              }}
+            />
+          ) : (
+            <EmptyStateCard
+              message={
+                query.trim()
+                  ? "No one added matches that name."
+                  : "No one is added yet."
+              }
+            />
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import {
+  CONTACT_ROW_HEIGHT_PX,
+  ContactGroup,
+} from "@/components/one-location/redesign/contact-picker/atoms";
+import { shouldVirtualizeList } from "@/lib/one-location/contact-picker-controls";
+import { cn } from "@/lib/utils";
+
+/**
+ * One list component for every roster in the picker.
+ *
+ * Windowing engages on exactly the same threshold that reveals the search
+ * controls, and for two reasons that happen to agree:
+ *
+ *   * A virtualizer measuring three rows costs more than it saves.
+ *   * jsdom reports every element as 0px tall, so a virtualized list renders
+ *     almost nothing under test. Below the threshold the rows are plain DOM,
+ *     which keeps small fixtures directly assertable — and the windowing that
+ *     matters at 100 contacts still engages exactly where it is needed.
+ *
+ * Above the threshold the scroll container is capped so the page keeps ONE
+ * scrolling surface per tab rather than nesting a tall inner scroller inside
+ * an equally tall outer one.
+ */
+export function VirtualContactList<T>({
+  items,
+  getKey,
+  renderItem,
+  maxHeightClassName = "max-h-[52vh]",
+  testId,
+  ariaLabel,
+}: {
+  items: readonly T[];
+  getKey: (item: T) => string;
+  renderItem: (item: T) => ReactNode;
+  maxHeightClassName?: string;
+  testId?: string;
+  ariaLabel?: string;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const virtualize = shouldVirtualizeList(items.length);
+
+  const virtualizer = useVirtualizer({
+    count: virtualize ? items.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => CONTACT_ROW_HEIGHT_PX,
+    // Five rows of runway on each side: enough that a fast flick never shows
+    // blank space, small enough that a 100-person list still mounts ~15 rows.
+    overscan: 5,
+    getItemKey: (index) => getKey(items[index] as T),
+  });
+
+  if (!virtualize) {
+    return (
+      <ContactGroup>
+        <div data-testid={testId} aria-label={ariaLabel} role={ariaLabel ? "list" : undefined}>
+          {items.map((item) => (
+            <div key={getKey(item)} role={ariaLabel ? "listitem" : undefined}>
+              {renderItem(item)}
+            </div>
+          ))}
+        </div>
+      </ContactGroup>
+    );
+  }
+
+  return (
+    <ContactGroup>
+      <div
+        ref={scrollRef}
+        data-testid={testId}
+        data-virtualized="true"
+        aria-label={ariaLabel}
+        role={ariaLabel ? "list" : undefined}
+        className={cn(
+          "overflow-y-auto overscroll-contain",
+          // Momentum scrolling in the Capacitor webview; without it a long
+          // roster scrolls with a dead, non-native feel on iOS.
+          "[-webkit-overflow-scrolling:touch]",
+          maxHeightClassName,
+        )}
+      >
+        <div
+          style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}
+        >
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const item = items[virtualItem.index] as T;
+            return (
+              <div
+                key={virtualItem.key}
+                // Measured rather than assumed: a name that wraps to two lines
+                // is taller than the estimate, and an unmeasured window drifts
+                // out of register with its own scrollbar over 100 rows.
+                ref={virtualizer.measureElement}
+                data-index={virtualItem.index}
+                role={ariaLabel ? "listitem" : undefined}
+                className="absolute left-0 top-0 w-full border-b border-[color:var(--app-separator)] last:border-b-0"
+                style={{ transform: `translateY(${virtualItem.start}px)` }}
+              >
+                {renderItem(item)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </ContactGroup>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -447,7 +447,15 @@ export type LocationHubViewModel = {
   onTriggerSos: (message?: string | null) => void | Promise<void>;
   onStopSos: () => void;
   onAddSmsContact: (recipientUserId: string) => void;
-  onAddSmsCircle: (circleId: string) => Promise<void>;
+  /**
+   * Adds a Circle's SMS-ready members. The picker passes the subset it
+   * resolved; omitting it keeps the whole-Circle behaviour for callers that
+   * still want it.
+   */
+  onAddSmsCircle: (
+    circleId: string,
+    memberUserIds?: readonly string[],
+  ) => Promise<void>;
   onRemoveSmsContact: (recipientUserId: string) => Promise<boolean>;
 
   /* Check-In (quick action) — reuses the encrypted share pipeline. Circle
@@ -1133,7 +1141,12 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             selectedUserIds={vm.smsContactUserIds}
             busyKey={vm.busy}
             onAdd={vm.onAddSmsContact}
-            onAddCircle={vm.onAddSmsCircle}
+            onAddCircleMembers={(circleId, userIds) =>
+              vm.onAddSmsCircle(circleId, userIds)
+            }
+            onLoadCircleMembers={(circleId) =>
+              vm.onResolveNamedCircleRecipients(circleId, "sms")
+            }
             onRemove={vm.onRemoveSmsContact}
             recipientLabel={vm.recipientLabel}
             recipientSubtitle={vm.recipientSubtitle}

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
-import { Loader2, UsersRound } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -17,19 +17,34 @@ import type {
   OneLocationCircleSummary,
   OneLocationRecipient,
 } from "@/lib/one-location/types";
-import { SECTION_HEADING } from "@/components/one-location/redesign/tokens";
+import type { CircleRecipientSelection } from "@/lib/one-location/circle-recipient-selection";
 import { TaskFlowHeader } from "@/components/one-location/redesign/primitives";
-import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
+import {
+  CONTACT_AVATAR_TONE,
+  ContactGroup,
+  ContactRow,
+  EmptyStateCard,
+  initials,
+} from "@/components/one-location/redesign/contact-picker/atoms";
+import { CircleMemberPicker } from "@/components/one-location/redesign/contact-picker/circle-member-picker";
+import { ContactListControls } from "@/components/one-location/redesign/contact-picker/list-controls";
+import {
+  SelectedContactsPill,
+  SelectedContactsSheet,
+} from "@/components/one-location/redesign/contact-picker/selected-review-sheet";
+import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import {
+  filterByContactQuery,
+  sortByContactMode,
+  type ContactSortMode,
+} from "@/lib/one-location/contact-picker-controls";
 
-/**
- * A person avatar reports no state of its own — the initials identify, the
- * trailing control acts. Keeping it neutral leaves exactly one accent per row
- * (the Add button) instead of two blues competing across the same 58px.
- */
-const CONTACT_AVATAR_TONE = cn(
-  roleClasses("neutral").tile,
-  roleClasses("neutral").glyph,
-);
+type SmsContactsTab = "circles" | "all-contacts";
+
+const TABS: ReadonlyArray<{ value: SmsContactsTab; label: string }> = [
+  { value: "circles", label: "Circles" },
+  { value: "all-contacts", label: "All Contacts" },
+];
 
 type SmsContactsFlowProps = {
   recipients: OneLocationRecipient[];
@@ -37,123 +52,95 @@ type SmsContactsFlowProps = {
   selectedUserIds: string[];
   busyKey: string | null;
   onAdd: (recipientUserId: string) => void;
-  onAddCircle: (circleId: string) => Promise<void>;
+  /**
+   * Commit a hand-picked subset of one Circle's members in a single pass.
+   *
+   * Replaces the old all-or-nothing `onAddCircle`. The picker resolves the
+   * roster itself and hands back exactly the people who were ticked, so a
+   * hundred-member Circle can contribute four contacts.
+   */
+  onAddCircleMembers: (circleId: string, userIds: string[]) => Promise<void>;
+  /** Resolves a Circle into its SMS-ready members, lazily, on expand. */
+  onLoadCircleMembers: (circleId: string) => Promise<CircleRecipientSelection>;
   onRemove: (recipientUserId: string) => Promise<boolean>;
   recipientLabel: (recipient: OneLocationRecipient) => string;
   recipientSubtitle: (recipient: OneLocationRecipient) => string;
   isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
 };
 
-function initials(value: string): string {
-  const parts = value.trim().split(/\s+/).filter(Boolean);
-  return ((parts[0]?.[0] ?? "?") + (parts[1]?.[0] ?? ""))
-    .slice(0, 2)
-    .toUpperCase();
-}
-
-function ContactRow({
-  recipient,
-  selected,
-  busy,
-  ready,
-  onAdd,
-  onAskRemove,
-  recipientLabel,
-}: {
-  recipient: OneLocationRecipient;
-  selected: boolean;
-  busy: boolean;
-  ready: boolean;
-  onAdd: () => void;
-  onAskRemove: () => void;
-  recipientLabel: (recipient: OneLocationRecipient) => string;
-}) {
-  const label = recipientLabel(recipient);
-  return (
-    <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
-      <span
-        className={cn(
-          "flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[15px] font-semibold",
-          CONTACT_AVATAR_TONE,
-        )}
-        aria-hidden
-      >
-        {initials(label)}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
-          {label}
-        </span>
-      </span>
-      {selected ? (
-        <button
-          type="button"
-          onClick={onAskRemove}
-          disabled={busy}
-          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full bg-[color:var(--app-destructive-tint)] px-3 text-[13px] font-semibold text-[color:var(--app-destructive)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:opacity-45"
-        >
-          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={onAdd}
-          disabled={busy || !ready}
-          aria-label={`Add ${label}`}
-          className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-muted-foreground"
-        >
-          {busy ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : ready ? (
-            "Add"
-          ) : (
-            "Setup"
-          )}
-        </button>
-      )}
-    </div>
-  );
-}
-
-function ContactGroup({ children }: { children: ReactNode }) {
-  return (
-    <div className="divide-y divide-[color:var(--app-separator)] overflow-hidden rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] shadow-none">
-      {children}
-    </div>
-  );
-}
-
-function EmptyStateCard({ message }: { message: string }) {
-  return (
-    <div className="flex min-h-[72px] w-full items-center justify-center rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-5 py-4 text-center text-[15px] font-normal leading-5 text-muted-foreground transition-all duration-200 ease-out shadow-none">
-      <p className="max-w-[280px]">{message}</p>
-    </div>
-  );
-}
-
+/**
+ * Who receives your emergency SMS.
+ *
+ * Two tabs, one selection. "Circles" is a roster of Circles that each expand
+ * into their own member picker; "All Contacts" is the flat directory. Both
+ * write to the same list, and the sticky pill above the bottom bar is how that
+ * list stays readable from either of them -- previously the only way to see
+ * who was on it was to scroll the whole screen counting rows wearing a Remove
+ * button.
+ *
+ * Selection commits as it happens rather than staging behind a submit: this
+ * screen has never had one, and a contact roster that silently discards edits
+ * when you navigate away would be a worse trade than the one extra request.
+ * The pill therefore counts what is actually saved, which is why it reads
+ * "added" and not "selected".
+ */
 export function SmsContactsFlow({
   recipients,
   circles,
   selectedUserIds,
   busyKey,
   onAdd,
-  onAddCircle,
+  onAddCircleMembers,
+  onLoadCircleMembers,
   onRemove,
   recipientLabel,
+  recipientSubtitle,
   isRecipientShareReady,
 }: SmsContactsFlowProps) {
+  // Circles first, as the issue orders them -- unless there are none, in
+  // which case landing on an empty tab makes the screen look broken before
+  // the person has done anything.
+  const [tab, setTab] = useState<SmsContactsTab>(() =>
+    circles.length ? "circles" : "all-contacts",
+  );
   const [pendingRemoval, setPendingRemoval] =
     useState<OneLocationRecipient | null>(null);
   const [removing, setRemoving] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [expandedCircleId, setExpandedCircleId] = useState<string | null>(null);
+
+  const [circleQuery, setCircleQuery] = useState("");
+  const [circleSort, setCircleSort] = useState<ContactSortMode>("default");
+  const [contactQuery, setContactQuery] = useState("");
+  const [contactSort, setContactSort] = useState<ContactSortMode>("default");
+
   const selectedIds = useMemo(
     () => new Set(selectedUserIds),
     [selectedUserIds],
   );
-  const selected = recipients.filter((recipient) =>
-    selectedIds.has(recipient.userId),
+  const selected = useMemo(
+    () => recipients.filter((recipient) => selectedIds.has(recipient.userId)),
+    [recipients, selectedIds],
   );
-  const available = recipients.filter(
-    (recipient) => !selectedIds.has(recipient.userId),
+
+  const visibleCircles = useMemo(
+    () =>
+      sortByContactMode(
+        filterByContactQuery(circles, circleQuery, (circle) => circle.name),
+        circleSort,
+        (circle) => circle.name,
+      ),
+    [circleQuery, circleSort, circles],
+  );
+
+  const visibleContacts = useMemo(
+    () =>
+      sortByContactMode(
+        filterByContactQuery(recipients, contactQuery, recipientLabel),
+        contactSort,
+        recipientLabel,
+      ),
+    [contactQuery, contactSort, recipientLabel, recipients],
   );
 
   const removePending = async () => {
@@ -167,12 +154,29 @@ export function SmsContactsFlow({
     }
   };
 
+  const askRemoveById = useCallback(
+    (recipientUserId: string) => {
+      const recipient = recipients.find(
+        (candidate) => candidate.userId === recipientUserId,
+      );
+      if (recipient) setPendingRemoval(recipient);
+    },
+    [recipients],
+  );
+
+  // The picker only ever passes ids it resolved from that Circle, so this is a
+  // pass-through -- but keeping it a stable callback means expanding a Circle
+  // does not re-run its roster effect on every parent render.
+  const addCircleMembers = useCallback(
+    (circleId: string, userIds: string[]) =>
+      onAddCircleMembers(circleId, userIds),
+    [onAddCircleMembers],
+  );
+
   return (
     // Renders inside the signed-in shell like every other Location task flow,
     // so the top bar keeps the single back control, the
-    // "Location › SMS contacts" trail and the profile avatar. It used to pin
-    // itself over the whole viewport, which hid all three and left it drawing
-    // its own back arrow.
+    // "Location > SMS contacts" trail and the profile avatar.
     <section data-testid="sms-contacts-screen">
       {/* 430px is a phone, not a layout. Held at every width it left most of a
           tablet or a desktop window as empty grey while the lists below scrolled
@@ -185,127 +189,172 @@ export function SmsContactsFlow({
           description="Emergency contacts."
         />
 
-        {circles.length ? (
-          <>
-            <p className={cn(SECTION_HEADING, "mb-2 mt-6 px-[6px]")}>
-              Circles
-            </p>
-            <ContactGroup>
-              {circles.map((circle, index) => {
-                const circleBusy = busyKey === `sms-circle:${circle.id}`;
-                // STATE BEATS CATEGORY: a circle is the people role, but one
-                // holding nobody except the viewer has nothing to report and
-                // stays neutral. `memberCount` includes the viewer, so the
-                // count that decides this is `memberCount - 1` — the same test
-                // the Circles list and the check-in flow apply.
-                const circleRole = roleClasses("people", {
-                  inactive: Math.max(0, circle.memberCount - 1) === 0,
-                });
-                return (
-                  <div
-                    key={circle.id}
-                    className={cn(
-                      "flex min-h-[58px] items-center gap-3 px-3.5 py-2",
-                      index < circles.length - 1 &&
-                        "border-b border-[color:var(--app-separator)]",
-                    )}
-                  >
-                    <span
+        {/* Two sections, named for what they hold. "Add contacts" described the
+            button on each row rather than the list, which left the screen with
+            a "Contacts" list and an "Add contacts" list that were the same
+            people in two states. */}
+        <div
+          role="tablist"
+          aria-label="Contact sources"
+          className="mt-6 flex gap-1.5 rounded-full bg-[color:var(--app-neutral-fill-strong)] p-1"
+        >
+          {TABS.map((entry) => {
+            const active = entry.value === tab;
+            return (
+              <button
+                key={entry.value}
+                type="button"
+                role="tab"
+                id={"sms-tab-" + entry.value}
+                aria-selected={active}
+                aria-controls={"sms-panel-" + entry.value}
+                onClick={() => setTab(entry.value)}
+                className={cn(
+                  "press-scale h-10 flex-1 rounded-full text-[15px] font-semibold transition-colors",
+                  active
+                    ? "bg-[color:var(--app-card-surface-default-solid)] text-foreground shadow-sm"
+                    : "text-muted-foreground",
+                )}
+              >
+                {entry.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-4">
+          {tab === "circles" ? (
+            <div
+              role="tabpanel"
+              id="sms-panel-circles"
+              aria-labelledby="sms-tab-circles"
+              data-testid="sms-circles-panel"
+            >
+              <ContactListControls
+                sourceCount={circles.length}
+                query={circleQuery}
+                onQueryChange={setCircleQuery}
+                sortMode={circleSort}
+                onSortModeChange={setCircleSort}
+                placeholder="Search Circles"
+                resultCount={visibleCircles.length}
+                voiceControlId="one-location-sms-circle-search"
+              />
+              {visibleCircles.length ? (
+                <ContactGroup>
+                  {visibleCircles.map((circle, index) => (
+                    <div
+                      key={circle.id}
                       className={cn(
-                        "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
-                        circleRole.tile,
-                        circleRole.glyph,
+                        index < visibleCircles.length - 1 &&
+                          "border-b border-[color:var(--app-separator)]",
                       )}
                     >
-                      <UsersRound className="h-[17px] w-[17px]" />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
-                        {circle.name}
-                      </span>
-                      <span className="mt-0.5 block text-[15px] leading-5 text-muted-foreground">
-                        {circle.memberCount} members
-                      </span>
-                    </span>
-                    <button
-                      type="button"
-                      disabled={Boolean(busyKey)}
-                      onClick={() => void onAddCircle(circle.id)}
-                      aria-label={`Add ${circle.name}`}
-                      className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:opacity-45"
-                    >
-                      {circleBusy ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        "Add"
-                      )}
-                    </button>
-                  </div>
-                );
-              })}
-            </ContactGroup>
-            {/* Growing a Circle deliberately does NOT live here. This screen
-                answers one question -- who gets the alert -- and a per-Circle
-                "Invite people / Share code" block for every Circle pushed that
-                list below the fold and mixed a membership task into a
-                contact-picking one. Growing a Circle stays on the People tab,
-                which owns membership. */}
-          </>
-        ) : null}
-
-
-        {/* Keep contacts in one column on every viewport. The previous desktop
-            split made a simple contact task feel scattered and disconnected. */}
-        <div className="mt-6 grid gap-6">
-          <div>
-            <p className={cn(SECTION_HEADING, "mb-2 px-[6px]")}>
-              Contacts
-            </p>
-            {selected.length ? (
-              <ContactGroup>
-                {selected.map((recipient) => (
-                  <ContactRow
-                    key={recipient.userId}
-                    recipient={recipient}
-                    selected
-                    ready={isRecipientShareReady(recipient)}
-                    busy={busyKey === `sms-contact:${recipient.userId}`}
-                    onAdd={() => onAdd(recipient.userId)}
-                    onAskRemove={() => setPendingRemoval(recipient)}
-                    recipientLabel={recipientLabel}
-                  />
-                ))}
-              </ContactGroup>
-            ) : (
-              <EmptyStateCard message="No contacts yet." />
-            )}
-          </div>
-
-          <div>
-            <p className={cn(SECTION_HEADING, "mb-2 px-[6px]")}>
-              Add contacts
-            </p>
-            {available.length ? (
-              <ContactGroup>
-                {available.map((recipient) => (
-                  <ContactRow
-                    key={recipient.userId}
-                    recipient={recipient}
-                    selected={false}
-                    ready={isRecipientShareReady(recipient)}
-                    busy={busyKey === `sms-contact:${recipient.userId}`}
-                    onAdd={() => onAdd(recipient.userId)}
-                    onAskRemove={() => setPendingRemoval(recipient)}
-                    recipientLabel={recipientLabel}
-                  />
-                ))}
-              </ContactGroup>
-            ) : (
-              <EmptyStateCard message="All contacts added." />
-            )}
-          </div>
+                      <CircleMemberPicker
+                        circle={circle}
+                        expanded={expandedCircleId === circle.id}
+                        onToggle={() =>
+                          setExpandedCircleId((current) =>
+                            current === circle.id ? null : circle.id,
+                          )
+                        }
+                        selectedUserIds={selectedIds}
+                        busy={Boolean(busyKey)}
+                        onLoadMembers={onLoadCircleMembers}
+                        onAddMembers={addCircleMembers}
+                        recipientLabel={(person) =>
+                          recipientLabel(person as OneLocationRecipient)
+                        }
+                      />
+                    </div>
+                  ))}
+                </ContactGroup>
+              ) : (
+                <EmptyStateCard
+                  message={
+                    circleQuery.trim()
+                      ? "No Circles match that name."
+                      : "No Circles yet."
+                  }
+                />
+              )}
+              {/* Growing a Circle deliberately does NOT live here. This screen
+                  answers one question -- who gets the alert -- and a per-Circle
+                  "Invite people / Share code" block for every Circle pushed that
+                  list below the fold and mixed a membership task into a
+                  contact-picking one. Growing a Circle stays on the People tab,
+                  which owns membership. */}
+            </div>
+          ) : (
+            <div
+              role="tabpanel"
+              id="sms-panel-all-contacts"
+              aria-labelledby="sms-tab-all-contacts"
+              data-testid="sms-all-contacts-panel"
+            >
+              <ContactListControls
+                sourceCount={recipients.length}
+                query={contactQuery}
+                onQueryChange={setContactQuery}
+                sortMode={contactSort}
+                onSortModeChange={setContactSort}
+                placeholder="Search contacts"
+                resultCount={visibleContacts.length}
+                voiceControlId="one-location-sms-contact-search"
+              />
+              {visibleContacts.length ? (
+                <VirtualContactList
+                  items={visibleContacts}
+                  getKey={(recipient) => recipient.userId}
+                  testId="sms-all-contacts-list"
+                  ariaLabel="All contacts"
+                  renderItem={(recipient) => {
+                    const label = recipientLabel(recipient);
+                    return (
+                      <ContactRow
+                        label={label}
+                        subtitle={recipientSubtitle(recipient)}
+                        selected={selectedIds.has(recipient.userId)}
+                        ready={isRecipientShareReady(recipient)}
+                        busy={busyKey === "sms-contact:" + recipient.userId}
+                        onAdd={() => onAdd(recipient.userId)}
+                        onRemove={() => setPendingRemoval(recipient)}
+                      />
+                    );
+                  }}
+                />
+              ) : (
+                <EmptyStateCard
+                  message={
+                    contactQuery.trim()
+                      ? "No contacts match that name."
+                      : "No contacts yet."
+                  }
+                />
+              )}
+            </div>
+          )}
         </div>
       </div>
+
+      <SelectedContactsPill
+        count={selected.length}
+        onOpen={() => setReviewOpen(true)}
+      />
+
+      <SelectedContactsSheet
+        open={reviewOpen}
+        onOpenChange={setReviewOpen}
+        recipients={selected}
+        busyUserId={
+          busyKey?.startsWith("sms-contact:")
+            ? busyKey.slice("sms-contact:".length)
+            : null
+        }
+        onRemove={askRemoveById}
+        recipientLabel={recipientLabel}
+        recipientSubtitle={recipientSubtitle}
+      />
 
       <AlertDialog
         open={Boolean(pendingRemoval)}
@@ -315,8 +364,8 @@ export function SmsContactsFlow({
       >
         {/* A sheet that rises from the thumb is right on a phone and odd on a
             desktop, where it lands far from the row that opened it and from the
-            pointer. Base classes stay exactly as they were — the phone case is
-            the tested one — and only wider viewports re-centre it. */}
+            pointer. Base classes stay exactly as they were -- the phone case is
+            the tested one -- and only wider viewports re-centre it. */}
         <AlertDialogContent
           size="sm"
           className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-[color:var(--app-card-surface-default-solid)] !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none md:!bottom-auto md:!top-1/2 md:!max-w-[400px] md:!-translate-y-1/2 md:!rounded-b-[24px] md:!pb-5 md:!shadow-xl"

--- a/hushh-webapp/lib/one-location/contact-picker-controls.ts
+++ b/hushh-webapp/lib/one-location/contact-picker-controls.ts
@@ -1,0 +1,147 @@
+/**
+ * The rules behind the contact picker's conditional controls, kept out of the
+ * components so they can be reasoned about — and tested — on their own.
+ *
+ * The picker has to serve two populations from one screen: an account with
+ * four contacts, where a search field and a sort menu are pure noise, and an
+ * account with a hundred, where finding one person without them is hopeless.
+ * Circles now hold up to 100 members (migration 158), so the second case is
+ * not hypothetical.
+ */
+
+/**
+ * Where "a list" becomes "too long to read".
+ *
+ * Ten rows at the picker's 58px row height is roughly one phone screenful, so
+ * the trigger is the honest one — controls appear exactly when the list stops
+ * fitting on screen — rather than a number chosen for looking round.
+ */
+export const CONTACT_LIST_CONTROLS_THRESHOLD = 10;
+
+/**
+ * Whether a section should be showing its search / sort controls.
+ *
+ * Two properties matter more than the comparison itself:
+ *
+ * 1. `sourceCount` must be the section's FULL list, never the filtered result.
+ *    Measuring the filtered list makes the controls destroy their own reason
+ *    to exist: type a query, the 40 rows become 4, the field unmounts, the
+ *    query dies with it, the list returns to 40, the field remounts. That is
+ *    not a hypothetical race — it is what the naive reading of "hide the
+ *    controls for short lists" compiles to.
+ *
+ * 2. Once revealed, they stay revealed (`alreadyRevealed`). Removing people
+ *    one at a time from a 12-person list would otherwise yank the search field
+ *    out from under a half-typed query the moment the eleventh went. The
+ *    controls come back only when the section is next mounted fresh.
+ */
+export function shouldRevealListControls(
+  sourceCount: number,
+  alreadyRevealed = false,
+): boolean {
+  if (alreadyRevealed) return true;
+  return sourceCount > CONTACT_LIST_CONTROLS_THRESHOLD;
+}
+
+/**
+ * Whether a list of this size should be handed to the virtualizer.
+ *
+ * Deliberately the same threshold. Below it, rows render plainly: a
+ * virtualizer measuring three rows costs more than it saves, and — the
+ * practical half — jsdom reports every element as 0px tall, so a virtualized
+ * list renders almost nothing under test. Small fixtures stay directly
+ * assertable, and the windowing that matters at 100 contacts still engages
+ * exactly where the controls do.
+ */
+export function shouldVirtualizeList(sourceCount: number): boolean {
+  return sourceCount > CONTACT_LIST_CONTROLS_THRESHOLD;
+}
+
+/**
+ * Fold case and accents so "renée" is found by "renee".
+ *
+ * Names are the whole search corpus here, and a picker that cannot find a name
+ * because of an acute accent is worse than one with no search at all — the
+ * person can see the contact exists and cannot reach it.
+ */
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase()
+    .trim();
+}
+
+/** A query shorter than this filters nothing; one character narrows nothing useful. */
+export const CONTACT_SEARCH_MIN_LENGTH = 1;
+
+export function contactQueryIsActive(query: string): boolean {
+  return normalizeSearchText(query).length >= CONTACT_SEARCH_MIN_LENGTH;
+}
+
+/**
+ * Match every whitespace-separated term independently, in any order, against
+ * any part of the haystack.
+ *
+ * "ankit singh" therefore finds "Ankit Kumar Singh", which a single substring
+ * match would not — and which is the exact shape of a real query, because a
+ * person types the first and last name they remember, not the middle one they
+ * do not.
+ */
+export function matchesContactQuery(haystack: string, query: string): boolean {
+  const needle = normalizeSearchText(query);
+  if (!needle) return true;
+  const hay = normalizeSearchText(haystack);
+  return needle.split(/\s+/).every((term) => hay.includes(term));
+}
+
+export function filterByContactQuery<T>(
+  items: readonly T[],
+  query: string,
+  toSearchableText: (item: T) => string,
+): T[] {
+  if (!contactQueryIsActive(query)) return [...items];
+  return items.filter((item) => matchesContactQuery(toSearchableText(item), query));
+}
+
+/**
+ * "Default" is the order the caller already put them in — for contacts that is
+ * the recommendation ranking the directory computed, which is more useful than
+ * the alphabet and must not be silently thrown away by offering sorting at all.
+ */
+export type ContactSortMode = "default" | "name-asc" | "name-desc";
+
+export const CONTACT_SORT_MODES: ReadonlyArray<{
+  value: ContactSortMode;
+  label: string;
+}> = [
+  { value: "default", label: "Suggested" },
+  { value: "name-asc", label: "A–Z" },
+  { value: "name-desc", label: "Z–A" },
+];
+
+export function sortByContactMode<T>(
+  items: readonly T[],
+  mode: ContactSortMode,
+  toName: (item: T) => string,
+): T[] {
+  const next = [...items];
+  if (mode === "default") return next;
+  // localeCompare with numeric so "Sam 2" sorts after "Sam 10" the way a person
+  // reading a list expects, and with sensitivity:"base" so case and accents do
+  // not split otherwise-adjacent names apart.
+  const direction = mode === "name-desc" ? -1 : 1;
+  return next.sort(
+    (left, right) =>
+      direction *
+      toName(left).localeCompare(toName(right), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+  );
+}
+
+/** "1 person" / "12 people" — the pill, the sheet and the toasts share one voice. */
+export function peoplePillLabel(count: number): string {
+  return `${count} ${count === 1 ? "person" : "people"} added`;
+}


### PR DESCRIPTION
Third of the sequence restoring the PRs the Monday rollback (#5603) reverted. Restores **#5477**.

Base is `main`, not the previous PR — a PR whose base is not `main` skips the test lanes here and still passes the gate.

## The sequence is now 8, not 10

Two of the original ten turned out to be **already back on `main`**, re-landed by others with better implementations. Restoring them again would have regressed that work:

- **#5367** — Ankit re-landed it (`08d17e00f`). His version follows the device with `map.setCenter()` instead of rebuilding the map on every GPS fix.
- **#5456** — the count-badge fix is on `main` (`{state.attendees.length ? …}`, so no bare "0"), the empty state is shorter (*"Nobody nearby yet"*), and the pin-rule sentence was **deliberately removed** there. The restored copy would have brought it back.

Each was verified against `main` before being dropped, not assumed.

## A correction to the plan

#5497 was listed as standalone. It is not — it edits `contact-picker/selected-review-sheet.tsx`, which arrives in **this** PR. The remaining order is strictly chronological: **#5477 → #5497 → #5505 → #5552 → #5560 → #5578 → #5601**.

## What this restores

Circles hold 100 rather than 20, and the pickers are rebuilt for that size. Search and sort appear only once a list is long enough to need them; above the same threshold rows go to a virtualizer so a hundred contacts do not all mount. Below it they stay plain DOM — jsdom measures every element as 0px tall, so a virtualized list renders almost nothing under test, and small fixtures stay directly assertable.

The reveal rule reads a section's **full** count, never the filtered one. Reading the filtered count makes the control delete itself: type a query, forty rows become four, the field unmounts, the query dies with it, the list returns to forty, the field remounts.

## Two repairs on top of the replay

- **Schema files resolved to `main`.** Migration 158, the three schema contracts and the manifest travelled with this change, but they already landed with the schema PR — and `main`'s 158 now carries the replay-safety fix (#5641) that this PR's older copy does not.
- **`test_member_limit_migration_is_registered_in_release_order`** asserted 158 was the *last* manifest entry. It was written while 158 was the head; 159 and 160 have since landed on top. Pinning to the tail asserts nothing about this migration and breaks whenever another is added, so it now checks 158 is registered and ordered after 157.

## Verification

```
tsc --noEmit                                              clean
eslint (changed web files)                                clean
vitest  one-location/redesign + lib/one-location    704 passed
pytest  circle service + member-limit + account      58 passed
verify:design-system                                      passed
verify:capacitor:static                                   passed
./bin/hushh protocol lint                                 clean
```