### PR TITLE
restore 4/8: move the SMS review pill under the header

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -309,7 +309,7 @@ describe("SmsContactsFlow", () => {
     });
   });
 
-  describe("sticky review pill and sheet", () => {
+  describe("review pill and sheet", () => {
     it("counts the added people and opens a sheet listing them", async () => {
       render(<SmsContactsFlow {...baseProps} />);
 
@@ -323,15 +323,38 @@ describe("SmsContactsFlow", () => {
       expect(within(sheet).queryByText("Neelesh")).not.toBeInTheDocument();
     });
 
-    it("sits above the app's own bottom chrome rather than a guessed offset", () => {
+    it("reads under the header and above the tabs, in flow", () => {
       render(<SmsContactsFlow {...baseProps} />);
 
-      const anchor = screen.getByTestId("sms-selected-pill").parentElement!;
-      // The shell publishes its height; hard-coding one breaks the moment the
-      // nav changes size or the keyboard opens.
-      expect(anchor.style.bottom).toContain("--bottom-chrome-full-height");
-      expect(anchor.style.bottom).toContain("--kb-height");
-      expect(anchor.style.bottom).toContain("safe-area-inset-bottom");
+      const pill = screen.getByTestId("sms-selected-pill");
+      const title = screen.getByRole("heading", { name: "SMS contacts" });
+      const tablist = screen.getByRole("tablist", { name: "Contact sources" });
+
+      // The defect this guards: the pill used to be lifted out of the flow and
+      // pinned near the bottom of the screen, which on a list short enough not
+      // to scroll left it sitting on top of the first contact row.
+      expect(
+        title.compareDocumentPosition(pill) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(
+        pill.compareDocumentPosition(tablist) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+
+      // In flow means in flow: no positioning, and no bottom offset left over
+      // from the version that floated.
+      const anchor = pill.parentElement!;
+      expect(anchor.className).not.toMatch(/\b(fixed|sticky|absolute)\b/);
+      expect(anchor.style.position).toBe("");
+      expect(anchor.style.bottom).toBe("");
+    });
+
+    it("renders the pill exactly once", () => {
+      render(<SmsContactsFlow {...baseProps} />);
+
+      // Moving it out of the footer slot is only a move if the old one went.
+      expect(screen.getAllByTestId("sms-selected-pill")).toHaveLength(1);
     });
 
     it("shows no pill at all when nobody is added", () => {

--- a/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
@@ -26,12 +26,12 @@ import type { OneLocationRecipient } from "@/lib/one-location/types";
 import { cn } from "@/lib/utils";
 
 /**
- * The sticky counter, and the sheet it opens.
+ * The selection summary, and the sheet it opens.
  *
  * Selection used to be readable only by scrolling the whole screen and
  * counting the rows wearing a Remove button -- across two sections, and soon
- * across two tabs. The pill answers "who is on this list" from anywhere in the
- * flow, and the sheet is where that answer gets edited.
+ * across two tabs. The pill answers "who is on this list" before the tabs are
+ * reached, and the sheet is where that answer gets edited.
  *
  * Vaul's drawer rather than a dialog, because this is a review surface a thumb
  * should be able to drag away: it is not a decision, and dismissing it must
@@ -46,26 +46,21 @@ export function SelectedContactsPill({
   onOpen: () => void;
 }) {
   // Nothing selected, nothing to review. An empty pill would be a permanent
-  // "0 people added" hovering over a screen whose whole job is to stop being 0.
+  // "0 people added" sitting under the title of a screen whose whole job is to
+  // stop being 0.
   if (count <= 0) return null;
   return (
-    // Sits above the app's own bottom chrome by reading the height the shell
-    // publishes (`--bottom-chrome-full-height`, set in app-bottom-shell) rather
-    // than guessing an offset that breaks the moment the nav changes height or
-    // the keyboard opens.
-    <div
-      className="pointer-events-none sticky z-40 flex justify-center px-4"
-      style={{
-        bottom:
-          "calc(var(--bottom-chrome-full-height, 0px) + var(--kb-height, 0px) + max(12px, env(safe-area-inset-bottom)))",
-      }}
-    >
+    // Reads as part of the header block: who is already on the list, answered
+    // once on the way down into the tabs. Floating it over the bottom of the
+    // screen instead meant that on a list short enough not to scroll it came to
+    // rest on top of the first contact row.
+    <div className="mt-6 flex justify-center px-4">
       <button
         type="button"
         onClick={onOpen}
         data-testid="sms-selected-pill"
         aria-label={"Review " + peoplePillLabel(count)}
-        className="press-scale pointer-events-auto flex h-11 max-w-full items-center gap-2 rounded-full bg-[color:var(--app-accent)] px-5 text-[15px] font-semibold text-[color:var(--app-accent-fg)] shadow-lg"
+        className="press-scale flex h-11 max-w-full items-center gap-2 rounded-full bg-[color:var(--app-accent)] px-5 text-[15px] font-semibold text-[color:var(--app-accent-fg)] shadow-lg"
       >
         <UsersRound className="h-4 w-4 shrink-0" aria-hidden />
         <span className="truncate">{peoplePillLabel(count)}</span>

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -189,6 +189,11 @@ export function SmsContactsFlow({
           description="Emergency contacts."
         />
 
+        <SelectedContactsPill
+          count={selected.length}
+          onOpen={() => setReviewOpen(true)}
+        />
+
         {/* Two sections, named for what they hold. "Add contacts" described the
             button on each row rather than the list, which left the screen with
             a "Contacts" list and an "Add contacts" list that were the same
@@ -336,11 +341,6 @@ export function SmsContactsFlow({
           )}
         </div>
       </div>
-
-      <SelectedContactsPill
-        count={selected.length}
-        onOpen={() => setReviewOpen(true)}
-      />
 
       <SelectedContactsSheet
         open={reviewOpen}


### PR DESCRIPTION
Fourth of the sequence restoring the PRs the Monday rollback (#5603) reverted. Restores **#5497**.

The selection summary sat where it competed with the screen title. It now reads directly under the header, above the list it summarises — so *"who is on this list"* is answered before the roster is scrolled rather than after.

## Depends on the previous PR

This edits `contact-picker/selected-review-sheet.tsx`, which does not exist on a base without the contact picker restored in **3/8** (#5477). That is why the original "standalone" grouping was wrong, and why the remaining order is strictly chronological:

**#5505 → #5552 → #5560 → #5578 → #5601**

## Verification

```
tsc --noEmit                                     clean
eslint (changed web files)                       clean
vitest  one-location/redesign            168 passed
verify:design-system                             passed
```

Base is `main`, 0 behind at push.