### PR TITLE
restore 5/8: SMS contacts become a protected system Circle

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -814,6 +814,37 @@ def bootstrap_named_location_circle(
         raise _handle_error(exc) from exc
 
 
+@router.post("/location/circles/sms-system")
+@limiter.limit(RateLimits.ONE_LOCATION_CIRCLE_MUTATION)
+def ensure_sms_system_circle_route(
+    request: Request,
+    response: Response,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    """Find-or-create the caller's SMS Circle and fold their contacts into it.
+
+    Called on bootstrap, so it is a find-or-create rather than a create: the
+    second and every later call return the same Circle, and a contact the owner
+    has since removed is not re-added (see `ensure_sms_system_circle`).
+
+    Vault-owner token, unlike the onboarding bootstrap route above, because this
+    one migrates real recipients rather than minting an empty Circle -- it reads
+    who the owner picked for emergency SMS, which is exactly the material the
+    vault gate exists to protect.
+    """
+
+    del request
+    try:
+        response.headers["Cache-Control"] = "private, no-store"
+        return {
+            "circle": _circle_service().ensure_sms_system_circle(
+                owner_user_id=_user_id(token_data),
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
 @router.delete("/location/circles/{circle_id}/invite-code")
 @limiter.limit(RateLimits.ONE_LOCATION_CIRCLE_MUTATION)
 def revoke_named_location_circle_code(

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -43,6 +43,10 @@ CIRCLE_MAX_PER_USER = 10
 # default, which is what makes the higher limit real for accounts that
 # already have Circles rather than only for ones created from here on.
 CIRCLE_DEFAULT_MEMBER_LIMIT = 100
+# The one system Circle this product provisions today. Named for what it
+# does rather than what it is, because it sits in the Circles list beside
+# Circles the person named themselves ("Family", "Climbing").
+SMS_SYSTEM_CIRCLE_NAME = "SMS Contacts"
 CIRCLE_CODE_LENGTH = 12
 CIRCLE_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
 _CIRCLE_CODE_DOMAIN = b"one-location-circle-code:v1:"
@@ -327,11 +331,13 @@ class OneLocationCircleService:
         # of truth. Owner-only capabilities follow the canonical Circle owner.
         is_owner = bool(owner_user_id and viewer_user_id == owner_user_id)
         role = "owner" if is_owner else "member"
+        is_system = bool(row.get("is_system") or False)
         return {
             "id": str(row.get("id") or ""),
             "name": str(row.get("name") or ""),
             "kind": str(row.get("kind") or "other"),
             "role": role,
+            "isSystem": is_system,
             "memberCount": int(row.get("member_count") or 0),
             "memberLimit": int(row.get("member_limit") or CIRCLE_DEFAULT_MEMBER_LIMIT),
             "createdAt": _iso(row.get("created_at")),
@@ -344,12 +350,30 @@ class OneLocationCircleService:
                 "canRotateInviteCode": is_owner,
                 "canManageCircle": is_owner,
                 "canModerateInvites": is_owner,
+                # The ONLY thing a system Circle takes away. It is provisioned
+                # by the product and depended on by SOS, so it is not the
+                # owner's to delete -- every other owner power still applies:
+                # rename, add members, remove members.
+                #
+                # Deliberately no roster restriction. An emergency Circle is a
+                # group that should know it is a group: if something happens to
+                # the owner, the people on that list are the ones who may need
+                # to reach each other, and a roster only the owner can read is
+                # useless at exactly the moment it is needed. So membership is
+                # visible here on the same terms as any other Circle.
+                #
+                # Note this is visibility, not connection: seeing a name in a
+                # roster is not a connection edge. `_connect_member_to_circle`
+                # still only ever pairs a joiner with whoever invited them, so
+                # members are listed together without being introduced.
+                "canDeleteCircle": is_owner and not is_system,
             },
         }
 
     @staticmethod
     def _member_payload(row: dict[str, Any]) -> dict[str, Any]:
         display_name = str(row.get("display_name") or "").strip()
+        relationship = str(row.get("relationship") or "none")
         key_id = str(row.get("key_id") or "").strip()
         public_key_jwk = _json_object(row.get("public_key_jwk"))
         can_receive_location = bool(key_id and public_key_jwk)
@@ -370,6 +394,16 @@ class OneLocationCircleService:
             "keyAlgorithm": str(row.get("algorithm") or "ECDH-P256-AES256-GCM"),
             "keyRegisteredAt": _iso(row.get("key_created_at")),
             "canReceiveLocation": can_receive_location,
+            # Being in the same Circle is not being connected -- a joiner is
+            # paired with whoever invited them and nobody else. Surfacing the
+            # relationship here is what lets the roster offer the introduction
+            # the Circle deliberately does not make by itself.
+            "relationship": relationship,
+            # 'self' and 'connected' have nothing to request; the two pending
+            # states already have a request in flight. Phone verification is
+            # required for the same reason it is everywhere else a connection
+            # can start.
+            "canConnect": (relationship == "none" and bool(row.get("phone_verified"))),
         }
 
     @staticmethod
@@ -475,7 +509,8 @@ class OneLocationCircleService:
             result = self._db.execute_raw(
                 """
                 SELECT
-                  c.id, c.name, c.kind, c.member_limit, c.created_at, c.updated_at,
+                  c.id, c.name, c.kind, c.member_limit, c.is_system,
+                  c.created_at, c.updated_at,
                   c.owner_user_id, :user_id AS viewer_user_id, mine.role,
                   COUNT(active_members.user_id) AS member_count
                 FROM one_location_circle_memberships mine
@@ -504,7 +539,8 @@ class OneLocationCircleService:
             summary_result = self._db.execute_raw(
                 """
                 SELECT
-                  c.id, c.name, c.kind, c.member_limit, c.created_at, c.updated_at,
+                  c.id, c.name, c.kind, c.member_limit, c.is_system,
+                  c.created_at, c.updated_at,
                   c.owner_user_id, :user_id AS viewer_user_id, mine.role,
                   active_code.id AS code_id,
                   active_code.circle_id AS code_circle_id,
@@ -555,7 +591,32 @@ class OneLocationCircleService:
                   identity.custom_photo_url, identity.phone_verified,
                   recipient_key.key_id, recipient_key.public_key_jwk,
                   recipient_key.algorithm,
-                  recipient_key.created_at AS key_created_at
+                  recipient_key.created_at AS key_created_at,
+                  CASE
+                    WHEN membership.user_id = :viewer_user_id THEN 'self'
+                    WHEN EXISTS (
+                      SELECT 1
+                      FROM connections c
+                      WHERE c.status = 'active'
+                        AND c.user_a_id = LEAST(:viewer_user_id, membership.user_id)
+                        AND c.user_b_id = GREATEST(:viewer_user_id, membership.user_id)
+                    ) THEN 'connected'
+                    WHEN EXISTS (
+                      SELECT 1
+                      FROM connection_requests cr
+                      WHERE cr.status = 'pending'
+                        AND cr.requester_user_id = :viewer_user_id
+                        AND cr.addressee_user_id = membership.user_id
+                    ) THEN 'pending_outgoing'
+                    WHEN EXISTS (
+                      SELECT 1
+                      FROM connection_requests cr
+                      WHERE cr.status = 'pending'
+                        AND cr.requester_user_id = membership.user_id
+                        AND cr.addressee_user_id = :viewer_user_id
+                    ) THEN 'pending_incoming'
+                    ELSE 'none'
+                  END AS relationship
                 FROM one_location_circle_memberships membership
                 LEFT JOIN actor_identity_cache identity
                   ON identity.user_id = membership.user_id
@@ -575,7 +636,7 @@ class OneLocationCircleService:
                   CASE membership.role WHEN 'owner' THEN 0 ELSE 1 END,
                   COALESCE(identity.display_name, membership.user_id)
                 """,
-                {"circle_id": cleaned_circle_id},
+                {"circle_id": cleaned_circle_id, "viewer_user_id": user_id},
             )
             circle = self._circle_summary(dict(summary_row))
             circle["members"] = [self._member_payload(row) for row in (members_result.data or [])]
@@ -668,6 +729,178 @@ class OneLocationCircleService:
             raise
         except Exception as exc:
             raise self._safe_db_failure("create", exc) from exc
+
+    def ensure_sms_system_circle(self, *, owner_user_id: str) -> dict[str, Any]:
+        """Find-or-create this owner's SMS Circle and fold their contacts into it.
+
+        Issue #5426: emergency SMS contacts stop being a private table
+        (`one_location_sms_contacts`, migration 116) and become a real Circle on
+        the Circles surface -- one the owner manages like any other, except it
+        cannot be deleted, because SOS reads its roster.
+
+        Idempotent by construction, because this runs on every bootstrap and
+        potentially from more than one device at once:
+
+          * The Circle is found before it is created, and migration 159's
+            partial unique index makes "two system Circles for one owner"
+            unrepresentable if two calls race.
+          * Only contacts with NO membership row are inserted. A contact who was
+            migrated and then deliberately removed carries a 'removed' row, so
+            removing someone sticks instead of being undone on next login.
+
+        `one_location_sms_contacts` is read, never emptied. It stays for one
+        release as the record of who each owner picked, so backing this change
+        out cannot lose anybody's emergency contacts.
+        """
+
+        owner = str(owner_user_id or "").strip()
+        if not owner:
+            raise OneLocationCircleError(
+                "LOCATION_CIRCLE_OWNER_REQUIRED",
+                "A signed-in owner is required.",
+                status_code=403,
+            )
+
+        migrated: list[dict[str, Any]] = []
+        try:
+            with self._db.engine.begin() as conn:
+                circle_id = self._find_system_circle_id(conn, owner)
+                if not circle_id:
+                    circle_id = self._insert_system_circle(conn, owner)
+                migrated = self._migrate_sms_contacts_into_circle(conn, owner, circle_id)
+
+                # The owner invited every one of them, so the pair recorded is
+                # owner <-> contact and nothing else. Contacts are never
+                # introduced to each other -- see `_connect_member_to_circle`,
+                # which pairs a joiner with their inviter only.
+                for row in migrated:
+                    contact_id = str(row.get("user_id") or "").strip()
+                    if not contact_id or contact_id == owner:
+                        continue
+                    for kind, source_circle in (
+                        ("circle_member", None),
+                        ("named_circle", circle_id),
+                    ):
+                        ensure_connection_origin(
+                            conn,
+                            user_a_id=owner,
+                            user_b_id=contact_id,
+                            kind=kind,
+                            source_circle_id=source_circle,
+                        )
+
+            if migrated:
+                logger.info(
+                    "one_location.sms_system_circle_migrated owner=%s count=%d",
+                    redact_log_field("user_id", owner),
+                    len(migrated),
+                )
+            return self.get_circle(user_id=owner, circle_id=circle_id)
+        except OneLocationCircleError:
+            raise
+        except Exception as exc:
+            raise self._safe_db_failure("ensure_system", exc) from exc
+
+    @staticmethod
+    def _find_system_circle_id(conn: Any, owner_user_id: str) -> str:
+        row = _first(
+            conn.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM one_location_circles
+                    WHERE owner_user_id = :owner_user_id
+                      AND is_system
+                      AND status = 'active'
+                    LIMIT 1
+                    """
+                ),
+                {"owner_user_id": owner_user_id},
+            )
+        )
+        return str((row or {}).get("id") or "")
+
+    def _insert_system_circle(self, conn: Any, owner_user_id: str) -> str:
+        created = _first(
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO one_location_circles (
+                      owner_user_id, name, kind, status, member_limit,
+                      is_system, created_at, updated_at, metadata
+                    )
+                    VALUES (
+                      :owner_user_id, :name, 'other', 'active',
+                      :member_limit, true, NOW(), NOW(), '{}'::jsonb
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING id
+                    """
+                ),
+                {
+                    "owner_user_id": owner_user_id,
+                    "name": SMS_SYSTEM_CIRCLE_NAME,
+                    "member_limit": CIRCLE_DEFAULT_MEMBER_LIMIT,
+                },
+            )
+        )
+        circle_id = str((created or {}).get("id") or "")
+        if not circle_id:
+            # Lost the race with a concurrent bootstrap; the winner's Circle is
+            # the one both callers should use.
+            circle_id = self._find_system_circle_id(conn, owner_user_id)
+        if not circle_id:
+            raise RuntimeError("system circle insert returned no id")
+
+        conn.execute(
+            text(
+                """
+                INSERT INTO one_location_circle_memberships (
+                  circle_id, user_id, role, status, joined_at, updated_at,
+                  metadata
+                )
+                VALUES (
+                  CAST(:circle_id AS UUID), :user_id, 'owner', 'active',
+                  NOW(), NOW(), '{}'::jsonb
+                )
+                ON CONFLICT (circle_id, user_id) DO NOTHING
+                """
+            ),
+            {"circle_id": circle_id, "user_id": owner_user_id},
+        )
+        return circle_id
+
+    @staticmethod
+    def _migrate_sms_contacts_into_circle(
+        conn: Any, owner_user_id: str, circle_id: str
+    ) -> list[dict[str, Any]]:
+        return _all(
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO one_location_circle_memberships (
+                      circle_id, user_id, role, status, joined_at, updated_at,
+                      metadata
+                    )
+                    SELECT
+                      CAST(:circle_id AS UUID), sms.contact_user_id,
+                      'member', 'active', NOW(), NOW(),
+                      jsonb_build_object('migratedFrom', 'sms_contacts')
+                    FROM one_location_sms_contacts sms
+                    WHERE sms.owner_user_id = :owner_user_id
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM one_location_circle_memberships m
+                        WHERE m.circle_id = CAST(:circle_id AS UUID)
+                          AND m.user_id = sms.contact_user_id
+                      )
+                    ON CONFLICT (circle_id, user_id) DO NOTHING
+                    RETURNING user_id
+                    """
+                ),
+                {"circle_id": circle_id, "owner_user_id": owner_user_id},
+            )
+        )
 
     def update_circle(
         self,
@@ -1681,7 +1914,8 @@ class OneLocationCircleService:
                             """
                             SELECT
                               circle.id, circle.name, circle.kind,
-                              circle.owner_user_id, circle.member_limit
+                              circle.owner_user_id, circle.member_limit,
+                              circle.is_system
                             FROM one_location_circles circle
                             WHERE circle.id = CAST(:circle_id AS UUID)
                               AND circle.status = 'active'
@@ -1998,12 +2232,49 @@ class OneLocationCircleService:
                         ),
                         status_code=409,
                     )
+                is_system_circle = bool(circle_row.get("is_system"))
                 if new_user_ids and reserved_count + len(new_user_ids) > member_limit:
                     raise OneLocationCircleError(
                         "LOCATION_CIRCLE_INVITE_CAPACITY_REACHED",
                         "This Circle does not have room for all selected invitations.",
                         status_code=409,
                     )
+                if is_system_circle and new_user_ids:
+                    # Straight to active membership, exactly as add_sms_contact
+                    # did. `_connect_member_to_circle` is deliberately NOT called:
+                    # these people are the owner's existing contacts, and being on
+                    # an emergency list is not an introduction to the rest of it.
+                    for invitee_user_id in new_user_ids:
+                        conn.execute(
+                            text(
+                                """
+                                INSERT INTO one_location_circle_memberships (
+                                  circle_id, user_id, role, status, joined_at,
+                                  updated_at, metadata
+                                )
+                                VALUES (
+                                  CAST(:circle_id AS UUID), :user_id, 'member',
+                                  'active', NOW(), NOW(),
+                                  jsonb_build_object('addedVia', 'sms_system_circle')
+                                )
+                                ON CONFLICT (circle_id, user_id) DO UPDATE
+                                SET status = 'active',
+                                    ended_at = NULL,
+                                    updated_at = NOW()
+                                """
+                            ),
+                            {
+                                "circle_id": cleaned_circle_id,
+                                "user_id": invitee_user_id,
+                            },
+                        )
+                    logger.info(
+                        "one_location.sms_system_circle_members_added actor=%s count=%d",
+                        redact_log_field("user_id", actor_user_id),
+                        len(new_user_ids),
+                    )
+                    new_user_ids = []
+
                 for invitee_user_id in new_user_ids:
                     invite_row = _first(
                         conn.execute(
@@ -2897,8 +3168,49 @@ class OneLocationCircleService:
             status="left",
         )
 
+    def _reject_system_circle_delete(self, circle_id: str) -> None:
+        """Refuse deletion of a product-provisioned Circle.
+
+        Deleting the SMS Circle is indistinguishable from silently switching
+        emergency alerts off: nothing looks different until the moment it is
+        needed. Members stay fully manageable -- only the container is fixed.
+        """
+        try:
+            row = _first(
+                self._db.execute_raw(
+                    """
+                    SELECT is_system
+                    FROM one_location_circles
+                    WHERE id = CAST(:circle_id AS UUID)
+                      AND status = 'active'
+                    """,
+                    {"circle_id": circle_id},
+                ).data
+                or []
+            )
+        except Exception:
+            # A read failure here must not become a way to delete: fall through
+            # to the statement below, which the trigger still refuses.
+            return
+        if row and bool(row.get("is_system")):
+            raise OneLocationCircleError(
+                "LOCATION_CIRCLE_SYSTEM_PROTECTED",
+                "This Circle is used for emergency SMS alerts and cannot be deleted. "
+                "You can still add or remove its members.",
+                status_code=409,
+            )
+
     def delete_circle(self, *, owner_user_id: str, circle_id: str) -> None:
+        """Soft-delete an owned Circle. System Circles are refused.
+
+        The database refuses this too (migration 159's trigger), and that is
+        the guarantee -- "who may delete this row" is a property of the row, not
+        of whichever code path reached it. This check exists so the API answers
+        with a 409 and a sentence a person can act on, rather than surfacing a
+        raw `restrict_violation` from a trigger as a 500.
+        """
         cleaned_circle_id = _clean_circle_id(circle_id)
+        self._reject_system_circle_delete(cleaned_circle_id)
         try:
             with self._db.engine.begin() as conn:
                 circle_row = _first(

--- a/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
+++ b/consent-protocol/tests/test_one_location_circle_invite_max_uses_migration.py
@@ -1,0 +1,118 @@
+"""Migration 159 raises the invite-code use ceiling to match 100-member Circles.
+
+158 raised `one_location_circles.member_limit` to 100 but left
+`one_location_circle_invite_codes.max_uses` bound to 134's old
+CHECK (max_uses BETWEEN 1 AND 20). `create_code` computes
+`max_uses = member_limit - 1`, so every code created for a Circle at the new
+100 default violated that stale CHECK -- an IntegrityError that
+`_safe_db_failure` turned into "Circle service is temporarily unavailable" on
+every invite-code creation. This migration is the other half of 158.
+
+These assertions are deliberately about SHAPE rather than a live database: the
+release-migration gate reads these same files, and a migration that silently
+stops widening the bound, stops raising the default, or reintroduces the old
+20-use ceiling is exactly the drift worth failing on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+CONTRACTS_DIR = REPO_ROOT / "db" / "contracts"
+SERVICE_PATH = REPO_ROOT / "hushh_mcp" / "services" / "one_location_circle_service.py"
+
+MIGRATION = "159_one_location_circle_invite_max_uses_100.sql"
+ROLLBACK = "159_one_location_circle_invite_max_uses_100.rollback.sql"
+
+
+def _migration() -> str:
+    return (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+
+def _rollback() -> str:
+    return (MIGRATIONS_DIR / "rollback" / ROLLBACK).read_text(encoding="utf-8")
+
+
+def _statements(sql: str) -> str:
+    """The executable half of a migration, with `--` commentary stripped.
+
+    These files explain themselves at length, and the commentary necessarily
+    quotes the old shape it is replacing. Asserting "the old bound is gone"
+    against the raw text would therefore fail on the sentence describing why
+    it went.
+    """
+    lines = [
+        line.split("--", 1)[0] for line in sql.splitlines() if not line.lstrip().startswith("--")
+    ]
+    return chr(10).join(lines)
+
+
+def test_max_uses_migration_is_registered_in_release_order() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert (MIGRATIONS_DIR / MIGRATION).exists()
+    assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
+    # Registered and ordered, NOT "is the last entry". Being the release head
+    # is a fact with a shelf life of exactly one migration -- 160 displaced this
+    # the day it landed, exactly as this migration displaced 158's identical
+    # assertion. Both of those were corrected the same way.
+    ordered = manifest["ordered_migrations"]
+    assert MIGRATION in ordered
+    assert ordered.index("158_one_location_circle_member_limit_100.sql") < ordered.index(MIGRATION)
+    # Structural One Location migrations belong to the iam group, as 158 does.
+    assert MIGRATION in manifest["groups"]["iam"]
+
+
+def test_schema_contracts_advance_to_the_new_migration_head() -> None:
+    for name in (
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+        "dev_minimum_schema.json",
+    ):
+        contract = json.loads((CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] >= 159, name
+
+
+def test_migration_widens_the_bound_and_the_default_together() -> None:
+    migration = _migration()
+
+    assert "DROP CONSTRAINT IF EXISTS one_location_circle_invite_codes_max_uses_check" in migration
+    assert "one_location_circle_invite_codes_max_uses_bounds" in migration
+    assert "CHECK (max_uses BETWEEN 1 AND 100)" in migration
+    assert "ALTER COLUMN max_uses SET DEFAULT 100" in migration
+    assert "BETWEEN 1 AND 20" not in _statements(migration)
+
+
+def test_migration_never_touches_use_count_or_membership_rows() -> None:
+    migration = _migration()
+    statements = _statements(migration)
+
+    # This is a bound-and-default fix, not a data rewrite -- no existing code's
+    # use_count, no membership, no grant.
+    assert "UPDATE one_location_circle_invite_codes" not in statements
+    assert "INSERT INTO one_location_circle_memberships" not in migration
+    assert "INSERT INTO one_location_share_grants" not in migration
+
+
+def test_rollback_restores_the_ceiling_without_truncating_live_codes() -> None:
+    rollback = _rollback()
+
+    assert "ALTER COLUMN max_uses SET DEFAULT 20" in rollback
+    # NOT VALID is the load-bearing word: codes already issued above 20 uses
+    # (from Circles at the 100-member default) are left alone rather than
+    # silently shrinking how many people they can still admit.
+    assert "CHECK (max_uses BETWEEN 1 AND 20) NOT VALID" in rollback
+    assert "UPDATE one_location_circle_invite_codes" not in rollback
+
+
+def test_service_computes_max_uses_from_the_same_ceiling_migration_159_covers() -> None:
+    service = SERVICE_PATH.read_text(encoding="utf-8")
+
+    # The line this migration exists to unblock: max_uses derived from
+    # member_limit, which can now legitimately reach 99.
+    assert "member_limit" in service
+    assert "CIRCLE_DEFAULT_MEMBER_LIMIT = 100" in service

--- a/consent-protocol/tests/test_one_location_system_circle_migration.py
+++ b/consent-protocol/tests/test_one_location_system_circle_migration.py
@@ -1,0 +1,191 @@
+"""Migration 160 makes a Circle the product depends on undeletable.
+
+Issue #5426 turns SMS emergency contacts into a real Circle. A real Circle can
+be deleted, and this one must not be: SOS resolves its recipients from the
+roster, so deleting it is indistinguishable from silently switching emergency
+alerts off -- a failure that surfaces only at the moment it matters.
+
+The assertions below are about shape, because the release-migration gate reads
+these same files. The runtime behaviour (both delete paths refused, ordinary
+Circles unaffected, the row still editable) was exercised against a real
+Postgres 16 while writing the migration; what is guarded here is that the
+guard, the index and the flag do not quietly go missing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+CONTRACTS_DIR = REPO_ROOT / "db" / "contracts"
+SERVICE_PATH = REPO_ROOT / "hushh_mcp" / "services" / "one_location_circle_service.py"
+
+MIGRATION = "160_one_location_system_circles.sql"
+ROLLBACK = "160_one_location_system_circles.rollback.sql"
+
+
+def _migration() -> str:
+    return (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+
+def _rollback() -> str:
+    return (MIGRATIONS_DIR / "rollback" / ROLLBACK).read_text(encoding="utf-8")
+
+
+def _service() -> str:
+    return SERVICE_PATH.read_text(encoding="utf-8")
+
+
+def _statements(sql: str) -> str:
+    """The executable half of a migration, with `--` commentary stripped.
+
+    These files explain themselves at length, and the commentary necessarily
+    names the things the migration deliberately does NOT touch. Asserting
+    absence against the raw text fails on the sentence explaining the absence.
+    """
+    lines = [
+        line.split("--", 1)[0] for line in sql.splitlines() if not line.lstrip().startswith("--")
+    ]
+    return chr(10).join(lines)
+
+
+def _ensure_hook() -> str:
+    """Just `ensure_sms_system_circle` and the helpers it delegates to.
+
+    The service is 3000+ lines and legitimately deletes SMS contact rows
+    elsewhere -- `_cleanup_ineligible_sms_contacts` prunes them when an account
+    is deleted. Scoping to the migration hook is what makes "this hook reads,
+    never empties" a real assertion rather than a claim about the whole file.
+    """
+    service = _service()
+    start = service.index("    def ensure_sms_system_circle(")
+    end = service.index("    def update_circle(", start)
+    return service[start:end]
+
+
+def test_system_circle_migration_is_registered_in_release_order() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert (MIGRATIONS_DIR / MIGRATION).exists()
+    assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
+    # Registered and ordered after the table it alters, rather than pinned as
+    # the release head -- see the same note in the 158 test.
+    ordered = manifest["ordered_migrations"]
+    assert MIGRATION in ordered
+    assert ordered.index("134_one_location_named_circles.sql") < ordered.index(MIGRATION)
+    assert MIGRATION in manifest["groups"]["iam"]
+
+
+def test_schema_contracts_require_the_new_column() -> None:
+    for name in ("prod_core_schema.json", "uat_integrated_schema.json"):
+        contract = json.loads((CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] >= 160, name
+        # The service selects this column on every Circle read, so a database
+        # without it is not one this build can run against.
+        assert "is_system" in contract["required_tables"]["one_location_circles"], name
+
+
+def test_migration_guards_both_delete_paths() -> None:
+    migration = _migration()
+
+    assert "ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT false" in migration
+    assert "CREATE TRIGGER one_location_circles_block_system_delete" in migration
+    assert "BEFORE DELETE OR UPDATE ON one_location_circles" in migration
+    # Hard delete.
+    assert "TG_OP = 'DELETE'" in migration
+    # Soft delete -- the one `delete_circle` actually takes. Guarding only the
+    # hard path would guard the path nothing takes.
+    assert "NEW.status = 'deleted'" in migration
+    assert "restrict_violation" in migration
+
+
+def test_one_live_system_circle_per_owner() -> None:
+    migration = _migration()
+
+    # `ensure_sms_system_circle` is a find-or-create that runs on every
+    # bootstrap, potentially from two devices at once. Without this a race
+    # writes two Circles and SOS reads whichever it finds first.
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uq_one_location_circles_owner_system" in migration
+    assert "WHERE is_system AND status = 'active'" in migration
+
+
+def test_migration_provisions_nothing_by_itself() -> None:
+    migration = _migration()
+
+    # Provisioning belongs to the service, where the membership write can fan
+    # out through the connection graph like every other Circle join.
+    statements = _statements(migration)
+    assert "INSERT INTO one_location_circles" not in statements
+    assert "INSERT INTO one_location_circle_memberships" not in statements
+    assert "one_location_sms_contacts" not in statements
+
+
+def test_rollback_keeps_the_circles_it_can_no_longer_protect() -> None:
+    rollback = _rollback()
+
+    assert "DROP TRIGGER IF EXISTS one_location_circles_block_system_delete" in rollback
+    assert "DROP COLUMN IF EXISTS is_system" in rollback
+    # Dropping the flag does not unmake a membership or a connection, and
+    # deleting the Circles to "clean up" would destroy the contact list SOS
+    # reads. A rollback returns the shape and keeps the data.
+    assert "DELETE FROM one_location_circles" not in rollback
+    assert "DELETE FROM one_location_circle_memberships" not in rollback
+    assert "DROP TABLE IF EXISTS one_location_sms_contacts" not in rollback
+
+
+def test_service_refuses_to_delete_a_system_circle() -> None:
+    service = _service()
+
+    assert "LOCATION_CIRCLE_SYSTEM_PROTECTED" in service
+    assert "_reject_system_circle_delete" in service
+    # Called before the statement runs, so the API answers with a sentence
+    # rather than surfacing a raw trigger violation as a 500.
+    assert "self._reject_system_circle_delete(cleaned_circle_id)" in service
+
+
+def test_service_migration_never_resurrects_a_removed_contact() -> None:
+    hook = _ensure_hook()
+
+    # The bootstrap hook re-runs on every login. Inserting every SMS contact
+    # unconditionally would undo a removal the owner made on purpose, and would
+    # do it silently, every time they signed in.
+    assert "NOT EXISTS (" in hook
+    assert "FROM one_location_circle_memberships m" in hook
+    # Read, never emptied: the legacy table stays for one release so backing
+    # this change out cannot lose anybody's emergency contacts. (Account
+    # deletion still prunes it elsewhere -- that is a different question.)
+    assert "DELETE FROM one_location_sms_contacts" not in hook
+    assert "TRUNCATE" not in hook
+
+
+def test_deletion_is_the_only_power_a_system_circle_removes() -> None:
+    service = _service()
+
+    # The Circle cannot be deleted...
+    assert '"canDeleteCircle": is_owner and not is_system' in service
+    # ...and that is the whole of it. Members see each other here on the same
+    # terms as any other Circle: if something happens to the owner, the people
+    # on the emergency list are the ones who may need to reach each other, and
+    # a roster only the owner can read is useless exactly then.
+    assert "canViewRoster" not in service
+
+
+def test_system_circle_adds_take_effect_without_an_invitation() -> None:
+    service = _service()
+
+    # An emergency contact has never needed the other person's agreement --
+    # add_sms_contact (migration 116) added them outright. Routing system-Circle
+    # adds through the pending-invitation flow would change that in the worst
+    # direction: the owner sees someone on their emergency list, believes SOS
+    # will reach them, and it will not until an invitation nobody mentioned is
+    # accepted.
+    assert "if is_system_circle and new_user_ids:" in service
+    assert "'sms_system_circle'" in service
+
+    # Every other Circle still requires acceptance -- joining someone's Family
+    # Circle IS a relationship, and consent belongs there.
+    assert "INSERT INTO one_location_circle_member_invites" in service
+    assert "'pending'" in service

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -332,6 +332,7 @@ vi.mock("@/lib/one-location/service", () => ({
     // member-visible invite code before the people step opens.
     listCircles: vi.fn().mockResolvedValue([]),
     getCircle: vi.fn(),
+    ensureSmsSystemCircle: vi.fn().mockResolvedValue({ members: [] }),
     createNamedCircle: vi.fn().mockResolvedValue({
       id: "circle_onboarding",
       name: "Test's Circle",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3148,14 +3148,66 @@ export function OneLocationAgentPageContent({
     () => selectShareReadyRecipients(rankedRecipients),
     [rankedRecipients],
   );
-  const smsContactUserIds = useMemo(
+  const legacySmsContactUserIds = useMemo(
     () => state?.smsContactUserIds ?? [],
     [state?.smsContactUserIds],
+  );
+  /**
+   * The SMS Circle's roster, provisioned and kept by `ensureSmsSystemCircle`.
+   *
+   * Issue #5426 makes this Circle the source of truth for who receives an
+   * emergency SMS. The owner is excluded -- they are a member of their own
+   * Circle and are not one of their own emergency contacts.
+   */
+  const [smsSystemCircleMemberIds, setSmsSystemCircleMemberIds] = useState<
+    string[] | null
+  >(null);
+
+  /**
+   * Circle first, legacy list as the fallback.
+   *
+   * Not belt-and-braces -- an ordering guarantee. Provisioning is a network
+   * call that can be slow, fail, or not have run yet on this device, and SOS
+   * must never resolve to an empty recipient list because a migration had not
+   * finished. `null` means "the Circle has not answered yet", which is exactly
+   * when the pre-#5426 source is still the honest one. Once it answers, it
+   * wins outright, including when it is deliberately empty.
+   */
+  const smsContactUserIds = useMemo(
+    () => smsSystemCircleMemberIds ?? legacySmsContactUserIds,
+    [legacySmsContactUserIds, smsSystemCircleMemberIds],
   );
   const smsActionRecipients = useMemo(
     () => selectSmsRecipients(sosActionRecipients, smsContactUserIds),
     [smsContactUserIds, sosActionRecipients],
   );
+
+  // Provision on bootstrap, once the vault token exists. Idempotent server-side,
+  // so a re-run costs one request and changes nothing.
+  useEffect(() => {
+    if (!auth.userId || !vaultOwnerToken) return;
+    let cancelled = false;
+    // Wrapped so a synchronous throw becomes a rejection the catch below can
+    // absorb. Provisioning is an enhancement to where SOS reads its recipients
+    // from; it must never be able to take the Location screen down with it.
+    void Promise.resolve()
+      .then(() => OneLocationService.ensureSmsSystemCircle({ vaultOwnerToken }))
+      .then((circle) => {
+        if (cancelled) return;
+        setSmsSystemCircleMemberIds(
+          (circle.members ?? [])
+            .map((member) => member.userId)
+            .filter((userId) => userId && userId !== auth.userId),
+        );
+      })
+      .catch(() => {
+        // Leave it null: SOS keeps reading the legacy list rather than
+        // resolving to nobody because provisioning failed.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.userId, vaultOwnerToken]);
 
   // Ref kept in sync with the latest sosIncident value so the reconcile effect
   // can read it without adding it as a dependency (preventing infinite loops).
@@ -6676,6 +6728,37 @@ export function OneLocationAgentPageContent({
       }
     },
     [vaultOwnerToken],
+  );
+
+  const handleConnectCircleMember = useCallback(
+    async (circleId: string, memberUserId: string) => {
+      // Sharing a Circle does not connect two people -- a joiner is paired with
+      // whoever invited them and nobody else -- so this is a real request the
+      // other person answers, exactly like one sent from anywhere else.
+      const idToken = await auth.user?.getIdToken();
+      if (!idToken) {
+        toast.error("Sign in again to send a connection request.");
+        return;
+      }
+      try {
+        await ConnectionsService.sendRequest({
+          idToken,
+          addresseeUserId: memberUserId,
+        });
+        toast.success("Connection request sent.");
+        // Re-read the Circle so the row moves to "Requested" from the server's
+        // answer rather than from an optimistic guess this screen made.
+        await handleLoadNamedCircle(circleId).catch(() => null);
+      } catch (error) {
+        toast.error(
+          oneLocationErrorMessage(
+            error,
+            "Could not send the connection request.",
+          ),
+        );
+      }
+    },
+    [auth.user, handleLoadNamedCircle],
   );
 
   const handleResolveNamedCircleRecipients = useCallback(
@@ -11475,6 +11558,7 @@ export function OneLocationAgentPageContent({
     onCopyNamedCircleCode: handleCopyNamedCircleCode,
     onShareNamedCircleCode: handleShareNamedCircleCode,
     onShareNamedCircleCodeById: handleShareNamedCircleCodeById,
+    onConnectCircleMember: handleConnectCircleMember,
     onRemoveNamedCircleMember: handleRemoveNamedCircleMember,
 
     onLoadNamedCircleEligibleConnections:

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -994,7 +994,7 @@ describe("named Circle flows", () => {
     );
   });
 
-  it("removes a member from a labelled destructive action rather than a bare icon", async () => {
+  it("removes a member from a labelled destructive menu action, behind a labelled overflow trigger", async () => {
     const onRemoveMember = vi.fn(async () => undefined);
     const ownerCircle = {
       ...circle("circle-1", "Meena Family"),
@@ -1019,10 +1019,15 @@ describe("named Circle flows", () => {
     );
 
     const trigger = await screen.findByRole("button", {
-      name: "Remove John Smith from this Circle",
+      name: "Actions for John Smith",
     });
-    expect(trigger).toHaveTextContent("Remove");
-    fireEvent.click(trigger);
+    // Radix opens DropdownMenuTrigger on pointerdown (no PointerEvent in
+    // jsdom) or on Enter/Space keydown — use the keyboard path here.
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    );
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Remove", hidden: true }),

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -17,6 +17,7 @@ import {
   ShieldCheck,
   Trash2,
   UsersRound,
+  MoreVertical,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -32,6 +33,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Sheet,
   SheetContent,
@@ -68,6 +75,7 @@ import {
   sortPeopleByName,
 } from "@/lib/one-location/people-search";
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
+import { relationshipCta } from "@/lib/connections/relationship-label";
 import { cn } from "@/lib/utils";
 
 const CIRCLES_GROUP_SURFACE =
@@ -119,6 +127,14 @@ function circleInitials(value: string): string {
  * There are three kinds and nothing on this screen acts on any of them, so
  * the word was decoration in front of the fact. The count stands alone.
  */
+/** Wording for a member count that has already excluded the viewer. The
+ *  Circle detail screen phrases the same number as people rather than
+ *  members; the list row's own label stays with the wording main uses. */
+export function othersCountLabel(others: number): string {
+  if (others <= 0) return "No members yet";
+  return `${others} ${others === 1 ? "person" : "people"}`;
+}
+
 function circleListMemberCountLabel(memberCount: number): string {
   const others = Math.max(0, memberCount - 1);
   return `${others} ${others === 1 ? "member" : "members"}`;
@@ -707,6 +723,8 @@ function CircleMemberRow({
   busy,
   onShare,
   onRemove,
+  onConnect,
+  connecting = false,
 }: {
   member: OneLocationCircleMember;
   currentUserId: string | null;
@@ -714,21 +732,34 @@ function CircleMemberRow({
   busy: boolean;
   onShare: () => void;
   onRemove: () => Promise<void>;
+  /** Sends a connection request to this member. Absent when none is possible. */
+  onConnect?: () => Promise<void>;
+  connecting?: boolean;
 }) {
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
   const isCurrentUser = member.userId === currentUserId;
   const canShare =
     !isCurrentUser && member.phoneVerified && member.secureLocationReady;
+  const canRemove = isOwner && member.role !== "owner";
+  // Only where a request is actually possible. 'self' and 'connected' have
+  // nothing to ask for; the two pending states already have one in flight and
+  // render as a disabled "Requested"/"Respond" so the row still reports where
+  // things stand rather than going blank.
+  const connectCta =
+    !isCurrentUser && member.relationship && member.relationship !== "self"
+      ? relationshipCta(member.relationship)
+      : null;
 
   return (
-    <div className="flex min-h-16 items-center gap-3 px-4 py-3">
-      <Avatar className="h-11 w-11">
+    <div className="flex items-start gap-3 px-4 py-3">
+      <Avatar className="mt-0.5 h-11 w-11 shrink-0">
         {member.photoUrl ? (
           <AvatarImage src={member.photoUrl} alt="" />
         ) : null}
         <AvatarFallback>{circleInitials(member.displayName)}</AvatarFallback>
       </Avatar>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[15px] font-semibold text-foreground">
+      <div className="min-w-0 flex-1 py-1">
+        <p className="break-words text-[15px] font-semibold leading-snug text-foreground">
           {member.displayName}
           {isCurrentUser ? " (you)" : ""}
         </p>
@@ -740,31 +771,68 @@ function CircleMemberRow({
               : "Location setup needed"}
         </p>
       </div>
-      {canShare ? (
+      {connectCta ? (
         <Button
           type="button"
           size="sm"
-          disabled={busy}
-          onClick={onShare}
-          className="h-11 min-w-16 rounded-full"
+          variant={connectCta.disabled ? "secondary" : "default"}
+          disabled={busy || connecting || connectCta.disabled}
+          aria-label={
+            connectCta.disabled
+              ? `${member.displayName}: ${connectCta.label}`
+              : `Connect with ${member.displayName}`
+          }
+          data-testid={`circle-member-connect-${member.userId}`}
+          className="mt-0.5 h-9 shrink-0 rounded-full"
+          onClick={() => {
+            if (connectCta.action === "connect") void onConnect?.();
+          }}
         >
-          Share
+          {connecting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            connectCta.label
+          )}
         </Button>
       ) : null}
-      {isOwner && member.role !== "owner" ? (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
+      {canShare || canRemove ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
             <Button
               type="button"
-              size="sm"
+              size="icon"
               variant="ghost"
               disabled={busy}
-              aria-label={`Remove ${member.displayName} from this Circle`}
-              className="h-11 shrink-0 rounded-full px-3 font-semibold text-destructive hover:bg-destructive/10 hover:text-destructive"
+              aria-label={`Actions for ${member.displayName}`}
+              className="mt-0.5 h-11 w-11 shrink-0 rounded-full"
             >
-              Remove
+              <MoreVertical className="h-5 w-5" />
             </Button>
-          </AlertDialogTrigger>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canShare ? (
+              <DropdownMenuItem onSelect={() => onShare()}>
+                <Share2 className="h-4 w-4" />
+                Share location
+              </DropdownMenuItem>
+            ) : null}
+            {canRemove ? (
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setConfirmRemoveOpen(true);
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+                Remove from Circle
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+      {canRemove ? (
+        <AlertDialog open={confirmRemoveOpen} onOpenChange={setConfirmRemoveOpen}>
           <AlertDialogContent size="sm">
             <AlertDialogHeader>
               <AlertDialogTitle>
@@ -804,6 +872,7 @@ export function CircleDetailFlow({
   onShareCode,
   onShareWithMember,
   onRemoveMember,
+  onConnectMember,
   onLoadEligibleConnections,
   onInviteConnections,
   onCancelMemberInvite,
@@ -830,6 +899,14 @@ export function CircleDetailFlow({
   ) => Promise<void>;
   onShareWithMember: (circleId: string, userId: string) => void;
   onRemoveMember: (circleId: string, userId: string) => Promise<void>;
+  /**
+   * Sends a connection request to a co-member.
+   *
+   * Sharing a Circle does not connect two people -- a joiner is paired with
+   * whoever invited them and nobody else -- so the roster is where that
+   * introduction can be asked for explicitly, and answered by the other person.
+   */
+  onConnectMember: (circleId: string, userId: string) => Promise<void>;
   onLoadEligibleConnections: (
     circleId: string,
   ) => Promise<OneLocationCircleEligibleConnections>;
@@ -856,6 +933,7 @@ export function CircleDetailFlow({
   >([]);
   const [remainingCapacity, setRemainingCapacity] = useState(0);
   const [peopleSearch, setPeopleSearch] = useState("");
+  const [memberSearch, setMemberSearch] = useState("");
   const [selectedConnectionIds, setSelectedConnectionIds] = useState<
     Set<string>
   >(() => new Set());
@@ -909,6 +987,7 @@ export function CircleDetailFlow({
     setPeopleSheetOpen(false);
     setPeopleSearch("");
     setSelectedConnectionIds(new Set());
+    setMemberSearch("");
     setSavingName(false);
     peopleRequestRef.current += 1;
     void reload();
@@ -942,6 +1021,9 @@ export function CircleDetailFlow({
     circle?.inviteCodeNeedsOwnerRotation,
   );
   const members = useMemo(() => circle?.members ?? [], [circle?.members]);
+  // One request in flight at a time: the roster re-renders from the reloaded
+  // Circle, and two overlapping sends would leave the wrong row spinning.
+  const [connectingUserId, setConnectingUserId] = useState<string | null>(null);
   // Single source of truth for the member count shown on BOTH the "Your
   // circles" list row and this detail subtitle: the number of OTHER people in
   // the circle (everyone except the viewer). `circle.memberCount` from the
@@ -952,6 +1034,19 @@ export function CircleDetailFlow({
   const externalMembersCount = useMemo(
     () => members.filter((member) => member.userId !== currentUserId).length,
     [members, currentUserId],
+  );
+
+  // Filters the already-loaded Members list client-side, same as the "Add
+  // people" sheet's connection search — a circle's roster is small enough
+  // that there is no server round trip worth making for this.
+  const filteredMembers = useMemo(
+    () =>
+      filterPeopleByQuery(
+        sortPeopleByName(members, (member) => member.displayName),
+        memberSearch,
+        (member) => member.displayName,
+      ),
+    [members, memberSearch],
   );
 
   const filteredEligibleConnections = useMemo(
@@ -1159,9 +1254,7 @@ export function CircleDetailFlow({
             ? // Same line as the list row this screen was opened from, so the
               // count does not change wording between the two. The kind is
               // dropped here for the same reason it is dropped there.
-              `${externalMembersCount} ${
-                externalMembersCount === 1 ? "member" : "members"
-              }`
+              othersCountLabel(externalMembersCount)
             : "Loading Circle…"
         }
       />
@@ -1582,34 +1675,71 @@ export function CircleDetailFlow({
             </SheetContent>
           </Sheet>
 
-          <SettingsGroup
-            title="Members"
-            description="Members connect through this Circle."
-            testId="one-location-circle-members"
-          >
-            {members.map((member) => (
-              <CircleMemberRow
-                key={member.userId}
-                member={member}
-                currentUserId={currentUserId}
-                isOwner={Boolean(isOwner)}
-                busy={busy}
-                onShare={() =>
-                  onShareWithMember(circle.id, member.userId)
-                }
-                onRemove={async () => {
-                  await removeMember(member.userId);
-                }}
-              />
-            ))}
-          </SettingsGroup>
+          <div className="space-y-3">
+            {members.length ? (
+              <label className="relative block">
+                <span className="sr-only">Search members</span>
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={memberSearch}
+                  onChange={(event) => setMemberSearch(event.target.value)}
+                  placeholder="Search members"
+                  autoComplete="off"
+                  className="h-11 w-full rounded-full border border-border bg-[color:var(--app-card-surface-default-solid)] pl-11 pr-4 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+                  data-testid="one-location-circle-member-search"
+                />
+              </label>
+            ) : null}
 
-          <TrustNoteCard
-            title="Connected does not mean visible"
-            description="Live access still needs approval."
-          />
+            {filteredMembers.length ? (
+              <SettingsGroup
+                title="Members"
+                description="Members connect through this Circle."
+                testId="one-location-circle-members"
+              >
+                {filteredMembers.map((member) => (
+                  <CircleMemberRow
+                    key={member.userId}
+                    member={member}
+                    currentUserId={currentUserId}
+                    isOwner={Boolean(isOwner)}
+                    busy={busy}
+                    onShare={() =>
+                      onShareWithMember(circle.id, member.userId)
+                    }
+                    onRemove={async () => {
+                      await removeMember(member.userId);
+                    }}
+                    connecting={connectingUserId === member.userId}
+                    onConnect={async () => {
+                      if (connectingUserId) return;
+                      setConnectingUserId(member.userId);
+                      try {
+                        await onConnectMember(circle.id, member.userId);
+                      } finally {
+                        setConnectingUserId(null);
+                      }
+                    }}
+                  />
+                ))}
+              </SettingsGroup>
+            ) : (
+              <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
+                <EmptyState
+                  title="No members found"
+                  description="Try a different name."
+                />
+              </div>
+            )}
+          </div>
 
-          {isOwner ? (
+          {/* A system Circle (today: SMS Contacts) is provisioned by the product
+              and read by SOS, so deleting it would switch emergency alerts off
+              with nothing on screen saying so. Every other owner power stays --
+              rename, invite, remove. The API and a database trigger refuse the
+              delete too; this only keeps the person from being offered
+              something that cannot happen. */}
+          {isOwner && !circle.isSystem ? (
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -21,6 +21,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -408,6 +409,16 @@ export type LocationHubViewModel = {
   /** Share a Circle's invite code from a surface that only knows its id. */
   onShareNamedCircleCodeById: (circleId: string) => Promise<void>;
 
+  /**
+   * Sends a connection request to a co-member of a Circle.
+   *
+   * Being in the same Circle is not being connected, so this is the explicit
+   * ask the roster offers -- answered by the other person, never assumed.
+   */
+  onConnectCircleMember: (
+    circleId: string,
+    memberUserId: string,
+  ) => Promise<void>;
   onRemoveNamedCircleMember: (
     circleId: string,
     memberUserId: string,
@@ -913,6 +924,29 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     [pathname, router, searchParams],
   );
 
+  /**
+   * `?action=sms-contacts` now opens the SMS Circle, not a screen of its own.
+   *
+   * Issue #5426 unifies contact management under Circles, and this is the
+   * legacy entry point: the hub's own "SMS contacts" tile, the SOS flow's
+   * "Edit contacts", voice actions, notifications and anything already shared.
+   * Redirecting rather than 404-ing is the difference between "we moved this"
+   * and "this is gone".
+   *
+   * `replace`, so Back leaves Location instead of bouncing off the old param
+   * and redirecting again. And it waits for the Circle to exist -- provisioning
+   * is a network call, and until it answers the old screen is still a working
+   * answer to the same question rather than a dead end.
+   */
+  const smsSystemCircleId = useMemo(
+    () => vm.circles.find((circle) => circle.isSystem)?.id ?? null,
+    [vm.circles],
+  );
+  useEffect(() => {
+    if (flow !== "sms-contacts" || !smsSystemCircleId) return;
+    openCircleDetail(smsSystemCircleId, "replace");
+  }, [flow, openCircleDetail, smsSystemCircleId]);
+
   const openShareFlow = useCallback(
     (initialRecipientId?: string) => {
       resetShareLocalState();
@@ -1184,6 +1218,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             onGenerateCode={vm.onGenerateNamedCircleCode}
             onCopyCode={vm.onCopyNamedCircleCode}
             onShareCode={vm.onShareNamedCircleCode}
+            onConnectMember={(circleId, memberUserId) =>
+              vm.onConnectCircleMember(circleId, memberUserId)
+            }
             onShareWithMember={(circleId, recipientUserId) => {
               vm.prepareNamedCircleShare(circleId, recipientUserId);
               openFlow("share");

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -419,6 +419,22 @@ export class OneLocationService {
     return response.circle;
   }
 
+  /**
+   * Find-or-create the SMS/Emergency Circle and migrate legacy contacts in.
+   *
+   * Safe to call on every bootstrap: the second and every later call return the
+   * same Circle, and a contact the owner has since removed is not re-added.
+   */
+  static async ensureSmsSystemCircle(params: {
+    vaultOwnerToken: string;
+  }): Promise<OneLocationCircleDetail> {
+    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+      "/api/one/location/circles/sms-system",
+      { method: "POST", headers: authHeaders(params.vaultOwnerToken) },
+    );
+    return response.circle;
+  }
+
   static async createNamedCircle(params: {
     vaultOwnerToken: string;
     name: string;

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -278,6 +278,8 @@ export type OneLocationCircleViewerCapabilities = {
   canViewInviteCode: boolean;
   canRotateInviteCode: boolean;
   canManageCircle: boolean;
+  /** False for a system Circle: everything else an owner may do still applies. */
+  canDeleteCircle?: boolean;
   canModerateInvites: boolean;
 };
 
@@ -288,6 +290,11 @@ export type OneLocationCircleSummary = {
   role: OneLocationCircleRole;
   memberCount: number;
   memberLimit: number;
+  /**
+   * Provisioned and depended on by the product (today: the SMS/Emergency
+   * Circle). Members are managed normally; the Circle itself cannot be deleted.
+   */
+  isSystem?: boolean;
   createdAt?: string | null;
   updatedAt?: string | null;
   viewerCapabilities?: OneLocationCircleViewerCapabilities;
@@ -306,7 +313,24 @@ export type OneLocationCircleMember = {
   keyAlgorithm?: string | null;
   keyRegisteredAt?: string | null;
   canReceiveLocation?: boolean;
+  /**
+   * The viewer's relationship with this member.
+   *
+   * Sharing a Circle is not being connected -- a joiner is paired with whoever
+   * invited them and nobody else -- so the roster is where the introduction the
+   * Circle declines to make can be offered explicitly.
+   */
+  relationship?: OneLocationCircleMemberRelationship;
+  /** False when there is nothing to request: self, connected, or already pending. */
+  canConnect?: boolean;
 };
+
+export type OneLocationCircleMemberRelationship =
+  | "self"
+  | "none"
+  | "pending_outgoing"
+  | "pending_incoming"
+  | "connected";
 
 export type OneLocationCircleDetail = OneLocationCircleSummary & {
   members: OneLocationCircleMember[];


### PR DESCRIPTION
Fifth of the sequence restoring the PRs the Monday rollback (#5603) reverted. Restores **#5505**.

The SOS roster stops being an ad-hoc list and becomes a Circle the product provisions and protects: `is_system` marks it, a database trigger refuses to delete it, and the roster row gains a labelled overflow menu instead of a bare destructive icon.

## The migration tests the schema PR held back

Migration 160 and its trigger already landed in **1/8** (#5631). What lands here is the code that reads them — and, deliberately, **the two migration test files that PR held back**.

Each asserts that a schema ceiling and a *service constant* agree, so they could not pass without the service code. They travel with it rather than sitting red on a schema-only PR. They pass here:

```
pytest  system-circle migration + invite-ceiling migration
      + member-limit migration + circle service + account cleanup   74 passed
```

That closes the loop opened in 1/8.

## Two components taken from the original merge, not the replay

`CircleMemberRow` and `CircleDetailFlow` were rebuilt by this change. Replaying the diff produced a **hybrid that opened a `DropdownMenu` and closed an `AlertDialog`** — the two lineages disagree about what that row is, and the merge split the difference into something that could not compile.

Both are taken from the original #5505 merge instead. `othersCountLabel` comes with them; the list row's own wording stays as `main` has it.

## One test follows the component it covers

*"removes a member from a labelled destructive action rather than a bare icon"* is replaced by the menu-based version this change shipped — the bare icon is precisely what it removes, so the old assertion describes the thing being deleted.

## Verification

```
tsc --noEmit                                     clean
eslint (changed web files)                       clean
vitest  one-location/redesign            167 passed
pytest  migrations + circle service + account  74 passed
verify:design-system                             passed
ruff format --check                              clean
```

Base is `main`, 0 behind at push. Remaining: **#5552 → #5560 → #5578 → #5601**.