### PR TITLE
fix(one-location): tint circle-member map pins instead of leaving them untinted

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -2363,6 +2363,47 @@ describe("LocationImmersiveMap reported map defects", () => {
     expect(markerPayload).not.toContain("avatars.test");
   });
 
+  it("tints a fresh circle-member pin distinctly instead of leaving it untinted (#5420)", async () => {
+    // Before this fix, a real (non-demo) person marker carried no `tint` at
+    // all, so `tintColor` reached the native bridge as `undefined` -- the
+    // marker fell back to whatever the platform SDK's default pin color
+    // happens to be, with no guaranteed contrast against map tiles.
+    //
+    // `capturedAt` is set to "now" (rather than reusing the fixed fixture
+    // timestamp `incomingMarker` uses elsewhere) so this marker reads as
+    // fresh regardless of when the suite runs -- a stale pin intentionally
+    // repaints to STALE_TINT, which would otherwise mask this assertion.
+    stubPhoneGeometry();
+    const freshMarker = incomingMarker(ANKIT, 25.4358, 81.8463);
+    const freshCapturedAt = new Date().toISOString();
+    freshMarker.envelope.capturedAt = freshCapturedAt;
+    freshMarker.envelope.plainPointForTest.capturedAt = freshCapturedAt;
+    serviceHarness.getMapState.mockResolvedValue({
+      markers: [freshMarker],
+      preferences: { presenceMode: "ghost" },
+    });
+
+    await renderReadyMap();
+    await waitFor(() => {
+      expect(screen.getByTestId("one-location-map")).toHaveAttribute(
+        "data-map-marker-count",
+        "1",
+      );
+    });
+
+    await waitFor(() => {
+      const drawn = mapHarness.map.addMarkers.mock.calls.at(-1)?.[0] as Array<{
+        tintColor?: { r: number; g: number; b: number; a: number };
+      }>;
+      // The batch may also include the self pin (its own, different tint);
+      // find the incoming circle-member pin specifically.
+      const personMarker = drawn?.find(
+        (marker) => marker.tintColor && marker.tintColor.r !== 0,
+      );
+      expect(personMarker?.tintColor).toEqual({ r: 88, g: 86, b: 214, a: 255 });
+    });
+  });
+
   it("falls back to the app's own initials when there is no profile photo", async () => {
     identityHarness.avatarUrl = null;
     stubPhoneGeometry();

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -264,6 +264,14 @@ type RenderMarker = {
 const STALE_TINT = { r: 142, g: 142, b: 147, a: 255 } as const;
 /** Location blue (--app-accent). The established map accent — never cyan. */
 const SELF_TINT = { r: 0, g: 122, b: 255, a: 255 } as const;
+/**
+ * Indigo (--app-people). Circle members and private shares had no tint at
+ * all before this — falling back to whatever the native SDK's default
+ * marker color happens to be, with no guaranteed contrast against map tiles
+ * and no visual link to the "people" role color used everywhere else this
+ * relationship is shown (Circles, Connect, trusted-contact rows).
+ */
+const PERSON_TINT = { r: 88, g: 86, b: 214, a: 255 } as const;
 /** Green (--app-success). A live check-in is a settled positive fact. */
 const PLACE_ACTIVE_TINT = { r: 52, g: 199, b: 89, a: 255 } as const;
 /**
@@ -1029,6 +1037,7 @@ export function LocationImmersiveMap({
               kind: "person",
               grantId: marker.grant.id,
               capturedAt: marker.envelope.capturedAt ?? null,
+              tint: PERSON_TINT,
             } satisfies RenderMarker;
           } catch {
             // A device without the recipient private key must not show a stale or


### PR DESCRIPTION
## Summary
Addresses #5420. Re-ships work that was reverted by #5603 (the 2026-08-20 Monday-baseline UAT rollback) -- same fix as the original #5454, reapplied fresh against current `main`.

Circle-member / private-share pins carried no `tint` field at all in the production (non-demo) marker-construction path (`location-immersive-map.tsx`). `self` (blue) and `place` (green/orange) markers already had a reserved tint constant each; `person` markers fell through with `tint: undefined`, so `tintColor` reached the native bridge (and the web preview renderer, which reads the same field) as `undefined` on every non-stale render -- no contrast guarantee against map tiles, and no reserved color at all.

Added `PERSON_TINT` (indigo, `{r:88,g:86,b:214}`, matching `--app-people` -- the same semantic color already used for this relationship everywhere else in the app: Circles, Connect, trusted-contact rows) alongside the existing `SELF_TINT`/`PLACE_ACTIVE_TINT`/`PLACE_PENDING_TINT` constants, and set it on the real person-marker construction path. Demo-mode markers already carry a tint from `locationMapDemoPeople()` and are unaffected.

**Scope note** (carried over from the original PR): the issue also asks for "crisp boundary rings (white/black outline strokes)". The `@capacitor/google-maps` `Marker` type exposes `tintColor` only -- no `strokeColor`/`fillColor`/halo property, unlike `Polygon`/`Circle` in the same SDK. A boundary ring would require custom pre-rendered PNG icon assets via `iconUrl` (SVG is unsupported on native per the SDK's own doc comment) -- asset-creation work, out of scope for this code fix.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on both changed files.
- [x] `vitest run __tests__/components/location-immersive-map.test.tsx` -- 50 passed, including a new regression test asserting a fresh circle-member marker's `tintColor` in the payload sent to `addMarkers` matches the new constant (it previously would have been `undefined`).