### PR TITLE
fix(connections): notify the requester when their request is accepted

### DIFF
--- a/consent-protocol/hushh_mcp/branding.py
+++ b/consent-protocol/hushh_mcp/branding.py
@@ -38,3 +38,14 @@ def connection_request_body(requester_label: str | None = None) -> str:
     """
     label = str(requester_label or "").strip() or GENERIC_REQUESTER_LABEL
     return f"{label} wants to connect with you on {BRAND_NAME}."
+
+
+def connection_accepted_body(approver_label: str | None = None) -> str:
+    """The one connection-accepted sentence, for every platform.
+
+    Same authority and same never-emits-None/undefined guarantee as
+    ``connection_request_body`` above, for the symmetric event: telling the
+    original requester that their request was accepted.
+    """
+    label = str(approver_label or "").strip() or GENERIC_REQUESTER_LABEL
+    return f"{label} accepted your connection request on {BRAND_NAME}."

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -161,6 +161,13 @@ def _default_notifier(
     )
 
 
+def _default_accept_notifier(*, requester_user_id: str, approver_user_id: str) -> None:
+    """Best-effort real push (deferred import keeps Firebase off the import path)."""
+    from hushh_mcp.services.push_notifications import send_connection_accepted_push
+
+    send_connection_accepted_push(requester_user_id, approver_user_id)
+
+
 def _default_scope_entries_lookup(owner_user_id: str) -> list[dict[str, Any]]:
     """Read discoverable scope metadata only; never materialized information."""
     from hushh_mcp.consent.scope_generator import DynamicScopeGenerator
@@ -177,12 +184,16 @@ class ConnectionsService:
         directory_visible: Callable[[str, str], bool] | None = None,
         scope_entries_lookup: Callable[[str], list[dict[str, Any]]] | None = None,
         notifier: Callable[..., Any] | None = None,
+        accept_notifier: Callable[..., Any] | None = None,
     ) -> None:
         self._directory_lookup = directory_lookup or _default_directory_lookup
         self._directory_search = directory_search or _default_directory_search
         self._directory_visible = directory_visible or _default_directory_visible
         self._scope_entries_lookup = scope_entries_lookup or _default_scope_entries_lookup
         self._notifier = notifier if notifier is not None else _default_notifier
+        self._accept_notifier = (
+            accept_notifier if accept_notifier is not None else _default_accept_notifier
+        )
 
     # ---- DB seam ----
     def _execute_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
@@ -1069,6 +1080,29 @@ class ConnectionsService:
         except Exception as exc:  # noqa: BLE001
             logger.warning("connections.notify_failed error=%s", exc)
 
+    def _notify_accepted(self, requester_user_id: str, approver_user_id: str) -> None:
+        """Fire the (best-effort) requester nudge. Never raises.
+
+        Guarded even though `connection_requests` and `connections` both carry
+        a `requester != addressee` / `user_a != user_b` CHECK constraint that
+        already makes requester == approver impossible -- matching the
+        actor-exclusion pattern used by every other symmetric-event notifier
+        in this codebase (see one_location_circle_service.send_circle_code_joined_push
+        call site) rather than relying solely on the DB invariant.
+        """
+        notifier = getattr(self, "_accept_notifier", None)
+        if notifier is None:
+            return
+        if not requester_user_id or requester_user_id == approver_user_id:
+            return
+        try:
+            notifier(
+                requester_user_id=requester_user_id,
+                approver_user_id=approver_user_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("connections.accept_notify_failed error=%s", exc)
+
     def _load_request(self, request_id: str, *, for_update: bool = False) -> dict[str, Any]:
         lock_clause = " FOR UPDATE" if for_update else ""
         row = self._execute_one(
@@ -1654,6 +1688,13 @@ class ConnectionsService:
                 )
             except Exception:  # noqa: BLE001 - feed projection cannot roll back consent
                 logger.exception("connections.accepted_feed_projection_failed")
+
+        # Push is a best-effort, post-commit nudge, same as the feed
+        # projection above. Requester-only: `user_id` here is the approver
+        # who just tapped Accept and does not need a push confirming their
+        # own action (see #5423 -- this notification did not exist at all
+        # before, on either side).
+        self._notify_accepted(requester, user_id)
 
         # Accepting a connection grants nothing on its own. Location sharing is
         # opt-in and one-directional: it starts only when a person explicitly

--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import quote
 
-from hushh_mcp.branding import connection_request_body
+from hushh_mcp.branding import connection_accepted_body, connection_request_body
 
 logger = logging.getLogger(__name__)
 
@@ -256,6 +256,43 @@ def send_connection_request_push(
         notification_tag=f"connection-request:{addressee_user_id}",
         notification_category="ONE_CONNECTIONS",
         data=client_data,
+    )
+
+
+def _connection_accepted_body(approver_name: str | None) -> str:
+    """Connection-accepted banner copy. Names the approver when we have one,
+    else falls back to the generic line -- never emits ``None``/``undefined``.
+
+    Thin wrapper kept for the existing call sites and tests; the sentence
+    itself lives in ``hushh_mcp.branding``, same reasoning as
+    ``_connection_request_body`` above.
+    """
+    return connection_accepted_body(approver_name)
+
+
+def send_connection_accepted_push(requester_user_id: str, approver_user_id: str) -> int:
+    """Tell the original requester that their connection request was accepted.
+
+    Addressed to the requester only -- the approver just took the action
+    themselves and does not need a push confirming their own tap. The banner
+    names the approver when the identity cache has a display name, and
+    degrades to a generic line otherwise (best-effort; the lookup never
+    blocks or raises)."""
+    approver_name = _lookup_display_name(approver_user_id)
+    body = _connection_accepted_body(approver_name)
+    return send_user_data_push(
+        requester_user_id,
+        notification_type="connection_accepted",
+        title="Connection accepted",
+        body=body,
+        deep_link="/one/consent?tab=connections",
+        notification_tag=f"connection-accepted:{requester_user_id}",
+        notification_category="ONE_CONNECTIONS",
+        # The in-app toast reads only this data map, never `body` -- the same
+        # reason send_connection_request_push's data carries requester_label
+        # (see #5422). Without approver_label here, the toast would say
+        # "Someone" even when the OS banner named the right person.
+        data={"approver_user_id": approver_user_id, "approver_label": approver_name},
     )
 
 

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -358,6 +358,77 @@ def test_accept_creates_connection_and_two_trusted_edges():
     assert not any("one_location_map_preferences" in c[0] for c in db.calls)
 
 
+def test_accept_notifies_requester_only():
+    """Accepting a request nudges the original requester -- not the approver.
+
+    Regression guard for #5423: before this, accept_request fired no push to
+    either side, and the acceptance flow's Kai chat confirmation text was
+    mistaken for a push notification. This asserts the real wiring.
+    """
+    svc = _svc()
+    calls = []
+    svc._accept_notifier = lambda **kw: calls.append(kw)
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [],  # proposal review -> no scopes
+            [{"id": "conn-1"}],
+            [{"id": "tc-1"}],
+            [{"id": "tc-2"}],
+            [{"id": "req-1"}],
+        ]
+    )
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        svc.accept_request("user-b", "req-1")
+    assert calls == [{"requester_user_id": "user-a", "approver_user_id": "user-b"}]
+
+
+def test_accept_notify_failure_does_not_break_write():
+    """A failing accept-notifier is swallowed; the connection is still made."""
+    svc = _svc()
+
+    def _boom(**_kw):
+        raise RuntimeError("fcm down")
+
+    svc._accept_notifier = _boom
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [],
+            [{"id": "conn-1"}],
+            [{"id": "tc-1"}],
+            [{"id": "tc-2"}],
+            [{"id": "req-1"}],
+        ]
+    )
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.accept_request("user-b", "req-1")
+    assert out["status"] == "accepted"
+
+
+def test_notify_accepted_suppresses_self_directed_push():
+    """Actor-exclusion guard: never nudge someone about their own action."""
+    svc = _svc()
+    calls = []
+    svc._accept_notifier = lambda **kw: calls.append(kw)
+    svc._notify_accepted("user-a", "user-a")
+    assert calls == []
+
+
 def test_accept_request_never_imports_or_calls_location_service():
     """Structural guard against re-wiring auto-share into accept_request.
 

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -4,7 +4,9 @@ from hushh_mcp.branding import BRAND_NAME
 from hushh_mcp.services import push_notifications as push_module
 from hushh_mcp.services.push_notifications import (
     _GENERIC_CONNECTION_REQUEST_BODY,
+    _connection_accepted_body,
     _connection_request_body,
+    send_connection_accepted_push,
     send_connection_request_push,
 )
 from hushh_mcp.services.requester_identity import (
@@ -46,6 +48,38 @@ def test_connection_request_body_spells_the_brand_correctly():
     """
     for value in (None, "Ankit"):
         body = _connection_request_body(value)
+        assert BRAND_NAME in body
+        assert "hushh" not in body.lower()
+
+
+def test_connection_accepted_body_names_the_approver():
+    assert _connection_accepted_body("Ankit") == "Ankit accepted your connection request on Hussh."
+
+
+def test_connection_accepted_body_trims_whitespace_around_the_name():
+    assert (
+        _connection_accepted_body("  Ankit Sharma  ")
+        == "Ankit Sharma accepted your connection request on Hussh."
+    )
+
+
+def test_connection_accepted_body_falls_back_when_name_is_missing():
+    fallback = "Someone accepted your connection request on Hussh."
+    assert _connection_accepted_body(None) == fallback
+    assert _connection_accepted_body("") == fallback
+    assert _connection_accepted_body("   ") == fallback
+
+
+def test_connection_accepted_body_never_emits_none_or_undefined():
+    for value in (None, "", "   ", "Ankit"):
+        body = _connection_accepted_body(value)
+        assert "None" not in body
+        assert "undefined" not in body
+
+
+def test_connection_accepted_body_spells_the_brand_correctly():
+    for value in (None, "Ankit"):
+        body = _connection_accepted_body(value)
         assert BRAND_NAME in body
         assert "hushh" not in body.lower()
 
@@ -162,6 +196,24 @@ def test_connection_request_push_prefers_the_caller_supplied_name(monkeypatch):
     )
 
     assert captured["data"]["requester_label"] == "Ankit"
+
+
+def test_connection_accepted_push_puts_the_approver_label_in_the_data_map(monkeypatch):
+    """Same class of bug #5422 fixed for the request push: the in-app toast
+    reads only the data map, never `body`."""
+    captured = _capture_push(monkeypatch)
+    monkeypatch.setattr(
+        push_module,
+        "_lookup_display_name",
+        lambda _user_id: "Ankit Sharma",
+    )
+
+    send_connection_accepted_push("requester-1", "approver-1")
+
+    assert captured["user_id"] == "requester-1"
+    assert captured["data"]["approver_label"] == "Ankit Sharma"
+    assert captured["data"]["approver_user_id"] == "approver-1"
+    assert captured["body"] == "Ankit Sharma accepted your connection request on Hussh."
 
 
 def test_connection_request_push_reaches_sse_from_a_sync_handler(monkeypatch):


### PR DESCRIPTION
## Summary
Addresses #5423. Re-ships work that was reverted by #5603 (the 2026-08-20 Monday-baseline UAT rollback) -- same fix as the original #5448, reapplied fresh against current `main`.

The bug report's premise was that accepting a connection request fires a push to the *approver* confirming their own action. Root-cause investigation found the actual state was simpler and worse: `accept_request` fires **no push notification at all today, to either side**. The "You're now connected" text the reporter saw is the Kai chat specialist's synchronous reply to whoever issued the accept command via chat, not an FCM push -- unrelated to the bug as filed.

The real gap is the missing requester-facing "your request was accepted" push described in the issue's Expected Behavior section.

## Changes
- `push_notifications.py`: new `send_connection_accepted_push(requester_user_id, approver_user_id)`, mirroring the existing `send_connection_request_push` pattern (deep link to Connections tab, generic-name fallback via `_connection_accepted_body`).
- `connections_service.py`: new injectable `_accept_notifier` (mirrors the existing `_notifier` seam used for `create_request`), a `_notify_accepted` method with an actor-exclusion guard, wired into `accept_request`'s existing best-effort post-commit block (same place the feed projection already lives).
- Actor-exclusion is enforced in code even though `connection_requests`/`connections` both carry a DB CHECK that already makes requester == approver impossible -- matching the same defense-in-depth pattern already used at `one_location_circle_service.py`'s circle-code-joined push call site.

**This closes a gap left open in the Connect live-refresh PR (#5605)**: `CONSENT_STATE_CHANGED_EVENT` already fires for `connection_request`; this is the missing symmetric event for the accept side, so once both are live, "someone accepts your outgoing request while you're on /connect" will also refresh without a reload.

## Test plan
- [x] `pytest tests/services/test_connections_service.py tests/services/test_push_notifications.py` -- 84 passed, including 3 new tests asserting: the requester (not the approver) receives the notification on accept, a failing notifier doesn't break the write, and self-directed notifications are suppressed, plus body-copy and data-map tests for the new push mirroring the existing request-push coverage.
- [x] `ruff check` / `ruff format --check` clean on all changed files.
- [x] `mypy` clean on changed lines (4 pre-existing unrelated errors elsewhere in the touched files, outside this diff's line ranges).