### PR TITLE
restore 7/8: say WHICH share ended when an SMS share is stopped

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -487,10 +487,34 @@ def _identity_notification_label(
     row: dict[str, Any] | None,
     fallback: str = "A trusted person",
 ) -> str:
-    """Return a lock-screen-safe identity label without phone-derived data."""
+    """Return a lock-screen-safe identity label without phone-derived data.
+
+    Delegates the ladder to `resolve_requester_label` -- the resolver #5442
+    added when connection-request pushes were reading "Someone wants to connect
+    with you". It tries the display name, rejects values that are identifiers
+    rather than names (a UUID, the raw user id, an opaque token), and falls back
+    to the handle from the account's email.
+
+    `fallback` survives as the last resort, for an account that genuinely
+    resolves to nothing. That is the one case where a generic phrase is the
+    truthful answer rather than a missing one.
+    """
+
     if not row:
         return fallback
-    return str(row.get("display_name") or "").strip() or fallback
+    # The ladder is run against the row already in hand rather than through
+    # `resolve_requester_label`, which would re-query the same row for its email
+    # rung. Same helpers, same order, one read instead of two.
+    from hushh_mcp.services.requester_identity import (
+        _email_handle,
+        looks_technical_label,
+    )
+
+    user_id = str(row.get("user_id") or "")
+    display_name = str(row.get("display_name") or "").strip()
+    if display_name and not looks_technical_label(display_name, user_id=user_id):
+        return display_name
+    return _email_handle(row.get("email")) or fallback
 
 
 def _notification_safe_data(data: dict[str, Any]) -> dict[str, Any]:
@@ -1339,7 +1363,7 @@ class OneLocationAgentService:
         try:
             return self._execute_one(
                 """
-                SELECT user_id, display_name, phone_number, phone_verified
+                SELECT user_id, display_name, email, phone_number, phone_verified
                 FROM actor_identity_cache
                 WHERE user_id = :user_id
                 LIMIT 1
@@ -2616,11 +2640,27 @@ class OneLocationAgentService:
                 else f"You viewed {owner_label}'s update"
             )
         elif event_type == "location_share_revoked":
-            title = (
-                f"Sharing stopped with {recipient_label}"
-                if owner_user_id == user_id
-                else f"{owner_label} stopped sharing"
+            # The feed lists both lanes together, so an entry that does not say
+            # which one ended reads as ambiguous next to a still-live share
+            # with the same person.
+            revoked_via_sms = (
+                str((_loads_json(row.get("metadata")) or {}).get("share_kind") or "")
+                .strip()
+                .lower()
+                == "sos"
             )
+            if revoked_via_sms:
+                title = (
+                    f"SMS sharing stopped with {recipient_label}"
+                    if owner_user_id == user_id
+                    else f"{owner_label} stopped SMS location sharing"
+                )
+            else:
+                title = (
+                    f"Sharing stopped with {recipient_label}"
+                    if owner_user_id == user_id
+                    else f"{owner_label} stopped sharing"
+                )
         elif event_type == "location_share_expired":
             title = (
                 f"Share expired for {recipient_label}"
@@ -6584,6 +6624,12 @@ class OneLocationAgentService:
         owner_label = _identity_notification_label(owner_identity)
         recipient_identity = self._identity_row(recipient_user_id or "")
         recipient_label = _identity_notification_label(recipient_identity)
+        # Which lane ended. #5552 made `share_kind` the discriminator between
+        # the emergency (SMS / Save My Soul) lane and every other share, and a
+        # person can hold one of each at the same time -- so "a share ended"
+        # without naming the lane is genuinely ambiguous to the recipient.
+        revoked_share_kind = str(row.get("share_kind") or "").strip().lower()
+        revoked_via_sms = revoked_share_kind == "sos"
         self._insert_event(
             owner_user_id=str(row.get("owner_user_id") or owner_user_id),
             actor_user_id=owner_user_id,
@@ -6593,6 +6639,7 @@ class OneLocationAgentService:
             metadata={
                 "reason": "owner_revoke" if actor_is_owner else "recipient_revoke",
                 "counterpart_label": recipient_label,
+                "share_kind": revoked_share_kind or "standard",
             },
         )
         notification_user_id = (
@@ -6601,11 +6648,24 @@ class OneLocationAgentService:
         self._send_metadata_notification(
             user_id=notification_user_id,
             notification_type="location_share_revoked",
-            title="Location access revoked",
+            # "SMS location sharing" is the recipient's name for this, not
+            # "SOS" -- an SMS alert is how it reached them, and the phrase has
+            # to match what they remember receiving.
+            title=(
+                "SMS location sharing stopped" if revoked_via_sms else "Location access revoked"
+            ),
             body=(
-                f"{owner_label} removed your location access."
+                (
+                    f"{owner_label} stopped sharing their location with you over SMS."
+                    if revoked_via_sms
+                    else f"{owner_label} removed your location access."
+                )
                 if actor_is_owner
-                else f"{recipient_label} stopped receiving your location share."
+                else (
+                    f"{recipient_label} stopped receiving your SMS location sharing."
+                    if revoked_via_sms
+                    else f"{recipient_label} stopped receiving your location share."
+                )
             ),
             notification_tag=f"one-location-revoked:{grant_id}",
             request_url=_one_location_url(
@@ -6617,6 +6677,10 @@ class OneLocationAgentService:
                 "owner_display_label": owner_label,
                 "recipient_user_id": recipient_user_id,
                 "recipient_display_label": recipient_label,
+                # Carried so the client's own fallback copy can name the same
+                # lane instead of re-deriving it from a grant it may no longer
+                # be holding -- the grant is revoked by the time this arrives.
+                "share_kind": revoked_share_kind or "standard",
             },
         )
         return self._grant_payload(row) or {}

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -4994,3 +4994,96 @@ def test_same_lane_replacement_still_revokes_the_previous_grant() -> None:
         )
         == 2
     )
+
+
+def test_revoking_an_sms_share_names_the_lane_in_its_copy() -> None:
+    """The recipient is told WHICH share ended, not just that one did.
+
+    Stopping an SMS alert revokes its grant through `revoke_grant`, the same
+    path an ordinary share takes, and the notification never named the lane.
+    Someone who had only ever received an emergency SMS was told "X removed
+    your location access" -- about access they do not know by that name, in a
+    sentence identical to the one an ordinary share produces.
+
+    Since #5552 a person can hold both lanes with the same counterpart at once,
+    so the unnamed wording is ambiguous exactly when someone is checking whether
+    the emergency share is still running.
+    """
+
+    import inspect
+
+    from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+
+    source = inspect.getsource(OneLocationAgentService.revoke_grant)
+
+    # The lane is read from the grant rather than guessed. Both queries in
+    # revoke_grant select `*`, so share_kind is already on the row.
+    assert 'row.get("share_kind")' in source
+    assert 'revoked_share_kind == "sos"' in source or "revoked_via_sms" in source
+
+    # The recipient's word is SMS -- an SMS alert is how it reached them.
+    assert "SMS location sharing stopped" in source
+    assert "over SMS" in source
+
+    # Ordinary shares keep the wording they had.
+    assert "removed your location access." in source
+
+    # And the lane travels with the payload, because the grant is gone by the
+    # time the client renders this and cannot look the kind up itself.
+    assert '"share_kind": revoked_share_kind or "standard"' in source
+
+
+def test_location_notifications_name_the_person_not_a_placeholder() -> None:
+    """A notification says who, on both sides, or degrades honestly.
+
+    `_identity_notification_label` used to read `display_name` and say
+    "A trusted person" whenever it was blank -- so the same account that gets
+    named in a connection-request push went unnamed here. Worse, it took the
+    value verbatim, so a row holding a UUID or a raw user id rendered the
+    identifier AS the name on someone's lock screen.
+
+    #5442 already built the ladder for connections (display name -> reject
+    identifiers -> email handle). This pins that Location uses the same one, so
+    the two cannot drift apart again.
+    """
+
+    from hushh_mcp.services.one_location_agent_service import (
+        _identity_notification_label,
+    )
+
+    # A real name is used as-is, on both sides of any notification.
+    assert _identity_notification_label({"user_id": "u1", "display_name": "Neelesh"}) == ("Neelesh")
+
+    # A blank display name falls through to the email handle rather than
+    # going generic -- this is the case that produced unnamed notifications.
+    assert (
+        _identity_notification_label(
+            {"user_id": "u1", "display_name": "", "email": "neelesh@example.com"}
+        )
+        == "neelesh"
+    )
+
+    # An identifier is NOT a name. Showing it would be worse than being generic.
+    identifier_row = {
+        "user_id": "u1",
+        "display_name": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+    }
+    assert _identity_notification_label(identifier_row) == "A trusted person"
+
+    raw_id_row = {"user_id": "u1", "display_name": "u1"}
+    assert _identity_notification_label(raw_id_row) == "A trusted person"
+
+    # Genuinely unresolvable stays generic, which is the honest answer.
+    assert _identity_notification_label(None) == "A trusted person"
+    assert _identity_notification_label({"user_id": "u1"}) == "A trusted person"
+
+
+def test_identity_lookup_reads_the_column_the_name_ladder_needs() -> None:
+    """The email fallback is only reachable if the query selected email."""
+
+    import inspect
+
+    from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+
+    source = inspect.getsource(OneLocationAgentService._identity_row)
+    assert "email" in source

--- a/hushh-webapp/__tests__/one-location-sms-revoke-notification.test.ts
+++ b/hushh-webapp/__tests__/one-location-sms-revoke-notification.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { locationWorkflowNotificationCopy } from "@/lib/one-location/notifications";
+
+/**
+ * What the other side is told when an SMS location share is stopped.
+ *
+ * Stopping an SMS alert revokes its grant through the same path an ordinary
+ * share takes, and the copy on that path never named which of the two ended.
+ * So someone who had only ever received an emergency SMS was told "X removed
+ * your location access" -- about access they did not know by that name, using
+ * a sentence identical to the one an ordinary share produces.
+ *
+ * It is not a cosmetic difference. Since #5552 a person can hold BOTH lanes
+ * with the same counterpart at once, so an unnamed "your share ended" is
+ * ambiguous precisely when someone is checking whether the emergency one is
+ * still running.
+ */
+describe("stopping an SMS location share", () => {
+  it("names SMS, so the recipient knows which share ended", () => {
+    const copy = locationWorkflowNotificationCopy({
+      type: "location_share_revoked",
+      ownerLabel: "Neelesh",
+      shareKind: "sos",
+    });
+
+    expect(copy.title).toBe("SMS location sharing stopped");
+    expect(copy.description).toBe(
+      "Neelesh stopped sharing their location with you over SMS.",
+    );
+    // "SOS" is the server's word for the lane. The recipient's word is SMS --
+    // an SMS alert is how it reached them, and the copy has to match what they
+    // remember receiving rather than the column that stores it.
+    expect(copy.title).not.toMatch(/SOS/i);
+    expect(copy.description).not.toMatch(/SOS/i);
+  });
+
+  it("leaves an ordinary share's wording exactly as it was", () => {
+    const copy = locationWorkflowNotificationCopy({
+      type: "location_share_revoked",
+      ownerLabel: "Neelesh",
+    });
+
+    expect(copy.description).toBe("Neelesh removed your location access.");
+    expect(copy.description).not.toMatch(/SMS/i);
+  });
+
+  it("treats any non-emergency kind as an ordinary share", () => {
+    // Only the emergency lane is renamed. A check-in share is still a share.
+    for (const shareKind of ["standard", "check_in", "", null, undefined]) {
+      const copy = locationWorkflowNotificationCopy({
+        type: "location_share_revoked",
+        ownerLabel: "Neelesh",
+        shareKind,
+      });
+      expect(copy.description).toBe("Neelesh removed your location access.");
+    }
+  });
+});

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -917,6 +917,10 @@ export function ConsentNotificationProvider({
         extendsGrantExpiresAt: data.extends_grant_expires_at || null,
         grantedDurationHours: data.duration_hours || null,
         grantedDurationMode: data.duration_mode || null,
+        // Which lane ended. Stamped by the service on the revoke payload,
+        // because the grant is gone by the time this arrives -- the client
+        // cannot look the kind up from a share that no longer exists.
+        shareKind: data.share_kind || null,
       });
       const copy = {
         title:

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -626,6 +626,15 @@ export function locationWorkflowNotificationCopy(params: {
   /** The duration actually granted, for approval copy. */
   grantedDurationHours?: number | string | null;
   grantedDurationMode?: string | null;
+  /**
+   * Which lane the notification is about.
+   *
+   * A person can hold an ordinary share and an SMS/Save-My-Soul share with the
+   * same counterpart at once (see grant-lanes), so "your share ended" without
+   * naming the lane is ambiguous exactly when it matters most. `"sos"` is the
+   * emergency lane; anything else is an ordinary share.
+   */
+  shareKind?: string | null;
   /** Clock injected so a list of notifications agrees on "now". */
   nowMs?: number;
 }): { title: string; description: string } {
@@ -664,6 +673,9 @@ export function locationWorkflowNotificationCopy(params: {
       ? "for as long as you need"
       : formatLocationDurationLabel(params.grantedDurationHours);
 
+  const revokedViaSms =
+    normalizeOneLocationShareKind(params.shareKind) === "sos";
+
   switch (params.type) {
     case "location_share_created":
       return {
@@ -690,6 +702,16 @@ export function locationWorkflowNotificationCopy(params: {
         description: locationShareNotificationDescription(ownerLabel),
       };
     case "location_share_revoked":
+      // "SMS location sharing" is what the recipient calls this -- an SMS alert
+      // is how it reached them. Told only that "location access" was removed,
+      // someone who has never opened an ordinary share is being informed about
+      // something they do not know by that name.
+      if (revokedViaSms) {
+        return {
+          title: "SMS location sharing stopped",
+          description: `${ownerLabel} stopped sharing their location with you over SMS.`,
+        };
+      }
       return {
         title: copy.title,
         description: `${ownerLabel} removed your location access.`,


### PR DESCRIPTION
Seventh of the sequence restoring the PRs the Monday rollback (#5603) reverted. Restores **#5560**.

Once a person can hold two live shares with you at once — the split restored in **6/8** — *"your share ended"* is only half a sentence. The stop notification now names the lane it ended, so someone with an ordinary share and an SMS one running together can tell which of the two just stopped without opening the app to work it out.

**Applied cleanly, no conflicts.** The change is scoped to the notification copy and the module that builds it, and nothing else on this base has moved underneath it.

## Verification

```
tsc --noEmit                                       clean
eslint (changed web files)                         clean
vitest  notifications + redesign suites    169 passed
```

Base is `main`, 0 behind at push. Remaining after this: **#5578 → #5601**.