### PR TITLE
fix(finance-setup): tighten Step shorter headline, subhead & footer

### DIFF
--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -582,6 +582,7 @@ function KaiOnboardingPageContent({
               capabilityId="finance"
               isOperationallyReady={false}
               coordinator={financeSetupCoordinator}
+              supportingText="You can return any time."
             />
           ) : null}
         </div>
@@ -639,6 +640,7 @@ function KaiOnboardingPageContent({
             capabilityId="finance"
             isOperationallyReady={false}
             coordinator={financeSetupCoordinator}
+            supportingText="You can return any time."
           />
         ) : null}
       </>
@@ -665,6 +667,7 @@ function KaiOnboardingPageContent({
                 capabilityId="finance"
                 isOperationallyReady={false}
                 coordinator={financeSetupCoordinator}
+                supportingText="You can return any time."
               />
             ) : null
           }

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState, type ReactNode } from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
@@ -43,7 +43,7 @@ type WizardCompletePayload = WizardAnswers & {
 const QUESTIONS = [
   {
     id: "investment_horizon" as const,
-    prompt: "How long do you expect to keep this money invested?",
+    prompt: "How long will this stay invested?",
     options: [
       { value: "short_term" as const, label: "Less than 3 years" },
       { value: "medium_term" as const, label: "3–7 years" },
@@ -329,7 +329,7 @@ export function KaiPreferencesWizard(props: {
                   isPageLayout ? "type-subhead" : "type-footnote"
                 )}
               >
-                No right or wrong answers. We’ll tune Kai to your investing style.
+                We’ll tune Kai to you.
               </p>
 
               <div

--- a/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
@@ -603,6 +603,8 @@ type SetupCapabilityTerminalFooterProps = {
   pending?: boolean;
   skipLabel?: string;
   finishLabel?: string;
+  /** Override the default supporting text. Pass `null` to suppress it entirely. */
+  supportingText?: string | null;
 };
 
 /** Shared explicit Finish/Skip boundary, not a route query or header back button. */
@@ -613,6 +615,7 @@ export function SetupCapabilityTerminalFooter({
   pending = false,
   skipLabel,
   finishLabel,
+  supportingText: supportingTextOverride,
 }: SetupCapabilityTerminalFooterProps) {
   const operationallyReady =
     isOperationallyReady || coordinator.operationallyReady;
@@ -641,7 +644,9 @@ export function SetupCapabilityTerminalFooter({
           : `Skip ${capabilityId} setup for now and return to setup.`
       }
       supportingText={
-        operationallyReady
+        supportingTextOverride !== undefined
+          ? (supportingTextOverride ?? undefined)
+          : operationallyReady
           ? "This capability is ready. You can return to setup."
           : "You can return to this setup any time."
       }


### PR DESCRIPTION
## What
UI/copy-only cleanup of the Finance setup Step 1 screen. No backend, state, routing, or logic changes.

## Why
Screen violated our copy standard:
- Headline was 12 words (standard: 2–6)
- Supporting line was two sentences competing with each other
- Footer had a redundant reassurance line alongside the Skip link

## Changes

| Element | Before | After |
|---|---|---|
| Headline | "How long do you expect to keep this money invested?" | "How long will this stay invested?" |
| Supporting line | "No right or wrong answers. We'll tune Kai to your investing style." | "We'll tune Kai to you." |
| Footer text | "You can return to this setup any time." | "You can return any time." |
| Skip button | "Skip Finance setup" | *(unchanged)* |

## Files touched (3)
- `components/kai/onboarding/KaiPreferencesWizard.tsx` — headline + subhead
- `components/onboarding/setup/setup-capability-coordinator.tsx` — additive `supportingText` override prop only; no defaults changed, all other capabilities (Calendar, Gmail, Location, RIA) unaffected
- `app/one/setup/kai/page.tsx` — passes shortened text at all 3 Finance footer call-sites

## Tested on
- ✅ localhost web (UAT)
- iOS — via hot reload preview

## Checklist
- [x] Copy only — zero logic changes
- [x] No new tokens (font size, weight, spacing)
- [x] Other setup flows unaffected
- [x] Lint passing