### PR TITLE
feat(voice): instant local greeting, remove the redundant relay greeting

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -132,6 +132,22 @@ _ONBOARDING_SCREENS = frozenset(
 _INPUT_MIME_DEFAULT = "audio/pcm;rate=16000"
 _OUTPUT_MIME = "audio/pcm;rate=24000"
 _INITIAL_GREETING_IDLE_SECONDS = 1.5
+
+
+def _greeting_eligible(screen: str, is_fresh_visitor: bool) -> bool:
+    """Whether this session should get the relay's own proactive greeting.
+
+    A fresh (pre-auth) visitor or someone on an onboarding screen needs the
+    proactive nudge -- there is no other greeting for them. A returning,
+    authenticated visitor on an ordinary screen gets an instant, purely
+    local greeting from the browser the moment they tap the mic instead;
+    this relay-side cue would arrive 1.5s+ later than that and say
+    something redundant on top of it, so it is skipped entirely for them
+    rather than raced against.
+    """
+    return (screen in _ONBOARDING_SCREENS) or is_fresh_visitor
+
+
 # Bounded wait for the first app_context frame before run_live opens. Audio
 # is buffered by LiveRequestQueue during the wait; raising this trades a few
 # hundred ms of first-response latency on slow clients for a correct action
@@ -536,37 +552,35 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
     session_started_at = time.monotonic()
 
     def _compose_greeting_prompt(screen: str, playbook: dict[str, Any] | None) -> str:
+        # Only ever called via _send_greeting, which only fires once
+        # _schedule_idle_greeting's _greeting_eligible gate has already
+        # passed -- so this is always the onboarding-flavored cue now. The
+        # plain "greet a returning visitor" text this used to fall back to
+        # is dead: a returning, authenticated visitor on an ordinary screen
+        # gets the instant local greeting instead and never reaches here.
         entry_cue = _bounded_text(playbook.get("entry_cue"), 240) if playbook else ""
         proactive = bool(playbook and playbook.get("proactivity") == "on_entry" and entry_cue)
-        onboarding = (screen in _ONBOARDING_SCREENS) or is_fresh_visitor
-        if onboarding:
-            return (
-                "[Session start - not user speech] This is a NEW visitor who is "
-                "just arriving to get set up. You are One, their private agent: "
-                "the relationship layer where they own their context, grant "
-                "consent, and summon specialists (like Kai for finance) to get "
-                "things done. Greet them warmly in one short sentence, welcome "
-                "them in for the first time, and gently invite them to begin "
-                "getting set up. Do NOT greet them as if they were returning (no "
-                "'welcome back', no 'back again'). If a screen is known, call "
-                "list_app_actions for the current screen first and name the one "
-                "next thing they can do here; ask for what you need in the same "
-                "breath. Do not list capabilities and do not ask more than one "
-                "light question. If their next reply is a short challenge or "
-                "follow-up such as 'so what?' or 'why?', answer the value "
-                "question directly before mentioning setup. "
-                + (
-                    f"The checked-in route cue is: {entry_cue} Use that active-screen "
-                    "guidance instead of an identity-only greeting."
-                    if proactive
-                    else ""
-                )
-            )
         return (
-            "[Session start - not user speech] Greet the user right now in one "
-            "short, warm sentence as One. Vary your greeting naturally between "
-            "sessions; do not repeat a stock phrase, do not list capabilities, "
-            "and do not ask more than one light question."
+            "[Session start - not user speech] This is a NEW visitor who is "
+            "just arriving to get set up. You are One, their private agent: "
+            "the relationship layer where they own their context, grant "
+            "consent, and summon specialists (like Kai for finance) to get "
+            "things done. Greet them warmly in one short sentence, welcome "
+            "them in for the first time, and gently invite them to begin "
+            "getting set up. Do NOT greet them as if they were returning (no "
+            "'welcome back', no 'back again'). If a screen is known, call "
+            "list_app_actions for the current screen first and name the one "
+            "next thing they can do here; ask for what you need in the same "
+            "breath. Do not list capabilities and do not ask more than one "
+            "light question. If their next reply is a short challenge or "
+            "follow-up such as 'so what?' or 'why?', answer the value "
+            "question directly before mentioning setup. "
+            + (
+                f"The checked-in route cue is: {entry_cue} Use that active-screen "
+                "guidance instead of an identity-only greeting."
+                if proactive
+                else ""
+            )
         )
 
     def _send_greeting(screen: str, playbook: dict[str, Any] | None, epoch: int) -> None:
@@ -591,6 +605,8 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
 
     def _schedule_idle_greeting(screen: str, playbook: dict[str, Any] | None = None) -> None:
         nonlocal greeting_task
+        if not _greeting_eligible(screen, is_fresh_visitor):
+            return
         _cancel_pending_greeting()
         epoch = greeting_gate.schedule()
         if epoch is None:

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -6,6 +6,7 @@ from api.routes.one.adk_live import (
     _GOAL_CONTINUATION_NOTE,
     _close_quietly,
     _goal_continuation_is_already_ready,
+    _greeting_eligible,
     _InitialGreetingGate,
     _navigation_continuation_screen,
     _receive_runtime_bootstrap,
@@ -40,6 +41,30 @@ def test_initial_greeting_gate_invalidates_a_pending_cue_after_visitor_activity(
     assert gate.may_send(epoch) is False
     assert gate.mark_sent(epoch) is False
     assert gate.schedule() is None
+
+
+def test_greeting_eligible_covers_fresh_visitors_and_onboarding_screens():
+    """A fresh (pre-auth) visitor always gets the proactive relay greeting,
+    on any screen -- there is no other greeting mechanism for them yet."""
+    assert _greeting_eligible("one_agents", is_fresh_visitor=True) is True
+    assert _greeting_eligible("", is_fresh_visitor=True) is True
+
+    # An authenticated visitor on an onboarding screen still gets it too.
+    assert _greeting_eligible("one_setup", is_fresh_visitor=False) is True
+    assert _greeting_eligible("kai_setup_wizard", is_fresh_visitor=False) is True
+
+
+def test_greeting_ineligible_for_a_returning_visitor_on_an_ordinary_screen():
+    """The actual fix: an authenticated visitor on an ordinary (non-
+    onboarding) screen must NOT get the relay's proactive greeting -- they
+    get an instant local one from the browser instead, and a 1.5s+-later
+    relay greeting on top of it would be redundant, not additive."""
+    assert _greeting_eligible("one_agents", is_fresh_visitor=False) is False
+    assert _greeting_eligible("one_location", is_fresh_visitor=False) is False
+    # The very first schedule call always passes an empty screen (the real
+    # one isn't known yet) -- must not schedule for an authenticated visitor
+    # before the first app_context arrives either.
+    assert _greeting_eligible("", is_fresh_visitor=False) is False
 
 
 class _BootstrapSocket:

--- a/hushh-webapp/__tests__/lib/voice/instant-local-greeting.test.ts
+++ b/hushh-webapp/__tests__/lib/voice/instant-local-greeting.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  playInstantLocalGreeting,
+  stopInstantLocalGreeting,
+} from "@/lib/voice/instant-local-greeting";
+
+function stubSpeechSynthesis() {
+  const speak = vi.fn();
+  const cancel = vi.fn();
+  const synthesis = {
+    speak,
+    cancel,
+    speaking: false,
+    pending: false,
+  };
+  vi.stubGlobal("speechSynthesis", synthesis);
+  vi.stubGlobal(
+    "SpeechSynthesisUtterance",
+    vi.fn(function (this: { text: string; rate: number }, text: string) {
+      this.text = text;
+      this.rate = 1;
+    }),
+  );
+  return synthesis;
+}
+
+describe("playInstantLocalGreeting", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("speaks immediately via the device's own text-to-speech, synchronously", () => {
+    const synthesis = stubSpeechSynthesis();
+
+    playInstantLocalGreeting();
+
+    // No await, no microtask flush -- this must be synchronous or it is not
+    // actually instant.
+    expect(synthesis.cancel).toHaveBeenCalledTimes(1);
+    expect(synthesis.speak).toHaveBeenCalledTimes(1);
+    expect(synthesis.speak.mock.calls[0][0]).toMatchObject({
+      text: expect.stringContaining("how can I help"),
+    });
+  });
+
+  it("clears any pending utterance first so a rapid double-tap never queues two greetings", () => {
+    const synthesis = stubSpeechSynthesis();
+
+    playInstantLocalGreeting();
+    playInstantLocalGreeting();
+
+    expect(synthesis.cancel).toHaveBeenCalledTimes(2);
+    expect(synthesis.speak).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing and never throws when the browser has no speechSynthesis", () => {
+    vi.stubGlobal("speechSynthesis", undefined);
+
+    expect(() => playInstantLocalGreeting()).not.toThrow();
+  });
+
+  it("swallows a speak() failure rather than breaking voice startup", () => {
+    const synthesis = stubSpeechSynthesis();
+    synthesis.speak.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(() => playInstantLocalGreeting()).not.toThrow();
+  });
+});
+
+describe("stopInstantLocalGreeting", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("cancels an in-progress greeting", () => {
+    const synthesis = stubSpeechSynthesis();
+    synthesis.speaking = true;
+
+    stopInstantLocalGreeting();
+
+    expect(synthesis.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a still-pending (not yet started) greeting too", () => {
+    const synthesis = stubSpeechSynthesis();
+    synthesis.pending = true;
+
+    stopInstantLocalGreeting();
+
+    expect(synthesis.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when nothing is speaking or pending", () => {
+    const synthesis = stubSpeechSynthesis();
+
+    stopInstantLocalGreeting();
+
+    expect(synthesis.cancel).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the browser has no speechSynthesis", () => {
+    vi.stubGlobal("speechSynthesis", undefined);
+
+    expect(() => stopInstantLocalGreeting()).not.toThrow();
+  });
+});

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -94,6 +94,10 @@ import type {
   AgentVoiceStatus,
 } from "@/lib/agent/agent-voice-state";
 import { redactSensitiveVoiceTranscript } from "@/lib/voice/voice-sensitive-redaction";
+import {
+  playInstantLocalGreeting,
+  stopInstantLocalGreeting,
+} from "@/lib/voice/instant-local-greeting";
 
 type PrewarmedGeminiRelay = {
   relayUrl: string;
@@ -265,6 +269,24 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   // consistently with the chat workspace, instead of recomputing locally.
   const runtime = useAgentRuntimeStateOptional();
   const { user, loading: authLoading } = useAuth();
+  // Prefer the shared runtime's derived signals so the bar and chat
+  // workspace agree on the home/onboarding surface; fall back to local
+  // computation when the provider is unavailable. Declared this early (used
+  // to live much further down, right where visualOnboardingChrome/
+  // physicalNavbarAbsent below still consume it) because startConversation
+  // needs onboardingGreeterMode/focusedOnboardingVoiceOnly before either of
+  // those computed further down would otherwise be initialized.
+  const isHomeRoute = runtime?.isHomeRoute ?? (pathname ?? "") === ROUTES.HOME;
+  const isLoginRoute = (pathname ?? "").startsWith(ROUTES.LOGIN);
+  // The logged-out welcome ("/") and the sign-in screen ("/login") both host
+  // the dogfooding onboarding voice greeter instead of unmounting the bar
+  // outright: it doubles as the pre-auth conversation starter and stays
+  // route-aware for whatever the signed-out flow visits next. On login the
+  // tier is anon_browsing, so the login route is opted in explicitly.
+  const onboardingGreeterMode =
+    (isHomeRoute && runtime?.tier === "anon_onboarding") || (isLoginRoute && !user);
+  const focusedOnboardingVoiceOnly =
+    isOneSetupRoute(pathname ?? "") || (pathname ?? "").startsWith(ROUTES.PHONE_MANDATE);
   const { theme, setTheme } = useTheme();
   const { vaultOwnerToken, vaultKey, isVaultUnlocked } = useVault();
   const { switchPersona } = usePersonaState();
@@ -299,6 +321,16 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const setVoiceStatus = useAgentVoiceState((s) => s.setStatus);
   const setVoiceLevel = useAgentVoiceState((s) => s.setLevel);
   const resetVoice = useAgentVoiceState((s) => s.reset);
+  // The instant local greeting (played synchronously on tap, see
+  // startConversation below) is short and normally finishes well before the
+  // real connection has anything to say -- but if the connection is
+  // unusually fast, stop it the moment real model audio actually starts so
+  // the two can never be heard overlapping.
+  useEffect(() => {
+    if (voiceStatus === "speaking") {
+      stopInstantLocalGreeting();
+    }
+  }, [voiceStatus]);
   const liveClientRef = useRef<RealtimeVoiceTransport | null>(null);
   const latestVoiceContextRef = useRef<OneVoiceContextSnapshot | null>(
     runtime?.oneVoiceContextSnapshot ?? null,
@@ -1275,6 +1307,14 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       stopConversation();
       return;
     }
+    // Instant, local, and reliable rather than raced against the relay: a
+    // fresh visitor or anyone on an onboarding screen still gets the relay's
+    // own richer greeting instead (see _greeting_eligible in adk_live.py,
+    // which this mirrors) -- speaking a flat local line on top of THAT
+    // greeting would just stack a second, worse one in front of it.
+    if (Boolean(user) && !onboardingGreeterMode && !focusedOnboardingVoiceOnly) {
+      playInstantLocalGreeting();
+    }
     const lease = appInteractionCoordinator.acquireVoiceLease({
       owner: "one_live",
       onRevoked: () => stopConversationRef.current(),
@@ -1355,8 +1395,10 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     stopConversation,
     vaultOwnerToken,
     vaultKey,
-    user?.uid,
+    user,
     setVoiceStatus,
+    onboardingGreeterMode,
+    focusedOnboardingVoiceOnly,
   ]);
 
   // Continuous voice context: when the user navigates while a live session is
@@ -1553,15 +1595,10 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
   // The root intro screen ("/") has no bottom nav, exactly like the onboarding
   // flow, so the bar must anchor above the safe area (not against the absent
-  // nav inset) and must not ride the scroll-hide translation there. Prefer the
-  // shared runtime's derived signals so the bar and chat workspace agree on the
-  // home/onboarding surface; fall back to local computation when the provider
-  // is unavailable.
-  const isHomeRoute = runtime?.isHomeRoute ?? (pathname ?? "") === ROUTES.HOME;
-  // The sign-in screen ("/login") is a signed-out onboarding surface with no
-  // bottom nav (same as "/"), so the bar must anchor above the safe area and
-  // must not ride a scroll-hide translation there.
-  const isLoginRoute = (pathname ?? "").startsWith(ROUTES.LOGIN);
+  // nav inset) and must not ride the scroll-hide translation there.
+  // isHomeRoute/isLoginRoute are declared near the top of the component now
+  // (startConversation needs onboardingGreeterMode/focusedOnboardingVoiceOnly,
+  // which need these, before this point).
   const isFoundationPublic = isFoundationPublicRoute(pathname ?? "");
   
   // The visual styling of the bar (width, aurora, etc.) aligns with the chat
@@ -1605,17 +1642,9 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   // auth transitions where the
   // app shell is not the host.
   const path = pathname ?? "";
-  // The logged-out welcome ("/") and the sign-in screen ("/login") both host
-  // the dogfooding onboarding voice greeter instead of unmounting the bar
-  // outright: it doubles as the pre-auth conversation starter and stays
-  // route-aware for whatever the signed-out flow visits next. On login the
-  // tier is anon_browsing, so the login route is opted in explicitly.
-  const onboardingGreeterMode =
-    (isHomeRoute && runtime?.tier === "anon_onboarding") ||
-    (isLoginRoute && !user);
-  const focusedOnboardingVoiceOnly =
-    isOneSetupRoute(pathname ?? "") ||
-    (pathname ?? "").startsWith(ROUTES.PHONE_MANDATE);
+  // onboardingGreeterMode/focusedOnboardingVoiceOnly are declared near the
+  // top of the component now (startConversation needs them before this
+  // point); both still describe exactly what their names say.
 
   // Signed-out dogfooding: greet the person the moment the onboarding welcome
   // ("/") loads, instead of waiting for a tap. This reuses the exact same

--- a/hushh-webapp/lib/voice/instant-local-greeting.ts
+++ b/hushh-webapp/lib/voice/instant-local-greeting.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { createVoiceTurnId, logVoiceMetric } from "@/lib/voice/voice-telemetry";
+
+/**
+ * The relay's own greeting (consent-protocol/api/routes/one/adk_live.py)
+ * takes a network round trip plus an idle hold plus model generation before
+ * its first audio chunk arrives -- several seconds a returning, already-set-up
+ * person spends looking at a silent mic. This speaks a fixed, local line the
+ * instant the mic is tapped, using the device's own text-to-speech so it has
+ * no dependency on the network or the model being ready.
+ *
+ * Deliberately not spoken for a fresh visitor or an onboarding screen: those
+ * sessions still get the relay's richer, context-aware greeting (see
+ * `_greeting_eligible` in adk_live.py), and this flat line would just be a
+ * second, worse greeting stacked in front of it.
+ */
+const INSTANT_GREETING_TEXT = "Hi, how can I help?";
+
+export function playInstantLocalGreeting(): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) {
+    logVoiceMetric({
+      metric: "voice_instant_greeting_unsupported",
+      value: 1,
+      turnId: createVoiceTurnId(),
+    });
+    return;
+  }
+  try {
+    // Clears anything left over from a rapid double-tap so utterances never
+    // queue up and play back to back.
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(INSTANT_GREETING_TEXT);
+    utterance.rate = 1.05;
+    window.speechSynthesis.speak(utterance);
+    logVoiceMetric({
+      metric: "voice_instant_greeting_played",
+      value: 1,
+      turnId: createVoiceTurnId(),
+    });
+  } catch (error) {
+    logVoiceMetric({
+      metric: "voice_instant_greeting_failed",
+      value: 1,
+      turnId: createVoiceTurnId(),
+      tags: { error: error instanceof Error ? error.message : String(error) },
+    });
+  }
+}
+
+/** Stop a still-playing instant greeting the moment real model audio starts,
+ * so the two can never overlap regardless of how fast the connection is. */
+export function stopInstantLocalGreeting(): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+  if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+    window.speechSynthesis.cancel();
+  }
+}


### PR DESCRIPTION
## Summary
Direct user report during an earlier session: tapping the mic gave 7-8s of silence before anything happened -- 3-4s connection handshake, then another 2-4s before "listening" actually meant anything. Traced the second wait to the relay's own proactive greeting: a 1.5s idle hold plus model generation/TTS latency before its first audio chunk arrives. Re-ships work that was reverted by #5603 (the 2026-08-20 Monday-baseline UAT rollback) -- same fix as the original #5469, reapplied fresh against current `main`.

Two-sided fix: exactly one greeting, spoken instantly, reliable -- not two greetings racing or stacking.

## Backend (`consent-protocol/api/routes/one/adk_live.py`)
- Extracted the existing onboarding/fresh-visitor test (previously inlined in `_compose_greeting_prompt`, only for wording) into a standalone `_greeting_eligible(screen, is_fresh_visitor)`, and used it to gate `_schedule_idle_greeting` itself. A returning, authenticated visitor on an ordinary (non-onboarding) screen no longer gets a relay-side greeting scheduled at all.
- Fresh (pre-auth) visitors and anyone on an onboarding screen (`_ONBOARDING_SCREENS`) are completely unaffected -- same condition, now reused for two things (wording *and* eligibility) instead of duplicated for one.
- `_compose_greeting_prompt`'s "greet a returning visitor" branch is now unreachable (its only caller is gated by the identical condition) -- removed rather than left as dead code.

## Frontend (`agent-bar.tsx` + new `lib/voice/instant-local-greeting.ts`)
- New `playInstantLocalGreeting()`, using the browser's own `speechSynthesis` -- zero network dependency, so it's the one thing in this flow that can actually be instant. Fired synchronously at the top of `startConversation()`, before any async work, gated on the same authenticated-and-not-onboarding condition (`onboardingGreeterMode`/`focusedOnboardingVoiceOnly`, relocated earlier in the component so `startConversation`'s closure can see them without a TDZ error).
- `stopInstantLocalGreeting()` cancels it the instant real model audio actually starts (`voiceStatus -> "speaking"`), so on an unusually fast connection the two can never be heard overlapping, regardless of timing.

## Test plan
- [x] `pytest tests/test_one_adk_live_protocol.py` -- 45 passed, including 2 new tests on `_greeting_eligible` covering every combination (fresh visitor, onboarding screen, ordinary authenticated screen, and the empty-screen case the very first schedule call always uses).
- [x] New `instant-local-greeting.test.ts` -- 8 passed: speaks synchronously (no await needed, confirming it's actually instant), clears a queued utterance on rapid double-tap, never throws when `speechSynthesis` is unsupported or `speak()` itself throws, and `stopInstantLocalGreeting` correctly no-ops vs. cancels.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on all changed files.
- [x] Relevant existing suites (`agent-voice-single-owner.contract.test.ts`, `agent-action-confirmation.contract.test.ts`) still pass.

**Note on unrelated failures**: `navbar-agent-trigger.contract.test.ts` and `one-location-onboarding-flow.test.tsx` fail on current `main` independent of this change -- verified by running them with this diff stashed out against a clean `main`. Pre-existing baseline issues, not touched here.