### PR TITLE
Fix Connect Around directory search and empty states

### DIFF
--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -133,7 +133,7 @@ describe("AdvisorsNearby", () => {
     });
     expect(await screen.findByText("Christine Cote")).toBeTruthy();
     expect(screen.getByText("Morgan Stanley · 47 yrs")).toBeTruthy();
-    expect(screen.getByText("~0.5 mi")).toBeTruthy();
+    expect(screen.getByText("~0.5 mi away")).toBeTruthy();
   });
 
   it("offers a ZIP search when the device says no", async () => {
@@ -449,6 +449,47 @@ describe("AdvisorsNearby", () => {
 
     await screen.findByTestId("advisors-empty");
     expect(screen.getByText("25 mi")).toBeTruthy();
+  });
+
+  it("filters fetched advisors locally and can clear a no-match search", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await screen.findByText("Christine Cote");
+
+    fireEvent.change(screen.getByTestId("advisors-search"), {
+      target: { value: "morgan" },
+    });
+    await waitFor(() => expect(screen.getByText("Christine Cote")).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId("advisors-search"), {
+      target: { value: "not a match" },
+    });
+    expect(await screen.findByTestId("advisors-search-empty")).toBeTruthy();
+    expect(mocks.searchNearby).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Clear search"));
+    expect(await screen.findByText("Christine Cote")).toBeTruthy();
+  });
+
+  it("widens an empty advisor search from its helpful zero state", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(result({ items: [] }));
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await screen.findByTestId("advisors-empty");
+
+    fireEvent.click(screen.getByText("Search within 25 mi"));
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
   });
 
   it("keeps the page on screen when Show more fails", async () => {

--- a/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
@@ -156,7 +156,7 @@ describe("InsuranceAgentsNearby", () => {
     await waitFor(() =>
       expect(screen.getByText("Auto · Commercial · Farm")).toBeTruthy(),
     );
-    expect(screen.getByText("~0.2 mi")).toBeTruthy();
+    expect(screen.getByText("~0.2 mi away")).toBeTruthy();
   });
 
   it("drops the status almost every agency shares, keeps the rare one", async () => {
@@ -287,6 +287,49 @@ describe("InsuranceAgentsNearby", () => {
     await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByText("25 mi"));
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
+  });
+
+  it("filters fetched agencies locally and can clear a no-match search", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    render(<InsuranceAgentsNearby getIdToken={getIdToken} />);
+    await screen.findByText("B G I Agency Network Inc.");
+
+    fireEvent.change(screen.getByTestId("insurance-agents-search"), {
+      target: { value: "kirkland" },
+    });
+    await waitFor(() =>
+      expect(screen.getByText("B G I Agency Network Inc.")).toBeTruthy(),
+    );
+
+    fireEvent.change(screen.getByTestId("insurance-agents-search"), {
+      target: { value: "not a match" },
+    });
+    expect(await screen.findByTestId("insurance-agents-search-empty")).toBeTruthy();
+    expect(mocks.searchNearby).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Clear search"));
+    expect(await screen.findByText("B G I Agency Network Inc.")).toBeTruthy();
+  });
+
+  it("widens an empty agency search from its helpful zero state", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(result({ items: [] }));
+    render(<InsuranceAgentsNearby getIdToken={getIdToken} />);
+    await screen.findByTestId("insurance-agents-empty");
+
+    fireEvent.click(screen.getByText("Search within 25 mi"));
     await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
     expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
   });

--- a/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
@@ -291,6 +291,37 @@ describe("PlacesNearby", () => {
     expect(mocks.streamNearby.mock.calls[1][0].radiusMi).toBe(15);
   });
 
+  it("filters fetched places locally and can clear a no-match search", async () => {
+    mocks.locationState = LOCATED;
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await screen.findByText("Hotel Vivanta");
+
+    fireEvent.change(screen.getByTestId("places-search"), {
+      target: { value: "hotel" },
+    });
+    await waitFor(() => expect(screen.getByText("Hotel Vivanta")).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId("places-search"), {
+      target: { value: "not a match" },
+    });
+    expect(await screen.findByTestId("places-search-empty")).toBeTruthy();
+    expect(mocks.streamNearby).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Clear search"));
+    expect(await screen.findByText("Hotel Vivanta")).toBeTruthy();
+  });
+
+  it("widens an empty places search from its helpful zero state", async () => {
+    mocks.locationState = LOCATED;
+    mocks.streamNearby.mockImplementation(streamOf([]));
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await screen.findByTestId("places-empty");
+
+    fireEvent.click(screen.getByText("Search within 15 mi"));
+    await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.streamNearby.mock.calls[1][0].radiusMi).toBe(15);
+  });
+
   it("lets the user retry a failure instead of stranding them", async () => {
     mocks.locationState = LOCATED;
     mocks.streamNearby.mockRejectedValue(new Error("Places are unavailable right now."));

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Building2, UserRound } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { AdvisorDetailSurface } from "@/components/connect/advisor-detail-surface";
 import {
   DirectoryAttributionFooter,
   DirectoryLoadingRows,
+  ExpandRadiusButton,
   LocationPrompt,
+  NearbyDirectorySearch,
+  NearbyDistanceBadge,
+  NearbyTagBadge,
   PostalCodeForm,
   QuietBlock,
 } from "@/components/connect/nearby-directory-ui";
 import { OfficeDetailSurface } from "@/components/connect/office-detail-surface";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { Button } from "@/lib/morphy-ux/button";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import { useCurrentLocation } from "@/lib/one-location/use-current-location";
@@ -62,6 +68,8 @@ export function AdvisorsNearby({
   /** A failed extra page. Kept apart from `error` so it never hides the list. */
   const [pageError, setPageError] = useState<string | null>(null);
   const [selected, setSelected] = useState<AdvisorCard | null>(null);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 200);
 
   const requestRef = useRef(0);
 
@@ -147,6 +155,24 @@ export function AdvisorsNearby({
     setAnchor({ kind: "postal", postalCode });
   }, []);
 
+  const filteredCards = useMemo(() => {
+    const needle = debouncedQuery.trim().toLowerCase();
+    if (!needle) return cards;
+    return cards.filter((card) =>
+      [
+        card.name,
+        card.firmName,
+        card.city,
+        card.state,
+        card.kind === "branch" ? "office" : "advisor",
+      ]
+        .filter((field): field is string => Boolean(field))
+        .some((field) => field.toLowerCase().includes(needle)),
+    );
+  }, [cards, debouncedQuery]);
+
+  const nextRadiusMi = ADVISOR_RADIUS_OPTIONS_MI.find((mi) => mi > radiusMi);
+
   if (!anchor) {
     return (
       <LocationPrompt
@@ -180,6 +206,15 @@ export function AdvisorsNearby({
 
       {narrowed ? (
         <p className="type-footnote text-muted-foreground">{narrowed}</p>
+      ) : null}
+
+      {!error && !loading && cards.length > 0 ? (
+        <NearbyDirectorySearch
+          value={query}
+          onChange={setQuery}
+          placeholder="Search advisors or firms"
+          testId="advisors-search"
+        />
       ) : null}
 
       {error && !loading ? (
@@ -218,19 +253,45 @@ export function AdvisorsNearby({
         // dead end.
         <QuietBlock
           title="Nothing nearby"
-          subtitle="Try a US ZIP."
+          subtitle="Try a US ZIP, or search a wider radius."
           testId="advisors-empty"
         >
-          <PostalCodeForm
-            busy={loading}
-            initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
-            onSearch={handlePostalCode}
-            testId="advisors-postal-input"
-          />
+          <div className="flex w-full flex-col items-center gap-4">
+            <PostalCodeForm
+              busy={loading}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="advisors-postal-input"
+            />
+            <ExpandRadiusButton
+              nextRadiusMi={nextRadiusMi}
+              onExpand={setRadiusMi}
+            />
+          </div>
         </QuietBlock>
       ) : null}
 
-      {error || (!loading && cards.length === 0) ? null : (
+      {!error && !loading && cards.length > 0 && filteredCards.length === 0 ? (
+        <QuietBlock
+          title="No matches"
+          subtitle="Try a different name or firm."
+          testId="advisors-search-empty"
+        >
+          <Button
+            type="button"
+            variant="none"
+            effect="fill"
+            size="sm"
+            onClick={() => setQuery("")}
+          >
+            Clear search
+          </Button>
+        </QuietBlock>
+      ) : null}
+
+      {error ||
+      (!loading && cards.length === 0) ||
+      (!loading && filteredCards.length === 0) ? null : (
         <SettingsGroup
           title={meta?.grouped ? "Offices" : "Advisors"}
           separatorInset
@@ -238,14 +299,19 @@ export function AdvisorsNearby({
           {loading ? (
             <DirectoryLoadingRows testId="advisors-loading" />
           ) : (
-            cards.map((card) => {
+            filteredCards.map((card) => {
               const distance = formatDistance(card.distanceMiles);
               return (
                 <SettingsRow
                   key={`${card.kind}-${card.id}`}
+                  icon={card.kind === "branch" ? Building2 : UserRound}
+                  iconTone="blue"
                   title={
                     <span className="flex min-w-0 items-center gap-2">
                       <span className="truncate">{card.name ?? "Advisor"}</span>
+                      <NearbyTagBadge>
+                        {card.kind === "branch" ? "Office" : "Advisor"}
+                      </NearbyTagBadge>
                       {card.hasDisclosures ? (
                         <span
                           className="size-1.5 shrink-0 rounded-full bg-amber-500"
@@ -259,13 +325,7 @@ export function AdvisorsNearby({
                   density="compact"
                   chevron
                   onClick={() => setSelected(card)}
-                  trailing={
-                    distance ? (
-                      <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
-                        {distance}
-                      </span>
-                    ) : undefined
-                  }
+                  trailing={<NearbyDistanceBadge distance={distance} />}
                 />
               );
             })

--- a/hushh-webapp/components/connect/insurance-agents-nearby.tsx
+++ b/hushh-webapp/components/connect/insurance-agents-nearby.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Building2 } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { InsuranceAgentDetailSurface } from "@/components/connect/insurance-agent-detail-surface";
 import {
   DirectoryAttributionFooter,
   DirectoryLoadingRows,
+  ExpandRadiusButton,
   LocationPrompt,
+  NearbyDirectorySearch,
+  NearbyDistanceBadge,
+  NearbyTagBadge,
   PostalCodeForm,
   QuietBlock,
 } from "@/components/connect/nearby-directory-ui";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { Button } from "@/lib/morphy-ux/button";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import { useCurrentLocation } from "@/lib/one-location/use-current-location";
@@ -67,6 +73,8 @@ export function InsuranceAgentsNearby({
   /** A failed extra page. Kept apart from `error` so it never hides the list. */
   const [pageError, setPageError] = useState<string | null>(null);
   const [selected, setSelected] = useState<InsuranceAgentCard | null>(null);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 200);
 
   const requestRef = useRef(0);
 
@@ -152,6 +160,20 @@ export function InsuranceAgentsNearby({
     setAnchor({ kind: "postal", postalCode });
   }, []);
 
+  const filteredCards = useMemo(() => {
+    const needle = debouncedQuery.trim().toLowerCase();
+    if (!needle) return cards;
+    return cards.filter((card) =>
+      [card.name, card.agencyType, card.tier, card.city, card.state]
+        .filter((field): field is string => Boolean(field))
+        .some((field) => field.toLowerCase().includes(needle)),
+    );
+  }, [cards, debouncedQuery]);
+
+  const nextRadiusMi = INSURANCE_AGENT_RADIUS_OPTIONS_MI.find(
+    (mi) => mi > radiusMi,
+  );
+
   if (!anchor) {
     return (
       <LocationPrompt
@@ -177,6 +199,15 @@ export function InsuranceAgentsNearby({
         options={RADIUS_OPTIONS}
         disabled={loading}
       />
+
+      {!error && !loading && cards.length > 0 ? (
+        <NearbyDirectorySearch
+          value={query}
+          onChange={setQuery}
+          placeholder="Search agencies"
+          testId="insurance-agents-search"
+        />
+      ) : null}
 
       {error && !loading ? (
         // Same reasoning as the advisers directory: keep the ZIP box reachable
@@ -212,24 +243,50 @@ export function InsuranceAgentsNearby({
         // can actually help rather than a dead end.
         <QuietBlock
           title="Nothing nearby"
-          subtitle="Try a US ZIP."
+          subtitle="Try a US ZIP, or search a wider radius."
           testId="insurance-agents-empty"
         >
-          <PostalCodeForm
-            busy={loading}
-            initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
-            onSearch={handlePostalCode}
-            testId="insurance-agents-postal-input"
-          />
+          <div className="flex w-full flex-col items-center gap-4">
+            <PostalCodeForm
+              busy={loading}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="insurance-agents-postal-input"
+            />
+            <ExpandRadiusButton
+              nextRadiusMi={nextRadiusMi}
+              onExpand={setRadiusMi}
+            />
+          </div>
         </QuietBlock>
       ) : null}
 
-      {error || (!loading && cards.length === 0) ? null : (
+      {!error && !loading && cards.length > 0 && filteredCards.length === 0 ? (
+        <QuietBlock
+          title="No matches"
+          subtitle="Try a different name."
+          testId="insurance-agents-search-empty"
+        >
+          <Button
+            type="button"
+            variant="none"
+            effect="fill"
+            size="sm"
+            onClick={() => setQuery("")}
+          >
+            Clear search
+          </Button>
+        </QuietBlock>
+      ) : null}
+
+      {error ||
+      (!loading && cards.length === 0) ||
+      (!loading && filteredCards.length === 0) ? null : (
         <SettingsGroup title="Agencies" separatorInset>
           {loading ? (
             <DirectoryLoadingRows testId="insurance-agents-loading" />
           ) : (
-            cards.map((card) => {
+            filteredCards.map((card) => {
               const distance = formatAgentDistance(card.distanceMiles);
               // Roughly one agency in fifty carries a standing status; the rest
               // share one default that is dropped rather than repeated on every
@@ -238,9 +295,12 @@ export function InsuranceAgentsNearby({
               return (
                 <SettingsRow
                   key={card.id}
+                  icon={Building2}
+                  iconTone="blue"
                   title={
                     <span className="flex min-w-0 items-center gap-2">
                       <span className="truncate">{card.name ?? "Agency"}</span>
+                      <NearbyTagBadge>Agency</NearbyTagBadge>
                       {status ? (
                         <span className="type-caption shrink-0 rounded-full bg-[color:var(--app-accent)]/10 px-1.5 py-0.5 text-[color:var(--app-accent)]">
                           {status}
@@ -252,13 +312,7 @@ export function InsuranceAgentsNearby({
                   density="compact"
                   chevron
                   onClick={() => setSelected(card)}
-                  trailing={
-                    distance ? (
-                      <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
-                        {distance}
-                      </span>
-                    ) : undefined
-                  }
+                  trailing={<NearbyDistanceBadge distance={distance} />}
                 />
               );
             })

--- a/hushh-webapp/components/connect/nearby-directory-ui.tsx
+++ b/hushh-webapp/components/connect/nearby-directory-ui.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Search as SearchIcon, X } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -10,6 +11,7 @@ import {
   RowDescription,
 } from "@/components/app-ui/typography";
 import { Button } from "@/lib/morphy-ux/button";
+import { cn } from "@/lib/morphy-ux/cn";
 
 /**
  * The presentational parts every "near you" directory shares.
@@ -104,6 +106,88 @@ export function PostalCodeForm({
         Search
       </Button>
     </form>
+  );
+}
+
+/** A responsive input that filters directory rows already held in memory. */
+export function NearbyDirectorySearch({
+  value,
+  onChange,
+  placeholder,
+  testId,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  testId: string;
+}) {
+  return (
+    <div className="relative">
+      <SearchIcon
+        className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80"
+        aria-hidden
+      />
+      <Input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        autoComplete="off"
+        className={cn("h-10 pl-9", value ? "pr-11" : "pr-3.5")}
+        data-testid={testId}
+      />
+      {value ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onChange("")}
+          className="absolute right-0 top-1/2 inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground/80 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** Consistent compact distance treatment for every nearby directory row. */
+export function NearbyDistanceBadge({ distance }: { distance: string | null }) {
+  if (!distance) return null;
+  return (
+    <span className="type-caption shrink-0 whitespace-nowrap rounded-full bg-muted px-2 py-0.5 tabular-nums text-muted-foreground">
+      {distance} away
+    </span>
+  );
+}
+
+/** A neutral classification marker used beside nearby result names. */
+export function NearbyTagBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="type-caption shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+/** Offers a wider search only while a larger configured radius remains. */
+export function ExpandRadiusButton({
+  nextRadiusMi,
+  onExpand,
+}: {
+  nextRadiusMi: number | undefined;
+  onExpand: (miles: number) => void;
+}) {
+  if (typeof nextRadiusMi !== "number") return null;
+  return (
+    <Button
+      type="button"
+      variant="none"
+      effect="fade"
+      size="sm"
+      onClick={() => onExpand(nextRadiusMi)}
+    >
+      Search within {nextRadiusMi} mi
+    </Button>
   );
 }
 

--- a/hushh-webapp/components/connect/places-nearby.tsx
+++ b/hushh-webapp/components/connect/places-nearby.tsx
@@ -1,16 +1,22 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { MapPin } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import {
   DirectoryAttributionFooter,
   DirectoryLoadingRows,
+  ExpandRadiusButton,
   LocationPrompt,
+  NearbyDirectorySearch,
+  NearbyDistanceBadge,
+  NearbyTagBadge,
   PostalCodeForm,
   QuietBlock,
 } from "@/components/connect/nearby-directory-ui";
 import { PlaceDetailSurface } from "@/components/connect/place-detail-surface";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { Button } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/morphy-ux/cn";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
@@ -76,6 +82,8 @@ export function PlacesNearby({
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<PlaceCard | null>(null);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 200);
 
   const requestRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
@@ -214,7 +222,7 @@ export function PlacesNearby({
     setAnchor({ kind: "postal", postalCode });
   }, []);
 
-  const visible = useMemo(() => {
+  const categoryVisible = useMemo(() => {
     if (chip !== ALL_CHIP) return byCategory[chip] ?? [];
     // The merged view is nearest-first across every bucket that has answered,
     // de-duplicated: a bank inside a shopping centre can legitimately arrive in
@@ -231,7 +239,23 @@ export function PlacesNearby({
     return merged.sort((a, b) => a.distanceMeters - b.distanceMeters);
   }, [byCategory, chip]);
 
+  const visible = useMemo(() => {
+    const needle = debouncedQuery.trim().toLowerCase();
+    if (!needle) return categoryVisible;
+    return categoryVisible.filter((card) =>
+      [
+        card.name,
+        card.categoryLabel,
+        placesCategoryLabel(card.category),
+        card.address,
+      ]
+        .filter((field): field is string => Boolean(field))
+        .some((field) => field.toLowerCase().includes(needle)),
+    );
+  }, [categoryVisible, debouncedQuery]);
+
   const answered = Object.keys(byCategory).length;
+  const nextRadiusMi = PLACES_RADIUS_OPTIONS_MI.find((mi) => mi > radiusMi);
 
   if (!anchor) {
     return (
@@ -301,6 +325,15 @@ export function PlacesNearby({
         })}
       </div>
 
+      {!error && categoryVisible.length > 0 ? (
+        <NearbyDirectorySearch
+          value={query}
+          onChange={setQuery}
+          placeholder="Search places"
+          testId="places-search"
+        />
+      ) : null}
+
       {error ? (
         <QuietBlock
           title={error}
@@ -329,7 +362,7 @@ export function PlacesNearby({
         </QuietBlock>
       ) : null}
 
-      {!error && !streaming && visible.length === 0 ? (
+      {!error && !streaming && categoryVisible.length === 0 ? (
         // Coordinates can be perfectly good and still match nothing — a radius
         // of one mile in open country is an honest empty. Offer the two things
         // that help: a wider radius above, and a different place to look.
@@ -338,23 +371,52 @@ export function PlacesNearby({
           subtitle="Try a wider radius, or another postcode."
           testId="places-empty"
         >
-          <PostalCodeForm
-            busy={streaming}
-            initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
-            onSearch={handlePostalCode}
-            testId="places-postal-input"
-            label="Postcode"
-            numericOnly={false}
-          />
+          <div className="flex w-full flex-col items-center gap-4">
+            <PostalCodeForm
+              busy={streaming}
+              initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+              onSearch={handlePostalCode}
+              testId="places-postal-input"
+              label="Postcode"
+              numericOnly={false}
+            />
+            <ExpandRadiusButton
+              nextRadiusMi={nextRadiusMi}
+              onExpand={setRadiusMi}
+            />
+          </div>
         </QuietBlock>
       ) : null}
 
-      {error || (!streaming && visible.length === 0) ? null : (
+      {!error &&
+      !streaming &&
+      categoryVisible.length > 0 &&
+      visible.length === 0 ? (
+        <QuietBlock
+          title="No matches"
+          subtitle="Try a different name or category."
+          testId="places-search-empty"
+        >
+          <Button
+            type="button"
+            variant="none"
+            effect="fill"
+            size="sm"
+            onClick={() => setQuery("")}
+          >
+            Clear search
+          </Button>
+        </QuietBlock>
+      ) : null}
+
+      {error ||
+      (!streaming && categoryVisible.length === 0) ||
+      (!streaming && visible.length === 0) ? null : (
         <SettingsGroup
           title={chip === ALL_CHIP ? "Nearby" : placesCategoryLabel(chip)}
           separatorInset
         >
-          {visible.length === 0 ? (
+          {categoryVisible.length === 0 ? (
             <DirectoryLoadingRows testId="places-loading" />
           ) : (
             visible.map((card) => {
@@ -362,18 +424,21 @@ export function PlacesNearby({
               return (
                 <SettingsRow
                   key={card.placeId}
-                  title={<span className="truncate">{card.name}</span>}
+                  icon={MapPin}
+                  iconTone="gray"
+                  title={
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate">{card.name}</span>
+                      <NearbyTagBadge>
+                        {placesCategoryLabel(card.category)}
+                      </NearbyTagBadge>
+                    </span>
+                  }
                   description={formatPlaceSubtitle(card) ?? undefined}
                   density="compact"
                   chevron
                   onClick={() => setSelected(card)}
-                  trailing={
-                    distance ? (
-                      <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
-                        {distance}
-                      </span>
-                    ) : undefined
-                  }
+                  trailing={<NearbyDistanceBadge distance={distance} />}
                 />
               );
             })


### PR DESCRIPTION
Fixes #5424

## Summary

- add debounced, client-side filtering to the Advisors, Insurance, and Places directories in Connect → Around
- standardize nearby-row tags, icons, and distance pills
- provide actionable no-result states for both an unmatched query and an empty radius

### Impact Map

- Routes touched: `/one/connect` (Around tab)
- API/schema/type changes: none
- Runtime DB data-plane changes: none
- Cache keys touched: none
- PKM effects: none
- Mobile parity impacts: web-only presentation; no native bridge or route-contract change
- Trust boundary touched: none
- Caller/proxy/backend pairing: unchanged; search filters already-fetched rows only
- Rollback or safe-failure behavior: removing the frontend-only components restores the prior directory presentation; provider and location recovery flows are unchanged
- UI browser proof: not run — canonical reviewer credentials are unavailable in this environment
- Docs updated: none; no contract changed

## Verification

- `npx vitest run components/connect/__tests__/advisors-nearby.test.tsx components/connect/__tests__/insurance-agents-nearby.test.tsx components/connect/__tests__/places-nearby.test.tsx` (64 passed)
- targeted ESLint (passed)
- `npm run typecheck` (passed)
- `npm run verify:design-system` (passed)
- `npm run verify:docs` (passed)
- `npm run verify:routes` blocked by absent `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; no credential workaround used