### PR TITLE
feat(one-location): the Request-location roster, built for a hundred people

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -13,6 +13,7 @@ import { ApiError } from "@/lib/services/api-client";
 // The rungs themselves, not a copy of their labels: Ask and Share must offer
 // the same ladder, so the test reads the same list the component does.
 import { SHARE_DURATION_LADDER } from "@/components/one-location/redesign/duration-presets";
+import { ROUTES } from "@/lib/navigation/routes";
 
 const {
   mockUseRequireAuth,
@@ -4397,6 +4398,45 @@ describe("OneLocationAgentPage", () => {
         extendsGrantId: "grant_from_request_live",
       }),
     );
+  });
+
+  it("offers a way to Connect when the person being looked for is not on the list", async () => {
+    // This roster is everyone you are already connected to, so "they are not
+    // here" has exactly one answer and it lives on another screen. Without
+    // this the empty state was a dead end, and a search that found nobody was
+    // worse: it proved the person was missing and offered nothing to do next.
+    mockGetState.mockResolvedValue(locationState());
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    const link = await screen.findByTestId(
+      "one-location-ask-manage-connections",
+    );
+    expect(link).toHaveAttribute("href", ROUTES.CONNECT);
+  });
+
+  it("keeps typing local so the roster is not refiltered on every keystroke", async () => {
+    // `setRecipientSearch` drives `visibleRecipients`, which re-runs the filter
+    // over the whole roster and re-renders every row. Wired straight to
+    // onChange that ran once per keystroke. The field now reads local state and
+    // only the debounced value reaches the view model -- so the character is on
+    // screen immediately while the work waits.
+    mockGetState.mockResolvedValue(locationState());
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    const field = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(field, { target: { value: "Tru" } });
+
+    // The character is visible at once; the filter has not run yet.
+    expect((field as HTMLInputElement).value).toBe("Tru");
+    expect(screen.getByText("Trusted B")).toBeInTheDocument();
   });
 
   it("removes an already-live person's access from the Ask flow's own list", async () => {

--- a/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
@@ -33,6 +33,9 @@ export function VirtualContactList<T>({
   maxHeightClassName = "max-h-[52vh]",
   testId,
   ariaLabel,
+  presentation = "grouped",
+  scrollClassName,
+  itemClassName,
 }: {
   items: readonly T[];
   getKey: (item: T) => string;
@@ -40,6 +43,24 @@ export function VirtualContactList<T>({
   maxHeightClassName?: string;
   testId?: string;
   ariaLabel?: string;
+  /**
+   * How the rows are dressed.
+   *
+   * `"grouped"` is the picker's own look and stays the default, so the two
+   * surfaces already using this component are untouched: one card shell,
+   * hairlines between rows.
+   *
+   * `"cards"` is for a list whose rows are ALREADY cards. The Ask flow renders
+   * `TrustedPersonCard`, and wrapping those in the group shell would put a
+   * card inside a card and draw a divider between two things that already have
+   * their own edges. Windowing is the part worth sharing; the dressing is not.
+   */
+  presentation?: "grouped" | "cards";
+  /** Replaces the scroll container's classes in `cards` presentation, so a
+   *  caller keeps the scrollbar and spacing its screen already had. */
+  scrollClassName?: string;
+  /** Per-row wrapper classes in `cards` presentation. */
+  itemClassName?: string;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const virtualize = shouldVirtualizeList(items.length);
@@ -54,22 +75,36 @@ export function VirtualContactList<T>({
     getItemKey: (index) => getKey(items[index] as T),
   });
 
+  const asCards = presentation === "cards";
+  const Shell = asCards
+    ? ({ children }: { children: ReactNode }) => <>{children}</>
+    : ContactGroup;
+
   if (!virtualize) {
     return (
-      <ContactGroup>
-        <div data-testid={testId} aria-label={ariaLabel} role={ariaLabel ? "list" : undefined}>
+      <Shell>
+        <div
+          data-testid={testId}
+          aria-label={ariaLabel}
+          role={ariaLabel ? "list" : undefined}
+          className={asCards ? scrollClassName : undefined}
+        >
           {items.map((item) => (
-            <div key={getKey(item)} role={ariaLabel ? "listitem" : undefined}>
+            <div
+              key={getKey(item)}
+              role={ariaLabel ? "listitem" : undefined}
+              className={asCards ? itemClassName : undefined}
+            >
               {renderItem(item)}
             </div>
           ))}
         </div>
-      </ContactGroup>
+      </Shell>
     );
   }
 
   return (
-    <ContactGroup>
+    <Shell>
       <div
         ref={scrollRef}
         data-testid={testId}
@@ -81,7 +116,7 @@ export function VirtualContactList<T>({
           // Momentum scrolling in the Capacitor webview; without it a long
           // roster scrolls with a dead, non-native feel on iOS.
           "[-webkit-overflow-scrolling:touch]",
-          maxHeightClassName,
+          asCards ? scrollClassName : maxHeightClassName,
         )}
       >
         <div
@@ -98,7 +133,12 @@ export function VirtualContactList<T>({
                 ref={virtualizer.measureElement}
                 data-index={virtualItem.index}
                 role={ariaLabel ? "listitem" : undefined}
-                className="absolute left-0 top-0 w-full border-b border-[color:var(--app-separator)] last:border-b-0"
+                className={cn(
+                  "absolute left-0 top-0 w-full",
+                  asCards
+                    ? itemClassName
+                    : "border-b border-[color:var(--app-separator)] last:border-b-0",
+                )}
                 style={{ transform: `translateY(${virtualItem.start}px)` }}
               >
                 {renderItem(item)}
@@ -107,6 +147,6 @@ export function VirtualContactList<T>({
           })}
         </div>
       </div>
-    </ContactGroup>
+    </Shell>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -43,6 +43,7 @@ import {
   ShieldCheck,
   UserPlus,
   UsersRound,
+  ChevronRight,
 } from "lucide-react";
 
 import { requestRecipientStatus } from "@/lib/one-location/request-recipient-status";
@@ -129,6 +130,12 @@ import { SavedLocationsSection } from "@/components/one-location/saved-locations
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import {
+  SelectedContactsPill,
+  SelectedContactsSheet,
+} from "@/components/one-location/redesign/contact-picker/selected-review-sheet";
 import { ROUTES } from "@/lib/navigation/routes";
 import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
@@ -3525,6 +3532,41 @@ function AskFlow({
   onClose: () => void;
 }) {
   const filtered = vm.visibleRecipients;
+  /**
+   * The field is local; the FILTER is debounced.
+   *
+   * `setRecipientSearch` drives `visibleRecipients`, which re-runs
+   * `filterPeopleByQuery` over the whole roster and re-renders every row. Wired
+   * straight to `onChange` that happened once per keystroke, which is what a
+   * hundred connections cannot afford. Typing stays instant because the input
+   * reads local state; only the query that does the work is delayed.
+   *
+   * 250ms, close to Connect's 300: long enough to swallow a burst of typing,
+   * short enough that the list feels answerable rather than laggy.
+   */
+  const [searchDraft, setSearchDraft] = useState(vm.recipientSearch);
+  const debouncedSearch = useDebouncedValue(searchDraft, 250);
+  useEffect(() => {
+    if (debouncedSearch !== vm.recipientSearch) {
+      vm.setRecipientSearch(debouncedSearch);
+    }
+    // `vm` is rebuilt every render; depending on it would re-fire this on every
+    // render and defeat the debounce entirely.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
+
+  // Selection is only ever readable by scrolling the roster and counting the
+  // rows wearing "Selected". The pill answers "who is on this list" without
+  // the scroll, and the sheet is where that answer gets edited.
+  const [selectionSheetOpen, setSelectionSheetOpen] = useState(false);
+  const selectedRecipients = useMemo(
+    () =>
+      vm.recipients.filter((recipient) =>
+        vm.selectedRequestOwnerIds.includes(recipient.userId),
+      ),
+    [vm.recipients, vm.selectedRequestOwnerIds],
+  );
+
   // Keep the person on this screen after sending so the confirmation is tied to
   // the specific request they just made, rather than popping straight back to
   // the hub.
@@ -3588,13 +3630,31 @@ function AskFlow({
 
       <section className="space-y-3">
         <AppSectionLabel as="h2">People</AppSectionLabel>
-        <PersonSearchInput
-          value={vm.recipientSearch}
-          onChange={vm.setRecipientSearch}
-        />
+        <PersonSearchInput value={searchDraft} onChange={setSearchDraft} />
+        {vm.selectedRequestOwnerIds.length ? (
+          <SelectedContactsPill
+            count={vm.selectedRequestOwnerIds.length}
+            onOpen={() => setSelectionSheetOpen(true)}
+          />
+        ) : null}
         {filtered.length ? (
-          <div className={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}>
-            {filtered.map((r) => {
+          /* Windowed above the picker's own threshold, plain DOM below it.
+             The rule is `shouldVirtualizeList`, imported rather than
+             re-implemented, so this list and the contact picker cannot drift
+             apart on where "too long to render whole" begins.
+
+             `presentation="cards"` because these rows are already cards: the
+             grouped shell would put a card inside a card and draw a divider
+             between two things that have their own edges. */
+          <VirtualContactList
+            items={filtered}
+            getKey={(r) => r.userId}
+            scrollClassName={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}
+            itemClassName="pb-2.5 last:pb-0"
+            presentation="cards"
+            testId="one-location-ask-recipients"
+            ariaLabel="People you can ask"
+            renderItem={(r) => {
               const selected = vm.selectedRequestOwnerIds.includes(r.userId);
               // Every row used to read "Ready for private sharing" with Select
               // as the only affordance, whoever the person was and whatever had
@@ -3704,8 +3764,8 @@ function AskFlow({
                   }
                 />
               );
-            })}
-          </div>
+            }}
+          />
         ) : (
           <div className="mt-3">
             {vm.recipientSearch.trim() ? (
@@ -3721,7 +3781,31 @@ function AskFlow({
             )}
           </div>
         )}
+        {/* The way out. This list is everyone you are already connected to, so
+            "they are not here" has exactly one answer, and it lives on another
+            screen. Without this the empty state was a dead end and a search
+            that found nobody was worse -- it proved the person was missing and
+            offered nothing to do about it. */}
+        <a
+          href={ROUTES.CONNECT}
+          data-testid="one-location-ask-manage-connections"
+          className="mt-3 inline-flex min-h-11 items-center gap-1 rounded-full px-1 text-[15px] font-medium text-[color:var(--app-accent)]"
+        >
+          Don&apos;t see someone? Manage connections
+          <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+        </a>
       </section>
+
+      <SelectedContactsSheet
+        open={selectionSheetOpen}
+        onOpenChange={setSelectionSheetOpen}
+        recipients={selectedRecipients}
+        busyUserId={null}
+        onRemove={(recipientUserId) =>
+          vm.toggleRequestOwner(recipientUserId, "ask_flow")
+        }
+        recipientLabel={vm.recipientLabel}
+      />
 
       {/* Ask and Share are the same decision pointed in opposite directions,
           so they are now the same card: one surface, "How long" over the


### PR DESCRIPTION
Closes **#5606** — the first of #5421's four parts. The picker was written for a handful of contacts and is now opened by accounts holding a hundred.

## What changes

**Search is local; the filter is debounced (250ms).** Typing was wired straight to `setRecipientSearch`, which drives `visibleRecipients`, which re-runs the filter over the whole roster and re-renders every row — *once per keystroke*. The character is still on screen immediately; only the work waits.

**The roster is windowed** above the picker's own threshold and plain DOM below it. `shouldVirtualizeList` is **imported rather than re-implemented**, so this list and the contact picker cannot drift apart on where "too long to render whole" begins. Below the threshold rows stay plain — jsdom measures every element as 0px tall, so a virtualized list renders almost nothing under test, and small fixtures stay directly assertable.

**A selection pill.** Selection was readable only by scrolling the roster and counting the rows wearing "Selected". The pill answers *"who is on this list"* without the scroll; the sheet is where that answer gets edited.

**A way out to Connect.** This roster is everyone you are already connected to, so "they are not here" has exactly one answer and it lives on another screen. The empty state was a dead end — and a search that found nobody was worse: it proved the person was missing and offered nothing to do next.

## One shared-component change, made safely

`VirtualContactList` gains a `cards` presentation rather than the Ask flow copying its windowing. These rows are **already cards**, and the grouped shell would put a card inside a card and draw a divider between two things that have their own edges.

`grouped` stays the **default**, and neither existing consumer passes the new prop — verified by grep, and their suites pass unchanged.

## Header contract

`?action=ask` is a compliant Location surface (eyebrow `Location`, title `Request location` matching its crumb). The diff touches **no part of it** — verified: zero matches for `TaskFlowHeader`, `eyebrow`, `<h1>` or `ChevronLeft` in the changed lines.

## Explicitly NOT in this change

The per-row `requestRecipientStatus` call and the 30-second interval that re-renders the whole roster. **Windowing reduces how many rows do that work; it does not reduce the work per row.** That is #5607, still open, and it is the larger of the two problems.

## Verification

```
tsc --noEmit                                             clean
eslint (all three changed files)                         clean
vitest  redesign suites + debounce hook          201 passed
vitest  agent page (incl. 2 new Ask-flow tests)  103 passed
verify:design-system                                     passed
verify:capacitor:static                                  passed
```

Base is `main`, 0 behind at push.