### PR TITLE
perf(one-location): stop the Request roster recomputing every row, twice a minute

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -46,7 +46,10 @@ import {
   ChevronRight,
 } from "lucide-react";
 
-import { requestRecipientStatus } from "@/lib/one-location/request-recipient-status";
+import {
+  requestRecipientStatus,
+  type RequestRecipientStatus,
+} from "@/lib/one-location/request-recipient-status";
 import {
   locationApproveActionLabel,
   locationAskPromptLine,
@@ -3603,10 +3606,86 @@ function AskFlow({
   // Coarse on purpose: these labels move in minutes, so a 30s tick keeps them
   // honest without re-rendering a list of people every second.
   const [statusNowMs, setStatusNowMs] = useState(() => Date.now());
+
+  /**
+   * Every live grant with each owner, indexed once.
+   *
+   * The row used to run `receivedGrants.find(...)` for itself, so a roster of R
+   * people scanned the grant list R times per render. Worse, `find` was written
+   * when a person and a grant were the same thing: an owner can now hold an
+   * ordinary share and an SMS (SOS) one at the same time, and `find` bound the
+   * row to whichever happened to come first.
+   *
+   * `groupGrantsByCounterpart` is the shared answer the People directory and
+   * Shared-with-me already use, and its `primaryGrant` is `grants[0]` in the
+   * caller's order -- the same grant `find` returned. So this indexes the work
+   * without moving the answer, and the other lane is now reachable rather than
+   * silently dropped.
+   */
+  const receivedGroupsByOwner = useMemo(() => {
+    const byOwner = new globalThis.Map<string, OneLocationGrantLaneGroup>();
+    // `"recipient"` -- the side argument names WHICH SIDE I AM, so for grants
+    // shared WITH me the counterpart to key on is the owner. Passing "owner"
+    // here keys every group by my own id and the lookup finds nothing; the
+    // Shared-with-me list a few hundred lines up passes "recipient" for the
+    // same array, for the same reason.
+    for (const group of groupGrantsByCounterpart(
+      vm.receivedGrants,
+      "recipient",
+    )) {
+      byOwner.set(group.counterpartUserId, group);
+    }
+    return byOwner;
+  }, [vm.receivedGrants]);
+
+  /**
+   * What each visible row says, computed once per data change.
+   *
+   * `requestRecipientStatus` filters AND sorts `requestedByMe` on every call,
+   * so calling it inside the render loop cost R x O(G log G) per render -- and
+   * a 30-second tick paid it again whether or not anything had happened. The
+   * inputs are the same for every row; only the recipient id differs.
+   */
+  const statusByRecipient = useMemo(() => {
+    const byRecipient = new globalThis.Map<string, RequestRecipientStatus>();
+    for (const recipient of filtered) {
+      byRecipient.set(
+        recipient.userId,
+        requestRecipientStatus({
+          recipientUserId: recipient.userId,
+          requestedByMe: vm.requestedByMe,
+          receivedGrants: vm.receivedGrants,
+          nowMs: statusNowMs,
+        }),
+      );
+    }
+    return byRecipient;
+  }, [filtered, vm.requestedByMe, vm.receivedGrants, statusNowMs]);
+
+  /**
+   * Whether anything on screen is actually measured against the clock.
+   *
+   * "Asked 6m ago" and "Sharing with you, 29 more min" go stale; "Ready for
+   * private sharing" does not. A roster of people you have never asked and who
+   * are not sharing has nothing that ages, and re-rendering it every 30 seconds
+   * is CPU spent to redraw identical text -- battery, on a phone.
+   */
+  const hasTimeRelativeRow = useMemo(
+    () =>
+      [...statusByRecipient.values()].some(
+        (status) =>
+          status.statusLabel !== undefined ||
+          status.pendingRequestId !== undefined ||
+          status.tone !== "ready",
+      ),
+    [statusByRecipient],
+  );
+
   useEffect(() => {
+    if (!hasTimeRelativeRow) return;
     const timer = window.setInterval(() => setStatusNowMs(Date.now()), 30_000);
     return () => window.clearInterval(timer);
-  }, []);
+  }, [hasTimeRelativeRow]);
   return (
     <div className="space-y-5">
       <TaskFlowHeader
@@ -3661,21 +3740,24 @@ function AskFlow({
               // already happened with them -- so there was no active status to
               // read, and somebody who had just asked came back to a row
               // offering to ask again.
-              const status = requestRecipientStatus({
-                recipientUserId: r.userId,
-                requestedByMe: vm.requestedByMe,
-                receivedGrants: vm.receivedGrants,
-                nowMs: statusNowMs,
-              });
+              // Both read from an index built once above, not recomputed per
+              // row. `statusByRecipient` always has this id: it is built from
+              // the same `filtered` array being mapped here.
+              const status =
+                statusByRecipient.get(r.userId) ??
+                requestRecipientStatus({
+                  recipientUserId: r.userId,
+                  requestedByMe: vm.requestedByMe,
+                  receivedGrants: vm.receivedGrants,
+                  nowMs: statusNowMs,
+                });
               // A row already Live is the one place this list had no way off
               // it: the person keeps showing up "already sharing" with
               // nothing to do about that but wait it out or leave the screen
               // entirely to find the Shared with me / Requests sent list
               // that could end or shorten it.
-              const activeGrant = vm.receivedGrants.find(
-                (grant) =>
-                  grant.ownerUserId === r.userId && grant.status === "active",
-              );
+              const activeGrant =
+                receivedGroupsByOwner.get(r.userId)?.primaryGrant;
               const isEditingThis =
                 Boolean(activeGrant) && vm.editingGrantId === activeGrant?.id;
               // The unanswered ask this row is reporting, if any. The row used


### PR DESCRIPTION
Closes **#5607** — the second of #5421's four parts, and the larger half of the problem the first one could not reach.

The previous PR windowed the roster, which reduces *how many rows* do the work. It does not reduce *the work per row*. This does.

## What was happening per row, per render

- **`requestRecipientStatus` filters AND sorts `requestedByMe` on every call.** Called inside the map, a roster of R people against G requests cost **R × O(G log G)** — for inputs that are identical on every row except the id.
- **`receivedGrants.find(...)`** scanned the grant list again, once per row.
- **A 30-second interval** re-rendered the whole roster whether or not anything had changed, paying both of the above again.

## What it does now

Each is computed once. `statusByRecipient` and `receivedGroupsByOwner` are memoised on the data they read; the rows look themselves up.

**The grant index reuses `groupGrantsByCounterpart`** — the helper the People directory and Shared-with-me already use — rather than a second hand-rolled `find`. Its `primaryGrant` is `grants[0]` in the caller's order, which is *exactly what `find` returned*, so this indexes the work **without moving the answer**.

It also fixes a latent bug the old `find` carried: an owner can hold an ordinary share and an SMS (SOS) one at the same time, and `find` bound the row to whichever came first with no way to reach the other.

**The tick is gated on `hasTimeRelativeRow`.** "Asked 6m ago" and "Sharing with you, 29 more min" go stale; "Ready for private sharing" does not. A roster of people you have never asked and who are not sharing has nothing that ages, so it no longer re-renders every 30 seconds to redraw identical text — which on a phone is battery, not just frames.

## One correction worth recording

The first attempt passed `side: "owner"` to the grouping helper. That argument names **which side you are** — so for grants shared *with* you, the counterpart is the owner and the correct value is `"recipient"`. Passing `"owner"` keyed every group by the viewer's own id and the lookup found nothing.

**Eight tests caught it**, which is why they run before the commit rather than after. The Shared-with-me list a few hundred lines up passes `"recipient"` for the same array, for the same reason.

## Verification

```
tsc --noEmit                                             clean
eslint                                                   clean
vitest  redesign suites + recipient-status       209 passed
vitest  agent page (incl. 8 live-grant tests)    103 passed
verify:design-system                                     passed
```

The eight live-grant Ask-flow tests are the ones that pin this behaviour — they exercise the edit, stop, shorten and extend paths that read `activeGrant`.

Base is `main`, 0 behind at push.