### PR TITLE
feat(voice): add a deterministic multi-name spoken-name resolver

### DIFF
--- a/hushh-webapp/lib/one-location/__tests__/resolve-spoken-names.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/resolve-spoken-names.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ambiguousMatchNames,
+  normalizeSpokenName,
+  resolveSpokenNames,
+  splitSpokenNames,
+} from "@/lib/one-location/resolve-spoken-names";
+
+type Person = { id: string; name: string };
+
+const ALICE: Person = { id: "1", name: "Alice Chen" };
+const BOB: Person = { id: "2", name: "Bob Lee" };
+const SARAH_CHEN: Person = { id: "3", name: "Sarah Chen" };
+const SARAH_LEE: Person = { id: "4", name: "Sarah Lee" };
+const ANDERSON: Person = { id: "5", name: "Anderson Cole" };
+const PEOPLE = [ALICE, BOB, SARAH_CHEN, SARAH_LEE, ANDERSON];
+
+describe("normalizeSpokenName", () => {
+  it("strips case, accents, and punctuation", () => {
+    expect(normalizeSpokenName("Zoë O'Brien!")).toBe("zoe o brien");
+  });
+
+  it("collapses repeated whitespace left by stripped punctuation", () => {
+    expect(normalizeSpokenName("Mum   &   Dad")).toBe("mum dad");
+  });
+
+  it("keeps combining marks so non-Latin scripts remain self-matching", () => {
+    expect(normalizeSpokenName("परिवार")).toBe("परिवार");
+  });
+});
+
+describe("splitSpokenNames", () => {
+  it("returns a single-element array when there is no delimiter", () => {
+    expect(splitSpokenNames("Alice")).toEqual(["Alice"]);
+  });
+
+  it("splits on a comma", () => {
+    expect(splitSpokenNames("Alice, Bob")).toEqual(["Alice", "Bob"]);
+  });
+
+  it("splits on the standalone word 'and'", () => {
+    expect(splitSpokenNames("Alice and Bob")).toEqual(["Alice", "Bob"]);
+  });
+
+  it("does not split inside a name that merely contains the letters 'and'", () => {
+    expect(splitSpokenNames("Anderson Cole")).toEqual(["Anderson Cole"]);
+  });
+
+  it("splits on '&' and ';'", () => {
+    expect(splitSpokenNames("Alice & Bob; Sarah")).toEqual(["Alice", "Bob", "Sarah"]);
+  });
+
+  it("handles three names mixing delimiters", () => {
+    expect(splitSpokenNames("Alice, Bob and Sarah")).toEqual(["Alice", "Bob", "Sarah"]);
+  });
+
+  it("drops empty fragments from a trailing delimiter", () => {
+    expect(splitSpokenNames("Alice, ")).toEqual(["Alice"]);
+    expect(splitSpokenNames("")).toEqual([]);
+    expect(splitSpokenNames("   ")).toEqual([]);
+  });
+});
+
+describe("resolveSpokenNames", () => {
+  it("resolves a single name exactly like the old single-name behavior", () => {
+    const result = resolveSpokenNames(PEOPLE, "alice", (p) => p.name);
+    expect(result).toEqual({ resolved: [ALICE], unresolved: [] });
+  });
+
+  it("resolves multiple named people from one utterance", () => {
+    const result = resolveSpokenNames(PEOPLE, "Alice and Bob", (p) => p.name);
+    expect(result.resolved).toEqual([ALICE, BOB]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves what it can and reports the rest when one name is unknown", () => {
+    const result = resolveSpokenNames(PEOPLE, "Alice and Rahul", (p) => p.name);
+    expect(result.resolved).toEqual([ALICE]);
+    expect(result.unresolved).toEqual([
+      { spokenText: "Rahul", kind: "not_found" },
+    ]);
+  });
+
+  it("resolves what it can and reports an ambiguous name separately", () => {
+    const result = resolveSpokenNames(PEOPLE, "Alice and Sarah", (p) => p.name);
+    expect(result.resolved).toEqual([ALICE]);
+    expect(result.unresolved).toEqual([
+      { spokenText: "Sarah", kind: "ambiguous", matches: [SARAH_CHEN, SARAH_LEE] },
+    ]);
+  });
+
+  it("never guesses between two or more matches for the same spoken name", () => {
+    const result = resolveSpokenNames(PEOPLE, "Sarah", (p) => p.name);
+    expect(result.resolved).toEqual([]);
+    expect(result.unresolved).toEqual([
+      { spokenText: "Sarah", kind: "ambiguous", matches: [SARAH_CHEN, SARAH_LEE] },
+    ]);
+  });
+
+  it("is case- and accent-insensitive per name", () => {
+    const result = resolveSpokenNames(PEOPLE, "ALICE and bob", (p) => p.name);
+    expect(result.resolved).toEqual([ALICE, BOB]);
+  });
+
+  it("does not split a real person's name containing 'and'", () => {
+    const result = resolveSpokenNames(PEOPLE, "Anderson", (p) => p.name);
+    expect(result).toEqual({ resolved: [ANDERSON], unresolved: [] });
+  });
+
+  it("returns nothing for an empty or whitespace-only utterance", () => {
+    expect(resolveSpokenNames(PEOPLE, "", (p) => p.name)).toEqual({
+      resolved: [],
+      unresolved: [],
+    });
+    expect(resolveSpokenNames(PEOPLE, "   ", (p) => p.name)).toEqual({
+      resolved: [],
+      unresolved: [],
+    });
+  });
+
+  it("matches against a separate search text but still returns the real item", () => {
+    type Contact = { id: string; name: string; phone: string };
+    const alice: Contact = { id: "1", name: "Alice Chen", phone: "***1234" };
+    const result = resolveSpokenNames(
+      [alice],
+      "1234",
+      (c) => c.name,
+      (c) => `${c.name} ${c.phone}`,
+    );
+    expect(result).toEqual({ resolved: [alice], unresolved: [] });
+  });
+});
+
+describe("ambiguousMatchNames", () => {
+  it("joins matched names for a disambiguation prompt", () => {
+    expect(ambiguousMatchNames([SARAH_CHEN, SARAH_LEE], (p) => p.name)).toBe(
+      "Sarah Chen, Sarah Lee",
+    );
+  });
+
+  it("bounds the list so a huge tie does not flood the summary", () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({ id: String(i), name: `Person ${i}` }));
+    expect(ambiguousMatchNames(many, (p) => p.name, 4).split(", ")).toHaveLength(4);
+  });
+
+  it("drops empty/missing names instead of leaving stray commas", () => {
+    const mixed = [SARAH_CHEN, { id: "5", name: "" }, ANDERSON];
+    expect(ambiguousMatchNames(mixed, (p) => p.name)).toBe("Sarah Chen, Anderson Cole");
+  });
+});

--- a/hushh-webapp/lib/one-location/resolve-spoken-names.ts
+++ b/hushh-webapp/lib/one-location/resolve-spoken-names.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministically resolve one or more spoken names from a single voice
+ * utterance against a list of candidates -- the shared decision behind every
+ * "do X to the person(s) named Y" voice action across Location and Circles.
+ *
+ * Names are split out of the RAW utterance ("," / "&" / ";" / the word
+ * "and") BEFORE any normalization, because normalizeSpokenName() strips
+ * exactly those characters -- splitting after normalizing would destroy the
+ * delimiters this needs. Each resulting name is then matched independently,
+ * by substring, never exact: a person says "Sarah", not "Sarah Chen".
+ *
+ * A person can name several people in one turn ("share with Alice and
+ * Bob"), and each name resolves on its own: some may match cleanly, one may
+ * be ambiguous, another may not be found -- all in the same call, so the
+ * caller can apply everything that resolved and report the rest back in one
+ * turn instead of failing the whole request over one bad name.
+ */
+
+/** Normalize a spoken or stored name: no case, no accents, no punctuation. */
+export function normalizeSpokenName(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    // Punctuation out so "Mum & Dad" and "Mum and Dad" are not two different
+    // circles to a speaker. Unicode classes, not [a-z0-9]: a circle named in
+    // Hindi or Arabic must stay matchable rather than normalizing to nothing.
+    // \p{M} is load-bearing -- Devanagari vowel signs are marks, not letters,
+    // so without it "परिवार" shreds into "पर व र" and never matches itself.
+    .replace(/[^\p{L}\p{N}\p{M}\s]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+// Matches ",", "&", ";", or the standalone word "and" (case-insensitive,
+// word-bounded so it never fires inside a name like "Anderson"). Applied to
+// the RAW utterance, before normalizeSpokenName would erase all of these.
+const NAME_DELIMITER_PATTERN = /\s*(?:,|&|;|\band\b)\s*/giu;
+
+/** Split one spoken utterance into candidate names. A single name with no
+ * delimiter returns a 1-element array, so every existing single-name call
+ * site is a strict subset of this behavior. */
+export function splitSpokenNames(raw: string): string[] {
+  return raw
+    .split(NAME_DELIMITER_PATTERN)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export type PersonResolution<T> =
+  | { spokenText: string; kind: "resolved"; match: T }
+  | { spokenText: string; kind: "ambiguous"; matches: T[] }
+  | { spokenText: string; kind: "not_found" };
+
+export type MultiNameResolution<T> = {
+  /** Every candidate that matched exactly one name unambiguously. */
+  resolved: T[];
+  /** Every spoken name that did not resolve cleanly, in the order spoken. */
+  unresolved: PersonResolution<T>[];
+};
+
+export function resolveSpokenNames<T>(
+  candidates: readonly T[],
+  raw: string,
+  displayName: (item: T) => string | null | undefined,
+  /**
+   * What each spoken name is actually matched against, when it differs from
+   * the clean display name -- e.g. connections search across name + masked
+   * phone, but only the name belongs in a spoken disambiguation prompt.
+   * Defaults to `displayName` so most callers only ever pass one function.
+   */
+  searchText: (item: T) => string | null | undefined = displayName,
+): MultiNameResolution<T> {
+  const resolved: T[] = [];
+  const unresolved: PersonResolution<T>[] = [];
+  for (const spokenText of splitSpokenNames(raw)) {
+    const target = normalizeSpokenName(spokenText);
+    if (!target) continue;
+    const matches = candidates.filter((item) =>
+      normalizeSpokenName(String(searchText(item) || "")).includes(target),
+    );
+    if (matches.length === 0) {
+      unresolved.push({ spokenText, kind: "not_found" });
+    } else if (matches.length === 1) {
+      resolved.push(matches[0]!);
+    } else {
+      unresolved.push({ spokenText, kind: "ambiguous", matches });
+    }
+  }
+  return { resolved, unresolved };
+}
+
+/** Bounded, comma-joined names for a "which one did you mean?" summary. */
+export function ambiguousMatchNames<T>(
+  matches: readonly T[],
+  displayName: (item: T) => string | null | undefined,
+  limit = 4,
+): string {
+  return matches
+    .slice(0, limit)
+    .map((item) => (displayName(item) || "").trim())
+    .filter(Boolean)
+    .join(", ");
+}


### PR DESCRIPTION
## Summary
Part of Voice Engine v1.2 (#5677), requirement: person-targeting voice actions should support multiple people in one turn ("share with Alice and Bob"), resolved deterministically rather than by hoping the model makes one tool call per name.

Three independent, duplicated single-name substring matchers exist today across Location and Circles handlers, and all three give up the instant more than one name is spoken. This adds one shared module, `lib/one-location/resolve-spoken-names.ts`, to replace them. **This is a pure addition -- no existing call sites are touched yet**; migrating them is a follow-up PR once this lands.

- `normalizeSpokenName()`: relocated here from `app/one/location/page.tsx` verbatim (same Unicode-safe diacritic/punctuation stripping). It has ~10 other callers in `page.tsx` (circle-name equality checks, saved-location category matching) unrelated to person-resolution, so it stays a plain exported utility rather than folding into the multi-name logic, and `page.tsx` will import it from here instead of defining it locally in the migration PR.
- `splitSpokenNames()`: splits a RAW utterance on `,` / `&` / `;` / the standalone word "and" -- deliberately BEFORE normalization, since `normalizeSpokenName()` strips exactly those characters and splitting after would destroy the delimiters. Word-bounded so "Anderson" never splits into pieces on the "and" it contains. A string with no delimiter returns a 1-element array, so every existing single-name call site is a strict subset of this behavior.
- `resolveSpokenNames()`: resolves every split name independently against a candidate list -- some may match cleanly, one may be ambiguous, another may not be found, all in the same call. Returns `{ resolved: T[], unresolved: PersonResolution<T>[] }` so a caller can apply everything that resolved and report the rest back in one turn, instead of failing the whole request over one bad name.
- `ambiguousMatchNames()`: carried over unchanged from the module it replaces, for "which one did you mean?" summaries.

## Test plan
- [x] `vitest run` -- 22 new tests passing, covering: single-name backward compatibility, comma/`&`/`;`/"and" delimiter splitting, the "Anderson" word-boundary edge case, partial resolution (some resolved, one ambiguous, one not found -- all in one call), case/accent insensitivity, empty/whitespace input.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean.