### PR TITLE
test(web): repair current main contract baseline

### DIFF
--- a/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
@@ -32,17 +32,17 @@ describe("Profile canonical page layout", () => {
     );
     expect(source).not.toContain('<UserIcon className="h-12 w-12" />');
   });
-  it("gives account metadata the full compact header width", () => {
+  it("gives account metadata the full centered compact header width", () => {
     const source = readFileSync(
       join(process.cwd(), "app/profile/profile-workspace-page.tsx"),
       "utf8",
     );
 
     expect(source).toContain(
-      'className="profile-home-copy w-full min-w-0 max-w-full',
+      'className="profile-home-hero flex w-full min-w-0 flex-col items-center gap-2 px-0 text-center sm:px-6"',
     );
     expect(source).toContain(
-      'gap-2.5 px-0 text-center sm:px-6',
+      'className="profile-home-copy flex w-full min-w-0 max-w-full flex-col items-center justify-center gap-1"',
     );
     expect(source).not.toContain(
       'gap-2.5 px-4 text-center sm:px-6',

--- a/hushh-webapp/__tests__/app/profile/security-delete-contract.test.ts
+++ b/hushh-webapp/__tests__/app/profile/security-delete-contract.test.ts
@@ -26,9 +26,7 @@ describe("profile security deletion contract", () => {
   it("allows no-vault account deletion without forcing vault creation", () => {
     expect(profilePageSource).toContain("if (!nextHasVault)");
     expect(profilePageSource).toContain("setShowDeleteConfirm(true);");
-    expect(profilePageSource).toContain(
-      "No vault exists yet. This deletes cloud-linked account records.",
-    );
+    expect(profilePageSource).toContain("Deletes cloud-linked records.");
     expect(profilePageSource).not.toContain("Create vault to delete account");
   });
 
@@ -59,7 +57,7 @@ describe("profile security deletion contract", () => {
   });
 
   it("offers a reset-account path that keeps the account and re-runs setup", () => {
-    expect(profilePageSource).toContain("Reset your One account?");
+    expect(profilePageSource).toContain("Reset account?");
     expect(profilePageSource).toContain('"Yes, reset my account"');
     expect(profilePageSource).toContain(
       "AccountService.resetAccount(resolution.token)",

--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -440,13 +440,13 @@ describe("RiaPicksPage", () => {
     await screen.findByText("NVDA");
     expect(screen.queryByRole("button", { name: /copy from kai/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /^upload$/i })).toBeNull();
-    expect(screen.queryByRole("link", { name: /template/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /template/i })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /my list/i }));
 
     expect(screen.getByRole("button", { name: /copy from kai/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^upload$/i })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /^template$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^template$/i })).toBeTruthy();
     expect(screen.queryByText("List source")).toBeNull();
     expect(
       screen.queryByText(
@@ -470,14 +470,14 @@ describe("RiaPicksPage", () => {
     expect(screen.getAllByRole("button", { name: /^upload$/i })).toHaveLength(
       1,
     );
-    expect(screen.getAllByRole("link", { name: /^template$/i })).toHaveLength(
+    expect(screen.getAllByRole("button", { name: /^template$/i })).toHaveLength(
       1,
     );
     fireEvent.click(screen.getByRole("button", { name: /^upload$/i }));
 
     expect(screen.getByText("Upload a top-picks CSV")).toBeTruthy();
     expect(
-      screen.getByRole("link", { name: /download template/i }),
+      screen.getByRole("button", { name: /download template/i }),
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /upload and replace top picks/i }),

--- a/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
@@ -39,7 +39,7 @@ describe("AgentSectionDropdown", () => {
     expect(await screen.findByTestId("agent-section-search")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_finance")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_ria")).toBeTruthy();
-    expect(screen.queryByTestId("top_agent_section_gmail")).toBeNull();
+    expect(screen.getByTestId("top_agent_section_gmail")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_consent")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_pkm")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_connected-systems")).toBeTruthy();

--- a/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
@@ -10,12 +10,12 @@ function read(relativePath: string) {
 }
 
 describe("canonical workspace hierarchy", () => {
-  it("keeps nested Profile pages behind the stack-owned shared header", () => {
+  it("keeps nested Profile pages behind the stack-owned shared PageHeader", () => {
     const stack = read("components/profile/profile-stack-navigator.tsx");
 
-    expect(stack).toContain("function StackHeader");
     expect(stack).toContain("<PageHeader");
     expect(stack).toContain('data-profile-stack-content="true"');
+    expect(stack).not.toContain("function StackHeader");
     expect(stack).not.toContain("<AppPageShell");
   });
 

--- a/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
@@ -136,7 +136,7 @@ describe("CapabilityCinematicIntroGate", () => {
     expect(action.className).toContain("text-center");
   });
 
-  it("top-anchors the shared intro instead of vertically centering the first setup screen", () => {
+  it("uses one fixed centered canvas without a nested fullscreen shell", () => {
     render(
       <CapabilityCinematicIntroGate capabilityId="location">
         <p>Location body</p>
@@ -151,12 +151,15 @@ describe("CapabilityCinematicIntroGate", () => {
     );
 
     expect(intro).toBeTruthy();
-    expect(shell).toBeTruthy();
+    expect(shell).toBeNull();
+    expect(intro?.className).toContain("fixed");
+    expect(intro?.className).toContain("inset-0");
+    expect(intro?.className).toContain("justify-center");
+    expect(intro?.className).toContain("items-center");
     expect(intro?.className).not.toContain("my-auto");
-    expect(shell?.className).not.toContain("justify-center");
   });
 
-  it("does not add a second viewport-height centering layer when the intro is embedded", () => {
+  it("reuses the same fixed centered canvas when the intro is embedded", () => {
     render(
       <CapabilityCinematicIntroGate capabilityId="finance" embedded>
         <p>Finance preferences</p>
@@ -168,8 +171,11 @@ describe("CapabilityCinematicIntroGate", () => {
     );
 
     expect(intro).toBeTruthy();
+    expect(intro?.className).toContain("fixed");
+    expect(intro?.className).toContain("inset-0");
+    expect(intro?.className).toContain("justify-center");
+    expect(intro?.className).toContain("items-center");
     expect(intro?.className).not.toContain("min-h-[calc(100dvh");
-    expect(intro?.className).not.toContain("justify-center");
     expect(intro?.className).not.toContain("my-auto");
   });
 

--- a/hushh-webapp/__tests__/components/foundation-public-ambient.test.tsx
+++ b/hushh-webapp/__tests__/components/foundation-public-ambient.test.tsx
@@ -17,23 +17,26 @@ describe("FoundationPublicAmbient", () => {
     expect(screen.getByTestId("foundation-canvas")).toHaveClass("foundation-public-ambient");
   });
 
-  it("gives the light canvas a visible four-corner accent wash and grain", () => {
+  it("uses the shared grouped canvas without a decorative wash or grain", () => {
     const css = readFileSync(join(process.cwd(), "app/globals.css"), "utf8");
     const lightBlockMatch = css.match(
-      /\.foundation-public-ambient \{[^}]*\}/,
+      /^\.foundation-public-ambient \{[^}]*\}/m,
     );
     expect(lightBlockMatch).toBeTruthy();
     const lightBlock = lightBlockMatch![0];
 
-    // Stronger than dark mode's 6-8%, not weaker: mixing the same percentage
-    // of accent into near-white reads far fainter than into near-black, so
-    // light mode needs more, not less, to actually read as an accent glow.
-    expect(lightBlock).toContain("--foundation-grain-opacity: 0.1");
-    expect(lightBlock).toContain("--foundation-ambient-primary: 12%");
-    expect(lightBlock).toContain("radial-gradient");
-    expect(lightBlock).not.toContain("background-image: none");
+    expect(lightBlock).toContain("--foundation-grain-opacity: 0");
+    expect(lightBlock).toContain(
+      "background-color: var(--app-grouped-background)",
+    );
+    expect(lightBlock).toContain("background-image: none");
+    expect(lightBlock).not.toContain("radial-gradient");
 
-    expect(css).toContain("--foundation-grain-opacity: 0.08");
-    expect(css).toContain("opacity: var(--foundation-grain-opacity, 0.035)");
+    const darkBlock = css.match(
+      /^\.dark \.foundation-public-ambient \{[^}]*\}/m,
+    )?.[0];
+    expect(darkBlock).toContain("--foundation-grain-opacity: 0");
+    expect(darkBlock).toContain("background-image: none");
+    expect(css).toMatch(/\.one-grain \{\s*display: none !important;/m);
   });
 });

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -120,7 +120,7 @@ describe("Navbar bottom chrome contract", () => {
     );
     expect(bottomShell).toContain('<AgentBar layout="slot" />');
     expect(bottomShell).toContain("items-center gap-1.5");
-    expect(agentBar).toContain('? "h-10 rounded-[1.25rem] px-2"');
+    expect(agentBar).toContain('? "h-11 rounded-[22px] px-2.5"');
     expect(agentBar).toContain("var(--app-agent-bar-max-width)");
     expect(bottomShell).toContain("var(--bottom-chrome-full-height)");
     expect(bottomShell).toContain("--app-bottom-shell-height");

--- a/hushh-webapp/__tests__/components/one-agent-roster-metrics.test.ts
+++ b/hushh-webapp/__tests__/components/one-agent-roster-metrics.test.ts
@@ -40,10 +40,10 @@ describe("One agent roster cache metrics", () => {
       finance: { value: "NVDA", label: "+6.40%" },
       ria: { value: "3", label: "active clients" },
       email: { value: "1", label: "approval waiting" },
-      consent: { value: "1", label: "request to review" },
-      location: { value: "1", label: "live share" },
-      pkm: { value: "12", label: "saved details" },
-      "connected-systems": { value: "2", label: "connected systems" },
+      consent: { value: "1", label: "request" },
+      location: { value: "1", label: "live" },
+      pkm: { value: "12", label: "saved" },
+      "connected-systems": { value: "2", label: "connected" },
     });
   });
 

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -745,7 +745,11 @@ describe("OneLocationOnboardingFlow", () => {
     const contactsScreen = screen.getByTestId(
       "one-location-onboarding-contacts",
     );
-    expect(contactsScreen.firstElementChild?.className).toContain(
+    const contactsSurface = screen.getByTestId(
+      "one-location-onboarding-contacts-surface",
+    );
+    expect(contactsScreen).toContainElement(contactsSurface);
+    expect(contactsSurface.className).toContain(
       "bg-[color:var(--app-grouped-background)]",
     );
 

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -28,7 +28,7 @@ describe("One Location settings placement", () => {
 
   it("offers Request Location inside the unified Actions grid", () => {
     // Request location is an action, not status or utility. It belongs beside
-    // Share location, Check-In, and Send SOS in the Actions grid, while
+    // Share location, Check-In, and SMS in the Actions grid, while
     // Settings stays quiet in More.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
@@ -37,7 +37,7 @@ describe("One Location settings placement", () => {
     expect(nowSource).toContain('data-testid="one-location-now-actions"');
     expect(nowSource).toContain('testId: "one-location-request-row"');
     expect(nowSource).toContain('title: "Request location"');
-    expect(nowSource).toContain('title: "Send SOS"');
+    expect(nowSource).toContain('title: "SMS"');
 
     const actionsIndex = nowSource.indexOf("LocationActionGrid");
     const requestIndex = nowSource.indexOf('title: "Request location"');

--- a/hushh-webapp/__tests__/components/page-sections.test.tsx
+++ b/hushh-webapp/__tests__/components/page-sections.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { PageHeader, SectionHeader } from "@/components/app-ui/page-sections";
 
 describe("PageHeader", () => {
-  it("uses the shared mobile stacking and description clamp slots", () => {
+  it("uses the shared mobile stacking and keeps the full description", () => {
     const { container } = render(
       <PageHeader
         eyebrow="Picks"
@@ -26,15 +26,15 @@ describe("PageHeader", () => {
     expect(leading?.className).toContain("self-stretch");
     expect(row?.className).toContain("flex-col");
     expect(row?.className).toContain("sm:flex-row");
-    expect(description?.className).toContain("line-clamp-1");
-    expect(description?.className).not.toContain("sm:line-clamp-none");
+    expect(description?.className).toContain("ui-text-page-subtitle");
+    expect(description?.className).not.toContain("line-clamp");
     expect(actions?.className).toContain("sm:shrink-0");
     expect(screen.getByRole("button", { name: "Upload" })).toBeTruthy();
   });
 });
 
 describe("SectionHeader", () => {
-  it("applies the same mobile clamp and action layout rules", () => {
+  it("applies the same full-description and action layout rules", () => {
     const { container } = render(
       <SectionHeader
         eyebrow="My list"
@@ -55,8 +55,8 @@ describe("SectionHeader", () => {
     expect(leading?.className).toContain("self-stretch");
     expect(row?.className).toContain("flex-col");
     expect(row?.className).toContain("sm:flex-row");
-    expect(description?.className).toContain("line-clamp-1");
-    expect(description?.className).not.toContain("sm:line-clamp-none");
+    expect(description?.className).toContain("ui-text-page-subtitle");
+    expect(description?.className).not.toContain("line-clamp");
     expect(actions?.className).toContain("sm:justify-end");
     expect(screen.getByRole("button", { name: "Template" })).toBeTruthy();
   });

--- a/hushh-webapp/__tests__/services/crm-encrypted-fields-v1.test.ts
+++ b/hushh-webapp/__tests__/services/crm-encrypted-fields-v1.test.ts
@@ -8,7 +8,7 @@ import {
 import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
 
 function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  return Uint8Array.from(bytes).buffer;
 }
 
 function joined(ciphertext: string, tag: string): ArrayBuffer {

--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -116,6 +116,12 @@ describe("observability route map", () => {
     expect(resolveRouteId("/one/profile/preferences/gemini")).toBe(
       "profile_preferences_gemini",
     );
+    expect(resolveRouteId("/one/profile/preferences/voice")).toBe(
+      "profile_preferences_voice",
+    );
+    expect(resolveRouteId("/one/profile/preferences/voice/changelog")).toBe(
+      "profile_preferences_voice_changelog",
+    );
     expect(resolveRouteId("/portfolio/shared")).toBe("portfolio_shared");
     expect(resolveRouteId("/ria/clients")).toBe("ria_clients");
     expect(resolveRouteId("/ria/clients/user_123")).toBe("ria_workspace");

--- a/hushh-webapp/__tests__/services/user-local-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/user-local-state-service.test.ts
@@ -44,6 +44,7 @@ vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
 
 vi.mock("@capacitor/core", () => ({
   Capacitor: { isNativePlatform: () => false },
+  registerPlugin: vi.fn(() => ({})),
 }));
 
 import { UserLocalStateService } from "@/lib/services/user-local-state-service";

--- a/hushh-webapp/__tests__/vault/trusted-device-passkey-handoff.test.ts
+++ b/hushh-webapp/__tests__/vault/trusted-device-passkey-handoff.test.ts
@@ -35,10 +35,7 @@ function decodeBase64(value: string): Uint8Array {
 }
 
 function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength,
-  ) as ArrayBuffer;
+  return Uint8Array.from(bytes).buffer;
 }
 
 describe("trusted-device passkey vault handoff", () => {

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -24,6 +24,8 @@ export const ROUTE_ID_VALUES = [
   "profile_preferences_kai",
   "profile_preferences_gemini",
   "profile_preferences_device",
+  "profile_preferences_voice",
+  "profile_preferences_voice_changelog",
   "profile_security",
   "profile_security_vault",
   "profile_security_session",
@@ -163,6 +165,10 @@ export function resolveRouteId(rawPathname: string): RouteId {
     return "profile_preferences_gemini";
   if (pathname === ROUTES.PROFILE_PREFERENCES_DEVICE)
     return "profile_preferences_device";
+  if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE)
+    return "profile_preferences_voice";
+  if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG)
+    return "profile_preferences_voice_changelog";
   if (pathname === ROUTES.PROFILE_SECURITY) return "profile_security";
   if (pathname === ROUTES.PROFILE_SECURITY_VAULT)
     return "profile_security_vault";


### PR DESCRIPTION
## Summary

- align stale web contract assertions with behavior already serving from main
- make WebCrypto fixtures and the Capacitor mock portable under the queue runtime
- add the two existing voice preference routes to the observability map

This is the narrow CI prerequisite for the Hushh Tech UAT client work. It changes no product runtime behavior beyond observability IDs for routes that already exist.

## Proof

- `npm run test:ci`: 599 files passed, 1 skipped; 4,665 tests passed, 6 skipped
- `npm run typecheck`: passed
- `npm run lint`: passed with zero warnings
- queue-environment `npm run build`: passed
- `git diff --check`: passed

Part of #5684
