### PR TITLE
fix(uat): allow only the approved Vertex bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
             backend:
               - 'consent-protocol/**'
               - 'packages/hushh-mcp/**'
+              - 'deploy/backend.cloudbuild.yaml'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/deploy-uat.yml'
               - '.github/workflows/queue-validation.yml'
               - '.github/workflows/main-post-merge-smoke.yml'
               - 'scripts/ci/**'

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -47,6 +47,7 @@ tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
 tests/test_one_location_db_error_detail_cwe209.py
 tests/test_cloudbuild_step_arg_limit.py
+tests/test_uat_deploy_no_traffic_contract.py
 tests/test_deploy_sha_gate_payload_size.py
 tests/services/test_advisor_directory_service.py
 tests/test_advisors_runtime_config_wiring.py

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -79,12 +79,18 @@ def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None
     assert "gcloud services describe" not in backend_build
 
 
-def test_cross_project_vertex_fallback_is_dev_only_and_shared_by_readiness() -> None:
+def test_cross_project_vertex_fallback_is_dev_or_exact_uat_bridge_only() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
+    uat_workflow = _read(".github/workflows/deploy-uat.yml")
+    production_workflow = _read(".github/workflows/deploy-production.yml")
 
     assert 'if [[ "${_DEPLOY_ENV}" == "dev" ]]; then' in backend_build
     assert 'genai_project_id="hushh-pda-uat"' in backend_build
-    assert '"${_DEPLOY_ENV}" != "dev"' in backend_build
+    assert backend_build.count('case "${_DEPLOY_ENV}:${genai_project_id}" in') == 1
+    assert "dev:hushh-pda-uat|uat:hushh-gemini-bridge)" in backend_build
+    assert "Cross-project managed Vertex target is not allowlisted." in backend_build
+    assert "##_GENAI_PROJECT_ID=hushh-gemini-bridge" in uat_workflow
+    assert "hushh-gemini-bridge" not in production_workflow
     assert "roles/serviceusage.serviceUsageConsumer" in backend_build
     assert '"GOOGLE_CLOUD_PROJECT=${genai_project_id}"' in backend_build
     assert backend_build.count('"GOOGLE_CLOUD_PROJECT=${genai_project_id}"') == 1

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -93,9 +93,14 @@ steps:
             genai_project_id="hushh-pda-uat"
           fi
         fi
-        if [[ "${genai_project_id}" != "$PROJECT_ID" && "${_DEPLOY_ENV}" != "dev" ]]; then
-          echo "Cross-project managed Vertex is allowed only for the isolated dev lane." >&2
-          exit 1
+        if [[ "${genai_project_id}" != "$PROJECT_ID" ]]; then
+          case "${_DEPLOY_ENV}:${genai_project_id}" in
+            dev:hushh-pda-uat|uat:hushh-gemini-bridge) ;;
+            *)
+              echo "Cross-project managed Vertex target is not allowlisted." >&2
+              exit 1
+              ;;
+          esac
         fi
         gcloud iam service-accounts describe "${_RUNTIME_SERVICE_ACCOUNT}" \
           --project="$PROJECT_ID" >/dev/null
@@ -139,10 +144,6 @@ steps:
           if [[ "${_DEPLOY_ENV}" == "dev" ]]; then
             genai_project_id="hushh-pda-uat"
           fi
-        fi
-        if [[ "${genai_project_id}" != "$PROJECT_ID" && "${_DEPLOY_ENV}" != "dev" ]]; then
-          echo "Cross-project managed Vertex is allowed only for the isolated dev lane." >&2
-          exit 1
         fi
         add_secret() {
           local secret_name="$1"


### PR DESCRIPTION
# Description

Repair the contract exposed by UAT run 32445030669: the current UAT workflow selected the intentional `hushh-gemini-bridge`, while the exact requested release SHA still rejected every non-development cross-project Vertex target.

This keeps production same-project, centralizes the cross-project allowlist before deployment, permits only `dev:hushh-pda-uat` and `uat:hushh-gemini-bridge`, and makes future workflow/build changes run the blocking Protocol lane. Part of #5684.

## 📌 Impact Map (Required)

- Routes touched: None.
- API / schema / type changes: None.
- Cache keys touched: None.
- Runtime DB data-plane changes: None.
- World-model domain summary effects: None.
- Mobile parity impacts: None; deploy governance only.
- Docs updated: None.
- Top-level / devex / config files touched: `deploy/backend.cloudbuild.yaml`, `.github/workflows/ci.yml`, the protocol CI manifest, and its UAT deploy contract test. These attach to the existing governed UAT Cloud Build and PR validation workflows.
- Trust boundary touched: UAT deployment authority. Only the exact UAT Vertex billing bridge is added; production and arbitrary cross-project targets remain denied.
- Caller / proxy / backend pairing: UAT `deploy-uat.yml` bridge substitution now matches the backend build allowlist.
- Rollback or safe-failure behavior: the failed release created no candidate revision and retained prior 100% traffic; this patch changes only the predeploy allowlist.
- UI browser or Playwright proof: Not applicable; no UI change.
- Verification commands executed: focused 21-test deploy/Cloud Build contract suite and `./bin/hushh codex pre-pr`.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and PR #5692 were checked; this repairs its missing paired build contract.
- [x] This changes the reachable UAT deployment path.
- [x] Production surface proved: production workflow contains no bridge target; generic cross-project targets hit the default denial.
- [x] Required local checks are current on exact head and the commit is signed off.
- [x] Maintainer edits are enabled.
- [x] Not a stacked pull request.

## 🛑 Tri-Flow Architecture Check

- [x] Web: Not applicable; deployment contract only.
- [x] iOS: Not applicable.
- [x] Android: Not applicable.

## 🧪 Testing

- [x] `pytest -q consent-protocol/tests/test_uat_deploy_no_traffic_contract.py consent-protocol/tests/test_cloudbuild_step_arg_limit.py` — 21 passed.
- [x] `./bin/hushh codex pre-pr` — passed on Node 24.19.0 and Python 3.13.13.
- [x] Web build, typecheck, lint, and 4,687 tests passed in the local mirror.
- [x] Protocol 1,217 tests passed, including the new always-on UAT deploy contract.
- [x] Commit is signed off.

## 📸 Screenshots / Video

Not applicable; no UI-visible change.

## 🛡️ Privacy & Consent

- [x] Does not add access to user data.
- [x] Sensitive surface: deploy only.
- [x] Safe failure remains fail-closed for every non-allowlisted project pair.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.
