### PR TITLE
fix(uat): pin shared Firebase authority

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -29,6 +29,7 @@ permissions:
 
 env:
   GCP_PROJECT_ID: hushh-pda-uat
+  UAT_FIREBASE_PROJECT_ID: hushh-pda
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   RUNTIME_SERVICE_ACCOUNT: consent-protocol-runtime@hushh-pda-uat.iam.gserviceaccount.com
@@ -621,6 +622,7 @@ jobs:
         run: |
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
             --project "${{ env.GCP_PROJECT_ID }}" \
+            --expected-firebase-project "${{ env.UAT_FIREBASE_PROJECT_ID }}" \
             --region "${{ env.GCP_REGION }}" \
             --backend-service "${{ env.BACKEND_SERVICE }}" \
             --frontend-service "${{ env.FRONTEND_SERVICE }}" \
@@ -643,6 +645,7 @@ jobs:
           sleep 20
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
             --project "${{ env.GCP_PROJECT_ID }}" \
+            --expected-firebase-project "${{ env.UAT_FIREBASE_PROJECT_ID }}" \
             --region "${{ env.GCP_REGION }}" \
             --backend-service "${{ env.BACKEND_SERVICE }}" \
             --frontend-service "${{ env.FRONTEND_SERVICE }}" \

--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -2,8 +2,9 @@ name: Release iOS to App Store
 
 # Public App Store release for Hushh One iOS. Cuts a build from an exact green
 # `main` SHA and — by product decision — ships the SAME frontend + backend that
-# is live on UAT: it builds the Capacitor app against the UAT backend + UAT
-# Firebase (hushh-pda-uat), signs with Apple-managed signing via an App Store
+# is live on UAT: it builds the Capacitor app against the UAT backend + shared
+# Firebase authority (hushh-pda; config stored in hushh-pda-uat Secret Manager),
+# signs with Apple-managed signing via an App Store
 # Connect API key using the production APNs entitlement (AppRelease.entitlements,
 # required for any store binary), uploads to App Store Connect, sets the required
 # "What's New in This Version" notes, attaches the build, and — when asked — takes
@@ -17,7 +18,7 @@ name: Release iOS to App Store
 #
 # Backend note: this store build points at the UAT backend on purpose (latest
 # frontend + latest backend, matching UAT). Push on a store binary routes through
-# Apple's PRODUCTION APNs, so the UAT Firebase project must hold a production APNs
+# Apple's PRODUCTION APNs, so the shared Firebase project must hold a production APNs
 # key for notifications to deliver — see the runbook.
 #
 # TestFlight sibling: .github/workflows/ship-ios-testflight.yml
@@ -57,8 +58,9 @@ permissions:
 env:
   # This public App Store build ships the UAT frontend + UAT backend by product
   # decision (same as what's live on UAT / TestFlight), so it authenticates to
-  # and reads its contract from hushh-pda-uat, exactly like the TestFlight
-  # pipeline. The App Store vs TestFlight difference is only the submission layer.
+  # and reads its runtime contract from hushh-pda-uat Secret Manager, exactly
+  # like the TestFlight pipeline. Firebase identity remains on hushh-pda. The
+  # App Store vs TestFlight difference is only the submission layer.
   GCP_PROJECT_ID: hushh-pda-uat
   GCP_REGION: us-central1
   IOS_BUNDLE_ID: com.hushh.app
@@ -152,7 +154,8 @@ jobs:
         with:
           # UAT-scoped SA key (repo-level secret, inherited by the production
           # environment). This build's contract, Firebase config, and ASC key all
-          # live in hushh-pda-uat, so it authenticates there like TestFlight does.
+          # live in hushh-pda-uat Secret Manager; the Firebase config itself targets
+          # the shared hushh-pda identity authority.
           credentials_json: ${{ secrets.GCP_SA_KEY_UAT }}
 
       - name: Set up gcloud
@@ -249,7 +252,7 @@ jobs:
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"
 
-          # Native GoogleService-Info.plist for the iOS target (UAT Firebase).
+          # Native GoogleService-Info.plist for the shared Firebase authority.
           PLIST_DEST="hushh-webapp/ios/App/App/GoogleService-Info.plist"
           if ! gcloud secrets describe IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
             echo "Missing GCP secret IOS_GOOGLESERVICE_INFO_PLIST_B64 in ${GCP_PROJECT_ID}." >&2
@@ -373,7 +376,7 @@ jobs:
           # CODE_SIGN_ENTITLEMENTS override swaps aps-environment development ->
           # production for the released binary without editing the committed
           # pbxproj. A store binary must use production APNs regardless of which
-          # backend/Firebase it talks to (here UAT), so the UAT Firebase project
+          # backend/Firebase config it talks to, so the shared Firebase project
           # needs a production APNs key for push to deliver -- see the runbook.
           xcodebuild \
             -project "${XCODE_PROJECT}" \

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -1,9 +1,10 @@
 name: Ship iOS to TestFlight
 
 # One-click: cut a Hushh One iOS build from the latest green `main` (the SHA that
-# UAT runs), build the Capacitor app against the UAT backend + UAT Firebase, sign
+# UAT runs), build the Capacitor app against the UAT backend + shared hushh-pda
+# Firebase authority (config stored in hushh-pda-uat Secret Manager), sign
 # it with Apple-managed signing via an App Store Connect API key, and upload to
-# TestFlight. TestFlight only -- no App Store review, no prod backend/Firebase.
+# TestFlight. TestFlight only -- no App Store review and no production backend.
 #
 # Web sibling: .github/workflows/deploy-uat.yml (same SHA -> UAT website).
 # Runbook + secret setup: docs/guides/mobile/ship-ios-testflight.md

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -48,6 +48,7 @@ tests/test_stream_agent_thinking_gemini_error_cwe209.py
 tests/test_one_location_db_error_detail_cwe209.py
 tests/test_cloudbuild_step_arg_limit.py
 tests/test_uat_deploy_no_traffic_contract.py
+tests/test_verify_env_secrets_parity.py
 tests/test_deploy_sha_gate_payload_size.py
 tests/services/test_advisor_directory_service.py
 tests/test_advisors_runtime_config_wiring.py

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -40,6 +40,17 @@ def test_uat_deploy_builds_candidates_without_serving_traffic() -> None:
     )
 
 
+def test_uat_deploy_pins_the_shared_firebase_authority() -> None:
+    workflow_source = _read(".github/workflows/deploy-uat.yml")
+    workflow = yaml.safe_load(workflow_source)
+
+    assert workflow["env"]["UAT_FIREBASE_PROJECT_ID"] == "hushh-pda"
+    assert (
+        workflow_source.count('--expected-firebase-project "${{ env.UAT_FIREBASE_PROJECT_ID }}"')
+        == 2
+    )
+
+
 def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
     uat_workflow = _read(".github/workflows/deploy-uat.yml")

--- a/consent-protocol/tests/test_verify_env_secrets_parity.py
+++ b/consent-protocol/tests/test_verify_env_secrets_parity.py
@@ -102,3 +102,37 @@ def test_firebase_project_contract_fails_closed_on_project_mismatch(monkeypatch)
         "status": "mismatch",
         "credentials": "mismatch",
     }
+
+
+def test_firebase_project_contract_accepts_exact_expected_project(monkeypatch) -> None:
+    values = {
+        "FIREBASE_ADMIN_CREDENTIALS_JSON": '{"project_id":"hushh-pda"}',
+        "NEXT_PUBLIC_FIREBASE_PROJECT_ID": "hushh-pda",
+    }
+    monkeypatch.setattr(parity, "_read_secret_value", lambda _project, key: values.get(key))
+
+    assert parity._firebase_project_contract(
+        "hushh-pda-uat",
+        expected_project="hushh-pda",
+    ) == {
+        "status": "valid",
+        "credentials": "valid",
+        "expected": "valid",
+    }
+
+
+def test_firebase_project_contract_rejects_matching_but_unexpected_project(monkeypatch) -> None:
+    values = {
+        "FIREBASE_ADMIN_CREDENTIALS_JSON": '{"project_id":"hushh-pda-uat"}',
+        "NEXT_PUBLIC_FIREBASE_PROJECT_ID": "hushh-pda-uat",
+    }
+    monkeypatch.setattr(parity, "_read_secret_value", lambda _project, key: values.get(key))
+
+    assert parity._firebase_project_contract(
+        "hushh-pda-uat",
+        expected_project="hushh-pda",
+    ) == {
+        "status": "unexpected_project",
+        "credentials": "valid",
+        "expected": "mismatch",
+    }

--- a/deploy/app_store_deployment.md
+++ b/deploy/app_store_deployment.md
@@ -5,8 +5,8 @@
 >   current UAT build and uploads it to TestFlight — runbook:
 >   [docs/guides/mobile/ship-ios-testflight.md](../docs/guides/mobile/ship-ios-testflight.md).
 > - **Public App Store:** `make ios-prod-release` (or
->   `.github/workflows/release-ios-appstore.yml`) builds against the **UAT backend + UAT Firebase**
->   (`hushh-pda-uat`, the same latest frontend+backend as TestFlight), signs with the production APNs
+>   `.github/workflows/release-ios-appstore.yml`) builds against the **UAT backend + shared Firebase authority**
+>   (`hushh-pda`; its config is stored in `hushh-pda-uat` Secret Manager), signs with the production APNs
 >   entitlement, uploads to App Store Connect, sets "What's New," attaches the build, and — one-click,
 >   opt-in — submits for public Apple review — runbook:
 >   [docs/guides/mobile/release-ios-appstore.md](../docs/guides/mobile/release-ios-appstore.md).

--- a/docs/guides/mobile/release-ios-appstore.md
+++ b/docs/guides/mobile/release-ios-appstore.md
@@ -11,7 +11,8 @@ Canonical visual owner: [Mobile Guide](../mobile.md).
 ## What this is
 
 One command builds a **public App Store** Hussh One iOS release from an exact green `main` SHA,
-wires it to the **UAT backend + UAT Firebase** (`hushh-pda-uat`) — the *same* latest
+wires it to the **UAT backend + shared Firebase authority** (`hushh-pda`; its config is stored in
+`hushh-pda-uat` Secret Manager) — the *same* latest
 frontend+backend that is live on UAT and ships to TestFlight — signs it with the **production APNs
 entitlement** via Apple-managed signing, uploads it to **App Store Connect**, sets the version's
 **"What's New"** text, attaches the build, and (opt-in, one click) **submits it for public Apple
@@ -23,7 +24,7 @@ review**. By default it stops *before* the final, irreversible "Submit for App S
 > submission layer differs.
 
 The build still archives with **production APNs** entitlements (correct for *any* App Store binary —
-push on a store build routes through Apple's PRODUCTION APNs). That means the **UAT Firebase project
+push on a store build routes through Apple's PRODUCTION APNs). That means the **shared Firebase project
 must hold a production APNs key** for push notifications to deliver on the released app.
 
 For an internal TestFlight build (no review), use the sibling pipeline: `ship-ios-testflight`
@@ -34,7 +35,7 @@ For an internal TestFlight build (no review), use the sibling pipeline: `ship-io
 - **Dispatcher:** `scripts/release/dispatch-ios-appstore.mjs` (resolves SHA, confirms, dispatches, watches).
 - **Runner:** GitHub-hosted `macos-15`, Xcode 26.3 — GCP has no macOS instances and local builds
   hang inside iCloud Drive, so only the *dispatch* runs on your machine; the Apple build runs in CI.
-- **Target:** bundle `com.hushh.app`, version `1.3.6`, **UAT** backend + Firebase (`hushh-pda-uat`),
+- **Target:** bundle `com.hushh.app`, version `1.3.6`, **UAT** backend + Firebase (`hushh-pda`),
   ASC app id `6757718917`.
 
 ## The final command
@@ -155,7 +156,7 @@ export/upload, or version/build validation):
 | `IOS_GOOGLESERVICE_INFO_PLIST_B64` | Base64 of the **UAT** iOS `GoogleService-Info.plist`. |
 | `BACKEND_URL` | UAT backend origin (the `*uat*` / UAT Cloud Run host). |
 | `APP_FRONTEND_ORIGIN` | UAT app origin (`https://uat.one.hushh.ai`). |
-| `NEXT_PUBLIC_FIREBASE_API_KEY` … `NEXT_PUBLIC_FIREBASE_VAPID_KEY` | UAT Firebase web contract (see the workflow's `require` list). |
+| `NEXT_PUBLIC_FIREBASE_API_KEY` … `NEXT_PUBLIC_FIREBASE_VAPID_KEY` | UAT-selected web config for the shared `hushh-pda` Firebase authority (see the workflow's `require` list). |
 
 Create each once (use `versions add` instead of `create` if it already exists):
 

--- a/docs/guides/mobile/ship-android-playstore.md
+++ b/docs/guides/mobile/ship-android-playstore.md
@@ -11,7 +11,7 @@ Canonical visual owner: [Mobile Guide](../mobile.md).
 ## What this is
 
 One click cuts a Hussh One Android App Bundle (`.aab`) from an explicitly selected green `main` SHA,
-builds the Capacitor app against the **UAT backend + UAT Firebase**, signs it with the
+builds the Capacitor app against the **UAT backend + shared Firebase authority**, signs it with the
 **Android Release Upload Keystore**, and **uploads it to Google Play Console** (internal, alpha,
 beta, or production track).
 

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -11,7 +11,7 @@ Canonical visual owner: [Mobile Guide](../mobile.md).
 ## What this is
 
 One click cuts a Hussh One iOS build from an explicitly selected green `main` SHA, builds the Capacitor app against the
-**UAT backend + UAT Firebase**, signs it with **Apple-managed signing via an App Store Connect
+**UAT backend + shared Firebase authority**, signs it with **Apple-managed signing via an App Store Connect
 API key**, and **uploads it to TestFlight**. No manual "Missing Compliance" click, no public App
 Store submission.
 
@@ -19,7 +19,7 @@ Store submission.
 - **Skill:** say `ship ios` (see `.claude/skills/ship-ios-testflight/SKILL.md`).
 - **Runner:** GitHub-hosted `macos-15` (GCP has no macOS instances; only the *dispatch* is local).
 - **Target:** bundle `com.hushh.app`, the repository's current `MARKETING_VERSION`, TestFlight
-  internal testers (no Beta App Review), UAT backend + Firebase `hushh-pda-uat`.
+  internal testers (no Beta App Review), UAT backend + Firebase `hushh-pda`.
 
 ### Version Cadence & Closed Pre-Release Trains
 
@@ -50,9 +50,11 @@ upload out of "Missing Compliance".
 
 ## One-time setup (secret-touching — the operator does this)
 
-All signing + Firebase material lives in **GCP Secret Manager**, project **`hushh-pda-uat`** (the
-store `deploy/README.md` already designates for native signing assets). Nothing App Store-related
-is a GitHub secret. The workflow reads these with the existing `GCP_SA_KEY_UAT` service account.
+All signing + Firebase configuration material lives in **GCP Secret Manager**, project
+**`hushh-pda-uat`** (the store `deploy/README.md` already designates for native signing assets).
+The Firebase configuration itself targets the shared **`hushh-pda`** identity authority. Nothing
+App Store-related is a GitHub secret. The workflow reads these with the existing
+`GCP_SA_KEY_UAT` service account.
 
 ### 1. App Store Connect API key
 

--- a/docs/reference/architecture/hushh-tech-uat-client.md
+++ b/docs/reference/architecture/hushh-tech-uat-client.md
@@ -177,7 +177,9 @@ The backend feature flag, exact developer app id, audience, redirect allowlist,
 Firebase UID cohort, launch pepper, shared Redis limiter, proxy audience, and
 trusted proxy service-account allowlist must all be present. Production is hard-disabled
 even if configuration drifts. HushhTech must also prove at build and runtime
-that it uses the `hushh-pda-uat` Firebase authority.
+that its Admin and web-client configuration both use the shared `hushh-pda`
+Firebase authority. `hushh-pda-uat` remains the UAT runtime and Secret Manager
+project; it is not a separate Firebase identity authority.
 
 Rollback first disables both cohort flags, then restores captured prior Cloud
 Run revisions if needed. Migration 162 is additive; tables remain inert and no

--- a/scripts/ops/verify-env-secrets-parity.py
+++ b/scripts/ops/verify-env-secrets-parity.py
@@ -354,7 +354,11 @@ def _domain_runtime_contract(project: str) -> dict[str, str]:
     }
 
 
-def _firebase_project_contract(project: str) -> dict[str, str]:
+def _firebase_project_contract(
+    project: str,
+    *,
+    expected_project: str | None = None,
+) -> dict[str, str]:
     """Prove Firebase Admin and public client configuration target one project.
 
     The Admin credential itself is never rendered. This only compares its
@@ -379,10 +383,21 @@ def _firebase_project_contract(project: str) -> dict[str, str]:
     if not admin_project:
         return {"status": "invalid_credentials", "credentials": "invalid"}
 
-    return {
-        "status": "valid" if admin_project == client_project.strip() else "mismatch",
-        "credentials": "valid" if admin_project == client_project.strip() else "mismatch",
-    }
+    if admin_project != client_project.strip():
+        return {"status": "mismatch", "credentials": "mismatch"}
+
+    expected = str(expected_project or "").strip()
+    if expected and admin_project != expected:
+        return {
+            "status": "unexpected_project",
+            "credentials": "valid",
+            "expected": "mismatch",
+        }
+
+    result = {"status": "valid", "credentials": "valid"}
+    if expected:
+        result["expected"] = "valid"
+    return result
 
 
 def _format_names(names: Iterable[str]) -> str:
@@ -710,6 +725,12 @@ def main() -> int:
         description="Verify required GCP Secret Manager keys for deploy parity."
     )
     parser.add_argument("--project", required=True, help="GCP project id")
+    parser.add_argument(
+        "--expected-firebase-project",
+        help=(
+            "Optional exact public Firebase project id required after Admin/client parity."
+        ),
+    )
     parser.add_argument("--region", default="us-central1", help="Reserved for parity interface")
     parser.add_argument(
         "--backend-service",
@@ -951,7 +972,10 @@ def main() -> int:
             report["classifications"].append("domain_runtime_contract_failed")
 
     if checks_frontend:
-        firebase_project_contract = _firebase_project_contract(args.project)
+        firebase_project_contract = _firebase_project_contract(
+            args.project,
+            expected_project=args.expected_firebase_project,
+        )
         report["firebase_project_contract"] = firebase_project_contract
         print(f"Firebase project contract: {firebase_project_contract['status']}")
         if firebase_project_contract["status"] != "valid":

--- a/scripts/release/dispatch-ios-appstore.mjs
+++ b/scripts/release/dispatch-ios-appstore.mjs
@@ -14,8 +14,8 @@
  * runner, because GCP has no macOS instances and local builds hang inside iCloud
  * Drive. This script is the thin, auditable dispatcher.
  *
- * BACKEND: the public App Store build ships the SAME UAT backend + UAT Firebase
- * (hushh-pda-uat) as TestFlight — the latest frontend+backend that is live on
+ * BACKEND: the public App Store build ships the SAME UAT backend + shared Firebase
+ * authority (hushh-pda; config stored in hushh-pda-uat) as TestFlight — the latest frontend+backend that is live on
  * UAT. It is NOT built against a separate production backend.
  *
  * SAFETY / IRREVERSIBILITY


### PR DESCRIPTION
# Description

Pins the proven shared Firebase authority (`hushh-pda`) in the Hushh Research UAT deploy parity gate. This prevents the UAT runtime project (`hushh-pda-uat`) from being mistaken for a second identity authority before the Hushh Tech client cohort can be enabled.

Part of #5684.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] Listed below: `verify-env-secrets-parity.py` accepts an optional exact Firebase project expectation and reports status labels only.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: comments and runbooks now identify `hushh-pda` as the shared Firebase authority; no native build or runtime command changed.
- Docs updated (exact files):
  - [x] `deploy/app_store_deployment.md`, `docs/guides/mobile/release-ios-appstore.md`, `docs/guides/mobile/ship-android-playstore.md`, `docs/guides/mobile/ship-ios-testflight.md`, `docs/reference/architecture/hushh-tech-uat-client.md`
- Top-level / devex / config / generated / ignore files touched:
  - [x] Existing UAT deploy and parity-verification workflow only; backend test manifest includes the new regression file.
- Trust boundary touched:
  - [x] Deploy and auth configuration parity: Admin and browser Firebase project IDs must agree and equal `hushh-pda`.
- Caller / proxy / backend pairing:
  - [x] `.github/workflows/deploy-uat.yml` passes the exact expected authority to both parity attempts.
- Rollback or safe-failure behavior:
  - [x] Mismatch fails before a healthy UAT release is declared; no secret values are rendered.
- UI browser or Playwright proof:
  - [x] Not applicable; no UI behavior changed.
- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`
  - [x] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (no native artifact change)
  - [ ] `python scripts/ops/kai-system-audit.py ...` (no Kai runtime change)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR extends the merged Hushh Tech UAT client foundation without duplicating another PR.
- [x] Current reachable deploy verification and canonical release documentation are changed.
- [x] Reachable production attach point: UAT deploy parity attempts in `.github/workflows/deploy-uat.yml`.
- [x] New tests import and exercise the real parity verifier and parse the deployed workflow source.
- [x] New verifier option is wired to both UAT parity attempts and the blocking protocol test manifest.
- [x] Production surface proved: no production deploy path, feature flag, callback, Firebase directory, Supabase surface, or secret value changed.
- [x] Required checks will be read on the exact PR head; commit is signed off.
- [x] Maintainer edits are enabled.
- [x] Predecessor: #5693.
- [x] This follow-up corrects the live authority mismatch found during post-merge UAT setup.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: UAT deploy parity only; no Next.js behavior change.
- [x] **iOS**: not applicable; comments/runbooks only.
- [x] **Android**: not applicable; runbook wording only.

## 🧪 Testing

- [x] Tested on Web through the complete pre-PR mirror; no visible UI changed.
- [ ] Tested on iOS Simulator/Device (not applicable)
- [ ] Tested on Android Emulator/Device (not applicable)
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

Focused parity/workflow tests: 25 passed. Full protocol: 1,228 passed. Complete pre-PR mirror passed under repository Node 24, including web 4,687 passed / 6 skipped, backend, Model Context Protocol, private-place, build, lint, types, security, docs, governance, release, and native parity gates.

## 📸 Screenshots / Video

Not applicable: no UI-visible behavior changed.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [x] Consent check not applicable.
- [x] Sensitive surface touched: auth configuration parity and UAT deploy.
- [x] Error path: mismatched or unexpected Firebase authority fails closed without logging credential values.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice change.
