### PR TITLE
fix(ui): center KYC preface skip button and remove desktop hover underline

### DIFF
--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -95,19 +95,22 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
           <div className="flex items-center justify-between">
             <div className="w-16" />
             <div className="h-1.5 w-12 rounded-full bg-muted/50" />
-            <Button
-              type="button"
-              variant="link"
-              effect="fade"
-              size="sm"
-              onClick={handleSkip}
-              className="w-16 justify-end text-[14px] font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground rounded-full px-3 py-1.5 h-auto transition-colors"
-              showRipple={false}
-              aria-label="Skip identity checks"
-            >
-              Skip
-            </Button>
+            <div className="flex w-16 justify-end md:justify-center">
+              <Button
+                type="button"
+                variant="link"
+                effect="fade"
+                size="sm"
+                onClick={handleSkip}
+                className="h-auto rounded-full px-3 py-1.5 text-[14px] font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors md:!no-underline md:hover:!no-underline"
+                showRipple={false}
+                aria-label="Skip identity checks"
+              >
+                Skip
+              </Button>
+            </div>
           </div>
+
 
           <div className="mx-auto flex w-full flex-col text-center">
             <div className="space-y-2 mb-8">


### PR DESCRIPTION
**Summary**

Resolves a layout alignment asymmetry and unwanted text decoration on the "Skip" action button within the KYC Identity Preface step (`/one/setup/email` and `/one/kyc`).

**What Changed**

* **Desktop Centering:** Wrapped the "Skip" action in an isolated flex layout container (`flex w-16 justify-end md:justify-center`) to mathematically center the text inside its pill container on desktop viewports while maintaining mobile layout parity.
* **Removed Hover Underline:** Added responsive utility overrides (`md:!no-underline md:hover:!no-underline`) to prevent the default link variant from rendering a hyperlink underline during desktop hover states.
* **Preserved Logic & Boundaries:** 100% isolated to UI/CSS presentation. No routing hooks, state handlers, API calls, or underlying `handleSkip` / vault behaviors were modified.

**UX Goal**

Ensure the top navigation controls in the KYC onboarding flow match the design system's pill-button visual language, eliminating layout shifts and conflicting hyperlink underlines on desktop screens.

**Affected Files & Routes**

* **File:** `hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx`
* **Routes:** `/one/setup/email`, `/one/kyc`

**Verification**

* Verified responsive alignment on desktop viewports (`>= 768px`) and mobile viewports.
* Verified that hover states on desktop do not render an underline.
* Verified that clicking `Skip` still triggers `onComplete()` and navigation flows as expected.
* Ran local UI audit on Chrome / Safari viewports with zero layout regressions.