### PR TITLE
feat(one-location): pin Send to the Ask flow, with the count beside it

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -4400,6 +4400,34 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("keeps the count with the action, since the two are a screen apart", async () => {
+    // Send sits after the roster, the duration ladder, the reason chips and the
+    // message box. Scrolling to it used to lose the only place that said how
+    // many people were chosen, so the last check before an outward action was
+    // to scroll back up and count rows.
+    mockGetState.mockResolvedValue(locationState());
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    // Nothing chosen: the bar is there, the count is not -- an empty line
+    // announcing zero is noise.
+    expect(screen.getByTestId("one-location-ask-send-bar")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("one-location-ask-selection-summary"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Select Trusted B/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("one-location-ask-selection-summary"),
+      ).toHaveTextContent("1 person selected"),
+    );
+  });
+
   it("offers a way to Connect when the person being looked for is not on the list", async () => {
     // This roster is everyone you are already connected to, so "they are not
     // here" has exactly one answer and it lives on another screen. Without

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -3953,6 +3953,43 @@ function AskFlow({
         const isFormValid = vm.selectedRequestOwnerIds.length > 0;
         const sending = vm.busy === "request";
         return (
+          /**
+           * Pinned, because choosing someone and sending to them were never on
+           * screen together.
+           *
+           * Send sits after the roster, the duration ladder, the reason chips
+           * and the message box -- roughly a screen and a half below the person
+           * being picked. So the count travels with it: scrolling away from the
+           * roster used to lose the only place that said how many were chosen.
+           *
+           * `sticky`, not `fixed`. A fixed bar covers content and has to be
+           * paid for with page padding that is wrong at one end or the other.
+           * This one rides the page and settles into place at the bottom of the
+           * flow, so nothing is ever permanently underneath it.
+           *
+           * The offset is the app's own composed bottom inset plus the
+           * keyboard: on iOS the on-screen keyboard would otherwise sit over
+           * the action a person just reached for.
+           */
+          <div
+            data-testid="one-location-ask-send-bar"
+            className="sticky z-10 -mx-1 mt-1 space-y-2 rounded-2xl bg-[color:var(--app-primary-surface)]/95 px-1 py-2 backdrop-blur supports-[backdrop-filter]:bg-[color:var(--app-primary-surface)]/80"
+            style={{
+              bottom:
+                "calc(var(--app-bottom-inset, 0px) + var(--kb-height, 0px) + 0.5rem)",
+            }}
+          >
+            {isFormValid ? (
+              <p
+                aria-live="polite"
+                data-testid="one-location-ask-selection-summary"
+                className={cn(MUTED_TEXT, "px-1")}
+              >
+                {vm.selectedRequestOwnerIds.length === 1
+                  ? "1 person selected"
+                  : `${vm.selectedRequestOwnerIds.length} people selected`}
+              </p>
+            ) : null}
           <Button
             onClick={() => {
               // Never submit an incomplete form even if the click somehow
@@ -3978,6 +4015,7 @@ function AskFlow({
           >
             Send request
           </Button>
+          </div>
         );
       })()}
 


### PR DESCRIPTION
Part of **#5608**. **Not for merge until tested** — raising it for review and a local pass first.

## The problem

Choosing someone and sending to them were never on screen together. Send sits after the roster, the duration ladder, the reason chips and the message box — roughly a screen and a half below the person being picked.

Scrolling to it also lost the only place that said **how many** were chosen, so the last check before an outward action was to scroll back up and count rows.

## The decisions

**`sticky`, not `fixed`.** A fixed bar covers content and has to be paid for with page padding that is wrong at one end or the other. This one rides the page and settles into place at the end of the flow, so nothing is ever permanently underneath it.

**Offset is `--app-bottom-inset` + `--kb-height`.** The app's own composed bottom chrome, plus the keyboard — on iOS the on-screen keyboard would otherwise sit over the action a person just reached for.

**The count appears only once something is selected.** A line announcing zero is noise, and the roster's own pill already answers *"who"* while it is on screen. `aria-live="polite"`, so the number is spoken as it changes rather than only when the button is reached.

## Connect's half is deliberately NOT here

The issue assumes Connect's search field sits above the list it filters. **It does not.** That field searches the *directory* and already sits directly above the directory results — **below** the "My connections" group.

Pinning it would fix the top of the screen to a control that does not filter what is under it. That surface needs a different answer, so **#5608 stays open** with this recorded rather than half-applied.

## Verification

```
tsc          no new errors (the 5 on this tsconfig are pre-existing on clean
             main — an unrelated hushh-tech proxy module missing `redis`)
eslint       clean
vitest       104 agent-page tests, incl. a new one pinning the bar's presence
             and the count's appearance
design-system passed
```

Local `vitest` on the broader redesign directory hits worker-exit flakes on my machine (79 passed, 0 failed, 6 worker errors) — CI runs it properly.

Base is `main`, 0 behind at push.