### PR TITLE
feat(one-voice): migrate the canonical live model to gemini-3.1-flash-live-preview

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -447,15 +447,25 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             runtime_vertex_project=runtime_vertex_project,
             runtime_vertex_location=runtime_vertex_location,
         )
-    except ValueError as exc:
+    except (ValueError, RuntimeError) as exc:
         # Safe class-only close reasons. Never reflect the credential or a raw
         # provider response to the browser, logger, telemetry, or websocket.
+        # RuntimeError covers managed_live_key_missing from
+        # _build_one_live_model: the canonical live model rides the
+        # developer_api transport and cannot start without the Hussh-managed
+        # live key, so close cleanly instead of crashing the websocket.
         reason = str(exc)
         logger.info("one_adk_live_runtime_bootstrap_rejected reason=%s", reason)
         if reason == "byok_live_unsupported":
             await _close_quietly(
                 websocket, code=1008, reason="BYOK Live is unavailable. Use managed Gemini."
             )
+        elif reason.startswith("managed_live_key_missing"):
+            logger.error(
+                "one_adk_live_managed_key_missing: managed voice is not "
+                "provisioned in this environment (HUSHH_MANAGED_GEMINI_LIVE_API_KEY)"
+            )
+            await _close_quietly(websocket, code=1013, reason="Voice is temporarily unavailable.")
         else:
             await _close_quietly(
                 websocket, code=1008, reason="Voice session configuration was not accepted."
@@ -613,10 +623,11 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
     _schedule_idle_greeting("")
 
     # Last screen injected as model-visible context. Screen changes arrive as
-    # app_context frames; sending content mid-generation PREEMPTS the model's
-    # current turn on the Live API, so screen text is injected only when the
-    # screen truly changed (never for the first frame; session state already
-    # carries it for tools).
+    # app_context frames; on 2.x live models, sending content mid-generation
+    # PREEMPTS the model's current turn on the Live API (on Gemini 3.x live
+    # models the frame rides send_realtime_input, which does not preempt), so
+    # screen text is injected only when the screen truly changed (never for
+    # the first frame; session state already carries it for tools).
     last_injected_route_key: Optional[str] = None
     last_injected_entry_key: Optional[str] = None
     first_app_context_seen = False
@@ -1258,9 +1269,13 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 )
                 # ONE frame for one settlement, continuation included.
                 #
-                # Each `send_content` closes a user turn on the Live API and
-                # elicits a full response, so a settlement that armed a
-                # continuation used to make One answer twice for a single
+                # Each `send_content` elicits a full model response: on 2.x
+                # live models it closes a user turn as client content, and on
+                # Gemini 3.x live models google-adk transposes the single-text
+                # frame into `send_realtime_input(text=...)`, which the
+                # 2026-08-21 ADK rehearsal verified also elicits a complete
+                # turn. Either way, a settlement that armed a continuation
+                # used to make One answer twice for a single
                 # event: once about the outcome, once about the continuation.
                 # That is a second, independent source of the repetition QA
                 # reported, on the journey path rather than the specialist one.

--- a/consent-protocol/contracts/agents/product-agent-registry.v2.json
+++ b/consent-protocol/contracts/agents/product-agent-registry.v2.json
@@ -1759,7 +1759,7 @@
       },
       "capabilities": {
         "heads": {
-          "live": "gemini-live-2.5-flash-native-audio",
+          "live": "gemini-3.1-flash-live-preview",
           "specialist_text": "gemini-3.7-flash",
           "text": "gemini-3.7-flash"
         },

--- a/consent-protocol/hushh_mcp/agents/one/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/one/agent.yaml
@@ -82,4 +82,4 @@ capabilities:
   heads:
     text: gemini-3.7-flash
     specialist_text: gemini-3.7-flash
-    live: gemini-live-2.5-flash-native-audio
+    live: gemini-3.1-flash-live-preview

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import logging
 import os
 import time
-from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -133,24 +132,30 @@ APP_ROUTES: dict[str, str] = {
     "profile": "/profile",
 }
 
-# Voice head runs the GA native-audio Live model on Vertex ADC (regional
-# only; it is NOT published on the global endpoint, so the live client pins
-# a region via AGENT_ONE_ADK_LOCATION). Model is env-swappable through
-# AGENT_ONE_ADK_MODEL with no code change.
+# Voice head model contract. The canonical live model is authored in the One
+# manifest (heads.live) and env-swappable through AGENT_ONE_ADK_MODEL with no
+# code change; the transport per model comes from GEMINI_LIVE_COMPATIBILITY.
 #
-# MODEL CONTRACT - do not bump to a gemini-3.x Live model casually:
-# gemini-live-2.5-flash-native-audio is the GA "Recommended" Vertex Live
-# model and supports send_client_content THROUGHOUT the session. The relay
-# (api/routes/one/adk_live.py) depends on mid-session send_content for
-# greetings, app_speech, user_text turns, settlement notes, and route-change
-# notes. On Gemini 3.x Live, send_client_content only seeds initial history;
-# a 3.x swap would silently break every one of those injection paths.
-# _build_one_live_model() logs a warning if the override looks like 3.x.
+# MODEL CONTRACT (updated 2026-08-21 after an ADK Live rehearsal):
+# gemini-3.1-flash-live-preview is the canonical live model. It is served on
+# the Gemini Developer API only (verified: the Vertex publisher endpoint 404s
+# in us-central1/us-east4/europe-west4/asia-southeast1), so its transport is
+# developer_api with a Hussh-managed key (HUSHH_MANAGED_GEMINI_LIVE_API_KEY).
+# The relay's mid-session injections (greetings, app_speech, user_text turns,
+# settlement notes, route-change notes) all queue single-text-part Contents;
+# on Gemini 3.x Live model names, google-adk (>=2.4.0) transposes each of
+# those into session.send_realtime_input(text=...) automatically
+# (google/adk/models/gemini_llm_connection.py), which the rehearsal verified
+# elicits complete model turns mid-session. The rehearsal also verified that
+# mid-session send_client_content itself is honored on the current 3.1
+# preview build, so both injection channels are live. Rollback lever: set
+# AGENT_ONE_ADK_MODEL=gemini-live-2.5-flash-native-audio (GA, Vertex) — its
+# matrix entry and Vertex transport remain fully supported below.
 _ONE_HEADS = _ONE_MANIFEST.capabilities.get("heads", {})
 _ONE_MODEL = (
     os.getenv("AGENT_ONE_ADK_MODEL")
     or (_ONE_HEADS.get("live") if isinstance(_ONE_HEADS, dict) else None)
-    or "gemini-live-2.5-flash-native-audio"
+    or "gemini-3.1-flash-live-preview"
 ).strip()
 _ONE_LIVE_LOCATION = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").strip()
 # The Developer API Live contract is intentionally separate from the Vertex
@@ -165,36 +170,12 @@ _SPECIALIST_MODEL = (
 ).strip()
 
 
-@dataclass(frozen=True)
-class GeminiLiveCompatibility:
-    """One relay requirements for one named Gemini Live model contract."""
-
-    transport: Literal["vertex", "developer_api"]
-    supports_mid_session_client_content: bool
-    operator_enablement_required: bool
-
-
-# The relay injects redacted route state and correlated action settlements after
-# setup, so it requires client content throughout a session. Keep the model
-# differences declarative: adding a Developer API model is an explicit contract
-# decision plus an ADK rehearsal, never a best-effort name-prefix heuristic.
-GEMINI_LIVE_COMPATIBILITY: dict[str, GeminiLiveCompatibility] = {
-    "gemini-live-2.5-flash-native-audio": GeminiLiveCompatibility(
-        transport="vertex",
-        supports_mid_session_client_content=True,
-        operator_enablement_required=False,
-    ),
-    "gemini-2.5-flash-live-preview": GeminiLiveCompatibility(
-        transport="developer_api",
-        supports_mid_session_client_content=True,
-        operator_enablement_required=True,
-    ),
-    "gemini-3.1-flash-live-preview": GeminiLiveCompatibility(
-        transport="developer_api",
-        supports_mid_session_client_content=False,
-        operator_enablement_required=True,
-    ),
-}
+# The Live compatibility registry lives in runtime_providers so the deploy
+# verifier can consult it without importing this module's heavy dependency
+# chain; re-exported here because this is its historical import site.
+from hushh_mcp.runtime_providers.live_compatibility import (  # noqa: E402
+    GEMINI_LIVE_COMPATIBILITY,
+)
 
 
 def _onboarding_goals_enabled(user_id: str) -> bool:
@@ -213,23 +194,49 @@ def _onboarding_goals_enabled(user_id: str) -> bool:
     return not allowlist or user_id in allowlist
 
 
-def _build_one_live_model():
-    """Live model for One's voice head.
+def _managed_live_api_key() -> str:
+    """Hussh-managed Developer API key for developer_api-transport live models.
 
-    Wraps the model id in an ADK ``Gemini`` with an explicit regional
-    location when running on Vertex, because the native-audio Live model is
-    served regionally (us-central1 etc.), not on the global endpoint the
-    genai client defaults to.
+    Distinct from BYOK by design: this key is Hussh-owned (minted in the
+    Gemini billing-bridge project, Secret Manager-delivered) and is only ever
+    used for the canonical managed live model. A person's BYOK key still flows
+    exclusively through build_one_live_runner's BYOK lane.
     """
-    if _ONE_MODEL.startswith("gemini-3"):
+    return (os.getenv("HUSHH_MANAGED_GEMINI_LIVE_API_KEY") or "").strip()
+
+
+def _build_one_live_model():
+    """Live model for One's voice head, built on the model's declared transport.
+
+    vertex transport wraps the model id in an ADK ``Gemini`` with an explicit
+    regional location (Vertex live models are served regionally, not on the
+    global endpoint the genai client defaults to). developer_api transport
+    builds the same ADK ``Gemini`` against the Gemini Developer API with the
+    Hussh-managed live key — required for gemini-3.1-flash-live-preview, which
+    is not published on Vertex.
+    """
+    compat = GEMINI_LIVE_COMPATIBILITY.get(_ONE_MODEL)
+    if compat is None:
         logger.warning(
-            "one_adk_live_model_contract_risk model=%s: Gemini 3.x Live treats "
-            "send_client_content as init-history-only; the relay's mid-session "
-            "content injection (greetings, app_speech, settlement and route "
-            "notes) will not work. Stay on gemini-live-2.5-flash-native-audio "
-            "until those paths are migrated to send_realtime_input.",
+            "one_adk_live_model_contract_risk model=%s: not declared in "
+            "GEMINI_LIVE_COMPATIBILITY. The relay's mid-session injection "
+            "channels have not been rehearsed for this model; falling back to "
+            "managed Vertex transport. Author a matrix entry after an ADK "
+            "rehearsal before shipping this model.",
             _ONE_MODEL,
         )
+    if compat is not None and compat.transport == "developer_api":
+        key = _managed_live_api_key()
+        if not key:
+            raise RuntimeError(
+                "managed_live_key_missing: the canonical live model "
+                f"'{_ONE_MODEL}' uses the developer_api transport and requires "
+                "HUSHH_MANAGED_GEMINI_LIVE_API_KEY. Set the secret, or roll "
+                "back with AGENT_ONE_ADK_MODEL=gemini-live-2.5-flash-native-audio."
+            )
+        from hushh_mcp.runtime_providers import build_gemini_byok_adk_model
+
+        return build_gemini_byok_adk_model(_ONE_MODEL, key)
     return build_managed_gemini_adk_model(
         _ONE_MODEL,
         vertex_location=_ONE_LIVE_LOCATION,
@@ -1447,11 +1454,14 @@ def build_one_live_runner(
 ) -> Runner:
     """Return the managed runner or an isolated, connection-local BYOK runner.
 
-    The BYOK Live compatibility gate is deliberately explicit. The current
-    managed runner relies on Vertex's 2.5 native-audio contract; a Developer
-    API model can only be enabled once it is named through the strict model
-    allowlist and the deployment flag. This prevents an API key from causing a
-    credential fallback or an unverified model swap.
+    The BYOK Live compatibility gate is deliberately explicit. The managed
+    runner resolves its own transport (developer_api with the Hussh-managed
+    live key for the canonical gemini-3.1-flash-live-preview; Vertex ADC for
+    vertex-transport models); a BYOK Developer API model can only be enabled
+    once it is named through the strict model allowlist and the deployment
+    flag, and its live + specialist models are built from the person's key
+    explicitly. This prevents an API key from causing a credential fallback
+    or an unverified model swap in either direction.
     """
     if runtime_mode == "hushh_managed_vertex":
         return get_one_runner()

--- a/consent-protocol/hushh_mcp/runtime_providers/factory.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/factory.py
@@ -430,3 +430,21 @@ def build_gemini_byok_adk_model(
         model=clean_model,
         client_kwargs={"vertexai": False, "api_key": clean_key},
     )
+
+
+def build_developer_api_live_client(api_key: str) -> Any:
+    """Direct google-genai client for developer_api-transport Live models.
+
+    Used by the deploy-time managed-runtime verifier to probe the canonical
+    live model when its GEMINI_LIVE_COMPATIBILITY transport is developer_api
+    (e.g. gemini-3.1-flash-live-preview, which is not published on Vertex).
+    Pins ``vertexai=False`` so an ambient managed Vertex environment can never
+    capture the managed live key. Client construction stays centralized here
+    per test_genai_client_construction_is_centralized.
+    """
+    from google import genai
+
+    clean_key = str(api_key or "").strip()
+    if not clean_key:
+        raise ValueError("Developer API live client requires an API key")
+    return genai.Client(vertexai=False, api_key=clean_key)

--- a/consent-protocol/hushh_mcp/runtime_providers/live_compatibility.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/live_compatibility.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Declarative Gemini Live model compatibility registry.
+
+Lives in runtime_providers (dependency-light) rather than one_adk so the
+deploy-time managed-runtime verifier can read the matrix without importing
+the full agent tree, whose import chain requires app security configuration
+(APP_SIGNING_KEY et al.) that the verifier job does not carry.
+
+The relay injects redacted route state and correlated action settlements after
+setup, so every model here must support mid-session injection. On 2.x live
+models that channel is send_client_content; on 3.x live model names google-adk
+transposes the same queue.send_content calls into send_realtime_input(text=...)
+(single non-partial text part), so the flag means "the relay's mid-session
+injections reach the model", whichever wire channel carries them. Keep the
+model differences declarative: adding a model is an explicit contract decision
+plus an ADK rehearsal, never a best-effort name-prefix heuristic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class GeminiLiveCompatibility:
+    """One relay requirements for one named Gemini Live model contract."""
+
+    transport: Literal["vertex", "developer_api"]
+    supports_mid_session_client_content: bool
+    operator_enablement_required: bool
+
+
+GEMINI_LIVE_COMPATIBILITY: dict[str, GeminiLiveCompatibility] = {
+    "gemini-live-2.5-flash-native-audio": GeminiLiveCompatibility(
+        transport="vertex",
+        supports_mid_session_client_content=True,
+        operator_enablement_required=False,
+    ),
+    "gemini-2.5-flash-live-preview": GeminiLiveCompatibility(
+        transport="developer_api",
+        supports_mid_session_client_content=True,
+        operator_enablement_required=True,
+    ),
+    # Canonical since 2026-08-21. Rehearsed on the Developer API: BIDI audio
+    # setup, initial + MID-SESSION send_client_content, and mid-session
+    # send_realtime_input(text=...) all elicited complete model turns. Not
+    # served on Vertex (publisher endpoint 404s across regions), hence
+    # developer_api transport with the Hussh-managed live key.
+    "gemini-3.1-flash-live-preview": GeminiLiveCompatibility(
+        transport="developer_api",
+        supports_mid_session_client_content=True,
+        operator_enablement_required=True,
+    ),
+}

--- a/consent-protocol/hushh_mcp/runtime_providers/registry.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/registry.py
@@ -71,6 +71,14 @@ _MODELS: tuple[ModelEntry, ...] = (
         model="gemini-live-2.5-flash-native-audio",
         supports_native_realtime=True,
     ),
+    # Canonical live model since 2026-08-21. Developer API transport only
+    # (not published on Vertex), so no supported_vertex_locations contract;
+    # the endpoint decision lives in GEMINI_LIVE_COMPATIBILITY (agent_tree).
+    ModelEntry(
+        provider="gemini",
+        model="gemini-3.1-flash-live-preview",
+        supports_native_realtime=True,
+    ),
     # Anthropic -- native SDK adapter; chained-only voice (no native realtime API).
     ModelEntry(
         provider="anthropic",

--- a/consent-protocol/scripts/verify_managed_vertex_runtime.py
+++ b/consent-protocol/scripts/verify_managed_vertex_runtime.py
@@ -75,12 +75,31 @@ async def main() -> dict[str, object]:
     binding = ManagedGeminiRuntimeBinding.from_environment()
     models, live_model = _managed_manifest_models()
     live_location = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").strip()
-    live_binding = ManagedGeminiRuntimeBinding(
-        project=binding.project,
-        locations=(live_location,),
-        auth_mode=binding.auth_mode,
+    # The live model's endpoint follows its declared transport, mirroring
+    # agent_tree._build_one_live_model: vertex-transport live models probe the
+    # regional Vertex Live endpoint; developer_api-transport models (e.g. the
+    # canonical gemini-3.1-flash-live-preview, which is not published on
+    # Vertex) probe the Gemini Developer API with the Hussh-managed live key.
+    from hushh_mcp.runtime_providers.live_compatibility import (
+        GEMINI_LIVE_COMPATIBILITY,
     )
-    live_client = live_binding.build_direct_client()
+
+    _live_compat = GEMINI_LIVE_COMPATIBILITY.get(live_model)
+    _live_is_developer_api = _live_compat is not None and _live_compat.transport == "developer_api"
+    if _live_is_developer_api:
+        from hushh_mcp.runtime_providers.factory import build_developer_api_live_client
+
+        _managed_live_key = (os.getenv("HUSHH_MANAGED_GEMINI_LIVE_API_KEY") or "").strip()
+        live_client = (
+            build_developer_api_live_client(_managed_live_key) if _managed_live_key else None
+        )
+    else:
+        live_binding = ManagedGeminiRuntimeBinding(
+            project=binding.project,
+            locations=(live_location,),
+            auth_mode=binding.auth_mode,
+        )
+        live_client = live_binding.build_direct_client()
 
     def binding_for(location: str) -> ManagedGeminiRuntimeBinding:
         return ManagedGeminiRuntimeBinding(
@@ -136,6 +155,16 @@ async def main() -> dict[str, object]:
         await asyncio.wait_for(consume_first_response(), timeout=PROBE_TIMEOUT_SECONDS)
 
     async def probe_live_setup() -> None:
+        if live_client is None:
+            # developer_api transport with no managed key in this environment.
+            # The runtime fails loudly at session build (managed_live_key_missing
+            # in agent_tree), so the release evidence records the gap instead of
+            # silently passing a probe that never connected.
+            raise RuntimeError(
+                "managed_live_key_missing: developer_api live model "
+                f"'{live_model}' cannot be probed without "
+                "HUSHH_MANAGED_GEMINI_LIVE_API_KEY"
+            )
         manager = live_client.aio.live.connect(
             model=live_model,
             config=types.LiveConnectConfig(response_modalities=[types.Modality.AUDIO]),
@@ -166,7 +195,8 @@ async def main() -> dict[str, object]:
         for location in locations_for(model):
             labelled.append((f"text:{model}@{location}", probe_text(model, location)))
             labelled.append((f"adk:{model}@{location}", probe_adk_text(model, location)))
-    labelled.append((f"live:{live_model}@{live_location}", probe_live_setup()))
+    _live_endpoint = "developer_api" if _live_is_developer_api else live_location
+    labelled.append((f"live:{live_model}@{_live_endpoint}", probe_live_setup()))
 
     outcomes = await asyncio.gather(*(coro for _, coro in labelled), return_exceptions=True)
 
@@ -194,7 +224,7 @@ async def main() -> dict[str, object]:
         "advisory": is_advisory(classification),
         "models": list(models),
         "live_model": live_model,
-        "live_location": live_location,
+        "live_location": _live_endpoint,
         "probes": probes,
         # A provider-side denial is returned before any model-specific
         # validation, so an outage verdict does NOT clear the candidate. Say so,

--- a/consent-protocol/tests/services/test_runtime_providers.py
+++ b/consent-protocol/tests/services/test_runtime_providers.py
@@ -133,9 +133,15 @@ def test_resolve_model_entry_empty_model_uses_default():
     assert entry.model == default_model_for_provider("gemini")
 
 
-def test_only_gemini_live_model_advertises_native_realtime():
+def test_only_gemini_live_models_advertise_native_realtime():
     assert resolve_model_entry("gemini", "gemini-3.5-flash").supports_native_realtime is False
     assert resolve_model_entry("gemini", "gemini-3.1-flash-lite").supports_native_realtime is False
+    # Canonical live model (developer_api transport) and the Vertex GA
+    # rollback model are the only two realtime-capable entries.
+    assert (
+        resolve_model_entry("gemini", "gemini-3.1-flash-live-preview").supports_native_realtime
+        is True
+    )
     assert (
         resolve_model_entry("gemini", "gemini-live-2.5-flash-native-audio").supports_native_realtime
         is True

--- a/consent-protocol/tests/test_agent_manifests.py
+++ b/consent-protocol/tests/test_agent_manifests.py
@@ -104,7 +104,7 @@ def test_gemini_model_matrix_uses_current_workload_equivalents() -> None:
     assert one.capabilities["heads"] == {
         "text": "gemini-3.7-flash",
         "specialist_text": "gemini-3.7-flash",
-        "live": "gemini-live-2.5-flash-native-audio",
+        "live": "gemini-3.1-flash-live-preview",
     }
 
 

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -60,6 +60,20 @@ from hushh_mcp.services.live_voice_context import (
 
 
 class TestAgentTreeShape:
+    @pytest.fixture(autouse=True)
+    def _managed_live_key(self, monkeypatch: pytest.MonkeyPatch):
+        """The canonical live model rides the developer_api transport, so
+        building the voice head requires the Hussh-managed live key; tests
+        provide a dummy (no session is ever opened at build time)."""
+        monkeypatch.setenv("HUSHH_MANAGED_GEMINI_LIVE_API_KEY", "test-managed-live-key")
+
+    def test_voice_head_fails_closed_without_the_managed_live_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("HUSHH_MANAGED_GEMINI_LIVE_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="managed_live_key_missing"):
+            _tree._build_one_live_model()
+
     def test_root_agent_is_one_with_full_roster(self):
         agent = build_one_root_agent()
         assert agent.name == "one"
@@ -134,16 +148,30 @@ class TestAgentTreeShape:
         assert finance_tool.agent.model is turn_model
         assert investor_tool.agent.model is turn_model
 
-    def test_byok_live_registry_rejects_models_without_mid_session_content(
+    def test_byok_live_registry_rejects_models_outside_the_matrix(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        """Fail-closed contract: an unrehearsed model has no matrix entry."""
         monkeypatch.setenv("HUSHH_GEMINI_BYOK_LIVE_ENABLED", "true")
-        monkeypatch.setattr(_tree, "_BYOK_LIVE_MODEL", "gemini-3.1-flash-live-preview")
+        monkeypatch.setattr(_tree, "_BYOK_LIVE_MODEL", "gemini-9.9-flash-live-preview")
         with pytest.raises(ValueError, match="byok_live_unsupported"):
             _tree.build_one_live_runner(
                 runtime_mode="byok",
                 runtime_credential="test-key",
             )
+
+    def test_byok_live_registry_accepts_gemini_31_flash_live(self, monkeypatch: pytest.MonkeyPatch):
+        """gemini-3.1-flash-live-preview passed its 2026-08-21 ADK rehearsal:
+        mid-session injections reach the model (ADK transposes single-text-part
+        send_content to send_realtime_input on 3.x names), so the matrix now
+        declares it compatible and the BYOK gate must accept it."""
+        monkeypatch.setenv("HUSHH_GEMINI_BYOK_LIVE_ENABLED", "true")
+        monkeypatch.setattr(_tree, "_BYOK_LIVE_MODEL", "gemini-3.1-flash-live-preview")
+        runner = _tree.build_one_live_runner(
+            runtime_mode="byok",
+            runtime_credential="test-key",
+        )
+        assert runner is not None
 
     def test_identity_instruction_answers_name_question(self):
         assert "I'm One" in ONE_IDENTITY_INSTRUCTION

--- a/contracts/agents/product-agent-registry.v2.json
+++ b/contracts/agents/product-agent-registry.v2.json
@@ -1759,7 +1759,7 @@
       },
       "capabilities": {
         "heads": {
-          "live": "gemini-live-2.5-flash-native-audio",
+          "live": "gemini-3.1-flash-live-preview",
           "specialist_text": "gemini-3.7-flash",
           "text": "gemini-3.7-flash"
         },

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4988,7 +4988,7 @@
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "7e80edea1cd750f9883c78a6aca19341b5e4cb4d842f7a2ade9a49d446957f34",
-    "agent_registry": "a421da6c4298782fb21585d240f52d9a36b032a80ded56ec114107bb80a7b175",
+    "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
     "cache_manifest": "a920c21d5fd0aa406d20ce8a46b6aa88caf32c0cb033ff3a91e274ec6097258c",
     "data_plane": "3b2f555c7835a04a7802b93e72df0014b6e5fbdbcae986e9d3cd019e4aa64846",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -168,6 +168,9 @@ steps:
         if [[ -n "${_PLAID_ACCESS_TOKEN_KEY_SECRET}" ]]; then
           secrets="${secrets},PLAID_ACCESS_TOKEN_KEY=${_PLAID_ACCESS_TOKEN_KEY_SECRET}:latest"
         fi
+        # Hussh-managed Developer API key for the developer_api-transport live
+        # model (gemini-3.1-flash-live-preview is not published on Vertex).
+        add_secret "${_HUSHH_MANAGED_GEMINI_LIVE_API_KEY_SECRET}" "HUSHH_MANAGED_GEMINI_LIVE_API_KEY"
         add_secret "${_FINNHUB_API_KEY_SECRET}" "FINNHUB_API_KEY"
         add_secret "${_PMP_API_KEY_SECRET}" "PMP_API_KEY"
         add_secret "${_NEWSAPI_KEY_SECRET}" "NEWSAPI_KEY"
@@ -366,6 +369,13 @@ steps:
             genai_project_id="hushh-pda-uat"
           fi
         fi
+        # The probe needs the managed live key when the canonical live model
+        # rides the developer_api transport; mounted only when the secret
+        # exists so lanes without it still create the job.
+        live_key_secret_flag=""
+        if gcloud secrets describe "${_HUSHH_MANAGED_GEMINI_LIVE_API_KEY_SECRET}" --project="$PROJECT_ID" >/dev/null 2>&1; then
+          live_key_secret_flag="--set-secrets=HUSHH_MANAGED_GEMINI_LIVE_API_KEY=${_HUSHH_MANAGED_GEMINI_LIVE_API_KEY_SECRET}:latest"
+        fi
         job_name="${_BACKEND_SERVICE}-genai-readiness"
         gcloud run jobs deploy "${job_name}" \
           --project="$PROJECT_ID" \
@@ -375,6 +385,7 @@ steps:
           --command="python" \
           --args="scripts/verify_managed_vertex_runtime.py" \
           --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
+          ${live_key_secret_flag} \
           --max-retries=0 \
           --task-timeout=90s \
           --quiet
@@ -477,6 +488,9 @@ substitutions:
   _FIREBASE_ADMIN_CREDENTIALS_SECRET: FIREBASE_ADMIN_CREDENTIALS_JSON
   _BACKEND_RUNTIME_CONFIG_JSON_SECRET: BACKEND_RUNTIME_CONFIG_JSON
   _PLAID_ACCESS_TOKEN_KEY_SECRET: ""
+  # Defaulted to the canonical secret name so every lane picks it up without
+  # workflow changes; add_secret skips gracefully where the secret is absent.
+  _HUSHH_MANAGED_GEMINI_LIVE_API_KEY_SECRET: HUSHH_MANAGED_GEMINI_LIVE_API_KEY
   _FINNHUB_API_KEY_SECRET: ""
   _PMP_API_KEY_SECRET: ""
   _NEWSAPI_KEY_SECRET: ""

--- a/docs/reference/one/README.md
+++ b/docs/reference/one/README.md
@@ -43,7 +43,7 @@ for finance-specialist runtime references, and keep future-only One plans under
 
 ## References
 
-- [one-voice-runtime-architecture.md](./one-voice-runtime-architecture.md): current One Voice runtime: ADK `Runner.run_live` over Vertex, One's root agent tree (google_search, open_screen, AgentTool Finance/RIA, specialist turn tools), the browser wire protocol, relay ticket auth, and the consent/directive boundary.
+- [one-voice-runtime-architecture.md](./one-voice-runtime-architecture.md): current One Voice runtime: ADK `Runner.run_live` over the model's declared transport (Gemini Developer API for the canonical live model; Vertex for the rollback), One's root agent tree (google_search, open_screen, AgentTool Finance/RIA, specialist turn tools), the browser wire protocol, relay ticket auth, and the consent/directive boundary.
 - [one-goal-framework.md](./one-goal-framework.md): governed goal planning and running across Gemini Live voice, Agent Chat, typed search, command bar, and UI action buttons.
 - [one-agent-hierarchy.md](./one-agent-hierarchy.md): current One-led app agent hierarchy, A2A/specialist registry, consent authority cascade, and Codex subagent boundary.
 - [gemini-runtime-configuration.md](./gemini-runtime-configuration.md): Connections-owned managed Gemini and Google AI Studio BYOK boundary for typed turns and live voice.

--- a/docs/reference/one/gemini-runtime-configuration.md
+++ b/docs/reference/one/gemini-runtime-configuration.md
@@ -56,8 +56,11 @@ The bounded credential/readiness probe uses the same manifest-owned
 `gemini-3.7-flash` model as normal typed private-agent reasoning. Successful
 setup therefore proves authentication, exact-model access, billing/quota
 availability, and one minimal generation before a key can be saved. Managed
-voice uses `gemini-live-2.5-flash-native-audio`. No standalone TTS fallback is
-configured.
+voice uses `gemini-3.1-flash-live-preview` over the Gemini Developer API with
+the Hussh-managed live key (`HUSHH_MANAGED_GEMINI_LIVE_API_KEY`); the model is
+not published on Vertex, and `gemini-live-2.5-flash-native-audio` (GA, Vertex)
+remains the declared rollback via `AGENT_ONE_ADK_MODEL`. No standalone TTS
+fallback is configured.
 
 Gemini 3.7 text requests use the global Vertex endpoint and omit legacy
 sampling controls. The runtime retains `thinking_level` for bounded reasoning;
@@ -66,12 +69,16 @@ it does not send `temperature`, `top_p`, `top_k`, `candidate_count`, or
 
 ## Live Compatibility Registry
 
-Hussh-managed Vertex remains the default. BYOK Live is disabled unless an
+Hussh-managed credentials remain the default. BYOK Live is disabled unless an
 operator explicitly enables a registry-approved model after an ADK UAT
-rehearsal. `gemini-2.5-flash-live-preview` is the current candidate because it
-supports the relay's mid-session client-content updates. Gemini 3.1 Live is
-not eligible: its current contract limits `send_client_content` to initial
-history, while One needs later route-state and action-settlement updates.
+rehearsal. `gemini-3.1-flash-live-preview` is the canonical registry entry: the
+2026-08-21 ADK rehearsal verified that the relay's later route-state and
+action-settlement updates reach it mid-session — google-adk transposes each
+single-text-part `send_content` into `send_realtime_input(text=...)` on Gemini
+3.x Live names, and the rehearsal additionally confirmed mid-session
+`send_client_content` is honored on the current preview build.
+`gemini-2.5-flash-live-preview` and `gemini-live-2.5-flash-native-audio` stay
+registry-approved as client-content-channel models.
 
 Google Cloud Vertex API-key BYOK is available for typed turns. It is not yet a
 voice-compatible transport, so the app keeps it out of the live relay and

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -156,9 +156,13 @@ inside One's agent tree on the backend.
 What shipped:
 
 - `consent-protocol/hushh_mcp/one_adk/agent_tree.py` builds One as the root
-  `LlmAgent` (name `one`, model `gemini-live-2.5-flash-native-audio` via
-  `AGENT_ONE_ADK_MODEL`; the native-audio Live model is served regionally on
-  Vertex, so the live client pins `AGENT_ONE_ADK_LOCATION`, default
+  `LlmAgent` (name `one`, model `gemini-3.1-flash-live-preview` via
+  `AGENT_ONE_ADK_MODEL`; its `GEMINI_LIVE_COMPATIBILITY` entry declares the
+  `developer_api` transport — the model is not published on Vertex — so the
+  builder uses the Hussh-managed live key `HUSHH_MANAGED_GEMINI_LIVE_API_KEY`;
+  Vertex-transport models such as the
+  `gemini-live-2.5-flash-native-audio` rollback instead pin
+  `AGENT_ONE_ADK_LOCATION`, default
   `us-central1`) with the full roster wired as tools: `google_search`,
   `open_screen`, `AgentTool(finance)`, `AgentTool(ria)`, and specialist-turn
   function wrappers.
@@ -199,7 +203,7 @@ catalog rather than a single blanket default:
 | --- | --- | --- |
 | One typed Agent Chat, semantic action selection, and agentic specialists | `gemini-3.7-flash` | GA Flash text/function head on the global Vertex endpoint |
 | Bounded summary reduction, receipt extraction, and runtime readiness probes | `gemini-3.1-flash-lite` | Lower-cost, lower-latency bounded work |
-| Agent Bar bidirectional speech | `gemini-live-2.5-flash-native-audio` | Current native-audio Live model; served from the configured Live region |
+| Agent Bar bidirectional speech | `gemini-3.1-flash-live-preview` | Canonical Live model; served on the Gemini Developer API with the Hussh-managed live key (`gemini-live-2.5-flash-native-audio` on Vertex is the declared rollback) |
 
 Text models are explicitly marked `supports_native_realtime=false`; only the
 named Live model can acquire the realtime transport. Gemini 3.7 Flash is not a
@@ -247,9 +251,10 @@ known capability gap, not a permission bypass.
   remain on managed Vertex.
 - Live BYOK is disabled by default. The relay accepts it only after an operator
   selects a registry-approved Developer API model and enables it after an ADK
-  rehearsal. The registry currently permits `gemini-2.5-flash-live-preview`;
-  `gemini-3.1-flash-live-preview` fails closed because its Live contract does
-  not support the relay's required mid-session client-content updates. A Google
+  rehearsal. The registry permits `gemini-3.1-flash-live-preview` (the
+  canonical live model — its 2026-08-21 ADK rehearsal verified the relay's
+  mid-session updates reach it, riding `send_realtime_input(text=...)` via
+  google-adk's 3.x transposition) and `gemini-2.5-flash-live-preview`. A Google
   Cloud Vertex API key is currently typed-turn only and is rejected before the
   live relay; its Live endpoint/model contract needs its own UAT rehearsal. An
   unsupported, invalid, or quota-limited key offers managed Gemini instead;

--- a/scripts/ops/verify-env-secrets-parity.py
+++ b/scripts/ops/verify-env-secrets-parity.py
@@ -39,9 +39,7 @@ BACKEND_GMAIL_REQUIRED = (
     "GMAIL_OAUTH_TOKEN_KEY",
 )
 
-BACKEND_ONE_EMAIL_SECRET_REQUIRED = (
-    "ONE_EMAIL_WATCH_RENEW_TOKEN",
-)
+BACKEND_ONE_EMAIL_SECRET_REQUIRED = ("ONE_EMAIL_WATCH_RENEW_TOKEN",)
 
 BACKEND_ONE_EMAIL_RUNTIME_REQUIRED = (
     "ONE_EMAIL_ADDRESS",
@@ -59,6 +57,10 @@ BACKEND_ONE_EMAIL_RUNTIME_REQUIRED = (
 BACKEND_VOICE_REQUIRED = (
     "OPENAI_API_KEY",
     "VOICE_RUNTIME_CONFIG_JSON",
+    # Hussh-managed Developer API key for the canonical live voice model
+    # (gemini-3.1-flash-live-preview rides the developer_api transport; the
+    # relay fails closed with "Voice is temporarily unavailable" without it).
+    "HUSHH_MANAGED_GEMINI_LIVE_API_KEY",
 )
 
 BACKEND_CONNECTED_SYSTEMS_REQUIRED = (
@@ -472,10 +474,7 @@ def _container_env_map(service_json: dict[str, Any] | None) -> dict[str, dict[st
     # container directly at ``spec.containers``. Candidate validation must
     # inspect that second shape before traffic is promoted.
     containers = (
-        service_json.get("spec", {})
-        .get("template", {})
-        .get("spec", {})
-        .get("containers", [])
+        service_json.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
     )
     if not containers:
         containers = service_json.get("spec", {}).get("containers", [])
@@ -586,7 +585,9 @@ def _classify_runtime_key(
 ) -> dict[str, Any]:
     if key not in env_map:
         matched_legacy_keys = [candidate for candidate in legacy_keys if candidate in env_map]
-        matched_components = [candidate for candidate in legacy_component_keys if candidate in env_map]
+        matched_components = [
+            candidate for candidate in legacy_component_keys if candidate in env_map
+        ]
         if matched_legacy_keys or matched_components:
             return {
                 "key": key,
@@ -635,9 +636,7 @@ def _classifications_from_runtime_entries(entries: list[dict[str, Any]]) -> list
     return classifications
 
 
-def _literal_runtime_value(
-    env_map: dict[str, dict[str, Any]], key: str
-) -> str:
+def _literal_runtime_value(env_map: dict[str, dict[str, Any]], key: str) -> str:
     entry = env_map.get(key)
     if not isinstance(entry, dict) or isinstance(entry.get("valueFrom"), dict):
         return ""
@@ -650,22 +649,16 @@ def _one_email_runtime_semantics(
     """Validate public One mailbox routing values without rendering secrets."""
 
     mailbox = _literal_runtime_value(env_map, "ONE_EMAIL_ADDRESS").lower()
-    delegated_user = _literal_runtime_value(
-        env_map, "ONE_EMAIL_DELEGATED_USER"
-    ).lower()
+    delegated_user = _literal_runtime_value(env_map, "ONE_EMAIL_DELEGATED_USER").lower()
     topic = _literal_runtime_value(env_map, "ONE_EMAIL_PUBSUB_TOPIC")
-    audience = urlsplit(
-        _literal_runtime_value(env_map, "ONE_EMAIL_WEBHOOK_AUDIENCE")
-    )
+    audience = urlsplit(_literal_runtime_value(env_map, "ONE_EMAIL_WEBHOOK_AUDIENCE"))
     webhook_service_account = _literal_runtime_value(
         env_map, "ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL"
     ).lower()
     checks = {
         "mailbox": mailbox == "one@hushh.ai",
         "delegated_user": delegated_user == "one@hushh.ai",
-        "pubsub_topic": (
-            topic.startswith("projects/") and "/topics/" in topic
-        ),
+        "pubsub_topic": (topic.startswith("projects/") and "/topics/" in topic),
         "webhook_audience": (
             audience.scheme == "https"
             and bool(audience.netloc)
@@ -673,20 +666,14 @@ def _one_email_runtime_semantics(
             and not audience.query
             and not audience.fragment
         ),
-        "webhook_service_account": webhook_service_account.endswith(
-            ".iam.gserviceaccount.com"
-        ),
-        "webhook_auth": _literal_runtime_value(
-            env_map, "ONE_EMAIL_WEBHOOK_AUTH_ENABLED"
-        ).lower()
+        "webhook_service_account": webhook_service_account.endswith(".iam.gserviceaccount.com"),
+        "webhook_auth": _literal_runtime_value(env_map, "ONE_EMAIL_WEBHOOK_AUTH_ENABLED").lower()
         == "true",
         "watch_renew_auth": _literal_runtime_value(
             env_map, "ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED"
         ).lower()
         == "true",
-        "default_scope": _literal_runtime_value(
-            env_map, "ONE_EMAIL_KYC_DEFAULT_SCOPE"
-        )
+        "default_scope": _literal_runtime_value(env_map, "ONE_EMAIL_KYC_DEFAULT_SCOPE")
         == "attr.identity.*",
         "strict_client_zk": _literal_runtime_value(
             env_map, "ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED"
@@ -695,10 +682,7 @@ def _one_email_runtime_semantics(
     }
     return {
         "status": "valid" if all(checks.values()) else "mismatch",
-        "checks": {
-            key: "valid" if value else "mismatch"
-            for key, value in checks.items()
-        },
+        "checks": {key: "valid" if value else "mismatch" for key, value in checks.items()},
     }
 
 
@@ -727,9 +711,7 @@ def main() -> int:
     parser.add_argument("--project", required=True, help="GCP project id")
     parser.add_argument(
         "--expected-firebase-project",
-        help=(
-            "Optional exact public Firebase project id required after Admin/client parity."
-        ),
+        help=("Optional exact public Firebase project id required after Admin/client parity."),
     )
     parser.add_argument("--region", default="us-central1", help="Reserved for parity interface")
     parser.add_argument(
@@ -813,9 +795,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    checks_backend, checks_frontend = _parity_targets(
-        args.backend_revision, args.frontend_revision
-    )
+    checks_backend, checks_frontend = _parity_targets(args.backend_revision, args.frontend_revision)
 
     required = list(BACKEND_REQUIRED if checks_backend else ())
     if checks_frontend:
@@ -852,15 +832,11 @@ def main() -> int:
         "required": {
             "backend": list(BACKEND_REQUIRED) if checks_backend else [],
             "frontend": list(FRONTEND_REQUIRED) if checks_frontend else [],
-            "gmail": list(BACKEND_GMAIL_REQUIRED)
-            if checks_backend and args.require_gmail
-            else [],
+            "gmail": list(BACKEND_GMAIL_REQUIRED) if checks_backend and args.require_gmail else [],
             "one_email": list(BACKEND_ONE_EMAIL_SECRET_REQUIRED)
             if checks_backend and args.require_one_email
             else [],
-            "voice": list(BACKEND_VOICE_REQUIRED)
-            if checks_backend and args.require_voice
-            else [],
+            "voice": list(BACKEND_VOICE_REQUIRED) if checks_backend and args.require_voice else [],
             "connected_systems": list(BACKEND_CONNECTED_SYSTEMS_REQUIRED)
             if checks_backend and args.require_connected_systems
             else [],
@@ -870,13 +846,13 @@ def main() -> int:
             "prod_phone_test": list(BACKEND_PROD_PHONE_TEST_REQUIRED)
             if checks_backend and args.require_prod_phone_test
             else [],
-            "plaid": list(BACKEND_PLAID_REQUIRED)
-            if checks_backend and args.require_plaid
-            else [],
+            "plaid": list(BACKEND_PLAID_REQUIRED) if checks_backend and args.require_plaid else [],
             "market": list(BACKEND_MARKET_REQUIRED)
             if checks_backend and args.require_market_data
             else [],
-            "native_release": list(NATIVE_RELEASE_REQUIRED) if args.require_native_artifacts else [],
+            "native_release": list(NATIVE_RELEASE_REQUIRED)
+            if args.require_native_artifacts
+            else [],
         },
         "missing_secrets": sorted(missing),
         "classifications": [],
@@ -898,8 +874,7 @@ def main() -> int:
     print(f"Parity targets: backend={checks_backend}, frontend={checks_frontend}")
     if checks_backend:
         print(
-            f"Required backend secrets ({len(BACKEND_REQUIRED)}): "
-            f"{_format_names(BACKEND_REQUIRED)}"
+            f"Required backend secrets ({len(BACKEND_REQUIRED)}): {_format_names(BACKEND_REQUIRED)}"
         )
     if checks_backend and args.require_plaid:
         print(
@@ -1071,8 +1046,7 @@ def main() -> int:
         backend_reviewer_smoke_entries = []
         if checks_backend and args.require_reviewer_smoke:
             backend_reviewer_smoke_entries = [
-                _classify_runtime_key(backend_env, key)
-                for key in BACKEND_REVIEWER_SMOKE_REQUIRED
+                _classify_runtime_key(backend_env, key) for key in BACKEND_REVIEWER_SMOKE_REQUIRED
             ]
 
         report["runtime_contract"]["frontend"] = frontend_entries
@@ -1080,9 +1054,7 @@ def main() -> int:
         report["runtime_contract"]["backend_gmail"] = backend_gmail_entries
         report["runtime_contract"]["backend_one_email"] = backend_one_email_entries
         report["runtime_contract"]["backend_voice"] = backend_voice_entries
-        report["runtime_contract"]["backend_connected_systems"] = (
-            backend_connected_systems_entries
-        )
+        report["runtime_contract"]["backend_connected_systems"] = backend_connected_systems_entries
         report["runtime_contract"]["backend_reviewer_smoke"] = backend_reviewer_smoke_entries
         report["runtime_contract"]["frontend_serving_revisions"] = frontend_revisions
         report["runtime_contract"]["backend_serving_revisions"] = backend_revisions
@@ -1090,14 +1062,9 @@ def main() -> int:
         if checks_backend and args.require_one_email:
             one_email_runtime_semantics = _one_email_runtime_semantics(backend_env)
             report["one_email_runtime_semantics"] = one_email_runtime_semantics
-            print(
-                "One email runtime semantics: "
-                f"{one_email_runtime_semantics['status']}"
-            )
+            print(f"One email runtime semantics: {one_email_runtime_semantics['status']}")
             if one_email_runtime_semantics["status"] != "valid":
-                report["classifications"].append(
-                    "one_email_runtime_semantics_failed"
-                )
+                report["classifications"].append("one_email_runtime_semantics_failed")
 
         runtime_classifications = []
         runtime_classifications.extend(_classifications_from_runtime_entries(frontend_entries))
@@ -1120,7 +1087,9 @@ def main() -> int:
         if checks_backend:
             print(_render_runtime_summary("Backend runtime env contract", backend_entries))
         if checks_backend and args.require_gmail:
-            print(_render_runtime_summary("Backend Gmail runtime env contract", backend_gmail_entries))
+            print(
+                _render_runtime_summary("Backend Gmail runtime env contract", backend_gmail_entries)
+            )
         if checks_backend and args.require_one_email:
             print(
                 _render_runtime_summary(
@@ -1129,7 +1098,9 @@ def main() -> int:
                 )
             )
         if checks_backend and args.require_voice:
-            print(_render_runtime_summary("Backend voice runtime env contract", backend_voice_entries))
+            print(
+                _render_runtime_summary("Backend voice runtime env contract", backend_voice_entries)
+            )
         if checks_backend and args.require_connected_systems:
             print(
                 _render_runtime_summary(


### PR DESCRIPTION
## What
Migrates One's canonical live voice model from `gemini-live-2.5-flash-native-audio` (Vertex, GA) to **`gemini-3.1-flash-live-preview`** — Google's newest live audio model — end to end: manifest head, compatibility matrix, transport-aware model builder, registry entry, deploy verifier, deploy config, tests, and docs.

## Empirical basis (the registry's required ADK rehearsal, run 2026-08-21)
- **Not on Vertex:** the publisher endpoint 404s for this model in us-central1 / us-east4 / europe-west4 / asia-southeast1 → it serves on the **Gemini Developer API** (matching the matrix's original `developer_api` declaration).
- **Mid-session injection works:** on the Developer API, BIDI audio setup, initial **and mid-session** `send_client_content`, and mid-session `send_realtime_input(text=...)` all elicited complete model turns. The init-history-only limitation recorded in the matrix is no longer observable on the current preview build.
- **google-adk 2.4.0 handles the transposition:** on Gemini 3.x Live names it converts the relay's single-text-part `queue.send_content` calls into `send_realtime_input(text=...)` (`gemini_llm_connection.py:129`) — every relay injection path (greeting, route note, goal nudge, settlement, app_speech, user_text, timeout) is single-text-part, so **zero relay code changes**.
- **End-to-end PASS:** a rehearsal through this branch's `_build_one_live_model` → `Runner.run_live` → `LiveRequestQueue.send_content` answered both the initial and a mid-session injection (transcribed) with audio streaming.

## Key design points
- **Managed key, not BYOK:** the model needs a Developer API key. A Hussh-owned key (`HUSHH_MANAGED_GEMINI_LIVE_API_KEY`, Secret Manager) is minted in the **Gemini billing bridge project** — same $500/mo-budgeted, Gemini-only project already carrying Vertex traffic during the dunning bridge. Audio token pricing is identical to the 2.5 model ($3/1M in, $12/1M out per the pricing export).
- **Fail-closed everywhere:** missing key → `managed_live_key_missing` at runner build; the relay closes the websocket cleanly (1013 "Voice is temporarily unavailable"); the deploy readiness probe fails loudly; the env-secrets parity gate now requires the secret for voice-complete environments.
- **Matrix relocated** to `runtime_providers/live_compatibility.py` (dependency-light) so the deploy verifier can read it without `agent_tree`'s `APP_SIGNING_KEY` import chain — an adversarial reviewer reproduced that crash empirically under the exact Cloud Run job env; the relocation fixes it (re-exported from `agent_tree` for compatibility).
- **Rollback lever:** `AGENT_ONE_ADK_MODEL=gemini-live-2.5-flash-native-audio` — the GA Vertex model's registry/matrix entries are intentionally retained.

## Verification
- 264 affected tests green locally (manifests, runtime providers, agent tree incl. new BYOK-acceptance + key-fail-closed tests, live protocol, bounds, cloudbuild arg-limit, secrets parity).
- Independent adversarial review completed; all three confirmed defects fixed in this PR (relay RuntimeError handling, parity gate, verifier import chain).

## ⚠️ Deploy prerequisites (per environment)
| Project | Secret `HUSHH_MANAGED_GEMINI_LIVE_API_KEY` | Effect if absent |
|---|---|---|
| hushh-pda-uat | ✅ provisioned | — |
| hushh-pda-dev | ✅ provisioned | — |
| **hushh-pda (prod)** | ❌ **deliberately NOT provisioned** | next prod backend deploy fails at the readiness probe (default-on) |

Prod is unprovisioned **on purpose**: provisioning it routes prod voice through the personal-card billing bridge, which is currently held pending the billing-account dunning resolution. Before the first prod deploy of this change, either provision the secret (accepting bridge billing for prod voice) or resolve the dunning and mint a corporate-billed key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)