### PR TITLE
feat(one-location): arrange the Request roster once it stops being short

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -4428,6 +4428,62 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("drops the arrangement while a query is active", async () => {
+    // A search result is ordered by how well each person matches. Headings over
+    // that would name an order the list does not have, so the sections go and
+    // the caller's ranking passes through untouched.
+    mockGetState.mockResolvedValue(locationState());
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    fireEvent.change(screen.getByPlaceholderText(/search/i), {
+      target: { value: "Tru" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("one-location-ask-section-header:recent"),
+      ).toBeNull();
+      expect(
+        screen.queryByTestId("one-location-ask-section-header:all"),
+      ).toBeNull();
+    });
+  });
+
+  it("keeps a section heading out of the list of people", async () => {
+    // The roster carries `role="list"`, and every entry in it is wrapped as a
+    // `listitem`. A heading is not one of the people, so it opts out --
+    // otherwise a screen reader reads "Recent" as an entry between two names.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      // The page derives `requestedByMe` from `requests`, filtered to the ones
+      // this viewer sent, so the fixture has to seed the field the API returns.
+      requests: [
+        {
+          id: "req_recent",
+          ownerUserId: "user_b",
+          requesterUserId: "user_a",
+          status: "pending",
+          requestedAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openAskFlow();
+
+    const heading = await screen.findByTestId(
+      "one-location-ask-section-header:recent",
+    );
+    expect(heading.tagName).toBe("H3");
+    expect(heading.parentElement).toHaveAttribute("role", "presentation");
+  });
+
   it("offers a way to Connect when the person being looked for is not on the list", async () => {
     // This roster is everyone you are already connected to, so "they are not
     // here" has exactly one answer and it lives on another screen. Without

--- a/hushh-webapp/__tests__/lib/one-location/recipient-sections.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/recipient-sections.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RECENT_SECTION_LIMIT,
+  flattenRecipientSections,
+  lastInteractionByUserId,
+  sectionRecipients,
+} from "@/lib/one-location/recipient-sections";
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+  OneLocationRecipient,
+} from "@/lib/one-location/types";
+
+function person(userId: string, displayName: string) {
+  return { userId, displayName } as OneLocationRecipient;
+}
+
+const label = (recipient: OneLocationRecipient) =>
+  recipient.displayName ?? recipient.userId;
+
+function request(
+  ownerUserId: string,
+  requestedAt: string | null,
+  resolvedAt: string | null = null,
+) {
+  return { ownerUserId, requestedAt, resolvedAt } as OneLocationAccessRequest;
+}
+
+function grant(
+  fields: Partial<OneLocationGrant> & { createdAt: string | null },
+) {
+  return fields as OneLocationGrant;
+}
+
+describe("lastInteractionByUserId", () => {
+  it("reads recency from all three things this screen already knows", () => {
+    const byUserId = lastInteractionByUserId({
+      requestedByMe: [request("asked", "2026-08-01T00:00:00Z")],
+      receivedGrants: [
+        grant({ ownerUserId: "gave-me", createdAt: "2026-08-02T00:00:00Z" }),
+      ],
+      ownerGrants: [
+        grant({ recipientUserId: "i-gave", createdAt: "2026-08-03T00:00:00Z" }),
+      ],
+    });
+
+    expect(byUserId.get("asked")).toBe(Date.parse("2026-08-01T00:00:00Z"));
+    expect(byUserId.get("gave-me")).toBe(Date.parse("2026-08-02T00:00:00Z"));
+    expect(byUserId.get("i-gave")).toBe(Date.parse("2026-08-03T00:00:00Z"));
+  });
+
+  it("keeps the NEWEST touch when one person appears more than once", () => {
+    // Somebody you asked in June and who shared with you in August is a person
+    // you dealt with in August. Taking the first one found would bury them.
+    const byUserId = lastInteractionByUserId({
+      requestedByMe: [request("u1", "2026-06-01T00:00:00Z")],
+      receivedGrants: [
+        grant({ ownerUserId: "u1", createdAt: "2026-08-01T00:00:00Z" }),
+      ],
+      ownerGrants: [],
+    });
+
+    expect(byUserId.get("u1")).toBe(Date.parse("2026-08-01T00:00:00Z"));
+  });
+
+  it("falls back to when a request was answered if it never recorded a send", () => {
+    const byUserId = lastInteractionByUserId({
+      requestedByMe: [request("u1", null, "2026-08-05T00:00:00Z")],
+      receivedGrants: [],
+      ownerGrants: [],
+    });
+
+    expect(byUserId.get("u1")).toBe(Date.parse("2026-08-05T00:00:00Z"));
+  });
+
+  it("ignores a timestamp it cannot read rather than sorting on NaN", () => {
+    const byUserId = lastInteractionByUserId({
+      requestedByMe: [request("u1", "not-a-date")],
+      receivedGrants: [],
+      ownerGrants: [],
+    });
+
+    expect(byUserId.has("u1")).toBe(false);
+  });
+});
+
+describe("sectionRecipients", () => {
+  const roster = [
+    person("u1", "Zoya Khan"),
+    person("u2", "Aarav Mehta"),
+    person("u3", "Divya Rajendran"),
+  ];
+
+  it("returns one unlabelled run while a query is active", () => {
+    // A search result is ordered by how well each person matches. An alphabet
+    // laid over that would describe an arrangement the list does not have, so
+    // the caller's order passes straight through and nothing is titled.
+    const sections = sectionRecipients({
+      recipients: roster,
+      lastInteraction: new Map([["u3", 10]]),
+      label,
+      querying: true,
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBeUndefined();
+    expect(sections[0].recipients.map((r) => r.userId)).toEqual([
+      "u1",
+      "u2",
+      "u3",
+    ]);
+  });
+
+  it("puts people you have dealt with first, newest first, and the rest A-Z", () => {
+    const sections = sectionRecipients({
+      recipients: roster,
+      lastInteraction: new Map([
+        ["u1", 100],
+        ["u3", 200],
+      ]),
+      label,
+      querying: false,
+    });
+
+    expect(sections.map((s) => s.title)).toEqual(["Recent", "All"]);
+    expect(sections[0].recipients.map((r) => r.displayName)).toEqual([
+      "Divya Rajendran",
+      "Zoya Khan",
+    ]);
+    expect(sections[1].recipients.map((r) => r.displayName)).toEqual([
+      "Aarav Mehta",
+    ]);
+  });
+
+  it("never lists the same person twice", () => {
+    // In a list you READ a duplicate is a convenience. In a list you SELECT
+    // from it is two rows that must agree about one selection, and the moment
+    // they disagree the screen is lying about what is chosen.
+    const sections = sectionRecipients({
+      recipients: roster,
+      lastInteraction: new Map([["u3", 1]]),
+      label,
+      querying: false,
+    });
+
+    const ids = sections.flatMap((s) => s.recipients.map((r) => r.userId));
+    expect(ids).toHaveLength(new Set(ids).size);
+    expect(ids).toHaveLength(roster.length);
+  });
+
+  it("caps Recent, so the alphabet never loses more than a handful", () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      person(`u${i}`, `Person ${i}`),
+    );
+    const interactions = new Map(many.map((p, i) => [p.userId, i]));
+
+    const sections = sectionRecipients({
+      recipients: many,
+      lastInteraction: interactions,
+      label,
+      querying: false,
+    });
+
+    expect(sections[0].recipients).toHaveLength(RECENT_SECTION_LIMIT);
+    expect(sections[1].recipients).toHaveLength(12 - RECENT_SECTION_LIMIT);
+  });
+
+  it("leaves a roster nobody has been dealt with unlabelled", () => {
+    // One run with nothing above it is just the roster. A lone "All" heading
+    // names a distinction that is not being drawn.
+    const sections = sectionRecipients({
+      recipients: roster,
+      lastInteraction: new Map(),
+      label,
+      querying: false,
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBeUndefined();
+    expect(sections[0].recipients.map((r) => r.displayName)).toEqual([
+      "Aarav Mehta",
+      "Divya Rajendran",
+      "Zoya Khan",
+    ]);
+  });
+
+  it("sorts an accented name where a person looks for it", () => {
+    const sections = sectionRecipients({
+      recipients: [person("u1", "Zoya"), person("u2", "Émile")],
+      lastInteraction: new Map(),
+      label,
+      querying: false,
+    });
+
+    expect(sections[0].recipients.map((r) => r.displayName)).toEqual([
+      "Émile",
+      "Zoya",
+    ]);
+  });
+
+  it("returns nothing for an empty roster", () => {
+    expect(
+      sectionRecipients({
+        recipients: [],
+        lastInteraction: new Map(),
+        label,
+        querying: false,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("flattenRecipientSections", () => {
+  it("interleaves headers and people into one windowable list", () => {
+    // One flat array, so the virtualizer measures headers and rows through the
+    // same window instead of a scroller per section.
+    const rows = flattenRecipientSections([
+      { key: "recent", title: "Recent", recipients: [person("u1", "A")] },
+      { key: "all", title: "All", recipients: [person("u2", "B")] },
+    ]);
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "header",
+      "recipient",
+      "header",
+      "recipient",
+    ]);
+    expect(rows.map((row) => row.key)).toEqual([
+      "header:recent",
+      "u1",
+      "header:all",
+      "u2",
+    ]);
+  });
+
+  it("emits no header for an untitled run", () => {
+    const rows = flattenRecipientSections([
+      { key: "results", recipients: [person("u1", "A")] },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("recipient");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/virtual-list.tsx
@@ -36,6 +36,7 @@ export function VirtualContactList<T>({
   presentation = "grouped",
   scrollClassName,
   itemClassName,
+  getItemRole,
 }: {
   items: readonly T[];
   getKey: (item: T) => string;
@@ -61,6 +62,19 @@ export function VirtualContactList<T>({
   scrollClassName?: string;
   /** Per-row wrapper classes in `cards` presentation. */
   itemClassName?: string;
+  /**
+   * Overrides one row's ARIA role.
+   *
+   * A list that carries section headers has rows that are NOT list items. The
+   * default wraps every entry as `listitem` under the list's own role, which
+   * would announce "Recent" as one of the people. Returning `"presentation"`
+   * for a header takes it back out of the list without taking it off screen,
+   * so a screen reader hears the heading and then the people under it.
+   *
+   * Omitted by every caller that has no headers, which keeps their markup
+   * byte-identical.
+   */
+  getItemRole?: (item: T) => string | undefined;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const virtualize = shouldVirtualizeList(items.length);
@@ -92,7 +106,7 @@ export function VirtualContactList<T>({
           {items.map((item) => (
             <div
               key={getKey(item)}
-              role={ariaLabel ? "listitem" : undefined}
+              role={getItemRole?.(item) ?? (ariaLabel ? "listitem" : undefined)}
               className={asCards ? itemClassName : undefined}
             >
               {renderItem(item)}
@@ -132,7 +146,9 @@ export function VirtualContactList<T>({
                 // out of register with its own scrollbar over 100 rows.
                 ref={virtualizer.measureElement}
                 data-index={virtualItem.index}
-                role={ariaLabel ? "listitem" : undefined}
+                role={
+                  getItemRole?.(item) ?? (ariaLabel ? "listitem" : undefined)
+                }
                 className={cn(
                   "absolute left-0 top-0 w-full",
                   asCards

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -138,6 +138,11 @@ import {
   SelectedContactsPill,
   SelectedContactsSheet,
 } from "@/components/one-location/redesign/contact-picker/selected-review-sheet";
+import {
+  flattenRecipientSections,
+  lastInteractionByUserId,
+  sectionRecipients,
+} from "@/lib/one-location/recipient-sections";
 import { ROUTES } from "@/lib/navigation/routes";
 import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
@@ -3630,6 +3635,39 @@ function AskFlow({
    * without moving the answer, and the other lane is now reachable rather than
    * silently dropped.
    */
+  /**
+   * The roster, arranged.
+   *
+   * Recency comes from what this screen already holds -- a request you sent, a
+   * share they gave you, a share you gave them -- so no new storage and no
+   * invented "frequently contacted", which nothing in this product counts.
+   *
+   * While a query is active the arrangement is dropped: a search result is
+   * ordered by how well each person matches, and headings over that would name
+   * an order the list does not have.
+   */
+  const lastInteraction = useMemo(
+    () =>
+      lastInteractionByUserId({
+        requestedByMe: vm.requestedByMe,
+        receivedGrants: vm.receivedGrants,
+        ownerGrants: vm.activeOwnerGrants,
+      }),
+    [vm.requestedByMe, vm.receivedGrants, vm.activeOwnerGrants],
+  );
+  const rosterRows = useMemo(
+    () =>
+      flattenRecipientSections(
+        sectionRecipients({
+          recipients: filtered,
+          lastInteraction,
+          label: vm.recipientLabel,
+          querying: vm.recipientSearch.trim().length > 0,
+        }),
+      ),
+    [filtered, lastInteraction, vm.recipientLabel, vm.recipientSearch],
+  );
+
   const receivedGroupsByOwner = useMemo(() => {
     const byOwner = new globalThis.Map<string, OneLocationGrantLaneGroup>();
     // `"recipient"` -- the side argument names WHICH SIDE I AM, so for grants
@@ -3731,14 +3769,36 @@ function AskFlow({
              grouped shell would put a card inside a card and draw a divider
              between two things that have their own edges. */
           <VirtualContactList
-            items={filtered}
-            getKey={(r) => r.userId}
+            items={rosterRows}
+            getKey={(row) => row.key}
             scrollClassName={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}
             itemClassName="pb-2.5 last:pb-0"
             presentation="cards"
             testId="one-location-ask-recipients"
             ariaLabel="People you can ask"
-            renderItem={(r) => {
+            // A section heading is not one of the people. Taking it out of the
+            // list stops a screen reader announcing "Recent" as an entry.
+            getItemRole={(row) =>
+              row.kind === "header" ? "presentation" : undefined
+            }
+            renderItem={(row) => {
+              // Headers ride the SAME windowed list as the rows, rather than a
+              // scroller per section: two capped scrollers stacked inside one
+              // screen is the shape this flow already rejected once.
+              if (row.kind === "header") {
+                return (
+                  // The screen's own section type, not a second one invented
+                  // here: "People" a few lines up is the same primitive.
+                  <AppSectionLabel
+                    as="h3"
+                    data-testid={`one-location-ask-section-${row.key}`}
+                    className="px-1 pt-1"
+                  >
+                    {row.title}
+                  </AppSectionLabel>
+                );
+              }
+              const r = row.recipient;
               const selected = vm.selectedRequestOwnerIds.includes(r.userId);
               // Every row used to read "Ready for private sharing" with Select
               // as the only affordance, whoever the person was and whatever had

--- a/hushh-webapp/lib/one-location/recipient-sections.ts
+++ b/hushh-webapp/lib/one-location/recipient-sections.ts
@@ -1,0 +1,195 @@
+import type {
+  OneLocationAccessRequest,
+  OneLocationGrant,
+  OneLocationRecipient,
+} from "@/lib/one-location/types";
+
+/**
+ * How a roster of people is arranged once it stops being short.
+ *
+ * Kept out of the component for the same reason `contact-picker-controls`
+ * is: the rules below are decisions, and a decision that lives inside JSX
+ * cannot be reasoned about or tested on its own.
+ *
+ * Two of these rules were product questions rather than engineering ones, and
+ * the answers are recorded here so the next reader does not have to re-derive
+ * them from the code.
+ */
+
+/** One labelled run of people. A section with no title is the whole roster,
+ *  unarranged -- what a search result is. */
+export type RecipientSection = {
+  key: string;
+  /** Absent while a query is active: see `sectionRecipients`. */
+  title?: string;
+  recipients: OneLocationRecipient[];
+};
+
+/**
+ * How many people "Recent" is allowed to hold.
+ *
+ * Five, because Recent is a shortcut and not a second roster. It also has to
+ * stay small for the reason below: a person in Recent is NOT repeated in All,
+ * so every name Recent takes is a name the alphabet loses.
+ */
+export const RECENT_SECTION_LIMIT = 5;
+
+/** Milliseconds, or null when the timestamp is missing or unparseable. */
+function timestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function newer(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}
+
+/**
+ * When you last had anything to do with each person, by user id.
+ *
+ * "Frequently contacted" was the other half of the original request and is
+ * deliberately NOT built: nothing in this product counts interactions, so a
+ * frequency section could only be invented, and a list that claims to know how
+ * often you talk to someone while guessing is worse than one that does not
+ * claim it. Recency IS knowable from what the screen already holds --
+ *
+ *   * a request you sent them (`requestedAt`, falling back to `resolvedAt`),
+ *   * a share they gave you (`createdAt` on a received grant),
+ *   * a share you gave them (`createdAt` on an owned grant).
+ *
+ * -- so that is what the section is called and what it means.
+ */
+export function lastInteractionByUserId(input: {
+  requestedByMe: readonly OneLocationAccessRequest[];
+  receivedGrants: readonly OneLocationGrant[];
+  ownerGrants: readonly OneLocationGrant[];
+}): Map<string, number> {
+  const byUserId = new Map<string, number>();
+
+  const record = (userId: string | undefined | null, at: number | null) => {
+    if (!userId || at === null) return;
+    byUserId.set(userId, newer(byUserId.get(userId) ?? null, at) as number);
+  };
+
+  for (const request of input.requestedByMe) {
+    record(
+      request.ownerUserId,
+      newer(timestamp(request.requestedAt), timestamp(request.resolvedAt)),
+    );
+  }
+  for (const grant of input.receivedGrants) {
+    record(grant.ownerUserId, timestamp(grant.createdAt));
+  }
+  for (const grant of input.ownerGrants) {
+    record(grant.recipientUserId, timestamp(grant.createdAt));
+  }
+
+  return byUserId;
+}
+
+/**
+ * Arrange a roster into the sections a long list needs.
+ *
+ * **While a query is active there are no sections.** A search returns one run
+ * of people ordered by how well they match, and an alphabet laid over that
+ * would be describing an arrangement the list does not have -- the caller's
+ * order is passed straight through. This is the resolution of "does A-Z
+ * survive relevance ranking": it does not, and the honest answer is to stop
+ * claiming an arrangement rather than to rank twice.
+ *
+ * With no query: **Recent** (people you have actually dealt with, newest
+ * first, capped) then **All** (everyone else, A-Z).
+ *
+ * Recent EXCLUDES its people from All rather than repeating them. In a list
+ * you read, a duplicate is a convenience; in a list you SELECT from, the same
+ * person appearing twice means two rows that must agree about one selection,
+ * and the moment they disagree the screen is lying. The cap keeps the cost of
+ * that choice small: at most five names are missing from the alphabet, and the
+ * search field finds them instantly either way.
+ */
+export function sectionRecipients(input: {
+  recipients: readonly OneLocationRecipient[];
+  lastInteraction: Map<string, number>;
+  /** Sorts and labels people the same way the screen does. */
+  label: (recipient: OneLocationRecipient) => string;
+  /** True when the caller's order is a relevance ranking, not an arrangement. */
+  querying: boolean;
+  recentLimit?: number;
+}): RecipientSection[] {
+  const { recipients, lastInteraction, label, querying } = input;
+  const recentLimit = input.recentLimit ?? RECENT_SECTION_LIMIT;
+
+  if (!recipients.length) return [];
+
+  if (querying) {
+    return [{ key: "results", recipients: [...recipients] }];
+  }
+
+  const recent = recipients
+    .filter((recipient) => lastInteraction.has(recipient.userId))
+    .sort(
+      (left, right) =>
+        (lastInteraction.get(right.userId) ?? 0) -
+        (lastInteraction.get(left.userId) ?? 0),
+    )
+    .slice(0, recentLimit);
+
+  const recentIds = new Set(recent.map((recipient) => recipient.userId));
+  const rest = recipients
+    .filter((recipient) => !recentIds.has(recipient.userId))
+    // `localeCompare` rather than `<`: an accented name sorts next to its
+    // unaccented spelling here, which is where a person looks for it.
+    .sort((left, right) =>
+      label(left).localeCompare(label(right), undefined, {
+        sensitivity: "base",
+      }),
+    );
+
+  const sections: RecipientSection[] = [];
+  if (recent.length) {
+    sections.push({ key: "recent", title: "Recent", recipients: recent });
+  }
+  if (rest.length) {
+    sections.push({
+      key: "all",
+      // Only worth naming once there is something above it to tell it apart
+      // from. A single unlabelled run is just the roster.
+      title: recent.length ? "All" : undefined,
+      recipients: rest,
+    });
+  }
+  return sections;
+}
+
+/** A section header or one person, in the order they are rendered. Flattened
+ *  so the virtualizer windows headers and rows through one list rather than
+ *  nesting a scroller per section. */
+export type RecipientRow =
+  | { kind: "header"; key: string; title: string }
+  | { kind: "recipient"; key: string; recipient: OneLocationRecipient };
+
+export function flattenRecipientSections(
+  sections: readonly RecipientSection[],
+): RecipientRow[] {
+  const rows: RecipientRow[] = [];
+  for (const section of sections) {
+    if (section.title) {
+      rows.push({
+        kind: "header",
+        key: `header:${section.key}`,
+        title: section.title,
+      });
+    }
+    for (const recipient of section.recipients) {
+      rows.push({
+        kind: "recipient",
+        key: recipient.userId,
+        recipient,
+      });
+    }
+  }
+  return rows;
+}


### PR DESCRIPTION
Part of **#5609**. **Not for merge until tested.**

Four product questions had to be answered before any of this could be written. The answers live in `lib/one-location/recipient-sections.ts` — as tested rules, not as implicit behaviour inside JSX.

## The four answers

**1. "Recent", not "frequently contacted."** Nothing in this product counts interactions, so a frequency section could only be *invented* — and a list that claims to know how often you talk to someone while guessing is worse than one that never claims it.

Recency **is** knowable from what the screen already holds: a request you sent, a share they gave you, a share you gave them. The newest of the three wins, so somebody asked in June who shared with you in August is an August person. No new storage.

**2. A query drops the arrangement.** A search result is ordered by how well each person matches; headings laid over that would name an order the list does not have. So while a query is active there are **no sections** and the ranking passes through untouched.

That is the answer to *"does A–Z survive relevance ranking"* — it does not, and the honest move is to stop claiming an arrangement rather than to rank twice.

**3. Recent excludes its people from All.** In a list you *read*, a duplicate is a convenience. In a list you **select** from, it is two rows that must agree about one selection — and the moment they disagree the screen is lying about what is chosen. The cap of five keeps the cost small: at most five names are out of the alphabet, and the search field finds them instantly either way.

**4. Headers ride the same window as the rows.** Flattened into one array the virtualizer measures through a single window, rather than a scroller per section — two capped scrollers stacked inside one screen is the shape this flow already rejected once.

## Two parts deliberately NOT here — #5609 stays open

**No A–Z jump rail.** A rail belongs beside a full-height roster. This one is a 340px box inside a scrolling form, and a rail next to it would compete with the rows for width on the phones this ships to. Sections plus the search field answer "find one person" without it.

**Nothing on Connect.** Its search does not sit above the list people assume it filters — it searches the *directory* and already sits directly above the directory results, **below** "My connections". And its list is server-paged, where an index that cannot jump across pages would be a lie. That surface needs paging resolved first.

## Verification

```
tsc          no new errors
eslint       clean
vitest  recipient-sections rules            13 passed  (new)
vitest  lib suites                         142 passed
vitest  agent page                         104 passed
             (incl. a new one pinning that a query drops the sections)
verify:design-system                             passed
```

Base is `main`, 0 behind at push.