### PR TITLE
Polish location share request flows

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -1085,6 +1085,31 @@ describe("Connect — the phone-width geometry QA reported", () => {
     expect(classes.has("justify-end")).toBe(true);
   });
 
+  it("keeps My connections scrollable when the list grows", async () => {
+    // Three connections fit naturally. A hundred should not turn the top of
+    // Connect into a full-page receipt before the search field appears.
+    mocks.listConnections.mockResolvedValue(
+      Array.from({ length: 12 }, (_, index) => ({
+        connectionId: `c-${index}`,
+        userId: `u-${index}`,
+        displayName: `Trusted Person ${index + 1}`,
+        maskedEmail: `t***${index}@example.com`,
+      })),
+    );
+
+    const { container } = render(<ConnectPageClient />);
+    expect(await screen.findByText("My connections (12)")).toBeTruthy();
+
+    const list = container.querySelector(
+      '[data-testid="connect-my-connections-group"] [data-inset-separators="true"]',
+    );
+    expect(list).toBeTruthy();
+    expect(list!.className).toContain("max-h-[232px]");
+    expect(list!.className).toContain("overflow-y-auto");
+    expect(list!.className).toContain("overscroll-contain");
+    expect(list!.className).toContain("sm:max-h-[320px]");
+  });
+
   it("asks for the search field in two words", async () => {
     render(<ConnectPageClient />);
     expect(await screen.findByPlaceholderText("Search people")).toBeTruthy();

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -12,7 +12,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/services/api-client";
 // The rungs themselves, not a copy of their labels: Ask and Share must offer
 // the same ladder, so the test reads the same list the component does.
-import { SHARE_DURATION_LADDER } from "@/components/one-location/redesign/duration-presets";
 import { ROUTES } from "@/lib/navigation/routes";
 
 const {
@@ -1946,7 +1945,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeTruthy();
     // Move the duration off its default so the reset below has something to
     // actually reset.
-    fireEvent.click(screen.getByRole("button", { name: "4 hours" }));
+    fireEvent.click(screen.getByRole("button", { name: "1 hour" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Optional note" }), {
       target: { value: "Meet me by the entrance" },
     });
@@ -2029,13 +2028,13 @@ describe("OneLocationAgentPage", () => {
       screen.queryByRole("radio", { name: /Approximate area/i }),
     ).toBeNull();
     // Back to the 15-minute default, and back to the collapsed ladder — a
-    // reopened flow that kept "4 hours" pressed would be offering a length
+    // reopened flow that kept "1 hour" pressed would be offering a length
     // this share never chose.
     expect(screen.getByRole("button", { name: "15 min" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.getByRole("button", { name: "4 hours" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "1 hour" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -4018,18 +4017,20 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openAskFlow();
 
-    // Every rung the Share ladder offers, in the same order.
-    for (const rung of SHARE_DURATION_LADDER) {
+    // Request uses the same compact ladder pattern as Share, but it cannot ask
+    // for open-ended access to someone else's location.
+    for (const label of ["15 min", "1 hour", "Custom"]) {
       expect(
-        screen.getByRole("button", { name: rung.label }),
-        `Ask is missing the "${rung.label}" rung`,
+        screen.getByRole("button", { name: label }),
+        `Ask is missing the "${label}" rung`,
       ).toBeTruthy();
     }
+    expect(screen.queryByRole("button", { name: "Until I stop" })).toBeNull();
     // And no wheel: the spinbuttons only exist inside the wheel, and mounting
     // one here is what the report was about.
     expect(screen.queryByRole("spinbutton", { name: "Hours" })).toBeNull();
     expect(screen.queryByRole("spinbutton", { name: "Minutes" })).toBeNull();
-  });
+  }, 10_000);
 
   it("sends an approval-first location request without sharing coordinates", async () => {
     mockGetState.mockResolvedValue({
@@ -4048,14 +4049,10 @@ describe("OneLocationAgentPage", () => {
         name: /Select Trusted B for location request/i,
       }),
     );
-    fireEvent.change(
-      screen.getByPlaceholderText(
-        "Hey, can you share your location until we meet?",
-      ),
-      {
-        target: { value: "Need pickup coordination" },
-      },
-    );
+    expect(
+      screen.queryByPlaceholderText("Hey, can you share your location until we meet?"),
+    ).toBeNull();
+    expect(screen.queryByPlaceholderText("What should they know?")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
 
     await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
@@ -4065,7 +4062,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockRequestAccess).toHaveBeenCalledWith({
       vaultOwnerToken: "vault-token",
       ownerUserId: "user_b",
-      message: "Safety check-in — Need pickup coordination",
+      message: "Safety check-in",
       requestedDurationHours: 1,
       requestedDurationMode: "timed",
     });
@@ -4079,7 +4076,7 @@ describe("OneLocationAgentPage", () => {
         selected_count: 1,
         success_count: 1,
         failure_count: 0,
-        has_note: true,
+        has_note: false,
       }),
     );
     await waitFor(() =>

--- a/hushh-webapp/__tests__/lib/feed/feed-location-request-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-location-request-lines.test.ts
@@ -127,6 +127,19 @@ describe("the requester's side of the same exchange", () => {
     );
   });
 
+  it("makes owner-side share rows clear", () => {
+    const presented = presentFeedItem(
+      item({
+        event_type: "location_share_created",
+        metadata: {
+          counterpart_label: "Abdul Rashid",
+        },
+      }),
+    );
+    expect(presented.label).toBe("Abdul Rashid");
+    expect(presented.description).toBe("You started sharing location");
+  });
+
   it("says a refused extension leaves current access alone", () => {
     const presented = presentFeedItem(
       item({

--- a/hushh-webapp/__tests__/lib/one-location/request-message.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/request-message.test.ts
@@ -33,4 +33,11 @@ describe("buildOneLocationRequestMessage", () => {
     );
     expect(buildOneLocationRequestMessage(null, "   ")).toBeUndefined();
   });
+
+  it("uses the typed text directly when Other is selected", () => {
+    expect(buildOneLocationRequestMessage("Other", "Running late")).toBe(
+      "Running late",
+    );
+    expect(buildOneLocationRequestMessage("Other", "")).toBe("Other");
+  });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1449,6 +1449,12 @@ export default function ConnectPageClient() {
                   : `My connections (${sortedConnections.length})`
               }
               separatorInset
+              contentClassName={
+                sortedConnections.length > 0
+                  ? "max-h-[232px] overflow-y-auto overscroll-contain sm:max-h-[320px]"
+                  : undefined
+              }
+              testId="connect-my-connections-group"
             >
               {sortedConnections.length === 0 ? (
                 <SettingsRow

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -387,6 +387,9 @@ const SHARE_VOICE_DURATION_VALUES = new Set<string>([
   ...SHARE_DURATION_LADDER.map((rung) => rung.value),
   SHARE_DURATION_UNTIL_STOP_VALUE,
   "0.5",
+  "2",
+  "4",
+  "8",
   "24",
 ]);
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/duration-presets.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/duration-presets.test.tsx
@@ -35,14 +35,15 @@ describe("DurationPresetPicker", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("sets exactly two hours in one tap", () => {
+  it("opens custom when the user wants anything beyond the core presets", () => {
     const onChange = vi.fn();
     render(<DurationPresetPicker value="0.25" onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "2 hours" }));
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
 
-    expect(onChange).toHaveBeenCalledWith("2");
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("spinbutton", { name: "Hours" })).toBeTruthy();
+    expect(screen.getByRole("spinbutton", { name: "Minutes" })).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("emits the caller's open-ended sentinel, not the wheel's own alias", () => {
@@ -136,7 +137,7 @@ describe("DurationPresetPicker", () => {
     }
   });
 
-  it("keeps the whole ladder on one screen: six cells plus the open-ended row", () => {
+  it("keeps the whole ladder focused: two presets, custom, and the open-ended row", () => {
     render(<DurationPresetPicker value="1" onChange={vi.fn()} />);
 
     expect(
@@ -144,9 +145,6 @@ describe("DurationPresetPicker", () => {
     ).toEqual([
       "15 min",
       "1 hour",
-      "2 hours",
-      "4 hours",
-      "8 hours",
       "Custom",
       "Until I stop",
     ]);

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -18,7 +18,10 @@ export type DurationRung = { value: string; label: string };
  * somebody asks for it.
  *
  * Rungs run from the 15-minute product floor (also the backend's floor —
- * `MIN_DURATION_HOURS = 0.25`) to a working day, roughly doubling each step.
+ * `MIN_DURATION_HOURS = 0.25`) to a compact upper choice. Anything between
+ * or beyond these common picks belongs behind `Custom`, where it is still one
+ * deliberate tap away without making the default state read like a settings
+ * panel.
  *
  * "Today" is deliberately absent. Its length is unreadable from its label —
  * 15 hours at 9am, 4 hours at 8pm — and it cannot survive the wheel at all:
@@ -28,9 +31,6 @@ export type DurationRung = { value: string; label: string };
 export const SHARE_DURATION_LADDER: DurationRung[] = [
   { value: "0.25", label: "15 min" },
   { value: "1", label: "1 hour" },
-  { value: "2", label: "2 hours" },
-  { value: "4", label: "4 hours" },
-  { value: "8", label: "8 hours" },
 ];
 
 export const SHARE_DURATION_UNTIL_STOP_VALUE = "until_stopped";
@@ -55,18 +55,18 @@ export const DURATION_CUSTOM_VISIBLE_ROWS = 3;
  * raw <button>, not the morphy Button — that component's `size.default`
  * carries `min-h-[50px]` (a different tailwind-merge group from `h-*`, so it
  * survives every override) and `.ui-text-button-label`, which sets
- * `font-size: 17px !important`. At 17px "8 hours" does not fit an 80px cell
- * at 320px, and the grid reflows on exactly the phones that matter.
+ * `font-size: 17px !important`. At 17px "Until I stop" does not fit a compact
+ * iPhone cell, and the grid reflows on exactly the phones that matter.
  *
  * From `sm` up the same cells stop being a grid and become a wrapping row of
- * content-width chips. A 3-column grid stretches: inside the 880px Location
- * shell each cell reached 258px, and inside the wider Share card 440px — six
- * slabs and a seventh full-width bar, 148px of screen to choose a number. As
+ * content-width chips. A fixed grid stretches: inside the 880px Location
+ * shell each cell reached 258px, and inside the wider Share card 440px —
+ * slabs instead of choices. As
  * chips the whole ladder is one 44px row. Phones keep the grid, because ragged
- * wrapping at 320px is worse than a tidy 3-column block and that layout is
+ * wrapping at 320px is worse than a tidy two-column block and that layout is
  * already measured by e2e/one-location-duration-ladder.layout.spec.ts.
  */
-export const DURATION_GRID_CLASS = "grid grid-cols-3 gap-2 sm:flex sm:flex-wrap";
+export const DURATION_GRID_CLASS = "grid grid-cols-2 gap-2 sm:flex sm:flex-wrap";
 export const DURATION_CELL_CLASS =
   "flex min-h-11 items-center justify-center whitespace-nowrap rounded-[14px] border px-2 text-center text-[15px] font-semibold leading-5 transition-colors touch-manipulation sm:px-4";
 export const DURATION_CELL_OFF_CLASS =
@@ -180,15 +180,11 @@ export function DurationPresetPicker({
 
         {/* The open-ended rung. Same height, border and radius as every cell
             beside it: it is the longest duration on the ladder, not a switch
-            that greys out the control it sits under — which is where it was,
-            and why its position read as wrong.
+            that greys out the control it sits under.
 
-            It sits INSIDE the ladder, not under it. On a phone `col-span-3`
-            gives it the full third row, which is the one place its label does
-            not fit an 80px cell at 320px. From `sm` up the ladder is a
-            wrapping chip row, where a column span means nothing and it is
-            simply the last chip — so the whole control is one row instead of
-            two rows plus a bar. */}
+            It sits INSIDE the ladder, not under it, and shares the same
+            two-by-two mobile grid as the timed choices. From `sm` up the
+            ladder is a wrapping chip row, where it is simply the last chip. */}
         {allowUntilStop ? (
           <button
             type="button"
@@ -196,7 +192,6 @@ export function DurationPresetPicker({
             onClick={() => pickRung(untilStopValue)}
             className={cn(
               DURATION_CELL_CLASS,
-              "col-span-3",
               isUntilStop ? DURATION_CELL_ON_CLASS : DURATION_CELL_OFF_CLASS,
             )}
           >

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -43,6 +43,7 @@ import {
   UserPlus,
   UsersRound,
   ChevronRight,
+  X,
 } from "lucide-react";
 
 import {
@@ -135,10 +136,6 @@ import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography"
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
 import {
-  SelectedContactsPill,
-  SelectedContactsSheet,
-} from "@/components/one-location/redesign/contact-picker/selected-review-sheet";
-import {
   flattenRecipientSections,
   lastInteractionByUserId,
   sectionRecipients,
@@ -168,6 +165,7 @@ import { useMediaQuery } from "@/lib/morphy-ux/use-media-query";
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
 export const ONE_LOCATION_SHARE_DEFAULT_DURATION_HOURS = "0.25";
+const ONE_LOCATION_REQUEST_REASON_MAX_LENGTH = 80;
 
 export type PrivateCheckInResult = {
   succeededRecipientIds: string[];
@@ -3066,10 +3064,6 @@ function ShareFlow({
     // Only claim the Circle while it is still whole. A partially deselected
     // roster is a hand-picked list of people, and this is the last surface that
     // may overstate who is included.
-    const selectedCircle = shareCircleFullySelected
-      ? vm.selectedShareCircleSelection
-      : null;
-    const peopleNoun = selectedReady.length === 1 ? "person" : "people";
     return (
       // A single-column consent form does not get wider just because the window
       // does. Measured at 1440 this step rendered an 824px card holding a 420px
@@ -3089,70 +3083,6 @@ function ShareFlow({
           eyebrow="Step 2 of 2 · Confirm"
           title="Ready to share?"
         />
-
-        <section className="space-y-3">
-          {/* Label and its Edit action on one line, group beneath. The card
-              this replaced carried the action inside its own header; a group
-              owns its title, so the affordance sits beside the label it edits
-              rather than inside the surface it edits. */}
-          <div className="flex items-end justify-between gap-3 px-1">
-            <div className="min-w-0">
-              <AppSectionLabel as="h2">Can see you</AppSectionLabel>
-              <p className={MUTED_TEXT}>
-                {selectedCircle
-                  ? `${selectedCircle.circle.name} · ${selectedReady.length} ${peopleNoun}`
-                  : `${selectedReady.length} ${peopleNoun}`}
-              </p>
-            </div>
-            {/* Raw <button>, not the morphy Button: that component's
-                `size.default` carries `min-h-[50px]`, which lives in a
-                different tailwind-merge group from `h-*` and therefore
-                survives `h-9`. The control rendered 36px tall against a
-                50px min-height — under Apple's 44pt tap target on one axis
-                and over the row's own height on the other. */}
-            <button
-              type="button"
-              onClick={backToPeople}
-              aria-label="Change who can see you"
-              className="flex min-h-11 shrink-0 items-center rounded-full px-3 text-sm font-semibold text-[color:var(--app-accent)]"
-            >
-              Edit
-            </button>
-          </div>
-          {selectedReady.length ? (
-            /* A real <ul>, not a stack of divs: this is the read-back of who is
-               about to see you, and "list, 3 items" is exactly what a screen
-               reader should say here. Painted with the same surface, radius and
-               inset hairlines SettingsGroup uses, so it is the group shape with
-               the list semantics kept. */
-            <ul
-              aria-label="People who can see your location"
-              className="divide-y divide-border/60 overflow-hidden rounded-[var(--app-card-radius-standard,24px)] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)]"
-            >
-              {selectedReady.map((recipient) => (
-                <li
-                  key={recipient.userId}
-                  className="flex min-h-[56px] items-center gap-3 px-[var(--settings-row-px)] py-[var(--settings-row-py)]"
-                >
-                  <Avatar
-                    initials={initialsFrom(vm.recipientLabel(recipient))}
-                  />
-                  <RowLabel
-                    as="span"
-                    className="min-w-0 flex-1 break-words [overflow-wrap:anywhere]"
-                  >
-                    {vm.recipientLabel(recipient)}
-                  </RowLabel>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState
-              title="Nobody chosen yet"
-              description="Tap Edit to choose people."
-            />
-          )}
-        </section>
 
         <SectionCard>
           <div className="space-y-5">
@@ -3222,14 +3152,23 @@ function ShareFlow({
           </div>
         </SectionCard>
 
-        {/* No "Location type" row. It read back whichever option was picked,
-            which made the consent step the most convincing part of a promise
-            nothing kept — see the note above ShareFlow. */}
-        <TrustNoteCard
-          description={
-            vm.shareDurationHours === "until_stopped"
-              ? "Encrypted. Stop anytime."
-              : "Encrypted. Ends automatically."
+        <SelectedRecipientsRail
+          title="Can see you"
+          ariaLabel="People who can see your location"
+          recipients={selectedReady}
+          onRemove={(recipientUserId) =>
+            vm.toggleShareRecipient(recipientUserId, "share_flow")
+          }
+          recipientLabel={vm.recipientLabel}
+          trailing={
+            <button
+              type="button"
+              onClick={backToPeople}
+              aria-label="Change who can see you"
+              className="flex min-h-11 shrink-0 items-center rounded-full px-3 text-sm font-semibold text-[color:var(--app-accent)]"
+            >
+              Edit
+            </button>
           }
         />
 
@@ -3303,21 +3242,6 @@ function ShareFlow({
               />
             );
           })}
-          {vm.selectedShareCircleSelection && shareCircleFullySelected ? (
-            <p className={cn(MUTED_TEXT, "mt-3")}>
-              Current ready members only; future members are never added
-              automatically.
-              {vm.selectedShareCircleSelection.excluded.filter(
-                (item) => item.reason !== "self",
-              ).length
-                ? ` ${
-                    vm.selectedShareCircleSelection.excluded.filter(
-                      (item) => item.reason !== "self",
-                    ).length
-                  } member(s) need Location setup and are not included.`
-                : ""}
-            </p>
-          ) : null}
         </SettingsGroup>
       ) : null}
       <PersonSearchInput
@@ -3571,10 +3495,6 @@ function AskFlow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch]);
 
-  // Selection is only ever readable by scrolling the roster and counting the
-  // rows wearing "Selected". The pill answers "who is on this list" without
-  // the scroll, and the sheet is where that answer gets edited.
-  const [selectionSheetOpen, setSelectionSheetOpen] = useState(false);
   const selectedRecipients = useMemo(
     () =>
       vm.recipients.filter((recipient) =>
@@ -3753,12 +3673,6 @@ function AskFlow({
       <section className="space-y-3">
         <AppSectionLabel as="h2">People</AppSectionLabel>
         <PersonSearchInput value={searchDraft} onChange={setSearchDraft} />
-        {vm.selectedRequestOwnerIds.length ? (
-          <SelectedContactsPill
-            count={vm.selectedRequestOwnerIds.length}
-            onOpen={() => setSelectionSheetOpen(true)}
-          />
-        ) : null}
         {filtered.length ? (
           /* Windowed above the picker's own threshold, plain DOM below it.
              The rule is `shouldVirtualizeList`, imported rather than
@@ -3941,29 +3855,16 @@ function AskFlow({
           Don&apos;t see someone? Manage connections
           <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
         </a>
+        <SelectedRecipientsRail
+          title="Selected"
+          recipients={selectedRecipients}
+          onRemove={(recipientUserId) =>
+            vm.toggleRequestOwner(recipientUserId, "ask_flow")
+          }
+          recipientLabel={vm.recipientLabel}
+        />
       </section>
 
-      <SelectedContactsSheet
-        open={selectionSheetOpen}
-        onOpenChange={setSelectionSheetOpen}
-        recipients={selectedRecipients}
-        busyUserId={null}
-        onRemove={(recipientUserId) =>
-          vm.toggleRequestOwner(recipientUserId, "ask_flow")
-        }
-        recipientLabel={vm.recipientLabel}
-      />
-
-      {/* Ask and Share are the same decision pointed in opposite directions,
-          so they are now the same card: one surface, "How long" over the
-          ladder, then the next field. Ask used to put its duration in a
-          SettingsRow trailing slot as a two-column scroll wheel — a control
-          that needs 260px pinned to the right edge of a row, overlapping the
-          row it sat in and looking nothing like the screen people reach it
-          from.
-
-          Message keeps its own labelled block below: a two-row textarea is not
-          a row control. */}
       <SectionCard>
         <div className="space-y-5">
           <DurationSelector
@@ -3984,26 +3885,41 @@ function AskFlow({
           />
           <ReasonChips
             value={reason}
-            onChange={setReason}
+            onChange={(next) => {
+              setReason(next);
+              if (next !== "Other") vm.setRequestMessage("");
+            }}
             label="Reason"
             presentation="select"
           />
+          {reason === "Other" ? (
+            <div className="space-y-2.5">
+              <label
+                htmlFor="one-location-ask-other-reason"
+                className="text-sm font-semibold text-foreground"
+              >
+                Add reason
+              </label>
+              <textarea
+                id="one-location-ask-other-reason"
+                value={vm.requestMessage}
+                onChange={(e) =>
+                  vm.setRequestMessage(
+                    e.target.value.slice(
+                      0,
+                      ONE_LOCATION_REQUEST_REASON_MAX_LENGTH,
+                    ),
+                  )
+                }
+                rows={2}
+                maxLength={ONE_LOCATION_REQUEST_REASON_MAX_LENGTH}
+                placeholder="What should they know?"
+                className="block w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-compact)] px-3 pb-8 pt-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+              />
+            </div>
+          ) : null}
         </div>
       </SectionCard>
-
-      <section className="space-y-3">
-        <AppSectionLabel as="h2">Message</AppSectionLabel>
-        <textarea
-          value={vm.requestMessage}
-          onChange={(e) => vm.setRequestMessage(e.target.value)}
-          rows={2}
-          placeholder="Hey, can you share your location until we meet?"
-          /* bg-background is the light canvas colour, so on this screen the
-             field disappeared into the page exactly as the search input did.
-             Same surface as the group above it, in both themes. */
-          className="w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
-        />
-      </section>
 
       {/* Send is enabled once at least one recipient is chosen. Duration and
           reason default to sensible values, so gating Send on them too (added
@@ -4038,7 +3954,7 @@ function AskFlow({
            */
           <div
             data-testid="one-location-ask-send-bar"
-            className="sticky z-10 -mx-1 mt-1 space-y-2 rounded-2xl bg-[color:var(--app-primary-surface)]/95 px-1 py-2 backdrop-blur supports-[backdrop-filter]:bg-[color:var(--app-primary-surface)]/80"
+            className="sticky z-10 -mx-1 mt-1 space-y-2 rounded-2xl bg-[color:var(--app-card-surface-default-solid)] px-1 py-2"
             style={{
               bottom:
                 "calc(var(--app-bottom-inset, 0px) + var(--kb-height, 0px) + 0.5rem)",
@@ -4093,6 +4009,63 @@ function AskFlow({
           Done
         </Button>
       ) : null}
+    </div>
+  );
+}
+
+function SelectedRecipientsRail({
+  title,
+  ariaLabel,
+  recipients,
+  onRemove,
+  recipientLabel,
+  trailing,
+}: {
+  title: string;
+  ariaLabel?: string;
+  recipients: OneLocationRecipient[];
+  onRemove: (recipientUserId: string) => void;
+  recipientLabel: (recipient: OneLocationRecipient) => string;
+  trailing?: ReactNode;
+}) {
+  if (!recipients.length) return null;
+
+  return (
+    <div className="space-y-2 pt-1">
+      <div className="flex items-end justify-between gap-3 px-1">
+        <AppSectionLabel as="h3">{title}</AppSectionLabel>
+        {trailing}
+      </div>
+      <div
+        aria-label={ariaLabel ?? title}
+        role="list"
+        className="max-h-[176px] overflow-y-auto rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15"
+      >
+        {recipients.map((recipient) => {
+          const label = recipientLabel(recipient);
+          return (
+            <div key={recipient.userId} role="listitem">
+              <button
+                type="button"
+                onClick={() => onRemove(recipient.userId)}
+                aria-label={`Remove ${label}`}
+                className="group flex min-h-14 w-full items-center gap-3 border-b border-[color:var(--app-separator)] px-3 text-left last:border-b-0"
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]">
+                  <UsersRound className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">
+                  {label}
+                </span>
+                <X
+                  className="h-4 w-4 shrink-0 text-muted-foreground opacity-55 transition-opacity group-hover:opacity-100"
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/hushh-webapp/e2e/one-location-duration-ladder.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-duration-ladder.layout.spec.ts
@@ -28,9 +28,9 @@ import {
  *
  *   - a 44pt tap target that is really 36px (`h-9` is what the surrounding
  *     chips use, and what the old "Until I stop" toggle was)
- *   - "8 hours" or "Until I stop" clipped inside an 80px cell at 320px
- *   - the 3-column grid reflowing to 3 rows on an iPhone SE because one
- *     label wrapped
+ *   - "Until I stop" clipped inside a compact iPhone cell at 320px
+ *   - the compact grid reflowing to three rows on an iPhone SE because one
+ *     label wrapped or a fifth choice slipped back in
  *   - the whole control creeping back toward the 306px the founder called
  *     "taking much space"
  *
@@ -52,10 +52,10 @@ const WIDE_WIDTHS = [768, 1024, 1440] as const;
 /**
  * The widest a single duration chip may be on a desktop.
  *
- * A 3-column grid inside the 880px Location shell stretched each cell to 258px,
- * and inside the wider Share card to 440px — "8 hours" printed across a slab
- * half a screen wide, in the founder's words "not looking good". A chip sized
- * to "Until I stop" is ~120px.
+ * A fixed grid inside the 880px Location shell stretched each cell to 258px,
+ * and inside the wider Share card to 440px — short labels printed across slabs
+ * half a screen wide, in the founder's words "not looking good". Content-sized
+ * chips stay around the actual label width.
  */
 const WIDE_MAX_CELL_WIDTH_PX = 170;
 
@@ -64,14 +64,14 @@ const WIDE_MAX_CELL_WIDTH_PX = 170;
  * row of chips = 74. Slack for sub-pixel line boxes. Two rows would be 126 and
  * fail — which is the point.
  */
-const WIDE_COLLAPSED_MAX_HEIGHT_PX = 80;
+const WIDE_COLLAPSED_MAX_HEIGHT_PX = 84;
 
 /**
  * The collapsed control's budget, in CSS px:
- *   label/hint row 20 + gap 10 + row 44 + gap 8 + row 44 + gap 8 + row 44
- * = 178. Four px of slack for sub-pixel line boxes.
+ *   label/hint row 20 + gap 10 + row 44 + gap 8 + row 44
+ * = 126. Four px of slack for sub-pixel line boxes.
  */
-const COLLAPSED_MAX_HEIGHT_PX = 182;
+const COLLAPSED_MAX_HEIGHT_PX = 130;
 
 /**
  * Custom open: the collapsed ladder + gap 8 + pt-1 4 + a 3-row wheel 120 = 310.
@@ -158,7 +158,6 @@ async function buildFixture(customOpen = false): Promise<string> {
         <div class="${DURATION_GRID_CLASS}" data-grid>${gridCells}${cell(
           "Until I stop",
           false,
-          "col-span-3",
         )}</div>
         ${
           customOpen
@@ -286,8 +285,7 @@ test.describe("One Location duration ladder layout", () => {
         ).toBeGreaterThanOrEqual(44);
       }
 
-      // L2/L4 — no label may clip or wrap. "Until I stop" is the reason the
-      // open-ended rung is a full-width row and not a seventh grid cell.
+      // L2/L4 — no label may clip or wrap.
       for (const cell of measured.cells) {
         expect(cell.clipped, `"${cell.text}" is clipped`).toBe(false);
         expect(
@@ -296,9 +294,9 @@ test.describe("One Location duration ladder layout", () => {
         ).toBe(1);
       }
 
-      // L3 — the six grid cells stay in exactly two rows. A wrapped label
-      // reflows them to three and the control silently grows 52px.
-      const gridRows = new Set(measured.cells.slice(0, 6).map((c) => c.top));
+      // L3 — the compact choices stay in exactly two rows. A wrapped label or
+      // extra preset reflows them to three and the control silently grows 52px.
+      const gridRows = new Set(measured.cells.map((c) => c.top));
       expect(gridRows.size).toBe(2);
 
       // L5 — nothing pushes the page sideways at any width.
@@ -315,11 +313,11 @@ test.describe("One Location duration ladder layout", () => {
       // L7 — the budget. This is the founder's actual complaint, in a number.
       expect(measured.controlHeight).toBeLessThanOrEqual(COLLAPSED_MAX_HEIGHT_PX);
 
-      // L9 — the open-ended rung spans the ladder, so it reads as the last
-      // rung rather than a stray chip.
-      expect(
-        Math.abs(measured.untilStopWidth - measured.gridWidth),
-      ).toBeLessThanOrEqual(1);
+      // L9 — the open-ended rung stays a peer in the same 2x2 grid, not a
+      // detached full-width bar.
+      expect(measured.untilStopWidth).toBeLessThanOrEqual(
+        measured.gridWidth / 2 + 1,
+      );
 
       // L10 — no React/ARIA warnings from the new markup.
       expect(consoleErrors).toEqual([]);

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -164,7 +164,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
           ? shareAmount
             ? `Shared their location with you for ${shareAmount}`
             : "Shared their location with you"
-          : "Started sharing location",
+          : "You started sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }

--- a/hushh-webapp/lib/one-location/request-message.ts
+++ b/hushh-webapp/lib/one-location/request-message.ts
@@ -12,6 +12,10 @@ export function buildOneLocationRequestMessage(
   const normalizedReason = String(reason ?? "").trim();
   const normalizedMessage = String(message ?? "").trim();
 
+  if (normalizedReason === "Other") {
+    return normalizedMessage || normalizedReason;
+  }
+
   if (normalizedReason && normalizedMessage) {
     return `${normalizedReason} — ${normalizedMessage}`;
   }


### PR DESCRIPTION
## Summary
- remove the extra Share Location trust note bar and reduce the visible duration ladder to focused Apple-like choices
- align Share and Request Location with the same compact selected-people horizontal rail
- move Request `Other` copy into the Reason section and remove the separate Message block
- keep request/share behavior intact: Request has no `Until I stop`; Share keeps it; custom duration remains available

## Verification
- npm run test -- --run components/one-location/redesign/__tests__/duration-presets.test.tsx __tests__/lib/one-location/request-message.test.ts __tests__/components/one-location-agent-page.test.tsx -t "DurationPresetPicker|buildOneLocationRequestMessage|keeps the count|offers a way to Connect|keeps typing local|People who can see your location|Ready to share"
- npm run typecheck
- npx playwright test e2e/one-location-duration-ladder.layout.spec.ts --project=chromium
- npm run verify:design-system