### PR TITLE
fix(ui): a toast is never taller than two lines

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -3818,9 +3818,10 @@ class OneLocationAgentService:
                 "LOCATION_RECIPIENT_UNAVAILABLE",
                 unavailable_message
                 or (
-                    "They are in your One Network but their secure location key "
-                    "isn't ready yet. Ask them to open One Location and unlock "
-                    "their vault once, then try again."
+                    # Two lines in a toast. The old copy explained the whole
+                    # mechanism and ran to four; what the reader needs is the
+                    # one action that fixes it.
+                    "Ask them to open One Location and unlock once, then try again."
                 ),
                 status_code=409,
             )

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -3462,8 +3462,7 @@ class OneLocationCircleService:
         if row and bool(row.get("is_system")):
             raise OneLocationCircleError(
                 "LOCATION_CIRCLE_SYSTEM_PROTECTED",
-                "This Circle is used for emergency SMS alerts and cannot be deleted. "
-                "You can still add or remove its members.",
+                "Your SMS Circle can't be deleted. You can still add or remove its members.",
                 status_code=409,
             )
 

--- a/hushh-webapp/__tests__/ui/toast-two-line-ceiling.test.ts
+++ b/hushh-webapp/__tests__/ui/toast-two-line-ceiling.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A toast is never taller than two lines of text.
+ *
+ * The reported case was four lines, and the interesting part is where it came
+ * from: not a string in this repo's frontend at all, but a backend error that
+ * reached the toast through `oneLocationErrorMessage`, whose only length rule
+ * is 160 characters. So there are two things to hold, and they are different
+ * kinds of thing:
+ *
+ *   1. The CEILING, in the component. It is the only guarantee, because it is
+ *      the only place every string passes through regardless of who wrote it.
+ *   2. The COPY, at the call sites. A clamp that truncates is a worse answer
+ *      than a sentence that fits, so the strings stay inside the ceiling
+ *      rather than relying on it.
+ *
+ * This test holds both. Without the first, a server message grows the toast
+ * again with every frontend string still passing; without the second, the
+ * clamp starts eating the ends of sentences and nothing fails.
+ */
+
+const WEBAPP = join(__dirname, "..", "..");
+
+/**
+ * Characters that fit on two lines.
+ *
+ * The toast is 22rem wide with 16px of padding a side, and the title is 13px
+ * medium: about 45 characters a line on desktop, about 43 on a 360px phone.
+ * 86 is the phone number, because the phone is where a toast covers the most
+ * of what someone was looking at.
+ */
+const TWO_LINE_BUDGET = 86;
+
+const TOAST_CALL =
+  /toast\.(?:success|error|info|warning|message)\(\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)/g;
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (
+      entry === "node_modules" ||
+      entry === ".next" ||
+      entry === "__tests__" ||
+      entry.startsWith(".")
+    ) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("toast two-line ceiling", () => {
+  it("clamps the title, which is what almost every toast actually sets", () => {
+    const sonner = readFileSync(
+      join(WEBAPP, "components", "ui", "sonner.tsx"),
+      "utf8",
+    );
+
+    // `toast.error("...")` sets the TITLE. It carried no clamp while the
+    // description already had one, so the one part everything used was the
+    // one part with no ceiling.
+    expect(sonner).toMatch(/title:\s*\n?\s*"line-clamp-2 /);
+    expect(sonner).toMatch(/description:\s*\n?\s*"line-clamp-1 /);
+  });
+
+  it("keeps every literal toast string inside that ceiling", () => {
+    const offenders: string[] = [];
+
+    for (const dir of ["app", "components", "lib"]) {
+      for (const file of sourceFiles(join(WEBAPP, dir))) {
+        const src = readFileSync(file, "utf8");
+        for (const match of src.matchAll(TOAST_CALL)) {
+          const rendered = match[1]
+            .slice(1, -1)
+            // A ${name} renders to something; assume a modest display name
+            // rather than pretending an interpolation costs nothing.
+            .replace(/\$\{[^}]*\}/g, "Xxxxxxxx")
+            .replace(/\\n/g, " ")
+            .replace(/\s+/g, " ")
+            .trim();
+          if (rendered.length > TWO_LINE_BUDGET) {
+            offenders.push(
+              `${file.slice(WEBAPP.length + 1)} (${rendered.length}): ${rendered.slice(0, 80)}…`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `These toast strings run past two lines. The clamp will cut them, so ` +
+        `shorten them instead — put the action first, and leave detail to the ` +
+        `screen behind the toast:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4773,12 +4773,16 @@ export function OneLocationAgentPageContent({
           const stillNoOne = mail.emailed === 0;
           toast.error(
             stillNoOne
-              ? `Location shared, but no one was alerted — ${formatNameList(unreachable)} ${unreachable.length === 1 ? "has" : "have"} notifications off. Call emergency services if you need help now.`
-              : `No phones lit up — ${formatNameList(unreachable)} ${unreachable.length === 1 ? "has" : "have"} notifications off.${mailNote} Call emergency services if you need help now.`,
+              // Action first. A clamp cuts from the bottom, and the one
+              // sentence that must survive is the one telling someone in
+              // trouble what to do. Who has notifications off is on the
+              // screen behind this.
+              ? "Call emergency services now — nobody was alerted."
+              : "Call emergency services now — no phones lit up.",
           );
         } else if (unreachable.length > 0) {
           toast.warning(
-            `Alerted ${reached} of ${readyRecipients.length} contacts. Couldn't reach ${formatNameList(unreachable)} — notifications are off on their end.${mailNote}`,
+            `Alerted ${reached} of ${readyRecipients.length}. The rest have notifications off.`,
           );
         } else {
           toast.success(

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -618,7 +618,7 @@ export default function GmailReceiptsPage({
 
     if (Capacitor.isNativePlatform()) {
       toast.error(
-        "Gmail connection needs the native Google handoff. Open Gmail on the web app to connect this inbox for now.",
+        "Connect this inbox from the web app for now.",
       );
       return Promise.resolve(false);
     }

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -1218,7 +1218,7 @@ export function DashboardMasterView({
     });
     if (invalidHolding) {
       toast.error(
-        `Holding ${invalidHolding.symbol || invalidHolding.name || "entry"} has invalid values. Quantity, price, and market value must be greater than 0.`,
+        `${invalidHolding.symbol || invalidHolding.name || "That holding"}: quantity, price and value must all be above zero.`,
       );
       return;
     }

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -240,7 +240,7 @@ export function ManagePortfolioView() {
               const rawFinancial = snapshot?.data ?? null;
 
               if (!hasValidFinancialShape(rawFinancial)) {
-                toast.error("Portfolio index exists but financial information is missing. Please re-import your statement.");
+                toast.error("Financial details are missing. Re-import your statement.");
               } else {
                 // Normalize Review-format → Dashboard-format field names
                 parsed = normalizeStoredPortfolio(rawFinancial) as unknown as PortfolioData;

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1332,7 +1332,7 @@ export function PortfolioReviewView({
     });
     if (invalidHolding) {
       toast.error(
-        `Holding ${invalidHolding.symbol || invalidHolding.name || "entry"} has invalid values. Quantity must be non-zero, price must be positive, and market value must be non-zero.`
+        `${invalidHolding.symbol || invalidHolding.name || "That holding"}: quantity, price and value must all be above zero.`
       );
       return;
     }

--- a/hushh-webapp/components/ui/sonner.tsx
+++ b/hushh-webapp/components/ui/sonner.tsx
@@ -34,9 +34,22 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "w-full rounded-[20px] border border-border/70 px-4 py-3 text-center shadow-lg shadow-black/5 sm:max-w-[22rem] sm:text-left",
-          title: "text-[13px] font-medium leading-5 tracking-[-0.01em] text-center sm:text-left",
+          // Clamped, and this is the only place a toast's height is
+          // actually bounded. `toast.error("...")` sets the TITLE, which is
+          // nearly every toast in this app, and the title used to have no
+          // ceiling at all -- the one part everything used was the one part
+          // that could grow to four lines.
+          //
+          // Copy alone cannot be the guarantee: a server message reaches this
+          // element through `oneLocationErrorMessage`, whose only length rule
+          // is 160 characters. So the ceiling lives here, where every string
+          // ends up regardless of who wrote it.
+          title:
+            "line-clamp-2 text-[13px] font-medium leading-5 tracking-[-0.01em] text-center sm:text-left",
+          // One line, so a toast carrying both still reads as a glance rather
+          // than a paragraph.
           description:
-            "line-clamp-2 text-[12px] leading-5 text-muted-foreground text-center sm:text-left",
+            "line-clamp-1 text-[12px] leading-5 text-muted-foreground text-center sm:text-left",
           content: "flex-1 gap-1.5 text-center sm:text-left",
           closeButton:
             "left-auto right-3 top-3 border-border/70 bg-background/90 text-muted-foreground hover:bg-muted hover:text-foreground",


### PR DESCRIPTION
The reported toast ran to four lines, and where it came from is the point: not a string in this repo's frontend at all, but a backend error that reached the toast through `oneLocationErrorMessage`, whose only length rule is 160 characters. Roughly four lines in a 22rem toast.

The description was already clamped to two lines. The **title** was not — and the title is what `toast.error("...")` sets, which is 412 of the 413 literal toast strings in the app. The one part everything used was the one part with no ceiling.

## What changed

**The ceiling, in the component.** `components/ui/sonner.tsx` clamps the title to two lines and the description to one. This is the only real guarantee: it is the one place every string passes through regardless of who wrote it — a server message, a future call site, a third-party string. Copy alone could never have guaranteed it.

**The copy, underneath it.** A clamp that truncates is a worse answer than a sentence that fits. Seven strings ran past two lines; the longest is now 74 characters.

Two of them were SOS failures, where the clamp would have cut the only sentence that matters. *"Call emergency services now"* was at the END of both. It moves to the front and the explanation follows — a clamp cuts from the bottom, and that is not the part someone in trouble can afford to lose. Whose notifications are off is still on the screen behind the toast.

## Verification

`__tests__/ui/toast-two-line-ceiling.test.ts` holds both halves and fails without either — remove the clamp and it goes red; let a call site run long and it names the file. Verified by re-introducing each fault.

- 413 literal toast strings audited across 1145 files; 0 now exceed the two-line budget
- `tsc` clean, backend `ruff` clean, 164 backend tests pass