### PR TITLE
fix(finance): lock Portfolio and Analysis tabs to fixed static height and eliminate blank viewport space

### DIFF
--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1107,7 +1107,7 @@ export function KaiAnalysisPageContent() {
     <>
       {showWorkspace ? (
         <div
-          className="w-full min-w-0 max-w-full"
+          className="w-full min-w-0 max-w-full h-full overflow-hidden"
           data-testid={liveIntentReady ? "kai-analysis-active-run" : "kai-analysis-primary"}
         >
           <NativeTestBeacon
@@ -1308,7 +1308,7 @@ export function KaiAnalysisPageContent() {
           </AppPageContentRegion>
         </div>
       ) : !resolvingEntry ? (
-        <div className="w-full min-w-0 max-w-full" data-testid="kai-analysis-primary">
+        <div className="w-full min-w-0 max-w-full h-full overflow-hidden" data-testid="kai-analysis-primary">
           <NativeTestBeacon
             routeId={ROUTES.KAI_ANALYSIS}
             marker="native-route-kai-analysis"

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -3770,7 +3770,7 @@ export function KaiFlow({
   }
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col h-full overflow-hidden">
       {/* State-based rendering */}
       {state === "import_required" && (
         <PortfolioImportView

--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -21,6 +21,7 @@ import { KaiPreviewRouter } from "@/components/kai/views/kai-preview-router";
 import { KaiAnalysisPageContent } from "@/app/one/kai/analysis/page";
 import { scheduleFinanceWorkspaceWarmup } from "@/lib/kai/finance-workspace-warmup";
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
+import { cn } from "@/lib/utils";
 
 const FINANCE_TAB_DEFINITION = TOP_SHELL_TAB_REGISTRY.finance;
 type PortfolioTab = (typeof FINANCE_TAB_DEFINITION.tabs)[number]["value"];
@@ -98,7 +99,10 @@ export function KaiMarketHubPage() {
       fitContent
 
       width="reading"
-      className="relative !px-0 pb-32"
+      className={cn(
+        "relative !px-0",
+        visibleTab !== "market" && "overflow-hidden max-h-[calc(100dvh-var(--app-top-content-offset,84px))]"
+      )}
       data-finance-workspace="true"
       nativeTest={{
         routeId: KAI_MARKET_PATH,
@@ -114,14 +118,16 @@ export function KaiMarketHubPage() {
         onSelectionChange={(value) => setVisibleTab(value as PortfolioTab)}
         onSelectionCommit={(value) => setActiveTab(value as PortfolioTab)}
         panelInset="page"
+        heightMode="active"
+        viewportMinHeight="0"
       >
         <div className="h-full w-full">
           <AppPageContentRegion>
             <KaiPreviewRouter />
           </AppPageContentRegion>
         </div>
-        <div className="h-full w-full">
-          <AppPageContentRegion>
+        <div className="h-full w-full overflow-hidden">
+          <AppPageContentRegion className="h-full overflow-hidden">
             <KaiFlow
               userId={user.uid}
               mode="dashboard"
@@ -130,8 +136,8 @@ export function KaiMarketHubPage() {
             />
           </AppPageContentRegion>
         </div>
-        <div className="h-full w-full">
-          <AppPageContentRegion>
+        <div className="h-full w-full overflow-hidden">
+          <AppPageContentRegion className="h-full overflow-hidden">
             <KaiAnalysisPageContent />
           </AppPageContentRegion>
         </div>

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -1138,7 +1138,7 @@ export function AnalysisHistoryDashboard({
 
   // ----- Populated state -----
   return (
-    <div className="w-full space-y-6 pb-safe">
+    <div className="w-full space-y-6 pb-safe overflow-hidden">
       {/* Data Table */}
       <DataTable
         columns={columns}

--- a/hushh-webapp/components/kai/views/analysis-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-view.tsx
@@ -140,7 +140,7 @@ export function AnalysisView({
         </div>
       </div>
 
-      <div className="mx-auto w-full space-y-6 pb-36" style={APP_MEASURE_STYLES.reading}>
+      <div className="mx-auto w-full space-y-6 pb-8" style={APP_MEASURE_STYLES.reading}>
 
       {/* Decision Card */}
       <SurfaceCard>

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -30,7 +30,7 @@ import { requestInternalAppNavigation } from "@/lib/utils/browser-navigation";
 
 const analysisRootClassName = cn(
   marketSurfaceVariablesClassName,
-  "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
+  "relative isolate mx-auto flex min-h-0 w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
   "[--one-bg:var(--background)] [--one-card:var(--app-card-surface-default-solid)] [--one-surface:var(--app-card-surface-compact)]",
   "[--one-hairline:var(--foundation-hairline)] [--one-line:var(--foundation-hairline)]",
@@ -527,8 +527,8 @@ export function KaiAnalysisPreviewView() {
       </style>
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]" />
 
-      <div className="mx-auto flex min-h-screen w-full max-w-[1080px] flex-col">
-        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(190px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1080px] flex-col">
+        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(32px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
           <header className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <span className={cn(kaiPreviewEyebrowClassName, "text-[color:var(--one-fg3)]")}>

--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -185,7 +185,7 @@ const CONNECT_PICK =
 
 const connectRootClassName = cn(
   marketSurfaceVariablesClassName,
-  "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
+  "relative isolate mx-auto flex min-h-0 w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
   "[--one-bg:var(--background)] [--one-card:var(--app-card-surface-default-solid)] [--one-surface:var(--app-card-surface-compact)]",
   "[--one-hairline:var(--foundation-hairline)] [--one-line:var(--foundation-hairline)]",
@@ -662,8 +662,8 @@ export function KaiConnectPreviewView() {
       </style>
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]" />
 
-      <div className="mx-auto flex min-h-screen w-full max-w-[1080px] flex-col">
-        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(190px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1080px] flex-col">
+        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(32px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
           <header className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <span className={cn(kaiPreviewEyebrowClassName, "text-[color:var(--one-fg3)]")}>

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -162,7 +162,7 @@ function formatHeadlinePublished(value: string | null | undefined): string {
 
 const oneMarketRootClassName = cn(
   marketSurfaceVariablesClassName,
-  "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
+  "relative isolate mx-auto flex min-h-0 w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-transparent font-sans text-[color:var(--one-fg)] antialiased",
   // The page background always matches the app shell (--background) so the
   // route never paints its own lighter panel inside the shell (the "double


### PR DESCRIPTION
## Summary
Fixes vertical page scrolling and removes excess empty viewport space on the **Portfolio** (column 2) and **Analysis** (column 3) tabs within the Finance workspace (`/one/kai`).

## Key Changes
- **Dynamic Swipe Height**: Configured `SwipeViews` with `heightMode="active"` and `viewportMinHeight="0"` so active slides adapt precisely to their rendered content height without inheriting large heights from adjacent slides.
- **Fixed Container Boundaries**: Applied `max-h-[calc(100dvh-var(--app-top-content-offset,84px))]` and `overflow-hidden` to `AppPageShell` when viewing non-market tabs.
- **Excess Padding Cleanup**: Removed legacy `pb-32` (128px) padding on `AppPageShell`, replaced `min-h-screen` with `min-h-0` in preview views, and reduced `190px` / `pb-36` bottom paddings to standard compact spacing (`32px` / `pb-8`).

## Branch & Commits
- **Branch**: `fix/finance-tabs-static-layout-5514`
- **Commit**: `1cec768ab` (`fix(finance): lock Portfolio and Analysis tabs to fixed static height and eliminate blank viewport space`)

## Verification
- Verified via `npx eslint` (0 errors).
- Tested `http://localhost:3000/one/kai?tab=analysis` and `?tab=portfolio` — empty states remain 100% static with no vertical scrollbar or trailing blank space.