### PR TITLE
Polish Location menu action grid

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -904,9 +904,8 @@ describe("OneLocationAgentPage", () => {
     // Clearing the cache does not clear the resource's in-flight map. A test
     // that leaves a request pending would otherwise hand its dead promise to
     // the next test, which then never calls getState at all.
-    const { OneLocationStateResource } = await import(
-      "@/lib/one-location/one-location-state-resource"
-    );
+    const { OneLocationStateResource } =
+      await import("@/lib/one-location/one-location-state-resource");
     OneLocationStateResource.invalidate("user_a");
     const { forgetOneLocationControlPreference } =
       await import("@/lib/one-location/location-control-state");
@@ -1187,7 +1186,7 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("keeps every counted Now-hub row neutral while its count is zero", async () => {
+  it("hides Activity when every Activity count is zero", async () => {
     // State beats category. Colour on these three rows means "there is
     // something here", never "this row exists" — an empty Location screen
     // reporting 0, 0, 0 in three saturated tiles spends colour on nothing and
@@ -1202,18 +1201,10 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    const toneOf = async (title: string) => {
-      const row = (await screen.findByText(title)).closest(
-        '[data-slot="settings-row"], button, a, div[role="button"]',
-      );
-      return row
-        ?.querySelector('[data-slot="settings-row-icon"]')
-        ?.getAttribute("data-icon-tone");
-    };
-
-    expect(await toneOf("Active shares")).toBe("gray");
-    expect(await toneOf("Shared with me")).toBe("gray");
-    expect(await toneOf("Needs my review")).toBe("gray");
+    expect(screen.queryByTestId("one-location-now-activity")).toBeNull();
+    expect(screen.queryByText("Active shares")).toBeNull();
+    expect(screen.queryByText("Shared with me")).toBeNull();
+    expect(screen.queryByText("Needs my review")).toBeNull();
   });
 
   it("keeps Activity rows visually quiet even when counts are non-zero", async () => {
@@ -1268,7 +1259,7 @@ describe("OneLocationAgentPage", () => {
     // Now has one action home: Share, Request, Check-In, and SMS are peer
     // choices in a 2x2 panel. Generated state and utility destinations stay in
     // list groups, which keeps the tab from reading like a dashboard.
-    mockGetState.mockResolvedValue({ ...locationState(), ownerGrants: [] });
+    mockGetState.mockResolvedValue(locationState());
 
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
@@ -1291,11 +1282,9 @@ describe("OneLocationAgentPage", () => {
     actionCells?.forEach((cell) => {
       expect(cell.className).toContain("items-center");
       expect(cell.className).toContain("text-center");
-      expect(cell.className).toContain("min-h-[94px]");
+      expect(cell.className).toContain("min-h-24");
       expect(cell.className).toContain("rounded-[18px]");
-      expect(cell.className).toContain(
-        "shadow-[var(--app-card-shadow-standard)]",
-      );
+      expect(cell.className).toContain("ring-[color:var(--app-separator)]");
     });
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
@@ -1738,7 +1727,9 @@ describe("OneLocationAgentPage", () => {
     const alreadySharing = await screen.findByTestId(
       "one-location-share-already-sharing",
     );
-    expect(within(alreadySharing).getByText("Already sharing (1)")).toBeTruthy();
+    expect(
+      within(alreadySharing).getByText("Already sharing (1)"),
+    ).toBeTruthy();
     expect(within(alreadySharing).getByText("Trusted B")).toBeTruthy();
     // The same words the Active shares screen uses for the same grant. Two
     // screens describing one share must not disagree about how long is left.
@@ -1799,7 +1790,9 @@ describe("OneLocationAgentPage", () => {
     // point, so offering the choice made a privacy promise the share did not
     // keep. Asserting their absence is what stops the dead control returning
     // before there is a real precision mode to attach it to.
-    expect(screen.queryByText("Better for privacy and battery life")).toBeNull();
+    expect(
+      screen.queryByText("Better for privacy and battery life"),
+    ).toBeNull();
     expect(
       screen.queryByText("Updates while you move for your loved ones"),
     ).toBeNull();
@@ -1973,7 +1966,9 @@ describe("OneLocationAgentPage", () => {
 
     // Back to the people step so the pending permission below is attached to
     // Continue — the one control that now runs the device pre-flight.
-    fireEvent.click(screen.getByRole("button", { name: "Change who can see you" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Change who can see you" }),
+    );
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
@@ -2135,7 +2130,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.queryByRole("heading", { name: "Who can see you?" }),
     ).toBeNull();
-    expect(screen.getByText("Can see you")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Can see you")).toBeTruthy());
     expect(screen.getByText("Abdul Rashid")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Start sharing" })).toBeEnabled();
   });
@@ -2942,9 +2937,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("button", { name: "Try again" }),
     ).toBeEnabled();
-    expect(toast.error).toHaveBeenCalledWith(
-      "Check permission and try again.",
-    );
+    expect(toast.error).toHaveBeenCalledWith("Check permission and try again.");
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
@@ -3095,9 +3088,9 @@ describe("OneLocationAgentPage", () => {
 
     // The header agrees with what the person just did.
     await waitFor(() =>
-      expect(
-        screen.getByTestId("one-location-header-status").textContent,
-      ).toBe("Location on"),
+      expect(screen.getByTestId("one-location-header-status").textContent).toBe(
+        "Location on",
+      ),
     );
     expect(
       screen.getByRole("switch", { name: "Turn location off" }),
@@ -3219,9 +3212,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     expect(screen.getAllByText("Advisor C").length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("Invite them first").length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Invite them first").length).toBeGreaterThan(0);
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
@@ -3611,9 +3602,7 @@ describe("OneLocationAgentPage", () => {
       screen.getByRole("heading", { name: "Shared with me" }),
     ).toBeTruthy();
     await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
-    expect(
-      await screen.findByText("Location may be stale."),
-    ).toBeTruthy();
+    expect(await screen.findByText("Location may be stale.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Ask to refresh" })).toBeTruthy();
 
     expect(screen.getByText("Active")).toBeTruthy();
@@ -3717,9 +3706,7 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openTemporaryLinkFlow();
-    fireEvent.click(
-      screen.getByRole("button", { name: /^Create link$/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /^Create link$/i }));
 
     await waitFor(() =>
       expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1),
@@ -3825,7 +3812,7 @@ describe("OneLocationAgentPage", () => {
     // After a successful share the flow closes and returns to the main hub.
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /Active shares/i }),
+        screen.getByTestId("one-location-now-actions"),
       ).toBeTruthy(),
     );
     expect(
@@ -3883,7 +3870,12 @@ describe("OneLocationAgentPage", () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [
-        { ...base, id: "grant_b", recipientUserId: "user_b", recipientKeyId: "key_b" },
+        {
+          ...base,
+          id: "grant_b",
+          recipientUserId: "user_b",
+          recipientKeyId: "key_b",
+        },
         {
           ...base,
           id: "grant_d",
@@ -4148,7 +4140,9 @@ describe("OneLocationAgentPage", () => {
       }),
     );
     expect(
-      screen.queryByPlaceholderText("Hey, can you share your location until we meet?"),
+      screen.queryByPlaceholderText(
+        "Hey, can you share your location until we meet?",
+      ),
     ).toBeNull();
     expect(screen.queryByPlaceholderText("What should they know?")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
@@ -4295,7 +4289,9 @@ describe("OneLocationAgentPage", () => {
       ).toBeTruthy(),
     );
     expect(
-      screen.getByRole("button", { name: /Send request/i }).hasAttribute("disabled"),
+      screen
+        .getByRole("button", { name: /Send request/i })
+        .hasAttribute("disabled"),
     ).toBe(false);
     expect(screen.queryByRole("status")).toBeNull();
 
@@ -4548,10 +4544,10 @@ describe("OneLocationAgentPage", () => {
     });
   });
 
-  it("keeps a section heading out of the list of people", async () => {
+  it("keeps Request location as one compact list of people", async () => {
     // The roster carries `role="list"`, and every entry in it is wrapped as a
-    // `listitem`. A heading is not one of the people, so it opts out --
-    // otherwise a screen reader reads "Recent" as an entry between two names.
+    // `listitem`. The new compact treatment removes section headers entirely,
+    // so a screen reader never reads "Recent" as a person between two names.
     mockGetState.mockResolvedValue({
       ...locationState(),
       // The page derives `requestedByMe` from `requests`, filtered to the ones
@@ -4572,11 +4568,19 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openAskFlow();
 
-    const heading = await screen.findByTestId(
-      "one-location-ask-section-header:recent",
-    );
-    expect(heading.tagName).toBe("H3");
-    expect(heading.parentElement).toHaveAttribute("role", "presentation");
+    const list = await screen.findByTestId("one-location-ask-recipients");
+    expect(
+      screen.queryByTestId("one-location-ask-section-header:recent"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("one-location-ask-section-header:all"),
+    ).toBeNull();
+    expect(
+      within(list).getAllByRole("listitem").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      within(list).getByRole("button", { name: /Select Advisor C/i }),
+    ).toBeTruthy();
   });
 
   it("offers a way to Connect when the person being looked for is not on the list", async () => {
@@ -5131,7 +5135,9 @@ describe("OneLocationAgentPage", () => {
       await switchLocationTab("People", "Circles");
 
       const addPeople = screen.getByRole("button", { name: /Add people/i });
-      const search = await screen.findByPlaceholderText("Search trusted people");
+      const search = await screen.findByPlaceholderText(
+        "Search trusted people",
+      );
       const syncContacts = screen.getByRole("button", {
         name: /Find contacts/i,
       });
@@ -5355,9 +5361,7 @@ describe("OneLocationAgentPage", () => {
     await leaveLocationFeatureStep();
 
     await expectLocationInviteStep();
-    expect(
-      screen.queryByTestId("one-location-onboarding-contacts"),
-    ).toBeNull();
+    expect(screen.queryByTestId("one-location-onboarding-contacts")).toBeNull();
   });
 
   /* ------------------------------------------------------------------ *

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1282,10 +1282,7 @@ describe("OneLocationAgentPage", () => {
 
     const actionGrid = actions.querySelector("[data-one-location-action-grid]");
     expect(actionGrid?.className).toContain("grid-cols-2");
-    expect(actionGrid?.className).toContain("rounded-[22px]");
-    expect(actionGrid?.className).toContain(
-      "shadow-[var(--app-card-shadow-standard)]",
-    );
+    expect(actionGrid?.className).toContain("gap-2");
 
     const actionCells = actionGrid?.querySelectorAll(
       "[data-one-location-action-cell]",
@@ -1294,11 +1291,18 @@ describe("OneLocationAgentPage", () => {
     actionCells?.forEach((cell) => {
       expect(cell.className).toContain("items-center");
       expect(cell.className).toContain("text-center");
-      expect(cell.className).toContain("min-h-[116px]");
+      expect(cell.className).toContain("min-h-[94px]");
+      expect(cell.className).toContain("rounded-[18px]");
+      expect(cell.className).toContain(
+        "shadow-[var(--app-card-shadow-standard)]",
+      );
     });
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("[&_svg]:h-8");
+    ).toContain("rounded-[16px]");
+    expect(
+      actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
+    ).toContain("[&_svg]:h-6");
 
     const activity = screen.getByTestId("one-location-now-activity");
     expect(within(activity).getByText("Active shares")).toBeTruthy();

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -33,6 +33,14 @@ export const SHARE_DURATION_LADDER: DurationRung[] = [
   { value: "1", label: "1 hour" },
 ];
 
+export const REQUEST_DURATION_LADDER: DurationRung[] = [
+  { value: "0.25", label: "15 min" },
+  { value: "1", label: "1 hour" },
+  { value: "2", label: "2 hours" },
+  { value: "4", label: "4 hours" },
+  { value: "8", label: "8 hours" },
+];
+
 export const SHARE_DURATION_UNTIL_STOP_VALUE = "until_stopped";
 
 /** What `Custom` opens on when it is reached from the open-ended rung. */
@@ -66,7 +74,8 @@ export const DURATION_CUSTOM_VISIBLE_ROWS = 3;
  * wrapping at 320px is worse than a tidy two-column block and that layout is
  * already measured by e2e/one-location-duration-ladder.layout.spec.ts.
  */
-export const DURATION_GRID_CLASS = "grid grid-cols-2 gap-2 sm:flex sm:flex-wrap";
+export const DURATION_GRID_CLASS =
+  "grid grid-cols-2 gap-2 sm:flex sm:flex-wrap";
 export const DURATION_CELL_CLASS =
   "flex min-h-11 items-center justify-center whitespace-nowrap rounded-[14px] border px-2 text-center text-[15px] font-semibold leading-5 transition-colors touch-manipulation sm:px-4";
 export const DURATION_CELL_OFF_CLASS =

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1658,9 +1658,9 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
       <div
         data-ui-role="grouped-card"
         data-one-location-action-grid=""
-        className="grid grid-cols-2 overflow-hidden rounded-[22px] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)]"
+        className="grid grid-cols-2 gap-2 sm:gap-3"
       >
-        {items.map((item, index) => (
+        {items.map((item) => (
           <button
             key={item.controlId}
             type="button"
@@ -1671,21 +1671,17 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             data-voice-label={item.title}
             onClick={item.onClick}
             className={cn(
-              "group flex min-h-[116px] min-w-0 flex-col items-center justify-center gap-3 bg-transparent px-3 py-5 text-center transition-colors [-webkit-tap-highlight-color:transparent] hover:bg-[rgba(0,0,0,0.025)] active:bg-[rgba(120,120,128,0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-[126px]",
-              index % 2 === 0 &&
-                "border-r border-[color:var(--app-separator)]",
-              index < 2 &&
-                "border-b border-[color:var(--app-separator)]",
+              "group flex min-h-[94px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] px-3 py-4 text-center shadow-[var(--app-card-shadow-standard)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-card-surface-compact)] active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-[108px]",
             )}
           >
             <span
               aria-hidden
               data-one-location-action-icon=""
               className={cn(
-                "inline-flex h-12 w-12 shrink-0 items-center justify-center [&_svg]:h-8 [&_svg]:w-8 [&_svg]:stroke-[1.95]",
+                "inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[16px] transition-transform group-active:scale-95 [&_svg]:h-6 [&_svg]:w-6 [&_svg]:stroke-[2]",
                 item.tone === "red"
-                  ? "text-[color:var(--app-destructive)]"
-                  : "text-[color:var(--app-accent-deep)]",
+                  ? "bg-[color:var(--app-destructive-tint)] text-[color:var(--app-destructive)]"
+                  : "bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)]",
               )}
             >
               {item.icon}
@@ -1693,7 +1689,7 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             <RowLabel
               as="span"
               className={cn(
-                "min-w-0 text-[15px] font-semibold leading-5",
+                "min-w-0 text-[14px] font-semibold leading-[18px] sm:text-[15px] sm:leading-5",
                 item.tone === "red" && "text-[color:var(--app-destructive)]",
               )}
             >

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -30,15 +30,18 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import {
+  Loader2,
   Lock,
   Map,
   MapPin,
-  Navigation,
+  MessageCircleWarning,
+  Pencil,
   Send,
   Check,
+  CalendarCheck2,
   Shield,
   ShieldCheck,
-  UserPlus,
+  UserRoundPlus,
   UsersRound,
   ChevronRight,
   X,
@@ -91,6 +94,7 @@ import {
   Avatar,
   EmptyState,
   SectionCard,
+  StatusPill,
   TaskFlowHeader,
   TrustNoteCard,
   WarningCard,
@@ -101,7 +105,6 @@ import {
   RequestCard,
   SharedWithMeCard,
   TemporaryLinkCard,
-  TrustedPersonCard,
   type GrantViewStatus,
 } from "./cards";
 
@@ -119,6 +122,7 @@ import {
   ReasonChips,
   type ReasonValue,
 } from "./selectors";
+import { REQUEST_DURATION_LADDER } from "./duration-presets";
 import {
   LiveShareStatusCard,
   ShareCountdownText,
@@ -129,10 +133,12 @@ import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts
 import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { VirtualContactList } from "@/components/one-location/redesign/contact-picker/virtual-list";
+import { ContactAvatar } from "@/components/one-location/redesign/contact-picker/atoms";
 import {
   flattenRecipientSections,
   lastInteractionByUserId,
@@ -1120,14 +1126,19 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       return;
     }
     const desired = requested;
-    if (desired === "none" && pendingFlowRef.current !== "none") {
+    if (pendingFlowRef.current !== "none" && desired !== pendingFlowRef.current) {
       return;
     }
+    const wasPendingProgrammaticOpen = pendingFlowRef.current === desired;
     pendingFlowRef.current = "none";
     const previousFlow = activeFlowRef.current;
     if (previousFlow === "share" && desired !== "share") {
       resetShareDraft();
-    } else if (previousFlow !== "share" && desired === "share") {
+    } else if (
+      previousFlow !== "share" &&
+      desired === "share" &&
+      !wasPendingProgrammaticOpen
+    ) {
       resetShareDraft();
     }
     activeFlowRef.current = desired;
@@ -1195,7 +1206,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   if (flow !== "none") {
     return (
       <div
-        className="space-y-6"
+        className="space-y-6 pb-[calc(150px+env(safe-area-inset-bottom))]"
         data-ambient-chrome-ignore
         data-testid="one-location-action-flow"
       >
@@ -1472,6 +1483,10 @@ function NowHub({
     vm.activeOwnerGrants.length,
     vm.liveShare?.count ?? 0,
   );
+  const hasActivity =
+    activeShareCount > 0 ||
+    vm.receivedGrants.length > 0 ||
+    vm.pendingOwnerRequests.length > 0;
 
   return (
     <div className="space-y-4" data-testid="one-location-now-hub">
@@ -1517,7 +1532,7 @@ function NowHub({
         items={[
           {
             title: "Share location",
-            icon: <Navigation />,
+            icon: <Send />,
             tone: "blue",
             onClick: onStartShare,
             controlId: "one-location-action-share",
@@ -1526,7 +1541,7 @@ function NowHub({
           },
           {
             title: "Request location",
-            icon: <UserPlus />,
+            icon: <UserRoundPlus />,
             tone: "blue",
             onClick: onRequestLocation,
             controlId: "one-location-action-ask",
@@ -1535,7 +1550,7 @@ function NowHub({
           },
           {
             title: "Check-In",
-            icon: <ShieldCheck />,
+            icon: <CalendarCheck2 />,
             tone: "blue",
             onClick: onCheckIn,
             controlId: "one-location-action-check-in",
@@ -1543,7 +1558,7 @@ function NowHub({
           },
           {
             title: "SMS",
-            icon: <Shield />,
+            icon: <MessageCircleWarning />,
             tone: "red",
             onClick: onSos,
             controlId: "one-location-action-sos",
@@ -1552,48 +1567,50 @@ function NowHub({
         ]}
       />
 
-      <div className="space-y-2">
-        <LocationNowGroupLabel>Activity</LocationNowGroupLabel>
-        <SettingsGroup
-          separatorInset
-          testId="one-location-now-activity"
-          shellClassName={groupedShellClassName}
-        >
-          <SettingsRow
-            icon={UsersRound}
-            iconTone="gray"
-            title="Active shares"
-            density="compact"
-            trailing={activeShareCount}
-            chevron
-            onClick={onOpenActiveShares}
-            voiceControlId="one-location-action-active-shares"
-            voiceActionId="location.open_active_shares"
-          />
-          <SettingsRow
-            icon={MapPin}
-            iconTone="gray"
-            title="Shared with me"
-            density="compact"
-            trailing={vm.receivedGrants.length}
-            chevron
-            onClick={onOpenSharedWithMe}
-            voiceControlId="one-location-action-shared-with-me"
-            voiceActionId="location.open_shared_with_me"
-          />
-          <SettingsRow
-            icon={ShieldCheck}
-            iconTone="gray"
-            title="Needs my review"
-            density="compact"
-            trailing={vm.pendingOwnerRequests.length}
-            chevron
-            onClick={onOpenNeedsReview}
-            voiceControlId="one-location-action-needs-review"
-            voiceActionId="location.open_needs_review"
-          />
-        </SettingsGroup>
-      </div>
+      {hasActivity ? (
+        <div className="space-y-2">
+          <LocationNowGroupLabel>Activity</LocationNowGroupLabel>
+          <SettingsGroup
+            separatorInset
+            testId="one-location-now-activity"
+            shellClassName={groupedShellClassName}
+          >
+            <SettingsRow
+              icon={UsersRound}
+              iconTone="gray"
+              title="Active shares"
+              density="compact"
+              trailing={activeShareCount}
+              chevron
+              onClick={onOpenActiveShares}
+              voiceControlId="one-location-action-active-shares"
+              voiceActionId="location.open_active_shares"
+            />
+            <SettingsRow
+              icon={MapPin}
+              iconTone="gray"
+              title="Shared with me"
+              density="compact"
+              trailing={vm.receivedGrants.length}
+              chevron
+              onClick={onOpenSharedWithMe}
+              voiceControlId="one-location-action-shared-with-me"
+              voiceActionId="location.open_shared_with_me"
+            />
+            <SettingsRow
+              icon={ShieldCheck}
+              iconTone="gray"
+              title="Needs my review"
+              density="compact"
+              trailing={vm.pendingOwnerRequests.length}
+              chevron
+              onClick={onOpenNeedsReview}
+              voiceControlId="one-location-action-needs-review"
+              voiceActionId="location.open_needs_review"
+            />
+          </SettingsGroup>
+        </div>
+      ) : null}
 
       <div className="space-y-2">
         <LocationNowGroupLabel>More</LocationNowGroupLabel>
@@ -1653,12 +1670,12 @@ type LocationActionGridItem = {
 
 function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
   return (
-    <section className="space-y-2.5" data-testid="one-location-now-actions">
+    <section className="space-y-2" data-testid="one-location-now-actions">
       <LocationNowGroupLabel>Actions</LocationNowGroupLabel>
       <div
         data-ui-role="grouped-card"
         data-one-location-action-grid=""
-        className="grid grid-cols-2 gap-2 sm:gap-3"
+        className="grid grid-cols-2 gap-2 sm:gap-2.5"
       >
         {items.map((item) => (
           <button
@@ -1671,17 +1688,17 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             data-voice-label={item.title}
             onClick={item.onClick}
             className={cn(
-              "group flex min-h-[94px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] px-3 py-4 text-center shadow-[var(--app-card-shadow-standard)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-card-surface-compact)] active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-[108px]",
+              "group flex min-h-24 min-w-0 flex-col items-center justify-center gap-2.5 rounded-[18px] bg-[color:var(--app-primary-surface)] px-3 py-3 text-center shadow-[0_1px_1px_rgba(0,0,0,0.035),0_8px_20px_rgba(0,0,0,0.045)] ring-1 ring-inset ring-[color:var(--app-separator)] transition-[background-color,box-shadow,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-card-surface-default-solid)] hover:shadow-[0_1px_2px_rgba(0,0,0,0.045),0_12px_26px_rgba(0,0,0,0.055)] active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-[104px]",
             )}
           >
             <span
               aria-hidden
               data-one-location-action-icon=""
               className={cn(
-                "inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[16px] transition-transform group-active:scale-95 [&_svg]:h-6 [&_svg]:w-6 [&_svg]:stroke-[2]",
+                "inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[16px] transition-transform group-active:scale-95 [&_svg]:h-6 [&_svg]:w-6 [&_svg]:stroke-2",
                 item.tone === "red"
-                  ? "bg-[color:var(--app-destructive-tint)] text-[color:var(--app-destructive)]"
-                  : "bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)]",
+                  ? "bg-[color:var(--app-destructive-tint)] text-[color:var(--app-destructive)] shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--app-destructive)_14%,transparent)]"
+                  : "bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent)] shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--app-accent)_12%,transparent)]",
               )}
             >
               {item.icon}
@@ -1689,7 +1706,7 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             <RowLabel
               as="span"
               className={cn(
-                "min-w-0 text-[14px] font-semibold leading-[18px] sm:text-[15px] sm:leading-5",
+                "min-w-0 text-[14px] font-semibold leading-[18px] tracking-[-0.01em] text-[color:var(--app-label)] sm:text-[15px] sm:leading-5",
                 item.tone === "red" && "text-[color:var(--app-destructive)]",
               )}
             >
@@ -1869,7 +1886,8 @@ function LocationDetailFlow({
               // One share is still one tap. The chevron only appears for a
               // person who genuinely has two, so nothing about the common case
               // grew a step.
-              const single = group.grants.length === 1 ? group.primaryGrant : null;
+              const single =
+                group.grants.length === 1 ? group.primaryGrant : null;
               return (
                 <SettingsRow
                   key={group.counterpartUserId}
@@ -1930,7 +1948,9 @@ function LocationDetailFlow({
                     ) : (
                       <ShareLanesDisclosure
                         expanded={expanded}
-                        onToggle={() => toggleLaneExpansion(group.counterpartUserId)}
+                        onToggle={() =>
+                          toggleLaneExpansion(group.counterpartUserId)
+                        }
                         controlsId={lanesId}
                         label={`Manage your shares with ${name}`}
                       />
@@ -1971,115 +1991,115 @@ function LocationDetailFlow({
                 Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
                 <div key={group.counterpartUserId} data-grant-id={grant.id}>
-                <SharedWithMeCard
-                  isSmsTriggered={Boolean(group.smsGrant)}
-                  name={ownerName}
-                  statusLine={
-                    multiLane
-                      ? `${group.grants.length} live shares`
-                      : grant.durationMode === "until_stopped"
-                        ? "Until stopped"
-                        : grant.expiresAt
-                          ? `Access until ${vm.formatDateTime(grant.expiresAt)}`
-                          : "Active"
-                  }
-                  shareLanes={
-                    multiLane ? (
-                      // One control per SHARE. The card's own Remove is a
-                      // single button, and with two shares behind one card it
-                      // could only ever drop one of them -- silently, since
-                      // nothing on screen would say which. `revoke_grant`
-                      // accepts the recipient as well as the owner (it records
-                      // the difference as `recipient_revoke`), so these are
-                      // real controls, not decoration.
-                      <div data-testid="one-location-received-share-lanes">
-                        <ShareLanesDisclosure
-                          expanded={lanesExpanded}
-                          onToggle={() =>
-                            toggleLaneExpansion(group.counterpartUserId)
-                          }
-                          controlsId={lanesId}
-                          label={`Show the shares ${ownerName} has with you`}
-                        />
-                        <div id={lanesId} hidden={!lanesExpanded}>
-                          <PersonShareLanes
-                            group={group}
-                            counterpartName={ownerName}
-                            formatEndsAt={vm.formatDateTime}
-                            action="remove"
-                            onStopGrant={vm.onStopGrant}
-                            revokingGrantId={vm.revokingGrantId}
+                  <SharedWithMeCard
+                    isSmsTriggered={Boolean(group.smsGrant)}
+                    name={ownerName}
+                    statusLine={
+                      multiLane
+                        ? `${group.grants.length} live shares`
+                        : grant.durationMode === "until_stopped"
+                          ? "Until stopped"
+                          : grant.expiresAt
+                            ? `Access until ${vm.formatDateTime(grant.expiresAt)}`
+                            : "Active"
+                    }
+                    shareLanes={
+                      multiLane ? (
+                        // One control per SHARE. The card's own Remove is a
+                        // single button, and with two shares behind one card it
+                        // could only ever drop one of them -- silently, since
+                        // nothing on screen would say which. `revoke_grant`
+                        // accepts the recipient as well as the owner (it records
+                        // the difference as `recipient_revoke`), so these are
+                        // real controls, not decoration.
+                        <div data-testid="one-location-received-share-lanes">
+                          <ShareLanesDisclosure
+                            expanded={lanesExpanded}
+                            onToggle={() =>
+                              toggleLaneExpansion(group.counterpartUserId)
+                            }
+                            controlsId={lanesId}
+                            label={`Show the shares ${ownerName} has with you`}
                           />
+                          <div id={lanesId} hidden={!lanesExpanded}>
+                            <PersonShareLanes
+                              group={group}
+                              counterpartName={ownerName}
+                              formatEndsAt={vm.formatDateTime}
+                              action="remove"
+                              onStopGrant={vm.onStopGrant}
+                              revokingGrantId={vm.revokingGrantId}
+                            />
+                          </div>
                         </div>
-                      </div>
-                    ) : null
-                  }
-                  previewExpanded={expanded}
-                  mapHref={point ? vm.mapLocationHref(point) : undefined}
-                  onView={() => onExpandGrant(grant)}
-                  onDismiss={() => onCollapseGrant(grant.id)}
-                  onRecenter={
-                    point ? () => recenterGrantViewport(grant.id) : undefined
-                  }
-                  // Suppressed for a person holding two shares: the card's
-                  // single Remove would silently act on only one of them, and
-                  // the breakdown above already carries one per share.
-                  onRemove={
-                    multiLane ? undefined : () => vm.onStopGrant(grant.id)
-                  }
-                  removeBusy={vm.revokingGrantId === grant.id}
-                  viewBusy={vm.busy === "view"}
-                  message={
-                    point?.checkIn?.message ?? grant.shareMessage ?? undefined
-                  }
-                  address={
-                    addressEntry?.status === "done" ? addressEntry.text : null
-                  }
-                  addressLoading={
-                    Boolean(point) && addressEntry?.status === "loading"
-                  }
-                  coordinatesFallback={
-                    point
-                      ? `${point.latitude.toFixed(5)}, ${point.longitude.toFixed(5)}`
-                      : undefined
-                  }
-                  // Only while there is nothing to look at. Once a point lands
-                  // it is the answer, and a leftover "waiting for their first
-                  // update" line under a live map would contradict it.
-                  viewStatus={
-                    point ? null : (vm.grantViewStatuses?.[grant.id] ?? null)
-                  }
-                  onAskReshare={() => vm.onAskReshare(grant)}
-                  askReshareBusy={vm.busy === "request"}
-                >
-                  {expanded && point
-                    ? vm.renderMapPreview(
-                        point,
-                        false,
-                        `${grant.id}:${grantViewportResetKeys[grant.id] ?? 0}`,
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => vm.onAskReshare(grant)}
-                          disabled={vm.busy === "request"}
-                          className="h-8 rounded-full border-amber-500/30 bg-white/70 px-3 text-[12px] font-semibold text-amber-800 hover:bg-white dark:border-amber-300/25 dark:bg-white/10 dark:text-amber-100 dark:hover:bg-white/15"
-                        >
-                          {vm.busy === "request" ? (
-                            <span
-                              className="mr-1.5 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
-                              aria-hidden="true"
-                            />
-                          ) : (
-                            <Send
-                              className="mr-1.5 h-3.5 w-3.5"
-                              aria-hidden="true"
-                            />
-                          )}
-                          Ask to refresh
-                        </Button>,
-                      )
-                    : null}
-                </SharedWithMeCard>
+                      ) : null
+                    }
+                    previewExpanded={expanded}
+                    mapHref={point ? vm.mapLocationHref(point) : undefined}
+                    onView={() => onExpandGrant(grant)}
+                    onDismiss={() => onCollapseGrant(grant.id)}
+                    onRecenter={
+                      point ? () => recenterGrantViewport(grant.id) : undefined
+                    }
+                    // Suppressed for a person holding two shares: the card's
+                    // single Remove would silently act on only one of them, and
+                    // the breakdown above already carries one per share.
+                    onRemove={
+                      multiLane ? undefined : () => vm.onStopGrant(grant.id)
+                    }
+                    removeBusy={vm.revokingGrantId === grant.id}
+                    viewBusy={vm.busy === "view"}
+                    message={
+                      point?.checkIn?.message ?? grant.shareMessage ?? undefined
+                    }
+                    address={
+                      addressEntry?.status === "done" ? addressEntry.text : null
+                    }
+                    addressLoading={
+                      Boolean(point) && addressEntry?.status === "loading"
+                    }
+                    coordinatesFallback={
+                      point
+                        ? `${point.latitude.toFixed(5)}, ${point.longitude.toFixed(5)}`
+                        : undefined
+                    }
+                    // Only while there is nothing to look at. Once a point lands
+                    // it is the answer, and a leftover "waiting for their first
+                    // update" line under a live map would contradict it.
+                    viewStatus={
+                      point ? null : (vm.grantViewStatuses?.[grant.id] ?? null)
+                    }
+                    onAskReshare={() => vm.onAskReshare(grant)}
+                    askReshareBusy={vm.busy === "request"}
+                  >
+                    {expanded && point
+                      ? vm.renderMapPreview(
+                          point,
+                          false,
+                          `${grant.id}:${grantViewportResetKeys[grant.id] ?? 0}`,
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => vm.onAskReshare(grant)}
+                            disabled={vm.busy === "request"}
+                            className="h-8 rounded-full border-amber-500/30 bg-white/70 px-3 text-[12px] font-semibold text-amber-800 hover:bg-white dark:border-amber-300/25 dark:bg-white/10 dark:text-amber-100 dark:hover:bg-white/15"
+                          >
+                            {vm.busy === "request" ? (
+                              <span
+                                className="mr-1.5 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <Send
+                                className="mr-1.5 h-3.5 w-3.5"
+                                aria-hidden="true"
+                              />
+                            )}
+                            Ask to refresh
+                          </Button>,
+                        )
+                      : null}
+                  </SharedWithMeCard>
                 </div>
               );
             })}
@@ -2495,7 +2515,8 @@ function PeopleHub({
                   data-testid="one-location-people-list"
                 >
                   {filtered.map((r, i) => {
-                    const shareGroup = ownerGroupsByUserId.get(r.userId) ?? null;
+                    const shareGroup =
+                      ownerGroupsByUserId.get(r.userId) ?? null;
                     const sharing = Boolean(shareGroup);
                     // One share is still one tap: the row keeps its single
                     // Stop and grows nothing. The breakdown appears only for a
@@ -3619,6 +3640,124 @@ function SelectionDot({ selected }: { selected: boolean }) {
   );
 }
 
+function RequestRecipientListRow({
+  name,
+  subtitle,
+  tone,
+  statusLabel,
+  selectable,
+  selected,
+  actionAriaLabel,
+  onSelect,
+  onEdit,
+  editActive,
+  onRemove,
+  removeAriaLabel,
+  removeBusy,
+  expandedContent,
+}: {
+  name: string;
+  subtitle?: string;
+  tone: "ready" | "pending" | "neutral";
+  statusLabel?: string;
+  selectable: boolean;
+  selected: boolean;
+  actionAriaLabel: string;
+  onSelect?: () => void;
+  onEdit?: () => void;
+  editActive?: boolean;
+  onRemove?: () => void;
+  removeAriaLabel?: string;
+  removeBusy?: boolean;
+  expandedContent?: ReactNode;
+}) {
+  const pillTone =
+    statusLabel === "Live"
+      ? "live"
+      : tone === "pending"
+        ? "pending"
+        : "neutral";
+
+  return (
+    <div
+      className={cn(
+        "min-w-0 bg-transparent",
+        selected && selectable && "bg-[color:var(--app-accent)]/5",
+      )}
+    >
+      <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
+        <ContactAvatar label={name} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+            {name}
+          </span>
+          {subtitle ? (
+            <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+              {subtitle}
+            </span>
+          ) : null}
+        </span>
+        <span className="flex shrink-0 items-center gap-2">
+          {statusLabel ? (
+            <StatusPill tone={pillTone} className="px-2 py-0 text-[12px]">
+              {statusLabel}
+            </StatusPill>
+          ) : null}
+          {onEdit ? (
+            <ShellActionSurface
+              variant="icon"
+              className="h-8 w-8 shrink-0"
+              aria-label={`${editActive ? "Cancel editing" : "Edit"} access for ${name}`}
+              aria-pressed={editActive}
+              onClick={onEdit}
+            >
+              <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+            </ShellActionSurface>
+          ) : null}
+          {onRemove ? (
+            <ShellActionSurface
+              variant="icon"
+              className="h-8 w-8 shrink-0 text-destructive"
+              aria-label={removeAriaLabel ?? `Remove ${name}'s access`}
+              onClick={onRemove}
+              disabled={removeBusy}
+            >
+              {removeBusy ? (
+                <Loader2
+                  className="h-3.5 w-3.5 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
+            </ShellActionSurface>
+          ) : null}
+          {selectable && onSelect ? (
+            <Button
+              size="sm"
+              onClick={onSelect}
+              aria-label={actionAriaLabel}
+              className={cn(
+                "h-8 shrink-0 rounded-full px-3 text-[13px] font-semibold",
+                selected
+                  ? "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+                  : "bg-[color:var(--app-secondary-system-fill)] text-foreground hover:bg-[color:var(--app-secondary-system-fill)]/80",
+              )}
+            >
+              {selected ? "Selected" : "Select"}
+            </Button>
+          ) : null}
+        </span>
+      </div>
+      {expandedContent ? (
+        <div className="border-t border-[color:var(--app-separator)] px-3.5 py-3">
+          {expandedContent}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 /* =================================================================== */
 /* ASK FLOW                                                             */
 /* =================================================================== */
@@ -3750,6 +3889,10 @@ function AskFlow({
       ),
     [filtered, lastInteraction, vm.recipientLabel, vm.recipientSearch],
   );
+  const rosterRecipientRows = useMemo(
+    () => rosterRows.filter((row) => row.kind === "recipient"),
+    [rosterRows],
+  );
 
   const receivedGroupsByOwner = useMemo(() => {
     const byOwner = new globalThis.Map<string, OneLocationGrantLaneGroup>();
@@ -3815,6 +3958,28 @@ function AskFlow({
     const timer = window.setInterval(() => setStatusNowMs(Date.now()), 30_000);
     return () => window.clearInterval(timer);
   }, [hasTimeRelativeRow]);
+
+  const isRequestFormValid = vm.selectedRequestOwnerIds.length > 0;
+  const sendingRequest = vm.busy === "request";
+  const sendRequest = () => {
+    // Never submit an incomplete form even if the click somehow reaches the
+    // handler (e.g. keyboard/AT), and never double-fire.
+    if (!isRequestFormValid || sendingRequest || sendInFlightRef.current)
+      return;
+    sendInFlightRef.current = true;
+    sentSelectionRef.current = vm.selectedRequestOwnerIds;
+    void (async () => {
+      try {
+        // Confirm only what actually happened: the banner appears on a
+        // resolved success, and a failure leaves the composer intact with its
+        // own error toast.
+        setJustSent(await vm.onSendRequest(reason));
+      } finally {
+        sendInFlightRef.current = false;
+      }
+    })();
+  };
+
   return (
     <div className="space-y-5">
       <TaskFlowHeader
@@ -3837,44 +4002,12 @@ function AskFlow({
         <AppSectionLabel as="h2">People</AppSectionLabel>
         <PersonSearchInput value={searchDraft} onChange={setSearchDraft} />
         {filtered.length ? (
-          /* Windowed above the picker's own threshold, plain DOM below it.
-             The rule is `shouldVirtualizeList`, imported rather than
-             re-implemented, so this list and the contact picker cannot drift
-             apart on where "too long to render whole" begins.
-
-             `presentation="cards"` because these rows are already cards: the
-             grouped shell would put a card inside a card and draw a divider
-             between two things that have their own edges. */
           <VirtualContactList
-            items={rosterRows}
+            items={rosterRecipientRows}
             getKey={(row) => row.key}
-            scrollClassName={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}
-            itemClassName="pb-2.5 last:pb-0"
-            presentation="cards"
             testId="one-location-ask-recipients"
             ariaLabel="People you can ask"
-            // A section heading is not one of the people. Taking it out of the
-            // list stops a screen reader announcing "Recent" as an entry.
-            getItemRole={(row) =>
-              row.kind === "header" ? "presentation" : undefined
-            }
             renderItem={(row) => {
-              // Headers ride the SAME windowed list as the rows, rather than a
-              // scroller per section: two capped scrollers stacked inside one
-              // screen is the shape this flow already rejected once.
-              if (row.kind === "header") {
-                return (
-                  // The screen's own section type, not a second one invented
-                  // here: "People" a few lines up is the same primitive.
-                  <AppSectionLabel
-                    as="h3"
-                    data-testid={`one-location-ask-section-${row.key}`}
-                    className="px-1 pt-1"
-                  >
-                    {row.title}
-                  </AppSectionLabel>
-                );
-              }
               const r = row.recipient;
               const selected = vm.selectedRequestOwnerIds.includes(r.userId);
               // Every row used to read "Ready for private sharing" with Select
@@ -3898,8 +4031,9 @@ function AskFlow({
               // nothing to do about that but wait it out or leave the screen
               // entirely to find the Shared with me / Requests sent list
               // that could end or shorten it.
-              const activeGrant =
-                receivedGroupsByOwner.get(r.userId)?.primaryGrant;
+              const activeGrant = receivedGroupsByOwner.get(
+                r.userId,
+              )?.primaryGrant;
               const isEditingThis =
                 Boolean(activeGrant) && vm.editingGrantId === activeGrant?.id;
               // The unanswered ask this row is reporting, if any. The row used
@@ -3908,23 +4042,21 @@ function AskFlow({
               const pendingRequestId = status.pendingRequestId;
               const recipientLabel = vm.recipientLabel(r);
               return (
-                <TrustedPersonCard
+                <RequestRecipientListRow
                   key={r.userId}
                   name={recipientLabel}
-                  subtitle={status.subtitle}
+                  subtitle={
+                    status.selectable && status.tone === "ready"
+                      ? undefined
+                      : status.subtitle
+                  }
                   tone={status.tone}
                   statusLabel={status.statusLabel}
-                  actionLabel={
-                    status.selectable
-                      ? selected
-                        ? "Selected"
-                        : "Select"
-                      : undefined
-                  }
+                  selectable={status.selectable}
                   actionAriaLabel={`${
                     selected ? "Deselect" : "Select"
                   } ${recipientLabel} for location request`}
-                  onAction={
+                  onSelect={
                     status.selectable
                       ? () => vm.toggleRequestOwner(r.userId, "ask_flow")
                       : undefined
@@ -3962,7 +4094,7 @@ function AskFlow({
                   }
                   expandedContent={
                     isEditingThis && activeGrant ? (
-                      <>
+                      <div className="space-y-3">
                         <DurationSelector
                           value={vm.editGrantDurationHours}
                           onChange={vm.setEditGrantDurationHours}
@@ -3983,7 +4115,7 @@ function AskFlow({
                         >
                           Save
                         </Button>
-                      </>
+                      </div>
                     ) : undefined
                   }
                 />
@@ -4045,6 +4177,7 @@ function AskFlow({
                public-link lanes later run Number() over, so a non-numeric
                sentinel here posts NaN to a `gt=0` field. */
             allowUntilStop={false}
+            rungs={REQUEST_DURATION_LADDER}
           />
           <ReasonChips
             value={reason}
@@ -4081,49 +4214,12 @@ function AskFlow({
               />
             </div>
           ) : null}
-        </div>
-      </SectionCard>
-
-      {/* Send is enabled once at least one recipient is chosen. Duration and
-          reason default to sensible values, so gating Send on them too (added
-          in #5108) blocked submitting even when the request was already valid;
-          that extra gating is intentionally removed here.
-
-          The button keeps the action accent in every state. Success is a status,
-          and it is already said twice — by the banner above and by each person's
-          row turning to "Asked" — so recolouring the primary action green said it
-          a third time and cost the screen its one action colour. */}
-      {(() => {
-        const isFormValid = vm.selectedRequestOwnerIds.length > 0;
-        const sending = vm.busy === "request";
-        return (
-          /**
-           * Pinned, because choosing someone and sending to them were never on
-           * screen together.
-           *
-           * Send sits after the roster, the duration ladder, the reason chips
-           * and the message box -- roughly a screen and a half below the person
-           * being picked. So the count travels with it: scrolling away from the
-           * roster used to lose the only place that said how many were chosen.
-           *
-           * `sticky`, not `fixed`. A fixed bar covers content and has to be
-           * paid for with page padding that is wrong at one end or the other.
-           * This one rides the page and settles into place at the bottom of the
-           * flow, so nothing is ever permanently underneath it.
-           *
-           * The offset is the app's own composed bottom inset plus the
-           * keyboard: on iOS the on-screen keyboard would otherwise sit over
-           * the action a person just reached for.
-           */
-          <div
-            data-testid="one-location-ask-send-bar"
-            className="sticky z-10 -mx-1 mt-1 space-y-2 rounded-2xl bg-[color:var(--app-card-surface-default-solid)] px-1 py-2"
-            style={{
-              bottom:
-                "calc(var(--app-bottom-inset, 0px) + var(--kb-height, 0px) + 0.5rem)",
-            }}
-          >
-            {isFormValid ? (
+          {/* Send is enabled once at least one recipient is chosen. Duration and
+              reason default to sensible values, so gating Send on them too would
+              block a valid request. It lives in the same card as the form so it
+              cannot cover Reason or the inline Other field. */}
+          <div data-testid="one-location-ask-send-bar" className="space-y-2">
+            {isRequestFormValid ? (
               <p
                 aria-live="polite"
                 data-testid="one-location-ask-selection-summary"
@@ -4134,34 +4230,18 @@ function AskFlow({
                   : `${vm.selectedRequestOwnerIds.length} people selected`}
               </p>
             ) : null}
-          <Button
-            onClick={() => {
-              // Never submit an incomplete form even if the click somehow
-              // reaches the handler (e.g. keyboard/AT), and never double-fire.
-              if (!isFormValid || sending || sendInFlightRef.current) return;
-              sendInFlightRef.current = true;
-              sentSelectionRef.current = vm.selectedRequestOwnerIds;
-              void (async () => {
-                try {
-                  // Confirm only what actually happened: the banner appears on a
-                  // resolved success, and a failure leaves the composer intact
-                  // with its own error toast.
-                  setJustSent(await vm.onSendRequest(reason));
-                } finally {
-                  sendInFlightRef.current = false;
-                }
-              })();
-            }}
-            disabled={!isFormValid || sending}
-            aria-disabled={!isFormValid || sending}
-            isLoading={sending}
-            className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
-          >
-            Send request
-          </Button>
+            <Button
+              onClick={sendRequest}
+              disabled={!isRequestFormValid || sendingRequest}
+              aria-disabled={!isRequestFormValid || sendingRequest}
+              isLoading={sendingRequest}
+              className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 disabled:pointer-events-none disabled:bg-black/10 disabled:text-black/35 disabled:opacity-100 dark:disabled:bg-white/10 dark:disabled:text-white/35"
+            >
+              Send request
+            </Button>
           </div>
-        );
-      })()}
+        </div>
+      </SectionCard>
 
       {justSent ? (
         <Button
@@ -4259,7 +4339,7 @@ function InviteFlow({
         <SectionCard>
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]">
-              <UserPlus className="h-5 w-5" />
+              <UserRoundPlus className="h-5 w-5" />
             </span>
             <div className="min-w-0 flex-1">
               <p className="text-base font-semibold text-foreground">

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/lib/utils";
 import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
 import { DurationWheelPicker } from "./duration-wheel-picker";
 import { DurationPresetPicker } from "./duration-presets";
+import type { DurationRung } from "./duration-presets";
 
 export const LOCATION_SEARCH_INPUT_CLASSNAME =
   "h-11 w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] pl-10 pr-4 text-base text-foreground outline-none transition-shadow placeholder:text-muted-foreground focus:ring-2 focus:ring-inset focus:ring-[color:var(--app-accent-ring)] [&::-webkit-search-cancel-button]:appearance-none";
@@ -50,6 +51,7 @@ export function DurationSelector({
   untilStopValue,
   allowUntilStop = true,
   maxWidthClassName = "max-w-[420px]",
+  rungs,
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -82,6 +84,8 @@ export function DurationSelector({
    * of sitting short inside its own card.
    */
   maxWidthClassName?: string | null;
+  /** Presets used by the visible ladder presentation. */
+  rungs?: DurationRung[];
 }) {
   const labelId = useId();
 
@@ -102,10 +106,7 @@ export function DurationSelector({
         // far apart they read.
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
           {label ? (
-            <p
-              id={labelId}
-              className="text-sm font-semibold text-foreground"
-            >
+            <p id={labelId} className="text-sm font-semibold text-foreground">
               {label}
             </p>
           ) : (
@@ -122,6 +123,7 @@ export function DurationSelector({
         <DurationPresetPicker
           value={value}
           onChange={onChange}
+          {...(rungs ? { rungs } : {})}
           allowUntilStop={allowUntilStop}
           labelledBy={label ? labelId : undefined}
           {...(untilStopValue ? { untilStopValue } : {})}
@@ -230,7 +232,8 @@ export function LocationTypeSelector({
               className={cn(
                 SUBCARD_SURFACE,
                 "flex items-center justify-between p-3.5 text-left transition-colors",
-                active && "border-[color:var(--app-accent)]/50 ring-1 ring-[color:var(--app-accent-ring)]",
+                active &&
+                  "border-[color:var(--app-accent)]/50 ring-1 ring-[color:var(--app-accent-ring)]",
               )}
             >
               <span>
@@ -262,10 +265,7 @@ export function LocationTypeSelector({
 }
 
 export type ReasonValue =
-  | "Safety check-in"
-  | "Meeting nearby"
-  | "Pick-up"
-  | "Other";
+  "Safety check-in" | "Meeting nearby" | "Pick-up" | "Other";
 
 export const REASON_CHIPS: ReasonValue[] = [
   "Safety check-in",
@@ -310,7 +310,11 @@ export function ReasonChips({
           >
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
-          <SelectContent align="start" position="popper" className="rounded-[14px]">
+          <SelectContent
+            align="start"
+            position="popper"
+            className="rounded-[14px]"
+          >
             {REASON_CHIPS.map((reason) => (
               <SelectItem key={reason} value={reason}>
                 {reason}


### PR DESCRIPTION
## Summary
- Restyle the Location menu Actions area into four premium tappable cards.
- Keep Share location, Request location, Check-In, and SMS handlers/routes unchanged.
- Update the Location page contract test to lock the new card anatomy.

## Verification
- npm run test -- --run __tests__/components/one-location-agent-page.test.tsx
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs
- npm run typecheck
- npm run test -- --run __tests__/components/one-location-agent-page.test.tsx -t "opens Circle member Share directly"
- npm run test -- --run __tests__/components/one-location-agent-page.test.tsx -t "requests native foreground permission"

## Note
- Full npm run verify:one-location was also attempted; it hit two suite-order/interference failures in one-location-agent-page.test.tsx, and both failing tests pass when isolated.