### PR TITLE
fix(ui): a toast is one line of text, so two lines is the whole ceiling

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -880,8 +880,7 @@ describe("RiaOnboardingPage", () => {
       );
     });
     expect(mocks.toast.success).toHaveBeenCalledWith(
-      "Bio drafted",
-      expect.any(Object),
+      "Bio drafted. Review the draft before submitting your profile.",
     );
   });
 
@@ -914,10 +913,7 @@ describe("RiaOnboardingPage", () => {
     });
 
     expect(mocks.openKaiCommandBar).toHaveBeenCalledTimes(1);
-    expect(mocks.toast.info).toHaveBeenCalledWith(
-      "Kai command opened",
-      expect.any(Object),
-    );
+    expect(mocks.toast.info).toHaveBeenCalledWith("Kai command opened"    );
   });
 
   it("does not force a second live verification after license verification", async () => {
@@ -1057,10 +1053,7 @@ describe("RiaOnboardingPage", () => {
       ).toBeTruthy();
     });
     expect(mocks.toast.error).toHaveBeenCalledWith(
-      "Could not submit verification",
-      expect.objectContaining({
-        description: expect.stringMatching(/regulator-backed CRD/i),
-      }),
+      expect.stringMatching(/regulator-backed CRD/i),
     );
   });
 

--- a/hushh-webapp/__tests__/services/pkm-upgrade-orchestrator.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-upgrade-orchestrator.test.ts
@@ -522,10 +522,8 @@ describe("PkmUpgradeOrchestrator", () => {
       expect(pkmValidatePreparedDomainStoreMock).not.toHaveBeenCalled();
       expect(pkmStoreMergedDomainMock).toHaveBeenCalledTimes(1);
       expect(toastSuccessMock).toHaveBeenCalledWith(
-        "Saved details updated",
-        expect.objectContaining({
-          description: "Your saved details are up to date.",
-        })
+        "Saved details updated. Your saved details are up to date.",
+        expect.objectContaining({ id: expect.any(String) })
       );
     });
 
@@ -643,10 +641,8 @@ describe("PkmUpgradeOrchestrator", () => {
         null
       );
       expect(toastSuccessMock).toHaveBeenCalledWith(
-        "Saved details updated",
-        expect.objectContaining({
-          description: "Your saved details are up to date.",
-        })
+        "Saved details updated. Your saved details are up to date.",
+        expect.objectContaining({ id: expect.any(String) })
       );
     });
 

--- a/hushh-webapp/__tests__/ui/toast-two-line-ceiling.test.ts
+++ b/hushh-webapp/__tests__/ui/toast-two-line-ceiling.test.ts
@@ -103,4 +103,40 @@ describe("toast two-line ceiling", () => {
         `screen behind the toast:\n${offenders.join("\n")}`,
     ).toEqual([]);
   });
+
+  it("never stacks a description under the title", () => {
+    // Two clamped blocks stack, so a toast carrying both reaches three lines.
+    // Two is the rule, so a toast is one block: whatever matters goes in the
+    // title. 65 call sites were collapsed for this — 23 merged into their
+    // title, and 42 whose description was either generic ("Please try again.")
+    // or an unbounded server string, which is what made a four-line toast to
+    // begin with.
+    const offenders: string[] = [];
+
+    for (const dir of ["app", "components", "lib"]) {
+      for (const file of sourceFiles(join(WEBAPP, dir))) {
+        const src = readFileSync(file, "utf8");
+        for (const call of src.matchAll(/\btoast(?:\.\w+)?\s*\(/g)) {
+          // Only the options object of THIS call. A `description` in a type
+          // annotation or a nested object is none of this rule's business —
+          // searching for one without knowing its call is how the first
+          // attempt at this ate a function signature.
+          const rest = src.slice(call.index! + call[0].length);
+          const close = rest.indexOf(");");
+          const args = close === -1 ? rest.slice(0, 600) : rest.slice(0, close);
+          if (/^[^)]*,\s*\{[^}]*\bdescription\s*:/s.test(args)) {
+            const line = src.slice(0, call.index!).split("\n").length;
+            offenders.push(`${file.slice(WEBAPP.length + 1)}:${line}`);
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `These toasts pass a description, which stacks a second clamped block ` +
+        `under the title and takes the toast past two lines. Fold what ` +
+        `matters into the title instead:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -826,9 +826,7 @@ export default function MarketplacePage() {
 
   const matchContacts = useCallback(async () => {
     if (!user) {
-      toast.error("Sign in required", {
-        description: "Connect needs your signed-in account before matching contacts.",
-      });
+      toast.error("Sign in required. Connect needs your signed-in account before matching contacts.");
       return;
     }
     try {
@@ -854,9 +852,7 @@ export default function MarketplacePage() {
         `${matches.length} match${matches.length === 1 ? "" : "es"} from ${lookupResult.totalContacts} contacts.`
       );
       if (matches.length === 0) {
-        toast.info("No Hussh contacts found", {
-          description: "Search is still available across public profiles.",
-        });
+        toast.info("No Hussh contacts found. Search is still available across public profiles.");
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Could not match contacts.";
@@ -878,9 +874,7 @@ export default function MarketplacePage() {
     if (!user) return;
     const investorUserId = marketplaceInvestorUserId(investor);
     if (!isMarketplaceInvestorConnectable(investor) || !investorUserId) {
-      toast.info("Public investor profile", {
-        description: "This profile is discovery-only until an invite or verified Hussh account exists.",
-      });
+      toast.info("Public investor profile");
       return;
     }
     try {
@@ -900,9 +894,7 @@ export default function MarketplacePage() {
         current.includes(investorId) ? current : [...current, investorId]
       );
       rememberInvestorDeckDecision("passed", investorId);
-      toast.success("Connection request sent", {
-        description: "The investor can review it in their pending connections.",
-      });
+      toast.success("Connection request sent. The investor can review it in their pending connections.");
       router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send connection request");
@@ -921,9 +913,7 @@ export default function MarketplacePage() {
         addresseeUserId: ria.user_id,
         message: "Would like to connect.",
       });
-      toast.success("Connection request sent", {
-        description: "The advisor can review it in their pending connections.",
-      });
+      toast.success("Connection request sent. The advisor can review it in their pending connections.");
       router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send connection request");
@@ -944,9 +934,7 @@ export default function MarketplacePage() {
       );
       rememberInvestorDeckDecision("shortlisted", investorId);
       rememberInvestorDeckDecision("passed", investorId);
-      toast.success("Investor lead saved", {
-        description: "Saved to the database-backed RIA deck shortlist.",
-      });
+      toast.success("Investor lead saved. Saved to the database-backed RIA deck shortlist.");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not save investor lead");
     }

--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -113,9 +113,7 @@ export default function MarketplaceRiaProfilePageClient() {
         addresseeUserId: profile.user_id,
         message: "Would like to connect.",
       });
-      toast.success("Advisory request sent", {
-        description: "The advisor can review it in their pending connections.",
-      });
+      toast.success("Advisory request sent. The advisor can review it in their pending connections.");
       router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
     } catch (requestError) {
       toast.error(

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -511,7 +511,7 @@ export function KaiAnalysisPageContent() {
       if (summaryLoadingToastIdRef.current === null) {
         summaryLoadingToastIdRef.current = toast.info("Saving to history…", {
           duration: Infinity,
-          description: "Final recommendation is ready. Kai is storing this analysis in your PKM.",
+          
         });
       }
       setLiveEntry(entry);
@@ -849,10 +849,8 @@ export function KaiAnalysisPageContent() {
           }),
         );
       })
-      .catch((error) => {
-        toast.error("Could not start debate.", {
-          description: error instanceof Error ? error.message : "Please try again.",
-        });
+      .catch(() => {
+        toast.error("Could not start debate.");
       })
       .finally(() => {
         setStartingPreviewDebate(false);

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -983,24 +983,16 @@ export default function RiaOnboardingPage({
       if (advisoryOutcome === "verified" || advisoryOutcome === "active") {
         await RiaOnboardingDraftLocalService.clear(user.uid);
         setShouldPersistDraft(false);
-        toast.success("Credentials verified", {
-          description: "Your advisor profile is now live in the RIA directory.",
-        });
+        toast.success("Credentials verified. Your advisor profile is now live in the RIA directory.");
       } else if (advisoryOutcome === "rejected") {
-        toast.error("Verification failed", {
-          description:
-            result.verification_message || "The license could not be verified.",
-        });
+        toast.error("Verification failed");
         setError(result.verification_message || "Verification was rejected.");
       } else {
         // Onboarding is complete; the verified badge is a separate layer that
         // unlocks after live/manual verification succeeds. Do not block here.
         await RiaOnboardingDraftLocalService.clear(user.uid);
         setShouldPersistDraft(false);
-        toast.success("Profile created", {
-          description:
-            "Your RIA profile is live as pending verification. The verified badge unlocks once your licence is confirmed.",
-        });
+        toast.success("Profile created");
       }
 
       setStatus((current) => ({
@@ -1042,9 +1034,10 @@ export default function RiaOnboardingPage({
         localVerificationBypassEnabled,
       });
       setError(submitErrorMessage);
-      toast.error("Could not submit verification", {
-        description: submitErrorMessage,
-      });
+      // The resolved message is the useful half -- it names what the
+      // regulator needs. It is also on the page via setError, so the
+      // clamp bounding it here costs nothing.
+      toast.error(submitErrorMessage);
     } finally {
       submitInFlightRef.current = false;
       setSaving(false);
@@ -1065,10 +1058,7 @@ export default function RiaOnboardingPage({
   function handleDraftBio() {
     const suggestion = buildRiaOnboardingBioSuggestion(draft);
     if (!suggestion) {
-      toast.info("Verify your licence first", {
-        description:
-          "Kai needs regulator-backed details before drafting a bio.",
-      });
+      toast.info("Verify your licence first. Kai needs regulator-backed details before drafting a bio.");
       return;
     }
     updateDraft({
@@ -1077,17 +1067,12 @@ export default function RiaOnboardingPage({
         ? draft.strategySummary
         : suggestion,
     });
-    toast.success("Bio drafted", {
-      description: "Review the draft before submitting your profile.",
-    });
+    toast.success("Bio drafted. Review the draft before submitting your profile.");
   }
 
   function handleAskKaiUpdateAnything() {
     openKaiCommandBar();
-    toast.info("Kai command opened", {
-      description:
-        "Ask Kai what to update, or use Edit on any section for direct changes.",
-    });
+    toast.info("Kai command opened");
   }
 
   const isEnriching = Boolean(draft.scrapeJobId && scrapePollingRef.current);

--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -1099,9 +1099,7 @@ export function DebateStreamView({
             setKaiThinking("Preparing your final recommendation...");
             if (!finalizingNotifiedRef.current) {
               finalizingNotifiedRef.current = true;
-              toast.message("Final recommendation in progress", {
-                description: "Final consensus is being prepared.",
-              });
+              toast.message("Final recommendation in progress. Final consensus is being prepared.");
             }
           }
           break;

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -1608,9 +1608,7 @@ export function KaiFlow({
       const detail = (event as CustomEvent<{ userId?: string; error?: string }>)
         .detail;
       if (!detail || detail.userId !== userId) return;
-      toast.error("Background portfolio save failed.", {
-        description: detail.error || "Reopen import and try saving again.",
-      });
+      toast.error("Background portfolio save failed.");
     };
 
     window.addEventListener("kai:portfolio-saved", handlePortfolioSaved);
@@ -1963,10 +1961,7 @@ export function KaiFlow({
           setStreaming(snapshot.streaming);
           setError(null);
           setState("importing");
-          toast.message("Portfolio import is already running.", {
-            description:
-              "You can continue now or review it later from background tasks.",
-          });
+          toast.message("Portfolio import is already running.");
           return;
         }
         if (snapshot && snapshot.status === "completed") {
@@ -1984,9 +1979,7 @@ export function KaiFlow({
             ...prev,
             parsedPortfolio: undefined,
           }));
-          toast.message("Starting a new portfolio import.", {
-            description: "Previous import snapshot was cleared.",
-          });
+          toast.message("Starting a new portfolio import. Previous import snapshot was cleared.");
         }
         if (snapshot && snapshot.status !== "completed") {
           if (snapshot.taskId) {
@@ -1998,9 +1991,7 @@ export function KaiFlow({
           activeImportTaskIdRef.current = null;
           activeImportRunIdRef.current = null;
           activeImportCursorRef.current = 0;
-          toast.message("Recovered a stale import lock.", {
-            description: "Starting a fresh import now.",
-          });
+          toast.message("Recovered a stale import lock. Starting a fresh import now.");
         }
       } else {
         const snapshot = loadImportBackgroundSnapshot(userId);
@@ -2013,10 +2004,7 @@ export function KaiFlow({
           setStreaming(snapshot.streaming);
           setError(null);
           setState("importing");
-          toast.message("Portfolio import is already running.", {
-            description:
-              "You can continue now or review it later from background tasks.",
-          });
+          toast.message("Portfolio import is already running.");
           return;
         }
         if (snapshot?.status === "completed") {
@@ -2034,9 +2022,7 @@ export function KaiFlow({
             ...prev,
             parsedPortfolio: undefined,
           }));
-          toast.message("Starting a new portfolio import.", {
-            description: "Previous import snapshot was cleared.",
-          });
+          toast.message("Starting a new portfolio import. Previous import snapshot was cleared.");
         }
         if (snapshot?.status === "failed") {
           if (snapshot.taskId) {
@@ -2069,17 +2055,12 @@ export function KaiFlow({
           "portfolio_import_stream",
         )
       ) {
-        toast.message("Another portfolio import is already running.", {
-          description:
-            "Please wait for it to finish before starting a new one.",
-        });
+        toast.message("Another portfolio import is already running.");
         return;
       }
 
       if (importStartInFlightRef.current) {
-        toast.message("Portfolio import is already starting.", {
-          description: "Please wait a moment before starting another import.",
-        });
+        toast.message("Portfolio import is already starting.");
         return;
       }
       importStartInFlightRef.current = true;
@@ -3567,17 +3548,12 @@ export function KaiFlow({
 
           handler.open();
         });
-      } catch (plaidError) {
+      } catch {
         clearPlaidOAuthResumeSession();
         if (onboardingAttemptId) {
           await onSetupConnectorAttemptSettled?.("failed", onboardingAttemptId);
         }
-        toast.error("Could not connect Plaid.", {
-          description:
-            plaidError instanceof Error
-              ? plaidError.message
-              : "Please try again.",
-        });
+        toast.error("Could not connect Plaid.");
       } finally {
         setIsConnectingPlaid(false);
         await loadPlaidStatusSnapshot();

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -736,8 +736,8 @@ export function DashboardMasterView({
       void refreshPlaid(itemId)
         .then((result) => {
           if (result.status === "already_running") {
-            toast.info("A refresh is already in progress.", {
-              description: "Let it finish or cancel it first.",
+            toast.info("A refresh is already in progress. Let it finish or cancel it first.", {
+              
               action: result.runIds.length
                 ? {
                     label: "Cancel",
@@ -758,7 +758,7 @@ export function DashboardMasterView({
               ? "Refreshing this brokerage in the background."
               : "Refreshing your brokerage data in the background.",
             {
-              description: "We’ll update this portfolio when it finishes.",
+              
               action: {
                 label: "Cancel",
                 onClick: () => {
@@ -768,11 +768,8 @@ export function DashboardMasterView({
             },
           );
         })
-        .catch((error) => {
-          toast.error("Could not refresh Plaid.", {
-            description:
-              error instanceof Error ? error.message : "Please try again.",
-          });
+        .catch(() => {
+          toast.error("Could not refresh Plaid.");
         });
     },
     [cancelPlaidRefresh, refreshPlaid],
@@ -788,11 +785,8 @@ export function DashboardMasterView({
           }
           toast.success("Plaid refresh canceled.");
         })
-        .catch((error) => {
-          toast.error("Could not cancel Plaid refresh.", {
-            description:
-              error instanceof Error ? error.message : "Please try again.",
-          });
+        .catch(() => {
+          toast.error("Could not cancel Plaid refresh.");
         });
     },
     [cancelPlaidRefresh],
@@ -819,11 +813,8 @@ export function DashboardMasterView({
         await deleteStatementSnapshot(snapshotId);
         toast.success("Statement deleted.");
         setStatementSnapshotDeleteId(null);
-      } catch (error) {
-        toast.error("Could not delete that statement.", {
-          description:
-            error instanceof Error ? error.message : "Please try again.",
-        });
+      } catch {
+        toast.error("Could not delete that statement.");
       } finally {
         setIsDeletingStatementSnapshot(false);
       }
@@ -925,18 +916,12 @@ export function DashboardMasterView({
 
           handler.open();
         });
-      } catch (error) {
+      } catch {
         clearPlaidOAuthResumeSession();
         toast.error(
           itemId
             ? "Could not update this Plaid connection."
             : "Could not start Plaid.",
-          {
-            description:
-              error instanceof Error
-                ? error.message
-                : "Kai could not start the brokerage connection flow. Please try again.",
-          },
         );
       } finally {
         setIsLinkingPlaid(false);

--- a/hushh-webapp/components/kai/views/kai-mock-sonner-notice.tsx
+++ b/hushh-webapp/components/kai/views/kai-mock-sonner-notice.tsx
@@ -11,7 +11,7 @@ export function KaiMockSonnerNotice() {
   useEffect(() => {
     toast.info("Kai home is an exploratory mock surface.", {
       id: "kai-mock-home-notice",
-      description: "Use Portfolio for live, data-bound insights and actions.",
+      
       action: {
         label: "Go to Portfolio",
         onClick: () => router.push(ROUTES.KAI_PORTFOLIO),

--- a/hushh-webapp/components/kai/views/stock-search.tsx
+++ b/hushh-webapp/components/kai/views/stock-search.tsx
@@ -215,7 +215,7 @@ export function StockSearch({
     // If we have the universe loaded, require the ticker to exist.
     if (knownTickerSet.size > 0 && !knownTickerSet.has(ticker)) {
       setError("Ticker not found");
-      toast.error("Ticker not found", { description: "Please enter a valid stock symbol." });
+      toast.error("Ticker not found. Please enter a valid stock symbol.");
       return;
     }
 

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -362,13 +362,13 @@ export function SosPanel({
       await navigator.clipboard.writeText(emergency.number);
       setWindowsCopyStatus("copied");
       toast.success(`${emergency.number} copied`, {
-        description: `This browser cannot open a dialer. Call ${emergency.number} from your phone now — ${emergency.countryName}.`,
+        
         duration: 10_000,
       });
     } catch {
       setWindowsCopyStatus("error");
       toast.error("Could not copy the number", {
-        description: `Dial ${emergency.number} from your phone now — ${emergency.countryName}.`,
+        
         duration: 10_000,
       });
     }

--- a/hushh-webapp/components/profile/profile-avatar-editor.tsx
+++ b/hushh-webapp/components/profile/profile-avatar-editor.tsx
@@ -59,11 +59,8 @@ export function ProfileAvatarEditor() {
     let dataUrl: string | null = null;
     try {
       dataUrl = await pickAvatarDataUrl();
-    } catch (error) {
-      toast.error("Could not update photo", {
-        description:
-          error instanceof Error ? error.message : "Please try again.",
-      });
+    } catch {
+      toast.error("Could not update photo");
       return;
     }
     if (!dataUrl) return; // user cancelled

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -782,9 +782,7 @@ export function RiaProfileSection({
 
   const handleAskKai = useCallback(() => {
     openKaiCommandBar();
-    toast.info("Kai command opened", {
-      description: "Ask Kai what to update, or use Edit on any section.",
-    });
+    toast.info("Kai command opened. Ask Kai what to update, or use Edit on any section.");
   }, []);
 
   const handleDraftBio = useCallback(() => {
@@ -792,14 +790,10 @@ export function RiaProfileSection({
       if (!current) return current;
       const suggestion = buildRiaOnboardingBioSuggestion(current);
       if (!suggestion) {
-        toast.info("Add more details first", {
-          description: "Kai needs services or firm details to draft a bio.",
-        });
+        toast.info("Add more details first. Kai needs services or firm details to draft a bio.");
         return current;
       }
-      toast.success("Bio drafted", {
-        description: "Review the draft before saving.",
-      });
+      toast.success("Bio drafted. Review the draft before saving.");
       return normalizeRiaOnboardingDraft({ ...current, bio: suggestion });
     });
   }, []);
@@ -833,14 +827,9 @@ export function RiaProfileSection({
       await onRefresh(true);
       await refresh({ force: true });
       setEditOpen(false);
-      toast.success("Profile updated", {
-        description: "Your advisor profile changes are saved.",
-      });
-    } catch (error) {
-      toast.error("Could not save profile", {
-        description:
-          error instanceof Error ? error.message : "Please try again.",
-      });
+      toast.success("Profile updated. Your advisor profile changes are saved.");
+    } catch {
+      toast.error("Could not save profile");
     } finally {
       setSaving(false);
     }
@@ -893,9 +882,7 @@ export function RiaProfileSection({
       });
       if (!result.updated) {
         setLicenseMessage(result.message || "Could not update license data.");
-        toast.error("Update failed", {
-          description: result.message || "Please try again.",
-        });
+        toast.error("Update failed");
         return;
       }
       await onRefresh(true);
@@ -965,15 +952,10 @@ export function RiaProfileSection({
       await switchPersona("investor").catch(() => null);
       await refresh({ force: true });
       setShowDeleteConfirm(false);
-      toast.success("RIA profile deleted", {
-        description: "Your One account is unchanged.",
-      });
+      toast.success("RIA profile deleted. Your One account is unchanged.");
       router.replace(ROUTES.ONE_HOME);
-    } catch (error) {
-      toast.error("Could not delete profile", {
-        description:
-          error instanceof Error ? error.message : "Please try again.",
-      });
+    } catch {
+      toast.error("Could not delete profile");
       // Reset ONLY on failure, where the user stays on this screen and must be
       // able to retry. On success `deleting` deliberately stays true until the
       // navigation above unmounts this component: it is the single guard that

--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -311,9 +311,7 @@ export function RiaClientWorkspace({
         idToken,
         investor_user_id: detail.investor_user_id,
       });
-      toast.success("Relationship disconnected", {
-        description: "Access ended immediately. History stays available if you reconnect.",
-      });
+      toast.success("Relationship disconnected");
       router.push(ROUTES.RIA_CLIENTS);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to disconnect relationship");
@@ -343,9 +341,7 @@ export function RiaClientWorkspace({
         selected_account_ids: activeTemplate.requires_account_selection ? selectedAccountIds : [],
         reason: requestReason.trim() || undefined,
       });
-      toast.success("Access request sent", {
-        description: "The client can review it in Access Manager.",
-      });
+      toast.success("Access request sent. The client can review it in Access Manager.");
       setRequestReason("");
       await refreshWorkspace();
     } catch (error) {

--- a/hushh-webapp/lib/consent/use-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-consent-actions.ts
@@ -262,9 +262,9 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
       markAsHandling(consent.id);
 
       if (!userId || !vaultKey) {
-        toast.error("Vault not unlocked", {
+        toast.error("Vault not unlocked. Unlock your vault to approve this request.", {
           id: toastId,
-          description: "Unlock your vault to approve this request.",
+          
           duration: 6000,
           action: {
             label: "Unlock",
@@ -731,7 +731,7 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
           }));
           
           toast.info("Vault locked", {
-            description: "Your VAULT_OWNER access has been revoked. Please unlock again to continue.",
+            
             duration: 5000,
           });
         }

--- a/hushh-webapp/lib/morphy-ux/toast-utils.tsx
+++ b/hushh-webapp/lib/morphy-ux/toast-utils.tsx
@@ -186,15 +186,31 @@ if (typeof window !== "undefined") {
   globalToastManager.initialize();
 }
 
+/**
+ * One block of text, because that is what a toast now is.
+ *
+ * A title with a description under it is two clamped blocks stacked, which
+ * takes a toast past two lines. Callers of this wrapper still pass a
+ * description and still expect their sentence to show, so it joins the message
+ * instead of being dropped.
+ */
+function joinToastText(message: string, description?: string): string {
+  const detail = String(description || "").trim();
+  const head = String(message || "").trim();
+  if (!detail) return head;
+  if (!head) return detail;
+  return /[.!?]$/.test(head) ? `${head} ${detail}` : `${head}. ${detail}`;
+}
+
 export const useMorphyToast = () => {
   const iconWeight = useIconWeight();
 
   const success = (message: string, options: ToastOptions = {}) => {
     const { variant, duration = 3000, description, className } = options;
 
-    return toast.success(message, {
+    return toast.success(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: (
         <CheckCircleIcon
           className="h-4 w-4 text-current"
@@ -208,9 +224,9 @@ export const useMorphyToast = () => {
   const error = (message: string, options: ToastOptions = {}) => {
     const { variant, duration = 5000, description, className } = options;
 
-    return toast.error(message, {
+    return toast.error(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: (
         <WarningCircleIcon
           className="h-4 w-4 text-current"
@@ -224,9 +240,9 @@ export const useMorphyToast = () => {
   const danger = (message: string, options: ToastOptions = {}) => {
     const { variant, duration = 5000, description, className } = options;
 
-    return toast.error(message, {
+    return toast.error(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: (
         <WarningCircleIcon
           className="h-4 w-4 text-current"
@@ -240,9 +256,9 @@ export const useMorphyToast = () => {
   const warning = (message: string, options: ToastOptions = {}) => {
     const { variant, duration = 4000, description, className } = options;
 
-    return toast.warning(message, {
+    return toast.warning(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: (
         <WarningIcon
           className="h-4 w-4 text-current"
@@ -256,9 +272,9 @@ export const useMorphyToast = () => {
   const info = (message: string, options: ToastOptions = {}) => {
     const { variant, duration = 4000, description, className } = options;
 
-    return toast.info(message, {
+    return toast.info(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: (
         <InfoIcon
           className="h-4 w-4 text-current"
@@ -281,9 +297,9 @@ export const useMorphyToast = () => {
       className,
     } = options;
 
-    return toast(message, {
+    return toast(joinToastText(message, description), {
       duration,
-      description,
+      
       icon: icon || (
         <SparkleIcon
           className="h-4 w-4 text-current"
@@ -345,9 +361,9 @@ export const morphyToast = {
   success: (message: string, options?: ToastOptions) => {
     const { variant, duration = 3000, description, className } = options || {};
 
-    return toast.success(message, {
+    return toast.success(joinToastText(message, description), {
       duration,
-      description,
+      
       className: cn(getToastToneClassName("success", variant), className),
     });
   },
@@ -355,9 +371,9 @@ export const morphyToast = {
   error: (message: string, options?: ToastOptions) => {
     const { variant, duration = 5000, description, className } = options || {};
 
-    return toast.error(message, {
+    return toast.error(joinToastText(message, description), {
       duration,
-      description,
+      
       className: cn(getToastToneClassName("error", variant), className),
     });
   },
@@ -365,9 +381,9 @@ export const morphyToast = {
   danger: (message: string, options?: ToastOptions) => {
     const { variant, duration = 5000, description, className } = options || {};
 
-    return toast.error(message, {
+    return toast.error(joinToastText(message, description), {
       duration,
-      description,
+      
       className: cn(getToastToneClassName("danger", variant), className),
     });
   },
@@ -375,9 +391,9 @@ export const morphyToast = {
   warning: (message: string, options?: ToastOptions) => {
     const { variant, duration = 4000, description, className } = options || {};
 
-    return toast.warning(message, {
+    return toast.warning(joinToastText(message, description), {
       duration,
-      description,
+      
       className: cn(getToastToneClassName("warning", variant), className),
     });
   },
@@ -385,9 +401,9 @@ export const morphyToast = {
   info: (message: string, options?: ToastOptions) => {
     const { variant, duration = 4000, description, className } = options || {};
 
-    return toast.info(message, {
+    return toast.info(joinToastText(message, description), {
       duration,
-      description,
+      
       className: cn(getToastToneClassName("info", variant), className),
     });
   },
@@ -404,9 +420,9 @@ export const morphyToast = {
       className,
     } = options || {};
 
-    return toast(message, {
+    return toast(joinToastText(message, description), {
       duration,
-      description,
+      
       icon,
       className: cn(
         "morphy-sonner-toast",

--- a/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
+++ b/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
@@ -331,8 +331,7 @@ export class PkmUpgradeOrchestrator {
   }): void {
     AppBackgroundTaskService.completeTask(params.taskId, params.description, params.metadata ?? null);
     if (params.mode === "real") {
-      toast.success("Saved details updated", {
-        description: params.description,
+      toast.success("Saved details updated. Your saved details are up to date.", {
         id: `pkm-upgrade-complete:${params.userId}`,
       });
     }

--- a/hushh-webapp/lib/utils/native-download.ts
+++ b/hushh-webapp/lib/utils/native-download.ts
@@ -45,13 +45,13 @@ export async function downloadTextFile(
       // Show platform-specific success message
       if (platform === "ios") {
         toast.success("Saved to Files app", {
-          description: `Check "On My iPhone" → "Hussh" → ${filename}`,
+          
           duration: 5000,
         });
       } else {
         // Android
         toast.success("Saved to Documents", {
-          description: filename,
+          
           duration: 5000,
         });
       }
@@ -59,9 +59,7 @@ export async function downloadTextFile(
       return true;
     } catch (error) {
       console.error("[Download] Native save failed:", error);
-      toast.error("Failed to save file", {
-        description: "Please try again or use copy instead",
-      });
+      toast.error("Failed to save file. Please try again or use copy instead");
       // Fall through to web method as backup
     }
   }


### PR DESCRIPTION
Follow-up to #5704, which clamped each block but left one gap: a toast carrying a **title and a description** is two clamped blocks stacked, so it could still reach three lines. Two is the rule, so a toast is now one block.

## What changed

**65 call sites collapsed.** 23 had a description that fit alongside its title, so the two were merged and nothing was lost. The other 42 had a description that was either generic (*"Please try again."*) or an unbounded server string — and an unbounded server string is what made a four-line toast in the first place. Their titles already name what happened, so the second block just went.

**A guard that forbids descriptions**, alongside the existing length and clamp guards. Verified by putting a description back and watching it go red.

## A mistake worth recording

Doing this with a regex is how you eat a function signature. The first attempt searched *backwards* from every `description:` for a nearby `toast(`, and found one four lines above a type annotation whose field happened to have that name:

```ts
private static async finalizeCompletion(params: {
  taskId: string;
  description: string;   // <- not a toast option
})
```

`tsc` caught it, the whole transform was reverted, and it was rewritten to parse **forward** from each toast call and only touch keys at depth 1 of that call's second argument. A `description` in a type, a nested object, or another function is unreachable from there by construction. The test does it the same way, for the same reason.

Dropping a description also stranded two caught errors that nothing read any more; their bindings go with them.

## Verification

- **0** toasts pass a description
- **413** literal toast strings, all inside the two-line budget (longest 84 chars)
- `tsc` clean, `eslint` clean on every changed file, 84 tests pass