### PR TITLE
feat(connect): offer an invite when a search finds nobody

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   searchDirectory: vi.fn(),
@@ -13,6 +13,9 @@ const mocks = vi.hoisted(() => ({
   searchInformationScopes: vi.fn(),
   onConnectionCapabilityMutated: vi.fn(),
   routerPush: vi.fn(),
+  shareLink: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
   // The real hook hands back the same user across renders. Rebuilding it per
   // render would retrigger every effect keyed on it and spin forever, which
   // would say nothing about the page.
@@ -63,10 +66,22 @@ vi.mock("@/components/connect/nearby-directories", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
 
+// The ladder itself (native sheet -> Web Share -> clipboard) is proved in
+// __tests__/share/share-link.test.ts. What belongs here is the page's half of
+// the contract: when an invite is offered, and what it hands over.
+vi.mock("@/lib/share/share-link", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/share/share-link")>(
+      "@/lib/share/share-link",
+    );
+  return { ...actual, shareLink: mocks.shareLink };
+});
+
 import ConnectPageClient from "@/app/connect/page-client";
+import { ShareUnavailableError } from "@/lib/share/share-link";
 import { resolveLocalOnboardingHandler } from "@/lib/agent/local-onboarding-actions";
 import { parseVoiceCard, parseVoiceConfirm } from "@/lib/voice/voice-action-card";
 
@@ -1180,5 +1195,223 @@ describe("Connect — the phone-width geometry QA reported", () => {
     );
     // Not a single bare verb: the label has to carry the plural.
     expect(toggle.textContent!.split(/\s+/).length).toBeGreaterThan(1);
+  });
+});
+
+describe("Connect — inviting someone who is not on One yet", () => {
+  // jsdom serves the page from http://localhost, which is exactly the origin a
+  // recipient cannot open, so the build origin stands in for it here the same
+  // way it does inside the iOS and Android shells.
+  const REAL_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://one.hushh.ai";
+    mocks.shareLink.mockResolvedValue("native-share");
+  });
+
+  afterEach(() => {
+    if (REAL_APP_URL === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = REAL_APP_URL;
+  });
+
+  async function searchForNobody(query = "Bob Kanjilal") {
+    mocks.searchDirectory.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: query },
+    });
+    return screen.findByText(`No one matches "${query}"`);
+  }
+
+  it("offers an invite instead of stopping at the dead end", async () => {
+    // The whole point of the issue: "No one matches" is a true statement and
+    // an unhelpful one, because the likeliest reason a name is missing is that
+    // the person has not joined.
+    await searchForNobody();
+
+    expect(await screen.findByText("Invite them to One")).toBeTruthy();
+    expect(
+      screen.getByText("Send them the app. You can connect once they join."),
+    ).toBeTruthy();
+  });
+
+  it("leaves the no-results row inert, so only the invite is tappable", async () => {
+    // "No one matches Bob" states a fact. Making it a control would mean
+    // tapping a sentence to do something it does not describe.
+    const row = await searchForNobody();
+    const factRow = row.closest("[data-testid='settings-row']");
+    expect(factRow).toBeTruthy();
+    expect(factRow?.querySelector("button")).toBeNull();
+  });
+
+  it("shares the app itself, with nothing attached to it", async () => {
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalledTimes(1));
+    const sent = mocks.shareLink.mock.calls[0][0];
+    // Option B: no token, no code, no pending connection. Nobody is added to
+    // anything by receiving this, and consent is still asked for later through
+    // the normal request flow.
+    expect(sent.url).toBe("https://one.hushh.ai/");
+    expect(new URL(sent.url).search).toBe("");
+    // The link lives in `url` only -- WhatsApp and Messages append it to
+    // `text`, and a link in both is delivered twice.
+    expect(sent.text).not.toContain("http");
+  });
+
+  it("does not name the person who was searched for", async () => {
+    // The query is a string somebody typed, not a verified identity, and the
+    // recipient of the message is not that string. Putting it in the invite
+    // would deliver "invite Bob Kanjilal" to whoever the sender picks.
+    await searchForNobody("Bob Kanjilal");
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalled());
+    expect(JSON.stringify(mocks.shareLink.mock.calls[0][0])).not.toContain(
+      "Bob Kanjilal",
+    );
+  });
+
+  it("says nothing extra when the sheet did the talking", async () => {
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalled());
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("confirms the clipboard fallback, which is the one send nobody sees", async () => {
+    mocks.shareLink.mockResolvedValue("copied");
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith("Invite link copied."),
+    );
+  });
+
+  it("treats a dismissed sheet as a decision, not a failure", async () => {
+    const cancelled = new Error("Share canceled");
+    cancelled.name = "AbortError";
+    mocks.shareLink.mockRejectedValue(cancelled);
+
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalled());
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("tells a browser that cannot share that there is nothing to retry", async () => {
+    mocks.shareLink.mockRejectedValue(new ShareUnavailableError());
+
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "This browser cannot share links.",
+      ),
+    );
+  });
+
+  it("reports a share that failed inside a channel that does exist", async () => {
+    mocks.shareLink.mockRejectedValue(new Error("Something went wrong"));
+
+    await searchForNobody();
+    fireEvent.click(await screen.findByText("Invite them to One"));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Could not share the invite.",
+      ),
+    );
+  });
+
+  it("does not open a second sheet when the row is tapped twice", async () => {
+    // On iOS the promise settles only when the sheet is dismissed, and asking
+    // to present a second sheet over the first is rejected outright -- so a
+    // double tap used to earn an error toast.
+    let release: (value: string) => void = () => {};
+    mocks.shareLink.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    await searchForNobody();
+    const invite = await screen.findByText("Invite them to One");
+    fireEvent.click(invite);
+    fireEvent.click(invite);
+
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      release("native-share");
+    });
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("can be used again once the first sheet closes", async () => {
+    await searchForNobody();
+    const invite = await screen.findByText("Invite them to One");
+    fireEvent.click(invite);
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(invite);
+    await waitFor(() => expect(mocks.shareLink).toHaveBeenCalledTimes(2));
+  });
+
+  it("is not offered before anyone has searched", async () => {
+    // Nothing has been looked for, so nothing is missing. The unsearched
+    // surface is a starting point, not a failure.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+
+    expect(await screen.findByText("No people yet")).toBeTruthy();
+    expect(screen.queryByText("Invite them to One")).toBeNull();
+  });
+
+  it("is not offered on RIAs, where a missing name means something else", async () => {
+    // A name absent from RIAs means their adviser profile is not verified --
+    // very often a person who is already on One. An app link does not fix that
+    // and would send someone to invite an existing member.
+    mocks.searchDirectory.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      page: 1,
+    });
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    fireEvent.change(screen.getByLabelText("Search people"), {
+      target: { value: "Bob Kanjilal" },
+    });
+
+    expect(
+      await screen.findByText('No one matches "Bob Kanjilal"'),
+    ).toBeTruthy();
+    expect(screen.queryByText("Invite them to One")).toBeNull();
+  });
+
+  it("is not offered when this build has no link a recipient could open", async () => {
+    // A native build with no origin baked in. Offering a button that cannot
+    // produce a working link is worse than not offering one.
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    await searchForNobody();
+    expect(screen.queryByText("Invite them to One")).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/connect/invite-to-one.test.ts
+++ b/hushh-webapp/__tests__/connect/invite-to-one.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  INVITE_TO_ONE_DIALOG_TITLE,
+  INVITE_TO_ONE_SHARE_TEXT,
+  INVITE_TO_ONE_SHARE_TITLE,
+  buildInviteToOneShare,
+  buildInviteToOneUrl,
+} from "@/lib/connect/invite-to-one";
+import { resolveShareableAppOrigin } from "@/lib/share/app-origin";
+
+vi.mock("@/lib/share/app-origin", () => ({
+  resolveShareableAppOrigin: vi.fn(),
+}));
+
+const mockOrigin = vi.mocked(resolveShareableAppOrigin);
+
+beforeEach(() => {
+  mockOrigin.mockReturnValue("https://one.hushh.ai");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildInviteToOneUrl", () => {
+  it("points at the anonymous onboarding entry, with nothing attached", () => {
+    // Option B, deliberately: no token, no code, no pending connection. What
+    // is shared is the app, and the recipient decides for themselves.
+    expect(buildInviteToOneUrl()).toBe("https://one.hushh.ai/");
+  });
+
+  it("carries no query string that could be read as an authorization", () => {
+    const url = new URL(buildInviteToOneUrl() as string);
+    expect(url.search).toBe("");
+    expect(url.pathname).toBe("/");
+  });
+
+  it("follows the origin, so a UAT invite stays on UAT", () => {
+    mockOrigin.mockReturnValue("https://uat.one.hushh.ai");
+    expect(buildInviteToOneUrl()).toBe("https://uat.one.hushh.ai/");
+  });
+
+  it("does not double the slash when the origin already ends in one", () => {
+    // `resolveShareableAppOrigin` strips it, but a caller reading this URL in
+    // a share sheet should never see `https://one.hushh.ai//`.
+    mockOrigin.mockReturnValue("https://one.hushh.ai");
+    const withoutScheme = buildInviteToOneUrl()?.replace(/^https?:\/\//, "");
+    expect(withoutScheme).not.toContain("//");
+  });
+
+  it("is null when the build has no origin a recipient could open", () => {
+    mockOrigin.mockReturnValue(null);
+    expect(buildInviteToOneUrl()).toBeNull();
+  });
+});
+
+describe("buildInviteToOneShare", () => {
+  it("returns a payload the share ladder can send as-is", () => {
+    expect(buildInviteToOneShare()).toEqual({
+      title: INVITE_TO_ONE_SHARE_TITLE,
+      text: INVITE_TO_ONE_SHARE_TEXT,
+      dialogTitle: INVITE_TO_ONE_DIALOG_TITLE,
+      url: "https://one.hushh.ai/",
+    });
+  });
+
+  it("keeps the link out of the text, so targets that append url send it once", () => {
+    // WhatsApp and Messages append `url` to `text`. A link written into both
+    // is delivered twice, which is how the Circle invite read before it was
+    // fixed.
+    const share = buildInviteToOneShare();
+    expect(share?.text).not.toContain("http");
+    expect(share?.title).not.toContain("http");
+  });
+
+  it("does not name the sender, who is already visible in the thread", () => {
+    const share = buildInviteToOneShare();
+    expect(share?.text).toBe("Join me on One so we can connect.");
+  });
+
+  it("is null when there is no link, so no unusable invite is offered", () => {
+    mockOrigin.mockReturnValue(null);
+    expect(buildInviteToOneShare()).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/share/app-origin.test.ts
+++ b/hushh-webapp/__tests__/share/app-origin.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  normalizeWebOrigin,
+  resolveShareableAppOrigin,
+} from "@/lib/share/app-origin";
+
+const ORIGINAL_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+
+/**
+ * jsdom's `window.location.origin` is read-only, so each case installs its own
+ * location object. Restored afterwards -- a leaked origin would silently
+ * decide the outcome of whatever test ran next.
+ */
+function setWindowOrigin(origin: string | undefined): void {
+  if (origin === undefined) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: undefined,
+    });
+    return;
+  }
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin },
+  });
+}
+
+const realLocation = window.location;
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_APP_URL;
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: realLocation,
+  });
+  if (ORIGINAL_APP_URL === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+  else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_APP_URL;
+});
+
+describe("normalizeWebOrigin", () => {
+  it("keeps a real https origin and drops a trailing slash", () => {
+    expect(normalizeWebOrigin("https://one.hushh.ai/")).toBe(
+      "https://one.hushh.ai",
+    );
+  });
+
+  it("rejects the iOS Capacitor scheme", () => {
+    // `ios.scheme` in capacitor.config.ts. Not http(s), so it never reaches
+    // the host check.
+    expect(normalizeWebOrigin("App://localhost")).toBeNull();
+  });
+
+  it("rejects the Android Capacitor origin, which passes the scheme check", () => {
+    // This is the one that shipped a dead link: it IS https, and it resolves
+    // to the recipient's own device.
+    expect(normalizeWebOrigin("https://localhost")).toBeNull();
+  });
+
+  it("rejects loopback by address as well as by name", () => {
+    expect(normalizeWebOrigin("http://127.0.0.1:3000")).toBeNull();
+    expect(normalizeWebOrigin("http://[::1]:3000")).toBeNull();
+  });
+
+  it("rejects empty, malformed, and non-string input", () => {
+    expect(normalizeWebOrigin("")).toBeNull();
+    expect(normalizeWebOrigin("   ")).toBeNull();
+    expect(normalizeWebOrigin(null)).toBeNull();
+    expect(normalizeWebOrigin(undefined)).toBeNull();
+    expect(normalizeWebOrigin("one.hushh.ai")).toBeNull();
+    expect(normalizeWebOrigin("https://")).toBeNull();
+  });
+});
+
+describe("resolveShareableAppOrigin", () => {
+  it("prefers the live origin, so a link shared from UAT points at UAT", () => {
+    setWindowOrigin("https://uat.one.hushh.ai");
+    process.env.NEXT_PUBLIC_APP_URL = "https://one.hushh.ai";
+    expect(resolveShareableAppOrigin()).toBe("https://uat.one.hushh.ai");
+  });
+
+  it("falls back to the build origin inside the Android shell", () => {
+    setWindowOrigin("https://localhost");
+    process.env.NEXT_PUBLIC_APP_URL = "https://one.hushh.ai";
+    expect(resolveShareableAppOrigin()).toBe("https://one.hushh.ai");
+  });
+
+  it("falls back to the build origin inside the iOS shell", () => {
+    setWindowOrigin("App://localhost");
+    process.env.NEXT_PUBLIC_APP_URL = "https://one.hushh.ai";
+    expect(resolveShareableAppOrigin()).toBe("https://one.hushh.ai");
+  });
+
+  it("returns null when neither is usable, rather than a broken origin", () => {
+    setWindowOrigin("https://localhost");
+    expect(resolveShareableAppOrigin()).toBeNull();
+  });
+
+  it("returns null on a dev server, where the origin is loopback", () => {
+    setWindowOrigin("http://localhost:3000");
+    expect(resolveShareableAppOrigin()).toBeNull();
+  });
+
+  it("survives a window with no location object", () => {
+    setWindowOrigin(undefined);
+    process.env.NEXT_PUBLIC_APP_URL = "https://one.hushh.ai";
+    expect(resolveShareableAppOrigin()).toBe("https://one.hushh.ai");
+  });
+});

--- a/hushh-webapp/__tests__/share/share-link.test.ts
+++ b/hushh-webapp/__tests__/share/share-link.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Capacitor } from "@capacitor/core";
+import { Share } from "@capacitor/share";
+
+import {
+  ShareUnavailableError,
+  isShareCancellationError,
+  shareLink,
+} from "@/lib/share/share-link";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: vi.fn() },
+}));
+
+vi.mock("@capacitor/share", () => ({
+  Share: { share: vi.fn() },
+}));
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+const payload = {
+  title: "Join me on One",
+  text: "Join me on One so we can connect.",
+  dialogTitle: "Invite to One",
+  url: "https://one.hushh.ai/",
+};
+
+function setWebShare(handler: ((data: ShareData) => Promise<void>) | null) {
+  Object.defineProperty(navigator, "share", {
+    configurable: true,
+    writable: true,
+    value: handler ?? undefined,
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  setWebShare(null);
+});
+
+describe("shareLink on the installed iOS and Android apps", () => {
+  it("uses the native sheet and reports it", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Share.share).mockResolvedValue({} as never);
+
+    await expect(shareLink(payload)).resolves.toBe("native-share");
+    expect(Share.share).toHaveBeenCalledWith({
+      title: payload.title,
+      text: payload.text,
+      dialogTitle: payload.dialogTitle,
+      url: payload.url,
+    });
+  });
+
+  it("prefers the native sheet even where Web Share also exists", async () => {
+    // Android's webview exposes navigator.share. Inside the shell the native
+    // sheet is still the right one -- it is the sheet the OS themes and the
+    // one the person expects from every other app on the device.
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Share.share).mockResolvedValue({} as never);
+    const webShare = vi.fn().mockResolvedValue(undefined);
+    setWebShare(webShare);
+
+    await expect(shareLink(payload)).resolves.toBe("native-share");
+    expect(webShare).not.toHaveBeenCalled();
+  });
+
+  it("omits url entirely when there is no link, rather than sending undefined", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Share.share).mockResolvedValue({} as never);
+
+    await shareLink({ ...payload, url: undefined });
+    expect(Share.share).toHaveBeenCalledWith(
+      expect.not.objectContaining({ url: expect.anything() }),
+    );
+  });
+
+  it("treats a whitespace-only url as no url", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Share.share).mockResolvedValue({} as never);
+
+    await shareLink({ ...payload, url: "   " });
+    expect(Share.share).toHaveBeenCalledWith(
+      expect.not.objectContaining({ url: expect.anything() }),
+    );
+  });
+});
+
+describe("shareLink on the web", () => {
+  it("uses Web Share where the browser has it", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    const webShare = vi.fn().mockResolvedValue(undefined);
+    setWebShare(webShare);
+
+    await expect(shareLink(payload)).resolves.toBe("web-share");
+    expect(webShare).toHaveBeenCalledWith({
+      title: payload.title,
+      text: payload.text,
+      url: payload.url,
+    });
+  });
+
+  it("falls back to the clipboard on a desktop browser without Web Share", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+    await expect(shareLink(payload)).resolves.toBe("copied");
+    // The link has to survive the fallback: on this rung nothing appends it,
+    // so text alone would put an invite with no way in on the clipboard.
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      `${payload.text}\n${payload.url}`,
+    );
+  });
+
+  it("copies the text alone when there is no link", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+    await shareLink({ ...payload, url: undefined });
+    expect(copyToClipboard).toHaveBeenCalledWith(payload.text);
+  });
+
+  it("throws ShareUnavailableError when every rung is missing", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    vi.mocked(copyToClipboard).mockResolvedValue(false);
+
+    await expect(shareLink(payload)).rejects.toBeInstanceOf(
+      ShareUnavailableError,
+    );
+  });
+
+  it("does not mistake an unavailable device for a cancelled share", async () => {
+    // These two are the whole reason the caller branches: one is silent, the
+    // other has to say something.
+    expect(isShareCancellationError(new ShareUnavailableError())).toBe(false);
+  });
+});
+
+describe("isShareCancellationError", () => {
+  it("recognises the Web Share abort", () => {
+    const abort = new Error("The operation was aborted.");
+    abort.name = "AbortError";
+    expect(isShareCancellationError(abort)).toBe(true);
+  });
+
+  it("recognises the Capacitor cancellation, in both spellings", () => {
+    expect(isShareCancellationError(new Error("Share canceled"))).toBe(true);
+    expect(isShareCancellationError(new Error("Share cancelled"))).toBe(true);
+    expect(isShareCancellationError(new Error("  share CANCELLED  "))).toBe(
+      true,
+    );
+  });
+
+  it("does not swallow a real failure", () => {
+    expect(isShareCancellationError(new Error("Network request failed"))).toBe(
+      false,
+    );
+    expect(isShareCancellationError(null)).toBe(false);
+    expect(isShareCancellationError(undefined)).toBe(false);
+    expect(isShareCancellationError("Share cancelled")).toBe(false);
+  });
+});

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { BadgeCheck, Loader2, Lock, Search as SearchIcon, UserRound, Users, X } from "lucide-react";
+import { BadgeCheck, Loader2, Lock, Search as SearchIcon, Share2, UserRound, Users, X } from "lucide-react";
 
 import {
   AppPageContentRegion,
@@ -14,6 +14,12 @@ import { NearbyDirectories } from "@/components/connect/nearby-directories";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { SurfaceStack } from "@/components/app-ui/surfaces";
+import { buildInviteToOneShare } from "@/lib/connect/invite-to-one";
+import {
+  isShareCancellationError,
+  ShareUnavailableError,
+  shareLink,
+} from "@/lib/share/share-link";
 import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -424,6 +430,56 @@ export default function ConnectPageClient() {
   // the same mistake as asking for page 3 of a query they just retyped.
   const directoryAudience = CONNECT_TAB_AUDIENCE[tab];
   const isAdvisorTab = tab === "advisors";
+  // Searching a name and finding nobody has one likely explanation the
+  // directory cannot act on: that person has not joined yet. Offered on People
+  // only -- People searches the whole of One, so "not here" really does mean
+  // "not on One". A name missing from RIAs means their adviser profile is not
+  // verified, and one missing from Around you means they are not nearby;
+  // neither is fixed by an app link, and offering one there would send someone
+  // to invite a person who is already a member.
+  //
+  // Resolved once, not inside the handler: an invite the build cannot produce
+  // a working link for is not offered at all, rather than rendered as a button
+  // that fails when tapped.
+  const inviteToOneShare = useMemo(() => buildInviteToOneShare(), []);
+  const canInviteToOne = tab === "people" && inviteToOneShare !== null;
+
+  // A share sheet is modal but not instant: on iOS it animates in, and the
+  // promise does not settle until it is dismissed. Two taps in that window
+  // asked the platform to present a second sheet over the first, which iOS
+  // rejects outright -- the person got an error toast for tapping twice. The
+  // guard is a ref rather than state because the sheet is its own feedback;
+  // re-rendering a row to disable it would only make the list flicker under
+  // the sheet that just covered it.
+  const invitingRef = useRef(false);
+
+  const handleInviteToOne = useCallback(async () => {
+    if (!inviteToOneShare || invitingRef.current) return;
+    invitingRef.current = true;
+    try {
+      const delivery = await shareLink(inviteToOneShare);
+      // Only the clipboard fallback needs saying out loud. The native sheet and
+      // Web Share both show the person their own send, so a toast on top of
+      // that reports something they just watched happen.
+      if (delivery === "copied") toast.success("Invite link copied.");
+    } catch (error) {
+      // Dismissing the sheet is a decision, not a failure.
+      if (isShareCancellationError(error)) return;
+      toast.error(
+        error instanceof ShareUnavailableError
+          ? // Nothing to retry: no sheet, no Web Share, and the clipboard was
+            // refused. Saying "could not share" would invite a second tap that
+            // cannot go anywhere either.
+            "This browser cannot share links."
+          : // The channel exists and something went wrong inside it, so the
+            // copy stays neutral about which rung failed.
+            "Could not share the invite.",
+      );
+    } finally {
+      invitingRef.current = false;
+    }
+  }, [inviteToOneShare]);
+
   const resultSetKey = `${directoryAudience}:${pageSize}:${trimmedQuery}`;
   const [renderedResultSetKey, setRenderedResultSetKey] = useState(resultSetKey);
   if (renderedResultSetKey !== resultSetKey) {
@@ -1692,16 +1748,36 @@ export default function ConnectPageClient() {
                   // section rendered as blank space under its own heading.
                   // An empty result has to say so.
                   hasQuery ? (
-                    <SettingsRow
-                      title={`No one matches "${trimmedQuery}"`}
-                      description={
-                        isAdvisorTab
-                          ? "Try People, or their full name."
-                          : "Try their full name."
-                      }
-                      density="compact"
-                      disabled
-                    />
+                    <>
+                      <SettingsRow
+                        title={`No one matches "${trimmedQuery}"`}
+                        description={
+                          isAdvisorTab
+                            ? "Try People, or their full name."
+                            : "Try their full name."
+                        }
+                        density="compact"
+                        disabled
+                      />
+                      {/* The row above states a fact, so it stays inert; an
+                          invite is a separate offer and gets its own row
+                          rather than making "No one matches Bob" tappable.
+                          Read together they are the two things left to try:
+                          spell it out, or bring them here. */}
+                      {canInviteToOne ? (
+                        <SettingsRow
+                          icon={Share2}
+                          iconTone="blue"
+                          title="Invite them to One"
+                          description="Send them the app. You can connect once they join."
+                          density="compact"
+                          onClick={() => {
+                            void handleInviteToOne();
+                          }}
+                          testId="connect-invite-to-one"
+                        />
+                      ) : null}
+                    </>
                   ) : (
                     <SettingsRow
                       title={isAdvisorTab ? "No advisors yet" : "No people yet"}

--- a/hushh-webapp/lib/connect/invite-to-one.ts
+++ b/hushh-webapp/lib/connect/invite-to-one.ts
@@ -1,0 +1,74 @@
+import { resolveShareableAppOrigin } from "@/lib/share/app-origin";
+
+/**
+ * Inviting somebody who is not on One yet.
+ *
+ * Connect searches the One directory. Search a name that is not in it and the
+ * screen says "No one matches" and stops -- correct, and a dead end, because
+ * the single most likely reason a name is missing is that the person has not
+ * joined. The directory has no answer for that; the answer is outside the app.
+ *
+ * What is shared is deliberately just the app: no invite token, no pending
+ * connection, no code. Nobody is added to anything by receiving this, and the
+ * sender is not committed to anything by sending it. A recipient who taps it
+ * lands on the same anonymous onboarding entry as any other first-time visitor
+ * and decides for themselves; if they join, they are found by the next search
+ * and connected through the normal request flow, which is where consent is
+ * asked for and recorded. An invite that pre-authorized a connection would be
+ * asking one person to consent on another person's behalf.
+ */
+
+/** The share sheet's own title -- what the sender sees while choosing an app. */
+export const INVITE_TO_ONE_DIALOG_TITLE = "Invite to One";
+
+/**
+ * The message the recipient reads.
+ *
+ * Read in a chat thread, where the sender's name and photo are already on
+ * screen, so the copy does not introduce the sender -- that would be the one
+ * line the recipient does not need. It says what is being asked and nothing
+ * more. The link is not repeated here: most share targets (WhatsApp, Messages)
+ * append `url` to `text`, and a link written into both is delivered twice.
+ */
+export const INVITE_TO_ONE_SHARE_TEXT = "Join me on One so we can connect.";
+
+/** What the sheet calls the thing being shared, where a target shows a title. */
+export const INVITE_TO_ONE_SHARE_TITLE = "Join me on One";
+
+/**
+ * The invite link, or null when this build cannot produce one a recipient
+ * could open.
+ *
+ * Null is not a failure to report: it means the app has no shareable origin --
+ * a native build with no `NEXT_PUBLIC_APP_URL` baked in -- and an invite whose
+ * link is dead is worse than no invite at all, so the caller simply does not
+ * offer one. See `lib/share/app-origin.ts` for why a device's own origin is
+ * never usable here.
+ */
+export function buildInviteToOneUrl(): string | null {
+  const origin = resolveShareableAppOrigin();
+  return origin ? `${origin}/` : null;
+}
+
+/**
+ * The full payload for `shareLink`, or null when there is no link to send.
+ *
+ * Returned as one object so the row that offers the invite and the handler
+ * that sends it agree on whether an invite exists -- checking the origin twice
+ * is how a button that cannot work gets rendered.
+ */
+export function buildInviteToOneShare(): {
+  title: string;
+  text: string;
+  dialogTitle: string;
+  url: string;
+} | null {
+  const url = buildInviteToOneUrl();
+  if (!url) return null;
+  return {
+    title: INVITE_TO_ONE_SHARE_TITLE,
+    text: INVITE_TO_ONE_SHARE_TEXT,
+    dialogTitle: INVITE_TO_ONE_DIALOG_TITLE,
+    url,
+  };
+}

--- a/hushh-webapp/lib/one-location/circle-join-url.ts
+++ b/hushh-webapp/lib/one-location/circle-join-url.ts
@@ -6,6 +6,8 @@
  * in-app "Join with code" flow with the field pre-filled, so a recipient can tap
  * the link instead of copy-pasting the raw code.
  */
+import { resolveShareableAppOrigin } from "@/lib/share/app-origin";
+
 export const CIRCLE_JOIN_CODE_PARAM = "code";
 
 /**
@@ -22,50 +24,19 @@ export function formatCircleCodeForDisplay(raw: string): string {
   return normalized.replace(/(.{4})(?=.)/g, "$1-");
 }
 
-const WEB_ORIGIN = /^https?:\/\//i;
-const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])$/i;
-
-/**
- * An origin only counts if the person receiving the invite could open it.
- *
- * That rules out Capacitor's two runtime origins -- `App://localhost` on iOS
- * (rejected on scheme) and `https://localhost` on Android (rejected on host,
- * since it passes an http(s) check but resolves to the recipient's own device).
- */
-function normalizeWebOrigin(value: string | null | undefined): string | null {
-  const trimmed = String(value || "")
-    .trim()
-    .replace(/\/+$/, "");
-  if (!WEB_ORIGIN.test(trimmed)) return null;
-  try {
-    return LOOPBACK_HOST.test(new URL(trimmed).hostname) ? null : trimmed;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * The origin a shared join link must point at.
  *
- * Capacitor does not serve the installed app from a web origin: iOS runs on the
- * custom `App://localhost` scheme (`ios.scheme` in capacitor.config.ts) and
- * Android on `https://localhost`. Sharing `window.location.origin` from a device
- * therefore delivered `App://localhost/circle/join?code=...` -- a link that is
- * dead for whoever receives it, which is why the invite only ever worked when
- * shared from a browser.
- *
- * The live origin still wins on the web so a UAT invite keeps pointing at UAT.
- * Only when it is not a real web origin do we fall back to the origin baked into
- * the build (NEXT_PUBLIC_APP_URL, set by the TestFlight/App Store/Play
- * workflows). Returns null when neither is usable, which makes callers share the
- * code on its own rather than a broken link.
+ * Kept as a Circle-named export because that is how every caller here reads,
+ * but the resolution itself is shared: Capacitor does not serve the installed
+ * app from a web origin, so sharing `window.location.origin` from a device
+ * delivered `App://localhost/circle/join?code=...` -- a link that is dead for
+ * whoever receives it, which is why the invite only ever worked when shared
+ * from a browser. `resolveShareableAppOrigin` owns that rule now, so a second
+ * surface cannot reintroduce the bug by resolving its own origin.
  */
 export function resolveCircleJoinOrigin(): string | null {
-  const live =
-    typeof window === "undefined"
-      ? null
-      : normalizeWebOrigin(window.location?.origin);
-  return live ?? normalizeWebOrigin(process.env.NEXT_PUBLIC_APP_URL);
+  return resolveShareableAppOrigin();
 }
 
 export function buildCircleJoinUrl(origin: string, code: string): string {

--- a/hushh-webapp/lib/one-location/share-circle-code.ts
+++ b/hushh-webapp/lib/one-location/share-circle-code.ts
@@ -1,21 +1,15 @@
-import { copyToClipboard } from "@/lib/utils/clipboard";
+import {
+  isShareCancellationError as isShareCancelled,
+  shareLink,
+  type ShareDelivery,
+} from "@/lib/share/share-link";
 
-export type CircleCodeShareDelivery =
-  | "native-share"
-  | "web-share"
-  | "copied";
+/** Kept as an alias so existing imports read unchanged. */
+export type CircleCodeShareDelivery = ShareDelivery;
 
-export function isShareCancellationError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const candidate = error as { name?: unknown; message?: unknown };
-  const name = typeof candidate.name === "string" ? candidate.name : "";
-  const message =
-    typeof candidate.message === "string" ? candidate.message.trim() : "";
-  return (
-    name === "AbortError" ||
-    /^share cancell?ed$/i.test(message)
-  );
-}
+/** Re-exported: cancelling a share is not a failure, and every caller here
+ *  already checks it under this name. */
+export const isShareCancellationError = isShareCancelled;
 
 /**
  * How a Circle is named inside share copy ("Join my <label> on One …").
@@ -74,35 +68,5 @@ export async function shareNamedCircleCode(params: {
   dialogTitle: string;
   url?: string;
 }): Promise<CircleCodeShareDelivery> {
-  const url = params.url?.trim() ? params.url.trim() : undefined;
-  const { Capacitor } = await import("@capacitor/core");
-  if (Capacitor.isNativePlatform()) {
-    const { Share } =
-      (await import("@capacitor/share")) as typeof import("@capacitor/share");
-    await Share.share({
-      title: params.title,
-      text: params.text,
-      dialogTitle: params.dialogTitle,
-      ...(url ? { url } : {}),
-    });
-    return "native-share";
-  }
-
-  if (
-    typeof navigator !== "undefined" &&
-    typeof navigator.share === "function"
-  ) {
-    await navigator.share({
-      title: params.title,
-      text: params.text,
-      ...(url ? { url } : {}),
-    });
-    return "web-share";
-  }
-
-  // Clipboard fallback keeps the link alongside the text so nothing is lost when
-  // neither native nor Web Share is available.
-  const clipboardText = url ? `${params.text}\n${url}` : params.text;
-  if (await copyToClipboard(clipboardText)) return "copied";
-  throw new Error("Sharing is not supported on this device.");
+  return shareLink(params);
 }

--- a/hushh-webapp/lib/share/app-origin.ts
+++ b/hushh-webapp/lib/share/app-origin.ts
@@ -1,0 +1,55 @@
+/**
+ * The origin a link has to carry when it leaves the app.
+ *
+ * Extracted from `lib/one-location/circle-join-url.ts`, where this was written
+ * first and named after the one link that needed it. Nothing about it is
+ * Circle-specific, and the trap it exists to avoid is the kind that is only
+ * found once: Capacitor does not serve the installed app from a web origin --
+ * iOS runs on the custom `App://localhost` scheme (`ios.scheme` in
+ * capacitor.config.ts) and Android on `https://localhost` -- so a second
+ * surface that reached for `window.location.origin` would ship a link that is
+ * dead for everybody who receives it, and would look correct in every browser
+ * test. One copy, shared.
+ */
+
+const WEB_ORIGIN = /^https?:\/\//i;
+const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])$/i;
+
+/**
+ * An origin only counts if the person receiving the link could open it.
+ *
+ * That rules out both Capacitor runtime origins -- `App://localhost` is
+ * rejected on scheme, `https://localhost` on host, since it passes an http(s)
+ * check but resolves to the recipient's own device.
+ */
+export function normalizeWebOrigin(
+  value: string | null | undefined,
+): string | null {
+  const trimmed = String(value || "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (!WEB_ORIGIN.test(trimmed)) return null;
+  try {
+    return LOOPBACK_HOST.test(new URL(trimmed).hostname) ? null : trimmed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The origin shared links point at.
+ *
+ * The live origin wins on the web, so a link shared from UAT keeps pointing at
+ * UAT. Only when it is not a real web origin do we fall back to the origin
+ * baked into the build (NEXT_PUBLIC_APP_URL, set by the TestFlight/App
+ * Store/Play workflows). Returns null when neither is usable, which callers
+ * read as "there is no link worth sharing" rather than papering over it with a
+ * broken one.
+ */
+export function resolveShareableAppOrigin(): string | null {
+  const live =
+    typeof window === "undefined"
+      ? null
+      : normalizeWebOrigin(window.location?.origin);
+  return live ?? normalizeWebOrigin(process.env.NEXT_PUBLIC_APP_URL);
+}

--- a/hushh-webapp/lib/share/share-link.ts
+++ b/hushh-webapp/lib/share/share-link.ts
@@ -1,0 +1,99 @@
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+/**
+ * Handing a link to whatever the device uses for sharing.
+ *
+ * Extracted from `lib/one-location/share-circle-code.ts`, where this ladder was
+ * written first and named after the one thing that needed it. The behaviour was
+ * never Circle-specific -- native sheet, then Web Share, then the clipboard --
+ * and a second surface asking to share something should not have to import a
+ * function called `shareNamedCircleCode` to do it, nor copy the ladder and let
+ * the two drift.
+ */
+
+export type ShareDelivery = "native-share" | "web-share" | "copied";
+
+/**
+ * A share the person dismissed.
+ *
+ * Both Web Share and the Capacitor sheet report a cancelled share as a thrown
+ * error, so a caller that treats every rejection as a failure shows an error
+ * toast to somebody who simply changed their mind. Every caller checks this
+ * first.
+ */
+export function isShareCancellationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; message?: unknown };
+  const name = typeof candidate.name === "string" ? candidate.name : "";
+  const message =
+    typeof candidate.message === "string" ? candidate.message.trim() : "";
+  return name === "AbortError" || /^share cancell?ed$/i.test(message);
+}
+
+/**
+ * The device offered no way to share at all.
+ *
+ * Distinct from a share that failed: every rung of the ladder was tried and
+ * none of them exists here -- no native sheet, no Web Share, and a clipboard
+ * that refused. It is thrown rather than returned because callers already
+ * branch on `catch`, and a caller that forgot to check a returned failure code
+ * would quietly report success. Callers that want to say something more useful
+ * than "that did not work" check for it by instance rather than by matching
+ * the message, which is free to change.
+ */
+export class ShareUnavailableError extends Error {
+  constructor() {
+    super("Sharing is not supported on this device.");
+    this.name = "ShareUnavailableError";
+  }
+}
+
+/**
+ * Share text, and optionally a link, through the best channel this device has.
+ *
+ * When a `url` is supplied it is the ONLY place the link should appear: most
+ * share targets (WhatsApp, Messages) append `url` to `text`, so a link repeated
+ * inside `text` is delivered twice. Callers keep `text` link-free and let it
+ * carry the human-readable part.
+ *
+ * Capacitor owns the native iOS/Android sheet; browsers use Web Share and then
+ * the clipboard, which keeps the link alongside the text so nothing is lost
+ * where neither exists.
+ */
+export async function shareLink(params: {
+  title: string;
+  text: string;
+  dialogTitle: string;
+  url?: string;
+}): Promise<ShareDelivery> {
+  const url = params.url?.trim() ? params.url.trim() : undefined;
+  const { Capacitor } = await import("@capacitor/core");
+  if (Capacitor.isNativePlatform()) {
+    const { Share } = (await import(
+      "@capacitor/share"
+    )) as typeof import("@capacitor/share");
+    await Share.share({
+      title: params.title,
+      text: params.text,
+      dialogTitle: params.dialogTitle,
+      ...(url ? { url } : {}),
+    });
+    return "native-share";
+  }
+
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.share === "function"
+  ) {
+    await navigator.share({
+      title: params.title,
+      text: params.text,
+      ...(url ? { url } : {}),
+    });
+    return "web-share";
+  }
+
+  const clipboardText = url ? `${params.text}\n${url}` : params.text;
+  if (await copyToClipboard(clipboardText)) return "copied";
+  throw new ShareUnavailableError();
+}

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -51,6 +51,7 @@
     "native:voice:test": "npm run ios:voice:test && npm run android:voice:test",
     "ios:device:ui:test": "node ./scripts/native/assert-destructive-native-audit.mjs && bash ./scripts/native/ios-device-ui-test.sh",
     "verify:cache": "vitest run __tests__/services/cache-sync-mutation-cascade.test.ts __tests__/services/cache-service.test.ts __tests__/services/cache-hit-rate-contract.test.ts __tests__/services/use-stale-resource.test.tsx __tests__/services/use-stale-resource-lifecycle.test.tsx __tests__/services/pkm-cache.test.ts __tests__/services/pkm-domain-resource.test.ts",
+    "verify:share-ladder": "vitest run __tests__/share/app-origin.test.ts __tests__/share/share-link.test.ts __tests__/connect/invite-to-one.test.ts __tests__/one-location/share-circle-code.test.ts __tests__/one-location/circle-join-url.test.ts",
     "verify:connect-search": "vitest run __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts",
     "verify:accent": "vitest run __tests__/lib/theme-accent.test.ts",
     "verify:bottom-sheet": "vitest run __tests__/components/bottom-sheet-drag-dismiss.contract.test.tsx __tests__/components/shared-sheet-consumers.contract.test.tsx",

--- a/scripts/ci/web-targeted-check.sh
+++ b/scripts/ci/web-targeted-check.sh
@@ -89,6 +89,29 @@ if has_match '^(hushh-webapp/(app/connect/|__tests__/app/connect/|lib/services/c
   ran=1
 fi
 
+# The share ladder, and the origin a shared link has to carry.
+#
+# Both were extracted out of lib/one-location so Connect's "Invite them to One"
+# could reuse them instead of copying a ladder that had already been debugged
+# once. That leaves one module with two live consumers -- the Circle invite
+# share and Connect's invite -- and only the Connect half looks like Connect. A
+# change to lib/share/ that reads as Connect work can therefore break the
+# Circle invite, on a pull request where nothing in components/one-location/ or
+# app/connect/ was touched and no pack above fires.
+#
+# The origin resolver is the one that matters. Capacitor does not serve the
+# installed app from a web origin (App://localhost on iOS, https://localhost on
+# Android), so a regression there ships a link that is dead for every recipient
+# and looks perfectly correct in a browser -- the exact bug the Circle invite
+# was fixed for once already.
+#
+# Both consumers' suites run, not just the new one, because "the extraction did
+# not change Circle behaviour" is the claim that needs holding.
+if has_match '^hushh-webapp/(lib/share/|lib/connect/|__tests__/share/|__tests__/connect/|lib/one-location/(share-circle-code|circle-join-url)\.ts)'; then
+  run_check "Share ladder and link origin" npm run verify:share-ladder
+  ran=1
+fi
+
 # One Location's share and request flows. Until this pack existed, NOTHING in
 # components/one-location/ matched any targeted glob above -- so the duration
 # pickers, the share recipient picker and the whole hub could be changed on a


### PR DESCRIPTION
Closes #5709. Sub-issue 5 of 5 for #5421.

## The dead end

Connect searches the One directory. Search a name that is not in it and the screen renders one inert row — "No one matches «Bob»", "Try their full name" — and stops there.

That is true, and it is unhelpful, because the likeliest reason a name is missing is that the person has not joined. It is the one explanation the directory cannot act on: the answer is outside the app.

The empty state now carries a second row.

```
No one matches "Bob Kanjilal"
Try their full name.

📤  Invite them to One
    Send them the app. You can connect once they join.
```

Two rows, not one tappable row: the first states a fact and stays inert — making "No one matches Bob" a control would mean tapping a sentence to do something it does not describe. Read together they are the two things left to try: spell it out, or bring them here.

## What is actually shared

**Just the app.** No invite token, no pending connection, no code, no query string — the bare origin, `https://one.hushh.ai/`.

Nobody is added to anything by receiving it, and the sender is not committed to anything by sending it. A recipient who taps it lands on the same anonymous onboarding entry as any other first-time visitor. If they join, they are found by the next search and connected through the normal request flow — which is where consent is asked for and recorded.

An invite that pre-authorized a connection would be asking one person to consent on another person's behalf. That is the thing this deliberately does not do.

The searched string is never sent either. A query is something somebody typed, not a verified identity, and the recipient of the message is not that string; putting it in the invite would deliver "invite Bob Kanjilal" to whoever the sender happens to pick.

## People only

| Tab | A missing name means | Invite? |
| --- | --- | --- |
| People | not on One — this tab searches the whole directory | **yes** |
| RIAs | their adviser profile is not verified | no |
| Around you | they are not physically nearby | no |

The last two are very often people who *are* already members. An app link does not fix either, and offering one there sends someone to invite an existing user.

## Two modules come out of one-location

The second surface needed both, and copying either would have let the two drift.

| New | Was | Why it is shared |
| --- | --- | --- |
| `lib/share/share-link.ts` | `shareNamedCircleCode` | native sheet → Web Share → clipboard; never Circle-specific |
| `lib/share/app-origin.ts` | `resolveCircleJoinOrigin` | the origin a link must carry |

The origin one matters most. **Capacitor does not serve the installed app from a web origin** — iOS runs on `App://localhost`, Android on `https://localhost` — so a surface that reaches for `window.location.origin` ships a link that is dead for everybody who receives it, and looks perfectly correct in every browser test. That bug was already found and fixed once for Circle invites; this keeps there being one copy of the fix rather than two.

Both Circle callers now delegate. Behaviour is unchanged and their existing suites pass untouched — `share-circle-code.test.ts` and `circle-join-url.test.ts` are not modified by this PR, which is the point.

## Handled across all three shells

**Sender**

| Shell | Channel | Feedback |
| --- | --- | --- |
| iOS app | native sheet | the sheet is its own feedback |
| Android app | native sheet | the sheet is its own feedback |
| Mobile web | Web Share | the sheet is its own feedback |
| Desktop web (Chrome/Edge) | Web Share | the sheet is its own feedback |
| Desktop web (no Web Share) | clipboard | "Invite link copied." |
| No channel at all | — | "This browser cannot share links." |
| Sheet dismissed | — | silent |
| Build with no shareable origin | — | the row is not rendered |
| Row tapped twice | one sheet | — |

Two of these are fixes rather than plumbing:

- **`ShareUnavailableError`** replaces a bare `Error`, so "the device gave us no way to share" can be told from "the channel exists and failed" by instance rather than by matching a message. The first says there is nothing to retry; the second stays neutral about which rung broke. The Circle caller keeps its existing generic branch, unchanged.
- **A re-entry guard.** On iOS the share promise settles only when the sheet is *dismissed*, and asking to present a second sheet over the first is rejected outright — so a double tap earned an error toast. A ref rather than state, because the sheet is its own feedback and re-rendering the row to disable it would only flicker the list underneath the sheet that just covered it.

**Recipient** — every platform opens `/`, the anonymous onboarding entry, and can sign up on the web immediately. Someone already signed in resolves to their own post-auth route; no dead end there either.

Deep links are deliberately **not** part of this. Both `.well-known` routes exist but are passkey-only — the AASA carries `applinks: { apps: [], details: [] }` and `assetlinks.json` delegates only `common.get_login_creds`. So a shared link always opens the browser rather than an installed app, which for an *invite* is correct by definition: the recipient does not have the app. Enabling Universal Links / App Links needs AASA `applinks.details`, a native release and store review, and belongs in its own issue. No App Store or Play Store URL exists anywhere in the repo, so none is invented — the web landing is the honest destination on every platform.

## Verification

| Check | Result |
| --- | --- |
| `vitest` — 14 new page tests, 12 related suites | 157 passed |
| `verify:connect-search` | 56 passed |
| `tsc --noEmit` | clean |
| `eslint` (changed files) | clean |
| `verify:design-system` | passed |
| `verify:service-boundary` | passed |
| `verify:capacitor:static` | passed |
| `verify:surface-map` | current |

New coverage: `__tests__/share/app-origin.test.ts` (both Capacitor origins rejected, loopback by name and by address, UAT keeps pointing at UAT), `__tests__/share/share-link.test.ts` (every rung, both cancellation spellings, url omitted rather than sent as `undefined`), `__tests__/connect/invite-to-one.test.ts` (bare origin, no query string, link kept out of `text`), and fourteen cases on the page itself covering the whole sender table above.

## Please do not merge yet

@DamriaNeelesh is testing this on UAT first.
