### PR TITLE
Add invite-to-claim CTA for unclaimed businesses during Check-In

### DIFF
--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -55,6 +55,7 @@ vi.mock("sonner", () => ({
   toast: {
     error: vi.fn(),
     success: vi.fn(),
+    message: vi.fn(),
   },
 }));
 
@@ -2102,7 +2103,78 @@ describe("NearbyCheckInSheet", () => {
   });
 
   describe("unclaimed business invite", () => {
-    it("offers to invite an unclaimed business once a place is selected", async () => {
+    it("never shows the CTA when the provider sends no claim status", async () => {
+      // The default fixture (set in the outer beforeEach) carries no
+      // businessClaimStatus field, exactly like every real provider response
+      // today. "Unknown" must never be rendered as "unclaimed".
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /Stanford University/ }),
+      );
+
+      expect(
+        screen.queryByTestId("nearby-unclaimed-business-card"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show the CTA for a place explicitly marked claimed", async () => {
+      service.nearbyPlaces.mockResolvedValue([
+        {
+          placeId: "stanford-main",
+          text: "Stanford University",
+          name: "Stanford University",
+          address: "450 Jane Stanford Way",
+          category: "University",
+          categories: ["education"],
+          distanceMeters: 48,
+          latitude: 37.4276,
+          longitude: -122.1697,
+          businessClaimStatus: "claimed",
+        },
+      ]);
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /Stanford University/ }),
+      );
+
+      expect(
+        screen.queryByTestId("nearby-unclaimed-business-card"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("offers to invite a business the provider marks unclaimed", async () => {
+      service.nearbyPlaces.mockResolvedValue([
+        {
+          placeId: "stanford-main",
+          text: "Stanford University",
+          name: "Stanford University",
+          address: "450 Jane Stanford Way",
+          category: "University",
+          categories: ["education"],
+          distanceMeters: 48,
+          latitude: 37.4276,
+          longitude: -122.1697,
+          businessClaimStatus: "unclaimed",
+        },
+      ]);
       render(
         <NearbyCheckInSheet
           open
@@ -2131,7 +2203,21 @@ describe("NearbyCheckInSheet", () => {
       ).toBeInTheDocument();
     });
 
-    it("confirms before sending the invite and marks it sent afterward", async () => {
+    it("confirms the request without claiming an invite was actually sent", async () => {
+      service.nearbyPlaces.mockResolvedValue([
+        {
+          placeId: "stanford-main",
+          text: "Stanford University",
+          name: "Stanford University",
+          address: "450 Jane Stanford Way",
+          category: "University",
+          categories: ["education"],
+          distanceMeters: 48,
+          latitude: 37.4276,
+          longitude: -122.1697,
+          businessClaimStatus: "unclaimed",
+        },
+      ]);
       render(
         <NearbyCheckInSheet
           open
@@ -2154,27 +2240,42 @@ describe("NearbyCheckInSheet", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Hushh will send Stanford University an invite on your behalf/,
+          /Sending isn't available yet, so no invite goes out until it is/,
         ),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
+      fireEvent.click(screen.getByRole("button", { name: "Confirm request" }));
 
       await waitFor(() => {
         expect(
-          screen.getByTestId("nearby-unclaimed-business-invite-sent"),
-        ).toHaveTextContent("Invite sent on behalf of Hushh");
+          screen.getByTestId("nearby-unclaimed-business-invite-requested"),
+        ).toHaveTextContent("Noted. Sending isn't available yet.");
       });
       expect(
         screen.queryByRole("button", { name: "Send invite to claim business" }),
       ).not.toBeInTheDocument();
       const { toast } = await import("sonner");
-      expect(toast.success).toHaveBeenCalledWith(
-        "Hushh will invite Stanford University to claim their profile.",
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(toast.message).toHaveBeenCalledWith(
+        "Sending isn't available yet. We'll let you know once invites can reach Stanford University.",
       );
     });
 
-    it("cancels without sending or marking the place invited", async () => {
+    it("cancels without noting the request or marking the place invited", async () => {
+      service.nearbyPlaces.mockResolvedValue([
+        {
+          placeId: "stanford-main",
+          text: "Stanford University",
+          name: "Stanford University",
+          address: "450 Jane Stanford Way",
+          category: "University",
+          categories: ["education"],
+          distanceMeters: 48,
+          latitude: 37.4276,
+          longitude: -122.1697,
+          businessClaimStatus: "unclaimed",
+        },
+      ]);
       render(
         <NearbyCheckInSheet
           open
@@ -2204,8 +2305,10 @@ describe("NearbyCheckInSheet", () => {
         screen.getByRole("button", { name: "Send invite to claim business" }),
       ).toBeInTheDocument();
       expect(
-        screen.queryByTestId("nearby-unclaimed-business-invite-sent"),
+        screen.queryByTestId("nearby-unclaimed-business-invite-requested"),
       ).not.toBeInTheDocument();
+      const { toast } = await import("sonner");
+      expect(toast.message).not.toHaveBeenCalled();
     });
   });
 });

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -2100,4 +2100,112 @@ describe("NearbyCheckInSheet", () => {
       });
     });
   });
+
+  describe("unclaimed business invite", () => {
+    it("offers to invite an unclaimed business once a place is selected", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByTestId("nearby-unclaimed-business-card"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /Stanford University/ }),
+      );
+
+      const card = screen.getByTestId("nearby-unclaimed-business-card");
+      expect(card).toHaveTextContent("This business profile is unclaimed");
+      expect(card).toHaveTextContent(
+        "Send an invite on behalf of Hushh to claim profile.",
+      );
+      expect(
+        screen.getByRole("button", { name: "Send invite to claim business" }),
+      ).toBeInTheDocument();
+    });
+
+    it("confirms before sending the invite and marks it sent afterward", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /Stanford University/ }),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: "Send invite to claim business" }),
+      );
+
+      expect(
+        await screen.findByText("Send invite to claim business?"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Hushh will send Stanford University an invite on your behalf/,
+        ),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("nearby-unclaimed-business-invite-sent"),
+        ).toHaveTextContent("Invite sent on behalf of Hushh");
+      });
+      expect(
+        screen.queryByRole("button", { name: "Send invite to claim business" }),
+      ).not.toBeInTheDocument();
+      const { toast } = await import("sonner");
+      expect(toast.success).toHaveBeenCalledWith(
+        "Hushh will invite Stanford University to claim their profile.",
+      );
+    });
+
+    it("cancels without sending or marking the place invited", async () => {
+      render(
+        <NearbyCheckInSheet
+          open
+          ownerId="user-1"
+          vaultOwnerToken="owner-token"
+          captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /Stanford University/ }),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: "Send invite to claim business" }),
+      );
+      await screen.findByText("Send invite to claim business?");
+
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Send invite to claim business?"),
+        ).not.toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("button", { name: "Send invite to claim business" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("nearby-unclaimed-business-invite-sent"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -359,16 +359,21 @@ function timeLeftLabel(expiresAt: string): string {
 }
 
 /**
- * Whether the selected place has a claimed Hushh business profile.
+ * Whether the selected place is known -- from real backend data -- to have
+ * no claimed Hushh business profile.
  *
- * No place has ever been claimed -- there is no backend concept of a claimed
- * business yet -- so every real result is honestly "unclaimed" until the
- * claiming system tracked in issue #5459 exists to say otherwise.
+ * No current provider populates `businessClaimStatus`, so this is `false`
+ * for every real result today. That is deliberate: the claiming system
+ * tracked in issue #5459 does not exist yet, so "unknown" must never be
+ * treated as "unclaimed" -- doing so would show an invite CTA on every
+ * place, including ones that may already be claimed once that system
+ * ships. The CTA activates automatically the moment a provider starts
+ * sending this field.
  */
 function isPlaceUnclaimed(
   place: OneLocationNearbyPlaceSuggestion | null,
 ): boolean {
-  return place !== null;
+  return place?.businessClaimStatus === "unclaimed";
 }
 
 function initials(label: string): string {
@@ -528,7 +533,7 @@ export function NearbyCheckInSheet({
   const [placesError, setPlacesError] = useState<string | null>(null);
   const [accuracyNotice, setAccuracyNotice] = useState<string | null>(null);
   const [visiblePlacesCount, setVisiblePlacesCount] = useState(3);
-  const [invitedBusinessPlaceIds, setInvitedBusinessPlaceIds] = useState<
+  const [requestedBusinessInvitePlaceIds, setRequestedBusinessInvitePlaceIds] = useState<
     Set<string>
   >(new Set());
   const [pendingBusinessInvitePlaceId, setPendingBusinessInvitePlaceId] =
@@ -949,7 +954,7 @@ export function NearbyCheckInSheet({
     setPresenceLoadError(null);
     setPlacesError(null);
     setAccuracyNotice(null);
-    setInvitedBusinessPlaceIds(new Set());
+    setRequestedBusinessInvitePlaceIds(new Set());
     setPendingBusinessInvitePlaceId(null);
     publishState(EMPTY_NEARBY_STATE);
     return () => {
@@ -984,7 +989,7 @@ export function NearbyCheckInSheet({
     setLocationRecovery(null);
     setPresenceLoadError(null);
     setPlacesError(null);
-    setInvitedBusinessPlaceIds(new Set());
+    setRequestedBusinessInvitePlaceIds(new Set());
     setPendingBusinessInvitePlaceId(null);
     void loadPresence(!open, expectedOwnerEpoch).then((next) => {
       if (
@@ -1184,17 +1189,23 @@ export function NearbyCheckInSheet({
     ? selectedPlace.name?.trim() || selectedPlace.text
     : "";
   const selectedPlaceUnclaimed = isPlaceUnclaimed(selectedPlace);
-  const selectedPlaceInviteSent = selectedPlace
-    ? invitedBusinessPlaceIds.has(selectedPlace.placeId)
+  const selectedPlaceInviteRequested = selectedPlace
+    ? requestedBusinessInvitePlaceIds.has(selectedPlace.placeId)
     : false;
 
+  /**
+   * Records that the owner asked to invite this business, without claiming
+   * an SMS was sent -- there is no dispatch backend behind this yet (out of
+   * scope for #5459's Check-In slice), so the only honest outcome is "we
+   * noted the request", never a success state.
+   */
   const confirmBusinessInvite = () => {
     if (!selectedPlace) return;
     const placeId = selectedPlace.placeId;
-    setInvitedBusinessPlaceIds((current) => new Set(current).add(placeId));
+    setRequestedBusinessInvitePlaceIds((current) => new Set(current).add(placeId));
     setPendingBusinessInvitePlaceId(null);
-    toast.success(
-      `Hushh will invite ${selectedPlaceName || "this business"} to claim their profile.`,
+    toast.message(
+      `Sending isn't available yet. We'll let you know once invites can reach ${selectedPlaceName || "this business"}.`,
     );
   };
 
@@ -2119,13 +2130,12 @@ export function NearbyCheckInSheet({
                           <p className="mt-0.5 text-xs leading-4 text-muted-foreground">
                             Send an invite on behalf of Hushh to claim profile.
                           </p>
-                          {selectedPlaceInviteSent ? (
+                          {selectedPlaceInviteRequested ? (
                             <p
-                              className="mt-2 flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
-                              data-testid="nearby-unclaimed-business-invite-sent"
+                              className="mt-2 text-xs font-medium text-muted-foreground"
+                              data-testid="nearby-unclaimed-business-invite-requested"
                             >
-                              <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                              Invite sent on behalf of Hushh
+                              Noted. Sending isn&apos;t available yet.
                             </p>
                           ) : (
                             <Button
@@ -2327,14 +2337,15 @@ export function NearbyCheckInSheet({
           <AlertDialogHeader>
             <AlertDialogTitle>Send invite to claim business?</AlertDialogTitle>
             <AlertDialogDescription>
-              Hushh will send {selectedPlaceName || "this business"} an
-              invite on your behalf to claim and verify their profile.
+              This notes your request for {selectedPlaceName || "this business"} to
+              claim and verify their profile. Sending isn&apos;t available yet, so
+              no invite goes out until it is.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={confirmBusinessInvite}>
-              Send invite
+              Confirm request
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -9,6 +9,7 @@ import {
   type CSSProperties,
 } from "react";
 import {
+  Building2,
   Check,
   ChevronDown,
   Compass,
@@ -40,6 +41,16 @@ import {
   CHECK_OUT_BUTTON_VARIANT,
 } from "@/components/one-location/nearby-check-in/check-in-panel-layout";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -347,6 +358,19 @@ function timeLeftLabel(expiresAt: string): string {
   return remainder ? `${hours}h ${remainder}m left` : `${hours}h left`;
 }
 
+/**
+ * Whether the selected place has a claimed Hushh business profile.
+ *
+ * No place has ever been claimed -- there is no backend concept of a claimed
+ * business yet -- so every real result is honestly "unclaimed" until the
+ * claiming system tracked in issue #5459 exists to say otherwise.
+ */
+function isPlaceUnclaimed(
+  place: OneLocationNearbyPlaceSuggestion | null,
+): boolean {
+  return place !== null;
+}
+
 function initials(label: string): string {
   return (
     label
@@ -504,6 +528,11 @@ export function NearbyCheckInSheet({
   const [placesError, setPlacesError] = useState<string | null>(null);
   const [accuracyNotice, setAccuracyNotice] = useState<string | null>(null);
   const [visiblePlacesCount, setVisiblePlacesCount] = useState(3);
+  const [invitedBusinessPlaceIds, setInvitedBusinessPlaceIds] = useState<
+    Set<string>
+  >(new Set());
+  const [pendingBusinessInvitePlaceId, setPendingBusinessInvitePlaceId] =
+    useState<string | null>(null);
 
   const typedSearchActive = search.trim().length >= 2;
 
@@ -920,6 +949,8 @@ export function NearbyCheckInSheet({
     setPresenceLoadError(null);
     setPlacesError(null);
     setAccuracyNotice(null);
+    setInvitedBusinessPlaceIds(new Set());
+    setPendingBusinessInvitePlaceId(null);
     publishState(EMPTY_NEARBY_STATE);
     return () => {
       requestGenerationRef.current += 1;
@@ -953,6 +984,8 @@ export function NearbyCheckInSheet({
     setLocationRecovery(null);
     setPresenceLoadError(null);
     setPlacesError(null);
+    setInvitedBusinessPlaceIds(new Set());
+    setPendingBusinessInvitePlaceId(null);
     void loadPresence(!open, expectedOwnerEpoch).then((next) => {
       if (
         !open ||
@@ -1147,6 +1180,23 @@ export function NearbyCheckInSheet({
     () => offsetFromPoint(selectedPlace, point),
     [point, selectedPlace],
   );
+  const selectedPlaceName = selectedPlace
+    ? selectedPlace.name?.trim() || selectedPlace.text
+    : "";
+  const selectedPlaceUnclaimed = isPlaceUnclaimed(selectedPlace);
+  const selectedPlaceInviteSent = selectedPlace
+    ? invitedBusinessPlaceIds.has(selectedPlace.placeId)
+    : false;
+
+  const confirmBusinessInvite = () => {
+    if (!selectedPlace) return;
+    const placeId = selectedPlace.placeId;
+    setInvitedBusinessPlaceIds((current) => new Set(current).add(placeId));
+    setPendingBusinessInvitePlaceId(null);
+    toast.success(
+      `Hushh will invite ${selectedPlaceName || "this business"} to claim their profile.`,
+    );
+  };
 
   /** How far the owner has moved from the place they are checked in to. */
   const activeDriftMeters = useMemo(() => {
@@ -2053,6 +2103,48 @@ export function NearbyCheckInSheet({
                         <span>{offsetNotice(selectedPlaceOffsetMeters)}</span>
                       </p>
                     ) : null}
+                    {selectedPlace && selectedPlaceUnclaimed ? (
+                      <div
+                        className="mt-3 flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/40 p-4"
+                        data-testid="nearby-unclaimed-business-card"
+                      >
+                        <Building2
+                          className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+                          aria-hidden="true"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-semibold">
+                            This business profile is unclaimed
+                          </p>
+                          <p className="mt-0.5 text-xs leading-4 text-muted-foreground">
+                            Send an invite on behalf of Hushh to claim profile.
+                          </p>
+                          {selectedPlaceInviteSent ? (
+                            <p
+                              className="mt-2 flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+                              data-testid="nearby-unclaimed-business-invite-sent"
+                            >
+                              <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                              Invite sent on behalf of Hushh
+                            </p>
+                          ) : (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="secondary"
+                              className="mt-2"
+                              onClick={() =>
+                                setPendingBusinessInvitePlaceId(
+                                  selectedPlace.placeId,
+                                )
+                              }
+                            >
+                              Send invite to claim business
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    ) : null}
                     {!places.length &&
                     !capturing &&
                     !searching &&
@@ -2222,6 +2314,31 @@ export function NearbyCheckInSheet({
           )}
         </div>
       </SheetContent>
+      <AlertDialog
+        open={
+          pendingBusinessInvitePlaceId !== null &&
+          pendingBusinessInvitePlaceId === selectedPlace?.placeId
+        }
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setPendingBusinessInvitePlaceId(null);
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Send invite to claim business?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Hushh will send {selectedPlaceName || "this business"} an
+              invite on your behalf to claim and verify their profile.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmBusinessInvite}>
+              Send invite
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Sheet>
   );
 }

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -524,6 +524,13 @@ export type OneLocationNearbyPlaceSuggestion = {
    * nearby sweep locally instead of re-querying per chip and re-truncating.
    */
   categories?: OneLocationNearbyPlaceCategory[] | null;
+  /**
+   * Whether this place has a claimed Hushh business profile, per the
+   * business-claiming backend. No current provider populates this field, so
+   * it is `undefined`/`null` on every real result today -- callers must
+   * treat that as "unknown", never as "unclaimed".
+   */
+  businessClaimStatus?: "claimed" | "unclaimed" | null;
 };
 
 export type OneLocationNearbyRelationship =


### PR DESCRIPTION
## Summary
Part of #5459.

- Nearby Check-In detects that the selected place has a real, provider-confirmed unclaimed business profile and shows a card: *"This business profile is unclaimed — Send an invite on behalf of Hushh to claim profile."*
- **CTA only surfaces on a real signal.** `isPlaceUnclaimed()` requires an explicit `businessClaimStatus: "unclaimed"` field on the place (added to `OneLocationNearbyPlaceSuggestion`). No current provider populates this field, so the CTA stays hidden on real data today and activates automatically once a provider starts sending it — "unknown" is never treated as "unclaimed".
- Tapping **Send invite to claim business** opens a confirmation dialog naming the business and explaining that sending isn't live yet.
- **Confirming does not claim success.** There is no SMS dispatch backend behind this yet, so confirming only notes the request locally (`toast.message`, not `toast.success`) and shows "Noted. Sending isn't available yet." — never a false "Invite sent" state.
- Canceling leaves everything untouched.

## Explicitly out of scope for this PR
- OTP generation/verification backend
- SMS dispatch
- The business claim landing page and profile transition
- Any other acceptance criteria from #5459 beyond the Check-In CTA

## Test plan
- [x] `npx vitest run components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx` — 50 passed (50), including 5 in the unclaimed-business-invite suite: CTA never shows on the default (no-signal) fixture, CTA stays hidden when explicitly marked `claimed`, CTA appears only when marked `unclaimed`, confirming notes the request without claiming success, canceling leaves state and toasts untouched.
- [x] `tsc --noEmit` clean on the touched files
- [x] `eslint` clean on the touched files