### PR TITLE
fix(one-location): cache Places API check-in and directory lookups

### DIFF
--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import time
 from typing import Any, Literal
 from urllib.parse import quote
 
@@ -32,6 +33,69 @@ _NEARBY_CHECK_IN_RESULT_LIMIT = 20
 # Ceiling for the merged multi-request sweep. Each category bucket contributes
 # its own 20-result budget, so a hotel is never crowded out by restaurants.
 _NEARBY_CHECK_IN_MERGED_LIMIT = 80
+
+# Repeat opens at the same spot (home, office) are the dominant real-world
+# pattern for both the check-in picker and the directory, so a short cache
+# keyed on a coarse grid cell avoids re-billing Google for a location that
+# has not moved. 3 decimal places is ~110 m at the equator -- tighter than
+# the 500 m check-in radius, so a hit still means "the same immediate area",
+# not "somewhere down the block". In-process only: nothing here is written
+# to disk, a log, or a database, and it is empty again on the next deploy.
+_PLACES_CACHE_TTL_SECONDS = 600.0
+_PLACES_CACHE_CELL_DECIMALS = 3
+
+# Two independent caches: the check-in picker's "all" sweep and the
+# directory's per-category, caller-chosen-radius lookups have different key
+# shapes and must not collide with each other.
+_nearby_places_cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]] = {}
+_directory_cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]] = {}
+# A module-level indirection so a test can freeze/advance time deterministically
+# instead of sleeping for real seconds to prove TTL expiry.
+_cache_clock = time.monotonic
+
+
+def clear_places_cache() -> None:
+    """Reset both Places response caches.
+
+    Call this between tests -- otherwise a cache hit from one test (many
+    reuse the same lat/lng as "the" standard test point) silently serves a
+    different test's mock response instead of exercising a fresh call.
+    """
+
+    _nearby_places_cache.clear()
+    _directory_cache.clear()
+
+
+def _geo_cell(lat: float, lng: float) -> tuple[float, float]:
+    return (
+        round(float(lat), _PLACES_CACHE_CELL_DECIMALS),
+        round(float(lng), _PLACES_CACHE_CELL_DECIMALS),
+    )
+
+
+def _cache_get(
+    cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]],
+    cache_key: tuple[Any, ...],
+) -> list[dict[str, Any]] | None:
+    entry = cache.get(cache_key)
+    if entry is None:
+        return None
+    inserted_at, value = entry
+    if _cache_clock() - inserted_at > _PLACES_CACHE_TTL_SECONDS:
+        del cache[cache_key]
+        return None
+    # A copy: the caller is free to slice/sort/mutate its result without
+    # corrupting what the next hit returns.
+    return list(value)
+
+
+def _cache_set(
+    cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]],
+    cache_key: tuple[Any, ...],
+    value: list[dict[str, Any]],
+) -> None:
+    cache[cache_key] = (_cache_clock(), list(value))
+
 
 NearbyPlaceCategory = Literal[
     "all",
@@ -816,10 +880,18 @@ class GoogleMapsService:
         bucket concurrently and merges: each bucket brings its own 20-result
         budget, so no category can crowd out another.
 
-        The request point is sent to Google only for this foreground request and
-        is not cached or logged by this service. Exact distance helps the owner
-        choose a place but is never included in nearby-person responses.
+        The request point is never logged or persisted by this service. It is
+        sent to Google for a foreground request, and briefly held in an
+        in-process cache (see `_PLACES_CACHE_TTL_SECONDS`) so a drawer reopened
+        at a spot that has not moved is answered without billing Google again.
+        Exact distance helps the owner choose a place but is never included in
+        nearby-person responses.
         """
+
+        cache_key = (category, *_geo_cell(lat, lng))
+        cached = _cache_get(_nearby_places_cache, cache_key)
+        if cached is not None:
+            return cached
 
         key = _require_key()
         # (chip this request stands for, types it filters on). The leading
@@ -898,7 +970,9 @@ class GoogleMapsService:
         limit = (
             _NEARBY_CHECK_IN_MERGED_LIMIT if category == "all" else _NEARBY_CHECK_IN_RESULT_LIMIT
         )
-        return results[:limit]
+        bounded = results[:limit]
+        _cache_set(_nearby_places_cache, cache_key, bounded)
+        return bounded
 
     async def search_directory_category(
         self,
@@ -920,8 +994,12 @@ class GoogleMapsService:
         picker is answering "where am I standing", so 500 m is the honest bound;
         a directory is answering "what is around here", where the reader chooses.
 
-        The request point is sent to Google for this foreground request only. It
-        is not cached, logged, or persisted by this service.
+        The request point is never logged or persisted by this service. It is
+        sent to Google for a foreground request, and briefly held in an
+        in-process cache (see `_PLACES_CACHE_TTL_SECONDS`) keyed on category,
+        grid cell, and the clamped radius/limit -- so tapping between radius
+        tiers or reopening the same category on the same visit does not
+        re-bill Google for an answer already in hand.
         """
 
         key = _require_key()
@@ -935,6 +1013,11 @@ class GoogleMapsService:
 
         bounded_radius = max(1.0, min(float(radius_meters), _DIRECTORY_MAX_RADIUS_METERS))
         bounded_limit = max(1, min(int(limit), _DIRECTORY_MAX_RESULT_COUNT))
+
+        cache_key = (category, *_geo_cell(lat, lng), round(bounded_radius), bounded_limit)
+        cached = _cache_get(_directory_cache, cache_key)
+        if cached is not None:
+            return cached
 
         body: dict[str, Any] = {
             "maxResultCount": bounded_limit,
@@ -987,6 +1070,7 @@ class GoogleMapsService:
                 rows.append(row)
 
         rows.sort(key=lambda item: (item["distanceMeters"], str(item["name"]).casefold()))
+        _cache_set(_directory_cache, cache_key, rows)
         return rows
 
     def _normalize_directory_place(

--- a/consent-protocol/tests/conftest.py
+++ b/consent-protocol/tests/conftest.py
@@ -34,7 +34,14 @@ os.environ.setdefault(
 
 @pytest.fixture(autouse=True)
 def isolate_runtime_env(monkeypatch: pytest.MonkeyPatch):
+    # Local import: hushh_mcp.config resolves APP_SIGNING_KEY at import time,
+    # so importing this at module level (before the setdefault calls above
+    # run) breaks collection in any environment without a real .env -- e.g. a
+    # clean checkout with no dev secrets on disk.
+    from hushh_mcp.services.google_maps_service import clear_places_cache
+
     clear_runtime_settings_caches()
+    clear_places_cache()
     monkeypatch.setenv("TESTING", "true")
     monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_pytest_only_32chars_min")
     monkeypatch.setenv(
@@ -50,6 +57,7 @@ def isolate_runtime_env(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv(key, raising=False)
     yield
     clear_runtime_settings_caches()
+    clear_places_cache()
 
 
 # ============================================================================

--- a/consent-protocol/tests/services/test_google_maps_service.py
+++ b/consent-protocol/tests/services/test_google_maps_service.py
@@ -738,3 +738,172 @@ async def test_resolve_postal_code_without_a_key_makes_no_call(monkeypatch):
     monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
     assert await gms.GoogleMapsService().resolve_postal_code(query="SANDY, UT") == ""
     assert called is False
+
+
+# --------------------------------------------------------------------------- #
+# Response cache -- repeat opens at a spot that has not moved must not re-bill
+# Google. See `_PLACES_CACHE_TTL_SECONDS` / `_geo_cell` in google_maps_service.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_reuses_a_cached_answer_for_the_same_cell(monkeypatch):
+    """A drawer reopened at home ten times a day must cost one provider call."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            json={
+                "places": [
+                    {
+                        "id": "spot-a",
+                        "displayName": {"text": "Spot A"},
+                        "shortFormattedAddress": "Stanford, CA",
+                        "primaryType": "university",
+                        "primaryTypeDisplayName": {"text": "University"},
+                        "businessStatus": "OPERATIONAL",
+                        "location": {"latitude": 37.4276, "longitude": -122.1697},
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    svc = gms.GoogleMapsService()
+    first = await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    second = await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+
+    assert calls == 1
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_cache_misses_for_a_materially_different_cell(monkeypatch):
+    """A real move to a new area must still reach Google, not a stale cache."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    svc = gms.GoogleMapsService()
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    await svc.nearby_places(lat=37.9000, lng=-122.1697, category="education")
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_cache_expires_after_the_ttl(monkeypatch):
+    calls = 0
+    clock = {"t": 0.0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    monkeypatch.setattr(gms, "_cache_clock", lambda: clock["t"])
+
+    svc = gms.GoogleMapsService()
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    clock["t"] += gms._PLACES_CACHE_TTL_SECONDS + 1
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_clear_places_cache_forces_a_fresh_lookup(monkeypatch):
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    svc = gms.GoogleMapsService()
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    gms.clear_places_cache()
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_search_directory_category_reuses_a_cached_answer(monkeypatch):
+    """Reopening the same directory category on the same visit costs one call."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            json={
+                "places": [
+                    {
+                        "id": "hotel-a",
+                        "displayName": {"text": "Hotel A"},
+                        "location": {"latitude": 12.9716, "longitude": 77.5946},
+                        "businessStatus": "OPERATIONAL",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    svc = gms.GoogleMapsService()
+    first = await svc.search_directory_category(
+        lat=12.9716, lng=77.5946, category="hotels_stays", radius_meters=8046.72, limit=8
+    )
+    second = await svc.search_directory_category(
+        lat=12.9716, lng=77.5946, category="hotels_stays", radius_meters=8046.72, limit=8
+    )
+
+    assert calls == 1
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_search_directory_category_cache_key_includes_radius(monkeypatch):
+    """A different radius tier is a genuinely different answer, not a cache hit."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    svc = gms.GoogleMapsService()
+    await svc.search_directory_category(
+        lat=12.9716, lng=77.5946, category="hotels_stays", radius_meters=1_600.0, limit=8
+    )
+    await svc.search_directory_category(
+        lat=12.9716, lng=77.5946, category="hotels_stays", radius_meters=24_000.0, limit=8
+    )
+
+    assert calls == 2


### PR DESCRIPTION
## Summary
- `nearby_places()` (check-in drawer "All" sweep) and `search_directory_category()` (Connect "Places near you") called Google Places fresh on every request with zero caching — traced via Cloud Monitoring to ~$9-14/day of ongoing spend on `hushh-pda-uat`, the dominant driver of an unexplained daily Places API charge.
- Adds a 10-minute TTL, in-process response cache keyed on category + a coarse geo-cell (~110m grid), plus radius/limit for the directory lookup, so a drawer/directory reopened at a spot that hasn't moved is served from cache instead of re-billing Google.
- Unrelated: a separate one-time ~$4-5k batch-crawl spend in `hushh-tech-prod` (different project, different cause) was already investigated and confirmed fully stopped — not touched by this PR.

## Test plan
- [x] 6 new tests covering cache hit/miss/TTL-expiry/explicit-clear for both `nearby_places()` and `search_directory_category()`
- [x] `tests/services/test_google_maps_service.py` + `tests/test_places_directory.py` + `tests/test_one_location_nearby_presence_routes.py`: 82/82 passing
- [x] Full backend suite run against this branch AND against origin/main baseline — identical pre-existing 65 failed/12 errors on both, zero regressions introduced
- [x] `ruff check` + `ruff format --check` clean
- [x] Verified test collection works in a venv with no `.env` file present (import-order fix: a top-level conftest.py import of the new cache helper was resolving `APP_SIGNING_KEY` before the test-default env vars were set — moved to a local import inside the fixture)

Closes #5721