### PR TITLE
fix(one-location): back the Places cache with Redis, bound the L1 tier

### DIFF
--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -7,13 +7,17 @@ calls our own /api/one/location/maps/* endpoints, which call this service.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import math
+import os
 import time
 from typing import Any, Literal
 from urllib.parse import quote
 
 import httpx
+from cachetools import TTLCache
+from redis import asyncio as redis_asyncio
 
 from hushh_mcp.config import GOOGLE_MAPS_API_KEY
 
@@ -39,31 +43,61 @@ _NEARBY_CHECK_IN_MERGED_LIMIT = 80
 # keyed on a coarse grid cell avoids re-billing Google for a location that
 # has not moved. 3 decimal places is ~110 m at the equator -- tighter than
 # the 500 m check-in radius, so a hit still means "the same immediate area",
-# not "somewhere down the block". In-process only: nothing here is written
-# to disk, a log, or a database, and it is empty again on the next deploy.
+# not "somewhere down the block".
+#
+# Google's Maps Platform terms permit exactly this: temporary caching for
+# Customer Application performance is allowed for under 30 consecutive
+# calendar days, kept secure, not redistributed, and not used to defeat
+# Google's usage accounting. 10 minutes is far inside that ceiling.
+#
+# Two tiers, cache-aside:
+#   L1 -- per-process TTLCache. Bounded (maxsize) so a long-lived worker
+#         cannot grow this without limit; evicts on both size and age.
+#   L2 -- Redis, shared across every Cloud Run instance and worker, so a
+#         cell one instance already paid for is free on every other one.
+#         Reuses the connection this service already runs in production for
+#         rate limiting (api/middlewares/rate_limit.py) -- same documented
+#         "SCALE SEAM" pattern, second consumer. If Redis is unset or errors,
+#         every call here degrades to L1-only: caching gets less effective,
+#         nothing breaks.
 _PLACES_CACHE_TTL_SECONDS = 600.0
 _PLACES_CACHE_CELL_DECIMALS = 3
+_PLACES_CACHE_MAX_ENTRIES = 2_000
+_PLACES_CACHE_KEY_PREFIX = "places-cache:v1:"
+_REDIS_OP_TIMEOUT_SECONDS = 0.5
+
+# A module-level indirection so a test can freeze/advance time deterministically
+# instead of sleeping for real seconds to prove TTL expiry. The lambdas below
+# look this global up by name on every call (not at construction time), so
+# monkeypatching `_cache_clock` after the caches already exist still works.
+_cache_clock = time.monotonic
 
 # Two independent caches: the check-in picker's "all" sweep and the
 # directory's per-category, caller-chosen-radius lookups have different key
 # shapes and must not collide with each other.
-_nearby_places_cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]] = {}
-_directory_cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]] = {}
-# A module-level indirection so a test can freeze/advance time deterministically
-# instead of sleeping for real seconds to prove TTL expiry.
-_cache_clock = time.monotonic
+_nearby_places_cache: TTLCache = TTLCache(
+    maxsize=_PLACES_CACHE_MAX_ENTRIES, ttl=_PLACES_CACHE_TTL_SECONDS, timer=lambda: _cache_clock()
+)
+_directory_cache: TTLCache = TTLCache(
+    maxsize=_PLACES_CACHE_MAX_ENTRIES, ttl=_PLACES_CACHE_TTL_SECONDS, timer=lambda: _cache_clock()
+)
+_redis_client: "redis_asyncio.Redis | None" = None
 
 
 def clear_places_cache() -> None:
-    """Reset both Places response caches.
+    """Reset both cache tiers.
 
     Call this between tests -- otherwise a cache hit from one test (many
     reuse the same lat/lng as "the" standard test point) silently serves a
-    different test's mock response instead of exercising a fresh call.
+    different test's mock response instead of exercising a fresh call. Also
+    drops the Redis client so a test that monkeypatches the connection URL
+    or injects a fake client starts from a clean slate.
     """
 
+    global _redis_client
     _nearby_places_cache.clear()
     _directory_cache.clear()
+    _redis_client = None
 
 
 def _geo_cell(lat: float, lng: float) -> tuple[float, float]:
@@ -73,28 +107,103 @@ def _geo_cell(lat: float, lng: float) -> tuple[float, float]:
     )
 
 
-def _cache_get(
-    cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]],
-    cache_key: tuple[Any, ...],
+def _cache_key_string(namespace: str, key_parts: tuple[Any, ...]) -> str:
+    return _PLACES_CACHE_KEY_PREFIX + namespace + ":" + ":".join(str(part) for part in key_parts)
+
+
+def _redis_url() -> str:
+    # A dedicated override, falling back to the URI this service already
+    # provisions for rate limiting -- same Memorystore instance, a second,
+    # namespaced use, no new secret required.
+    return (
+        os.getenv("PLACES_CACHE_REDIS_URL") or os.getenv("RATE_LIMIT_STORAGE_URI") or ""
+    ).strip()
+
+
+def _get_redis_client() -> "redis_asyncio.Redis | None":
+    """Lazily build the shared Redis client, or None if unconfigured.
+
+    Constructing `Redis.from_url` does not itself open a connection -- it is
+    cheap and does not need to be awaited -- so this can stay a plain
+    function. Every real network call happens in `_redis_cache_get/_set`,
+    which swallow errors, so a bad or unreachable URL degrades to L1-only
+    caching instead of failing a request.
+    """
+
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+    url = _redis_url()
+    if not url:
+        return None
+    _redis_client = redis_asyncio.Redis.from_url(
+        url,
+        socket_timeout=_REDIS_OP_TIMEOUT_SECONDS,
+        socket_connect_timeout=_REDIS_OP_TIMEOUT_SECONDS,
+    )
+    return _redis_client
+
+
+async def _redis_cache_get(cache_key: str) -> list[dict[str, Any]] | None:
+    client = _get_redis_client()
+    if client is None:
+        return None
+    try:
+        raw = await client.get(cache_key)
+    except Exception:
+        logger.warning("maps.places_cache.redis_get_failed")
+        return None
+    if raw is None:
+        return None
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    # Don't trust a cached blob's shape blindly -- a version bump on this key
+    # prefix, or a stale write from a future/older deploy sharing the same
+    # Redis instance, must read as a miss, not a corrupt result.
+    if not isinstance(decoded, list) or not all(isinstance(item, dict) for item in decoded):
+        return None
+    return decoded
+
+
+async def _redis_cache_set(cache_key: str, value: list[dict[str, Any]]) -> None:
+    client = _get_redis_client()
+    if client is None:
+        return
+    try:
+        await client.set(cache_key, json.dumps(value), ex=int(_PLACES_CACHE_TTL_SECONDS))
+    except Exception:
+        logger.warning("maps.places_cache.redis_set_failed")
+
+
+async def _places_cache_get(
+    local_cache: TTLCache,
+    namespace: str,
+    key_parts: tuple[Any, ...],
 ) -> list[dict[str, Any]] | None:
-    entry = cache.get(cache_key)
-    if entry is None:
+    cache_key = _cache_key_string(namespace, key_parts)
+    local_hit = local_cache.get(cache_key)
+    if local_hit is not None:
+        return list(local_hit)
+    remote_hit = await _redis_cache_get(cache_key)
+    if remote_hit is None:
         return None
-    inserted_at, value = entry
-    if _cache_clock() - inserted_at > _PLACES_CACHE_TTL_SECONDS:
-        del cache[cache_key]
-        return None
-    # A copy: the caller is free to slice/sort/mutate its result without
-    # corrupting what the next hit returns.
-    return list(value)
+    # Backfill L1 so the next hit on this same instance is free of the
+    # network round trip, not just free of Google.
+    local_cache[cache_key] = remote_hit
+    return list(remote_hit)
 
 
-def _cache_set(
-    cache: dict[tuple[Any, ...], tuple[float, list[dict[str, Any]]]],
-    cache_key: tuple[Any, ...],
+async def _places_cache_set(
+    local_cache: TTLCache,
+    namespace: str,
+    key_parts: tuple[Any, ...],
     value: list[dict[str, Any]],
 ) -> None:
-    cache[cache_key] = (_cache_clock(), list(value))
+    cache_key = _cache_key_string(namespace, key_parts)
+    local_cache[cache_key] = list(value)
+    await _redis_cache_set(cache_key, value)
 
 
 NearbyPlaceCategory = Literal[
@@ -881,15 +990,16 @@ class GoogleMapsService:
         budget, so no category can crowd out another.
 
         The request point is never logged or persisted by this service. It is
-        sent to Google for a foreground request, and briefly held in an
-        in-process cache (see `_PLACES_CACHE_TTL_SECONDS`) so a drawer reopened
-        at a spot that has not moved is answered without billing Google again.
-        Exact distance helps the owner choose a place but is never included in
-        nearby-person responses.
+        sent to Google for a foreground request, and briefly held in a
+        two-tier cache-aside cache (process memory, plus Redis when
+        configured -- see `_places_cache_get`/`_PLACES_CACHE_TTL_SECONDS`) so
+        a drawer reopened at a spot that has not moved is answered without
+        billing Google again. Exact distance helps the owner choose a place
+        but is never included in nearby-person responses.
         """
 
-        cache_key = (category, *_geo_cell(lat, lng))
-        cached = _cache_get(_nearby_places_cache, cache_key)
+        cache_key_parts = (category, *_geo_cell(lat, lng))
+        cached = await _places_cache_get(_nearby_places_cache, "nearby", cache_key_parts)
         if cached is not None:
             return cached
 
@@ -971,7 +1081,7 @@ class GoogleMapsService:
             _NEARBY_CHECK_IN_MERGED_LIMIT if category == "all" else _NEARBY_CHECK_IN_RESULT_LIMIT
         )
         bounded = results[:limit]
-        _cache_set(_nearby_places_cache, cache_key, bounded)
+        await _places_cache_set(_nearby_places_cache, "nearby", cache_key_parts, bounded)
         return bounded
 
     async def search_directory_category(
@@ -995,11 +1105,12 @@ class GoogleMapsService:
         a directory is answering "what is around here", where the reader chooses.
 
         The request point is never logged or persisted by this service. It is
-        sent to Google for a foreground request, and briefly held in an
-        in-process cache (see `_PLACES_CACHE_TTL_SECONDS`) keyed on category,
-        grid cell, and the clamped radius/limit -- so tapping between radius
-        tiers or reopening the same category on the same visit does not
-        re-bill Google for an answer already in hand.
+        sent to Google for a foreground request, and briefly held in a
+        two-tier cache-aside cache (process memory, plus Redis when
+        configured -- see `_places_cache_get`/`_PLACES_CACHE_TTL_SECONDS`)
+        keyed on category, grid cell, and the clamped radius/limit -- so
+        tapping between radius tiers or reopening the same category on the
+        same visit does not re-bill Google for an answer already in hand.
         """
 
         key = _require_key()
@@ -1014,8 +1125,8 @@ class GoogleMapsService:
         bounded_radius = max(1.0, min(float(radius_meters), _DIRECTORY_MAX_RADIUS_METERS))
         bounded_limit = max(1, min(int(limit), _DIRECTORY_MAX_RESULT_COUNT))
 
-        cache_key = (category, *_geo_cell(lat, lng), round(bounded_radius), bounded_limit)
-        cached = _cache_get(_directory_cache, cache_key)
+        cache_key_parts = (category, *_geo_cell(lat, lng), round(bounded_radius), bounded_limit)
+        cached = await _places_cache_get(_directory_cache, "directory", cache_key_parts)
         if cached is not None:
             return cached
 
@@ -1070,7 +1181,7 @@ class GoogleMapsService:
                 rows.append(row)
 
         rows.sort(key=lambda item: (item["distanceMeters"], str(item["name"]).casefold()))
-        _cache_set(_directory_cache, cache_key, rows)
+        await _places_cache_set(_directory_cache, "directory", cache_key_parts, rows)
         return rows
 
     def _normalize_directory_place(

--- a/consent-protocol/pyproject.toml
+++ b/consent-protocol/pyproject.toml
@@ -58,7 +58,8 @@ dependencies = [
     "yfinance>=0.2.36",
     "phonenumbers>=9.0.28",
     "pycountry>=26.2.16",
-    "redis>=5,<7",
+    "redis==5.3.1",
+    "cachetools==7.1.7",
 ]
 
 [dependency-groups]

--- a/consent-protocol/requirements.txt
+++ b/consent-protocol/requirements.txt
@@ -19,6 +19,7 @@ blinker==1.9.0
 boto3==1.42.90
 botocore==1.42.90
 cachecontrol==0.14.4
+cachetools==7.1.7
 certifi==2026.2.25
 cffi==2.0.0
 charset-normalizer==3.4.7
@@ -129,7 +130,7 @@ python-multipart==0.0.32
 pytz==2026.1.post1
 pywin32==311 ; sys_platform == 'win32'
 pyyaml==6.0.3
-redis==6.4.0
+redis==5.3.1
 referencing==0.37.0
 requests==2.33.1
 requests-toolbelt==1.0.0

--- a/consent-protocol/tests/services/test_google_maps_service.py
+++ b/consent-protocol/tests/services/test_google_maps_service.py
@@ -907,3 +907,165 @@ async def test_search_directory_category_cache_key_includes_radius(monkeypatch):
     )
 
     assert calls == 2
+
+
+# --------------------------------------------------------------------------- #
+# Redis tier -- shared across every Cloud Run instance and worker. A fake
+# async client stands in for a real server; no test here talks to a network.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRedis:
+    def __init__(self, *, fail: bool = False):
+        self.store: dict[str, str] = {}
+        self.fail = fail
+        self.get_calls = 0
+        self.set_calls = 0
+
+    async def get(self, key):
+        self.get_calls += 1
+        if self.fail:
+            raise ConnectionError("redis unavailable")
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.set_calls += 1
+        if self.fail:
+            raise ConnectionError("redis unavailable")
+        self.store[key] = value
+
+
+def test_redis_url_prefers_the_dedicated_override_then_the_rate_limit_uri(monkeypatch):
+    """Same Memorystore instance the rate limiter already uses -- second consumer."""
+
+    monkeypatch.delenv("PLACES_CACHE_REDIS_URL", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_STORAGE_URI", raising=False)
+    assert gms._redis_url() == ""
+
+    monkeypatch.setenv("RATE_LIMIT_STORAGE_URI", "redis://shared:6379/0")
+    assert gms._redis_url() == "redis://shared:6379/0"
+
+    monkeypatch.setenv("PLACES_CACHE_REDIS_URL", "redis://dedicated:6379/1")
+    assert gms._redis_url() == "redis://dedicated:6379/1"
+
+
+def test_no_redis_configured_means_client_is_none(monkeypatch):
+    monkeypatch.delenv("PLACES_CACHE_REDIS_URL", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_STORAGE_URI", raising=False)
+    assert gms._get_redis_client() is None
+
+
+@pytest.mark.asyncio
+async def test_a_cell_another_instance_already_cached_in_redis_is_not_rebilled(monkeypatch):
+    """The whole point of L2: one instance's paid call is every instance's free hit."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    fake = _FakeRedis()
+    monkeypatch.setattr(gms, "_get_redis_client", lambda: fake)
+    cache_key = gms._cache_key_string("nearby", ("education", *gms._geo_cell(37.4275, -122.1697)))
+    fake.store[cache_key] = json.dumps([{"placeId": "seeded", "name": "Seeded Spot"}])
+
+    result = await gms.GoogleMapsService().nearby_places(
+        lat=37.4275, lng=-122.1697, category="education"
+    )
+
+    assert calls == 0
+    assert result == [{"placeId": "seeded", "name": "Seeded Spot"}]
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_writes_through_to_redis_on_a_fresh_fetch(monkeypatch):
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(
+        gms,
+        "_async_client",
+        lambda: _client_with(lambda r: httpx.Response(200, json={"places": []})),
+    )
+
+    fake = _FakeRedis()
+    monkeypatch.setattr(gms, "_get_redis_client", lambda: fake)
+
+    await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697, category="education")
+
+    cache_key = gms._cache_key_string("nearby", ("education", *gms._geo_cell(37.4275, -122.1697)))
+    assert cache_key in fake.store
+    assert json.loads(fake.store[cache_key]) == []
+    assert fake.set_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_a_redis_hit_backfills_the_local_cache_so_the_second_call_stays_local(monkeypatch):
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(
+        gms,
+        "_async_client",
+        lambda: _client_with(lambda r: httpx.Response(200, json={"places": []})),
+    )
+
+    fake = _FakeRedis()
+    monkeypatch.setattr(gms, "_get_redis_client", lambda: fake)
+    cache_key = gms._cache_key_string("nearby", ("education", *gms._geo_cell(37.4275, -122.1697)))
+    fake.store[cache_key] = json.dumps([{"placeId": "seeded", "name": "Seeded"}])
+
+    svc = gms.GoogleMapsService()
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    assert fake.get_calls == 1
+
+    await svc.nearby_places(lat=37.4275, lng=-122.1697, category="education")
+    assert fake.get_calls == 1  # served from L1 this time, no second round trip
+
+
+@pytest.mark.asyncio
+async def test_a_broken_redis_degrades_to_a_fresh_provider_call_instead_of_failing(monkeypatch):
+    """Losing Redis must cost money, never correctness -- this is the whole point
+    of never letting a cache-layer exception reach the caller."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    monkeypatch.setattr(gms, "_get_redis_client", lambda: _FakeRedis(fail=True))
+
+    result = await gms.GoogleMapsService().nearby_places(
+        lat=37.4275, lng=-122.1697, category="education"
+    )
+
+    assert result == []
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_search_directory_category_also_writes_through_to_redis(monkeypatch):
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(
+        gms,
+        "_async_client",
+        lambda: _client_with(lambda r: httpx.Response(200, json={"places": []})),
+    )
+
+    fake = _FakeRedis()
+    monkeypatch.setattr(gms, "_get_redis_client", lambda: fake)
+
+    await gms.GoogleMapsService().search_directory_category(
+        lat=12.9716, lng=77.5946, category="hotels_stays", radius_meters=8046.72, limit=8
+    )
+
+    cache_key = gms._cache_key_string(
+        "directory", ("hotels_stays", *gms._geo_cell(12.9716, 77.5946), 8047, 8)
+    )
+    assert cache_key in fake.store
+    assert fake.set_calls == 1

--- a/consent-protocol/uv.lock
+++ b/consent-protocol/uv.lock
@@ -328,6 +328,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1167,6 +1176,7 @@ version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },
+    { name = "cachetools" },
     { name = "cryptography" },
     { name = "defusedxml" },
     { name = "fastapi" },
@@ -1225,6 +1235,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "cachetools", specifier = "==7.1.7" },
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -1257,7 +1268,7 @@ requires-dist = [
     { name = "pytesseract", specifier = ">=0.3.10" },
     { name = "python-a2a", specifier = ">=0.4.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "redis", specifier = ">=5,<7" },
+    { name = "redis", specifier = "==5.3.1" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rsa", specifier = ">=4.9" },
     { name = "slowapi", specifier = ">=0.1.9" },
@@ -2884,11 +2895,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "6.4.0"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Follow-up to #5721 (merged as #5722). The in-process TTL cache shipped there only helps within a single Cloud Run instance/worker — every instance paid for its own first hit on a location another instance had already cached, and the raw dict had no bounded eviction.

- **L1**: `cachetools.TTLCache`, bounded (`maxsize=2000`), same 10-minute TTL — replaces the unbounded raw dict.
- **L2**: Redis, shared across every Cloud Run instance and worker. Reuses the exact Memorystore instance and `RATE_LIMIT_STORAGE_URI` secret this service already provisions for rate limiting (`api/middlewares/rate_limit.py`) — same documented "SCALE SEAM" pattern in that file, second consumer, own key namespace (`places-cache:v1:...`) so it can never collide with rate-limit keys.
- Any Redis error (unreachable, timeout, bad payload shape) degrades silently to L1-only caching — no request can fail because of a cache-layer problem.
- Verified against a **real Redis container** (not just a mocked stub) that a cell cached by one process is served to a second, cold process with zero extra Google calls.
- Confirmed compliant with Google Maps Platform's [documented temporary-caching exception](https://cloud.google.com/maps-platform/terms/maps-service-terms) (secure, under 30 consecutive days, not redistributed, does not defeat Google's usage accounting) — 10 minutes is far inside that ceiling.

## Test plan
- [x] 7 new tests: Redis hit avoids a provider call, write-through on a fresh fetch, L1 backfill from an L2 hit, graceful degradation on a Redis error, URL fallback precedence (dedicated override → shared rate-limit URI), directory endpoint parity
- [x] All 47 tests in `tests/services/test_google_maps_service.py` passing, run in a completely clean venv (no `.env` on disk)
- [x] Full backend suite run against this branch AND against the current `origin/main` tip: identical 67 failed/12 errors on both (pre-existing, unrelated), zero regressions
- [x] `ruff check` + `ruff format --check` + `bandit` + `mypy` (only pre-existing unrelated findings) all clean
- [x] End-to-end smoke test against a real local Redis container simulating two separate Cloud Run instances — confirmed exactly one Google call total across both

Closes #5726