### PR TITLE
Fix/ria claim profile back navigation

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -247,6 +247,33 @@ describe("top shell breadcrumbs", () => {
     ).toBe("/one");
   });
 
+  it("shows shared top-left back navigation for the RIA claim flow", () => {
+    expect(resolveTopShellBreadcrumb("/ria/claim")).toEqual({
+      backHref: "/ria/onboarding",
+      width: "content",
+      align: "center",
+      hideBack: false,
+      items: [
+        { label: "RIA", href: "/ria/onboarding" },
+        { label: "Claim profile" },
+      ],
+    });
+
+    const returnToSetup = new URLSearchParams();
+    returnToSetup.set("return_to", "/one/setup");
+
+    expect(resolveTopShellBreadcrumb("/ria/claim", returnToSetup)).toEqual({
+      backHref: "/one/setup",
+      width: "content",
+      align: "center",
+      hideBack: false,
+      items: [
+        { label: "RIA", href: "/one/setup" },
+        { label: "Claim profile" },
+      ],
+    });
+  });
+
   it("gives per-capability setup steps a back affordance to the hub", () => {
     expect(resolveTopShellBreadcrumb("/one/setup/finance")).toEqual({
       backHref: "/one/setup",

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -487,16 +487,12 @@ export default function RiaClaimPage() {
   }, []);
 
   const handleBack = useCallback(() => {
-    if (step === "phone") {
-      router.push(returnTo || ROUTES.RIA_ONBOARDING);
-      return;
-    }
     if (step === "found") {
       resetToPhone();
       return;
     }
     setStep("found");
-  }, [resetToPhone, returnTo, router, step]);
+  }, [resetToPhone, step]);
 
   const outcome = lookup?.outcome ?? null;
   const candidates: RiaClaimCandidate[] = lookup?.candidates ?? [];
@@ -556,7 +552,7 @@ export default function RiaClaimPage() {
       />
       <FullscreenFlowShell width="reading" className="px-0">
         <div className="mx-auto flex w-full max-w-[34rem] flex-col gap-6 px-6 pb-[var(--app-scroll-bottom-pad)] pt-4">
-          {step !== "done" ? (
+          {step !== "phone" && step !== "done" ? (
             <button
               type="button"
               onClick={handleBack}

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -486,6 +486,18 @@ export default function RiaClaimPage() {
     setError(null);
   }, []);
 
+  const handleBack = useCallback(() => {
+    if (step === "phone") {
+      router.push(returnTo || ROUTES.RIA_ONBOARDING);
+      return;
+    }
+    if (step === "found") {
+      resetToPhone();
+      return;
+    }
+    setStep("found");
+  }, [resetToPhone, returnTo, router, step]);
+
   const outcome = lookup?.outcome ?? null;
   const candidates: RiaClaimCandidate[] = lookup?.candidates ?? [];
   const adviserCount = lookup?.current_adviser_count ?? null;
@@ -544,14 +556,14 @@ export default function RiaClaimPage() {
       />
       <FullscreenFlowShell width="reading" className="px-0">
         <div className="mx-auto flex w-full max-w-[34rem] flex-col gap-6 px-6 pb-[var(--app-scroll-bottom-pad)] pt-4">
-          {step !== "phone" && step !== "done" ? (
+          {step !== "done" ? (
             <button
               type="button"
-              onClick={() => (step === "found" ? resetToPhone() : setStep("found"))}
-              className="flex h-10 w-10 items-center justify-center rounded-full bg-muted/20 transition-transform active:scale-95"
+              onClick={handleBack}
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-muted/20 text-muted-foreground transition-all hover:bg-muted/40 hover:text-foreground active:scale-95"
               aria-label="Back"
             >
-              <ChevronLeft className="h-5 w-5" />
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
             </button>
           ) : null}
 

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -551,7 +551,7 @@ export default function RiaClaimPage() {
         dataState={nativeDataState}
       />
       <FullscreenFlowShell width="reading" className="px-0">
-        <div className="mx-auto flex w-full max-w-[34rem] flex-col gap-6 px-6 pb-[var(--app-scroll-bottom-pad)] pt-4">
+        <div className="mx-auto flex w-full max-w-[34rem] flex-col gap-6 px-6 pb-[var(--ria-onboarding-cta-bottom-clearance,var(--app-scroll-bottom-pad))] pt-4">
           {step !== "phone" && step !== "done" ? (
             <button
               type="button"

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
@@ -201,6 +201,7 @@ export default function RiaOnboardingPage({
   onSetupSkip?: () => void | Promise<void>;
 } = {}) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const { user, phoneNumber } = useAuth();
   const {
@@ -217,6 +218,7 @@ export default function RiaOnboardingPage({
   //   ?reinitiate=1   → re-run the whole 5-step wizard (start at welcome)
   // A generic ?step= is also honoured.
   const editParam = searchParams?.get("edit") ?? null;
+  const currentRoute = `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`;
   const setupOrigin =
     setupMode ||
     normalizeInternalRouteHref(searchParams?.get("from")) === ROUTES.ONE_SETUP;
@@ -534,7 +536,7 @@ export default function RiaOnboardingPage({
           { signal: controller.signal },
         ).finally(() => clearTimeout(timer));
         if (isClaimableLookupOutcome(lookup)) {
-          router.replace(buildRiaClaimRoute(phone));
+          router.replace(buildRiaClaimRoute(phone, { returnTo: currentRoute }));
         }
       } catch {
         /* stay in the wizard */
@@ -542,7 +544,7 @@ export default function RiaOnboardingPage({
     })();
     // phoneNumber is in the deps so the probe re-runs once the backend phone
     // hydrates, which happens after the first render for a Google sign-in.
-  }, [entryMode, user, phoneNumber, router]);
+  }, [currentRoute, entryMode, user, phoneNumber, router]);
 
   useEffect(() => {
     if (!user || !draftReady || iamUnavailable || !shouldPersistDraft) return;

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-welcome.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-welcome.tsx
@@ -2,9 +2,9 @@
 
 import { Phone, User, Users } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
-import { ROUTES } from "@/lib/navigation/routes";
+import { buildRiaClaimRoute } from "@/lib/ria/ria-claim-entry";
 
 const OPTIONS: {
   value: "individual" | "firm";
@@ -34,6 +34,9 @@ export function OnboardingStepWelcome({
   onSelect: (type: "individual" | "firm") => void;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentRoute = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
   return (
     <SettingsGroup embedded separatorInset>
       <SettingsRow
@@ -42,7 +45,7 @@ export function OnboardingStepWelcome({
         title="Claim your profile"
         description="Use the office number on your SEC filing."
         chevron
-        onClick={() => router.push(ROUTES.RIA_CLAIM)}
+        onClick={() => router.push(buildRiaClaimRoute("", { returnTo: currentRoute }))}
       />
       {OPTIONS.map((option) => {
         const selected = onboardingType === option.value;

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -510,6 +510,22 @@ function resolveTopShellBreadcrumbInner(
     }
   }
 
+  if (pathname === ROUTES.RIA_CLAIM) {
+    const returnHref =
+      normalizeInternalRouteHref(searchParams?.get("return_to")) ||
+      ROUTES.RIA_ONBOARDING;
+    return {
+      backHref: returnHref,
+      width: "content",
+      align: "center",
+      hideBack: false,
+      items: [
+        { label: "RIA", href: returnHref },
+        { label: "Claim profile" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.RIA_ONBOARDING) {
     const originHref = normalizeInternalRouteHref(searchParams?.get("from"));
     return {


### PR DESCRIPTION
The RIA → Claim Your Profile screen currently does not provide a visible Back navigation control, making it unclear how users should return to the previous RIA screen after entering the profile-claim flow.

Actual behavior:
The Claim Your Profile screen displays the profile-claim interface, but there is no clear in-app Back button or navigation affordance. This creates a navigation inconsistency and may leave users dependent on browser/device navigation.

Expected behavior:
A clearly visible and accessible Back control should be provided in the upper-left area of the Claim Your Profile screen, following the existing RIA/design-system navigation pattern. Selecting it should return the user to the appropriate previous RIA destination.

Scope:
This is strictly a frontend UI/UX improvement. The change must not modify authentication, profile-claiming logic, office-number lookup, APIs, backend services, data fetching, business logic, Talk to One functionality, or bottom navigation behavior.

Acceptance criteria:

Back control is clearly visible on Claim Your Profile.
Back control follows the existing RIA visual/design-system pattern.
Back navigation leads to the correct existing RIA destination.
Appropriate mobile touch target and accessibility label are provided.
Layout remains correct on desktop and mobile/iOS.
No horizontal overflow or content overlap is introduced.
Existing Claim Your Profile functionality remains unchanged.
No backend, API, authentication, or business-logic changes are introduced.

Refs #5836
