### PR TITLE
fix(agent): reference the real CTA label in the authorization toast

### DIFF
--- a/hushh-webapp/__tests__/components/agent-action-confirmation.contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-action-confirmation.contract.test.ts
@@ -20,7 +20,7 @@ describe("private-agent action confirmation contract", () => {
     expect(consumeAt).toBeGreaterThan(confirmAt);
     expect(receiptAt).toBeGreaterThan(consumeAt);
     expect(executeAt).toBeGreaterThan(receiptAt);
-    expect(source).toContain("Authorized. Tap Run to execute.");
+    expect(source).toContain('Authorized. Tap "${pending.event.label || "Run"}" to continue.');
     expect(source).toContain("executeTrustedActivationGatewayAction");
     expect(source).toContain("A new user turn supersedes any unconfirmed proposal");
     expect(source).toContain("setPendingAppAction(null);");

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -4235,7 +4235,9 @@ export function AgentChatWorkspace({
                         setPendingAppAction((current) =>
                           current === pending ? { ...current, receipt } : current,
                         );
-                        toast.success("Authorized. Tap Run to execute.");
+                        toast.success(
+                          `Authorized. Tap "${pending.event.label || "Run"}" to continue.`,
+                        );
                         return;
                       }
                       await pending.execute(pending.receipt);


### PR DESCRIPTION
## Summary
- The Advisor Agent chat's post-authorize toast hardcoded "Authorized. Tap Run to execute." while the actual confirm button relabels itself to the action's own name (e.g. "Edit RIA services and fees") once authorized. There is no "Run" button, so the toast pointed users at a control that doesn't exist.
- The toast now interpolates the real CTA label from the same source the button itself uses (`pending.event.label`), so the message always matches what's on screen.

## Route affected
`/ria/profile` — Advisor Agent chat action-confirmation flow (component: `components/agent/agent-chat-workspace.tsx`).

## Test plan
- [x] `npx vitest run __tests__/components/agent-action-confirmation.contract.test.ts` — passes, asserting the toast source now interpolates the CTA label.
- [x] Reviewed the confirm/authorize code path end to end to confirm the interpolated label matches `confirmLabel` shown on the button after authorization.

Fixes #5720