### PR TITLE
feat(one-location): give the people search a way out when it finds nobody

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-people-empty-connect-bridge.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-people-empty-connect-bridge.contract.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Looking for someone who is not there yet has one continuous path.
+ *
+ * A person searching the People list for a name is asking one question: where
+ * is this person? There are three answers, and until now the first one was a
+ * dead end.
+ *
+ *   1. People search finds nobody   -> hand over to Connect        (this PR)
+ *   2. Connect search finds nobody  -> offer "Invite them to One"  (on main)
+ *   3. They accept the invite       -> they appear in both lists
+ *
+ * Steps 2 and 3 already existed. Step 1 ended at "No matching people / Try a
+ * different name.", which answers a question nobody asked and leaves the
+ * person to guess that Connect is the next place to look. The chain only works
+ * end to end if every link points at the next one.
+ *
+ * These are source contracts rather than render tests because both surfaces
+ * need a full view-model to mount, and what is worth protecting is narrow: the
+ * links exist and point where they say.
+ */
+
+function source(...parts: string[]): string {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+const HUB = source(
+  "components",
+  "one-location",
+  "redesign",
+  "location-redesign-hub.tsx",
+);
+const CONNECT = source("app", "connect", "page-client.tsx");
+
+function peopleEmptyState(src: string): string {
+  // Identified by the two titles it switches between, not by line number.
+  const anchor = src.indexOf('hasSearch ? "No matching people"');
+  expect(
+    anchor,
+    "the People empty state was renamed; update this contract with it",
+  ).toBeGreaterThan(-1);
+  const open = src.lastIndexOf("<EmptyState", anchor);
+  const close = src.indexOf("/>", anchor);
+  return src.slice(open, close + 2);
+}
+
+describe("link 1 — People search hands over to Connect", () => {
+  const block = peopleEmptyState(HUB);
+
+  it("asks the question the person is actually asking", () => {
+    expect(block).toContain("Don't see who you're looking for?");
+  });
+
+  it("offers the way into Connect", () => {
+    expect(block).toContain("action=");
+    expect(block).toContain("Manage connections in Connect");
+  });
+
+  it("offers the same bridge when there are no connections at all", () => {
+    expect(block).toContain("Add someone in Connect");
+  });
+
+  it("routes through the hub's single Connect entry point", () => {
+    // The same one the header's Add people button uses, so the two cannot
+    // drift to different destinations.
+    expect(block).toContain("onClick={onAddConnections}");
+    expect(HUB).toContain(
+      "onAddConnections={() => router.push(ROUTES.CONNECT)}",
+    );
+  });
+});
+
+describe("link 2 — Connect search offers the invite", () => {
+  it("says plainly that a search matched nobody", () => {
+    expect(CONNECT).toContain('No one matches "${trimmedQuery}"');
+  });
+
+  it("offers Invite them to One from that same dead end", () => {
+    expect(CONNECT).toContain("Invite them to One");
+    expect(CONNECT).toContain("handleInviteToOne");
+    expect(CONNECT).toContain('testId="connect-invite-to-one"');
+  });
+
+  it("keeps the invite a separate offer, not a tappable statement of fact", () => {
+    // "No one matches Bob" is a fact and stays inert; the invite is a choice
+    // and gets its own row. Collapsing them would make the fact look like an
+    // action and hide the one thing left to try.
+    const anchor = CONNECT.indexOf('No one matches "${trimmedQuery}"');
+    const row = CONNECT.slice(anchor, anchor + 400);
+    expect(row).toContain("disabled");
+  });
+});
+
+describe("the chain holds end to end", () => {
+  it("lands on the tab that actually offers the invite", () => {
+    // `canInviteToOne` is gated on `tab === "people"`. Arriving from the
+    // People bridge onto any other tab would complete two links of the chain
+    // and hide the third, which is worse than no bridge: the person would be
+    // sent somewhere that looks like the same dead end.
+    expect(CONNECT).toContain('useState<ConnectTab>("people")');
+    expect(CONNECT).toContain('tab === "people"');
+  });
+
+  it("every link points at the next one", () => {
+    // 1 -> Connect
+    expect(peopleEmptyState(HUB)).toContain("Manage connections in Connect");
+    expect(HUB).toContain("ROUTES.CONNECT");
+    // 2 -> invite
+    expect(CONNECT).toContain("Invite them to One");
+    // 3 -> the invite is a real share, not a placeholder
+    expect(CONNECT).toContain("buildInviteToOneShare");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2557,8 +2557,32 @@ function PeopleHub({
                     }
                     description={
                       hasSearch
-                        ? "Try a different name."
+                        ? "Don't see who you're looking for?"
                         : "Invite someone to start sharing."
+                    }
+                    // The first link in a chain that already had its other
+                    // two. A name matching nobody here usually belongs to
+                    // someone not connected yet, so this hands over to
+                    // Connect -- where a search that also finds nobody offers
+                    // "Invite them to One". Without it the person had to guess
+                    // that Connect was the next place to look.
+                    //
+                    // The header actions sit above the list and are out of
+                    // view once results have scrolled, so the way out belongs
+                    // here, where the dead end is.
+                    action={
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        onClick={onAddConnections}
+                        data-voice-control-id="one-location-empty-connect-bridge"
+                        className={PEOPLE_HEADER_ACTION}
+                      >
+                        {hasSearch
+                          ? "Manage connections in Connect →"
+                          : "Add someone in Connect →"}
+                      </Button>
                     }
                   />
                 </div>


### PR DESCRIPTION
## Why this was not on UAT

It was never built. I checked before assuming a regression:

- The copy does not exist anywhere in the repo — `grep` for *"Don't see who you're looking for"*, *"Manage connections in Connect"*, *"Add new in Connect"* returns nothing
- The people-list `EmptyState` in `location-redesign-hub.tsx` renders a title and a description and **no action**
- PR #4646 *"add Connect shortcut to People"* did land, but it put an **Add Connections** button on a different surface. That is the header row — `Find contacts / Invite / Add people` — not the empty state

So UAT is showing exactly what main contains.

## What changed

Typing a name that matches none of your connections ended at *"No matching people / Try a different name."* — which answers a question the person did not ask. The name they typed is usually somebody they have **not connected to yet**, and the only thing that helps is a way into Connect.

The header actions are presumably why this looked handled. They are not: the header sits above the list and is out of view the moment results have scrolled, and it is not where someone is looking when a search comes back empty. **The way out belongs at the dead end.**

Both states get one, worded for what the person is actually doing:

| State | Bridge |
| --- | --- |
| Search matched nobody | `Manage connections in Connect →` |
| No connections at all | `Add someone in Connect →` |

It routes through `onAddConnections`, the hub's existing single Connect entry point — the same one the header's **Add people** button uses, so the two cannot drift to different destinations.

## Verification

`__tests__/components/one-location-people-empty-connect-bridge.contract.test.ts` fails if the action is dropped, if either line is reworded away, or if the bridge is rewired somewhere other than Connect. Verified by removing the bridge and watching all three go red.

`tsc` and `eslint` clean.