### PR TITLE
feat(location): make a live location link on the Links tab, one at a time

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -198,7 +198,12 @@ class ReferralRequest(_CamelModel):
 
 
 class CreatePublicInviteRequest(_CamelModel):
-    duration_hours: float = Field(default=1, alias="durationHours", gt=0, le=24)
+    # `le=1`, not `le=24`. A public link is readable by anyone holding it, which
+    # is a different promise from a private share to a named person who can be
+    # un-shared -- and 24 was the private ceiling, copied. The service checks it
+    # again (PUBLIC_INVITE_MAX_DURATION_HOURS): this stops the request at the
+    # edge with a field-level error, that one holds for every other caller.
+    duration_hours: float = Field(default=1, alias="durationHours", gt=0, le=1)
     location_snapshot: dict[str, Any] | None = Field(default=None, alias="locationSnapshot")
 
 
@@ -1039,10 +1044,18 @@ def cancel_named_circle_member_invite(
 
 
 @router.post("/location/public-invites")
+# Every sibling mutation on this router is throttled and this one was not, so
+# nothing stood between a retry loop -- or a double tap on a slow connection --
+# and a run of simultaneously live public links. Same budget as the circle
+# mutations: minting a link people can watch you through is not something
+# anyone does six times a minute on purpose.
+@limiter.limit(RateLimits.ONE_LOCATION_CIRCLE_MUTATION)
 def create_public_location_invite(
+    request: Request,
     payload: CreatePublicInviteRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ):
+    del request
     try:
         return _service().create_public_invite(
             owner_user_id=_user_id(token_data),
@@ -1080,10 +1093,13 @@ def submit_public_location_invite(
 
 
 @router.delete("/location/public-invites/{invite_id}")
+@limiter.limit(RateLimits.ONE_LOCATION_CIRCLE_MUTATION)
 def revoke_public_location_invite(
+    request: Request,
     invite_id: _InviteId,
     token_data: dict = Depends(require_vault_owner_token),
 ):
+    del request
     try:
         return {
             "invite": _service().revoke_public_invite(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import base64
 import contextvars
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -30,6 +32,7 @@ from hushh_mcp.operons.location.policy import (
     normalize_duration_mode,
     normalize_source_platform,
 )
+from hushh_mcp.runtime_settings import get_core_security_settings
 from hushh_mcp.types import AgentID, UserID
 from mcp_modules.log_redaction import redact_log_field, redact_log_value
 
@@ -444,6 +447,85 @@ def _normalize_phone_digits(value: Any) -> str:
 
 def _hash_public_value(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+# The public-link token is DERIVED from the invite row's UUID rather than
+# generated at random, so the owner can read their own live link back.
+#
+# It used to be `secrets.token_urlsafe(32)`, hashed on the way in and returned
+# exactly once in the create response. Nothing could recover it afterwards --
+# not the owner, not a second device, not the same tab after a reload -- so an
+# invite the server reported as active had a link the product could no longer
+# show. Copy and Share silently did nothing, and the only way back was to
+# revoke.
+#
+# The row UUID is not secret; the app signing key supplies the entropy, exactly
+# as `one_location_circle_service._code_for_invite_id` does for Circle codes. A
+# database-only compromise still yields nothing but the UUID and a keyed
+# digest. Rows minted before this carry no version marker, so their token stays
+# unrecoverable and the payload simply omits the URL -- unchanged behaviour for
+# them, rather than a wrong link.
+_PUBLIC_INVITE_TOKEN_DOMAIN = b"one-location-public-invite-token:v1:"
+_PUBLIC_INVITE_CODE_VERSION = "derived-v1"
+
+
+def _public_invite_signing_key() -> bytes:
+    return get_core_security_settings().app_signing_key.encode("utf-8")
+
+
+def _public_invite_token_for_id(invite_id: str) -> str:
+    """The share token belonging to one invite row, re-derivable on every read."""
+
+    normalized_invite_id = str(uuid.UUID(str(invite_id)))
+    digest = hmac.new(
+        _public_invite_signing_key(),
+        _PUBLIC_INVITE_TOKEN_DOMAIN + normalized_invite_id.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _public_invite_token_if_derivable(row: dict[str, Any] | None) -> str | None:
+    """The share token for an invite row, or None if it cannot be recovered.
+
+    Re-derives the token from the row's UUID and checks it against the
+    digest that was stored when the row was written. Two rows fail that
+    check, and both must fail closed:
+
+      - anything minted before tokens were derived from the id, which
+        carries no `codeVersion` and whose random token is gone for good
+      - a row whose stored digest no longer matches, which means the
+        signing key rotated or the row was tampered with
+
+    Returning a token that does not resolve would be worse than returning
+    none: the owner would copy a link that 404s and have no reason to think
+    it was ever broken.
+    """
+
+    if not row:
+        return None
+    metadata = _loads_json(row.get("metadata")) or {}
+    if not isinstance(metadata, dict):
+        return None
+    if metadata.get("codeVersion") != _PUBLIC_INVITE_CODE_VERSION:
+        return None
+    invite_id = str(row.get("id") or "")
+    if not invite_id:
+        return None
+    try:
+        token = _public_invite_token_for_id(invite_id)
+    except (ValueError, AttributeError):
+        return None
+    stored_hash = str(row.get("public_code_hash") or "")
+    if not stored_hash:
+        return None
+    if not hmac.compare_digest(stored_hash, _hash_public_value(token)):
+        logger.warning(
+            "one_location.public_invite_token_integrity_failed invite=%s",
+            redact_log_field("invite_id", invite_id),
+        )
+        return None
+    return token
 
 
 def _public_invite_url(token: str) -> str:
@@ -2452,6 +2534,21 @@ class OneLocationAgentService:
         }
         if safe_label:
             payload["ownerLabel"] = safe_label
+        # The owner's own link, handed back on every read.
+        #
+        # This branch is owner-only -- the `public` branch above is what a
+        # recipient sees, and it must never carry the token. For the owner the
+        # link is the whole point of the object: without it the product could
+        # report "you have a live link" and then have nothing to copy, which is
+        # exactly what happened after any reload.
+        #
+        # Only while the invite can still be used. A revoked or expired row's
+        # token no longer resolves, so offering it would hand over a link that
+        # 404s.
+        if str(row.get("status") or "") == "active":
+            token = _public_invite_token_if_derivable(row)
+            if token:
+                payload["publicUrl"] = _public_invite_url(token)
         return payload
 
     @staticmethod
@@ -5711,26 +5808,101 @@ class OneLocationAgentService:
                 str(exc),
                 status_code=422,
             ) from exc
-        raw_token = secrets.token_urlsafe(32)
+        # Expiry is written lazily -- `_expire_public_invite` only flips a row
+        # when something reads it -- so a link whose time has passed can still
+        # be sitting at status 'active'. Settle that here first, or the reuse
+        # check below hands back a dead link instead of minting a fresh one.
+        self._execute_one(
+            """
+            UPDATE one_location_public_invites
+            SET status = 'expired', updated_at = NOW()
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at <= NOW()
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+
+        # One live public link per person, enforced where it can actually hold.
+        #
+        # Nothing stopped a second: no unique index, no lookup, just an INSERT.
+        # A reload, a second device or a double tap therefore left two links
+        # resolvable while the screen showed one, and revoking the one on
+        # screen left the other watching. The client now hides its create
+        # control while a link is live, but a client rule is not an invariant --
+        # a stale tab defeats it.
+        #
+        # Reuse rather than reject: this is the same call the person makes when
+        # they mean "give me my link", and a 409 would be a dead end on a
+        # screen whose whole job is to hand it over. Matches
+        # `one_location_circle_service.create_invite_code`, which returns the
+        # circle's existing active code rather than minting a second.
+        existing = self._execute_one(
+            """
+            SELECT *
+            FROM one_location_public_invites
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at > NOW()
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        if existing:
+            existing_token = _public_invite_token_if_derivable(existing)
+            if existing_token:
+                existing_payload = self._public_invite_payload(existing)
+                if existing_payload:
+                    return {
+                        "invite": existing_payload,
+                        "publicToken": existing_token,
+                        "publicUrl": _public_invite_url(existing_token),
+                        # The caller asked for a link and got one; it is simply
+                        # the one that was already live. Named so a client can
+                        # tell "created" from "here is the one you have" without
+                        # comparing timestamps.
+                        "reused": True,
+                    }
+            # A row minted before tokens were derivable, or one whose digest no
+            # longer verifies. Its token is genuinely unrecoverable, so leaving
+            # it active would strand the owner behind a link nothing can show.
+            # Retire it and mint a replacement rather than refuse.
+            self._execute_one(
+                """
+                UPDATE one_location_public_invites
+                SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+                WHERE id = CAST(:invite_id AS UUID)
+                  AND status = 'active'
+                """,
+                {"invite_id": str(existing.get("id") or "")},
+            )
+
+        # The id is chosen here rather than by the default, because the token is
+        # derived FROM it and has to be known before the row exists.
+        invite_id = str(uuid.uuid4())
+        raw_token = _public_invite_token_for_id(invite_id)
         token_hash = _hash_public_value(raw_token)
         expires_at = _utcnow() + timedelta(hours=duration)
         public_location = self._public_location_snapshot_payload(location_snapshot)
-        metadata: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"codeVersion": _PUBLIC_INVITE_CODE_VERSION}
         if public_location:
             metadata["publicLocation"] = public_location
         row = self._execute_one(
             """
             INSERT INTO one_location_public_invites (
-              owner_user_id, public_code_hash, status, duration_hours,
+              id, owner_user_id, public_code_hash, status, duration_hours,
               expires_at, created_at, updated_at, metadata
             )
             VALUES (
+              CAST(:invite_id AS UUID),
               :owner_user_id, :public_code_hash, 'active', :duration_hours,
               :expires_at, NOW(), NOW(), CAST(:metadata_json AS JSONB)
             )
             RETURNING *
             """,
             {
+                "invite_id": invite_id,
                 "owner_user_id": owner_user_id,
                 "public_code_hash": token_hash,
                 "duration_hours": duration,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -465,6 +465,21 @@ def _hash_public_value(value: str) -> str:
 # digest. Rows minted before this carry no version marker, so their token stays
 # unrecoverable and the payload simply omits the URL -- unchanged behaviour for
 # them, rather than a wrong link.
+# A public link is readable by anyone who holds it, so its ceiling is one hour
+# and the screen says so.
+#
+# The screen was the ONLY thing saying so. `normalize_duration_hours` allows up
+# to 24, the Pydantic field allows up to 24, and the DB CHECK allows up to 24 --
+# all three are the private-share ceiling, which is a different promise made to
+# a named person who can be un-shared. A request carrying `durationHours: 24`
+# was accepted and minted a public link that watched the owner for a day.
+#
+# Rejected rather than clamped: silently shortening what was asked for is how
+# the client-side clamp hid this in the first place, and no shipped client can
+# reach this branch -- every public-link caller already clamps to one hour
+# before it posts.
+PUBLIC_INVITE_MAX_DURATION_HOURS = 1.0
+
 _PUBLIC_INVITE_TOKEN_DOMAIN = b"one-location-public-invite-token:v1:"
 _PUBLIC_INVITE_CODE_VERSION = "derived-v1"
 
@@ -5808,6 +5823,12 @@ class OneLocationAgentService:
                 str(exc),
                 status_code=422,
             ) from exc
+        if duration > PUBLIC_INVITE_MAX_DURATION_HOURS:
+            raise OneLocationAgentError(
+                "LOCATION_DURATION_INVALID",
+                "A public location link can stay live for at most 1 hour.",
+                status_code=422,
+            )
         # Expiry is written lazily -- `_expire_public_invite` only flips a row
         # when something reads it -- so a link whose time has passed can still
         # be sitting at status 'active'. Settle that here first, or the reuse

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -5451,3 +5451,30 @@ def test_the_owners_state_carries_the_link_back() -> None:
     ]
     assert len(invites) == 1
     assert invites[0]["publicUrl"] == created["publicUrl"]
+
+
+def test_a_public_link_cannot_be_asked_to_live_longer_than_an_hour() -> None:
+    # Anyone holding this link can watch, which is a different promise from a
+    # private share to a named person who can be un-shared. 24 was the private
+    # ceiling, copied into every layer -- Pydantic, normalize_duration_hours,
+    # the DB CHECK -- so the one-hour cap the screen showed was enforced only by
+    # the screen, and a crafted request minted a public link for a full day.
+    service = FourUserMemoryService()
+
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        service.create_public_invite(owner_user_id="user_a", duration_hours=24)
+
+    assert excinfo.value.code == "LOCATION_DURATION_INVALID"
+    assert excinfo.value.status_code == 422
+    assert not service.public_invites
+
+
+def test_the_durations_the_screen_offers_are_accepted() -> None:
+    service = FourUserMemoryService()
+
+    half = service.create_public_invite(owner_user_id="user_a", duration_hours=0.5)
+    assert half["invite"]["durationHours"] == 0.5
+
+    service.revoke_public_invite(owner_user_id="user_a", invite_id=half["invite"]["id"])
+    whole = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    assert whole["invite"]["durationHours"] == 1

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2112,7 +2112,10 @@ class FourUserMemoryService(OneLocationAgentService):
             self.referrals[referral_id] = row
             return row
         if "INSERT INTO one_location_public_invites" in sql:
-            invite_id = str(uuid.uuid4())
+            # The caller chooses the id now: the public token is derived from
+            # it, so a double that invents its own would store a digest that
+            # can never be re-derived, and every link would read as legacy.
+            invite_id = str(params.get("invite_id") or uuid.uuid4())
             row = {
                 "id": invite_id,
                 "owner_user_id": params["owner_user_id"],
@@ -2137,6 +2140,50 @@ class FourUserMemoryService(OneLocationAgentService):
                         "owner_phone_number": owner.get("phone_number"),
                     }
             return None
+        if (
+            "UPDATE one_location_public_invites" in sql
+            and "status = 'expired'" in sql
+            and "owner_user_id" in params
+        ):
+            # Settling lazily-expired rows before the reuse lookup. Expiry is
+            # written only when something reads a row, so a link past its time
+            # can still be sitting at 'active'.
+            now = datetime.now(timezone.utc)
+            for invite in self.public_invites.values():
+                if (
+                    invite["owner_user_id"] == params["owner_user_id"]
+                    and invite["status"] == "active"
+                    and invite["expires_at"] <= now
+                ):
+                    invite["status"] = "expired"
+            return None
+        if (
+            "UPDATE one_location_public_invites" in sql
+            and "status = 'revoked'" in sql
+            and "invite_id" in params
+        ):
+            invite = self.public_invites.get(params["invite_id"])
+            if invite and invite["status"] == "active":
+                invite["status"] = "revoked"
+                invite["revoked_at"] = datetime.now(timezone.utc)
+                return invite
+            return None
+        if (
+            "FROM one_location_public_invites" in sql
+            and "expires_at > NOW()" in sql
+            and "owner_user_id" in params
+        ):
+            # The reuse lookup: one live public link per person.
+            now = datetime.now(timezone.utc)
+            live = [
+                invite
+                for invite in self.public_invites.values()
+                if invite["owner_user_id"] == params["owner_user_id"]
+                and invite["status"] == "active"
+                and invite["expires_at"] > now
+            ]
+            live.sort(key=lambda invite: invite["created_at"], reverse=True)
+            return live[0] if live else None
         if "UPDATE one_location_public_invites" in sql and "status = 'expired'" in sql:
             invite = self.public_invites.get(params["invite_id"])
             if invite and invite["status"] == "active":
@@ -5120,3 +5167,287 @@ def test_only_the_relationship_scoped_list_may_show_an_email_handle() -> None:
         "the discovery directory must not opt into the email handle: it lists "
         "phone-verified strangers, not the viewer's connections"
     )
+
+
+# ---------------------------------------------------------------------------
+# Public location link: the owner has to be able to read their own link back.
+#
+# The token used to be `secrets.token_urlsafe(32)`, hashed on the way in and
+# returned exactly once. Nothing could recover it afterwards, so an invite the
+# server reported as active had a link the product could no longer show -- Copy
+# and Share silently did nothing after any reload. It is now derived from the
+# row's UUID with the app signing key, the same way Circle codes are.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _public_invite_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        one_location_agent_module,
+        "get_core_security_settings",
+        lambda: SimpleNamespace(app_signing_key="test-signing-key"),
+    )
+    return "test-signing-key"
+
+
+def _derivable_public_invite_row(invite_id: str, *, status: str = "active", **overrides) -> dict:
+    token = one_location_agent_module._public_invite_token_for_id(invite_id)
+    row = {
+        "id": invite_id,
+        "owner_user_id": "owner-1",
+        "public_code_hash": one_location_agent_module._hash_public_value(token),
+        "status": status,
+        "duration_hours": 1.0,
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+        "revoked_at": None,
+        "metadata": json.dumps(
+            {"codeVersion": one_location_agent_module._PUBLIC_INVITE_CODE_VERSION}
+        ),
+    }
+    row.update(overrides)
+    return row
+
+
+def test_public_invite_token_is_stable_for_one_invite(_public_invite_key) -> None:
+    invite_id = str(uuid.uuid4())
+    first = one_location_agent_module._public_invite_token_for_id(invite_id)
+    second = one_location_agent_module._public_invite_token_for_id(invite_id)
+    # The whole point: the same row yields the same link every time it is read.
+    assert first == second
+    assert first
+
+
+def test_public_invite_tokens_differ_between_invites(_public_invite_key) -> None:
+    left = one_location_agent_module._public_invite_token_for_id(str(uuid.uuid4()))
+    right = one_location_agent_module._public_invite_token_for_id(str(uuid.uuid4()))
+    assert left != right
+
+
+def test_public_invite_token_survives_a_url(_public_invite_key) -> None:
+    token = one_location_agent_module._public_invite_token_for_id(str(uuid.uuid4()))
+    # It is spent as a path segment, so base64's "+", "/" and "=" would either
+    # be re-encoded by the client or silently truncate the token.
+    assert "+" not in token
+    assert "/" not in token
+    assert "=" not in token
+    assert token == token.strip()
+
+
+def test_public_invite_token_is_not_the_bare_row_id(_public_invite_key) -> None:
+    # The id travels in the owner's own state payload. If the token were the id,
+    # anyone who saw one person's state could resolve their live location link.
+    invite_id = str(uuid.uuid4())
+    token = one_location_agent_module._public_invite_token_for_id(invite_id)
+    assert invite_id not in token
+    assert invite_id.replace("-", "") not in token
+
+
+def test_public_invite_token_changes_with_the_signing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invite_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        one_location_agent_module,
+        "get_core_security_settings",
+        lambda: SimpleNamespace(app_signing_key="key-one"),
+    )
+    first = one_location_agent_module._public_invite_token_for_id(invite_id)
+    monkeypatch.setattr(
+        one_location_agent_module,
+        "get_core_security_settings",
+        lambda: SimpleNamespace(app_signing_key="key-two"),
+    )
+    assert one_location_agent_module._public_invite_token_for_id(invite_id) != first
+
+
+def test_derivable_token_is_recovered_from_a_well_formed_row(
+    _public_invite_key,
+) -> None:
+    invite_id = str(uuid.uuid4())
+    row = _derivable_public_invite_row(invite_id)
+    assert one_location_agent_module._public_invite_token_if_derivable(
+        row
+    ) == one_location_agent_module._public_invite_token_for_id(invite_id)
+
+
+def test_legacy_rows_report_no_token_rather_than_a_wrong_one(
+    _public_invite_key,
+) -> None:
+    # Minted before tokens were derived from the id: the random token is gone
+    # for good. Returning a derived one would hand the owner a link that 404s.
+    row = _derivable_public_invite_row(str(uuid.uuid4()), metadata=json.dumps({}))
+    assert one_location_agent_module._public_invite_token_if_derivable(row) is None
+
+
+def test_a_row_whose_digest_does_not_match_reports_no_token(
+    _public_invite_key,
+) -> None:
+    # Signing key rotated, or the row was tampered with. Fail closed.
+    row = _derivable_public_invite_row(str(uuid.uuid4()))
+    row["public_code_hash"] = "0" * 64
+    assert one_location_agent_module._public_invite_token_if_derivable(row) is None
+
+
+def test_a_row_with_no_id_reports_no_token(_public_invite_key) -> None:
+    row = _derivable_public_invite_row(str(uuid.uuid4()))
+    row["id"] = ""
+    assert one_location_agent_module._public_invite_token_if_derivable(row) is None
+    assert one_location_agent_module._public_invite_token_if_derivable(None) is None
+
+
+def test_owner_payload_carries_the_link_for_an_active_invite(
+    _public_invite_key,
+) -> None:
+    invite_id = str(uuid.uuid4())
+    row = _derivable_public_invite_row(invite_id)
+    payload = OneLocationAgentService._public_invite_payload(row)
+    token = one_location_agent_module._public_invite_token_for_id(invite_id)
+    assert payload["publicUrl"] == f"/one/location/request/{token}"
+
+
+@pytest.mark.parametrize("status", ["revoked", "expired"])
+def test_owner_payload_withholds_the_link_once_it_stops_working(
+    _public_invite_key, status: str
+) -> None:
+    # The token no longer resolves, so offering it would hand over a dead link
+    # on a screen that still says "copy".
+    row = _derivable_public_invite_row(str(uuid.uuid4()), status=status)
+    payload = OneLocationAgentService._public_invite_payload(row)
+    assert "publicUrl" not in payload
+
+
+def test_owner_payload_withholds_the_link_for_a_legacy_invite(
+    _public_invite_key,
+) -> None:
+    row = _derivable_public_invite_row(str(uuid.uuid4()), metadata=json.dumps({}))
+    payload = OneLocationAgentService._public_invite_payload(row)
+    assert "publicUrl" not in payload
+
+
+def test_the_recipient_payload_never_carries_the_token(_public_invite_key) -> None:
+    # This is the branch a stranger holding the link receives. The token is the
+    # capability itself; echoing it back would put it in one more place for no
+    # reason, and would leak it to anyone the link was forwarded to.
+    row = _derivable_public_invite_row(str(uuid.uuid4()))
+    payload = OneLocationAgentService._public_invite_payload(row, public=True)
+    assert "publicUrl" not in payload
+    assert "id" not in payload
+    assert "ownerUserId" not in payload
+    serialized = json.dumps(payload)
+    assert one_location_agent_module._public_invite_token_for_id(row["id"]) not in serialized
+
+
+# ---------------------------------------------------------------------------
+# One live public location link per person.
+#
+# Nothing used to stop a second: no unique index, no lookup, just an INSERT. A
+# reload, a second device or a double tap left two links resolvable while the
+# screen showed one, and revoking the visible one left the other watching.
+# ---------------------------------------------------------------------------
+
+
+def _active_public_invites(service) -> list[dict]:
+    return [invite for invite in service.public_invites.values() if invite["status"] == "active"]
+
+
+def test_creating_a_second_public_link_hands_back_the_first() -> None:
+    service = FourUserMemoryService()
+
+    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    # Same link, not a second one: this call is what the person makes when they
+    # mean "give me my link", so it answers rather than refusing.
+    assert second["publicToken"] == first["publicToken"]
+    assert second["invite"]["id"] == first["invite"]["id"]
+    assert second["reused"] is True
+    assert first.get("reused") is not True
+    assert len(_active_public_invites(service)) == 1
+
+
+def test_the_reused_link_still_resolves() -> None:
+    # The point of reuse is that whoever already holds the link keeps seeing
+    # the owner. A token handed back that no longer resolved would be worse
+    # than a second link.
+    service = FourUserMemoryService()
+    service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    reused = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    resolved = service.resolve_public_invite(public_token=reused["publicToken"])
+    assert resolved["invite"]["status"] == "active"
+
+
+def test_one_persons_link_does_not_block_another_persons() -> None:
+    service = FourUserMemoryService()
+
+    mine = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    theirs = service.create_public_invite(owner_user_id="user_b", duration_hours=1)
+
+    assert mine["publicToken"] != theirs["publicToken"]
+    assert len(_active_public_invites(service)) == 2
+
+
+def test_revoking_frees_the_person_to_create_another() -> None:
+    service = FourUserMemoryService()
+
+    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    service.revoke_public_invite(owner_user_id="user_a", invite_id=first["invite"]["id"])
+    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    assert second["publicToken"] != first["publicToken"]
+    assert second.get("reused") is not True
+    assert len(_active_public_invites(service)) == 1
+
+
+def test_an_expired_link_does_not_block_a_new_one() -> None:
+    # Expiry is written lazily -- only when something reads the row -- so a
+    # link past its time can still be sitting at status 'active'. If create did
+    # not settle that first, the reuse lookup would hand back a dead link and
+    # the person could never make another.
+    service = FourUserMemoryService()
+
+    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    stale = service.public_invites[first["invite"]["id"]]
+    stale["expires_at"] = datetime.now(timezone.utc) - timedelta(minutes=5)
+    assert stale["status"] == "active"
+
+    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    assert second["publicToken"] != first["publicToken"]
+    assert second.get("reused") is not True
+    assert stale["status"] == "expired"
+    assert len(_active_public_invites(service)) == 1
+
+
+def test_a_link_whose_token_cannot_be_recovered_is_replaced() -> None:
+    # A row minted before tokens were derived from the id. Its token is gone
+    # for good, so leaving it active would strand the owner behind a link
+    # nothing can show and no create button.
+    service = FourUserMemoryService()
+
+    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    legacy = service.public_invites[first["invite"]["id"]]
+    legacy["metadata"] = {}
+
+    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    assert second["publicToken"] != first["publicToken"]
+    assert second.get("reused") is not True
+    assert legacy["status"] == "revoked"
+    assert len(_active_public_invites(service)) == 1
+
+
+def test_the_owners_state_carries_the_link_back() -> None:
+    # The whole reason the token is derived: after a reload the owner still has
+    # to be able to copy and share the link they already made.
+    service = FourUserMemoryService()
+    created = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    state = service.list_state(user_id="user_a")
+    invites = [
+        invite for invite in state["publicInvites"] if invite["id"] == created["invite"]["id"]
+    ]
+    assert len(invites) == 1
+    assert invites[0]["publicUrl"] == created["publicUrl"]

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -843,14 +843,18 @@ async function openAskFlow() {
   ).toBeTruthy();
 }
 
+/**
+ * The Links tab IS the create-a-link screen now.
+ *
+ * This used to click "Create link" to reach a separate `?action=temp-link`
+ * screen, whose own "Create link" was the one that actually created. The
+ * duration question and the create button are on the tab itself, so opening
+ * the tab is the whole of it -- and the helper asserts the duration control is
+ * there, which is what proves the screen collapsed rather than disappeared.
+ */
 async function openTemporaryLinkFlow() {
   fireEvent.click(screen.getByRole("button", { name: "Links" }));
-  fireEvent.click(
-    await screen.findByRole("button", { name: /Create link/i }),
-  );
-  expect(
-    await screen.findByRole("heading", { name: "Share outside your Circle" }),
-  ).toBeTruthy();
+  expect(await screen.findByText("Link stays live for")).toBeTruthy();
 }
 
 describe("OneLocationAgentPage", () => {
@@ -3271,14 +3275,19 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.queryByRole("heading", { name: "Pending invites" }),
     ).toBeNull();
-    // Links tab: "Active links" list + a single "Create link" CTA. The
-    // mock has no active links, so the empty state shows.
+    // Links tab: with no link live, the tab IS the create form -- heading,
+    // duration, and the button that creates. There is no separate screen and
+    // no "No active links" placeholder standing in for one; the form is the
+    // empty state.
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
       await screen.findByRole("button", { name: /Create link/i }),
     ).toBeTruthy();
     expect(screen.getByText("Active links")).toBeTruthy();
-    expect(screen.getByText("No active links")).toBeTruthy();
+    expect(screen.getByText("Link stays live for")).toBeTruthy();
+    // The paragraph that used to sit under the heading is gone.
+    expect(screen.queryByText(/Links you can send to anyone/i)).toBeNull();
+    expect(screen.queryByText("No active links")).toBeNull();
     expect(screen.queryByText("Public link responses")).toBeNull();
     expect(screen.queryByText(/Share a public location link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
@@ -3724,11 +3733,16 @@ describe("OneLocationAgentPage", () => {
       }),
     );
     expect(screen.queryByText(longPublicUrl)).toBeNull();
+    // The result replaces the form in place, on the same tab -- no third
+    // screen, and no "Done" to dismiss back to where you already are.
+    expect(await screen.findByText("Live location link")).toBeTruthy();
     expect(
-      await screen.findByRole("heading", {
-        name: "Public location link active",
-      }),
+      screen.getByText("Anyone with this link can view you"),
     ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Revoke/i })).toBeTruthy();
+    // And no way to make a second while this one is live.
+    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+    expect(screen.queryByText("Link stays live for")).toBeNull();
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
     );
@@ -5003,11 +5017,9 @@ describe("OneLocationAgentPage", () => {
     // duplicate "Share to contacts" that minted the same artifact; this is the
     // one remaining path, and it must still create the invite.
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
-    // Links hub CTA opens the flow; the flow's own CTA creates the invite.
-    // Both are labelled "Create link", so take the one on screen each time.
-    fireEvent.click(
-      await screen.findByRole("button", { name: /^Create link$/i }),
-    );
+    // One button, one press. There used to be two, both labelled "Create
+    // link": the tab's, which only navigated, and the flow screen's, which
+    // created. The first is gone.
     fireEvent.click(
       await screen.findByRole("button", { name: /^Create link$/i }),
     );
@@ -5574,4 +5586,113 @@ describe("OneLocationAgentPage", () => {
       vi.useRealTimers();
     }
   });
+
+  /**
+   * The Links tab after a reload.
+   *
+   * The share token used to be returned exactly once, at creation, and nothing
+   * could recover it -- so a returning session knew a link was live and had
+   * nothing to copy. Copy and Share early-returned with no toast, and the tab
+   * shipped a button that did nothing. The server now derives the token from
+   * the invite's own id and hands the URL back on every read.
+   */
+  function activePublicInvite(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "public-invite-1",
+      ownerUserId: "user_a",
+      status: "active",
+      durationHours: 1,
+      expiresAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+      createdAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      publicUrl: "/one/location/request/derived-token-abc",
+      ...overrides,
+    };
+  }
+
+  it("hands back a link made in an earlier session", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [activePublicInvite()],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("Live location link")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Copy/i }));
+
+    await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalled());
+    // The whole point: something real reaches the clipboard, and it is the
+    // token the server derived rather than an empty string.
+    expect(String(mockCopyToClipboard.mock.calls[0][0])).toContain(
+      "derived-token-abc",
+    );
+  });
+
+  it("offers no way to make a second link while one is live", async () => {
+    // Two are independently resolvable, revoking the visible one leaves the
+    // other watching, and the tab can only ever show the newest. Ending this
+    // one is the way to a different one.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [activePublicInvite()],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("Live location link")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+    expect(screen.queryByText("Link stays live for")).toBeNull();
+    // Ending it stays reachable -- that is the only exit.
+    expect(screen.getByRole("button", { name: /Revoke/i })).toBeTruthy();
+  });
+
+  it("lets a link whose URL cannot be recovered be stopped", async () => {
+    // Minted before the token was derivable. Copy and Share would be dead
+    // controls, so they are not offered -- but the link is still out there
+    // watching, so ending it cannot be a dead end.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [activePublicInvite({ publicUrl: undefined })],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("Live location link")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Stop this link/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Copy$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Share$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+  });
+
+  it("brings a bookmarked temp-link URL to the Links tab", async () => {
+    // The screen did not go away, it became the tab. "That's no longer there."
+    // would be a lie, and a confusing one on the screen that now owns it.
+    mockSearchParams.toString = () => "action=temp-link";
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "action" ? "temp-link" : null,
+    );
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    await waitFor(() =>
+      expect(mockRouterReplace).toHaveBeenCalledWith(
+        expect.stringContaining("view=links"),
+        expect.anything(),
+      ),
+    );
+    const replaced = String(mockRouterReplace.mock.calls.at(-1)?.[0] ?? "");
+    expect(replaced).not.toContain("action=temp-link");
+  });
+
 });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -7,7 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import { Children, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/lib/services/api-client";
 // The rungs themselves, not a copy of their labels: Ask and Share must offer
@@ -858,6 +858,13 @@ async function openTemporaryLinkFlow() {
 }
 
 describe("OneLocationAgentPage", () => {
+  afterEach(() => {
+    // A test that installs fake timers and then fails leaves them installed,
+    // and every test after it hangs on a clock that never moves -- three
+    // unrelated failures from one. Cheap to make impossible.
+    vi.useRealTimers();
+  });
+
   beforeEach(async () => {
     vi.clearAllMocks();
     // The shared store, holding a fix measured now — what a session with a
@@ -5693,6 +5700,85 @@ describe("OneLocationAgentPage", () => {
     );
     const replaced = String(mockRouterReplace.mock.calls.at(-1)?.[0] ?? "");
     expect(replaced).not.toContain("action=temp-link");
+  });
+
+
+  it("brings the create form back when the link runs out", async () => {
+    // The tab hides its create control whenever a link is live, and expiry is
+    // written server-side only when a row is READ -- nothing here refetches on
+    // a timer. Without a clock check the state this session already holds says
+    // "active" forever, so a link that ran out five minutes ago left the person
+    // looking at a dead card with no way past it until they reloaded.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [
+        activePublicInvite({
+          expiresAt: new Date(Date.now() + 250).toISOString(),
+        }),
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+    expect(await screen.findByText("Live location link")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+
+    // Real time, not fake. This suite's setup awaits real promises, and fake
+    // timers -- even advancing ones -- leave `waitFor` running on a clock the
+    // test controls, which hangs rather than fails. The expiry above is a few
+    // hundred milliseconds out, so waiting it out for real is cheaper than the
+    // machinery to pretend.
+    //
+    // `visibilitychange` is the same hook a phone uses coming back from
+    // background, and the page listens for it precisely so a screen that has
+    // been away does not wait out the next 30s tick.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(screen.queryByText("Live location link")).toBeNull();
+    expect(screen.getByText("Link stays live for")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Create link$/i })).toBeTruthy();
+  });
+
+  it("does not expire a link the server sent without an expiry", async () => {
+    // A missing timestamp is not evidence the link has run out. Treating it as
+    // expired would hide a working link and offer to make a second.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [activePublicInvite({ expiresAt: undefined })],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("Live location link")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+  });
+
+  it("treats a link that expired before the tab opened as gone", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [
+        activePublicInvite({
+          // Still "active" server-side: the row has not been read since.
+          expiresAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("Link stays live for")).toBeTruthy();
+    expect(screen.queryByText("Live location link")).toBeNull();
   });
 
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2504,7 +2504,27 @@ export function OneLocationAgentPageContent({
   const [referralTargets, setReferralTargets] = useState<
     Record<string, string>
   >({});
-  const [publicInviteUrl, setPublicInviteUrl] = useState("");
+  /**
+   * The link as it came back from the create call, this session only.
+   *
+   * Kept because the server's copy arrives one refetch later: between "created"
+   * and the next `getState` there is a window where the only place the URL
+   * exists is this variable. `publicInviteUrl` below prefers the server's copy
+   * and falls back to this one.
+   */
+  const [createdPublicInviteUrl, setCreatedPublicInviteUrl] = useState("");
+  /**
+   * The public link's own duration, deliberately not the shared `durationHours`.
+   *
+   * One `durationHours` string is written by the Ask composer and the Circle
+   * invite screen and read by all three lanes, which is how a public link ended
+   * up posting the 24 hours somebody picked on another screen. The clamp at
+   * post time caught that, but only by silently shortening what the person had
+   * been shown. Now that the control lives permanently on the Links tab rather
+   * than behind a button, it would be writing that shared string every time
+   * anyone browsed past it.
+   */
+  const [publicLinkDurationHours, setPublicLinkDurationHours] = useState("1");
   const [circleInviteUrl, setCircleInviteUrl] = useState("");
   const [
     incomingCircleMemberInvites,
@@ -3279,6 +3299,28 @@ export function OneLocationAgentPageContent({
       )[0] ?? null
     );
   }, [activePublicInvites]);
+  /**
+   * The live public link, whoever knows it.
+   *
+   * The server's copy wins. It is the only one that survives a reload, a second
+   * device, or a link the agent made -- and until it existed, this was simply
+   * `""` in all three cases, so Copy and Share early-returned and the Links tab
+   * shipped a button that did nothing. The create response is the fallback for
+   * the one moment the server has not caught up yet: `handleCreatePublicInvite`
+   * fires `refresh()` without awaiting it.
+   *
+   * Empty means there is genuinely no link to offer -- either none is live, or
+   * the live one predates derivable tokens and cannot be recovered. Callers
+   * must not read empty as "not loaded yet".
+   */
+  const publicInviteUrl = useMemo(() => {
+    const fromServer = latestActivePublicInvite?.publicUrl;
+    if (fromServer && String(fromServer).trim()) {
+      return publicInviteUrlLabel(String(fromServer).trim());
+    }
+    return createdPublicInviteUrl;
+  }, [createdPublicInviteUrl, latestActivePublicInvite]);
+
   const activeCircleInvites = useMemo(
     () =>
       (state?.circleInvites ?? []).filter(
@@ -6436,16 +6478,16 @@ export function OneLocationAgentPageContent({
       const point = readiness.point;
       const response = await OneLocationService.createPublicInvite({
         vaultOwnerToken,
-        durationHours: publicInviteDurationHours(durationHours),
+        durationHours: publicInviteDurationHours(publicLinkDurationHours),
         locationSnapshot: point,
       });
       const url = publicInviteUrlLabel(response.publicUrl);
-      setPublicInviteUrl(url);
+      setCreatedPublicInviteUrl(url);
       const copiedToClipboard = url ? await copyToClipboard(url) : false;
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
         result: "success",
-        duration_bucket: oneLocationDurationBucket(durationHours),
+        duration_bucket: oneLocationDurationBucket(publicLinkDurationHours),
         copied_to_clipboard: copiedToClipboard,
         active_invite_count: activePublicInvites.length + 1,
       });
@@ -6459,7 +6501,7 @@ export function OneLocationAgentPageContent({
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
         result: "error",
-        duration_bucket: oneLocationDurationBucket(durationHours),
+        duration_bucket: oneLocationDurationBucket(publicLinkDurationHours),
         copied_to_clipboard: false,
         active_invite_count: activePublicInvites.length,
       });
@@ -6474,8 +6516,8 @@ export function OneLocationAgentPageContent({
     }
   }, [
     activePublicInvites.length,
-    durationHours,
     ensureForegroundLocationReady,
+    publicLinkDurationHours,
     refresh,
     vaultOwnerToken,
   ]);
@@ -6526,15 +6568,15 @@ export function OneLocationAgentPageContent({
         const point = readiness.point;
         const response = await OneLocationService.createPublicInvite({
           vaultOwnerToken,
-          durationHours: publicInviteDurationHours(durationHours),
+          durationHours: publicInviteDurationHours(publicLinkDurationHours),
           locationSnapshot: point,
         });
         url = publicInviteUrlLabel(response.publicUrl);
-        setPublicInviteUrl(url);
+        setCreatedPublicInviteUrl(url);
         trackEvent("one_location_public_link_created", {
           route_id: "one_location",
           result: "success",
-          duration_bucket: oneLocationDurationBucket(durationHours),
+          duration_bucket: oneLocationDurationBucket(publicLinkDurationHours),
           copied_to_clipboard: false,
           active_invite_count: activePublicInvites.length + 1,
         });
@@ -6555,7 +6597,7 @@ export function OneLocationAgentPageContent({
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
         result: "error",
-        duration_bucket: oneLocationDurationBucket(durationHours),
+        duration_bucket: oneLocationDurationBucket(publicLinkDurationHours),
         copied_to_clipboard: false,
         active_invite_count: activePublicInvites.length,
       });
@@ -6565,9 +6607,9 @@ export function OneLocationAgentPageContent({
     }
   }, [
     activePublicInvites.length,
-    durationHours,
     ensureForegroundLocationReady,
     publicInviteUrl,
+    publicLinkDurationHours,
     refresh,
     vaultOwnerToken,
   ]);
@@ -7529,7 +7571,7 @@ export function OneLocationAgentPageContent({
           vaultOwnerToken,
           inviteId: invite.id,
         });
-        setPublicInviteUrl("");
+        setCreatedPublicInviteUrl("");
         toast.success("Public location link revoked.");
         void refresh().catch(() => null);
       } catch (error) {
@@ -11530,12 +11572,14 @@ export function OneLocationAgentPageContent({
     requestMessage,
     shareReviewOpen,
     publicInviteUrl,
+    publicLinkDurationHours,
     circleInviteUrl,
     setRecipientSearch,
     setShareRecipientSearch,
     setShareDurationHours,
     setShareMessage,
     setDurationHours,
+    setPublicLinkDurationHours,
     setRequestMessage,
     setShareReviewOpen,
     resetShareComposer,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1101,6 +1101,19 @@ const CIRCLE_INVITE_MAX_DURATION_HOURS = 24;
  */
 const PUBLIC_INVITE_MAX_DURATION_HOURS = 1;
 
+/**
+ * An ISO expiry as epoch ms, or null when there is nothing usable to compare.
+ *
+ * Null means "do not expire this locally" rather than "expired": a missing or
+ * unparseable timestamp is not evidence the link has run out, and treating it
+ * as such would hide a working link.
+ */
+function parseExpiryMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function publicInviteDurationHours(value: string): number {
   return inviteDurationHours(value, PUBLIC_INVITE_MAX_DURATION_HOURS);
 }
@@ -2511,8 +2524,18 @@ export function OneLocationAgentPageContent({
    * and the next `getState` there is a window where the only place the URL
    * exists is this variable. `publicInviteUrl` below prefers the server's copy
    * and falls back to this one.
+   *
+   * It carries its own expiry, and that is not decoration. A bare string
+   * outlived the link it named: once the invite ran out, the server stopped
+   * reporting it as active but this variable still held a URL, so the Links tab
+   * -- which hides its create control whenever a link is live -- kept showing a
+   * dead link with no way past it. The expiry here is the one the SERVER
+   * stamped, not the duration that was asked for, so the two agree.
    */
-  const [createdPublicInviteUrl, setCreatedPublicInviteUrl] = useState("");
+  const [createdPublicInvite, setCreatedPublicInvite] = useState<{
+    url: string;
+    expiresAtMs: number | null;
+  } | null>(null);
   /**
    * The public link's own duration, deliberately not the shared `durationHours`.
    *
@@ -3281,12 +3304,32 @@ export function OneLocationAgentPageContent({
         isOneLocationGrantUnwatched(auth.userId, grant.id),
     ).length;
   }, [auth.userId, unwatchedTick, state?.receivedGrants]);
+  /**
+   * Links that are live right now, by the clock as well as by the server.
+   *
+   * `status` alone is not enough. Expiry is written server-side only when a row
+   * is READ, and nothing on this screen refetches on a timer -- so a link that
+   * ran out five minutes ago is still `status: "active"` in the state this
+   * session already holds. That was harmless while the Links tab merely listed
+   * it. It is not harmless now: the tab hides its create control whenever a
+   * link is live, so a stale row left the person looking at a dead link with no
+   * way to make another until they reloaded the page.
+   *
+   * `nowMs` ticks every 30s and on return from background, so the create form
+   * comes back on its own, which is exactly the promise the tab makes.
+   *
+   * A row with no `expiresAt` is treated as live: the server sent it as active
+   * and we have nothing to contradict that with.
+   */
   const activePublicInvites = useMemo(
     () =>
-      (state?.publicInvites ?? []).filter(
-        (invite) => invite.status === "active",
-      ),
-    [state?.publicInvites],
+      (state?.publicInvites ?? []).filter((invite) => {
+        if (invite.status !== "active") return false;
+        if (!invite.expiresAt) return true;
+        const expiresAtMs = Date.parse(invite.expiresAt);
+        return !Number.isFinite(expiresAtMs) || expiresAtMs > nowMs;
+      }),
+    [nowMs, state?.publicInvites],
   );
   const latestActivePublicInvite = useMemo(() => {
     const inviteTime = (invite: OneLocationPublicInvite) =>
@@ -3318,8 +3361,17 @@ export function OneLocationAgentPageContent({
     if (fromServer && String(fromServer).trim()) {
       return publicInviteUrlLabel(String(fromServer).trim());
     }
-    return createdPublicInviteUrl;
-  }, [createdPublicInviteUrl, latestActivePublicInvite]);
+    if (!createdPublicInvite) return "";
+    // The fallback has to expire with the link it names, or it keeps a dead
+    // link on screen after `latestActivePublicInvite` has correctly let go.
+    if (
+      createdPublicInvite.expiresAtMs !== null &&
+      createdPublicInvite.expiresAtMs <= nowMs
+    ) {
+      return "";
+    }
+    return createdPublicInvite.url;
+  }, [createdPublicInvite, latestActivePublicInvite, nowMs]);
 
   const activeCircleInvites = useMemo(
     () =>
@@ -6482,7 +6534,10 @@ export function OneLocationAgentPageContent({
         locationSnapshot: point,
       });
       const url = publicInviteUrlLabel(response.publicUrl);
-      setCreatedPublicInviteUrl(url);
+      setCreatedPublicInvite({
+        url,
+        expiresAtMs: parseExpiryMs(response.invite?.expiresAt),
+      });
       const copiedToClipboard = url ? await copyToClipboard(url) : false;
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
@@ -6572,7 +6627,10 @@ export function OneLocationAgentPageContent({
           locationSnapshot: point,
         });
         url = publicInviteUrlLabel(response.publicUrl);
-        setCreatedPublicInviteUrl(url);
+        setCreatedPublicInvite({
+          url,
+          expiresAtMs: parseExpiryMs(response.invite?.expiresAt),
+        });
         trackEvent("one_location_public_link_created", {
           route_id: "one_location",
           result: "success",
@@ -7571,7 +7629,7 @@ export function OneLocationAgentPageContent({
           vaultOwnerToken,
           inviteId: invite.id,
         });
-        setCreatedPublicInviteUrl("");
+        setCreatedPublicInvite(null);
         toast.success("Public location link revoked.");
         void refresh().catch(() => null);
       } catch (error) {

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -30,12 +30,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import {
-  Link as LinkIcon,
   Lock,
   Map,
   MapPin,
   Navigation,
-  Plus,
   Send,
   Check,
   Shield,
@@ -308,6 +306,17 @@ export type LocationHubViewModel = {
   requestMessage: string;
   shareReviewOpen: boolean;
   publicInviteUrl: string;
+  /**
+   * The public link's own duration, kept apart from `durationHours`.
+   *
+   * That one string is written by the Ask composer and the Circle invite screen
+   * and read by all three lanes. The public-link control now sits permanently
+   * on the Links tab rather than behind a button, so sharing the string would
+   * mean anyone browsing past the tab rewrites what the other two screens
+   * offer.
+   */
+  publicLinkDurationHours: string;
+  setPublicLinkDurationHours: (value: string) => void;
   circleInviteUrl: string;
 
   /* setters (presentation state owned by page) */
@@ -559,7 +568,6 @@ type FlowKind =
   | "create-circle"
   | "join-circle"
   | "circle-detail"
-  | "temp-link"
   | "check-in"
   | "sos"
   | "sms-contacts"
@@ -587,7 +595,6 @@ const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
   "create-circle": "create-circle",
   "join-circle": "join-circle",
   "circle-detail": "circle-detail",
-  "temp-link": "temp-link",
   "check-in": "check-in",
   sos: "sos",
   "sms-contacts": "sms-contacts",
@@ -616,6 +623,24 @@ export function resolveSmsContactsBackFlow(
   // performs this navigation now, and it resolves the target the same way.
   return resolveSmsContactsBackAction(source);
 }
+
+/**
+ * Actions whose screen was folded into a hub tab rather than removed.
+ *
+ * Different from `RETIRED_ACTIONS` below, and the difference is what the
+ * person is told. A retired action is gone and says so. A relocated one still
+ * exists -- it is just no longer its own screen -- so it lands on the tab that
+ * absorbed it, quietly. "That's no longer there." would be a lie for these,
+ * and a confusing one, since the thing they asked for is on the screen they
+ * are now looking at.
+ *
+ * `temp-link` was the create-a-live-location-link screen. Its duration
+ * question and its create button are now on the Links tab itself, so every
+ * bookmark, history entry and Kai deep link pointing at it resolves there.
+ */
+const RELOCATED_ACTION_TABS: Readonly<Record<string, LocationHubTab>> = {
+  "temp-link": "links",
+};
 
 const RETIRED_ACTIONS = new Set([
   "drive-to",
@@ -1048,6 +1073,16 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       params.set(FLOW_ACTION_PARAM, action);
       router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     }
+    const relocatedTab = RELOCATED_ACTION_TABS[action];
+    if (relocatedTab) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete(FLOW_ACTION_PARAM);
+      params.set(LOCATION_HUB_TAB_PARAM, relocatedTab);
+      // No toast: the screen did not go away, it became this tab, and the
+      // person is looking at it.
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      return;
+    }
     if (RETIRED_ACTIONS.has(action)) {
       const params = new URLSearchParams(searchParams.toString());
       params.delete(FLOW_ACTION_PARAM);
@@ -1290,7 +1325,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             onManageSmsContacts={() => openFlow("sms-contacts")}
           />
         ) : (
-          <TemporaryLinkFlow vm={vm} onClose={closeFlow} />
+          // Every FlowKind above is matched, and `none` never reaches here.
+          // This used to fall through to the temporary-link screen, so any
+          // flow slug nobody had wired up quietly rendered "Share outside your
+          // Circle" instead of failing visibly.
+          null
         )}
       </div>
     );
@@ -1374,7 +1413,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           </LocationHubPanel>
 
           <LocationHubPanel>
-            <LinksHub vm={vm} onCreateTempLink={() => openFlow("temp-link")} />
+            <LinksHub vm={vm} />
           </LocationHubPanel>
         </SwipeViews>
       </div>
@@ -2778,70 +2817,164 @@ function ActiveLinkRow({
   );
 }
 
-function LinksHub({
-  vm,
-  onCreateTempLink,
-}: {
-  vm: LocationHubViewModel;
-  onCreateTempLink: () => void;
-}) {
+/**
+ * The Links tab, which is now the whole of the live-location-link flow.
+ *
+ * Making one used to take three screens: this tab, with a "Create link" button
+ * that created nothing and only navigated; a separate `?action=temp-link`
+ * screen carrying a warning, one duration question and the button that
+ * actually created; and then that same screen again, showing the result with a
+ * "Done" that returned here -- where the link appeared a third time, as a row,
+ * with only a Copy button. Two of those three screens existed to ask one
+ * question and to acknowledge its answer.
+ *
+ * The question is now asked here, and the answer replaces it in place.
+ *
+ * One live link at a time. While one is active there is no create control at
+ * all: not disabled, absent. A second link is not a thing the product wants to
+ * be able to make -- both stay independently resolvable, revoking the one on
+ * screen leaves the other watching, and the tab can only ever show the newest.
+ * The way to a different link is to end this one, which is a button already on
+ * the card. The server refuses the second as well (`create_public_invite`
+ * hands back the live one), because a rule that lives only in a component is
+ * defeated by a stale tab.
+ */
+function LinksHub({ vm }: { vm: LocationHubViewModel }) {
   const temp = vm.latestActivePublicInvite;
   const invite = vm.latestActiveCircleInvite;
-  const hasLinks = Boolean(temp) || Boolean(invite);
+  // Two separate questions, and both have to be asked.
+  //
+  //   is a link live?      `temp` -- the server's row
+  //   can we hand it over? `vm.publicInviteUrl` -- the URL itself
+  //
+  // Neither implies the other. An invite minted before its token could be
+  // re-derived from its row is live with no recoverable URL, so Copy would
+  // hand over nothing. And for one round trip after creating, the URL is known
+  // while the row is not: `onCreatePublicInvite` fires its refresh without
+  // awaiting it. Keying the whole tab on `temp` alone put the create form back
+  // on screen during that window, which reads as "nothing happened" and
+  // invites a second press.
+  const hasLiveLink = Boolean(temp) || Boolean(vm.publicInviteUrl);
+  const hasShareableLink = Boolean(vm.publicInviteUrl);
 
   return (
     <div className="space-y-4">
       <div className="px-[6px]">
         <SectionTitle as="h2">Active links</SectionTitle>
-        {/* This section lists two different things — a live location link and
-            a Circle invite link — and the invite shares no location at all.
-            Copy that described only the first was wrong for half the list,
-            and neither told a new user what a "link" is here. */}
-        <RowDescription as="p" className="mt-1">
-          Links you can send to anyone — to show where you are, or to invite
-          them to a Circle.
-        </RowDescription>
       </div>
 
-      {hasLinks ? (
-        <div className={cn("overflow-hidden px-3.5", SUBCARD_SURFACE)}>
-          {temp ? (
-            <ActiveLinkRow
-              first
-              tileClass="bg-[color:var(--app-purple)]/12 dark:bg-[color:var(--app-purple)]/15"
-              icon={
-                <LinkIcon className="h-[17px] w-[17px] text-[color:var(--app-purple)]" />
-              }
-              title="Live location link"
-              subtitle={`${vm.expiresCountdownLabel(temp.expiresAt)} · anyone with the link`}
-              onCopy={vm.onCopyPublicInvite}
-            />
-          ) : null}
-          {invite ? (
-            <ActiveLinkRow
-              first={!temp}
-              tileClass="bg-[color:var(--app-success)]/12 dark:bg-[color:var(--app-success)]/15"
-              icon={
-                <ShieldCheck className="h-[17px] w-[17px] text-[color:var(--app-success)]" />
-              }
-              title="Invite link"
-              subtitle={`${vm.expiresCountdownLabel(invite.expiresAt)} · one person`}
-              onCopy={vm.onCopyCircleInvite}
-            />
-          ) : null}
-        </div>
+      {hasLiveLink ? (
+        hasShareableLink ? (
+          <TemporaryLinkCard
+            title="Live location link"
+            statusLine="Anyone with this link can view you"
+            // No countdown until the row lands: inventing one from the
+            // duration that was picked would drift from the expiry the server
+            // actually stamped.
+            expiryLabel={
+              temp ? vm.expiresCountdownLabel(temp.expiresAt) : undefined
+            }
+            onCopy={vm.onCopyPublicInvite}
+            onShare={vm.onSharePublicInvite}
+            // Revoking needs the invite's id, which arrives with the row. In
+            // the moment before it does, the control shows itself as busy
+            // rather than pretending to work -- which is honest, because a
+            // refresh really is in flight. Copy and Share are unaffected: the
+            // URL is already in hand.
+            onRevoke={() => {
+              if (temp) vm.onRevokePublicInvite(temp);
+            }}
+            revokeBusy={vm.busy === "publicRevoke" || !temp}
+          />
+        ) : (
+          // Live, and its URL is gone: an invite from before the token could be
+          // re-derived from its row. Copy and Share would be dead controls, so
+          // they are not offered -- but the link is still out there watching,
+          // so ending it has to stay reachable. Saying why keeps this from
+          // reading as a bug the person should retry.
+          <div className={cn(SUBCARD_SURFACE, "space-y-3 p-3.5")}>
+            <div className="min-w-0">
+              <RowLabel as="p">Live location link</RowLabel>
+              <RowDescription as="p" className="mt-0.5">
+                Made on another device or before an update, so it cannot be
+                shown again here. Stop it to make a new one.
+              </RowDescription>
+            </div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                if (temp) vm.onRevokePublicInvite(temp);
+              }}
+              isLoading={vm.busy === "publicRevoke" || !temp}
+              className="h-9 w-full rounded-full text-sm"
+            >
+              Stop this link
+            </Button>
+          </div>
+        )
       ) : (
-        <EmptyState title="No active links" />
+        <div className="space-y-4">
+          <WarningCard
+            title="Anyone with this link can see you"
+            description="The link stops on its own."
+          />
+          <SettingsGroup title="Duration" separatorInset>
+            <SettingsRow
+              title="Link stays live for"
+              description="Anyone holding it can watch until then."
+              stackTrailingOnMobile
+              trailing={
+                <DurationSelector
+                  value={vm.publicLinkDurationHours}
+                  onChange={vm.setPublicLinkDurationHours}
+                  label=""
+                  // Deliberately shorter than the trusted-share durations:
+                  // anyone holding this link can watch, so the public ceiling
+                  // stays at 1 hour.
+                  options={[
+                    { value: "0.5", label: "30 min" },
+                    { value: "1", label: "1 hour" },
+                  ]}
+                />
+              }
+            />
+          </SettingsGroup>
+          {/* The label changes while it works. This press waits on a device fix
+              before it can post anything, so on a cold start it can sit for
+              several seconds -- and it used to sit as a bare spinner with the
+              label hidden, which is why it read as "taking longer than
+              expected" rather than as "still finding you". Naming the wait is
+              the fix available here; the wait itself is a GPS acquisition. */}
+          <Button
+            onClick={vm.onCreatePublicInvite}
+            isLoading={vm.busy === "publicInvite"}
+            data-voice-control-id="one-location-action-temp-link"
+            className="h-12 min-h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+          >
+            {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
+          </Button>
+        </div>
       )}
 
-      <Button
-        onClick={onCreateTempLink}
-        data-voice-control-id="one-location-action-temp-link"
-        className="w-full"
-      >
-        <Plus className="mr-2 h-4 w-4" />
-        Create link
-      </Button>
+      {/* A Circle invite is a different object on a different table with a
+          different ceiling, and it is not subject to the one-at-a-time rule
+          above: it admits one named person to a Circle rather than showing the
+          owner to anyone holding a URL. It keeps its row. */}
+      {invite ? (
+        <div className={cn("overflow-hidden px-3.5", SUBCARD_SURFACE)}>
+          <ActiveLinkRow
+            first
+            tileClass="bg-[color:var(--app-success)]/12 dark:bg-[color:var(--app-success)]/15"
+            icon={
+              <ShieldCheck className="h-[17px] w-[17px] text-[color:var(--app-success)]" />
+            }
+            title="Invite link"
+            subtitle={`${vm.expiresCountdownLabel(invite.expiresAt)} · one person`}
+            onCopy={vm.onCopyCircleInvite}
+          />
+        </div>
+      ) : null}
 
       <div className="flex items-start gap-2 px-1">
         <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -4239,99 +4372,3 @@ function InviteFlow({
 /* =================================================================== */
 
 /** Same precision story as ShareFlow — see the note there. */
-function TemporaryLinkFlow({
-  vm,
-  onClose,
-}: {
-  vm: LocationHubViewModel;
-  onClose: () => void;
-}) {
-  const created =
-    Boolean(vm.publicInviteUrl) || Boolean(vm.latestActivePublicInvite);
-
-  if (created) {
-    const invite = vm.latestActivePublicInvite;
-    return (
-      <div className="space-y-5">
-        <TaskFlowHeader
-          eyebrow="Copy, share or revoke"
-          title="Public location link active"
-        />
-        <WarningCard
-          title="Anyone with the link can view you."
-          description="The link stops on its own."
-        />
-        {invite ? (
-          <TemporaryLinkCard
-            title="Public location link active"
-            statusLine="Anyone with this link can view you"
-            expiryLabel={vm.expiresCountdownLabel(invite.expiresAt)}
-            onCopy={vm.onCopyPublicInvite}
-            onShare={vm.onSharePublicInvite}
-            onRevoke={() => vm.onRevokePublicInvite(invite)}
-            revokeBusy={vm.busy === "publicRevoke"}
-          />
-        ) : null}
-        <Button
-          variant="ghost"
-          onClick={onClose}
-          className="h-11 w-full rounded-2xl text-sm"
-        >
-          Done
-        </Button>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-5">
-      {/* The eyebrow, title and description all used to say "outside your
-          Circle", then the warning said "until it expires" and the trust note
-          said it a third time. The consent point is load-bearing here, so it is
-          stated ONCE, in the warning, where it carries the most weight. */}
-      <TaskFlowHeader title="Share outside your Circle" />
-      <WarningCard
-        title="Anyone with this link can see you"
-        description="The link stops on its own."
-      />
-      <SettingsGroup title="Duration" separatorInset>
-        <SettingsRow
-          title="Link stays live for"
-          description="Anyone holding it can watch until then."
-          stackTrailingOnMobile
-          trailing={
-            <DurationSelector
-              value={vm.durationHours}
-              onChange={vm.setDurationHours}
-              label=""
-              // Deliberately shorter than the trusted-share durations: anyone
-              // holding this link can watch, so the public ceiling stays at
-              // 1 hour.
-              options={[
-                { value: "0.5", label: "30 min" },
-                { value: "1", label: "1 hour" },
-              ]}
-            />
-          }
-        />
-      </SettingsGroup>
-      {/* The temporary link shares the same precise point as everything else,
-          so it offers no precision card either. The "expires automatically"
-          note that sat here was the third statement of the same fact — the
-          warning above and the duration control already carry it. */}
-      {/* The label changes while it works. This press waits on a device fix
-          before it can post anything, so on a cold start it can sit for
-          several seconds — and it used to sit as a bare spinner with the label
-          hidden, which is why it read as "taking longer than expected" rather
-          than as "still finding you". Naming the wait is the fix available
-          here; the wait itself is a GPS acquisition. */}
-      <Button
-        onClick={vm.onCreatePublicInvite}
-        isLoading={vm.busy === "publicInvite"}
-        className="h-12 min-h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-base font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-      >
-        {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
-      </Button>
-    </div>
-  );
-}

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -230,6 +230,20 @@ export type OneLocationPublicInvite = {
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
+  /**
+   * The owner's own share link, app-relative (`/one/location/request/<token>`).
+   *
+   * Present only for the owner, and only while the invite is still usable. The
+   * token used to be returned exactly once, at creation, and nothing could
+   * recover it afterwards -- so after a reload the app knew a link was live and
+   * had nothing to copy. The server now derives it from the invite id and hands
+   * it back on every read.
+   *
+   * Still optional, and callers must treat it that way: an invite minted before
+   * the token was derivable has no recoverable link, and the field is absent
+   * rather than wrong.
+   */
+  publicUrl?: string | null;
 };
 
 export type OneLocationPublicInviteSubmission = {


### PR DESCRIPTION
Closes #5744.

## Three screens became one

Creating a live location link used to take three.

1. **The Links tab** — "Active links", a paragraph, and a **Create link** button that created nothing and only navigated.
2. **`?action=temp-link`** — a warning, one duration question, and the **Create link** button that actually created.
3. **The same screen again** — the result, with a **Done** that returned to the Links tab, where the link appeared a third time as a row with only a Copy button.

Two of those existed to ask one question and to acknowledge its answer. The question is now asked on the Links tab, and the answer replaces it in place.

A bookmarked `?action=temp-link` resolves to the Links tab. Not to "That's no longer there." — the screen did not go away, it became the tab, and telling someone their link is gone while they look at it would be a strange thing to do.

## One live link at a time

While a link is live there is **no create control at all** — absent, not disabled.

A second link was never something the product wanted to be able to make: both stay independently resolvable, revoking the one on screen leaves the other watching, and the tab can only ever show the newest. The way to a different link is to end this one, which is a button on the card.

**The server enforces it too**, because a rule that lives in a component is defeated by a stale tab. `create_public_invite` now settles lazily-expired rows and then hands back the live invite instead of inserting a second — the same shape as `one_location_circle_service.create_invite_code`.

No index and no migration, deliberately. Expiry is written only when a row is read, so a partial unique index would falsely reject a new link after an unread expiry, and `CREATE UNIQUE INDEX` would fail outright on any account that already holds two.

## The owner can read their own link back

This is what made the rest safe to ship.

The token was `secrets.token_urlsafe(32)`, hashed on the way in and returned exactly once. Nothing recovered it afterwards — not the owner, not a second device, not the same tab after a reload — so an invite the server reported as active had a link the product could no longer show. `onCopyPublicInvite` and `onSharePublicInvite` early-returned with no toast.

**That already ships as a dead Copy button** on the Links tab row. Showing only that card would have made a dead end of the whole tab.

The token is now derived from the invite row's UUID with the app signing key — exactly as `_code_for_invite_id` does for Circle codes — and the owner's payload carries `publicUrl` on every read. The row UUID is not secret and the key supplies the entropy, so a database-only compromise still yields nothing but a UUID and a keyed digest. The recipient-facing payload is unchanged and still carries no token; there is a test that asserts it.

Rows minted before this have no recoverable token and are **not given a wrong one**. The payload omits the URL, the tab offers *Stop this link* rather than Copy and Share, and create retires the row and mints a replacement rather than leaving somebody stranded behind a link nothing can show.

## Also

- **The public link gets its own duration state.** One `durationHours` string is written by the Ask composer and the Circle invite screen and read by all three lanes — which is how a public link came to post the 24 hours somebody picked elsewhere, caught only by a clamp that silently shortened what the person had been shown. The control now sits permanently on the tab rather than behind a button, so sharing that string would mean anyone browsing past the tab rewrites what the other two screens offer.
- **The paragraph under "Active links" is gone**, as asked.
- **The Circle invite row is untouched.** It is a different table, a different route and a different ceiling, and it is not subject to the one-at-a-time rule — it admits one named person to a Circle rather than showing the owner to anyone holding a URL.
- The flow chain's fallthrough used to be the temporary-link screen, so any unwired flow slug quietly rendered "Share outside your Circle". It renders nothing now.

## Verification

| Check | Result |
| --- | --- |
| `pytest` — backend | 132 passed (19 new) |
| `verify:one-location` | 363 passed |
| `one-location-agent-page.test.tsx` | 111 passed (4 new) |
| `tsc --noEmit` | clean |
| `eslint` (changed files) | clean |
| `ruff check` / `ruff format` | clean |
| `verify:design-system` | passed |
| `verify:surface-map` | current |
| `verify:voice-gateway` | current |
| `verify:capacitor:static` | passed |

New coverage includes: the token is stable per invite and changes with the signing key; a legacy row reports no token rather than a wrong one; a digest that does not verify fails closed; the recipient payload never carries the token; a second create hands back the first and leaves one active row; revoke and expiry both free the person to create again; an unrecoverable link is replaced rather than left stranding; and on the client — a link made in an earlier session can still be copied, no create control appears while one is live, an unrecoverable link can still be stopped, and a bookmarked `temp-link` URL lands on the Links tab.


---

# Second commit — the rest of what the audit found

Mapping this surface before rewriting it turned up more than the rewrite strictly needed. The two that would have broken the new screen went in with it. These are the rest.

## A link that ran out now lets go on its own

The tab hides its create control whenever a link is live, and the promise attached to that is *"you can make another once this one expires."* **Nothing was keeping that promise.**

Expiry is written server-side only when a row is read, and nothing on this screen refetches on a timer — so a link that ran out five minutes ago was still `status: "active"` in the state the session already held. The person was left looking at a dead link with no way past it until they reloaded the page.

`activePublicInvites` now checks the clock as well as the status, on the 30s tick that already drives the countdowns and on return from background. A row with no `expiresAt` is still treated as live: a missing timestamp is not evidence a link has run out, and hiding a working link is the worse mistake.

The locally-held create-response URL had the same problem from the other side — a bare string outlived the link it named, so the tab kept showing a dead link even after the server row had correctly let go. It carries the expiry the **server** stamped now, not the duration that was asked for.

## The one-hour public ceiling is enforced where it is promised

The screen says a public link lasts at most an hour. The screen was the only thing saying so: Pydantic allowed 24, `normalize_duration_hours` allowed 24, and the DB `CHECK` allowed 24 — all three are the **private** ceiling, which is a different promise made to a named person who can be un-shared. A request carrying `durationHours: 24` was accepted and minted a public link that watched the owner for a day.

Now `le=1` on the request model and a service-level check behind it. Rejected rather than clamped: silently shortening what was asked for is how the client-side clamp hid this in the first place, and no shipped client can reach the branch — every caller already clamps to an hour before it posts.

## Minting a public link is throttled

Every sibling mutation on this router carries a rate limit and this one did not, so nothing stood between a retry loop — or a double tap on a slow connection — and a run of simultaneously live public links. Create and revoke both take the circle-mutation budget.

## Considered and deliberately not done

- **A partial unique index on `(owner_user_id) WHERE status = 'active'`.** Expiry is written lazily, so an un-read expired row is still `active` in the DB and the index would falsely reject a legitimate new link. It would also fail outright on any account that already holds two. The server-side reuse in `create_public_invite` gives the same invariant without either failure mode.
- **The `LIMIT 20` window on `publicInvites`.** An old account with more than twenty rows could have an active one fall out of the client's view. The server's own lookup for the active row is unbounded, so pressing Create in that state returns the existing link rather than minting a second — the outcome is already correct.
- **Kai revoking a link out from under the page.** The card shows until the next state read. Worth a fix, not worth a poll.

## Test-suite hygiene

The suite gets an `afterEach` that restores real timers. A test that installs fake ones and then fails leaves them installed, and every test after it hangs on a clock that never moves — three unrelated failures from one, which is what happened while writing the expiry test above.

## Verification after both commits

| Check | Result |
| --- | --- |
| `pytest` — backend | 134 passed |
| `verify:one-location` | 366 passed |
| `one-location-agent-page.test.tsx` | 114 passed |
| `tsc`, `eslint`, `ruff` | clean |
| design-system / surface-map / voice-gateway / capacitor parity | passed |
| CI on this PR | 15/15 green |
