### PR TITLE
fix(ria-setup): add bottom scroll inset so terminal action buttons remain clear of floating bottom bar across steps 1 to 5

### DIFF
--- a/hushh-webapp/app/one/setup/ria/ria-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/ria/ria-onboarding-setup-client.tsx
@@ -21,7 +21,7 @@ export function RiaOnboardingSetupClient() {
   if (!coordinator.isReady) return <SetupCapabilityLoading label="Preparing RIA setup…" />;
 
   return (
-    <div className="flex min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-bottom-inset,2rem))] w-full flex-col justify-center items-center space-y-4 pb-[calc(var(--app-bottom-inset)+1rem)]">
+    <div className="flex min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-bottom-inset,2rem))] w-full flex-col justify-center items-center space-y-4 pb-[calc(var(--app-bottom-inset)+6rem)]">
       <RiaOnboardingPage
         setupMode
         onSetupReadinessChange={setReady}

--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -64,7 +64,7 @@ export function OnboardingShell({
   const isAccent = heroImage?.variant === "accent";
   useScrollReset(currentStepIndex, { enabled: true });
   return (
-    <div className="mx-auto flex w-full max-w-[54rem] flex-col px-6 pb-[var(--app-scroll-bottom-pad)]">
+    <div className="mx-auto flex w-full max-w-[54rem] flex-col px-6 pb-[calc(var(--app-bottom-inset)+6rem)]">
       <div className="flex w-full flex-col">
         {/* Progress + step counter share one row (design has no back arrow —
             back/forward is by swipe within the pinned chrome). */}
@@ -209,7 +209,7 @@ export function OnboardingShell({
         <div className={cn(isHero ? "mt-[22px]" : "mt-[18px]")}>{children}</div>
 
         {!hideTerminal ? (
-          <div className="mt-8 space-y-1 pb-[calc(var(--app-bottom-inset)+1rem)]">
+          <div className="mt-8 space-y-1 pb-[calc(var(--app-bottom-inset)+6rem)]">
             <div className="mx-auto w-full sm:max-w-[22rem]">
               <Button
                 type="button"


### PR DESCRIPTION
## Summary
Fixes bottom button positioning and scrolling clearance across all 5 steps of the RIA Agent Setup wizard (`/one/setup/ria`).

## Key Changes
- **Bottom Inset Clearance**: Updated `OnboardingShell` (`components/ria/onboarding/onboarding-shell.tsx`) root container and terminal button block to use `pb-[calc(var(--app-bottom-inset)+6rem)]`.
- **Coordinator Alignment**: Updated `RiaOnboardingSetupClient` (`app/one/setup/ria/ria-onboarding-setup-client.tsx`) wrapper to apply `+6rem` bottom inset padding.
- **Result**: Terminal buttons ("Continue", "Verify licence", "Submit profile") sit 96px above the bottom edge, completely clear of the floating `Talk to One` bar across Steps 1 to 5.

## Branch & Commits
- **Branch**: `fix/ria-setup-scroll-bottom-padding-5515`
- **Commit**: `1739b11da` (`fix(ria-setup): add bottom scroll inset so terminal action buttons remain clear of floating bottom bar across steps 1 to 5`)

## Verification
- Verified via `npx eslint` (0 errors).
- Verified via localhost at `http://localhost:3000/one/setup/ria` — Steps 1 to 5 render with clear, un-obscured action buttons.