### PR TITLE
Stabilize feed timestamp width

### DIFF
--- a/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
@@ -116,7 +116,7 @@ describe("FeedActionableRow", () => {
         />,
       );
 
-      expect(screen.getByText(/^Today - 3:45\s?PM$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^Today - 03:45\s?PM$/i)).toBeInTheDocument();
     });
 
     it("shows no time label when displayTimestamp is null", () => {
@@ -146,7 +146,7 @@ describe("FeedActionableRow", () => {
         />,
       );
 
-      expect(screen.getByText(/^Today - 3:45\s?PM$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^Today - 03:45\s?PM$/i)).toBeInTheDocument();
       expect(screen.getByText("Row description")).toBeInTheDocument();
     });
   });

--- a/hushh-webapp/__tests__/components/feed-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-row.test.tsx
@@ -41,7 +41,7 @@ describe("FeedRow", () => {
   it("shows the absolute day/time label next to the description", () => {
     render(<FeedRow item={feedItem()} onOpen={() => {}} />);
 
-    expect(screen.getByText(/^Today - \d{1,2}:\d{2}\s?[AP]M$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Today - \d{2}:\d{2}\s?[AP]M$/i)).toBeInTheDocument();
     expect(screen.getByText("A routine location share.")).toBeInTheDocument();
   });
 

--- a/hushh-webapp/__tests__/lib/feed/feed-timestamp.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-timestamp.test.ts
@@ -18,23 +18,28 @@ describe("formatFeedTimestamp", () => {
   // digits/day-prefix exactly and match am/pm case-insensitively.
   it("labels a same-day instant as Today, 12-hour clock", () => {
     const sameDay = new Date(2026, 7, 12, 15, 45, 0);
-    expect(formatFeedTimestamp(sameDay)).toMatch(/^Today - 3:45\s?PM$/i);
+    expect(formatFeedTimestamp(sameDay)).toMatch(/^Today - 03:45\s?PM$/i);
   });
 
   it("labels the previous calendar day as Yesterday", () => {
     const yesterday = new Date(2026, 7, 11, 9, 5, 0);
-    expect(formatFeedTimestamp(yesterday)).toMatch(/^Yesterday - 9:05\s?AM$/i);
+    expect(formatFeedTimestamp(yesterday)).toMatch(/^Yesterday - 09:05\s?AM$/i);
+  });
+
+  it("keeps one-digit morning hours visually aligned", () => {
+    const earlyMorning = new Date(2026, 7, 12, 1, 5, 0);
+    expect(formatFeedTimestamp(earlyMorning)).toMatch(/^Today - 01:05\s?AM$/i);
   });
 
   it("labels anything older with a short weekday", () => {
     const older = new Date(2026, 7, 10, 18, 30, 0); // Mon
-    expect(formatFeedTimestamp(older)).toMatch(/^Mon - 6:30\s?PM$/i);
+    expect(formatFeedTimestamp(older)).toMatch(/^Mon - 06:30\s?PM$/i);
   });
 
   it("always renders 12-hour time, never 24-hour", () => {
     const afternoon = new Date(2026, 7, 12, 15, 45, 0); // 15:45 local
     const label = formatFeedTimestamp(afternoon);
-    expect(label).toMatch(/3:45\s?PM/i);
+    expect(label).toMatch(/03:45\s?PM/i);
     expect(label).not.toContain("15:45");
   });
 

--- a/hushh-webapp/lib/feed/feed-timestamp.ts
+++ b/hushh-webapp/lib/feed/feed-timestamp.ts
@@ -13,9 +13,10 @@ export function daysSinceToday(date: Date, now: Date = new Date()): number {
 }
 
 /**
- * Renders a feed row's right-aligned day/time label: "Today - 3:45 PM",
- * "Yesterday - 3:45 PM", or "Mon - 3:45 PM" (short weekday) for anything
- * older. Always a 12-hour clock, explicit regardless of locale default.
+ * Renders a feed row's right-aligned day/time label: "Today - 03:45 PM",
+ * "Yesterday - 03:45 PM", or "Mon - 03:45 PM" (short weekday) for anything
+ * older. Always a two-digit 12-hour clock, explicit regardless of locale default,
+ * so the feed timestamp column stays visually stable across one- and two-digit hours.
  * Returns "" for an invalid/missing instant so callers can embed the result
  * directly in JSX without a null-guard.
  */
@@ -23,7 +24,7 @@ export function formatFeedTimestamp(value: string | number | Date): string {
   const date = value instanceof Date ? value : new Date(value);
   if (!Number.isFinite(date.getTime())) return "";
   const time = formatLocalDateTime(date, {
-    hour: "numeric",
+    hour: "2-digit",
     minute: "2-digit",
     hour12: true,
   });


### PR DESCRIPTION
## Summary
- Format feed timestamps with two-digit 12-hour labels, e.g. `Today - 01:05 AM`, so the right-side timestamp column stays visually stable.
- Update feed timestamp, feed row, and actionable row tests to lock the aligned format.

## Verification
- `cd hushh-webapp && npm test -- --run __tests__/lib/feed/feed-timestamp.test.ts __tests__/components/feed-row.test.tsx __tests__/components/feed-actionable-row.test.tsx`
- `cd hushh-webapp && npm run typecheck`