### PR TITLE
fix(ria): seed edit-profile draft when opened via Advisor Agent

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -2871,9 +2871,7 @@ class OneLocationCircleService:
                 send_circle_member_invite_accepted_push(
                     inviter_user_id=str(invite_row.get("inviter_user_id") or ""),
                     invitee_user_id=user_id,
-                    invitee_display_name=str(
-                        invite_row.get("invitee_display_name") or ""
-                    ),
+                    invitee_display_name=str(invite_row.get("invitee_display_name") or ""),
                     circle_id=circle_id,
                     circle_name=str(invite_row.get("circle_name") or ""),
                     invite_id=cleaned_invite_id,

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -848,12 +848,12 @@ export function RiaProfileSection({
           "The RIA profile is busy. Try again when the current update finishes.",
       };
     }
-    setEditOpen(true);
+    openServicesEdit();
     return {
       status: "succeeded" as const,
       summary: "The RIA profile editor is open.",
     };
-  }, [deleting, saving]);
+  }, [deleting, openServicesEdit, saving]);
 
   useLocalOnboardingActionHandler(
     "ria.profile.edit_services",


### PR DESCRIPTION
## Summary
- The Advisor Agent's "Edit RIA services and fees" authorized action opens the Edit profile modal via the `ria.profile.edit_services` local action handler, which only called `setEditOpen(true)` and never seeded the `draft` state. Since the modal body renders `{draft ? (...) : null}`, the header/description showed but the body stayed empty.
- The manual "Edit services" button already seeds `draft` correctly via `openServicesEdit()`. The agent handler now reuses that same function instead of duplicating (and missing) the seeding logic.
- Also includes an incidental, unrelated mechanical `ruff format` fix for `consent-protocol/hushh_mcp/services/one_location_circle_service.py` — pre-existing formatting drift on `main` that the push hook's format-check gate blocks on.

Fixes #5724

## Test plan
- [x] `npx tsc --noEmit` on the changed file — no errors
- [x] Reproduced the exact repro steps locally: opened `/ria/profile`, used the Advisor Agent's "Edit RIA services and fees" action (via the Kai command bar, which drives the same `ria.profile.edit_services` local handler used by the authorized-action flow), and confirmed the Edit profile modal now renders its full body (services, fee structure, bio, location fields, Save button) instead of a blank area.