### PR TITLE
fix(ria): add Complete verification CTA to clients lock screen

### DIFF
--- a/hushh-webapp/__tests__/components/ria/ria-verification-gate.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-verification-gate.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  usePersonaState: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+
+import { RiaVerificationGate } from "@/components/ria/ria-page-shell";
+import { ROUTES } from "@/lib/navigation/routes";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
+
+describe("RiaVerificationGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the lock copy plus a CTA that routes to onboarding when unverified", () => {
+    mocks.usePersonaState.mockReturnValue({
+      loading: false,
+      riaOnboardingStatus: { advisory_status: "draft", verification_status: "draft" },
+    });
+
+    render(
+      <RiaVerificationGate>
+        <div data-testid="gated-content" />
+      </RiaVerificationGate>,
+    );
+
+    expect(screen.getByText(RIA_COPY.clients.verifyGate.title)).toBeTruthy();
+    expect(screen.queryByTestId("gated-content")).toBeNull();
+
+    const cta = screen.getByTestId("ria-clients-verify-gate-cta");
+    expect(cta.textContent).toContain(RIA_COPY.clients.verifyGate.cta);
+
+    fireEvent.click(cta);
+    expect(mocks.routerPush).toHaveBeenCalledWith(ROUTES.RIA_ONBOARDING);
+  });
+
+  it("renders children without the lock when verified", () => {
+    mocks.usePersonaState.mockReturnValue({
+      loading: false,
+      riaOnboardingStatus: { advisory_status: "active", verification_status: "active" },
+    });
+
+    render(
+      <RiaVerificationGate>
+        <div data-testid="gated-content" />
+      </RiaVerificationGate>,
+    );
+
+    expect(screen.getByTestId("gated-content")).toBeTruthy();
+    expect(screen.queryByTestId("ria-clients-verify-gate-cta")).toBeNull();
+  });
+});

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -3,9 +3,12 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { BriefcaseBusiness, ShieldAlert, ShieldCheck, TriangleAlert } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { ROUTES } from "@/lib/navigation/routes";
 import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
+import { Button } from "@/lib/morphy-ux/button";
 
 import {
   AppPageContentRegion,
@@ -262,6 +265,7 @@ export function isRiaVerified(status?: string | null): boolean {
 }
 
 export function RiaVerificationGate({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const { riaOnboardingStatus, loading } = usePersonaState();
   const status = riaOnboardingStatus?.advisory_status || riaOnboardingStatus?.verification_status;
 
@@ -280,6 +284,13 @@ export function RiaVerificationGate({ children }: { children: ReactNode }) {
           <p className="text-sm leading-6 text-muted-foreground">
             {RIA_COPY.clients.verifyGate.body}
           </p>
+          <Button
+            className="mt-4"
+            onClick={() => router.push(ROUTES.RIA_ONBOARDING)}
+            data-testid="ria-clients-verify-gate-cta"
+          >
+            {RIA_COPY.clients.verifyGate.cta}
+          </Button>
         </RiaSurface>
       </section>
     );

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -89,6 +89,7 @@ export const RIA_COPY = {
       title: "Verify your advisor account first",
       description: "Finish verification in onboarding to access investors.",
       body: "Locked until verification is complete.",
+      cta: "Complete verification",
     },
   },
 


### PR DESCRIPTION
## Summary
- `/ria/clients` locks unverified advisors out with "Verify your advisor account first" copy but gave no way to act on it.
- `RiaVerificationGate` now renders a "Complete verification" button that routes to `/ria/onboarding`.

## Test plan
- [x] `npx vitest run __tests__/components/ria/ria-verification-gate.test.tsx` — renders the CTA when unverified, clicking it calls `router.push(ROUTES.RIA_ONBOARDING)`; renders gated children (no CTA) when verified.
- [ ] Manual click-through on a real unverified advisor account (local backend/auth not available in this environment — see issue for repro steps).

Fixes https://github.com/hushh-labs/hushh-research/issues/5748