### PR TITLE
feat(voice): add walk-through mode, a live step timeline for multi-action requests

### DIFF
--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -69,8 +69,25 @@ describe("VoicePreferencesPanel", () => {
     expect(readVoicePreferences(userId).voiceEnabled).toBe(false);
     expect(screen.getByRole("switch", { name: "Location" })).toBeDisabled();
     expect(
-      screen.getByRole("switch", { name: "Require a tap to confirm risky actions" }),
+      screen.getByRole("switch", { name: "Require a tap to confirm" }),
     ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", { name: "Walk-through mode" }),
+    ).toBeDisabled();
+  });
+
+  it("walk-through mode defaults off and persists when turned on", () => {
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Walk-through mode" });
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+
+    expect(readVoicePreferences(userId).walkthroughMode).toBe(true);
+    expect(toggle).toBeChecked();
   });
 
   it("changelog shows a preview and \"See all updates\" opens the dedicated changelog page", () => {

--- a/hushh-webapp/__tests__/components/voice-walkthrough-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-walkthrough-panel.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  currentTaskSteps,
+  VoiceWalkthroughPanel,
+} from "@/components/agent/voice-walkthrough-panel";
+import {
+  appInteractionCoordinator,
+  type ActionRun,
+} from "@/lib/interaction/interaction-intent-coordinator";
+
+function run(overrides: Partial<ActionRun> & { id: string }): ActionRun {
+  return {
+    id: overrides.id,
+    actionId: overrides.actionId ?? "location.pause_updates",
+    label: overrides.label ?? "Pause updates",
+    source: overrides.source ?? "voice",
+    directiveId: overrides.directiveId ?? null,
+    goalId: overrides.goalId ?? null,
+    phase: overrides.phase ?? "executing",
+    message: overrides.message ?? "Working",
+    createdAtMs: overrides.createdAtMs ?? 0,
+    updatedAtMs: overrides.updatedAtMs ?? overrides.createdAtMs ?? 0,
+    completedAtMs: overrides.completedAtMs ?? null,
+  };
+}
+
+describe("currentTaskSteps", () => {
+  it("returns nothing for an empty history", () => {
+    expect(currentTaskSteps([])).toEqual([]);
+  });
+
+  it("groups steps sharing a goalId regardless of the time between them", () => {
+    const runs = [
+      run({ id: "a", goalId: "goal.x", createdAtMs: 0, updatedAtMs: 0 }),
+      run({ id: "b", goalId: "goal.x", createdAtMs: 60_000, updatedAtMs: 60_000 }),
+    ];
+    expect(currentTaskSteps(runs).map((step) => step.id)).toEqual(["a", "b"]);
+  });
+
+  it("groups goalId-less steps that arrive within the gap window", () => {
+    const runs = [
+      run({ id: "a", createdAtMs: 0, updatedAtMs: 1_000 }),
+      run({ id: "b", createdAtMs: 5_000, updatedAtMs: 5_000 }),
+    ];
+    expect(currentTaskSteps(runs).map((step) => step.id)).toEqual(["a", "b"]);
+  });
+
+  it("stops at a step that shares no goalId and arrived after the gap window", () => {
+    const runs = [
+      run({ id: "old", createdAtMs: 0, updatedAtMs: 0 }),
+      run({ id: "new", createdAtMs: 20_000, updatedAtMs: 20_000 }),
+    ];
+    expect(currentTaskSteps(runs).map((step) => step.id)).toEqual(["new"]);
+  });
+
+  it("walks past an unrelated older run once it reaches a run outside the gap", () => {
+    const runs = [
+      run({ id: "unrelated", createdAtMs: 0, updatedAtMs: 0 }),
+      run({ id: "b", goalId: "goal.x", createdAtMs: 30_000, updatedAtMs: 30_000 }),
+      run({ id: "c", goalId: "goal.x", createdAtMs: 30_500, updatedAtMs: 30_500 }),
+    ];
+    expect(currentTaskSteps(runs).map((step) => step.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("VoiceWalkthroughPanel", () => {
+  beforeEach(() => {
+    appInteractionCoordinator.resetActionRunsForTests();
+  });
+
+  it("renders nothing when walk-through mode is off, even with a running multi-step task", () => {
+    const first = appInteractionCoordinator.startActionRun({
+      actionId: "location.open_now",
+      label: "Open Location",
+      source: "voice",
+      goalId: "goal.share",
+    });
+    appInteractionCoordinator.startActionRun({
+      actionId: "location.select_share_recipient",
+      label: "Pick recipient",
+      source: "voice",
+      directiveId: first.directiveId ?? "d2",
+      goalId: "goal.share",
+    });
+
+    render(<VoiceWalkthroughPanel enabled={false} />);
+
+    expect(screen.queryByTestId("voice-walkthrough-panel")).toBeNull();
+  });
+
+  it("stays hidden for a single-step task, since the bar already shows its status", () => {
+    appInteractionCoordinator.startActionRun({
+      actionId: "location.pause_updates",
+      label: "Pause updates",
+      source: "voice",
+    });
+
+    render(<VoiceWalkthroughPanel enabled />);
+
+    expect(screen.queryByTestId("voice-walkthrough-panel")).toBeNull();
+  });
+
+  it("shows a live step list for a multi-step task when enabled", () => {
+    appInteractionCoordinator.startActionRun({
+      actionId: "location.open_now",
+      label: "Open Location",
+      source: "voice",
+      directiveId: "d1",
+      goalId: "goal.share",
+    });
+    appInteractionCoordinator.startActionRun({
+      actionId: "location.select_share_recipient",
+      label: "Pick recipient",
+      source: "voice",
+      directiveId: "d2",
+      goalId: "goal.share",
+    });
+
+    render(<VoiceWalkthroughPanel enabled />);
+
+    expect(screen.getByTestId("voice-walkthrough-panel")).toBeInTheDocument();
+    expect(screen.getByText("Open Location")).toBeInTheDocument();
+    expect(screen.getByText("Pick recipient")).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/lib/interaction-intent-coordinator.test.ts
+++ b/hushh-webapp/__tests__/lib/interaction-intent-coordinator.test.ts
@@ -157,6 +157,26 @@ describe("InteractionIntentCoordinator", () => {
     });
   });
 
+  it("carries an optional goalId through a run so related steps can be grouped later", () => {
+    const coordinator = new InteractionIntentCoordinator();
+    const withGoal = coordinator.startActionRun({
+      actionId: "location.pause_updates",
+      label: "Pause updates",
+      source: "voice",
+      directiveId: "directive_1",
+      goalId: "goal.location.pause_updates",
+    });
+    const withoutGoal = coordinator.startActionRun({
+      actionId: "connect.open_people",
+      label: "Open Connect people",
+      source: "voice",
+      directiveId: "directive_2",
+    });
+
+    expect(withGoal.goalId).toBe("goal.location.pause_updates");
+    expect(withoutGoal.goalId).toBeNull();
+  });
+
   it("cancels non-terminal interaction work on background without owning vault state", () => {
     const coordinator = new InteractionIntentCoordinator();
     const cancelNavigation = vi.fn();

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -25,6 +25,7 @@ import { useTheme } from "next-themes";
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { AgentVoiceWaveform } from "@/components/agent/agent-voice-waveform";
 import { VoiceActionCard } from "@/components/agent/voice-action-card";
+import { VoiceWalkthroughPanel } from "@/components/agent/voice-walkthrough-panel";
 import { useAuth } from "@/hooks/use-auth";
 import {
   executeAgentGatewayAction,
@@ -34,6 +35,10 @@ import {
 import { settleAgentGatewayAction } from "@/lib/agent/agent-gateway-action-settlement";
 import { useAgentRuntimeStateOptional } from "@/lib/agent/agent-runtime-context";
 import { requiresHardTapConfirmation } from "@/lib/agent/confirmation-tap-policy";
+import {
+  readVoicePreferences,
+  subscribeVoicePreferences,
+} from "@/lib/agent/voice-preferences";
 import { useOneConversationSession } from "@/lib/agent/one-conversation-session";
 import { ApiService } from "@/lib/services/api-service";
 import {
@@ -292,6 +297,20 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     clearJourneyApproval(reason);
   }, []);
   const activeActionRun = useActiveActionRun();
+  // Read directly rather than through AgentRuntimeState's snapshot: that
+  // snapshot is deliberately the subset of preferences the backend relay
+  // needs to see, and walk-through mode is a purely client-side rendering
+  // choice with nothing for the relay to act on.
+  const [walkthroughModeEnabled, setWalkthroughModeEnabled] = useState(
+    () => readVoicePreferences(user?.uid).walkthroughMode,
+  );
+  useEffect(() => {
+    setWalkthroughModeEnabled(readVoicePreferences(user?.uid).walkthroughMode);
+    if (!user?.uid) return;
+    return subscribeVoicePreferences(user.uid, (next) =>
+      setWalkthroughModeEnabled(next.walkthroughMode),
+    );
+  }, [user?.uid]);
   const pendingConfirmationRef = useRef<PendingVoiceConfirmation | null>(null);
   const voiceStatus = useAgentVoiceState((s) => s.status);
   const voiceMessage = useAgentVoiceState((s) => s.message);
@@ -767,6 +786,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
               label: action.label,
               source: "voice",
               directiveId,
+              goalId,
               message: `Preparing ${action.label}`,
             });
             actionRunId = actionRun.id;
@@ -1966,6 +1986,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           raised when an action could not run at all, so there is nothing
           pending to confirm at the same moment. */}
       <VoiceActionCard />
+      <VoiceWalkthroughPanel enabled={walkthroughModeEnabled} />
       {pendingConfirmation ? (
         <div
           role="dialog"

--- a/hushh-webapp/components/agent/voice-walkthrough-panel.tsx
+++ b/hushh-webapp/components/agent/voice-walkthrough-panel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { CheckCircle2, CircleDashed, Loader2, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import {
+  isTerminalActionRunPhase,
+  useActionRuns,
+  type ActionRun,
+} from "@/lib/interaction/interaction-intent-coordinator";
+
+/**
+ * Steps arriving within this long of the previous step's last update are
+ * shown as one task even without a shared `goalId` -- an authored journey
+ * aside, most multi-action requests are just One calling one action after
+ * another in quick succession, and there is no other signal that ties them
+ * together.
+ */
+const WALKTHROUGH_GROUP_GAP_MS = 8_000;
+/**
+ * How long a finished group stays on screen before it clears, so a task that
+ * just settled still gets a visible "done" beat instead of vanishing the
+ * instant its last step does.
+ */
+const WALKTHROUGH_LINGER_MS = 4_000;
+
+/**
+ * Walk backward from the newest run, gathering every run that either shares
+ * its `goalId` with the run ahead of it or arrived within the group gap --
+ * the current task, in order. Stops at the first run that matches neither,
+ * since that run belongs to whatever came before this task started.
+ */
+export function currentTaskSteps(runs: readonly ActionRun[]): ActionRun[] {
+  const last = runs[runs.length - 1];
+  if (!last) return [];
+  const group: ActionRun[] = [last];
+  for (let index = runs.length - 2; index >= 0; index -= 1) {
+    const run = runs[index];
+    const next = group[0];
+    if (!run || !next) break;
+    const sameGoal = Boolean(run.goalId) && run.goalId === next.goalId;
+    const withinGap = next.createdAtMs - run.updatedAtMs <= WALKTHROUGH_GROUP_GAP_MS;
+    if (!sameGoal && !withinGap) break;
+    group.unshift(run);
+  }
+  return group;
+}
+
+function StepIcon({ phase }: { phase: ActionRun["phase"] }) {
+  if (phase === "completed") {
+    return <CheckCircle2 className="size-4 shrink-0 text-emerald-500" aria-hidden="true" />;
+  }
+  if (phase === "failed" || phase === "blocked") {
+    return <XCircle className="size-4 shrink-0 text-destructive" aria-hidden="true" />;
+  }
+  if (phase === "cancelled") {
+    return <CircleDashed className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />;
+  }
+  return <Loader2 className="size-4 shrink-0 animate-spin text-primary" aria-hidden="true" />;
+}
+
+function stepTextClass(phase: ActionRun["phase"]): string {
+  if (phase === "failed" || phase === "blocked") return "truncate text-[13px] text-destructive";
+  if (phase === "cancelled") return "truncate text-[13px] text-muted-foreground";
+  if (phase === "completed") return "truncate text-[13px] text-muted-foreground";
+  return "truncate text-[13px] font-medium text-foreground";
+}
+
+/**
+ * A live list of the steps One is working through, shown alongside the
+ * spoken narration when the person has turned on walk-through mode (Voice
+ * Settings). Reuses the action-run events that already fire for every
+ * action -- solo or part of an authored journey -- rather than requiring a
+ * pre-declared multi-step plan: each new call simply appends to, or starts,
+ * the visible list.
+ *
+ * Deliberately hidden for a single-step task: a one-off action already has
+ * its own status text in the bar, and this panel earns its place once there
+ * is an actual sequence to follow.
+ */
+export function VoiceWalkthroughPanel({ enabled }: { enabled: boolean }) {
+  const runs = useActionRuns();
+  const group = enabled ? currentTaskSteps(runs) : [];
+  const last = group[group.length - 1] ?? null;
+  const active = last ? !isTerminalActionRunPhase(last.phase) : false;
+
+  const [linger, setLinger] = useState(false);
+  useEffect(() => {
+    if (!enabled || !last) {
+      setLinger(false);
+      return;
+    }
+    if (active) {
+      setLinger(true);
+      return;
+    }
+    setLinger(true);
+    const timer = setTimeout(() => setLinger(false), WALKTHROUGH_LINGER_MS);
+    return () => clearTimeout(timer);
+    // Only the settled run's identity and phase should re-arm the timer --
+    // re-running it on every unrelated snapshot would restart the clock on
+    // every step of a task still in progress.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, last?.id, last?.phase]);
+
+  if (!enabled || !linger || group.length < 2) return null;
+
+  return (
+    <div
+      className="agent-approval-glass pointer-events-none w-full max-w-[min(calc(100vw-3rem),392px)] rounded-3xl p-4 text-[#1d1d1f] dark:text-[#f5f5f7]"
+      data-testid="voice-walkthrough-panel"
+      role="status"
+      aria-live="polite"
+    >
+      <p className="pb-2 text-[13px] font-medium text-muted-foreground">
+        Working through this
+      </p>
+      <ul className="flex flex-col gap-2">
+        {group.map((step) => (
+          <li key={step.id} className="flex items-center gap-2.5">
+            <StepIcon phase={step.phase} />
+            <span className={stepTextClass(step.phase)}>{step.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -95,7 +95,7 @@ export function VoicePreferencesPanel({
       <SettingsGroup>
         <SettingsRow
           title="Voice control"
-          description="Let One act on what you say, everywhere in the app."
+          description="Let One act on what you say."
           trailing={
             <Switch
               checked={state.voiceEnabled}
@@ -107,13 +107,10 @@ export function VoicePreferencesPanel({
           }
         />
       </SettingsGroup>
-      <SettingsGroup
-        title="Safety"
-        description="Applies to actions that already ask for confirmation, like sharing your location or sending an SOS."
-      >
+      <SettingsGroup title="Safety" description="For actions that already ask to confirm.">
         <SettingsRow
-          title="Require a tap to confirm risky actions"
-          description="Turn this on to stop a spoken yes or no from confirming them."
+          title="Require a tap to confirm"
+          description="Stops a spoken yes or no from confirming."
           disabled={!state.voiceEnabled}
           trailing={
             <Switch
@@ -122,14 +119,31 @@ export function VoicePreferencesPanel({
               onCheckedChange={(checked) =>
                 set((current) => ({ ...current, requireTapConfirmation: checked }))
               }
-              aria-label="Require a tap to confirm risky actions"
+              aria-label="Require a tap to confirm"
+            />
+          }
+        />
+      </SettingsGroup>
+      <SettingsGroup title="Guidance" description="See each step as One works.">
+        <SettingsRow
+          title="Walk-through mode"
+          description="Follow along step by step."
+          disabled={!state.voiceEnabled}
+          trailing={
+            <Switch
+              checked={state.walkthroughMode}
+              disabled={!state.voiceEnabled}
+              onCheckedChange={(checked) =>
+                set((current) => ({ ...current, walkthroughMode: checked }))
+              }
+              aria-label="Walk-through mode"
             />
           }
         />
       </SettingsGroup>
       <SettingsGroup
         title="What voice can control"
-        description="Turn a domain off to stop voice from acting there. You can still use it by tap."
+        description="Turn a domain off to block voice there; tap still works."
       >
         {VOICE_ENGINE_DOMAINS.map((domain) => {
           const allowed = !state.disabledDomains.includes(domain.key);

--- a/hushh-webapp/lib/agent/__tests__/voice-preferences.test.ts
+++ b/hushh-webapp/lib/agent/__tests__/voice-preferences.test.ts
@@ -18,6 +18,7 @@ describe("One voice preferences", () => {
     expect(readVoicePreferences(userId)).toEqual({
       voiceEnabled: true,
       requireTapConfirmation: false,
+      walkthroughMode: false,
       disabledDomains: [],
     });
   });
@@ -26,11 +27,13 @@ describe("One voice preferences", () => {
     expect(readVoicePreferences(null)).toEqual({
       voiceEnabled: true,
       requireTapConfirmation: false,
+      walkthroughMode: false,
       disabledDomains: [],
     });
     expect(readVoicePreferences(undefined)).toEqual({
       voiceEnabled: true,
       requireTapConfirmation: false,
+      walkthroughMode: false,
       disabledDomains: [],
     });
   });
@@ -40,12 +43,14 @@ describe("One voice preferences", () => {
       ...current,
       voiceEnabled: false,
       requireTapConfirmation: true,
+      walkthroughMode: true,
       disabledDomains: ["location"],
     }));
 
     expect(readVoicePreferences(userId)).toEqual({
       voiceEnabled: false,
       requireTapConfirmation: true,
+      walkthroughMode: true,
       disabledDomains: ["location"],
     });
   });
@@ -59,6 +64,7 @@ describe("One voice preferences", () => {
     expect(readVoicePreferences(userId)).toEqual({
       voiceEnabled: true,
       requireTapConfirmation: false,
+      walkthroughMode: false,
       disabledDomains: [],
     });
   });
@@ -77,6 +83,15 @@ describe("One voice preferences", () => {
       "location",
       "email",
     ]);
+  });
+
+  it("reads walkthroughMode as off unless it is exactly true", () => {
+    window.localStorage.setItem(
+      `one_voice_preferences_v1:${userId}`,
+      JSON.stringify({ voiceEnabled: true, walkthroughMode: "yes" }),
+    );
+
+    expect(readVoicePreferences(userId).walkthroughMode).toBe(false);
   });
 
   it("notifies subscribers on update, and stops after unsubscribing", () => {
@@ -112,6 +127,7 @@ describe("One voice preferences", () => {
     expect(readVoicePreferences(userId)).toEqual({
       voiceEnabled: true,
       requireTapConfirmation: false,
+      walkthroughMode: false,
       disabledDomains: [],
     });
     expect(

--- a/hushh-webapp/lib/agent/voice-engine-changelog.ts
+++ b/hushh-webapp/lib/agent/voice-engine-changelog.ts
@@ -18,6 +18,34 @@ export type VoiceEngineChangelogEntry = {
 export const VOICE_ENGINE_CHANGELOG: readonly VoiceEngineChangelogEntry[] = [
   {
     version: "1.0",
+    date: "2026-08-22",
+    title: "Walk-through mode",
+    description:
+      "Turn on Walk-through mode in Voice Settings to see a live list of steps as One works through a request with more than one part, alongside what it says.",
+  },
+  {
+    version: "1.0",
+    date: "2026-08-22",
+    title: "Fixed: sending a connection request by voice required typing",
+    description:
+      "Connect could stop at a search box after hearing a name instead of sending the request itself. It now resolves the name and sends hands-free, the same way it always could.",
+  },
+  {
+    version: "1.0",
+    date: "2026-08-22",
+    title: "Location voice commands pick the right one more often",
+    description:
+      "A few Location commands sounded alike -- \"stop sharing\" versus \"stop sharing my location\", or the SOS screen versus a real alert -- and could be picked wrong. One now tells them apart correctly.",
+  },
+  {
+    version: "1.0",
+    date: "2026-08-22",
+    title: "Ambiguous names show a list to pick from",
+    description:
+      "When a spoken name matched more than one person in Location or Circles, One used to just say so and ask again. It now shows the matches so you can tap the right one.",
+  },
+  {
+    version: "1.0",
     date: "2026-08-16",
     title: "Voice settings",
     description:

--- a/hushh-webapp/lib/agent/voice-preferences.ts
+++ b/hushh-webapp/lib/agent/voice-preferences.ts
@@ -15,6 +15,11 @@ export type OneVoicePreferencesState = {
   voiceEnabled: boolean;
   /** When true, confirm_required voice actions must be tapped, not spoken. */
   requireTapConfirmation: boolean;
+  /**
+   * When true, show a live step-by-step panel narrating each action as One
+   * works through a multi-action request, alongside the spoken narration.
+   */
+  walkthroughMode: boolean;
   /** Domain keys (see voice-engine-domains.ts) the user has turned voice OFF for. */
   disabledDomains: string[];
 };
@@ -24,6 +29,7 @@ const PREFERENCES_KEY_PREFIX = "one_voice_preferences_v1:";
 const DEFAULT_STATE: OneVoicePreferencesState = {
   voiceEnabled: true,
   requireTapConfirmation: false,
+  walkthroughMode: false,
   disabledDomains: [],
 };
 
@@ -52,6 +58,7 @@ function sanitizeState(value: unknown): OneVoicePreferencesState {
   return {
     voiceEnabled: raw.voiceEnabled !== false,
     requireTapConfirmation: raw.requireTapConfirmation === true,
+    walkthroughMode: raw.walkthroughMode === true,
     disabledDomains,
   };
 }

--- a/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
+++ b/hushh-webapp/lib/interaction/interaction-intent-coordinator.ts
@@ -86,6 +86,14 @@ export type ActionRun = {
   label: string;
   source: InteractionIntentSource;
   directiveId: string | null;
+  /**
+   * The authored journey/goal this run belongs to, when the directive that
+   * started it named one. Two runs sharing a `goalId` are steps of the same
+   * multi-action task (e.g. a navigate step and the local-handler step it
+   * escorts) -- this is the only thing that ties them together, since each
+   * step still arrives as its own directive and its own run.
+   */
+  goalId: string | null;
   phase: ActionRunPhase;
   message: string;
   createdAtMs: number;
@@ -203,6 +211,7 @@ export class InteractionIntentCoordinator {
     label: string;
     source: InteractionIntentSource;
     directiveId?: string | null;
+    goalId?: string | null;
     phase?: Extract<ActionRunPhase, "acknowledged" | "preparing">;
     message?: string;
   }): ActionRun {
@@ -222,6 +231,7 @@ export class InteractionIntentCoordinator {
       label: input.label,
       source: input.source,
       directiveId: input.directiveId ?? null,
+      goalId: input.goalId ?? null,
       phase,
       message: input.message ?? actionRunMessage(phase, input.label),
       createdAtMs: now,
@@ -271,6 +281,18 @@ export class InteractionIntentCoordinator {
       phase,
       message: settlement.summary,
     });
+  }
+
+  /**
+   * Test-only. `cancelActiveActionRuns` marks runs terminal but keeps them in
+   * the rolling history for grouping (e.g. `VoiceWalkthroughPanel`), so a
+   * suite that starts real runs against the shared singleton needs a genuine
+   * wipe between tests -- otherwise a later test's runs land inside the
+   * still-recent grouping window of an earlier test's.
+   */
+  resetActionRunsForTests(): void {
+    this.actionRuns = [];
+    this.publish();
   }
 
   cancelActiveActionRuns(message = "Action cancelled"): void {
@@ -546,7 +568,7 @@ export function useActiveActionRun(): ActionRun | null {
   return null;
 }
 
-function isTerminalActionRunPhase(phase: ActionRunPhase): boolean {
+export function isTerminalActionRunPhase(phase: ActionRunPhase): boolean {
   return (
     phase === "completed" ||
     phase === "blocked" ||


### PR DESCRIPTION
## Summary
New Voice Settings toggle (default off, "Walk-through mode") that shows a live panel narrating each step as One works through a multi-action request, alongside the spoken narration.

- Reuses the action-run lifecycle every action already fires through (`appInteractionCoordinator.startActionRun`/`updateActionRun`) rather than requiring a pre-declared multi-step plan -- each new call simply appends to, or starts, the visible timeline.
- `ActionRun` gains an optional `goalId`, threaded from the directive's own goal id when one exists (an authored 2-step journey). Steps are grouped by matching `goalId`, or by arriving within an 8s gap of the previous step when there is no shared goal -- covering both an authored journey and a looser sequence of calls in the same task.
- Hidden for a single-step task, since the bar's own status text already covers that case; also hidden entirely unless the preference is on.
- `interaction-intent-coordinator.ts` gains a test-only `resetActionRunsForTests()` -- needed because the rolling action-run history is a shared singleton and real runs stamp real timestamps, so tests need a genuine wipe rather than relying on `cancelActiveActionRuns` (which marks terminal but keeps history).

Also, per user request: shortened the Voice Settings copy throughout (row titles/descriptions), and caught up the in-app "What's new" changelog with entries for this session's disambiguation-card (#5783) and hands-free-routing (#5786, #5787) work, none of which had one yet.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] `vitest run` -- 301 tests passed across the touched suites, including new coverage for the grouping logic (`currentTaskSteps`), the coordinator's `goalId` threading, the panel's render-gating (off / single-step / multi-step), and the new preference's persistence/fail-open/sanitize behavior
- [x] Full governed-artifact regeneration + `--check` sequence -- all current (this change touches no action contracts)
- [x] Confirmed 5 pre-existing, unrelated `.contract.test.ts` failures (source-text-matching tests already broken on `main` before this branch) are unaffected by this diff, verified via `git stash` against the clean base

Addresses #5677