### PR TITLE
fix(one-voice): pin an explicit prebuilt voice for the live model

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -74,6 +74,7 @@ from api.routes.one.relay_auth import (
 from hushh_mcp.one_adk.action_tools import _slot_fingerprint
 from hushh_mcp.one_adk.agent_tree import (
     ONE_APP_NAME,
+    ONE_LIVE_VOICE_NAME,
     STATE_CONSENT_TOKEN,
     STATE_PENDING_DIRECTIVE,
     STATE_SCREEN,
@@ -502,6 +503,16 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
     run_config = RunConfig(
         streaming_mode=StreamingMode.BIDI,
         response_modalities=[genai_types.Modality.AUDIO],
+        # Pinned explicitly: unset, each live model plays its own default
+        # voice, and the two models this relay supports sound audibly
+        # different from each other with nothing set here.
+        speech_config=genai_types.SpeechConfig(
+            voice_config=genai_types.VoiceConfig(
+                prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(
+                    voice_name=ONE_LIVE_VOICE_NAME
+                )
+            )
+        ),
         input_audio_transcription=genai_types.AudioTranscriptionConfig(),
         output_audio_transcription=genai_types.AudioTranscriptionConfig(),
         # No explicit trigger/target tokens: leaving both unset uses the

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -158,6 +158,15 @@ _ONE_MODEL = (
     or "gemini-3.1-flash-live-preview"
 ).strip()
 _ONE_LIVE_LOCATION = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").strip()
+# Neither live model pins a voice by default, so each one's own default voice
+# plays -- and the two differ audibly. Native audio models (both the 3.1
+# preview and the 2.5 GA model above) accept any Gemini TTS prebuilt voice
+# name via speech_config; "Kore" is Google's own flagship example voice
+# across the Live API docs. Public (no underscore prefix, unlike the other
+# constants here) because the relay builds RunConfig's speech_config from
+# this directly. Override per-environment with AGENT_ONE_ADK_VOICE_NAME if a
+# different one is wanted.
+ONE_LIVE_VOICE_NAME = (os.getenv("AGENT_ONE_ADK_VOICE_NAME") or "Kore").strip()
 # The Developer API Live contract is intentionally separate from the Vertex
 # contract above. It is disabled by default until an ADK integration rehearsal
 # has verified the selected model's BIDI audio, tool calls and mid-session


### PR DESCRIPTION
## Summary
Reported live: the voice changed character (perceived as switching from a warmer/feminine-sounding voice to a male-sounding one) with no relevant code change on our side. Root cause traced to `a7f9a2569` (2026-08-21) migrating the canonical live model from `gemini-live-2.5-flash-native-audio` to `gemini-3.1-flash-live-preview` -- neither model has ever had a `voice_name` pinned anywhere, so each one's own provider default plays, and the two differ audibly.

Both are native-audio models and accept any Gemini TTS prebuilt voice name via `RunConfig.speech_config` (confirmed against the installed `google-genai` SDK's `SpeechConfig`/`VoiceConfig`/`PrebuiltVoiceConfig` field names before wiring this up, and against current Gemini Live API docs). Pins `"Kore"` -- Google's own flagship example voice across the Live API docs -- as the default, overridable per-environment via `AGENT_ONE_ADK_VOICE_NAME`, matching the existing `AGENT_ONE_ADK_MODEL`/`AGENT_ONE_ADK_LOCATION` override pattern already established for this same live-model config.

Not necessarily the *exact* voice this app used before the 3.1 migration -- nothing recorded which one that was, since nothing pinned it before. This is a deliberate starting choice; the env var makes swapping it a one-line change, no redeploy of code needed.

## Test plan
- [x] Verified `SpeechConfig`/`VoiceConfig`/`PrebuiltVoiceConfig` field names directly against the installed `google-genai` package before use
- [x] `ruff check` and `ruff format --check` clean on both touched files
- [x] `pytest tests/test_one_adk_agent_tree.py tests/test_one_adk_live_protocol.py` -- 146 passed
- [x] Verified locally: backend restarts cleanly with the pinned voice, `/health` healthy

Addresses #5677