### PR TITLE
fix(one-voice): give connect.send_request an explicit journey instruction

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -432,6 +432,26 @@ ONE_IDENTITY_INSTRUCTION: str = (
     "join only if they accept. Say what the settlement says -- 'Invited Sarah "
     "to Family' -- and never say a person was added, is in the circle, or can "
     "see the location until a settlement says so.\n\n"
+    # Connect. Same shape as sharing a location, and told the same way for
+    # the same reason -- this surface had no worked example at all before,
+    # only the generic "call run_app_action, it will redirect you if
+    # needed" fallback, and a live session showed that redirect was not
+    # reliably being followed when the request started off the Connect
+    # screen: One asked for confirmation, heard yes, and nothing happened.
+    "Connecting with someone the person NAMES ('connect with Ankit', 'send "
+    "a connection request to Ankit and Kushal') is ALSO an authored "
+    "journey: call start_app_goal with action id 'connect.send_request' "
+    "and slots {'person': <the name exactly as you heard it>}, never "
+    "run_app_action for it directly -- start_app_goal opens Connect for "
+    "you when the person is elsewhere, which is most of the time this is "
+    "asked. More than one name in the same request means more than one "
+    "call, one person at a time: ask which to do first if it is not "
+    "obvious, then call start_app_goal for just that one name. Confirm and "
+    "wait for its settlement -- the same 'ASK FOR IT OUT LOUD... then STOP "
+    "and wait' rule below, and the same 'at most ONE action-producing tool "
+    "per turn' rule above -- before calling start_app_goal again for the "
+    "next name. Never call it for a second name while the first is still "
+    "pending, confirming, or settling.\n\n"
     "When an action needs confirmation, ASK FOR IT OUT LOUD as one short "
     "yes-or-no question naming what will happen and whatever makes it "
     "specific -- who, how long, how much: 'Share your location with Sarah for "


### PR DESCRIPTION
## Summary
Reported live: "send a connection request to Ankit and Kushal" asked which to do first, asked to confirm Ankit, heard yes -- then nothing happened, still on the One home screen.

The backend's off-screen redirect mechanism (`run_app_action` -> `use_start_app_goal` -> `start_app_goal`, proven by 146 passing tests including one named `test_sending_a_connection_request_is_reachable_from_every_screen`) is structurally sound -- verified by direct code reading and the existing test suite, not assumed.

But `connect.send_request` had **zero explicit instruction coverage** in the model's system instructions, unlike `location.select_share_recipient`, which has a detailed worked example explicitly telling the model to use `start_app_goal`, never `run_app_action`, because it's an authored journey. Connect's only guidance was the generic "`run_app_action` will redirect you if needed" fallback -- and the live session shows that redirect is not being reliably followed when the person is named off-screen.

This adds the same explicit pattern already proven for Location sharing: call `start_app_goal` directly for `connect.send_request`, one person at a time for a multi-name request, waiting for each to settle before the next.

**This is a best-effort mitigation for a live model-reliability issue, not a structural code fix** -- the underlying mechanics were already correct and tested. Flagging honestly: I could not reproduce the exact live failure locally, so this is targeted at the most likely cause (the model choosing the generic path instead of the journey-aware one) rather than a confirmed root cause.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/test_one_adk_agent_tree.py tests/test_one_adk_live_protocol.py` -- 146 passed
- [x] `bandit` clean (no new findings)
- [x] Verified locally: backend restarts cleanly with the updated instructions, `/health` healthy

Addresses #5677