### PR TITLE
fix(one-voice): give location.select_ask_recipient an explicit journey instruction

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -414,6 +414,28 @@ ONE_IDENTITY_INSTRUCTION: str = (
     # someone edits it back.
     "and choose again; never pick for them. If it says nobody matched, say so "
     "and stop.\n\n"
+    # Asking is the mirror of sharing and had no worked example of its own --
+    # only the Location share one above, which does not name send_request or
+    # select_ask_recipient anywhere. A live session showed exactly what that
+    # gap looks like: told to ask a named person, One landed on the request
+    # screen but never actually picked them, and Send stayed disabled.
+    "Requesting someone's location ('ask Neelesh where he is', 'request "
+    "Sarah's location') is the same shape as sharing, in reverse: navigate "
+    "first, then ask. Call start_app_goal with action id "
+    "'location.select_ask_recipient' and slots {'person': <the name exactly "
+    "as you heard it>}, never run_app_action, because this is an authored "
+    "journey the same way sharing's pick step is. It answers "
+    "'navigation_started'; say nothing about a recipient yet and ask no "
+    "question. Wait for the destination to settle, then call "
+    "continue_app_goal -- that is what actually runs the match. Its "
+    "settlement report is the first and only place the MATCHED name "
+    "appears; never say a name is picked before that report arrives. Once "
+    "it settles, call run_app_action with 'location.send_request' and SAY "
+    "the matched name as you do it -- 'Asking Sarah Chen where she is' -- "
+    "using the name from the report, never the name you heard. If several "
+    "people matched, ask which one and choose again; never pick for them. "
+    "If nobody matched, say so and stop. Unlike sharing, this needs no "
+    "duration: send_request has none to ask for.\n\n"
     # Circles. Two things go wrong without being told. The small one is asking
     # which circle when the person has exactly one. The serious one is
     # reporting an invitation as a completed add: joining is the other

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4987,7 +4987,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "dedae2806a405c9270f5bac388333421aa77b6021afa4914f1bc685e471f3101",
+    "action_gateway": "4bfebfd4601aee35d335e50f35bd6b852306aa8ac19ec2aa779f0af92750d779",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
     "cache_manifest": "a920c21d5fd0aa406d20ce8a46b6aa88caf32c0cb033ff3a91e274ec6097258c",
     "data_plane": "3b2f555c7835a04a7802b93e72df0014b6e5fbdbcae986e9d3cd019e4aa64846",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4987,7 +4987,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "4bfebfd4601aee35d335e50f35bd6b852306aa8ac19ec2aa779f0af92750d779",
+    "action_gateway": "dedae2806a405c9270f5bac388333421aa77b6021afa4914f1bc685e471f3101",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
     "cache_manifest": "a920c21d5fd0aa406d20ce8a46b6aa88caf32c0cb033ff3a91e274ec6097258c",
     "data_plane": "3b2f555c7835a04a7802b93e72df0014b6e5fbdbcae986e9d3cd019e4aa64846",


### PR DESCRIPTION
## Summary
Reported live: told to send a location request to a named person, One landed on the request screen but never actually picked them -- Send stayed disabled, nobody selected.

Same gap class as #5795 (the `connect.send_request` fix): `location.share_selected` has a detailed worked example telling the model to use `start_app_goal`, never `run_app_action`, because it's an authored journey -- but `location.select_ask_recipient` and `location.send_request` had **zero explicit instruction coverage**.

The underlying selection code was checked directly and is structurally correct:
- `addRequestOwner` (`page.tsx:7917-7940`) does a proper functional state update, keyed on the real `recipientId`.
- `location.select_ask_recipient`'s handler (`page.tsx:9558-9691`) mirrors `select_share_recipient`'s matching/ambiguity/disambiguation-card logic exactly.
- `contactSignalRecipients` (the pool the voice handler matches against) is derived directly from the same `recipients` array the UI renders from, via `enrichRecipientsWithContactSignal` -- an enrichment, not a remap, so `userId` values stay identical between the two.

So this targets the same class of live model-reliability gap the Connect fix already addressed, not a second code bug in the same area.

Adds the same explicit pattern already proven for both Location sharing and Connect: call `start_app_goal` directly for `select_ask_recipient`, wait for the destination to settle, then `continue_app_goal` to actually run the pick, then `run_app_action` with `send_request` once the name is confirmed.

**Best-effort against a live model-reliability issue, not a confirmed root-cause fix** -- flagging honestly, same as #5795.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `bandit` clean (no new findings)
- [x] `pytest tests/test_one_adk_agent_tree.py tests/test_one_adk_live_protocol.py` -- 146 passed

Addresses #5677