### PR TITLE
feat(voice): add a bounded fuzzy fallback to spoken name matching

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/resolve-spoken-names.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/resolve-spoken-names.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  joinNamesForSpeech,
+  normalizeSpokenName,
+  resolveSpokenNames,
+  splitSpokenNames,
+} from "@/lib/one-location/resolve-spoken-names";
+
+type Person = { id: string; name: string };
+
+function person(id: string, name: string): Person {
+  return { id, name };
+}
+
+const byName = (item: Person) => item.name;
+
+describe("resolveSpokenNames", () => {
+  it("resolves a clean substring match", () => {
+    const candidates = [person("1", "Sarah Chen"), person("2", "Priya Singh")];
+    const result = resolveSpokenNames(candidates, "Sarah", byName);
+    expect(result.resolved.map((r) => r.id)).toEqual(["1"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("still prefers an exact substring match over any fuzzy candidate", () => {
+    // "Ankit" is an exact substring hit on candidate 1; fuzzy must never run
+    // once substring already found something, so candidate 2 ("Ankeet") is
+    // never even considered here.
+    const candidates = [person("1", "Ankit Kumar"), person("2", "Ankeet Rao")];
+    const result = resolveSpokenNames(candidates, "Ankit", byName);
+    expect(result.resolved.map((r) => r.id)).toEqual(["1"]);
+  });
+
+  describe("fuzzy fallback", () => {
+    it("matches a one-letter-off mishearing when substring finds nothing", () => {
+      // "Nilesh" is not a substring of "Neelesh Hushh - 1" (missing the
+      // second e), so this only resolves through the fuzzy fallback.
+      const candidates = [person("1", "Neelesh Hushh - 1")];
+      const result = resolveSpokenNames(candidates, "Nilesh", byName);
+      expect(result.resolved.map((r) => r.id)).toEqual(["1"]);
+      expect(result.unresolved).toEqual([]);
+    });
+
+    it("matches an insertion-style mishearing (Ankeet for Ankit)", () => {
+      const candidates = [person("1", "Ankit Kumar")];
+      const result = resolveSpokenNames(candidates, "Ankeet", byName);
+      expect(result.resolved.map((r) => r.id)).toEqual(["1"]);
+    });
+
+    it("reports ambiguous, not a guess, when a fuzzy match is close to more than one person", () => {
+      const candidates = [person("1", "Ankit Kumar"), person("2", "Ankeet Rao")];
+      // "Anket" is one edit from both "Ankit" and "Ankeet" -- neither should
+      // be silently preferred, so this must surface both as a choice, the
+      // exact same shape a substring collision already produces.
+      const result = resolveSpokenNames(candidates, "Anket", byName);
+      expect(result.resolved).toEqual([]);
+      expect(result.unresolved).toEqual([
+        {
+          spokenText: "Anket",
+          kind: "ambiguous",
+          matches: expect.arrayContaining([
+            expect.objectContaining({ id: "1" }),
+            expect.objectContaining({ id: "2" }),
+          ]),
+        },
+      ]);
+    });
+
+    it("never fuzzy-matches short names, where a one-edit slip reaches too many unrelated people", () => {
+      const candidates = [person("1", "Amy Chen"), person("2", "Ivy Park")];
+      const result = resolveSpokenNames(candidates, "Amy", byName);
+      // Exact substring hit on "Amy" -- included to show the floor applies
+      // to the FALLBACK, not to real matches.
+      expect(result.resolved.map((r) => r.id)).toEqual(["1"]);
+
+      const noMatch = resolveSpokenNames(candidates, "Emy", byName);
+      // "Emy" is one edit from "Amy", but "Amy" is only 3 letters -- under
+      // the 4-letter floor, so this must stay not_found rather than guess.
+      expect(noMatch.resolved).toEqual([]);
+      expect(noMatch.unresolved).toEqual([{ spokenText: "Emy", kind: "not_found" }]);
+    });
+
+    it("stays not_found when nothing is close enough, fuzzy included", () => {
+      const candidates = [person("1", "Sarah Chen"), person("2", "Priya Singh")];
+      const result = resolveSpokenNames(candidates, "Zachary", byName);
+      expect(result.resolved).toEqual([]);
+      expect(result.unresolved).toEqual([
+        { spokenText: "Zachary", kind: "not_found" },
+      ]);
+    });
+
+    it("applies fuzzy independently per name in a multi-person turn", () => {
+      const candidates = [person("1", "Neelesh Hushh - 1"), person("2", "Priya Singh")];
+      const result = resolveSpokenNames(candidates, "Nilesh and Priya", byName);
+      expect(result.resolved.map((r) => r.id).sort()).toEqual(["1", "2"]);
+      expect(result.unresolved).toEqual([]);
+    });
+  });
+});
+
+describe("splitSpokenNames", () => {
+  it("returns a single-element array with no delimiter", () => {
+    expect(splitSpokenNames("Sarah")).toEqual(["Sarah"]);
+  });
+
+  it("splits on comma, ampersand, semicolon, and the word and", () => {
+    expect(splitSpokenNames("Alice, Bob & Carol; Dana and Erin")).toEqual([
+      "Alice",
+      "Bob",
+      "Carol",
+      "Dana",
+      "Erin",
+    ]);
+  });
+});
+
+describe("normalizeSpokenName", () => {
+  it("strips case, accents, and punctuation", () => {
+    // The apostrophe becomes a space, not nothing -- it is stripped by the
+    // same [^\p{L}\p{N}\p{M}\s] rule that turns "Mum & Dad" into two words,
+    // not one squashed-together word.
+    expect(normalizeSpokenName("Renée O'Brien")).toBe("renee o brien");
+  });
+});
+
+describe("joinNamesForSpeech", () => {
+  it("joins without an Oxford comma", () => {
+    expect(joinNamesForSpeech(["Alice", "Bob", "Sarah"])).toBe("Alice, Bob and Sarah");
+    expect(joinNamesForSpeech(["Alice", "Bob"])).toBe("Alice and Bob");
+    expect(joinNamesForSpeech(["Alice"])).toBe("Alice");
+  });
+});

--- a/hushh-webapp/lib/one-location/resolve-spoken-names.ts
+++ b/hushh-webapp/lib/one-location/resolve-spoken-names.ts
@@ -7,7 +7,12 @@
  * "and") BEFORE any normalization, because normalizeSpokenName() strips
  * exactly those characters -- splitting after normalizing would destroy the
  * delimiters this needs. Each resulting name is then matched independently,
- * by substring, never exact: a person says "Sarah", not "Sarah Chen".
+ * first by substring, then -- only when substring finds nothing -- by a
+ * bounded fuzzy fallback for the kind of one- or two-letter slip speech
+ * transcription actually makes ("Nilesh" heard for "Neelesh"). Fuzzy never
+ * runs when substring already matched something, so it can only turn a
+ * "not found" into a match; it never second-guesses or widens a match that
+ * already succeeded.
  *
  * A person can name several people in one turn ("share with Alice and
  * Bob"), and each name resolves on its own: some may match cleanly, one may
@@ -47,6 +52,64 @@ export function splitSpokenNames(raw: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Levenshtein edit distance: the fewest single-character insertions,
+ * deletions, or substitutions to turn `a` into `b`. Pure string distance,
+ * with no idea what a "name" is -- the safety guard lives in
+ * `isFuzzyMatch`'s threshold, not here.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+  let previousRow = Array.from({ length: b.length + 1 }, (_, index) => index);
+  for (let i = 1; i <= a.length; i += 1) {
+    const currentRow = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      currentRow.push(
+        Math.min(
+          currentRow[j - 1]! + 1, // insertion
+          previousRow[j]! + 1, // deletion
+          previousRow[j - 1]! + substitutionCost, // substitution
+        ),
+      );
+    }
+    previousRow = currentRow;
+  }
+  return previousRow[b.length]!;
+}
+
+/**
+ * How many character edits a word may be off by and still count as a fuzzy
+ * match, scaled to its length. Under 4 letters is never fuzzy-matched at
+ * all: a one-edit slip on "Al" or "Amy" reaches too many unrelated short
+ * names to be safe here, where a wrong match means a location shared with,
+ * or a request sent to, the wrong person. Longer names get a little more
+ * room, since a mis-heard syllable ("Nilesh" for "Neelesh", "Ankeet" for
+ * "Ankit") is a couple of letters, not a fraction of the word.
+ */
+function fuzzyMatchThreshold(wordLength: number): number {
+  if (wordLength < 4) return 0;
+  if (wordLength <= 5) return 1;
+  return 2;
+}
+
+/**
+ * True when `target` is a close spoken variant of `candidateWord` -- judged
+ * by the LONGER side's length, not the shorter. An insertion/deletion pair
+ * like "Ankit" (5) vs "Ankeet" (6) already spends one edit purely on the
+ * length gap; judging it by the shorter word's threshold would refuse a
+ * mishearing that adds or drops a single letter on top of a real edit.
+ */
+function isFuzzyMatch(target: string, candidateWord: string): boolean {
+  const threshold = fuzzyMatchThreshold(
+    Math.max(target.length, candidateWord.length),
+  );
+  if (threshold === 0) return false;
+  return levenshteinDistance(target, candidateWord) <= threshold;
+}
+
 /** A spoken name that did NOT resolve to exactly one candidate. A name that
  * resolved cleanly is not represented here -- it goes straight into
  * `MultiNameResolution.resolved` instead. */
@@ -78,9 +141,18 @@ export function resolveSpokenNames<T>(
   for (const spokenText of splitSpokenNames(raw)) {
     const target = normalizeSpokenName(spokenText);
     if (!target) continue;
-    const matches = candidates.filter((item) =>
+    let matches = candidates.filter((item) =>
       normalizeSpokenName(String(searchText(item) || "")).includes(target),
     );
+    if (matches.length === 0) {
+      matches = candidates.filter((item) => {
+        const normalized = normalizeSpokenName(String(searchText(item) || ""));
+        return (
+          isFuzzyMatch(target, normalized) ||
+          normalized.split(" ").some((word) => isFuzzyMatch(target, word))
+        );
+      });
+    }
     if (matches.length === 0) {
       unresolved.push({ spokenText, kind: "not_found" });
     } else if (matches.length === 1) {


### PR DESCRIPTION
## Summary
`resolveSpokenNames` matched by substring only, so any STT transcription slip -- "Nilesh" heard for "Neelesh", "Ankeet" for "Ankit" -- resolved to nothing, even though the person was right there in the connections list.

Fuzzy matching now runs only as a **fallback**, only when substring matching finds nothing for a given spoken name -- it never second-guesses or widens a match that already succeeded by substring.

- Bounded by a length-scaled Levenshtein edit-distance threshold: 0 edits under 4 letters (never fuzzy-matched at all), 1 up to 5 letters, 2 above -- judged by the **longer** of the two words being compared, so an insertion/deletion pair like "Ankit"/"Ankeet" isn't double-penalized for the length gap alone.
- A fuzzy match close to more than one candidate is reported exactly the same way a substring collision already is -- `ambiguous`, with every close match attached -- so it flows through the existing tap-to-pick disambiguation card and is never silently guessed. Verified this is the real behavior with a dedicated test, not assumed.

Scoped to voice name resolution only, per explicit direction -- typed search boxes (Connect, Location composer) are unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] New dedicated test file (`resolve-spoken-names.test.ts`, 12 tests): exact-match precedence over fuzzy, single-letter-slip fuzzy matches, insertion-style fuzzy matches, ambiguous-fuzzy routes to the disambiguation shape, short names never fuzzy-matched, no-match-at-all still reports not_found, fuzzy applies independently per name in a multi-person turn
- [x] `vitest run __tests__/voice/ __tests__/components/one-location-agent-page.test.tsx __tests__/app/connect/page-client.test.tsx` -- 432 passed, no regressions
- [x] Full governed-artifact regeneration + `--check` sequence -- all current (this change touches no action contracts)

Addresses #5677