### PR TITLE
feat(voice): show what a confirmation actually does, not just that it needs a yes

### DIFF
--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1999,6 +1999,17 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
               : "One is ready to"}
           </p>
           <p className="mt-1 text-[16px] font-semibold">{pendingActionLabel}</p>
+          {/* Sourced from the generated contract's own `meaning`, the same
+              field VoiceConfirm's `consequence` already reads for the 7
+              handler-authored cards -- so every confirmation names what will
+              actually happen, not just that something needs a yes, and stays
+              true when the action's behavior changes instead of drifting
+              into static copy nobody updates alongside it. */}
+          {pendingAction?.meaning ? (
+            <p className="mt-1 text-[13px] leading-relaxed">
+              {pendingAction.meaning}
+            </p>
+          ) : null}
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
             {pendingActionNeedsTrustedActivation
               ? "This tap opens the provider window and keeps One active here."


### PR DESCRIPTION
## Summary
Requested directly: bring back a visual pop-up for every "are you sure", with real content instead of a generic placeholder.

The generic confirmation dialog (every `confirm_required` action that doesn't author its own richer card -- i.e. everything except the 7 destructive actions with their own `VoiceConfirm` card) already renders as its own visual card, but only ever showed the action's label and a static instruction line -- "Sensitive values stay hidden. Say yes to run this, or no to cancel." -- with no description of what saying yes would actually do.

`pendingAction` is already resolved via `getKaiActionById` and already in scope where this renders (`agent-bar.tsx`). It carries the same `.meaning` field `VoiceConfirm` already sources its `consequence` text from for the 7 handler-authored cards -- so this reuses an existing, proven pattern rather than inventing new copy. Shown here too, every confirmation now names the real effect, sourced from the generated contract, and stays true when an action's behavior changes instead of drifting into static copy nobody updates alongside it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full governed-artifact regeneration + `--check` sequence -- all current (this change touches no action contracts)

Addresses #5677