### PR TITLE
fix(ui): improve KYC mobile actions

### DIFF
--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -1983,7 +1983,7 @@ export function OneKycWorkspace({
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="size-8"
+                            className="h-11 w-11 shrink-0"
                             aria-label="Remove request"
                             // Removing a request only opens the confirm dialog and is
                             // its own action; it must not be blocked by a background
@@ -2520,7 +2520,7 @@ export function OneKycWorkspace({
                 </SettingsGroup>
               ) : (
                 <SettingsGroup embedded title="Actions">
-                  <div className="flex flex-wrap gap-2 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+                  <div className="flex flex-col sm:flex-row gap-2 px-[var(--settings-row-px)] py-[var(--settings-row-py)] [&_button]:w-full sm:[&_button]:w-auto">
                     <button
                       type="button"
                       className={cn(BTN_OUTLINE)}


### PR DESCRIPTION
## Summary

Focusing on mobile responsiveness and iOS Human Interface Guideline alignment for the KYC detail panel.

## The Issue

- The `Trash2` remove button used `size-8` (32×32px), which is below the recommended 44×44px mobile touch target.
- The action buttons used `flex-wrap`, causing uneven wrapping on smaller screens.

## Changes Made

- Updated the remove button to `h-11 w-11 shrink-0` for a 44×44px touch target.
- Changed the Actions container from `flex-wrap` to `flex-col sm:flex-row`.
- Added `[&_button]:w-full sm:[&_button]:w-auto` to make buttons full-width on mobile while preserving the desktop layout.
- No business logic, routing, API calls, or KYC workflow behavior was changed.

## UX Goal

Improve mobile usability with accessible touch targets and a cleaner, predictable action-button layout while preserving the desktop experience.

## Affected File

- `hushh-webapp/app/one/kyc/page.tsx`
- Route: `/one/kyc`

## Verification

- Verified the 44×44px remove button touch target.
- Verified action buttons stack properly on mobile and remain inline on desktop.
- Ran `git diff --check` successfully.
- Confirmed changes are limited to UI/responsive styling.
