### PR TITLE
fix(ui): resolve touch dead zone in settings row trailing actions

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -512,7 +512,14 @@ export function SettingsRow({
             />
           </button>
           {trailingContent ? (
-            <div role="presentation" onClick={(e) => e.stopPropagation()}>
+            <div
+              role="presentation"
+              onClick={(e) => {
+                if (onClick) onClick();
+                else e.stopPropagation();
+              }}
+              className={onClick ? "cursor-pointer" : undefined}
+            >
               {trailingContent}
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

Resolves a touch interaction issue in the `SettingsRow` component where trailing actions created a dead zone on the right side of list items.

## The Issue

- The `trailingContent` container used `e.stopPropagation()` for all rows.
- This prevented clicks/taps on the chevron and right-side area from triggering the row's primary action.
- On mobile, this made part of the row feel unresponsive.

## Changes Made

- Updated the `trailingContent` wrapper to check whether the parent row has an `onClick` handler.
- When a row action exists, clicks now bubble to the parent and `cursor-pointer` is applied.
- When no row action exists, propagation is still stopped as before.
- No underlying business logic or navigation behavior was changed.

## UX Goal

Remove the touch dead zone and ensure the entire interactive row behaves consistently, especially on mobile.

## Affected File

- `hushh-webapp/components/app-ui/settings-ui.tsx`

## Verification

- Verified trailing-area clicks trigger the row action when available.
- Verified non-interactive rows still prevent unwanted event propagation.
- Verified the change is isolated to `SettingsRow` interaction behavior.
- Ran `git diff --check` successfully.
