### PR TITLE
fix(ui): correct iOS top notch overlap and text alignment in detail panels

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -669,10 +669,10 @@ export function AdaptiveDetailSurface({
               (event.currentTarget as HTMLElement).focus();
             }}
           >
-            <SheetHeader className="morphy-theme-content sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[var(--activeGlassColor)] px-4 py-3 text-left backdrop-blur-[var(--blur-standard)]">
-              <div className="flex min-w-0 items-center gap-3 pr-10">
+            <SheetHeader className="morphy-theme-content sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[var(--activeGlassColor)] px-4 pt-8 pb-3 text-left backdrop-blur-[var(--blur-standard)]">
+              <div className="flex min-w-0 items-center gap-3 pr-10 text-left">
                 {leading ? <div className="shrink-0">{leading}</div> : null}
-                <div className="min-w-0">
+                <div className="min-w-0 text-left">
                   {eyebrow ? (
                     <SectionLabel as="p">
                       {eyebrow}
@@ -726,10 +726,10 @@ export function AdaptiveDetailSurface({
             (e.currentTarget as HTMLElement).focus();
           }}
         >
-          <DrawerHeader className="morphy-theme-content sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[var(--activeGlassColor)] px-4 py-3 pr-14 text-left backdrop-blur-[var(--blur-standard)] sm:px-5 sm:py-4 sm:pr-14">
-            <div className="flex min-w-0 items-center gap-3">
+          <DrawerHeader className="morphy-theme-content sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[var(--activeGlassColor)] px-4 pt-8 pb-3 pr-14 text-left backdrop-blur-[var(--blur-standard)] sm:px-5 sm:pt-6 sm:pb-4 sm:pr-14">
+            <div className="flex min-w-0 items-center gap-3 text-left">
               {leading ? <div className="shrink-0">{leading}</div> : null}
-              <div className="min-w-0">
+              <div className="min-w-0 text-left">
                 {eyebrow ? (
                   <SectionLabel as="p">
                     {eyebrow}
@@ -786,9 +786,9 @@ export function AdaptiveDetailSurface({
         }}
       >
         <DialogHeader className="morphy-theme-content sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[var(--activeGlassColor)] px-6 py-4 pr-16 text-left backdrop-blur-[var(--blur-standard)]">
-          <div className="flex min-w-0 items-center gap-3">
+          <div className="flex min-w-0 items-center gap-3 text-left">
             {leading ? <div className="shrink-0">{leading}</div> : null}
-            <div className="min-w-0">
+            <div className="min-w-0 text-left">
               {eyebrow ? (
                 <SectionLabel as="p">
                   {eyebrow}


### PR DESCRIPTION
## Summary

This PR resolves visual alignment and safe-area padding issues in the global `AdaptiveDetailSurface` components to improve iOS layout consistency.

## The Issue

- **iOS Notch Overlap:** Full-screen mobile drawers and bottom sheets could extend too close to the iOS top notch / Dynamic Island area.
- **Text Alignment:** Detail panel titles and descriptions were inheriting centered flex styles instead of following the application's standard left-aligned layout.

## Changes Made

- **Safe Area Spacing:** Added `pt-8` to `SheetHeader` and `DrawerHeader` to provide additional top spacing on mobile.
- **Text Alignment:** Added `text-left` to the wrappers for `DialogTitle` and `DialogDescription`, including their mobile counterparts.
- **Consistent Layout:** Ensured detail panel headers maintain consistent alignment across mobile and desktop layouts.
- No business logic, routing, API calls, or component behavior was modified.

## UX Goal

Prevent content from conflicting with iOS system areas while maintaining a clean, consistent left-aligned header layout across detail panels.

## Affected File

- `hushh-webapp/components/app-ui/settings-ui.tsx`

## Verification

- Verified detail panels have sufficient top spacing on mobile.
- Verified titles and descriptions remain left-aligned.
- Verified desktop layout remains unaffected.
- Confirmed changes are limited to UI styling and spacing.
