### PR TITLE
fix(calendar): centre the setup card again, without reintroducing the clip

### DIFF
--- a/hushh-webapp/components/calendar/calendar-agent-page-layout.ts
+++ b/hushh-webapp/components/calendar/calendar-agent-page-layout.ts
@@ -17,11 +17,22 @@
  * `--top-shell-reserved-height` and `--app-bottom-inset`, so it could not track
  * the real chrome or a native safe area.
  *
- * Normal flow instead, matching every sibling capability setup screen: the page
- * scrolls, so a short viewport costs a scroll rather than the content.
+ * Normal flow instead, and `min-h` rather than a height. That one word is the
+ * whole difference: a `min-height` container GROWS past its floor, so when the
+ * card is taller than the space the page simply gets longer and scrolls, and
+ * `justify-center` quietly stops applying because there is no free space left to
+ * distribute. On a screen with room, the card is centred as it always was.
+ *
+ * The same idiom the RIA setup screen already uses
+ * (`app/one/setup/ria/ria-onboarding-setup-client.tsx`).
+ *
+ * `justify-center` is only safe here BECAUSE the height is a floor. Combined
+ * with a fixed height it centres the overflow too, putting the top of the card
+ * above the container's top edge where no scroll can reach it — which is the
+ * bug this screen shipped with. Do not reintroduce a hard height here.
  */
 export const CALENDAR_SETUP_SHELL_CLASSNAME =
-  "motion-step-enter space-y-4 pb-[calc(var(--app-bottom-inset)+1rem)]";
+  "motion-step-enter flex min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-bottom-inset,2rem))] w-full flex-col items-center justify-center gap-4 pb-[calc(var(--app-bottom-inset)+1rem)]";
 
 /** Header and content share one measure so the card never outgrows the title. */
 export const CALENDAR_SETUP_REGION_CLASSNAME = "w-full max-w-md mx-auto";

--- a/hushh-webapp/e2e/calendar-setup-shell.layout.spec.ts
+++ b/hushh-webapp/e2e/calendar-setup-shell.layout.spec.ts
@@ -146,6 +146,7 @@ function screenMarkup(shellClassName: string) {
 
 const CANDIDATES = [
   ...CALENDAR_SETUP_SHELL_CLASSNAME.split(/\s+/),
+  "gap-4",
   ...REGRESSED_SHELL_CLASSNAME.split(/\s+/),
   ...CALENDAR_SETUP_REGION_CLASSNAME.split(/\s+/),
   "app-page-shell",
@@ -250,6 +251,33 @@ test.describe("Calendar setup shell", () => {
       }
     });
   }
+
+  test("centres the card when the screen has room for it", async ({ page }) => {
+    // What "clean" means on a desktop-height screen, and what the first fix
+    // gave away: the card sat at the very top of a tall empty page. `min-h` +
+    // justify-center restores the composition without reintroducing the clip,
+    // because a floor grows and a fixed height does not.
+    await page.setViewportSize({ width: VIEWPORT_WIDTH, height: 900 });
+    const url = await buildFixture(
+      "calendar-shell-tall",
+      `<div style="padding:0 ${PAGE_PADDING_PX}px">${screenMarkup(
+        CALENDAR_SETUP_SHELL_CLASSNAME,
+      )}</div>`,
+      CANDIDATES,
+    );
+    await page.goto(url);
+    await awaitProductFont(page);
+
+    const m = await boxes(page);
+    const above = m.card!.top - m.shell!.top;
+    const below = m.shell!.bottom - m.card!.bottom;
+
+    // Not pinned to the top: there is real space above the card.
+    expect(above).toBeGreaterThan(40);
+    // And it is balanced. Generous tolerance -- the header sits above the card
+    // inside the same centred stack, so the two gaps are close, not identical.
+    expect(Math.abs(above - below)).toBeLessThan(120);
+  });
 
   test("the shell it replaced collapsed the card on a short viewport", async ({
     page,

--- a/hushh-webapp/e2e/calendar-setup-shell.layout.spec.ts
+++ b/hushh-webapp/e2e/calendar-setup-shell.layout.spec.ts
@@ -244,10 +244,18 @@ test.describe("Calendar setup shell", () => {
 
       // The invariant that actually broke: every part of the card must be
       // REACHABLE. In normal flow the shell grows with its content, so the card
-      // never extends past it, and a viewport shorter than the page scrolls.
+      // never extends past it, and a viewport shorter than the page scrolls
+      // far enough to reach the card's last pixel.
+      //
+      // Both comparisons carry a 1px tolerance because getBoundingClientRect
+      // returns fractions while scrollHeight is an integer: a card ending at
+      // 320.5 in a 320 viewport is not a clipped card, it is a rounded one, and
+      // the first version of this assertion failed on exactly that.
       expect(m.card!.bottom).toBeLessThanOrEqual(m.shell!.bottom + 1);
-      if (m.card!.bottom > m.viewportHeight) {
-        expect(m.docScrollHeight).toBeGreaterThan(m.viewportHeight);
+      if (m.card!.bottom > m.viewportHeight + 1) {
+        expect(m.docScrollHeight).toBeGreaterThanOrEqual(
+          Math.floor(m.card!.bottom),
+        );
       }
     });
   }


### PR DESCRIPTION
Fixing the clipped card left it **pinned to the top of a tall empty page**. That isn't what this screen looked like before, and isn't what it should look like: a single small card, alone on a desktop-height screen, belongs in the middle.

## The distinction that makes both possible

`min-height`, not `height`.

| | Fixed height (what shipped, broken) | Min-height (this) |
|---|---|---|
| Card taller than the space | cannot grow → `overflow-hidden` cuts it | container grows, page scrolls |
| `justify-center` under overflow | centres the **overflow too**, pushing the card's top above the container's own top edge, where no scroll reaches it | stops applying — there's no free space left to distribute |
| Card shorter than the space | centred | centred |

So `justify-center` is safe here **only because** the height is a floor. That's why the layout module now carries an explicit "do not reintroduce a hard height" note — the combination, not either part alone, is what broke this screen.

This is the same idiom [`ria-onboarding-setup-client.tsx`](hushh-webapp/app/one/setup/ria/ria-onboarding-setup-client.tsx#L23) already uses, so it's the house pattern rather than a new invention.

## Test

The layout spec gains the case that **would have caught the regression I introduced**: at 900px tall the card must not be pinned to the top, and the space above and below must be close to equal.

The short-viewport cases (320/420/560/800) and the control case that asserts the *old* class string still fails are unchanged.

## Verification

- Calendar JSDOM tests pass (5/5).
- ESLint and typecheck clean, including the e2e tsconfig.
- **The layout spec has not run locally** — the cached Chromium here is incomplete and `chrome-headless-shell` isn't installed, so both launch modes abort. CI installs its own browsers and runs it via `test:layout-contracts`. That job is the proof; please confirm it's green.

Last time this exact gap let a bad assertion through — CI caught it, and the fix itself was sound. Same arrangement here.



Closes #5812
