### PR TITLE
fix(finance): say what the Finance capability actually offers

### DIFF
--- a/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
@@ -24,7 +24,7 @@ describe("CapabilityCinematicIntroGate", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "See your money clearly.",
+        name: "Access your finances in one place.",
       }),
     ).toBeTruthy();
     expect(screen.queryByText("Finance preferences")).toBeNull();

--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -80,8 +80,8 @@ const SETUP_COPY_BY_ID: Record<
     setupBlurb: "See how your money is doing.",
     actionLabel: "Set up Finance",
     resumeActionLabel: "Finish Finance",
-    introPremise: "See your money clearly.",
-    introPromise: "Only the accounts you share. Nothing else.",
+    introPremise: "Access your finances in one place.",
+    introPromise: "Only the accounts you share.",
     setupBullets: [
       "Tell One how you like to invest.",
       "One reads your portfolio and tailors what it shows you.",


### PR DESCRIPTION
The Finance intro screen promised **comprehension**, about the wrong **noun**.

> ~~See your money clearly.~~
> ~~Only the accounts you share. Nothing else.~~

Becomes:

> **Access your finances in one place.**
> *Only the accounts you share.*

## Why the noun mattered

"Your money" reads as balances and spending. This capability is a portfolio:

| | |
|---|---|
| Catalog description | *"Market, portfolio, analysis, and RIA handoff."* |
| Setup bullets | *"Tell One how you like to invest" · "One reads your portfolio" · "Hand off to a real advisor"* |
| Routes | `market`, `investments`, `optimize`, `funding-trade`, `alpaca` |

Someone arriving for their bank balance was being told the wrong thing.

The subline also drops `Nothing else.` — the sentence already scopes itself, and the second fragment restated it in a way that protested slightly too much.

## One visual consequence, accepted deliberately

The premise is **34 characters** against the `<h1>`'s `max-w-[16ch] text-balance`, where the previous line was 23. It will set on **three lines rather than two** on narrow screens. The wording was chosen over the wrap; flagging it so it isn't mistaken for a layout bug later.

## Verification

- ESLint clean; no typecheck errors.
- The one test naming the old string is updated.

⚠️ **That test file is currently broken on `main`.** `__tests__/components/capability-cinematic-intro.test.tsx` fails **all ten** of its tests with `TypeError: Cannot read properties of undefined (reading 'clear')` — an import-level failure, verified identical with this change stashed. So the assertion I updated is not actually exercised today; it is corrected so it is right whenever that file is fixed.

That file is the only test coverage the capability intro gate has, and it has been dark for a while. Worth a separate fix — it means any regression in this screen currently ships unnoticed.



Closes #5815
