### PR TITLE
fix(ria): keep client roster summary across views

### DIFF
--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const { push } = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: {
+      uid: "ria_1",
+      getIdToken: async () => "token",
+    },
+  }),
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: () => ({
+    riaCapability: "active",
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/cache/use-stale-resource", () => ({
+  useStaleResource: () => ({
+    data: { items: [], total: 0, page: 1, limit: 100, has_more: false },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+
+vi.mock("@/components/app-ui/app-page-shell", () => ({
+  AppPageShell: ({ children }: { children?: React.ReactNode }) => <main>{children}</main>,
+  AppPageHeaderRegion: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  AppPageContentRegion: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/app-ui/page-sections", () => ({
+  PageHeader: ({
+    title,
+    description,
+  }: {
+    title: React.ReactNode;
+    description?: React.ReactNode;
+  }) => (
+    <header>
+      <h1>{title}</h1>
+      {description ? <p>{description}</p> : null}
+    </header>
+  ),
+}));
+
+vi.mock("@/components/profile/settings-ui", () => ({
+  SettingsGroup: ({
+    title,
+    description,
+    children,
+  }: {
+    title?: React.ReactNode;
+    description?: React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <section>
+      {title ? <h2>{title}</h2> : null}
+      {description ? <p>{description}</p> : null}
+      {children}
+    </section>
+  ),
+  SettingsSegmentedTabs: ({
+    value,
+    onValueChange,
+    options,
+  }: {
+    value: string;
+    onValueChange: (next: string) => void;
+    options: Array<{ value: string; label: string }>;
+  }) => (
+    <div role="tablist">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={value === option.value}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaCompatibilityState: ({ title }: { title: string }) => <div>{title}</div>,
+  RiaVerificationGate: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
+  NearbyAroundYou: () => <div>Nearby records pane</div>,
+}));
+
+import RiaClientsPage from "@/app/ria/clients/page";
+
+describe("RIA Clients page", () => {
+  it("keeps workspace copy on Connected and explains the Around You workspace boundary", () => {
+    render(<RiaClientsPage />);
+
+    expect(
+      screen.getByText(/One workspace per client/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Around you/i }));
+
+    expect(screen.queryByText(/One workspace per client/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Workspace access")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Connect first to open a client workspace/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Dedicated workspaces stay with Connected clients/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Nearby records pane")).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -128,5 +128,6 @@ describe("RIA Clients page", () => {
       screen.getByText(/Dedicated workspaces stay with Connected clients/i),
     ).toBeInTheDocument();
     expect(screen.getByText("Nearby records pane")).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -110,7 +110,7 @@ vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
 import RiaClientsPage from "@/app/ria/clients/page";
 
 describe("RIA Clients page", () => {
-  it("keeps workspace copy on Connected and explains the Around You workspace boundary", () => {
+  it("keeps the workspace summary visible when switching to Around You", () => {
     render(<RiaClientsPage />);
 
     expect(
@@ -119,13 +119,8 @@ describe("RIA Clients page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Around you/i }));
 
-    expect(screen.queryByText(/One workspace per client/i)).not.toBeInTheDocument();
-    expect(screen.getByText("Workspace access")).toBeInTheDocument();
     expect(
-      screen.getByText(/Connect first to open a client workspace/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Dedicated workspaces stay with Connected clients/i),
+      screen.getByText(/One workspace per client/i),
     ).toBeInTheDocument();
     expect(screen.getByText("Nearby records pane")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -230,7 +230,18 @@ export default function RiaClientsPage() {
           </div>
 
           {view === "nearby" ? (
-            <NearbyAroundYou />
+            <div className="flex flex-col gap-4">
+              <SettingsGroup
+                embedded
+                title={RIA_COPY.clients.aroundYouWorkspace.title}
+                description={RIA_COPY.clients.aroundYouWorkspace.description}
+              >
+                <div className="px-4 py-3 text-sm text-muted-foreground">
+                  {RIA_COPY.clients.aroundYouWorkspace.body}
+                </div>
+              </SettingsGroup>
+              <NearbyAroundYou />
+            </div>
           ) : (
           <SettingsGroup
             embedded

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -202,10 +202,7 @@ export default function RiaClientsPage() {
               ) : null}
             </span>
           }
-          // The roster count and its description belong to Connected. Carrying
-          // them over to Around you labelled a list of public records with a
-          // count of the advisor's own clients.
-          description={view === "connected" ? RIA_COPY.clients.description : undefined}
+          description={RIA_COPY.clients.description}
           icon={UserRound}
           accent="ria"
         />
@@ -230,18 +227,7 @@ export default function RiaClientsPage() {
           </div>
 
           {view === "nearby" ? (
-            <div className="flex flex-col gap-4">
-              <SettingsGroup
-                embedded
-                title={RIA_COPY.clients.aroundYouWorkspace.title}
-                description={RIA_COPY.clients.aroundYouWorkspace.description}
-              >
-                <div className="px-4 py-3 text-sm text-muted-foreground">
-                  {RIA_COPY.clients.aroundYouWorkspace.body}
-                </div>
-              </SettingsGroup>
-              <NearbyAroundYou />
-            </div>
+            <NearbyAroundYou />
           ) : (
           <SettingsGroup
             embedded

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -77,6 +77,11 @@ export const RIA_COPY = {
       title: "Connected investors",
       description: "Status, access, research, and explorer in one place.",
     },
+    aroundYouWorkspace: {
+      title: "Workspace access",
+      description: "Around You shows public records. Connect first to open a client workspace.",
+      body: "Public records can be shortlisted here. Dedicated workspaces stay with Connected clients.",
+    },
     loading: "Loading clients…",
     empty: "No connected investors yet.",
     browse: "Browse the marketplace",

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -77,11 +77,6 @@ export const RIA_COPY = {
       title: "Connected investors",
       description: "Status, access, research, and explorer in one place.",
     },
-    aroundYouWorkspace: {
-      title: "Workspace access",
-      description: "Around You shows public records. Connect first to open a client workspace.",
-      body: "Public records can be shortlisted here. Dedicated workspaces stay with Connected clients.",
-    },
     loading: "Loading clients…",
     empty: "No connected investors yet.",
     browse: "Browse the marketplace",


### PR DESCRIPTION
## Summary

Keeps the Client roster summary paragraph visible when switching between Connected and Around you in RIA Clients.

Refs #5780

## Scope

Frontend UI only.

Changed files:
- hushh-webapp/app/ria/clients/page.tsx
- hushh-webapp/__tests__/app/ria/clients-page.test.tsx

No backend, API, auth, connection logic, workspace creation, or package-lock changes.

## Verification

- npm.cmd run test:ci -- __tests__/app/ria/clients-page.test.tsx
- npx.cmd eslint app/ria/clients/page.tsx lib/ria/ria-screen-copy.ts __tests__/app/ria/clients-page.test.tsx --max-warnings=0
- git diff --check