### PR TITLE
feat(voice): reconnect a resumable session automatically instead of leaving it dropped

### DIFF
--- a/hushh-webapp/__tests__/services/gemini-live-client.test.ts
+++ b/hushh-webapp/__tests__/services/gemini-live-client.test.ts
@@ -131,4 +131,129 @@ describe("GeminiLiveClient mid-call session frames", () => {
 
     expect(onError).not.toHaveBeenCalled();
   });
+
+  it("marks a sessionEnded's resumability on the emitted error event", async () => {
+    const onEvent = vi.fn();
+    const transport = new GeminiLiveClient({ onEvent });
+    const connection = transport as unknown as {
+      handleSocketMessage: (data: unknown) => Promise<void>;
+    };
+
+    await connection.handleSocketMessage(
+      JSON.stringify({ sessionEnded: { reason: "provider_unavailable", resumable: true } }),
+    );
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", resumable: true }),
+    );
+  });
+});
+
+describe("GeminiLiveClient session resumption", () => {
+  it("stores an incoming resumption handle and hands it off in the closed event", async () => {
+    const onEvent = vi.fn();
+    const transport = new GeminiLiveClient({ onEvent });
+    const connection = transport as unknown as {
+      handleSocketMessage: (data: unknown) => Promise<void>;
+    };
+
+    await connection.handleSocketMessage(
+      JSON.stringify({ sessionResumption: { handle: "resume-abc" } }),
+    );
+    transport.stop();
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "closed", resumptionHandle: "resume-abc" }),
+    );
+  });
+
+  it("hands off null when no handle was ever received", () => {
+    const onEvent = vi.fn();
+    const transport = new GeminiLiveClient({ onEvent });
+
+    transport.stop();
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "closed", resumptionHandle: null }),
+    );
+  });
+
+  it("carries a stored resumption handle into the next bootstrap frame", async () => {
+    vi.useFakeTimers();
+    const OriginalWebSocket = global.WebSocket;
+    try {
+      const transport = new GeminiLiveClient();
+      const connection = transport as unknown as {
+        handleSocketMessage: (data: unknown) => Promise<void>;
+        connectSocket: (relayUrl: string) => void;
+      };
+      await connection.handleSocketMessage(
+        JSON.stringify({ sessionResumption: { handle: "resume-abc" } }),
+      );
+
+      const send = vi.fn();
+      const sockets: Array<{ onopen: (() => void) | null }> = [];
+      class FakeWebSocket {
+        onopen: (() => void) | null = null;
+        onmessage: ((event: { data: string }) => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        readyState = 1;
+        send = send;
+        close = vi.fn();
+        constructor() {
+          sockets.push(this);
+        }
+      }
+      // @ts-expect-error -- minimal stub standing in for the real WebSocket global
+      global.WebSocket = FakeWebSocket;
+
+      connection.connectSocket("wss://example.test/relay");
+      sockets[0]?.onopen?.();
+
+      expect(send).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse(send.mock.calls[0][0] as string) as Record<string, unknown>;
+      expect(sent.resumption_handle).toBe("resume-abc");
+    } finally {
+      global.WebSocket = OriginalWebSocket;
+      vi.useRealTimers();
+    }
+  });
+
+  it("omits resumption_handle from the bootstrap frame when nothing was ever received", () => {
+    vi.useFakeTimers();
+    const OriginalWebSocket = global.WebSocket;
+    try {
+      const transport = new GeminiLiveClient();
+      const connection = transport as unknown as {
+        connectSocket: (relayUrl: string) => void;
+      };
+
+      const send = vi.fn();
+      const sockets: Array<{ onopen: (() => void) | null }> = [];
+      class FakeWebSocket {
+        onopen: (() => void) | null = null;
+        onmessage: ((event: { data: string }) => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        readyState = 1;
+        send = send;
+        close = vi.fn();
+        constructor() {
+          sockets.push(this);
+        }
+      }
+      // @ts-expect-error -- minimal stub standing in for the real WebSocket global
+      global.WebSocket = FakeWebSocket;
+
+      connection.connectSocket("wss://example.test/relay");
+      sockets[0]?.onopen?.();
+
+      const sent = JSON.parse(send.mock.calls[0][0] as string) as Record<string, unknown>;
+      expect(sent).not.toHaveProperty("resumption_handle");
+    } finally {
+      global.WebSocket = OriginalWebSocket;
+      vi.useRealTimers();
+    }
+  });
 });

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -289,6 +289,10 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   // the bar highlights and an ambient waveform animates in place, reacting to
   // the user's voice (listening) and the agent's reply (speaking).
   const [conversationActive, setConversationActive] = useState(false);
+  // Bumped to trigger a deferred (re)start -- manual retry or automatic
+  // reconnect -- once conversationActive has genuinely settled. See the
+  // effect near startConversation for why this can't just call it directly.
+  const [retryNonce, setRetryNonce] = useState(0);
   const [pendingConfirmation, setPendingConfirmation] =
     useState<PendingVoiceConfirmation | null>(null);
   // The journey approval lives in module scope, not component state: it has
@@ -409,10 +413,32 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   // Tracks whether the active session ended with an error, so the bar can keep
   // showing the error status (instead of snapping shut) until it is dismissed.
   const erroredRef = useRef(false);
+  // Set only when the relay's own sessionEnded frame said the failure is
+  // resumable; cleared on every "closed" so a later unsignaled drop (a raw
+  // network blip, carrying no opinion either way) never inherits a stale
+  // "yes, reconnect" from an unrelated earlier failure.
+  const lastErrorResumableRef = useRef(false);
+  // The provider's own continuation token, handed off in the "closed" event
+  // just before the client instance carrying it is torn down. Consumed by
+  // the next start() -- manual retry or automatic reconnect alike -- so the
+  // provider continues the SAME conversation instead of starting fresh.
+  const lastResumptionHandleRef = useRef<string | null>(null);
+  const pendingResumptionHandleRef = useRef<string | null>(null);
+  // Deliberately conservative: at most ONE automatic reconnect for the whole
+  // life of this bar, not one per failure. A provider that keeps failing the
+  // same resumed conversation must never be able to loop silently -- a
+  // person tapping Try Again by hand (which re-arms this in retryConversation)
+  // is always a safe, bounded way past that cap, so nothing is actually lost
+  // by keeping the automatic side of this strict.
+  const autoReconnectedRef = useRef(false);
   // Ref indirection lets the idle-timer callback always call the CURRENT
   // stopConversation without needing it in handleTransportEvent's deps
   // (stopConversation is declared further down, after handleTransportEvent).
   const stopConversationRef = useRef<() => void>(() => {});
+  // Same indirection: startConversation is declared even further down, but
+  // handleTransportEvent needs to be able to trigger a reconnect the moment
+  // a resumable session closes.
+  const startConversationRef = useRef<() => void>(() => {});
   const handleTransportEventRef = useRef<(event: OneVoiceSessionEvent) => void>(
     () => {},
   );
@@ -544,6 +570,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           "The confirmation was cancelled because the voice session hit an error.",
         );
         erroredRef.current = true;
+        lastErrorResumableRef.current = event.resumable === true;
         setVoiceStatus("error", event.message, eventOptions);
         return;
       }
@@ -1084,7 +1111,26 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
         voiceLeaseRef.current?.release("transport_closed");
         voiceLeaseRef.current = null;
         activeRuntimeModeRef.current = null;
-        if (erroredRef.current) return;
+        lastResumptionHandleRef.current = event.resumptionHandle ?? null;
+        if (erroredRef.current) {
+          // A resumable failure gets one automatic attempt to pick the same
+          // conversation back up before this becomes something the person
+          // has to notice and act on themselves -- that is the entire point
+          // of the relay bothering to say "resumable" in the first place.
+          if (lastErrorResumableRef.current && !autoReconnectedRef.current) {
+            autoReconnectedRef.current = true;
+            pendingResumptionHandleRef.current = lastResumptionHandleRef.current;
+            erroredRef.current = false;
+            lastErrorResumableRef.current = false;
+            // Not just skipped this time -- startConversation's own guard
+            // treats a still-true conversationActive as "already running"
+            // and would route straight to stopConversation instead of
+            // actually reconnecting.
+            setConversationActive(false);
+            setRetryNonce((current) => current + 1);
+          }
+          return;
+        }
         setConversationActive(false);
       }
     },
@@ -1411,6 +1457,12 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     lastPushedContextRef.current = context
       ? actionableContextKey(context)
       : null;
+    // Consumed once: a resumption handle belongs to the session that just
+    // ended, not to whatever the person starts after it. Reading it here
+    // and clearing it in the same breath means an ordinary, unrelated later
+    // start never accidentally inherits a stale one.
+    const resumptionHandle = pendingResumptionHandleRef.current;
+    pendingResumptionHandleRef.current = null;
     void client.start({
       context,
       accessTier: runtime?.tier ?? null,
@@ -1423,6 +1475,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       runtimeCredentialTransport: runtimeConnection.transport,
       runtimeVertexProject: runtimeConnection.vertexProject,
       runtimeVertexLocation: runtimeConnection.vertexLocation,
+      resumptionHandle,
     });
   }, [
     conversationActive,
@@ -1447,12 +1500,16 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   // would wait forever for exactly that case -- the counter always changes,
   // regardless of whether conversationActive does, so the effect below is
   // guaranteed to run on every retry.
-  const startConversationRef = useRef<() => void>(() => {});
   useEffect(() => {
     startConversationRef.current = () => void startConversation();
   }, [startConversation]);
-  const [retryNonce, setRetryNonce] = useState(0);
+  // A manual retry gets the same continuation token an automatic reconnect
+  // would use, and resets the one-per-session automatic budget: a person
+  // choosing to retry by hand is a fresh decision, not a continuation of
+  // whatever already failed once automatically.
   const retryConversation = useCallback(() => {
+    pendingResumptionHandleRef.current = lastResumptionHandleRef.current;
+    autoReconnectedRef.current = false;
     stopConversation();
     setRetryNonce((current) => current + 1);
   }, [stopConversation]);

--- a/hushh-webapp/lib/services/gemini-live-client.ts
+++ b/hushh-webapp/lib/services/gemini-live-client.ts
@@ -255,6 +255,15 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
   private runtimeCredentialMode: "hushh_managed_vertex" | "byok" =
     "hushh_managed_vertex";
   private runtimeCredential: string | null = null;
+  /**
+   * The provider's own opaque continuation token. Seeded from `start()`'s
+   * options when reconnecting, and replaced every time the provider issues a
+   * fresh one (it rotates through a session, not just once). Sent on the next
+   * `runtime_bootstrap` this instance makes, and handed off in the `closed`
+   * event so a NEW instance -- start() always builds one -- can carry it
+   * forward.
+   */
+  private resumptionHandle: string | null = null;
   private runtimeCredentialTransport: "developer_api" | "vertex_api_key" =
     "developer_api";
   private runtimeVertexProject: string | null = null;
@@ -373,6 +382,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     this.startContext = context;
     this.latestContext = context;
     this.consentToken = options?.consentToken ?? null;
+    this.resumptionHandle = options?.resumptionHandle?.trim() || null;
     this.runtimeCredentialMode =
       options?.runtimeCredentialMode === "byok"
         ? "byok"
@@ -640,6 +650,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
           ...(this.runtimeCredentialMode === "byok" && credential
             ? { runtime_credential: credential }
             : {}),
+          ...(this.resumptionHandle
+            ? { resumption_handle: this.resumptionHandle }
+            : {}),
         }),
       );
       this.runtimeCredential = null;
@@ -709,7 +722,18 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     if (sessionEnded) {
       const reason = readString(sessionEnded.reason) ?? "unknown";
       const resumable = sessionEnded.resumable === true;
-      this.fail(describeSessionEndedReason(reason, resumable));
+      this.fail(describeSessionEndedReason(reason, resumable), resumable);
+      return;
+    }
+
+    // The provider's own continuation token, reissued through the life of a
+    // session (not just once). Kept for the next runtime_bootstrap this
+    // instance sends, and handed off via the `closed` event once this
+    // instance tears down, so a reconnect can carry it into a fresh one.
+    const sessionResumption = readRecord(message.sessionResumption);
+    const resumptionHandle = readString(sessionResumption?.handle);
+    if (resumptionHandle) {
+      this.resumptionHandle = resumptionHandle;
       return;
     }
 
@@ -1391,7 +1415,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     this.handlers.onOutputLevel?.(0);
   }
 
-  private fail(message: string): void {
+  private fail(message: string, resumable?: boolean): void {
     const eventOptions = this.nextEventOptions();
     this.handlers.onError?.(message, eventOptions);
     this.handlers.onEvent?.({
@@ -1401,6 +1425,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       sessionId: eventOptions.sessionId,
       sourceId: eventOptions.sourceId,
       sourceSeq: eventOptions.sourceSeq,
+      ...(resumable !== undefined ? { resumable } : {}),
     });
     this.stop();
   }
@@ -1475,6 +1500,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     this.handlers.onEvent?.({
       type: "closed",
       provider: this.provider,
+      resumptionHandle: this.resumptionHandle,
     });
     this.handlers.onClose?.();
   }

--- a/hushh-webapp/lib/voice/one-voice-transport.ts
+++ b/hushh-webapp/lib/voice/one-voice-transport.ts
@@ -32,10 +32,20 @@ export type OneVoiceSessionEvent =
       sessionId?: string | null;
       sourceId?: string | null;
       sourceSeq?: number | null;
+      /**
+       * Set only when the relay's own sessionEnded frame said so. A close
+       * with no such frame (a raw network drop, a user hangup) carries no
+       * opinion either way -- absence is not "not resumable", it is "unknown".
+       */
+      resumable?: boolean;
     }
   | {
       type: "closed";
       provider: OneVoiceProvider;
+      /** Whatever resumption handle the provider last issued this session, if
+       * any -- captured here since the client instance carrying it is torn
+       * down immediately after, so a reconnect needs it handed off now. */
+      resumptionHandle?: string | null;
     }
   | {
       type: "transcript_final";
@@ -109,6 +119,13 @@ export type OneVoiceTransportStartOptions = {
   runtimeCredentialTransport?: "developer_api" | "vertex_api_key" | null;
   runtimeVertexProject?: string | null;
   runtimeVertexLocation?: string | null;
+  /**
+   * An opaque provider token from a previous socket for this same
+   * conversation. Passing it lets a reconnect continue where the dropped
+   * session left off instead of starting over; omitted, a fresh conversation
+   * starts as it always did.
+   */
+  resumptionHandle?: string | null;
   signal?: AbortSignal;
 };
 


### PR DESCRIPTION
## Summary

Phase 3 of the [Voice Engine 1.x stability roadmap](https://claude.ai/code/artifact/5666f871-d444-406c-93be-761c272cde65) — reconnection. Stacked on #5818 (phase 2), since this needs its resumable-error classification to know when reconnecting is safe to attempt.

The backend has carried session-resumption machinery since before this roadmap started — it issues a continuation handle through the life of a session and accepts one back on `runtime_bootstrap` — but nothing on the client ever stored or returned one, so every drop restarted the conversation from nothing even when the provider was willing to continue it.

The client now stores the latest handle, sends it on the next bootstrap frame, and hands it off in the `closed` event just before the instance carrying it tears down (a fresh client is always created on the next `start()`, so the handoff has to happen there). A resumable session end (the relay's own classification, wired through in phase 2) now triggers one automatic reconnect using that handle, deferred a render so it does not race `startConversation`'s own `conversationActive` guard.

Deliberately capped at **one automatic attempt for the whole life of the bar**, not one per failure — a provider that keeps failing the same resumed conversation must never be able to loop silently. A person tapping Try Again re-arms it; that's judged a safe, bounded way past the cap since it's a fresh decision, not a repeat of what already failed once on its own.

`goAway`'s actual warning-window response (reconnecting *before* the provider cuts the session, not after) remains open — logged since phase 2, acted on not yet.

Addresses #5677

## Test plan

- [x] `tsc --noEmit` and `eslint` clean
- [x] 10 tests passing in `gemini-live-client.test.ts`, including the resumption-handle round trip through a real bootstrap frame (a `FakeWebSocket` swapped in for the global, since neither `connectSocket` nor the handshake is exported)