### PR TITLE
test(voice): cover the setup-timeout watchdog and pre-setup close mapping

### DIFF
--- a/hushh-webapp/__tests__/services/gemini-live-client.test.ts
+++ b/hushh-webapp/__tests__/services/gemini-live-client.test.ts
@@ -257,3 +257,70 @@ describe("GeminiLiveClient session resumption", () => {
     }
   });
 });
+
+describe("GeminiLiveClient connection setup", () => {
+  // Neither describeSocketCloseError nor the setup-timeout watchdog is
+  // exported -- both are reached the same way the real socket reaches them,
+  // through connectSocket's own onclose handler and its armed timer, using
+  // the same FakeWebSocket-swap approach as the resumption tests above.
+
+  class FakeWebSocket {
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onclose: ((event: { code: number; reason: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+    readyState = 0;
+    send = vi.fn();
+    close = vi.fn();
+  }
+
+  it("maps a pre-setup close reason to a specific, actionable message", () => {
+    const onError = vi.fn();
+    const transport = new GeminiLiveClient({ onError });
+    const connection = transport as unknown as {
+      connectSocket: (relayUrl: string) => void;
+      ws: FakeWebSocket | null;
+    };
+    const OriginalWebSocket = global.WebSocket;
+    // @ts-expect-error -- minimal stub standing in for the real WebSocket global
+    global.WebSocket = FakeWebSocket;
+    try {
+      connection.connectSocket("wss://example.test/relay");
+      connection.ws?.onclose?.({ code: 1008, reason: "denied access" });
+    } finally {
+      global.WebSocket = OriginalWebSocket;
+    }
+
+    expect(onError).toHaveBeenCalledWith(
+      "Voice is not enabled for this workspace yet. The Gemini project needs Live API access.",
+      expect.anything(),
+    );
+  });
+
+  it("fails with a diagnosable message if setupComplete never arrives", () => {
+    vi.useFakeTimers();
+    const OriginalWebSocket = global.WebSocket;
+    try {
+      const onError = vi.fn();
+      const transport = new GeminiLiveClient({ onError });
+      const connection = transport as unknown as {
+        connectSocket: (relayUrl: string) => void;
+      };
+      // @ts-expect-error -- minimal stub standing in for the real WebSocket global
+      global.WebSocket = FakeWebSocket;
+
+      connection.connectSocket("wss://example.test/relay");
+      expect(onError).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(20_000);
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining("Voice took too long to start"),
+        expect.anything(),
+      );
+    } finally {
+      global.WebSocket = OriginalWebSocket;
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5b of the [Voice Engine 1.x stability roadmap](https://claude.ai/code/artifact/5666f871-d444-406c-93be-761c272cde65) — remaining client-side test coverage. Stacked on #5819 (phase 3), since this appends to the `session resumption`/`mid-call session frames` describe blocks phase 3 added — its diff only makes sense on top of that scaffolding.

`gemini-live-client.ts` went into this roadmap with 3 tests covering none of its connection-lifecycle logic. This closes the last gap: the setup-timeout watchdog and `describeSocketCloseError`'s wiring, neither of which is exported — both reached the same way the real socket reaches them, through `connectSocket`'s own `onclose` handler and its armed timer, via the same `FakeWebSocket`-swap the resumption tests already established. Brings this file to 12 tests total across the roadmap's phases.

Addresses #5677

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run __tests__/services/gemini-live-client.test.ts` — 12/12 passing