### PR TITLE
fix(location): drop the "Saves once your lock is set." caption

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -406,9 +406,12 @@ describe("SaveLocationModal", () => {
     expect(
       screen.queryByLabelText(/Fill from this address/),
     ).not.toBeInTheDocument();
+    // The lock-deferred caption is gone: the modal now says the same thing
+    // whether or not a lock exists yet.
     expect(
-      screen.getByText(/Saves once your lock is set/i),
-    ).toBeInTheDocument();
+      screen.queryByText(/Saves once your lock is set/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Private to you.")).toBeInTheDocument();
     // The detected address is shown, and the Address box is filled from it.
     expect(
       screen.getByText("Kartavya Path, New Delhi, Delhi 110001, India"),

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -1278,9 +1278,7 @@ export function SaveLocationModal({
               {/* A caption, not a card. It reassures; it is not a control, and
                   the panel it used to sit in gave it a control's weight. */}
               <p className="px-1 text-[13px] leading-[18px] text-muted-foreground">
-                {deferredUntilVault
-                  ? "Saves once your lock is set."
-                  : "Private to you."}
+                Private to you.
               </p>
             </div>
 


### PR DESCRIPTION
Removes the caption under the address fields when no lock exists yet:

> ~~Saves once your lock is set.~~

It now reads **"Private to you."** in both states, instead of switching to a deferral notice.

`deferredUntilVault` still drives `autoComplete` on the three address inputs, so the prop stays and nothing is orphaned.

## One consequence, recorded rather than discovered later

That sentence was **the only thing on this screen** saying a save would not take effect yet.

- `deferredUntilVault` is `!vaultKey || !vaultOwnerToken`
- `canSave` does **not** include the vault — so someone without a lock can still tap **Save**
- the write defers, and now says so nowhere
- `saveBlockedReason` in the footer covers the *category* and *address* cases only

So this is a deliberate trade: a quieter screen, and a save whose deferral is silent. Flagging it because the next person to touch this modal will otherwise have to re-derive why the branch disappeared.

If the silence turns out to matter, the cheaper fix is probably a line in the footer next to `saveBlockedReason` at the moment of the tap, rather than a permanent caption — the same shape as the setup-hub toast in #5768.

## Verification

- **61 tests pass** in `save-location-modal.test.tsx`.
- The test that asserted the caption now asserts its **absence**, so the removal is pinned rather than merely done.
- No references to the string remain anywhere except that negative assertion.
- ESLint clean.



Closes #5826
