### PR TITLE
fix(location): ask the check-in question at a moment its answer can reach

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -313,7 +313,7 @@ describe("OneLocationOnboardingFlow", () => {
           .getByTestId("location-use-case-checkin")
           .querySelectorAll("[data-one-feature-title-line]"),
       ).map((line) => line.textContent),
-    ).toEqual(["Stuck in the", "check-in line?"]);
+    ).toEqual(["Dreading the", "check-in queue?"]);
     expect(
       Array.from(
         screen
@@ -335,7 +335,7 @@ describe("OneLocationOnboardingFlow", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: "Stuck in the check-in line?",
+        name: "Dreading the check-in queue?",
       }),
     ).toBeTruthy();
     expect(

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -725,7 +725,7 @@ function CheckInFeatureCard() {
           Check in
         </span>
         <TwoLineFeatureTitle
-          lines={["Stuck in the", "check-in line?"]}
+          lines={["Dreading the", "check-in queue?"]}
           className="text-[19px]"
         />
         <p

--- a/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
@@ -84,7 +84,7 @@ const CARD = `
          line once the fixture stopped using the machine's fallback font and
          started using the InterVariable the product ships. That reported a 22px
          overlap with the artwork at every width, on a card that is fine. -->
-    <div class="text-[19px] font-bold leading-[1.13] tracking-[-0.015em]" role="heading" aria-level="2" data-one-feature-title><span class="block whitespace-nowrap" data-one-feature-title-line>Stuck in the</span><span class="block whitespace-nowrap" data-one-feature-title-line>check-in line?</span></div>
+    <div class="text-[19px] font-bold leading-[1.13] tracking-[-0.015em]" role="heading" aria-level="2" data-one-feature-title><span class="block whitespace-nowrap" data-one-feature-title-line>Dreading the</span><span class="block whitespace-nowrap" data-one-feature-title-line>check-in queue?</span></div>
     <p class="text-[14px] leading-[1.4] text-[#747b86]" data-one-feature-body>Check in early, pick up your key, and skip the front desk.</p>
   </div>
   <div class="absolute inset-x-0 bottom-0 h-[52%]" data-one-use-case-art aria-hidden="true">


### PR DESCRIPTION
> ~~Stuck in the~~
> ~~check-in line?~~

becomes

> **Dreading the**
> **check-in queue?**

## The problem was tense, not wording

All three use-case cards run *problem-as-question → solution*. Two of them resolve in the moment they open:

| Question | Answer | Same moment? |
|---|---|---|
| Can't explain where you are? | Share your live location in one tap | ✅ |
| Need help but can't talk? | Send an SMS in seconds | ✅ |
| **Stuck in the check-in line?** | **Check in *early*, skip the front desk** | ❌ |

If you're already stuck in the line, checking in early is no longer available to you. The question named a predicament its own answer cannot reach.

**"Dreading"** moves the reader from *inside* the queue to *anticipating* it — which is exactly when checking in early is still an option.

It also drops one of **three** "check in"s in twelve words: the pill says *Check in*, the title said *check-in line*, the body says *Check in early*. Neither sibling card repeats its pill word in its title.

## Three places name this heading, and all three move together

1. The unit test's two-line array
2. Its accessible-name assertion — `TwoLineFeatureTitle` builds `aria-label` by joining the lines, so the accessible name changes with the copy
3. **The e2e layout fixture** — `one-location-checkin-card.layout.spec.ts` hardcodes this markup and measures the title box against the artwork for overlap. A stale fixture there would keep measuring copy that no longer ships, which is worse than a failing test.

## Verification

- 54 tests pass in `one-location-onboarding-flow.test.tsx`
- ESLint clean
- No references to the old string remain anywhere

The layout spec runs in CI (it's in `test:layout-contracts`); the new line is one character longer, so that job is the real check on whether the title still clears the artwork.

Closes #5828
