### PR TITLE
fix(location): a dead public link stops calling itself a request link

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -6311,7 +6311,7 @@ class OneLocationAgentService:
         if not invite:
             raise OneLocationAgentError(
                 "LOCATION_PUBLIC_INVITE_CREATE_FAILED",
-                "Could not create the public request link.",
+                "Could not create the live location link.",
                 status_code=500,
             )
         self._insert_event(
@@ -6422,11 +6422,21 @@ class OneLocationAgentService:
         return {"invite": invite}
 
     def _public_invite_row_for_token(self, *, public_token: str) -> dict[str, Any]:
+        """The live row behind a public token, or a refusal the recipient can read.
+
+        Both messages below are rendered verbatim on the recipient's page --
+        `page-client.tsx` takes `loadError.message` straight into the headline --
+        so they are product copy, not internal detail. They said "request link"
+        until the page moved to /view, which left the one screen a person sees
+        when their link has run out describing it as something that asks them
+        for a location rather than shows them one.
+        """
+
         normalized_token = str(public_token or "").strip()
         if len(normalized_token) < 16:
             raise OneLocationAgentError(
                 "LOCATION_PUBLIC_INVITE_INVALID",
-                "This request link is invalid.",
+                "This live location link is invalid.",
                 status_code=404,
             )
         row = self._execute_one(
@@ -6442,7 +6452,7 @@ class OneLocationAgentService:
         if not row or str(row.get("status") or "") != "active":
             raise OneLocationAgentError(
                 "LOCATION_PUBLIC_INVITE_NOT_ACTIVE",
-                "This request link is no longer active.",
+                "This live location link is no longer active.",
                 status_code=410 if row else 404,
             )
         return row

--- a/hushh-webapp/__tests__/app/one/location/public-location-view-page.test.tsx
+++ b/hushh-webapp/__tests__/app/one/location/public-location-view-page.test.tsx
@@ -213,7 +213,7 @@ describe("PublicLocationViewPageClient", () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mocks.resolvePublicInvite.mockResolvedValueOnce(invitePayload(3_000));
     mocks.resolvePublicInvite.mockRejectedValue(
-      new Error("This request link is no longer active."),
+      new Error("This live location link is no longer active."),
     );
 
     render(<PublicLocationViewPageClient />);


### PR DESCRIPTION
Follow-up to #5830, found on UAT against the real 410.

`app/one/location/view/[token]/page-client.tsx` takes `loadError.message` straight into the headline, so these strings are product copy on the recipient's screen, not internal detail:

| | before | after |
|---|---|---|
| token too short | "This **request** link is invalid." | "This **live location** link is invalid." |
| expired / revoked | "This **request** link is no longer active." | "This **live location** link is no longer active." |
| create failed | "Could not create the public **request** link." | "Could not create the **live location** link." |

The second is the one that matters: it is the entire headline a person reads when the link they were sent has run out — and after #5830 moved the page to `/view`, it described the link as something that asks them for a location rather than something that shows them one.

The submission-limit message keeps its wording — that path really is the request-only flow.

Verified on UAT before the change:
```
$ curl https://api.uat.hushh.ai/api/one/location/public-invites/<expired-token>
HTTP 410 {"code":"LOCATION_PUBLIC_INVITE_NOT_ACTIVE","message":"This request link is no longer active."}
```

170 pytest + the 12 view-page/redirect vitest cases pass; the vitest fixture that stubs this rejection moved with it.
