### PR TITLE
feat(voice): add a "what can I say" examples page, and log 1.3's changes

### DIFF
--- a/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
+++ b/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
@@ -4146,6 +4146,49 @@
       "native_surface_id": "native-route-profile"
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/examples",
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.examples",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.examples",
+        "purpose": "A read-only list of example phrases for what voice can do. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -3236,6 +3236,29 @@
       },
       "implementation_override": null,
       "lifecycle": "canonical",
+      "native_surface_id": null,
+      "page_file": "app/one/location/view/[token]/page.tsx",
+      "pathname": "/one/location/view/[token]",
+      "route_mode": "hidden",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.one.location.view.token"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
       "native_surface_id": "native-route-one-marketplace",
       "page_file": "app/one/marketplace/page.tsx",
       "pathname": "/one/marketplace",
@@ -5010,15 +5033,15 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "b65055314d010f24f216ab0b9bec38d01a3b2efb740a395b5aa3fa7fea03aaed",
+    "action_gateway": "dedae2806a405c9270f5bac388333421aa77b6021afa4914f1bc685e471f3101",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
-    "cache_manifest": "f2a52a778e3b424eccdc370fe55562d0ab1a8e10c82b245a27f32a80fada4b0e",
+    "cache_manifest": "21f651c3261477cb5cd678c08750179c3130166fbd614a7e130ed9649f4f87df",
     "data_plane": "3b2f555c7835a04a7802b93e72df0014b6e5fbdbcae986e9d3cd019e4aa64846",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "e6e3e5388d1f1660d0f72c295fceb091116bbf66944f00b85454fa7d2c76d768",
-    "route_index": "7a1a38bf3632abad1d4dc7ec7876a46744b0924fc9e3a742e36608ac7dd382b1",
-    "route_layout": "e2e74fa8d905b351451abb4ed1eae5dfc5c5c461a6067fdca97f5c90fd7dff98",
-    "surface_map": "ff1183f8a363c6aef21a19f1a13f55ead6bc149633a25cfc433e9ec9db43ef0d",
+    "route_index": "419ef434ac4338c4711a4ce6d6182427b1390072602dfdb22571d29cd4909a1e",
+    "route_layout": "fc199760c1dc52fab1d25b37da324fb10ac9e2b1c1d4130ff5798f8c8fffac05",
+    "surface_map": "511b4cef2b6d1c29eaa3899a7e24f0ed4e469858666f1fa668847afd5a3f0bbd",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
@@ -5030,7 +5053,7 @@
     "decision_required": 2,
     "in_process_specialists": 3,
     "one_specialist_tools": 5,
-    "physical_routes": 130,
+    "physical_routes": 131,
     "semantic_routes": 14,
     "table_families": 51
   }

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -3236,29 +3236,6 @@
       },
       "implementation_override": null,
       "lifecycle": "canonical",
-      "native_surface_id": null,
-      "page_file": "app/one/location/view/[token]/page.tsx",
-      "pathname": "/one/location/view/[token]",
-      "route_mode": "hidden",
-      "semantic_routes": [],
-      "voice": {
-        "action_ids": [],
-        "delegate_agent_ids": [],
-        "playbook_id": "route.one.location.view.token"
-      }
-    },
-    {
-      "alias": null,
-      "api_dependencies": [],
-      "cache": {
-        "policy": "memory-only",
-        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
-        "resource_classes": [
-          "unknown"
-        ]
-      },
-      "implementation_override": null,
-      "lifecycle": "canonical",
       "native_surface_id": "native-route-one-marketplace",
       "page_file": "app/one/marketplace/page.tsx",
       "pathname": "/one/marketplace",
@@ -3835,6 +3812,29 @@
         "action_ids": [],
         "delegate_agent_ids": [],
         "playbook_id": "route.profile.preferences.voice.changelog"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": null,
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "pathname": "/one/profile/preferences/voice/examples",
+      "route_mode": "standard",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.profile.preferences.voice.examples"
       }
     },
     {
@@ -5010,15 +5010,15 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "dedae2806a405c9270f5bac388333421aa77b6021afa4914f1bc685e471f3101",
+    "action_gateway": "b65055314d010f24f216ab0b9bec38d01a3b2efb740a395b5aa3fa7fea03aaed",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
-    "cache_manifest": "6574c987287a351b9a73c00886025df524faea9ec7cb34cc06b78236918d7aba",
+    "cache_manifest": "f2a52a778e3b424eccdc370fe55562d0ab1a8e10c82b245a27f32a80fada4b0e",
     "data_plane": "3b2f555c7835a04a7802b93e72df0014b6e5fbdbcae986e9d3cd019e4aa64846",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "e6e3e5388d1f1660d0f72c295fceb091116bbf66944f00b85454fa7d2c76d768",
-    "route_index": "7730a994507693cfda989d5f5de1352165a0a4995d30069d2afc15450cdb5f5a",
-    "route_layout": "140100aa318bb8252f73f0617d87551f3acc9fdbcf141235726ec5ba6e8b2075",
-    "surface_map": "01e971bf5b0dae1e8552a94b3abf1b69cde6a64db852f6491975f694a6319c1b",
+    "route_index": "7a1a38bf3632abad1d4dc7ec7876a46744b0924fc9e3a742e36608ac7dd382b1",
+    "route_layout": "e2e74fa8d905b351451abb4ed1eae5dfc5c5c461a6067fdca97f5c90fd7dff98",
+    "surface_map": "ff1183f8a363c6aef21a19f1a13f55ead6bc149633a25cfc433e9ec9db43ef0d",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -4146,6 +4146,49 @@
       "native_surface_id": "native-route-profile"
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/examples",
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.examples",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.examples",
+        "purpose": "A read-only list of example phrases for what voice can do. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/__tests__/components/voice-examples-page.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-examples-page.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VoiceExamplesPage } from "@/components/profile/voice-examples-page";
+import { VOICE_AGENT_EXAMPLE_GROUPS } from "@/lib/agent/voice-agent-examples";
+
+describe("VoiceExamplesPage", () => {
+  it("renders every example group and phrase", () => {
+    render(<VoiceExamplesPage />);
+
+    for (const group of VOICE_AGENT_EXAMPLE_GROUPS) {
+      expect(screen.getByText(group.label)).toBeInTheDocument();
+      for (const example of group.examples) {
+        expect(
+          screen.getByText(`“${example.phrase}”`),
+        ).toBeInTheDocument();
+      }
+    }
+  });
+
+  it("has no dead phrases -- every example maps to a real domain group", () => {
+    const keys = VOICE_AGENT_EXAMPLE_GROUPS.map((group) => group.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 describe("VoicePreferencesPanel", () => {
   it("shows the One header with the current engine version", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     expect(screen.getByRole("heading", { name: "One" })).toBeInTheDocument();
@@ -30,7 +30,7 @@ describe("VoicePreferencesPanel", () => {
 
   it("opens with voice on and every enforceable domain allowed, matching today's behavior", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     expect(screen.getByRole("switch", { name: "Voice control" })).toBeChecked();
@@ -41,7 +41,7 @@ describe("VoicePreferencesPanel", () => {
 
   it("Finance and Calendar show as coming soon, not a switch", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     expect(screen.queryByRole("switch", { name: "Finance" })).toBeNull();
@@ -51,7 +51,7 @@ describe("VoicePreferencesPanel", () => {
 
   it("turning off a domain persists to voice preferences", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     fireEvent.click(screen.getByRole("switch", { name: "Location" }));
@@ -61,7 +61,7 @@ describe("VoicePreferencesPanel", () => {
 
   it("turning off the master toggle disables the domain and safety switches", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     fireEvent.click(screen.getByRole("switch", { name: "Voice control" }));
@@ -78,7 +78,7 @@ describe("VoicePreferencesPanel", () => {
 
   it("walk-through mode defaults on and persists when turned off", () => {
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
     const toggle = screen.getByRole("switch", { name: "Walk-through mode" });
@@ -93,7 +93,7 @@ describe("VoicePreferencesPanel", () => {
   it("changelog shows a preview and \"See all updates\" opens the dedicated changelog page", () => {
     const onOpenChangelog = vi.fn();
     render(
-      <VoicePreferencesPanel userId={userId} onOpenChangelog={onOpenChangelog} />,
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={onOpenChangelog} onOpenExamples={() => {}} />,
     );
 
     expect(screen.getByText("What's new")).toBeInTheDocument();
@@ -103,5 +103,20 @@ describe("VoicePreferencesPanel", () => {
     fireEvent.click(seeAll);
 
     expect(onOpenChangelog).toHaveBeenCalledTimes(1);
+  });
+
+  it("\"What can I say\" opens the examples page", () => {
+    const onOpenExamples = vi.fn();
+    render(
+      <VoicePreferencesPanel
+        userId={userId}
+        onOpenChangelog={() => {}}
+        onOpenExamples={onOpenExamples}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /What can I say/ }));
+
+    expect(onOpenExamples).toHaveBeenCalledTimes(1);
   });
 });

--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -123,6 +123,9 @@ describe("observability route map", () => {
     expect(resolveRouteId("/one/profile/preferences/voice/changelog")).toBe(
       "profile_preferences_voice_changelog",
     );
+    expect(resolveRouteId("/one/profile/preferences/voice/examples")).toBe(
+      "profile_preferences_voice_examples",
+    );
     expect(resolveRouteId("/portfolio/shared")).toBe("portfolio_shared");
     expect(resolveRouteId("/ria/clients")).toBe("ria_clients");
     expect(resolveRouteId("/ria/clients/user_123")).toBe("ria_workspace");

--- a/hushh-webapp/app/one/profile/preferences/voice/examples/page.tsx
+++ b/hushh-webapp/app/one/profile/preferences/voice/examples/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/profile/profile-workspace-page";

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -71,6 +71,7 @@ import { GeminiLogo } from "@/components/brand/gemini-logo";
 import { GeminiRuntimeSettingsCard } from "@/components/connections/gemini-runtime-settings-card";
 import { VoicePreferencesPanel } from "@/components/profile/voice-preferences-panel";
 import { VoiceChangelogPage } from "@/components/profile/voice-changelog-page";
+import { VoiceExamplesPage } from "@/components/profile/voice-examples-page";
 import { ConnectedSystemsPanel } from "@/components/profile/connected-systems-panel";
 import { ThemeToggleLean } from "@/components/theme-toggle";
 import {
@@ -3919,7 +3920,11 @@ function ProfilePageContent() {
           />
         ),
       });
-    } else if (activeDetail === "voice" || activeDetail === "voice-changelog") {
+    } else if (
+      activeDetail === "voice" ||
+      activeDetail === "voice-changelog" ||
+      activeDetail === "voice-examples"
+    ) {
       profileStackEntries.push({
         key: "detail:voice",
         title: "Voice",
@@ -3930,6 +3935,9 @@ function ProfilePageContent() {
             onOpenChangelog={() =>
               updateProfileView({ detail: "voice-changelog" }, "push")
             }
+            onOpenExamples={() =>
+              updateProfileView({ detail: "voice-examples" }, "push")
+            }
           />
         ),
       });
@@ -3939,6 +3947,13 @@ function ProfilePageContent() {
           title: "What's new",
           description: "Voice engine updates and fixes.",
           content: <VoiceChangelogPage />,
+        });
+      } else if (activeDetail === "voice-examples") {
+        profileStackEntries.push({
+          key: "detail:voice-examples",
+          title: "What can I say",
+          description: "Examples for every part of the app.",
+          content: <VoiceExamplesPage />,
         });
       }
     }

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,16 +10,16 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 130,
-    "physical_page_count": 130,
-    "route_contract_count": 130,
-    "surface_map_count": 130,
+    "total_screens": 131,
+    "physical_page_count": 131,
+    "route_contract_count": 131,
+    "surface_map_count": 131,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 44,
       "vault-backed": 47,
-      "hidden flow": 15,
+      "hidden flow": 16,
       "auth/pre-vault": 6,
       "RIA/provider": 9,
       "PKM-secure": 6
@@ -2795,6 +2795,51 @@
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/one/location/request/[token]",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
+      "route": "/one/location/view/[token]",
+      "page_file": "app/one/location/view/[token]/page.tsx",
+      "route_contract_mode": "hidden",
+      "screen_class": "hidden flow",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/one/location/view/[token]",
       "surface_map_present": true,
       "route_contract_present": true,
       "evidence": {
@@ -5810,5 +5855,5 @@
       ]
     }
   ],
-  "content_sha256": "c34e4c1741f7a75b7f7a9287c3cbc7f29d7224a3301df7e3f45423365f9195d8"
+  "content_sha256": "d6e5aaeabf6d594813c5a21d0010dc7691a8642ea8ed84c7110f9d71951e4b3d"
 }

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -11,15 +11,15 @@
   },
   "summary": {
     "total_screens": 130,
-    "physical_page_count": 129,
+    "physical_page_count": 130,
     "route_contract_count": 130,
     "surface_map_count": 130,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 44,
-      "vault-backed": 46,
-      "hidden flow": 16,
+      "vault-backed": 47,
+      "hidden flow": 15,
       "auth/pre-vault": 6,
       "RIA/provider": 9,
       "PKM-secure": 6
@@ -2815,51 +2815,6 @@
       ]
     },
     {
-      "route": "/one/location/view/[token]",
-      "page_file": "app/one/location/view/[token]/page.tsx",
-      "route_contract_mode": "hidden",
-      "screen_class": "hidden flow",
-      "cache_policy": "memory-only",
-      "cache_keys": [],
-      "resource_classes": [
-        "unknown"
-      ],
-      "sensitivity_class": "app-metadata",
-      "ttl_class": "CACHE_TTL.MEDIUM",
-      "warm_source": "Route-local resource loader",
-      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
-      "mutation_invalidator": "CacheSyncService user/session invalidation",
-      "best_available_ux_path": [
-        "fresh memory",
-        "cold loader"
-      ],
-      "readiness_kpis": [
-        "route_readiness_completed",
-        "cache_resource_resolved",
-        "route_refresh_completed"
-      ],
-      "realtime_policy": "not realtime",
-      "reviewer_fixture": "/one/location/view/[token]",
-      "surface_map_present": true,
-      "route_contract_present": true,
-      "evidence": {
-        "cache_service": false,
-        "use_stale_resource": false,
-        "device_cache": false,
-        "secure_cache": false,
-        "cache_sync": false,
-        "resource_wrapper": false,
-        "direct_fetch": false,
-        "api_service": false,
-        "hushh_loader": false,
-        "sse_or_streaming": false,
-        "native_beacon": false
-      },
-      "findings": [
-        "no local cache primitive detected in page/contract source"
-      ]
-    },
-    {
       "route": "/one/marketplace",
       "page_file": "app/one/marketplace/page.tsx",
       "route_contract_mode": "standard",
@@ -3896,6 +3851,51 @@
         "native_beacon": false
       },
       "findings": []
+    },
+    {
+      "route": "/one/profile/preferences/voice/examples",
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "route_contract_mode": "standard",
+      "screen_class": "vault-backed",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/one/profile/preferences/voice/examples",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": true,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": true,
+        "resource_wrapper": true,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "review native route beacon coverage"
+      ]
     },
     {
       "route": "/one/profile/receipts",
@@ -5810,5 +5810,5 @@
       ]
     }
   ],
-  "content_sha256": "d13f52caaad364b826cbbc2978576a2cca2e5bcfe4fc36da38a0743b6a7f49da"
+  "content_sha256": "c34e4c1741f7a75b7f7a9287c3cbc7f29d7224a3301df7e3f45423365f9195d8"
 }

--- a/hushh-webapp/components/profile/voice-examples-page.tsx
+++ b/hushh-webapp/components/profile/voice-examples-page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { VOICE_AGENT_EXAMPLE_GROUPS } from "@/lib/agent/voice-agent-examples";
+
+export function VoiceExamplesPage() {
+  return (
+    <div className="space-y-4">
+      <p className="px-1 text-sm text-muted-foreground">
+        Tap the mic and say it in your own words -- these are just a starting point.
+      </p>
+      {VOICE_AGENT_EXAMPLE_GROUPS.map((group) => (
+        <SettingsGroup key={group.key} title={group.label}>
+          {group.examples.map((example) => (
+            <SettingsRow
+              key={example.phrase}
+              title={`“${example.phrase}”`}
+              description={example.result}
+            />
+          ))}
+        </SettingsGroup>
+      ))}
+      <p className="px-1 text-sm text-muted-foreground">
+        Finance and Calendar are coming to voice soon.
+      </p>
+    </div>
+  );
+}

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -70,9 +70,11 @@ function VoiceChangelog({ onOpenChangelog }: { onOpenChangelog: () => void }) {
 export function VoicePreferencesPanel({
   userId,
   onOpenChangelog,
+  onOpenExamples,
 }: {
   userId: string | null;
   onOpenChangelog: () => void;
+  onOpenExamples: () => void;
 }) {
   const [state, setState] = useState<OneVoicePreferencesState>(() =>
     readVoicePreferences(userId),
@@ -91,6 +93,14 @@ export function VoicePreferencesPanel({
   return (
     <div className="space-y-4">
       <VoiceHeader />
+      <SettingsGroup>
+        <SettingsRow
+          title="What can I say"
+          description="Examples for every part of the app."
+          chevron
+          onClick={onOpenExamples}
+        />
+      </SettingsGroup>
       <VoiceChangelog onOpenChangelog={onOpenChangelog} />
       <SettingsGroup>
         <SettingsRow

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -4146,6 +4146,49 @@
       "native_surface_id": "native-route-profile"
     },
     {
+      "route_pattern": "/one/profile/preferences/voice/examples",
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.preferences.voice.examples",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.voice.examples",
+        "purpose": "A read-only list of example phrases for what voice can do. Nothing to act on here.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_preferences",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/one/profile/receipts",
       "page_file": "app/one/profile/receipts/page.tsx",
       "route_mode": "redirect",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -615,7 +615,10 @@
           "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
         }
       },
-      "native": null,
+      "native": {
+        "route": "/circle/join",
+        "classification": "excluded-web-only"
+      },
       "shell": {
         "app_page_shell": true,
         "page_header": true,
@@ -4312,7 +4315,7 @@
       "physical_page_exists": true,
       "route_contract": {
         "mode": "hidden",
-        "exemption_reason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell.",
+        "exemption_reason": "Legacy public one-location link path. Forwards to /one/location/view/[token]; kept only so links minted before the rename keep resolving.",
         "shell_verification_file": null,
         "shell_verification_includes": [],
         "interaction_layer_policy": {
@@ -4320,7 +4323,56 @@
         },
         "voice_playbook": {
           "playbook_id": "route.one.location.request.token",
-          "purpose": "Help the person understand and use the request screen through its generated controls.",
+          "purpose": "Forwarding route only: say nothing and let the redirect complete.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": null,
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
+      "route": "/one/location/view/[token]",
+      "page_file": "app/one/location/view/[token]/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Public one-location live-location view is a standalone recipient page outside the signed-in app shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.one.location.view.token",
+          "purpose": "Help the person read the shared live location through its generated controls.",
           "screen": "app",
           "entry_cue": "",
           "proactivity": "ambient",
@@ -8783,5 +8835,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "5d36e4e08a3ad91ec98a46d3c63debd184d0d8e5952cbbc0f538c9e96442623e"
+  "content_sha256": "33acbe225dd23be2f13e015dd74833dc67b6e3edfe3663d70567cc6f7139c36c"
 }

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -615,10 +615,7 @@
           "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
         }
       },
-      "native": {
-        "route": "/circle/join",
-        "classification": "excluded-web-only"
-      },
+      "native": null,
       "shell": {
         "app_page_shell": true,
         "page_header": true,
@@ -4315,7 +4312,7 @@
       "physical_page_exists": true,
       "route_contract": {
         "mode": "hidden",
-        "exemption_reason": "Legacy public one-location link path. Forwards to /one/location/view/[token]; kept only so links minted before the rename keep resolving.",
+        "exemption_reason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell.",
         "shell_verification_file": null,
         "shell_verification_includes": [],
         "interaction_layer_policy": {
@@ -4323,56 +4320,7 @@
         },
         "voice_playbook": {
           "playbook_id": "route.one.location.request.token",
-          "purpose": "Forwarding route only: say nothing and let the redirect complete.",
-          "screen": "app",
-          "entry_cue": "",
-          "proactivity": "ambient",
-          "primary_action_id": null,
-          "happy_path_action_ids": [],
-          "required_inputs": [],
-          "recoveries": {
-            "blocked": "Explain the current guard and retain the goal.",
-            "cancelled": "Respect the cancellation and retain a safe next step.",
-            "failed": "Acknowledge the failure without claiming completion.",
-            "timeout": "Retain the goal and offer one safe retry.",
-            "callback_error": "Return to the verified callback recovery path without claiming success.",
-            "route_mismatch": "Use the verified current route and its generated actions only."
-          },
-          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
-          "next_route": null,
-          "return_policy": "navigate",
-          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
-        }
-      },
-      "native": null,
-      "shell": {
-        "app_page_shell": false,
-        "page_header": false,
-        "settings_ui": false,
-        "shared_loader": false,
-        "back_button_pattern": "shared-shell"
-      },
-      "voice_action_contract_file": null,
-      "voice_action_contract_ids": [],
-      "api_dependencies": [],
-      "native_plugin_dependencies": [],
-      "thread_and_consent_contract": null
-    },
-    {
-      "route": "/one/location/view/[token]",
-      "page_file": "app/one/location/view/[token]/page.tsx",
-      "physical_page_exists": true,
-      "route_contract": {
-        "mode": "hidden",
-        "exemption_reason": "Public one-location live-location view is a standalone recipient page outside the signed-in app shell.",
-        "shell_verification_file": null,
-        "shell_verification_includes": [],
-        "interaction_layer_policy": {
-          "allowed_families": []
-        },
-        "voice_playbook": {
-          "playbook_id": "route.one.location.view.token",
-          "purpose": "Help the person read the shared live location through its generated controls.",
+          "purpose": "Help the person understand and use the request screen through its generated controls.",
           "screen": "app",
           "entry_cue": "",
           "proactivity": "ambient",
@@ -5936,6 +5884,61 @@
           "loaded"
         ]
       },
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
+      "route": "/one/profile/preferences/voice/examples",
+      "page_file": "app/one/profile/preferences/voice/examples/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "standard",
+        "exemption_reason": null,
+        "shell_verification_file": "app/profile/profile-workspace-page.tsx",
+        "shell_verification_includes": [
+          "AppPageShell",
+          "AppPageHeaderRegion",
+          "AppPageContentRegion",
+          "PageHeader",
+          "SurfaceStack"
+        ],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.profile.preferences.voice.examples",
+          "purpose": "A read-only list of example phrases for what voice can do. Nothing to act on here.",
+          "screen": "profile_preferences",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": null,
       "shell": {
         "app_page_shell": false,
         "page_header": false,
@@ -8780,5 +8783,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "ff06513c3ce01ad6982e1ef62777aeaffd72ab3dcd9e7ee5841fed6c74d8d5bc"
+  "content_sha256": "5d36e4e08a3ad91ec98a46d3c63debd184d0d8e5952cbbc0f538c9e96442623e"
 }

--- a/hushh-webapp/lib/agent/voice-agent-examples.ts
+++ b/hushh-webapp/lib/agent/voice-agent-examples.ts
@@ -1,0 +1,106 @@
+/**
+ * Generic "what can I say" examples shown in Voice Settings, grouped the
+ * same way as VOICE_ENGINE_DOMAINS so the two screens read as one system.
+ * Every phrase names a real, shipped voice action -- not an aspirational
+ * one -- so update this alongside the action contract it illustrates, the
+ * same discipline as voice-engine-changelog.ts.
+ */
+export type VoiceAgentExample = {
+  phrase: string;
+  result: string;
+};
+
+export type VoiceAgentExampleGroup = {
+  key: string;
+  label: string;
+  examples: readonly VoiceAgentExample[];
+};
+
+export const VOICE_AGENT_EXAMPLE_GROUPS: readonly VoiceAgentExampleGroup[] = [
+  {
+    key: "location",
+    label: "Location",
+    examples: [
+      {
+        phrase: "Share my location with Priya for 2 hours",
+        result: "Shares for the time you say -- never assumed for you.",
+      },
+      {
+        phrase: "Ask Rohan where he is",
+        result: "Sends him a location request.",
+      },
+      {
+        phrase: "Who's sharing their location with me",
+        result: "Opens what's currently shared with you.",
+      },
+      {
+        phrase: "Create a circle called Family",
+        result: "Starts a new circle.",
+      },
+      {
+        phrase: "Stop sharing my location",
+        result: "Pauses every active share.",
+      },
+      {
+        phrase: "Trigger SOS",
+        result: "Opens the emergency SOS screen.",
+      },
+    ],
+  },
+  {
+    key: "connections",
+    label: "Connections",
+    examples: [
+      {
+        phrase: "Send a connection request to Kunal Shah",
+        result: "Finds the closest name match and sends it -- misheard names included.",
+      },
+      {
+        phrase: "Search for advisors near me",
+        result: "Opens Connect's nearby search.",
+      },
+      {
+        phrase: "Remove my connection with Asha Verma",
+        result: "Asks you to confirm, then removes it.",
+      },
+    ],
+  },
+  {
+    key: "email",
+    label: "Email",
+    examples: [
+      {
+        phrase: "Connect my Gmail",
+        result: "Starts the Gmail connection flow.",
+      },
+      {
+        phrase: "Sync my Gmail receipts now",
+        result: "Pulls in the latest receipts.",
+      },
+    ],
+  },
+  {
+    key: "kyc",
+    label: "Identity verification",
+    examples: [
+      {
+        phrase: "What's my verification status",
+        result: "Checks where your request stands.",
+      },
+      {
+        phrase: "Approve the response draft",
+        result: "Approves a drafted KYC response.",
+      },
+    ],
+  },
+  {
+    key: "consent",
+    label: "Consent Center",
+    examples: [
+      {
+        phrase: "Open Consent Center",
+        result: "Shows what you've shared, and with whom.",
+      },
+    ],
+  },
+] as const;

--- a/hushh-webapp/lib/agent/voice-engine-changelog.ts
+++ b/hushh-webapp/lib/agent/voice-engine-changelog.ts
@@ -5,7 +5,7 @@
  * VOICE_ENGINE_VERSION in the same PR, so the version shown in the settings
  * header always matches the changelog under it.
  */
-export const VOICE_ENGINE_VERSION = "1.0";
+export const VOICE_ENGINE_VERSION = "1.3";
 
 export type VoiceEngineChangelogEntry = {
   version: string;
@@ -16,6 +16,27 @@ export type VoiceEngineChangelogEntry = {
 };
 
 export const VOICE_ENGINE_CHANGELOG: readonly VoiceEngineChangelogEntry[] = [
+  {
+    version: "1.3",
+    date: "2026-08-23",
+    title: "A dropped connection reconnects on its own",
+    description:
+      "If the voice session drops in a way it can recover from, One now reconnects once by itself, right where the conversation left off, instead of leaving you talking to a dead microphone.",
+  },
+  {
+    version: "1.3",
+    date: "2026-08-23",
+    title: "Voice now says what went wrong, with a way back",
+    description:
+      "When a voice session breaks, you'll see the actual reason and a Try Again button in one tap -- instead of a status line that quietly stops updating.",
+  },
+  {
+    version: "1.3",
+    date: "2026-08-23",
+    title: "Fixed: voice could cut you off or wait too long to respond",
+    description:
+      "A turn-taking bug could make voice interrupt you mid-sentence or leave a longer-than-usual pause before responding. Fixed at the source.",
+  },
   {
     version: "1.0",
     date: "2026-08-22",

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -2902,6 +2902,42 @@
     }
   },
   {
+    "route": "/one/profile/preferences/voice/examples",
+    "mode": "standard",
+    "shellVerification": {
+      "file": "app/profile/profile-workspace-page.tsx",
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.preferences.voice.examples",
+      "purpose": "A read-only list of example phrases for what voice can do. Nothing to act on here.",
+      "screen": "profile_preferences",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
     "route": "/one/profile/security",
     "mode": "standard",
     "shellVerification": {

--- a/hushh-webapp/lib/navigation/profile-routes.ts
+++ b/hushh-webapp/lib/navigation/profile-routes.ts
@@ -21,6 +21,7 @@ export type ProfileDetail =
   | "device"
   | "voice"
   | "voice-changelog"
+  | "voice-examples"
   | "vault"
   | "session"
   | "gmail-connection"
@@ -100,7 +101,8 @@ export function normalizeProfileDetail(
       detail === "gemini" ||
       detail === "device" ||
       detail === "voice" ||
-      detail === "voice-changelog")
+      detail === "voice-changelog" ||
+      detail === "voice-examples")
   ) {
     return detail;
   }
@@ -220,6 +222,13 @@ export function buildProfileRoute(params?: {
         params?.searchParams,
       );
     }
+    if (detail === "voice-examples") {
+      return appendQuery(
+        ROUTES.PROFILE_PREFERENCES_VOICE_EXAMPLES,
+        {},
+        params?.searchParams,
+      );
+    }
     return appendQuery(ROUTES.PROFILE_PREFERENCES, {}, params?.searchParams);
   }
 
@@ -333,6 +342,9 @@ export function resolveProfileRouteState(
   }
   if (normalizedPath === ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG) {
     return { panel: "preferences", detail: "voice-changelog" };
+  }
+  if (normalizedPath === ROUTES.PROFILE_PREFERENCES_VOICE_EXAMPLES) {
+    return { panel: "preferences", detail: "voice-examples" };
   }
 
   if (normalizedPath === ROUTES.PROFILE_SECURITY) {

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -79,6 +79,8 @@ export const ROUTES = {
   PROFILE_PREFERENCES_VOICE: "/one/profile/preferences/voice",
   PROFILE_PREFERENCES_VOICE_CHANGELOG:
     "/one/profile/preferences/voice/changelog",
+  PROFILE_PREFERENCES_VOICE_EXAMPLES:
+    "/one/profile/preferences/voice/examples",
   PROFILE_SECURITY: "/one/profile/security",
   PROFILE_SECURITY_VAULT: "/one/profile/security/vault",
   PROFILE_SECURITY_SESSION: "/one/profile/security/session",

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -1081,6 +1081,23 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  // Same third-level nesting as the changelog above, for the "what can I
+  // say" examples screen.
+  if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE_EXAMPLES) {
+    const preferencesHref = profilePanelHref("preferences");
+    return {
+      backHref: ROUTES.PROFILE_PREFERENCES_VOICE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: ROUTES.PROFILE },
+        { label: "Preferences", href: preferencesHref },
+        { label: "Voice", href: ROUTES.PROFILE_PREFERENCES_VOICE },
+        { label: "What can I say" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.PROFILE_RECEIPTS) {
     return {
       backHref: ROUTES.GMAIL,

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -28,6 +28,7 @@ export const ROUTE_ID_VALUES = [
   "profile_preferences_device",
   "profile_preferences_voice",
   "profile_preferences_voice_changelog",
+  "profile_preferences_voice_examples",
   "profile_security",
   "profile_security_vault",
   "profile_security_session",
@@ -172,6 +173,8 @@ export function resolveRouteId(rawPathname: string): RouteId {
     return "profile_preferences_voice";
   if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE_CHANGELOG)
     return "profile_preferences_voice_changelog";
+  if (pathname === ROUTES.PROFILE_PREFERENCES_VOICE_EXAMPLES)
+    return "profile_preferences_voice_examples";
   if (pathname === ROUTES.PROFILE_SECURITY) return "profile_security";
   if (pathname === ROUTES.PROFILE_SECURITY_VAULT)
     return "profile_security_vault";


### PR DESCRIPTION
## Summary

Voice Settings had a changelog but no way to just see what's possible without reading version notes. Adds a dedicated **"What can I say"** page, grouped by domain (Location, Connections, Email, Identity verification, Consent Center), listing example phrases grounded in the real, shipped action inventory — not aspirational ones. Wired the same way the existing changelog page already is: a row on the main Voice Settings panel, a stacked profile detail, and its own thin `page.tsx` for deep-linking.

Also bumps `VOICE_ENGINE_VERSION` to "1.3" and logs the three user-facing outcomes of this session's stability roadmap as changelog entries: auto-reconnect, error surfacing with retry, and the turn-taking fix — none of which had been logged yet.

Touches the governed route/action-gateway/topology artifacts (new route: `/one/profile/preferences/voice/examples`), regenerated and verified against current `main`.

Addresses #5677

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched files
- [x] `vitest run` — 23/23 passing across the voice settings + observability suites
- [x] All governed-artifact checks (`verify:voice-gateway`, `verify:surface-map`, `audit:cache-coherence`, runtime topology `--check`) pass