### PR TITLE
feat(voice): add a voice picker to Voice Settings, and default to Leda

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -75,6 +75,7 @@ from hushh_mcp.one_adk.action_tools import _slot_fingerprint
 from hushh_mcp.one_adk.agent_tree import (
     ONE_APP_NAME,
     ONE_LIVE_VOICE_NAME,
+    ONE_LIVE_VOICE_OPTIONS,
     STATE_CONSENT_TOKEN,
     STATE_PENDING_DIRECTIVE,
     STATE_SCREEN,
@@ -255,6 +256,7 @@ async def _receive_runtime_bootstrap(
     str | None,
     str | None,
     str | None,
+    str | None,
 ]:
     """Read the one non-model-visible startup frame.
 
@@ -277,13 +279,29 @@ async def _receive_runtime_bootstrap(
     resumption_handle = str(message.get("resumption_handle") or "").strip()
     if len(resumption_handle) > _RESUMPTION_HANDLE_CAP:
         resumption_handle = ""
+    # A person's Voice Settings pick. Validated against the same curated
+    # allowlist the picker itself offers -- an unrecognized value (a stale
+    # client after the list changes, a tampered frame) falls back to the
+    # deployment default rather than forwarding an arbitrary string into
+    # PrebuiltVoiceConfig.
+    voice_name = str(message.get("voice_name") or "").strip()
+    if voice_name not in ONE_LIVE_VOICE_OPTIONS:
+        voice_name = ""
     mode = message.get("runtime_credential_mode")
     if mode == "hushh_managed_vertex":
         # Never accept a credential in managed mode, even if a buggy client
         # supplied one. This keeps the startup contract unambiguous.
         if message.get("runtime_credential") not in (None, ""):
             raise ValueError("runtime_bootstrap_invalid")
-        return "hushh_managed_vertex", None, "developer_api", None, None, resumption_handle or None
+        return (
+            "hushh_managed_vertex",
+            None,
+            "developer_api",
+            None,
+            None,
+            resumption_handle or None,
+            voice_name or None,
+        )
     if mode != "byok" or not uid:
         raise ValueError("runtime_bootstrap_invalid")
     credential = message.get("runtime_credential")
@@ -300,10 +318,26 @@ async def _receive_runtime_bootstrap(
     if transport == "vertex_api_key":
         if not _VERTEX_PROJECT_RE.fullmatch(project) or not _VERTEX_LOCATION_RE.fullmatch(location):
             raise ValueError("runtime_bootstrap_invalid")
-        return "byok", credential, "vertex_api_key", project, location, resumption_handle or None
+        return (
+            "byok",
+            credential,
+            "vertex_api_key",
+            project,
+            location,
+            resumption_handle or None,
+            voice_name or None,
+        )
     if project or location:
         raise ValueError("runtime_bootstrap_invalid")
-    return "byok", credential, "developer_api", None, None, resumption_handle or None
+    return (
+        "byok",
+        credential,
+        "developer_api",
+        None,
+        None,
+        resumption_handle or None,
+        voice_name or None,
+    )
 
 
 class _InitialGreetingGate:
@@ -452,6 +486,7 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             runtime_vertex_project,
             runtime_vertex_location,
             resumption_handle,
+            voice_name,
         ) = await _receive_runtime_bootstrap(websocket, uid=uid)
         runner = build_one_live_runner(
             runtime_mode=runtime_mode,
@@ -517,11 +552,14 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
         response_modalities=[genai_types.Modality.AUDIO],
         # Pinned explicitly: unset, each live model plays its own default
         # voice, and the two models this relay supports sound audibly
-        # different from each other with nothing set here.
+        # different from each other with nothing set here. A person's Voice
+        # Settings pick (already validated against ONE_LIVE_VOICE_OPTIONS in
+        # _receive_runtime_bootstrap) wins when present; otherwise the
+        # deployment default.
         speech_config=genai_types.SpeechConfig(
             voice_config=genai_types.VoiceConfig(
                 prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(
-                    voice_name=ONE_LIVE_VOICE_NAME
+                    voice_name=voice_name or ONE_LIVE_VOICE_NAME
                 )
             )
         ),

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -161,12 +161,28 @@ _ONE_LIVE_LOCATION = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").stri
 # Neither live model pins a voice by default, so each one's own default voice
 # plays -- and the two differ audibly. Native audio models (both the 3.1
 # preview and the 2.5 GA model above) accept any Gemini TTS prebuilt voice
-# name via speech_config; "Kore" is Google's own flagship example voice
-# across the Live API docs. Public (no underscore prefix, unlike the other
+# name via speech_config. Public (no underscore prefix, unlike the other
 # constants here) because the relay builds RunConfig's speech_config from
 # this directly. Override per-environment with AGENT_ONE_ADK_VOICE_NAME if a
 # different one is wanted.
-ONE_LIVE_VOICE_NAME = (os.getenv("AGENT_ONE_ADK_VOICE_NAME") or "Kore").strip()
+ONE_LIVE_VOICE_NAME = (os.getenv("AGENT_ONE_ADK_VOICE_NAME") or "Leda").strip()
+
+# The picker Voice Settings offers, keyed by the exact Gemini TTS prebuilt
+# voice name the relay will pass straight through to speech_config. Google
+# does not publish a gender per voice -- these are its own one-word tone
+# descriptors, kept here so the relay can reject anything else a tampered or
+# out-of-date client might send rather than forwarding an arbitrary string
+# into PrebuiltVoiceConfig. Deliberately a curated subset of the ~30-voice
+# catalog, not all of it -- a picker with thirty near-indistinguishable
+# options is not a feature.
+ONE_LIVE_VOICE_OPTIONS: dict[str, str] = {
+    "Leda": "Youthful",
+    "Aoede": "Breezy",
+    "Achernar": "Soft",
+    "Sulafat": "Warm",
+    "Kore": "Firm",
+    "Puck": "Upbeat",
+}
 # The Developer API Live contract is intentionally separate from the Vertex
 # contract above. It is disabled by default until an ADK integration rehearsal
 # has verified the selected model's BIDI audio, tool calls and mid-session

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,16 +97,18 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume = await _receive_runtime_bootstrap(
-        _BootstrapSocket(
-            {
-                "type": "runtime_bootstrap",
-                "runtime_credential_mode": "byok",
-                "runtime_credential": "test-key",
-                "runtime_credential_transport": "developer_api",
-            }
-        ),
-        uid="user_1",
+    mode, credential, transport, project, location, _resume, _voice = (
+        await _receive_runtime_bootstrap(
+            _BootstrapSocket(
+                {
+                    "type": "runtime_bootstrap",
+                    "runtime_credential_mode": "byok",
+                    "runtime_credential": "test-key",
+                    "runtime_credential_transport": "developer_api",
+                }
+            ),
+            uid="user_1",
+        )
     )
 
     assert mode == "byok"
@@ -118,18 +120,20 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume = await _receive_runtime_bootstrap(
-        _BootstrapSocket(
-            {
-                "type": "runtime_bootstrap",
-                "runtime_credential_mode": "byok",
-                "runtime_credential": "test-key",
-                "runtime_credential_transport": "vertex_api_key",
-                "runtime_vertex_project": "customer-vertex-project",
-                "runtime_vertex_location": "us-central1",
-            }
-        ),
-        uid="user_1",
+    mode, credential, transport, project, location, _resume, _voice = (
+        await _receive_runtime_bootstrap(
+            _BootstrapSocket(
+                {
+                    "type": "runtime_bootstrap",
+                    "runtime_credential_mode": "byok",
+                    "runtime_credential": "test-key",
+                    "runtime_credential_transport": "vertex_api_key",
+                    "runtime_vertex_project": "customer-vertex-project",
+                    "runtime_vertex_location": "us-central1",
+                }
+            ),
+            uid="user_1",
+        )
     )
 
     assert (mode, credential, transport, project, location) == (
@@ -154,6 +158,38 @@ async def test_runtime_bootstrap_rejects_a_credential_in_managed_mode():
             ),
             uid="user_1",
         )
+
+
+@pytest.mark.asyncio
+async def test_runtime_bootstrap_accepts_an_allowlisted_voice_name():
+    *_rest, voice_name = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "hushh_managed_vertex",
+                "voice_name": "Aoede",
+            }
+        ),
+        uid=None,
+    )
+
+    assert voice_name == "Aoede"
+
+
+@pytest.mark.asyncio
+async def test_runtime_bootstrap_drops_a_voice_name_outside_the_allowlist():
+    *_rest, voice_name = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "hushh_managed_vertex",
+                "voice_name": "not-a-real-voice",
+            }
+        ),
+        uid=None,
+    )
+
+    assert voice_name is None
 
 
 def test_live_context_keeps_only_bounded_redacted_ui_fields():

--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -105,6 +105,31 @@ describe("VoicePreferencesPanel", () => {
     expect(onOpenChangelog).toHaveBeenCalledTimes(1);
   });
 
+  it("voice defaults to Default and persists a pick", () => {
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Voice" }).textContent,
+    ).toContain("Default");
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Voice" }));
+    fireEvent.click(screen.getByRole("option", { name: "Leda — Youthful" }));
+
+    expect(readVoicePreferences(userId).voiceName).toBe("Leda");
+  });
+
+  it("turning off the master toggle disables the voice picker too", () => {
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Voice control" }));
+
+    expect(screen.getByRole("combobox", { name: "Voice" })).toBeDisabled();
+  });
+
   it("\"What can I say\" opens the examples page", () => {
     const onOpenExamples = vi.fn();
     render(

--- a/hushh-webapp/__tests__/lib/voice-persona-options.test.ts
+++ b/hushh-webapp/__tests__/lib/voice-persona-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  VOICE_PERSONA_OPTIONS,
+  isVoicePersonaName,
+} from "@/lib/agent/voice-persona-options";
+
+describe("voice persona options", () => {
+  it("accepts every listed option and rejects anything else", () => {
+    for (const option of VOICE_PERSONA_OPTIONS) {
+      expect(isVoicePersonaName(option.name)).toBe(true);
+    }
+
+    expect(isVoicePersonaName("not-a-real-voice")).toBe(false);
+    expect(isVoicePersonaName(null)).toBe(false);
+    expect(isVoicePersonaName(undefined)).toBe(false);
+    expect(isVoicePersonaName(42)).toBe(false);
+  });
+});

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1555,6 +1555,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       runtimeVertexProject: runtimeConnection.vertexProject,
       runtimeVertexLocation: runtimeConnection.vertexLocation,
       resumptionHandle,
+      voiceName: readVoicePreferences(user?.uid).voiceName,
     });
   }, [
     conversationActive,

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -7,6 +7,13 @@ import { PageSubtitle } from "@/components/app-ui/typography";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   readVoicePreferences,
   subscribeVoicePreferences,
   updateVoicePreferences,
@@ -17,6 +24,10 @@ import {
   VOICE_ENGINE_VERSION,
 } from "@/lib/agent/voice-engine-changelog";
 import { VOICE_ENGINE_DOMAINS } from "@/lib/agent/voice-engine-domains";
+import { VOICE_PERSONA_OPTIONS } from "@/lib/agent/voice-persona-options";
+
+/** Select has no null option, so the default pick gets its own sentinel value. */
+const VOICE_NAME_DEFAULT_VALUE = "__default__";
 
 const CHANGELOG_PREVIEW_COUNT = 2;
 
@@ -115,6 +126,41 @@ export function VoicePreferencesPanel({
               aria-label="Voice control"
             />
           }
+        />
+        <SettingsRow
+          title="Voice"
+          description="Pick who One sounds like."
+          disabled={!state.voiceEnabled}
+          trailing={
+            <Select
+              value={state.voiceName ?? VOICE_NAME_DEFAULT_VALUE}
+              disabled={!state.voiceEnabled}
+              onValueChange={(value) =>
+                set((current) => ({
+                  ...current,
+                  voiceName: value === VOICE_NAME_DEFAULT_VALUE ? null : value,
+                }))
+              }
+            >
+              <SelectTrigger
+                className="w-full sm:w-60 min-w-[11rem]"
+                aria-label="Voice"
+              >
+                <SelectValue placeholder="Default" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={VOICE_NAME_DEFAULT_VALUE}>
+                  Default
+                </SelectItem>
+                {VOICE_PERSONA_OPTIONS.map((option) => (
+                  <SelectItem key={option.name} value={option.name}>
+                    {option.name} — {option.descriptor}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
+          stackTrailingOnMobile
         />
       </SettingsGroup>
       <SettingsGroup title="Safety" description="For actions that already ask to confirm.">

--- a/hushh-webapp/lib/agent/voice-persona-options.ts
+++ b/hushh-webapp/lib/agent/voice-persona-options.ts
@@ -1,0 +1,30 @@
+/**
+ * The voice picker Voice Settings offers, keyed by the exact Gemini TTS
+ * prebuilt voice name sent to the relay. Must mirror
+ * ONE_LIVE_VOICE_OPTIONS in consent-protocol/hushh_mcp/one_adk/agent_tree.py
+ * exactly -- the backend validates against its own copy of this list and
+ * silently falls back to the deployment default for anything else, so a
+ * name added here without a matching backend entry would offer a choice
+ * that quietly does nothing.
+ */
+export type VoicePersonaOption = {
+  name: string;
+  descriptor: string;
+};
+
+export const VOICE_PERSONA_OPTIONS: readonly VoicePersonaOption[] = [
+  { name: "Leda", descriptor: "Youthful" },
+  { name: "Aoede", descriptor: "Breezy" },
+  { name: "Achernar", descriptor: "Soft" },
+  { name: "Sulafat", descriptor: "Warm" },
+  { name: "Kore", descriptor: "Firm" },
+  { name: "Puck", descriptor: "Upbeat" },
+] as const;
+
+export const VOICE_PERSONA_NAMES: ReadonlySet<string> = new Set(
+  VOICE_PERSONA_OPTIONS.map((option) => option.name),
+);
+
+export function isVoicePersonaName(value: unknown): value is string {
+  return typeof value === "string" && VOICE_PERSONA_NAMES.has(value);
+}

--- a/hushh-webapp/lib/agent/voice-preferences.ts
+++ b/hushh-webapp/lib/agent/voice-preferences.ts
@@ -1,3 +1,5 @@
+import { isVoicePersonaName } from "@/lib/agent/voice-persona-options";
+
 /**
  * Per-user, client-side preferences for One's voice/live-agent runtime.
  *
@@ -9,6 +11,10 @@
  * behavior -- voice on, spoken confirmation accepted, nothing domain-scoped
  * -- never to "block everything". A user who has never opened this panel
  * must see the identical voice experience they always have.
+ *
+ * `voiceName` is the one exception to "restriction only": it is a
+ * preference, not a guard, so its default is `null` (deployment default)
+ * rather than a specific name -- picking a persona is opt-in, not opt-out.
  */
 export type OneVoicePreferencesState = {
   /** Per-user override on top of the deployment-wide NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED flag. */
@@ -22,6 +28,13 @@ export type OneVoicePreferencesState = {
   walkthroughMode: boolean;
   /** Domain keys (see voice-engine-domains.ts) the user has turned voice OFF for. */
   disabledDomains: string[];
+  /**
+   * A Gemini TTS prebuilt voice name from voice-persona-options.ts, or null
+   * to use the deployment default. Sent to the relay on connect; the backend
+   * re-validates against its own copy of the allowlist, so an outdated or
+   * tampered value here just falls back silently rather than erroring.
+   */
+  voiceName: string | null;
 };
 
 const PREFERENCES_KEY_PREFIX = "one_voice_preferences_v1:";
@@ -31,6 +44,7 @@ const DEFAULT_STATE: OneVoicePreferencesState = {
   requireTapConfirmation: false,
   walkthroughMode: true,
   disabledDomains: [],
+  voiceName: null,
 };
 
 const runtimeByUser = new Map<string, OneVoicePreferencesState>();
@@ -64,6 +78,7 @@ function sanitizeState(value: unknown): OneVoicePreferencesState {
     // default, not as the implicit "off" every other flag falls back to.
     walkthroughMode: raw.walkthroughMode !== false,
     disabledDomains,
+    voiceName: isVoicePersonaName(raw.voiceName) ? raw.voiceName : null,
   };
 }
 

--- a/hushh-webapp/lib/services/gemini-live-client.ts
+++ b/hushh-webapp/lib/services/gemini-live-client.ts
@@ -264,6 +264,8 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
    * forward.
    */
   private resumptionHandle: string | null = null;
+  /** A Voice Settings persona pick, sent on runtime_bootstrap; null uses the deployment default. */
+  private voiceName: string | null = null;
   private runtimeCredentialTransport: "developer_api" | "vertex_api_key" =
     "developer_api";
   private runtimeVertexProject: string | null = null;
@@ -383,6 +385,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     this.latestContext = context;
     this.consentToken = options?.consentToken ?? null;
     this.resumptionHandle = options?.resumptionHandle?.trim() || null;
+    this.voiceName = options?.voiceName?.trim() || null;
     this.runtimeCredentialMode =
       options?.runtimeCredentialMode === "byok"
         ? "byok"
@@ -653,6 +656,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
           ...(this.resumptionHandle
             ? { resumption_handle: this.resumptionHandle }
             : {}),
+          ...(this.voiceName ? { voice_name: this.voiceName } : {}),
         }),
       );
       this.runtimeCredential = null;

--- a/hushh-webapp/lib/voice/one-voice-transport.ts
+++ b/hushh-webapp/lib/voice/one-voice-transport.ts
@@ -126,6 +126,8 @@ export type OneVoiceTransportStartOptions = {
    * starts as it always did.
    */
   resumptionHandle?: string | null;
+  /** A Gemini TTS prebuilt voice name from voice-persona-options.ts, or null/absent for the deployment default. */
+  voiceName?: string | null;
   signal?: AbortSignal;
 };
 


### PR DESCRIPTION
## Summary

The relay pinned a single voice ("Kore") for everyone, with no per-person choice. Google doesn't gender-label its prebuilt voices, so "Kore" (Google's own descriptor: "Firm") didn't read as the warm, soft voice some people wanted.

Rather than guess at one universal replacement, this adds a small curated picker to Voice Settings — Leda, Aoede, Achernar, Sulafat, Kore, Puck — and changes the deployment-wide fallback default to Leda (Youthful).

The pick is sent once on `runtime_bootstrap` and re-validated backend-side against `ONE_LIVE_VOICE_OPTIONS`, the same allowlist the picker itself offers — an unrecognized or tampered value falls back to the deployment default silently rather than forwarding an arbitrary string into `PrebuiltVoiceConfig`.

Addresses #5677

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched files
- [x] `vitest run` — 21/21 passing (voice-preferences-panel, voice-persona-options, gemini-live-client)
- [x] `ruff check` clean, `pytest tests/test_one_adk_live_protocol.py` — 46/46 passing (2 new: allowlisted voice accepted, out-of-allowlist voice dropped)