### PR TITLE
fix(ui): polish desktop row hover and resolve iOS mobile tap glitches

### DIFF
--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -1983,7 +1983,7 @@ export function OneKycWorkspace({
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="h-11 w-11 shrink-0"
+                            className="h-11 w-11 shrink-0 touch-manipulation transition-transform active:scale-90 hover:bg-transparent active:bg-foreground/5 [@media(hover:hover)]:hover:bg-foreground/5"
                             aria-label="Remove request"
                             // Removing a request only opens the confirm dialog and is
                             // its own action; it must not be blocked by a background

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -454,7 +454,9 @@ export function SettingsRow({
       "transition-[border-color,box-shadow] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0",
   );
   const primaryActionClassName = cn(
-    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    "relative isolate min-w-0 overflow-hidden border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[background-color,border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    "rounded-[inherit] [@media(hover:hover)]:rounded-xl",
+    "[@media(hover:hover)]:hover:bg-foreground/[0.04] active:bg-foreground/[0.065]",
     resolvedDensity === "compact" ? "min-h-[56px]" : "min-h-[60px]",
   );
   const voiceProps = {
@@ -551,7 +553,7 @@ export function SettingsRow({
           aria-hidden
           className={cn(
             "pointer-events-none absolute inset-0 z-[1] bg-transparent transition-[background-color]",
-            "group-hover/settings-row:bg-foreground/[0.04] group-active/settings-row:bg-foreground/[0.065]",
+            "[@media(hover:hover)]:group-hover/settings-row:bg-foreground/[0.04] group-active/settings-row:bg-foreground/[0.065]",
           )}
         />
       ) : null}


### PR DESCRIPTION
## Summary

This PR refines the interaction states for Settings/KYC rows, improving the desktop hover experience while fixing touch-related visual glitches on iOS.

## The Issues

1. **Desktop Hover:** Interactive rows with trailing actions showed a harsh, edge-to-edge rectangular hover background that didn’t match the rounded `SettingsGroup` design.
2. **Mobile Touch Glitch:** Tapping the `Trash2` button or row items on iOS could trigger a sticky `:hover` state, leaving the background visible and making the UI feel laggy.

## Changes Made

* **Desktop Hover:** Added a `rounded-xl` hover style for primary row actions only on pointer devices using `[@media(hover:hover)]`.
* **Touch Optimization:** Added `touch-manipulation` to the trash button to improve tap responsiveness on mobile.
* **Native Touch Feedback:** Removed the sticky mobile hover effect from the trash button and added `active:scale-90` for immediate visual feedback on tap.

## UX Goal

Provide a cleaner, more polished desktop hover experience while keeping touch interactions responsive and consistent with native iOS behavior.
