### PR TITLE
fix(location): restore menu activity counts

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -820,7 +820,10 @@ async function switchLocationTab(
 }
 
 async function openSharePersonStep() {
-  fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
+  fireEvent.click(
+    screen.queryByRole("button", { name: /^Share location$/i }) ??
+      screen.getByRole("button", { name: /^Share more$/i }),
+  );
   expect(
     await screen.findByRole("heading", { name: "Who can see you?" }),
   ).toBeTruthy();
@@ -1214,6 +1217,7 @@ describe("OneLocationAgentPage", () => {
     expect(within(activity).getByText("Active")).toBeTruthy();
     expect(within(activity).getByText("Shared With Me")).toBeTruthy();
     expect(within(activity).getByText("Needs Review")).toBeTruthy();
+    expect(within(activity).getAllByText("0").length).toBeGreaterThanOrEqual(3);
   });
 
   it("keeps Activity rows visually quiet even when counts are non-zero", async () => {
@@ -1284,9 +1288,9 @@ describe("OneLocationAgentPage", () => {
     ).toBeTruthy();
 
     const actions = await screen.findByTestId("one-location-now-actions");
-    expect(actions.className).toContain("space-y-2");
+    expect(actions.className).toContain("space-y-0");
     expect(actions.className).not.toContain("max-w-[282px]");
-    expect(within(actions).getByRole("heading", { name: "Actions" })).toBeTruthy();
+    expect(within(actions).queryByRole("heading", { name: "Actions" })).toBeNull();
     expect(
       within(actions).getByRole("button", { name: "Request location" }),
     ).toBeTruthy();
@@ -1359,7 +1363,7 @@ describe("OneLocationAgentPage", () => {
       name: "Location",
     });
     expect(headerActions.className).toContain("ml-auto");
-    expect(headerActions.className).toContain("items-center");
+    expect(headerActions.className).toContain("items-end");
     expect(headerActions.className).toContain("justify-center");
     // The actions column owns the switch and its compact visible status.
     const status = screen.getByTestId("one-location-header-status");
@@ -1374,8 +1378,9 @@ describe("OneLocationAgentPage", () => {
       "mt-1",
       "w-full",
       "whitespace-nowrap",
-      "text-center",
-      "text-[11px]",
+      "text-right",
+      "text-[12px]",
+      "font-medium",
     );
     expect(status.textContent).toBe("Location off");
     // Still the switch's description wherever it renders.

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -236,7 +236,22 @@ describe("LiveShareStatusCard", () => {
     expect(onChangeDuration).toHaveBeenCalledTimes(1);
 
     const ends = screen.getByText(/^Ends /);
-    expect(change.parentElement).toBe(ends.parentElement);
+    expect(change.closest("div")).toBe(ends.parentElement);
+  });
+
+  it("opens the share composer from the live timer card for another share", () => {
+    const onShareMore = vi.fn();
+    render(
+      <LiveShareStatusCard
+        status={status()}
+        onManage={vi.fn()}
+        onStop={vi.fn()}
+        onShareMore={onShareMore}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Share more" }).click();
+    expect(onShareMore).toHaveBeenCalledTimes(1);
   });
 
   it("hides Change time when there is no single share to change", () => {

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -104,6 +104,7 @@ export function LiveShareStatusCard({
   onStop,
   stopBusy,
   onChangeDuration,
+  onShareMore,
   onEnded,
 }: {
   status: LiveShareStatus;
@@ -121,6 +122,8 @@ export function LiveShareStatusCard({
    * different share to the person watching.
    */
   onChangeDuration?: () => void;
+  /** Opens the existing share composer while a share is already live. */
+  onShareMore?: () => void;
   /** Fired once when the countdown reaches zero, so the page can reconcile. */
   onEnded?: () => void;
 }) {
@@ -275,7 +278,7 @@ export function LiveShareStatusCard({
         </div>
       ) : null}
 
-      {footer || onChangeDuration ? (
+      {footer || onChangeDuration || onShareMore ? (
         <div className={LIVE_SHARE_FOOTER_ROW_CLASSNAME}>
           {footer ? (
             <p
@@ -289,23 +292,42 @@ export function LiveShareStatusCard({
             </p>
           ) : null}
 
-          {onChangeDuration ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onChangeDuration}
-              className={cn(
-                LIVE_SHARE_ACTION_CLASSNAME,
-                "text-[color:var(--app-accent)]",
-              )}
-              data-ui-contract="occlusion-sensitive"
-              data-ui-role="control"
-              data-ui-id="location-live-share-duration"
-              data-testid="one-location-live-share-change-time"
-            >
-              Change time
-            </Button>
-          ) : null}
+          <span className="ml-auto inline-flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+            {onChangeDuration ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onChangeDuration}
+                className={cn(
+                  LIVE_SHARE_ACTION_CLASSNAME,
+                  "text-[color:var(--app-accent)]",
+                )}
+                data-ui-contract="occlusion-sensitive"
+                data-ui-role="control"
+                data-ui-id="location-live-share-duration"
+                data-testid="one-location-live-share-change-time"
+              >
+                Change time
+              </Button>
+            ) : null}
+            {onShareMore ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onShareMore}
+                className={cn(
+                  LIVE_SHARE_ACTION_CLASSNAME,
+                  "text-[color:var(--app-accent)]",
+                )}
+                data-ui-contract="occlusion-sensitive"
+                data-ui-role="control"
+                data-ui-id="location-live-share-more"
+                data-testid="one-location-live-share-more"
+              >
+                Share more
+              </Button>
+            ) : null}
+          </span>
         </div>
       ) : null}
     </section>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -748,7 +748,7 @@ function LocationHeaderStatus({ vm }: { vm: LocationHubViewModel }) {
     <span
       id={LOCATION_HEADER_STATUS_ID}
       data-testid="one-location-header-status"
-      className="mt-1 block w-full whitespace-nowrap text-center text-[11px] font-normal leading-[14px] tracking-[-0.01em] text-[color:var(--app-secondary-label)]"
+      className="mt-1 block w-full whitespace-nowrap text-right text-[12px] font-medium leading-4 tracking-[-0.01em] text-[color:var(--app-secondary-label)]"
     >
       {locationHeaderStatusText(vm)}
     </span>
@@ -772,7 +772,7 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
     <div
       role="group"
       aria-label="Location"
-      className="ml-auto flex h-[58px] w-[72px] shrink-0 flex-col items-center justify-center overflow-visible"
+      className="ml-auto flex h-[58px] w-[104px] shrink-0 flex-col items-end justify-center overflow-visible"
       data-testid="one-location-header-actions"
     >
       <Switch
@@ -1509,6 +1509,7 @@ function NowHub({
               ? vm.onEditLiveShareDurationStart
               : undefined
           }
+          onShareMore={onStartShare}
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
@@ -1530,20 +1531,6 @@ function NowHub({
       ) : null}
       <LocationActionGrid
         items={[
-          ...(vm.liveShare
-            ? [
-                {
-                  title: "Share location",
-                  ariaLabel: "Share location",
-                  icon: <LocationMenuGlyph name="share" size={34} />,
-                  tone: "blue" as const,
-                  onClick: onStartShare,
-                  controlId: "one-location-action-share",
-                  actionId: "location.open_share",
-                  testId: "one-location-share-row",
-                },
-              ]
-            : []),
           {
             title: "Ask for location",
             ariaLabel: "Request location",
@@ -1586,6 +1573,7 @@ function NowHub({
           <LocationMenuListRow
             leading={<LocationMenuListIcon name="active" />}
             title="Active"
+            trailingValue={vm.activeOwnerGrants.length}
             ariaLabel="Active shares"
             onClick={onOpenActiveShares}
             voiceControlId="one-location-action-active-shares"
@@ -1594,6 +1582,7 @@ function NowHub({
           <LocationMenuListRow
             leading={<LocationMenuListIcon name="pin" />}
             title="Shared With Me"
+            trailingValue={vm.receivedGrants.length}
             ariaLabel="Shared with me"
             onClick={onOpenSharedWithMe}
             voiceControlId="one-location-action-shared-with-me"
@@ -1602,6 +1591,7 @@ function NowHub({
           <LocationMenuListRow
             leading={<LocationMenuListIcon name="review" />}
             title="Needs Review"
+            trailingValue={vm.pendingOwnerRequests.length}
             ariaLabel="Needs my review"
             onClick={onOpenNeedsReview}
             voiceControlId="one-location-action-needs-review"
@@ -1670,6 +1660,7 @@ function LocationMenuListGroup({
 function LocationMenuListRow({
   leading,
   title,
+  trailingValue,
   ariaLabel,
   onClick,
   testId,
@@ -1678,6 +1669,7 @@ function LocationMenuListRow({
 }: {
   leading: ReactNode;
   title: string;
+  trailingValue?: number;
   ariaLabel: string;
   onClick: () => void;
   testId?: string;
@@ -1701,10 +1693,17 @@ function LocationMenuListRow({
           {title}
         </span>
       </span>
-      <ChevronRight
-        aria-hidden="true"
-        className="h-5 w-5 shrink-0 text-[#c7c7cc] transition-transform group-active:translate-x-0.5"
-      />
+      <span className="flex shrink-0 items-center gap-2">
+        {typeof trailingValue === "number" ? (
+          <span className="min-w-4 text-right text-[16px] font-normal leading-[21px] tracking-[-0.01em] text-[#8e8e93]">
+            {trailingValue}
+          </span>
+        ) : null}
+        <ChevronRight
+          aria-hidden="true"
+          className="h-5 w-5 shrink-0 text-[#c7c7cc] transition-transform group-active:translate-x-0.5"
+        />
+      </span>
     </button>
   );
 }
@@ -1772,10 +1771,9 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
   return (
     <section
       aria-label="Actions"
-      className="space-y-2"
+      className="space-y-0"
       data-testid="one-location-now-actions"
     >
-      <LocationNowGroupLabel>Actions</LocationNowGroupLabel>
       <div
         data-one-location-action-grid=""
         className="grid w-full grid-cols-2 gap-3 sm:gap-4"


### PR DESCRIPTION
## Summary
- Keep the Location menu change frontend-only.
- Restore Activity row counts from existing Location state.
- Make the header Location status readable and remove the visible Actions label.

## Verification
- cd hushh-webapp && npx eslint components/one-location/redesign/location-redesign-hub.tsx __tests__/components/one-location-agent-page.test.tsx --max-warnings=0
- cd hushh-webapp && npx vitest run __tests__/components/one-location-agent-page.test.tsx --pool=threads --testTimeout=10000