### PR TITLE
fix(contacts): the discovery endpoint stops being an enumeration oracle

### DIFF
--- a/consent-protocol/api/middlewares/rate_limit.py
+++ b/consent-protocol/api/middlewares/rate_limit.py
@@ -166,6 +166,22 @@ class RateLimits:
     # Owners can rotate/revoke a code, but rapid churn is never a normal flow.
     ONE_LOCATION_CIRCLE_MUTATION = "6/minute"  # noqa: S105
 
+    # Contact discovery. This route answers "is the person behind this phone
+    # number on Hushh", a thousand numbers at a time, and it was the only
+    # identity-revealing route in the product carrying no limit at all --
+    # neither its own nor a global one, because SlowAPIMiddleware is never
+    # installed and GLOBAL_PER_IP is referenced nowhere outside its own test.
+    # An authenticated caller could walk the national number space against the
+    # user base at whatever rate their connection allowed.
+    #
+    # Two ceilings, because one number cannot describe the shape of the abuse.
+    # The per-minute bound stops a tight loop; the daily bound stops a patient
+    # one, which is the realistic version of this attack. A person syncing
+    # their address book does it once, and again occasionally after adding
+    # someone -- even a heavy multi-device day does not approach twenty.
+    CONTACT_DISCOVERY_MATCH = "4/minute"  # noqa: S105
+    CONTACT_DISCOVERY_MATCH_DAILY = "20/day"  # noqa: S105
+
     # The owner's own position heartbeat onto their live public link. Unlike
     # every other mutation on this router this one is SUPPOSED to repeat: the
     # web client publishes on a twenty-second heartbeat plus a movement watch

--- a/consent-protocol/api/middlewares/rate_limit.py
+++ b/consent-protocol/api/middlewares/rate_limit.py
@@ -35,18 +35,46 @@ logger = logging.getLogger(__name__)
 
 _HUSHH_TECH_PRODUCT_PREFIX = "/api/v1/products/hushh-tech/"
 
+#: Paths whose 429 reaches a person rather than a machine.
+#:
+#: slowapi's default body is `{"error": "Rate limit exceeded: 4 per 1 minute"}`,
+#: and the web client surfaces whatever string it finds straight into a toast.
+#: That is an acceptable answer for a developer hitting an API and a poor one
+#: for someone who has just pressed "Check more" on their contacts, so these
+#: paths get typed copy instead. Keep this list to routes a human actually
+#: triggers -- everything else is better served by the exact numeric limit.
+_TYPED_RATE_LIMIT_PATHS = (
+    _HUSHH_TECH_PRODUCT_PREFIX,
+    "/api/marketplace/contacts/match",
+)
+
+_TYPED_RATE_LIMIT_MESSAGES = {
+    "/api/marketplace/contacts/match": (
+        "You have checked your contacts a few times just now. Give it a minute and try again."
+    ),
+}
+
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
-    """Keep the product API typed and non-cacheable without changing other routes."""
-    if not request.url.path.startswith(_HUSHH_TECH_PRODUCT_PREFIX):
+    """Keep human-facing 429s typed and non-cacheable without changing other routes."""
+    path = request.url.path
+    if not path.startswith(_TYPED_RATE_LIMIT_PATHS):
         return _rate_limit_exceeded_handler(request, exc)
+    message = next(
+        (text for prefix, text in _TYPED_RATE_LIMIT_MESSAGES.items() if path.startswith(prefix)),
+        "Try again shortly.",
+    )
     response = JSONResponse(
         status_code=429,
         content={
             "detail": {
                 "code": "RATE_LIMITED",
-                "message": "Try again shortly.",
-            }
+                "message": message,
+            },
+            # slowapi's own shape, kept alongside the typed body so a client
+            # that reads `error` (as the marketplace client does) gets the same
+            # sentence rather than the raw limit string.
+            "error": message,
         },
         headers={
             "Cache-Control": "private, no-store",
@@ -175,12 +203,24 @@ class RateLimits:
     # user base at whatever rate their connection allowed.
     #
     # Two ceilings, because one number cannot describe the shape of the abuse.
-    # The per-minute bound stops a tight loop; the daily bound stops a patient
-    # one, which is the realistic version of this attack. A person syncing
-    # their address book does it once, and again occasionally after adding
-    # someone -- even a heavy multi-device day does not approach twenty.
-    CONTACT_DISCOVERY_MATCH = "4/minute"  # noqa: S105
-    CONTACT_DISCOVERY_MATCH_DAILY = "20/day"  # noqa: S105
+    # The per-minute bound stops a tight loop; the daily bound is the one that
+    # stops the patient walk, which is the realistic version of this attack.
+    #
+    # The minute bound is deliberately generous, and 4 was wrong. On the web
+    # the Contact Picker hands back only what the person hand-picked, so
+    # `describeContactSyncOutcome` offers a "Check more" action that re-runs
+    # the whole sync -- the product actively asks a user to press this
+    # repeatedly to cover a large address book ten contacts at a time. At 4 a
+    # minute the fifth press failed, and the refusal came from a limit meant
+    # for an attacker. Twelve leaves a press every five seconds, which is
+    # faster than a human can work the picker.
+    #
+    # Nothing is lost by that: the day bound is the security bound. Twenty
+    # draws of up to a thousand numbers is far more than any real address book
+    # needs across every surface and device, and far less than a walk of the
+    # number space requires.
+    CONTACT_DISCOVERY_MATCH = "12/minute"  # noqa: S105
+    CONTACT_DISCOVERY_MATCH_DAILY = "60/day"  # noqa: S105
 
     # The owner's own position heartbeat onto their live public link. Unlike
     # every other mutation on this router this one is SUPPOSED to repeat: the

--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import RateLimits, limiter
 from hushh_mcp.services.ria_iam_service import (
     IAMSchemaNotReadyError,
     RIAIAMPolicyError,
@@ -163,10 +164,22 @@ async def record_marketplace_investor_action(
 
 
 @router.post("/contacts/match")
+# Two ceilings on one route. See RateLimits.CONTACT_DISCOVERY_MATCH for why a
+# single number cannot express this: the minute bound stops a loop, the day
+# bound stops the patient walk that is the realistic way to enumerate a user
+# base through a discovery endpoint.
+#
+# Keyed per authenticated user by `get_rate_limit_key`, not per IP, which is
+# the bucket that matters here -- the route requires a Firebase identity, so a
+# caller cannot shed the limit by changing address.
+@limiter.limit(RateLimits.CONTACT_DISCOVERY_MATCH_DAILY)
+@limiter.limit(RateLimits.CONTACT_DISCOVERY_MATCH)
 async def match_marketplace_contacts(
+    request: Request,
     payload: MarketplaceContactMatchRequest,
     firebase_uid: str = Depends(require_firebase_auth),
 ):
+    del request
     service = RIAIAMService()
     try:
         items = await service.match_marketplace_contacts(

--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/hushh_mcp/consent/scope_helpers.py
+++ b/consent-protocol/hushh_mcp/consent/scope_helpers.py
@@ -67,6 +67,7 @@ def resolve_scope_to_enum(scope: str) -> ConsentScope:
         "cap.location.live.refer_request": ConsentScope.CAP_LOCATION_LIVE_REFER_REQUEST,
         "cap.pkm.marketplace.view": ConsentScope.CAP_PKM_MARKETPLACE_VIEW,
         "cap.pkm.marketplace.manage": ConsentScope.CAP_PKM_MARKETPLACE_MANAGE,
+        "cap.contact.discovery": ConsentScope.CAP_CONTACT_DISCOVERY,
     }
     if scope.startswith("agent."):
         resolved = _AGENT_SCOPE_MAP.get(scope)
@@ -257,6 +258,15 @@ def get_scope_display_metadata(scope: str) -> dict:
             "label": "Refer Location Request",
             "description": "Allow a recipient to refer another person into an owner approval flow",
             "icon_name": "user-plus",
+            "color_hex": "#0F766E",
+        },
+        "cap.contact.discovery": {
+            "label": "Find People You Know",
+            "description": (
+                "Match your address book against Hussh accounts. "
+                "Phone numbers are hashed on your device and never stored"
+            ),
+            "icon_name": "users",
             "color_hex": "#0F766E",
         },
     }

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -80,6 +80,9 @@ class ConsentScope(str, Enum):
     # a hard gate is a coordinated client change, and it should be one rather
     # than a silent outage.
     CAP_CONTACT_DISCOVERY = "cap.contact.discovery"
+    # Registered in `_STATIC_SCOPE_META` (hushh_mcp/consent/scope_helpers.py) so
+    # the consent surface renders a sentence rather than title-casing the raw
+    # handle into "Cap Contact Discovery".
 
     # ============ MARKETPLACE / PERSONAL INFORMATION AGENT CAPABILITIES ============
     # Capability scopes for the One Personal Information Agent — the marketplace

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -67,6 +67,20 @@ class ConsentScope(str, Enum):
     CAP_LOCATION_NEARBY_DISCOVER = "cap.location.nearby.discover"
     CAP_LOCATION_NEARBY_REVOKE = "cap.location.nearby.revoke"
 
+    # ==================== CONTACT DISCOVERY ====================
+    # Matching an address book against the user directory. Declared here so the
+    # capability has a name the consent surface can show and an audit row can
+    # carry -- until now, the single most identity-revealing query in the
+    # product was the only one with no scope attached to it at all.
+    #
+    # NOT yet enforced on `POST /api/marketplace/contacts/match`. That route
+    # authenticates with a Firebase ID token, and every shipped client -- web,
+    # iOS and Android -- calls it that way, so requiring a consent token here
+    # would break contact sync on all three the moment it deployed. Making this
+    # a hard gate is a coordinated client change, and it should be one rather
+    # than a silent outage.
+    CAP_CONTACT_DISCOVERY = "cap.contact.discovery"
+
     # ============ MARKETPLACE / PERSONAL INFORMATION AGENT CAPABILITIES ============
     # Capability scopes for the One Personal Information Agent — the marketplace
     # chatbot that lets an owner query, publish, and manage their own PKM data

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -9109,7 +9109,18 @@ class RIAIAMService:
                         "kind": kind,
                         "display_name": row["display_name"] or row["identity_display_name"],
                         "headline": row["headline"],
-                        "phone_last4": last4,
+                        # No phone digits, not even four.
+                        #
+                        # The caller derived every digest it sent from its own
+                        # address book, so it already holds the number behind
+                        # each match -- echoing part of it back tells the caller
+                        # nothing it did not have, and costs a real leak the
+                        # moment a response is logged, cached, or rendered into
+                        # a page. Both of those were happening: the marketplace
+                        # deck rendered these four digits into the DOM, and One
+                        # Location stripped them on arrival. A field one client
+                        # has to defend against and another leaks is a field
+                        # that should never have left the server.
                         "profile": profile,
                     }
                 )

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -90,3 +90,13 @@ tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
 tests/test_pool_acquire_is_bounded.py
+
+# Contact discovery.
+#
+# `POST /api/marketplace/contacts/match` answers "is the person behind this
+# phone number on Hushh", a thousand numbers at a time. It shipped with no rate
+# limit of its own and no global one to fall back on, and echoed four digits of
+# each matched person's number back. Neither had a single test, and this
+# manifest is the only pytest invocation in any lane -- so a guard absent from
+# it is decoration.
+tests/test_contact_discovery_hardening.py

--- a/consent-protocol/tests/test_contact_discovery_hardening.py
+++ b/consent-protocol/tests/test_contact_discovery_hardening.py
@@ -52,17 +52,32 @@ class TestContactMatchIsRateLimited:
         assert any("minute" in limit for limit in limits), limits
         assert any("day" in limit for limit in limits), limits
 
-    def test_the_bounds_are_small_enough_to_matter(self):
-        # Syncing an address book is a deliberate act, not a loop. A person
-        # does it once, and occasionally again after adding someone. If these
-        # numbers ever drift up to where a scripted walk is comfortable, the
-        # limit has stopped being a limit.
-        limits = _registered_limits()
-        per_minute = next(limit for limit in limits if "minute" in limit)
-        per_day = next(limit for limit in limits if "day" in limit)
+    def test_the_bounds_leave_room_for_the_loop_the_ui_offers(self):
+        """The minute bound must not refuse a person doing what we told them to.
 
-        assert int(per_minute.split()[0]) <= 10, per_minute
-        assert int(per_day.split()[0]) <= 50, per_day
+        On the web the Contact Picker returns only hand-picked entries, so
+        `describeContactSyncOutcome` offers a "Check more" action that re-runs
+        the whole sync — the product actively asks a user to press this
+        repeatedly to cover a large address book. At four a minute the fifth
+        press failed, and the refusal came from a limit meant for an attacker.
+        """
+
+        limits = _registered_limits()
+        per_minute = int(next(limit for limit in limits if "minute" in limit).split()[0])
+
+        # A press every five seconds is faster than a human works the picker.
+        assert per_minute >= 12, per_minute
+
+    def test_the_day_bound_is_the_one_that_stops_a_walk(self):
+        # Nothing is lost by a generous minute bound: the day bound is the
+        # security bound. It has to stay far below what enumerating a number
+        # space needs, and far above what a real address book does across
+        # every surface and device.
+        limits = _registered_limits()
+        per_day = int(next(limit for limit in limits if "day" in limit).split()[0])
+
+        assert per_day <= 100, per_day
+        assert per_day >= 40, per_day
 
     def test_the_limit_is_keyed_per_user_rather_than_per_address(self):
         # The route requires a Firebase identity, so an IP bucket would be the
@@ -73,6 +88,73 @@ class TestContactMatchIsRateLimited:
         from api.middlewares.rate_limit import get_rate_limit_key
 
         assert limiter._key_func is get_rate_limit_key
+
+
+class TestTheRefusalIsReadableByAPerson:
+    """A 429 on this route reaches a human, not a machine.
+
+    slowapi's default body is `{"error": "Rate limit exceeded: 12 per 1 minute"}`,
+    and the web client puts whatever string it finds straight into a toast. That
+    is a fine answer for a developer holding an API key and a poor one for
+    somebody who just pressed "Check more" on their contacts.
+    """
+
+    def _client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from slowapi.errors import RateLimitExceeded
+
+        from api.middleware import require_firebase_auth
+        from api.middlewares.rate_limit import limiter, rate_limit_exceeded_handler
+        from api.routes import marketplace
+
+        app = FastAPI()
+        app.include_router(marketplace.router)
+        app.state.limiter = limiter
+        app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+        app.dependency_overrides[require_firebase_auth] = lambda: "user_test_429"
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_the_body_says_something_a_person_can_act_on(self, monkeypatch):
+        # Force the limiter on: the pytest harness disables it so route tests
+        # are not throttled by shared buckets, which also means nothing else
+        # ever exercises this path.
+        from api.middlewares.rate_limit import limiter
+
+        monkeypatch.setattr(limiter, "enabled", True)
+        limiter.reset()
+
+        client = self._client()
+        payload = {"phone_lookups": [], "limit": 10, "scope": "one_network"}
+
+        statuses = [
+            client.post("/api/marketplace/contacts/match", json=payload).status_code
+            for _ in range(14)
+        ]
+        assert 429 in statuses, statuses
+
+        refused = client.post("/api/marketplace/contacts/match", json=payload)
+        assert refused.status_code == 429
+        body = refused.json()
+
+        message = body.get("detail", {}).get("message", "")
+        assert "contacts" in message.lower(), body
+        # The limit's own numbers are an implementation detail, and reading
+        # "12 per 1 minute" in a toast is how a person learns we have no copy
+        # for this state.
+        assert "per 1 minute" not in message, body
+        assert body.get("detail", {}).get("code") == "RATE_LIMITED", body
+        # The marketplace client reads `error`, not `detail.message`. Both
+        # carry the same sentence so neither surface falls back to the raw one.
+        assert body.get("error") == message, body
+
+    def test_other_routes_keep_slowapis_own_answer(self, monkeypatch):
+        # The typed body is opt-in per path. Widening it silently would change
+        # the shape every other rate-limited route returns.
+        from api.middlewares.rate_limit import _TYPED_RATE_LIMIT_PATHS
+
+        assert "/api/marketplace/contacts/match" in _TYPED_RATE_LIMIT_PATHS
+        assert not any(path.startswith("/api/one/location") for path in _TYPED_RATE_LIMIT_PATHS)
 
 
 class TestContactMatchLeaksNoPhoneDigits:

--- a/consent-protocol/tests/test_contact_discovery_hardening.py
+++ b/consent-protocol/tests/test_contact_discovery_hardening.py
@@ -1,0 +1,133 @@
+"""Contact discovery: the guards that were missing entirely.
+
+`POST /api/marketplace/contacts/match` answers "is the person behind this phone
+number on Hushh", a thousand numbers at a time. It shipped with no rate limit of
+its own and no global one to fall back on -- `SlowAPIMiddleware` is never
+installed and `RateLimits.GLOBAL_PER_IP` is referenced nowhere outside its own
+test -- so an authenticated caller could walk the national number space against
+the user base at whatever rate their connection allowed. It also echoed four
+digits of each matched person's number back.
+
+Neither of those had a single test. These are those tests.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from api.middlewares.rate_limit import RateLimits, limiter
+from api.routes.marketplace import (
+    MarketplaceContactLookup,
+    MarketplaceContactMatchRequest,
+)
+from hushh_mcp.constants import ConsentScope
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+_ROUTE_KEY = "api.routes.marketplace.match_marketplace_contacts"
+
+
+def _registered_limits() -> list[str]:
+    """The limit strings slowapi actually holds for the match route."""
+    route_limits = getattr(limiter, "_route_limits", {})
+    assert _ROUTE_KEY in route_limits, (
+        "the contact match route carries no rate limit at all -- this is the "
+        "enumeration oracle, not a style preference"
+    )
+    return [str(entry.limit) for entry in route_limits[_ROUTE_KEY]]
+
+
+class TestContactMatchIsRateLimited:
+    def test_the_route_is_bounded_per_minute_and_per_day(self):
+        """One ceiling cannot describe the shape of this abuse.
+
+        A per-minute bound stops a tight loop. It does nothing about the
+        patient walk -- a few requests a minute, all day -- which is the
+        realistic way somebody enumerates a user base through a discovery
+        endpoint. Both bounds have to be present.
+        """
+        limits = _registered_limits()
+
+        assert any("minute" in limit for limit in limits), limits
+        assert any("day" in limit for limit in limits), limits
+
+    def test_the_bounds_are_small_enough_to_matter(self):
+        # Syncing an address book is a deliberate act, not a loop. A person
+        # does it once, and occasionally again after adding someone. If these
+        # numbers ever drift up to where a scripted walk is comfortable, the
+        # limit has stopped being a limit.
+        limits = _registered_limits()
+        per_minute = next(limit for limit in limits if "minute" in limit)
+        per_day = next(limit for limit in limits if "day" in limit)
+
+        assert int(per_minute.split()[0]) <= 10, per_minute
+        assert int(per_day.split()[0]) <= 50, per_day
+
+    def test_the_limit_is_keyed_per_user_rather_than_per_address(self):
+        # The route requires a Firebase identity, so an IP bucket would be the
+        # wrong one -- a caller sheds it by changing address, and a whole
+        # office behind one NAT would share a budget they never spent.
+        source = inspect.getsource(limiter.__class__.__init__)
+        assert "key_func" in source
+        from api.middlewares.rate_limit import get_rate_limit_key
+
+        assert limiter._key_func is get_rate_limit_key
+
+
+class TestContactMatchLeaksNoPhoneDigits:
+    def test_the_match_payload_carries_no_phone_digits(self):
+        """Not even four of them.
+
+        The caller derived every digest it sent from its own address book, so
+        it already holds the number behind each match -- echoing part of it
+        back tells the caller nothing it did not have, and costs a real leak
+        the moment a response is logged, cached, or rendered into a page. Both
+        were happening: the marketplace deck rendered these digits into the
+        DOM while One Location stripped them on arrival.
+        """
+        source = inspect.getsource(RIAIAMService.match_marketplace_contacts)
+
+        # `last4` still appears as a local -- it is the index bucket the SQL
+        # pre-filter needs. What must not appear is a response key carrying it.
+        assert '"phone_last4"' not in source
+        assert "'phone_last4'" not in source
+
+    def test_last4_is_still_used_as_the_bucket_key(self):
+        # The digest decides a match; `last4` only narrows the candidate rows
+        # so the query is index-friendly. Removing the response field must not
+        # have removed the pre-filter with it.
+        source = inspect.getsource(RIAIAMService.match_marketplace_contacts)
+        assert "normalized_lookups" in source
+        assert "last4" in source
+
+
+class TestContactDiscoveryHasAName:
+    def test_the_capability_is_declared(self):
+        # Until this existed, the single most identity-revealing query in the
+        # product was the only one with no scope attached to it -- nothing the
+        # consent surface could show, nothing an audit row could carry.
+        assert ConsentScope.CAP_CONTACT_DISCOVERY.value == "cap.contact.discovery"
+        assert "cap.contact.discovery" in ConsentScope.list()
+
+
+class TestContactMatchRequestBounds:
+    """The payload bounds that were the only guard this route had."""
+
+    def test_a_digest_must_be_a_digest(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            MarketplaceContactLookup(hash="not-a-sha256", last4="1234")
+
+    def test_scope_is_closed(self):
+        from pydantic import ValidationError
+
+        assert MarketplaceContactMatchRequest().scope == "marketplace"
+        assert MarketplaceContactMatchRequest(scope="one_network").scope == "one_network"
+        with pytest.raises(ValidationError):
+            MarketplaceContactMatchRequest(scope="everything")
+
+    def test_the_constants_exist_under_their_documented_names(self):
+        assert RateLimits.CONTACT_DISCOVERY_MATCH
+        assert RateLimits.CONTACT_DISCOVERY_MATCH_DAILY

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -246,6 +246,28 @@ this first release.
 | POST | `/api/one/calendar/proposals` | VAULT_OWNER Bearer | Validate and persist a ten-minute create, reschedule, or cancel proposal; never mutates Google. |
 | POST | `/api/one/calendar/proposals/execute` | VAULT_OWNER Bearer | Execute one reviewed proposal after re-reading its event ETag; stale proposals fail closed. |
 
+### Contact Discovery
+
+Matching an address book against the Hushh user directory. The device normalizes each
+number to E.164 and hashes it; **raw phone numbers and contact names never leave the
+device**, and the server **persists nothing** — the request body is consumed in memory and
+discarded, so a contact who is not a Hushh user leaves no trace.
+
+`last4` is an index bucket, not an answer: it narrows the candidate rows so the query can
+use `idx_actor_identity_cache_phone_last4`, and the full digest is what decides a match.
+Nothing about a matched person's phone number is returned.
+
+Rate limited per authenticated user, on two ceilings — see
+`RateLimits.CONTACT_DISCOVERY_MATCH`. One number cannot describe the abuse: the per-minute
+bound stops a tight loop, the per-day bound stops the patient walk that is the realistic way
+to enumerate a user base through a discovery endpoint.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| POST | `/api/marketplace/contacts/match` | Firebase Bearer | Match up to 1000 `{hash, last4}` lookups against the directory. `scope: "one_network"` matches any phone-verified account that has not turned off contact discoverability (what One Location contact sync needs); `scope: "marketplace"` (the default) keeps the Connect deck's publicly-discoverable-profiles policy. Returns `user_id`, `kind`, `display_name`, `headline`, `profile` — and **no phone digits** |
+| GET | `/api/iam/contact-discoverability` | Firebase Bearer | Whether the signed-in account can be found by someone who has their number |
+| POST | `/api/iam/contact-discoverability` | Firebase Bearer | Turn that on or off. Defaults on — a match discloses nothing beyond confirming a number the requester already had |
+
 ### One Location Agent
 
 One Location Agent is One-owned live-location sharing for trusted people. The

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -248,10 +248,10 @@ this first release.
 
 ### Contact Discovery
 
-Matching an address book against the Hushh user directory. The device normalizes each
+Matching an address book against the Hussh user directory. The device normalizes each
 number to E.164 and hashes it; **raw phone numbers and contact names never leave the
 device**, and the server **persists nothing** — the request body is consumed in memory and
-discarded, so a contact who is not a Hushh user leaves no trace.
+discarded, so a contact who is not a Hussh user leaves no trace.
 
 `last4` is an index bucket, not an answer: it narrows the candidate rows so the query can
 use `idx_actor_identity_cache_phone_last4`, and the full digest is what decides a match.

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -259,8 +259,18 @@ Nothing about a matched person's phone number is returned.
 
 Rate limited per authenticated user, on two ceilings — see
 `RateLimits.CONTACT_DISCOVERY_MATCH`. One number cannot describe the abuse: the per-minute
-bound stops a tight loop, the per-day bound stops the patient walk that is the realistic way
-to enumerate a user base through a discovery endpoint.
+bound stops a tight loop, the per-day bound is the one that stops the patient walk, which is
+the realistic way to enumerate a user base through a discovery endpoint. The minute bound is
+deliberately generous because the web picker returns hand-picked contacts and the product
+offers a "Check more" action that re-runs the sync.
+
+**Both bounds are per worker process, not global.** slowapi falls back to in-process memory
+storage unless `RATE_LIMIT_STORAGE_URI` points at a shared backend. UAT passes that secret;
+production does not, and runs `gunicorn -w 2` on a scale-to-zero Cloud Run service — so in
+production the effective ceiling is the stated number multiplied by however many workers are
+live. That is survivable for a minute bound and materially weakens the day bound. Wiring
+`RATE_LIMIT_STORAGE_URI` into the production backend is what makes the number above the real
+one; until then, read it as a per-worker bound.
 
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |

--- a/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
@@ -110,6 +110,52 @@ describe("one location contact signals", () => {
     expect(JSON.stringify(result)).not.toContain("0101");
   });
 
+  it("strips phone-shaped fields wherever they sit in the payload", async () => {
+    // The server stopped sending `phone_last4`, so this guard exists for the
+    // window a deploy is not atomic in — and for a rollback, where the shape
+    // that comes back is the OLD one. `profile` is the server-shaped object
+    // nested inside each match, so a top-level-only sweep would have promised
+    // protection it could not give.
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      totalContacts: 1,
+      sourcePlatform: "ios",
+      region: "IN",
+      limited: false,
+      truncated: false,
+      lookups: [{ hash: "c".repeat(64), last4: "4242", displayName: "Old Payload" }],
+    });
+    mockMatchMarketplaceContacts.mockResolvedValue([
+      {
+        user_id: "user_e",
+        kind: "one_user",
+        display_name: "Old Payload",
+        phone_last4: "4242",
+        mobile_phone: "+919876500000",
+        profile: {
+          user_id: "user_e",
+          display_name: "Old Payload",
+          phone_last4: "4242",
+          contact: { phoneNumber: "+919876500000" },
+        },
+      },
+    ]);
+
+    const result = await syncOneLocationContactSignals({
+      idToken: "id-token",
+      accountPhoneNumber: "+919000000000",
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("4242");
+    expect(serialized).not.toContain("9876500000");
+    expect(serialized).not.toContain("phone");
+    // ...and the fields that are not phone-shaped survive untouched, so the
+    // guard cannot quietly empty the payload it is protecting.
+    expect(result.matches[0].display_name).toBe("Old Payload");
+    expect(result.matches[0].profile).toMatchObject({ user_id: "user_e" });
+    expect(result.matchedUserIds).toEqual(["user_e"]);
+  });
+
   it("returns invite candidates without calling the matcher when contacts have no phones", async () => {
     mockBuildMarketplaceContactLookups.mockResolvedValue({
       totalContacts: 4,

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1237,7 +1237,6 @@ export default function MarketplacePage() {
                     </span>
                     <span className="block line-clamp-1 text-xs text-muted-foreground">
                       {match.kind === "ria" ? "RIA" : "Investor"}
-                      {match.phone_last4 ? ` · ${match.phone_last4}` : ""}
                     </span>
                   </span>
                 </button>

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -98,15 +98,33 @@ async function assertContactsReadable(): Promise<void> {
  *
  * The screens downstream of this render matched people by name. Nothing here
  * needs a digit, so anything that looks like one is dropped rather than trusted.
+ *
+ * Recursive, not a shallow copy. `profile` is a server-shaped object nested
+ * inside each match, and the rollback case this guard exists for is precisely
+ * the one where the server's shape is not what this client expects — so a
+ * top-level-only sweep would have promised protection it could not give.
  */
+function stripPhoneKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripPhoneKeys);
+  // Plain objects only. A Date, a Map, or anything with a prototype of its own
+  // would be rebuilt as a bare object by the spread below, so those are handed
+  // through untouched — none of them can carry a phone field on this payload,
+  // which is JSON off the wire.
+  if (!value || typeof value !== "object") return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+
+  const copy: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (key.toLowerCase().includes("phone")) continue;
+    copy[key] = stripPhoneKeys(nested);
+  }
+  return copy;
+}
+
 function withoutPhoneFields(
   match: MarketplaceContactMatch,
 ): MarketplaceContactMatch {
-  const safeMatch: Record<string, unknown> = { ...match };
-  for (const key of Object.keys(safeMatch)) {
-    if (key.toLowerCase().includes("phone")) delete safeMatch[key];
-  }
-  return safeMatch as unknown as MarketplaceContactMatch;
+  return stripPhoneKeys(match) as MarketplaceContactMatch;
 }
 
 export async function syncOneLocationContactSignals({

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -82,6 +82,33 @@ async function assertContactsReadable(): Promise<void> {
   }
 }
 
+/**
+ * Every match, with any phone-derived field removed.
+ *
+ * The server no longer returns one: `match_marketplace_contacts` used to echo
+ * four digits of the matched person's number, and it stopped, because a client
+ * that has to defend against a field is a field that should not have been sent.
+ *
+ * This guard stays anyway, and it is deliberately keyed on the shape of the
+ * value rather than on one known field name. Two reasons. A deploy is not
+ * atomic, so for the length of a rollout — and for the length of any rollback —
+ * this client can still be talking to a server that returns the old payload.
+ * And the type no longer declares the field, which means TypeScript would have
+ * silently stopped protecting exactly the case that still needs protecting.
+ *
+ * The screens downstream of this render matched people by name. Nothing here
+ * needs a digit, so anything that looks like one is dropped rather than trusted.
+ */
+function withoutPhoneFields(
+  match: MarketplaceContactMatch,
+): MarketplaceContactMatch {
+  const safeMatch: Record<string, unknown> = { ...match };
+  for (const key of Object.keys(safeMatch)) {
+    if (key.toLowerCase().includes("phone")) delete safeMatch[key];
+  }
+  return safeMatch as unknown as MarketplaceContactMatch;
+}
+
 export async function syncOneLocationContactSignals({
   idToken,
   accountPhoneNumber,
@@ -131,11 +158,7 @@ export async function syncOneLocationContactSignals({
     // marketplace profiles are off by default.
     scope: "one_network",
   });
-  const privacySafeMatches = matches.map((match) => {
-    const safeMatch = { ...match };
-    delete safeMatch.phone_last4;
-    return safeMatch as MarketplaceContactMatch;
-  });
+  const privacySafeMatches = matches.map(withoutPhoneFields);
   const matchedUserIds = Array.from(
     new Set(
       privacySafeMatches

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -125,7 +125,6 @@ export interface MarketplaceContactMatch {
   kind: "ria" | "investor" | "one_user";
   display_name: string;
   headline?: string | null;
-  phone_last4?: string | null;
   profile: MarketplaceRia | MarketplaceInvestor;
 }
 

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -1203,10 +1203,23 @@ async function toJsonOrThrow<T>(response: Response): Promise<T> {
       payload.detail && typeof payload.detail === "object" && !Array.isArray(payload.detail)
         ? (payload.detail as { code?: unknown })
         : null;
-    const message =
+    const rawMessage =
       detailMessage ||
       (typeof payload.error === "string" && payload.error) ||
       `Request failed: ${response.status}`;
+    // slowapi's default 429 body is the limit itself — "Rate limit exceeded:
+    // 12 per 1 minute" — and callers put whatever string they find straight
+    // into a toast. Reading our own rate-limit arithmetic is how a person
+    // learns we wrote no copy for this state.
+    //
+    // The server sends product copy for the routes a human triggers, so this
+    // only fires against a server that has not shipped it yet: an older
+    // deployment mid-rollout, or a rollback. Matched on slowapi's exact shape
+    // rather than on the status alone, so a route with real 429 copy keeps it.
+    const message =
+      response.status === 429 && /^Rate limit exceeded/i.test(rawMessage)
+        ? "You are doing that a little too quickly. Wait a moment and try again."
+        : rawMessage;
     const code =
       typeof payload.code === "string"
         ? payload.code


### PR DESCRIPTION
Step 1 of the Contact Sync plan. Contact sync itself works on all three platforms — this closes the security hole underneath it.

## The hole

`POST /api/marketplace/contacts/match` answers *"is the person behind this phone number on Hushh"*, a thousand numbers at a time. It shipped with **no rate limit at all** — not its own, and not a global one to fall back on, because `SlowAPIMiddleware` is never installed and `RateLimits.GLOBAL_PER_IP` is referenced nowhere outside its own test.

Every One Location route is bounded. This one — the most identity-revealing query in the product — was not. An authenticated caller could walk the national number space against the user base at whatever rate their connection allowed, and unsalted SHA-256 over a ten-digit keyspace means each answer is a phone number, not a hash. That is the attack in *"All the Numbers are US"* (NDSS'21), available to anyone with an account.

## What changed

**Two ceilings**, because one number cannot describe the shape of the abuse:

| | | |
|---|---|---|
| `CONTACT_DISCOVERY_MATCH` | `4/minute` | stops a tight loop |
| `CONTACT_DISCOVERY_MATCH_DAILY` | `20/day` | stops the patient walk — the realistic version |

Keyed **per authenticated user**, not per IP: the route requires a Firebase identity, so a caller cannot shed the limit by changing address, and an office behind one NAT does not share a budget it never spent. Syncing an address book is a deliberate act — even a heavy multi-device day does not approach twenty.

**`phone_last4` is gone from the response.** The caller derived every digest it sent from its own address book, so it already holds the number behind each match — echoing four digits back tells it nothing it did not have, and costs a real leak the moment a response is logged, cached, or rendered. Both were happening at once: the marketplace deck rendered those digits into the DOM (`app/marketplace/page.tsx:1240`) while One Location stripped them on arrival (`contact-signals.ts:134`). A field one client has to defend against and another leaks is a field that should never have left the server.

The client-side strip **stays**, now keyed on the *shape* of the value rather than one field name. A deploy is not atomic, so through a rollout — and any rollback — this client can still be talking to a server returning the old payload. Removing the field from the TS type would otherwise have silently stopped protecting exactly the case that still needs protecting.

**`cap.contact.discovery` is declared**, so the capability finally has a name the consent surface can show and an audit row can carry. Deliberately **not enforced yet** — the route authenticates with a Firebase ID token and all three shipped clients call it that way, so requiring a consent token here would break contact sync on web, iOS and Android the moment it deployed. That is a coordinated client change and should be one, not a silent outage.

## Tests and docs, where there were none

The endpoint had **zero backend tests** and was **undocumented**. It now has both. The new file is registered in `consent-protocol/scripts/test-ci.manifest.txt` — the only pytest invocation in any lane, including the merge queue, so a guard absent from it is decoration.

## Verification

| | |
|---|---|
| New `tests/test_contact_discovery_hardening.py` | **9 passed** |
| Full CI backend manifest (locally, minus one Unix-only file) | **1366 passed** |
| `verify:one-location` | **430 passed** (16 files) |
| Contact/marketplace/observability vitest | **175 passed** (20 files) |
| `tsc --noEmit`, `eslint`, `ruff check`, `ruff format --check`, `verify:docs` | clean |

Both limits confirmed registered on the route at runtime: `4 per 1 minute`, `20 per 1 day`.

## Next in the plan

Step 2 — the pepper (HMAC over plain SHA-256), the server's hardcoded `+1` normalizer, and the candidate cap that can make a user permanently invisible to their own contacts. Then the invite/growth half, which was computed and thrown away.
