### PR TITLE
fix(location): the chat clamp test was asserting the value the clamp removes

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (

--- a/hushh-webapp/__tests__/components/use-location-chat.test.tsx
+++ b/hushh-webapp/__tests__/components/use-location-chat.test.tsx
@@ -439,6 +439,66 @@ describe("useLocationChat — action dispatcher", () => {
     expect(result.current.pendingAction).toBeNull();
   });
 
+  it.each([
+    [2, 1, "a proposal above the public ceiling"],
+    [24, 1, "the private-share ceiling, copied"],
+    [0.1, 0.25, "a proposal below the shared minimum"],
+    [0.5, 0.5, "a proposal already inside the range"],
+  ])(
+    "create_public_link clamps %s to %s — %s",
+    async (proposed, expected) => {
+      // The only path to createPublicInvite that does not go through the
+      // screen's own duration control. The value arrives from a model-authored
+      // directive, and the endpoint is `gt=0, le=1` — so an unclamped number
+      // reached an API that would 422 it after the person had already said yes.
+      const mockPoint = {
+        latitude: 10,
+        longitude: 20,
+        capturedAt: "now",
+        sourcePlatform: "web" as const,
+      };
+      mockChat
+        .mockResolvedValueOnce({
+          conversationId: "c-clamp",
+          response: "Creating a public link.",
+          isComplete: true,
+          stateChanged: false,
+          clientAction: {
+            id: "act-clamp",
+            type: "create_public_link" as const,
+            durationHours: proposed,
+            summary: "Create a public location link",
+          },
+        })
+        .mockResolvedValueOnce({
+          conversationId: "c-clamp",
+          response: "Link created!",
+          isComplete: true,
+          stateChanged: false,
+        });
+      vi.mocked(OneLocationService.captureCurrentPosition).mockResolvedValue(mockPoint);
+      vi.mocked(OneLocationService.createPublicInvite).mockResolvedValue({
+        invite: { id: "inv-c", ownerUserId: "u1", status: "active", durationHours: expected },
+        publicToken: "tokc",
+        publicUrl: "https://hushh.ai/location/tokc",
+      });
+
+      const { result } = renderHook(() =>
+        useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+      );
+      await act(async () => {
+        await result.current.send("create a public link");
+      });
+      await act(async () => {
+        await result.current.confirmAction();
+      });
+
+      expect(vi.mocked(OneLocationService.createPublicInvite)).toHaveBeenCalledWith(
+        expect.objectContaining({ durationHours: expected }),
+      );
+    },
+  );
+
   it("create_public_link: confirm captures, creates invite, reports completed with publicUrl", async () => {
     const mockPoint = {
       latitude: 10,
@@ -493,8 +553,17 @@ describe("useLocationChat — action dispatcher", () => {
     });
 
     expect(vi.mocked(OneLocationService.captureCurrentPosition)).toHaveBeenCalledTimes(1);
+    // Clamped to 1, not the 2 the model proposed.
+    //
+    // `CreatePublicInviteRequest.durationHours` is `gt=0, le=1` and the service
+    // refuses anything above PUBLIC_INVITE_MAX_DURATION_HOURS, because a public
+    // link is readable by anyone holding it — 24 was the PRIVATE share ceiling,
+    // copied. This is the one path to createPublicInvite that does not go
+    // through the screen's own duration control, and the value arrives from a
+    // model-authored directive, so an unclamped number reached an endpoint that
+    // would 422 it after the person had already said yes.
     expect(vi.mocked(OneLocationService.createPublicInvite)).toHaveBeenCalledWith(
-      expect.objectContaining({ durationHours: 2, locationSnapshot: mockPoint }),
+      expect.objectContaining({ durationHours: 1, locationSnapshot: mockPoint }),
     );
     expect(mockChat).toHaveBeenLastCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
**This test is red on `main` right now.** It broke in #5830 — mine — and went unnoticed because `__tests__/components/use-location-chat.test.tsx` is in none of the path-scoped vitest packs a PR runs.

## What happened

#5830 clamped the chat path's `create_public_link` duration:

```ts
durationHours: Math.min(PUBLIC_LINK_MAX_DURATION_HOURS, Math.max(PUBLIC_LINK_MIN_DURATION_HOURS, Number(action.durationHours) || 1))
```

Because `CreatePublicInviteRequest.durationHours` is `gt=0, le=1` and the service refuses anything above `PUBLIC_INVITE_MAX_DURATION_HOURS` — 24 was the *private* share ceiling, copied. That is the one route to `createPublicInvite` which does not pass through the screen's own duration control, and its value arrives from a **model-authored directive**, so an unclamped number reached an endpoint that would 422 it *after the person had already said yes*.

The test still asserted `durationHours: 2` — the exact number the clamp exists to remove.

## The fix

Corrected, and given the coverage it should have had in the first place: a table of four proposals across both bounds.

| proposed | expected | why |
|---|---|---|
| `2` | `1` | above the public ceiling |
| `24` | `1` | the private-share ceiling, copied — the original bug |
| `0.1` | `0.25` | below the shared minimum |
| `0.5` | `0.5` | already inside the range, untouched |

So the next person to touch the clamp finds out from a test rather than from a 422.

## Verified

`use-location-chat.test.tsx` — **22 passed** (was 17 passed / 1 failed).

I also ran the **entire** web suite (5024 tests) and diffed the failures against a worktree at `cd8688fc9`, the commit before #5830 merged, to be sure this was the only thing I broke. It was. Details in the PR discussion below.
