### PR TITLE
feat(contacts): let the people who are not on Hushh be invited

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (

--- a/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
@@ -16,7 +16,82 @@ const base = {
   sourcePlatform: "android" as const,
   limited: false,
   truncated: false,
+  inviteCandidateCount: 0,
 };
+
+describe("describeContactSyncOutcome — the people who are NOT on Hushh", () => {
+  // `inviteCandidateCount` has been computed on every sync since this file
+  // shipped and read by nothing except an analytics dimension. The product
+  // learned "forty of your contacts are not here yet", recorded it, and told
+  // the person nothing.
+
+  it("names them, and offers the invite, after a full read that matched", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a", "b"],
+      totalContacts: 50,
+      inviteCandidateCount: 48,
+    });
+    expect(outcome.title).toBe("2 people added as a contact signal.");
+    expect(outcome.description).toBe("48 contacts are not on Hushh yet.");
+    expect(outcome.remedy).toBe("invite");
+  });
+
+  it("offers the invite when a full read matched nobody", () => {
+    // The strongest moment for the loop: every contact is a candidate.
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 30,
+      inviteCandidateCount: 30,
+    });
+    expect(outcome.title).toBe("No One users matched from this contact scan.");
+    expect(outcome.description).toBe("30 contacts could be invited.");
+    expect(outcome.remedy).toBe("invite");
+  });
+
+  it("says nothing about inviting when everyone is already here", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      matchedUserIds: ["a", "b"],
+      totalContacts: 2,
+      inviteCandidateCount: 0,
+    });
+    expect(outcome.description).toBeUndefined();
+    expect(outcome.remedy).toBeNull();
+  });
+
+  it("never takes the slot from a remedy that widens a partial read", () => {
+    // A partial read owns the action with "Check more" / "Open Settings".
+    // Widening the read is the better next step than inviting out of a list
+    // the person has not finished choosing from — and the toast has one slot.
+    const web = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 10,
+      sourcePlatform: "web",
+      limited: true,
+      inviteCandidateCount: 10,
+    });
+    expect(web.remedy).toBe("pick_more");
+
+    const ios = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 10,
+      sourcePlatform: "ios",
+      limited: true,
+      inviteCandidateCount: 10,
+    });
+    expect(ios.remedy).toBe("open_settings");
+  });
+
+  it("singularises one candidate", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      totalContacts: 1,
+      inviteCandidateCount: 1,
+    });
+    expect(outcome.description).toBe("1 contact could be invited.");
+  });
+});
 
 describe("describeContactSyncOutcome", () => {
   it("reports a full read as a plain count with no remedy", () => {

--- a/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
@@ -142,6 +142,39 @@ describe("describeContactSyncOutcome", () => {
     expect(ios.description).toContain("shared with Hushh");
   });
 
+  it("does not answer a dismissed picker with a result it never had", () => {
+    // `contacts-web.ts` reads an AbortError as an empty read, so closing the
+    // sheet arrives here as limited + zero. The old wording -- "None of the 0
+    // contacts you shared are on Hushh yet" -- is shaped like a finding and
+    // reports one nobody asked for, on the most common way out of the flow.
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      sourcePlatform: "web",
+      limited: true,
+      totalContacts: 0,
+    });
+
+    expect(outcome.title).not.toMatch(/0 contacts/);
+    expect(outcome.title).not.toMatch(/are on Hushh yet/);
+    expect(outcome.title).toBe("No contacts were shared, so nothing was checked.");
+    // Still the remedy that widens the read, because that is the way forward.
+    expect(outcome.remedy).toBe("pick_more");
+  });
+
+  it("says where to widen it when iOS shared nothing at all", () => {
+    const outcome = describeContactSyncOutcome({
+      ...base,
+      sourcePlatform: "ios",
+      limited: true,
+      totalContacts: 0,
+    });
+
+    // Settings, not the picker: on iOS the empty subset is sticky, and
+    // openAppSettings is the only thing that changes it.
+    expect(outcome.remedy).toBe("open_settings");
+    expect(outcome.description).toMatch(/Settings/);
+  });
+
   it("does not claim nobody matched when only a subset was searched", () => {
     const outcome = describeContactSyncOutcome({
       ...base,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -371,6 +371,9 @@ import {
   DRIVE_ETA_MIN_RECOMPUTE_MOVE_METERS,
 } from "@/lib/one-location/eta-recompute";
 import { getApiBaseUrl } from "@/lib/services/api-service";
+import { buildInviteToOneShare } from "@/lib/connect/invite-to-one";
+import { ReferralService } from "@/lib/services/referral-service";
+import { shareLink } from "@/lib/share/share-link";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import {
   buildCircleInviteShareText,
@@ -6355,6 +6358,68 @@ export function OneLocationAgentPageContent({
     [auth.user],
   );
 
+  /**
+   * Share the app with the contacts a scan could not match.
+   *
+   * Sends the person's own REFERRAL link, not the generic invite. That is the
+   * whole difference between a share that is attributed and one that is not:
+   * `/r/<slug>` resolves server-side and records the attribution BEFORE the
+   * recipient reaches sign-in, so nothing downstream has to trust a slug the
+   * client hands back afterwards. `buildInviteToOneShare` is a bare origin with
+   * no token — perfectly correct for its own purpose, and unattributable.
+   *
+   * The generic invite stays as the fallback for the one case the referral
+   * system cannot serve: no link yet, or the summary call fails. Better a
+   * share that works and is not counted than a dead control.
+   *
+   * `rememberLocationInviteSource` is written either way. It is the local
+   * funnel signal, `"contact_sync"` has existed in that enum since it shipped
+   * and has never once been written, and first-touch wins inside it so this
+   * cannot overwrite an earlier, truer source.
+   */
+  const handleInviteContactCandidates = useCallback(async () => {
+    rememberLocationInviteSource("contact_sync");
+
+    let referralLink = "";
+    try {
+      const idToken = await auth.user?.getIdToken();
+      if (idToken) {
+        const summary = await ReferralService.getSummary({ idToken });
+        referralLink = String(summary?.link || "").trim();
+      }
+    } catch {
+      // A referral summary that will not load is not a reason to refuse the
+      // share. Fall through to the generic invite.
+    }
+
+    const share = referralLink
+      ? {
+          title: "Join me on Hushh",
+          text: "Join me on Hushh so we can share location.",
+          url: referralLink,
+          dialogTitle: "Invite to Hushh",
+        }
+      : buildInviteToOneShare();
+
+    if (!share) {
+      // No referral link AND no shareable origin — the same condition that
+      // hides the Connect invite row entirely rather than offering a link that
+      // resolves to nothing.
+      toast.error("Sharing is not available here.");
+      return;
+    }
+
+    try {
+      const delivery = await shareLink(share);
+      if (delivery === "copied") {
+        toast.success("Invite link copied.");
+      }
+    } catch (error) {
+      if (isShareCancellationError(error)) return;
+      toast.error("Could not open the share sheet.");
+    }
+  }, [auth.user]);
+
   const handleSyncContactSignal = useCallback(async () => {
     if (!auth.user?.getIdToken) {
       const message = "Sign in before syncing contacts.";
@@ -6429,7 +6494,25 @@ export function OneLocationAgentPageContent({
                   onClick: () => void openContactPermissionSettings(),
                 },
               }
-            : {}),
+            : outcome.remedy === "invite"
+              ? {
+                  action: {
+                    label: "Invite them",
+                    // The other half of a contact scan. Until now the count of
+                    // people who are NOT on One was computed on every sync and
+                    // read by nothing but an analytics dimension — the product
+                    // learned who was missing, recorded it, and offered the
+                    // person no way to act on it.
+                    //
+                    // Reuses the existing invite share rather than minting a
+                    // second one, and deliberately carries no pre-authorized
+                    // connection: `buildInviteToOneShare` documents why, and
+                    // an invite that consents on the recipient's behalf is not
+                    // an invite.
+                    onClick: () => void handleInviteContactCandidates(),
+                  },
+                }
+              : {}),
       };
       if (result.matchedUserIds.length > 0) {
         toast.success(outcome.title, outcomeOptions);
@@ -6475,7 +6558,7 @@ export function OneLocationAgentPageContent({
     } finally {
       setBusy(null);
     }
-  }, [auth.user, contactSignal]);
+  }, [auth.user, contactSignal, handleInviteContactCandidates]);
 
   useEffect(() => {
     handleSyncContactSignalRef.current = handleSyncContactSignal;

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -238,6 +238,23 @@ export function describeContactSyncOutcome(
       : "open_settings";
 
   if (result.limited) {
+    // Nothing was shared at all, which is not the same as nothing matching.
+    // The web picker returns exactly this shape when it is dismissed
+    // (`contacts-web.ts` treats an AbortError as an empty read), so closing the
+    // sheet was answered with "None of the 0 contacts you shared are on Hushh
+    // yet" -- a sentence shaped like a result, reporting one that was never
+    // asked for. iOS limited access with nothing selected lands here too.
+    if (result.totalContacts === 0) {
+      return {
+        title: "No contacts were shared, so nothing was checked.",
+        description:
+          remedy === "pick_more"
+            ? "Pick the people you want checked and they will be matched."
+            : "Share contacts with Hushh in Settings to have them checked.",
+        remedy,
+      };
+    }
+
     const scanned = contactsLabel(result.totalContacts);
     return {
       title: matched

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -183,6 +183,15 @@ export type ContactSyncRemedy =
   | "pick_more"
   /** Open OS settings to widen contact access (iOS limited access). */
   | "open_settings"
+  /**
+   * Some contacts are not on Hushh. Offer to invite them.
+   *
+   * Only ever returned where the remedy would otherwise be null. A partial
+   * read owns that slot with the remedy that widens it, and widening is the
+   * better next step than inviting out of a list the person has not finished
+   * choosing from.
+   */
+  | "invite"
   | null;
 
 export type ContactSyncOutcome = {
@@ -202,10 +211,20 @@ function contactsLabel(count: number): string {
 export function describeContactSyncOutcome(
   result: Pick<
     OneLocationContactSignalResult,
-    "matchedUserIds" | "totalContacts" | "sourcePlatform" | "limited" | "truncated"
+    | "matchedUserIds"
+    | "totalContacts"
+    | "sourcePlatform"
+    | "limited"
+    | "truncated"
+    | "inviteCandidateCount"
   >,
 ): ContactSyncOutcome {
   const matched = result.matchedUserIds.length;
+  // The other half of the answer. `inviteCandidateCount` has been computed on
+  // every sync since this file shipped and read by nothing except an analytics
+  // dimension — so the product learned "forty of your contacts are not here
+  // yet", recorded it, and told the person nothing.
+  const inviteCandidates = Math.max(0, result.inviteCandidateCount ?? 0);
 
   // The picker grants per-invocation and has no settings page to open, so
   // offering "Settings" there sends the user somewhere that cannot help —
@@ -235,7 +254,14 @@ export function describeContactSyncOutcome(
   if (!matched) {
     return {
       title: "No One users matched from this contact scan.",
-      remedy: null,
+      description: inviteCandidates
+        ? `${contactsLabel(inviteCandidates)} could be invited.`
+        : undefined,
+      // `invite` only ever appears where `remedy` would have been null. A
+      // partial read already owns that slot with the remedy that widens it,
+      // and widening the read is the better next step than inviting from a
+      // list the person has not finished picking.
+      remedy: inviteCandidates ? "invite" : null,
     };
   }
 
@@ -245,7 +271,9 @@ export function describeContactSyncOutcome(
     // the book was larger than the caps rather than deliberately narrowed.
     description: result.truncated
       ? "Your address book was larger than the sync limit, so some contacts were not checked."
-      : undefined,
-    remedy: null,
+      : inviteCandidates
+        ? `${contactsLabel(inviteCandidates)} are not on Hushh yet.`
+        : undefined,
+    remedy: inviteCandidates ? "invite" : null,
   };
 }


### PR DESCRIPTION
Step 4 of the Contact Sync plan — the growth half, which was computed and thrown away.

## A contact scan answers two questions and the product only ever asked one

`inviteCandidateCount` — how many of your contacts are **not** here — has been computed on every sync since `contact-signals.ts` shipped, and read by nothing except an analytics dimension (`page.tsx:6316`, `:6405`, `:6458`). The app learned *"forty of your contacts are not on Hushh yet"*, recorded it, and told the person nothing. There was **no per-contact invite anywhere**.

`describeContactSyncOutcome` now names them and offers the invite:

| state | title | description | action |
|---|---|---|---|
| full read, some matched | `2 people added as a contact signal.` | `48 contacts are not on Hushh yet.` | **Invite them** |
| full read, none matched | `No One users matched from this contact scan.` | `30 contacts could be invited.` | **Invite them** |
| everyone already here | *(count)* | — | none |
| partial read | *(scoped count)* | *(scoped)* | **Check more** / **Open Settings** |

`invite` only ever appears where `remedy` would have been `null`. A partial read keeps its own remedy — widening the read is a better next step than inviting out of a list the person has not finished choosing from, and the toast has one action slot.

## It shares the referral link, not the generic one

This is the whole difference between a share that is attributed and one that is not. `/r/<slug>` resolves server-side and records the attribution **before** the recipient reaches sign-in, so nothing downstream has to trust a slug the client hands back afterwards. `buildInviteToOneShare` is a bare origin with no token — correct for its own purpose, and unattributable — so it stays only as the fallback for the case the referral system cannot serve (no link yet, or the summary call fails). Better a share that works and is not counted than a dead control.

`rememberLocationInviteSource("contact_sync")` is also finally written. That value has existed in `GrowthLocationInviteSource` (`lib/observability/events.ts:63`) since the enum shipped and had **never once been recorded**, so every person who arrived because a friend's contact scan found them was attributed to nowhere. First-touch wins inside the helper, so it cannot overwrite an earlier, truer source.

## No schema change

"Who did I invite, and who joined since" needs a table and is deliberately **not** here. The loop works without it, and the table can be designed once there is traffic to shape it — rather than guessing at a shape now and carrying a migration for it.

## Verification

| | |
|---|---|
| `verify:one-location` | **430 passed** (16 files) |
| `verify:share-ladder` | **62 passed** (5 files) |
| `__tests__/lib/one-location/` + agent page | **277 passed** (17 files) |
| `tsc --noEmit`, `eslint` | clean |

Five new cases in `contact-sync-outcome.test.ts` cover both invite states, the "everyone is here" silence, singularisation, and — the one that matters most — that `invite` never takes the action slot from a remedy that widens a partial read.

Depends on nothing; independent of #5845 and #5848.


---

## Added after review of the finished flow

**A dismissed picker no longer gets answered with a result it never had.**
Closing the web Contact Picker was reported as:

> None of the 0 contacts you shared are on Hushh yet

A sentence shaped like a finding, reporting one nobody asked for, on the most
common way out of the flow. `contacts-web.ts` deliberately turns an `AbortError`
into an empty read — dismissing is not an error — but that empty read then
travelled down the partial-read branch, which assumes a subset was *chosen* and
phrases the count as a search result. Zero shared and zero matched are not the
same fact, and only one of them is worth telling somebody.

iOS limited access with nothing selected lands in the same place, so both are
handled, each with the remedy its surface can actually act on: the picker on web,
Settings on iOS, where a sticky empty subset is widened.

Verified failing before the fix, not merely passing after — reverting the branch
produces `expected 'None of the 0 contacts you shared are...' not to match /are
on Hushh yet/`. The assertions are written against the *shape* of the mistake (no
`0 contacts`, no `are on Hushh yet`) rather than only pinning the new string, so
rewording the copy later cannot quietly reintroduce a count-of-nothing.
