### PR TITLE
fix(contacts): two silent ways a real person went unfound

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -8922,14 +8922,44 @@ class RIAIAMService:
 
     @staticmethod
     def _normalize_contact_phone_for_hash(value: Any) -> str | None:
+        """A stored phone number as the E.164 string the client hashed.
+
+        No country guessing. This used to read a bare ten-digit number as North
+        American -- `if len(digits) == 10: return f"+1{digits}"` -- which is the
+        same bug the client-side normalizer removed and documented at
+        `lib/contacts/phone-normalization.ts:11-15`.
+
+        It is worse here than it was there. On the client a wrong guess only
+        produced a digest that missed. Here it fabricates an identity: a stored
+        `9876543210` belonging to an Indian account was hashed as
+        `+19876543210`, so a requester holding the real US number `+19876543210`
+        would have been told that stranger is on Hussh. A guess that can
+        disclose somebody's membership to a person who does not know them is
+        not a fallback, and returning nothing is the correct answer to a
+        question we cannot answer.
+
+        Every writer of `actor_identity_cache.phone_number` in this repo stores
+        E.164 with the leading `+` -- the Firebase mirror in
+        `ActorIdentityService.sync_from_firebase`, the token claim path, and the
+        UAT test-confirm path through `_normalize_phone_number`, which forces a
+        `+` unconditionally. Migration 047 added the column with no backfill.
+        The counter below exists to prove that from production traffic rather
+        than from reading the writers, because a row predating any of them
+        would now go unmatched instead of wrongly matched.
+        """
+
         raw = str(value or "").strip()
         digits = re.sub(r"\D", "", raw)
         if not digits:
             return None
-        if raw.startswith("+"):
-            return f"+{digits}"
-        if len(digits) == 10:
-            return f"+1{digits}"
+        if not raw.startswith("+"):
+            # Not an error and not fatal -- the row still matches whenever its
+            # digits already carry a country code. Logged without the number so
+            # the count is visible and the value never is.
+            logger.warning(
+                "contact_match.stored_phone_missing_plus digits_len=%s",
+                len(digits),
+            )
         return f"+{digits}"
 
     async def match_marketplace_contacts(
@@ -8981,7 +9011,24 @@ class RIAIAMService:
         # base grew past a few thousand accounts, so the pre-filter is now sized
         # against collision volume rather than the result limit, and still
         # bounded so a wide lookup set cannot pull an unbounded result set.
-        candidate_row_cap = min(max(limit_safe * 50, 500), 5000)
+        #
+        # Sized against the buckets actually asked for, not a flat ceiling.
+        #
+        # The old `min(..., 5000)` was a truncation with no meaning attached to
+        # it: rows come back `ORDER BY aic.user_id ASC`, an ordering the query's
+        # own comment calls arbitrary, and anything past the cap was never
+        # digest-compared. A last4 bucket holds roughly one ten-thousandth of
+        # the user base, so a full address book of 1000 buckets expects
+        # `users / 10` candidates -- which crosses 5000 at only fifty thousand
+        # accounts. Past that, a person whose Firebase uid sorts late was
+        # dropped from every large lookup, deterministically and permanently,
+        # and the response was an ordinary empty list. Somebody could be
+        # invisible to their own contacts forever with nothing to see.
+        #
+        # The bound is still real: `phone_lookups` is capped at 1000 by the
+        # route, so this cannot exceed 50k rows however the request is shaped,
+        # and the digest set that decides matches is bounded by the same 1000.
+        candidate_row_cap = min(max(len(last4_values) * 50, 500), 50_000)
 
         if normalized_scope == "one_network":
             # actor_profiles is LEFT JOINed so an account that has never had a

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -90,3 +90,12 @@ tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
 tests/test_pool_acquire_is_bounded.py
+
+# Contact matching correctness.
+#
+# Two ways a real person went unfound, both silent: the server normalizer read
+# a bare ten-digit number as North American (fabricating a US identity, which
+# could disclose a stranger's membership), and the candidate cap truncated the
+# pool on an ordering the query's own comment calls arbitrary. Neither had a
+# test, and this manifest is the only pytest invocation in any lane.
+tests/test_contact_match_correctness.py

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -74,6 +74,15 @@ tests/test_capability_health.py
 tests/test_managed_vertex_readiness_script.py
 tests/test_verify_uat_release.py
 
+# Contact matching correctness.
+#
+# Two ways a real person went unfound, both silent: the server normalizer read
+# a bare ten-digit number as North American (fabricating a US identity, which
+# could disclose a stranger's membership), and the candidate cap truncated the
+# pool on an ordering the query's own comment calls arbitrary. Neither had a
+# test, and this manifest is the only pytest invocation in any lane.
+tests/test_contact_match_correctness.py
+
 # One Location Circles, and the migration guards that protect them.
 #
 # Every file below was written to lock a behaviour that had already broken
@@ -90,12 +99,3 @@ tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
 tests/test_pool_acquire_is_bounded.py
-
-# Contact matching correctness.
-#
-# Two ways a real person went unfound, both silent: the server normalizer read
-# a bare ten-digit number as North American (fabricating a US identity, which
-# could disclose a stranger's membership), and the candidate cap truncated the
-# pool on an ordering the query's own comment calls arbitrary. Neither had a
-# test, and this manifest is the only pytest invocation in any lane.
-tests/test_contact_match_correctness.py

--- a/consent-protocol/tests/test_contact_match_correctness.py
+++ b/consent-protocol/tests/test_contact_match_correctness.py
@@ -1,0 +1,141 @@
+"""Contact matching: the two ways a real person went unfound.
+
+Both bugs sit in `RIAIAMService.match_marketplace_contacts`, both are silent,
+and neither had a test. The caller gets an ordinary empty list — indistinguishable
+from "none of your contacts are here" — so nothing on any screen could tell the
+difference between an honest answer and a broken one.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+
+class TestTheNormalizerDoesNotInventACountry:
+    """A stored number is read as E.164, never guessed into one.
+
+    This used to read a bare ten-digit number as North American --
+    `if len(digits) == 10: return f"+1{digits}"` -- the same bug the client-side
+    normalizer removed and documented at
+    `lib/contacts/phone-normalization.ts:11-15`.
+
+    It is worse on this side. On the client a wrong guess only produced a digest
+    that missed. Here it fabricates an identity: a stored `9876543210` on an
+    Indian account hashed as `+19876543210`, so a requester holding the real US
+    number `+19876543210` was told that stranger is on Hussh. A guess that can
+    disclose somebody's membership to a person who does not know them is not a
+    fallback.
+    """
+
+    def test_a_bare_ten_digit_number_is_not_assumed_american(self):
+        normalize = RIAIAMService._normalize_contact_phone_for_hash
+        assert normalize("9876543210") == "+9876543210"
+        assert normalize("9876543210") != "+19876543210"
+
+    def test_an_e164_number_is_left_exactly_as_it_is(self):
+        normalize = RIAIAMService._normalize_contact_phone_for_hash
+        assert normalize("+919876543210") == "+919876543210"
+        assert normalize("+91 98765-43210") == "+919876543210"
+        assert normalize("+1 650 555 1234") == "+16505551234"
+
+    def test_nothing_at_all_is_not_a_number(self):
+        normalize = RIAIAMService._normalize_contact_phone_for_hash
+        assert normalize("") is None
+        assert normalize("   ") is None
+        assert normalize(None) is None
+
+    def test_the_client_and_the_server_agree_on_the_same_string(self):
+        # The two normalizers must produce byte-identical E.164 or the digests
+        # never meet. The client emits strict E.164 through libphonenumber; the
+        # server's only job is to reproduce what is already stored in that shape.
+        normalize = RIAIAMService._normalize_contact_phone_for_hash
+        for stored in ("+919876543210", "+16505551234", "+447911123456"):
+            assert normalize(stored) == stored
+
+    def test_the_guess_is_gone_from_the_code_and_not_only_from_the_behaviour(self):
+        # Compared against the executable body with the docstring removed --
+        # that docstring quotes the deleted branch on purpose, so a naive
+        # substring search over the whole source matches the explanation
+        # instead of the code.
+        import ast
+        import textwrap
+
+        tree = ast.parse(
+            textwrap.dedent(inspect.getsource(RIAIAMService._normalize_contact_phone_for_hash))
+        )
+        function = tree.body[0]
+        assert isinstance(function, ast.FunctionDef)
+        body = function.body
+        if ast.get_docstring(function) is not None:
+            body = body[1:]
+        code = "".join(ast.unparse(node) for node in body)
+
+        assert "len(digits) == 10" not in code
+        assert "+1" not in code
+
+    def test_a_missing_plus_is_reported_rather_than_guessed_at(self, caplog):
+        # The counter is how we learn whether such a row exists in production,
+        # instead of reading the writers and hoping. It must never carry the
+        # number itself.
+        normalize = RIAIAMService._normalize_contact_phone_for_hash
+        with caplog.at_level(logging.WARNING):
+            normalize("919876543210")
+
+        assert "stored_phone_missing_plus" in caplog.text
+        assert "919876543210" not in caplog.text
+
+
+class TestEveryoneStaysReachable:
+    """The candidate cap must not decide who is findable.
+
+    Rows come back `ORDER BY aic.user_id ASC` -- an ordering the query's own
+    comment calls arbitrary -- and anything past the cap is never
+    digest-compared. A last4 bucket holds roughly one ten-thousandth of the user
+    base, so a full address book of 1000 buckets expects `users / 10`
+    candidates, which crosses the old flat 5000 at only fifty thousand accounts.
+    Past that, a person whose Firebase uid sorts late was dropped from every
+    large lookup, deterministically and permanently.
+    """
+
+    @staticmethod
+    def _cap_for(bucket_count: int) -> int:
+        # Mirrors the expression under test. Written out rather than imported so
+        # a change to the formula has to be made deliberately in both places.
+        return min(max(bucket_count * 50, 500), 50_000)
+
+    def test_the_cap_scales_with_the_buckets_actually_asked_for(self):
+        source = inspect.getsource(RIAIAMService.match_marketplace_contacts)
+        assert "len(last4_values) * 50" in source
+        # The old formula keyed off the RESULT limit, which has nothing to do
+        # with how many rows have to be examined to produce it.
+        assert "limit_safe * 50" not in source
+
+    def test_a_full_address_book_clears_a_hundred_thousand_accounts(self):
+        # 1000 buckets against 100k users expects ~10k candidates. The old cap
+        # was 5000 -- it truncated half of them.
+        assert self._cap_for(1000) >= 10_000
+        assert self._cap_for(1000) > 5000
+
+    def test_a_small_lookup_still_gets_a_floor(self):
+        # A handful of contacts must not end up with a cap so tight that one
+        # last4 collision crowds out the real row.
+        assert self._cap_for(1) == 500
+        assert self._cap_for(5) == 500
+
+    def test_the_bound_is_still_a_bound(self):
+        # `phone_lookups` is capped at 1000 by the route, so the worst request
+        # anyone can shape stays inside a size Postgres and the Python digest
+        # loop can both carry.
+        assert self._cap_for(1000) <= 50_000
+        assert self._cap_for(10_000) == 50_000
+
+    def test_the_digest_comparison_still_decides_the_match(self):
+        # The bucket is an index-friendly pre-filter and nothing more. If this
+        # ever became the thing that decided a match, every last4 collision
+        # would be a false positive about a stranger's membership.
+        source = inspect.getsource(RIAIAMService.match_marketplace_contacts)
+        assert "normalized_lookups" in source
+        assert "hashlib.sha256" in source

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (


### PR DESCRIPTION
Step 2 of the Contact Sync plan — the correctness half. Both bugs return an ordinary empty list, so nothing on any screen could tell an honest *"none of your contacts are here"* from a broken one. Neither had a test.

## 1. The normalizer invented a country

```python
if len(digits) == 10:
    return f"+1{digits}"   # ← gone
```

Same bug the **client** normalizer removed and documented (`lib/contacts/phone-normalization.ts:11-15`) — and worse on this side. On the client a wrong guess only produced a digest that missed. Here it **fabricates an identity**: a stored `9876543210` on an Indian account hashed as `+19876543210`, so a requester holding the real US number `+19876543210` was told *that stranger is on Hussh*.

A guess that can disclose somebody's membership to a person who does not know them is not a fallback.

Every writer of `actor_identity_cache.phone_number` in this repo stores E.164 with the leading `+` — the Firebase mirror, the token claim path, and the UAT test-confirm path (which forces a `+` unconditionally) — and migration 047 added the column with **no backfill**. So the branch should have been unreachable.

Rather than assert that from reading the writers, a `logger.warning` carrying the **digit count and never the number** now proves it from production traffic. A row predating all of them would go *unmatched* rather than *wrongly matched* — a miss, never a false positive about a stranger.

## 2. The candidate cap decided who was findable

```python
candidate_row_cap = min(max(limit_safe * 50, 500), 5000)   # ← keyed off the RESULT limit
```

Applied as `LIMIT` after `ORDER BY aic.user_id ASC` — an ordering the query's own comment calls arbitrary — and **anything past it was never digest-compared**.

A last4 bucket holds roughly one ten-thousandth of the user base, so a full address book of 1000 buckets expects `users / 10` candidates:

| users | expected candidates | old cap |
|---|---|---|
| 10,000 | 1,000 | fine |
| **50,000** | **5,000** | **at the wall** |
| 100,000 | 10,000 | half of them never compared |

Past that, a person whose Firebase uid sorts late was dropped from *every* large lookup — deterministically and permanently. They could be invisible to their own contacts forever, with nothing anywhere to see.

Now `min(max(len(last4_values) * 50, 500), 50_000)` — sized against the buckets actually asked for. Still bounded: `phone_lookups` is capped at 1000 by the route, so no request can pull more than 50k rows.

## What I deliberately did NOT do

Pushing the digest comparison into SQL (`encode(digest(...,'sha256'),'hex') = ANY(...)`) is the more elegant fix and would remove the cap's relevance entirely. **I left it alone.** It is not verifiable without a live Postgres, and a subtly wrong predicate there filters *everything* out — a worse version of the bug being fixed. The Python comparison stays the only thing that decides a match.

## Verification

| | |
|---|---|
| New `tests/test_contact_match_correctness.py` | **11 passed** |
| Full CI backend manifest (locally, minus one Unix-only file) | **1368 passed** — identical failure set to the pre-change baseline |
| `ruff check`, `ruff format --check` | clean |

Registered in `scripts/test-ci.manifest.txt` — the only pytest invocation in any lane, so a guard absent from it is decoration.

One of the two commits is the recurring `ruff format` drift in `test_one_adk_live_protocol.py` — fourth time this session, not this branch's code, and the pre-commit hook blocks every commit until it is flattened.

Independent of #5845, #5848, #5849, #5850.
