### PR TITLE
docs(contacts): the Play declaration this app now needs, and why we qualify

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (

--- a/docs/guides/mobile/ship-android-playstore.md
+++ b/docs/guides/mobile/ship-android-playstore.md
@@ -89,3 +89,75 @@ npm run android:release:playstore -- --dry-run     # build & sign only, no uploa
 
 1. Open repository on GitHub $\rightarrow$ **Actions** $\rightarrow$ **Ship Android to Google Play Store**.
 2. Click **Run workflow** $\rightarrow$ select track (`internal`, `alpha`, `beta`, `production`) $\rightarrow$ Click **Run workflow**.
+
+## Contacts: the Data safety declaration, and the April 2026 policy
+
+`READ_CONTACTS` is declared in `hushh-webapp/android/app/src/main/AndroidManifest.xml`
+and read by the first-party `HushhContacts` plugin, so this app is in scope for
+Google Play's **Contact Permissions policy**, announced 15 April 2026. Nothing in
+this repo covered it before, and the declaration is a human, one-time Play Console
+action that cannot be automated.
+
+### What the policy requires
+
+Apps targeting **Android 17+ (API 37+)** may request `READ_CONTACTS` only when
+*"the Android Contact Picker is not sufficient for your app to provide core
+functionality."* It is now a **restricted permission**, gated on a declaration.
+
+**Our use case is on the approved list.** Google names *"friend matching with
+server-side processing"* explicitly, and that is exactly what contact sync does:
+the device normalizes each number to E.164 and hashes it, the server matches the
+digests against the user directory, and the match feeds the One Location People
+list and Connect. Read the declaration from that sentence, not from "we sync
+contacts".
+
+What does **not** justify it: inviting or referring. That must use the system
+picker. Our invite path is picker-driven for exactly this reason — the share
+offered after a scan carries no contact data, only the sender's referral link.
+
+### Timeline
+
+| When | What |
+|---|---|
+| 15 April 2026 | Policy announced |
+| **September 2026** | Play Console prompts developers to submit declarations |
+| **January 2027** | Mandatory compliance; non-compliant apps are subject to removal |
+
+### The Data safety form must match the code
+
+A mismatch between the declared behaviour and the actual behaviour is a primary
+removal trigger, so declare what is true:
+
+- **Collected:** phone numbers, in the form of **unsalted SHA-256 digests plus
+  the last four digits**, transmitted to `POST /api/marketplace/contacts/match`.
+  Raw phone numbers and contact names **never leave the device** — see
+  `hushh-webapp/lib/marketplace/contact-matching.ts`.
+- **Stored:** nothing. `RIAIAMService.match_marketplace_contacts` performs zero
+  writes; the request body is consumed in memory and discarded, so a contact who
+  is not a Hussh user leaves no trace on any server.
+- **Shared with third parties:** no.
+- **Purpose:** app functionality (finding people you already know).
+- **Optional:** yes. The flow works fully for someone who grants nothing, and the
+  onboarding step removes itself when contacts are unavailable.
+
+### Prominent disclosure
+
+Play requires an in-app disclosure **before** the permission prompt, inside the
+app rather than only in the listing, and not buried in a menu. The One Location
+onboarding contacts screen already satisfies this — the privacy line renders
+*above* the button that triggers the OS prompt, and the prompt fires on tap
+rather than on mount:
+
+> Your contacts are checked using a one-way hash. One never stores your contact
+> list, and nobody is contacted for you.
+
+Anyone moving that line below the button, or making the prompt fire on screen
+entry, breaks the disclosure requirement as well as the UX intent.
+
+### iOS counterpart
+
+`PrivacyInfo.xcprivacy` currently declares `PhoneNumber` and `Name` but **not**
+`NSPrivacyCollectedDataTypeContacts`. Whether hashes-only egress counts as
+"collecting contacts" is the open question; either add the entry or record the
+written decision. `release-ios-appstore.md` already lists the privacy-manifest
+reconciliation as publish blocker #1, and this is part of it.


### PR DESCRIPTION
Step 5 of the Contact Sync plan. Docs only — no code, no behaviour change.

## Why now

`READ_CONTACTS` is declared in `AndroidManifest.xml:59` and read by the first-party `HushhContacts` plugin, so this app is in scope for Google Play's **Contact Permissions policy** of 15 April 2026. **Nothing in this repo covered it** — I grepped `ship-android-playstore.md` and the workflow for `data safety` / `contacts` / `permission` and the only hits were unrelated.

| When | What |
|---|---|
| 15 Apr 2026 | Policy announced |
| **Sept 2026** | Play Console prompts for declarations |
| **Jan 2027** | Mandatory; non-compliant apps subject to removal |

## The load-bearing fact

**Our use case is on Google's approved list.** They name *"friend matching with server-side processing"* explicitly, and that is exactly what contact sync does. The declaration has to be read from **that** sentence, not from "we sync contacts".

The distinction matters: **inviting and referring do not justify the permission** and must use the system picker. Ours already is picker-driven — the share offered after a scan carries no contact data at all, only the sender's referral link.

## The Data safety form, field by field

A mismatch between declared and actual behaviour is a primary removal trigger, so the doc writes out the honest answers — which are unusually good ones:

| | |
|---|---|
| Collected | phone numbers, as **SHA-256 digests + last four digits** |
| Raw numbers / contact names | **never leave the device** |
| Stored | **nothing** — `match_marketplace_contacts` performs zero writes; a contact who is not a Hussh user leaves no trace on any server |
| Shared with third parties | no |
| Optional | yes — the flow works fully for someone who grants nothing |

## Prominent disclosure

Play requires an in-app disclosure **before** the prompt, inside the app, not buried in a menu. The onboarding contacts screen already satisfies this, and the doc records *why* so the next person to move that copy knows what they would break: the privacy line renders **above** the button that triggers the OS prompt, and the prompt fires **on tap rather than on mount**.

## iOS counterpart, flagged not fixed

`PrivacyInfo.xcprivacy` declares `PhoneNumber` and `Name` but not `NSPrivacyCollectedDataTypeContacts`. Whether hashes-only egress counts as "collecting contacts" is a real question with a defensible answer either way — so the doc records it as a decision to make rather than making it. `release-ios-appstore.md` already calls the privacy-manifest reconciliation publish blocker #1; this is part of it.

## Verification

`verify-doc-brand.cjs`, `verify:docs`, and `bin/hushh docs verify` all pass.
