### PR TITLE
fix(ui): resolve mobile badge overflow and iOS safe-area footer overlaps

### DIFF
--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -2094,8 +2094,8 @@ export function OneKycWorkspace({
                     ? selectedEffectiveRequiredFields
                     : ["selected information"]
                   ).map((field) => (
-                    <Badge key={field} variant="outline">
-                      {field.replaceAll("_", " ")}
+                    <Badge key={field} variant="outline" className="max-w-full">
+                      <span className="block truncate">{field.replaceAll("_", " ")}</span>
                     </Badge>
                   ))}
                 </div>

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -703,7 +703,7 @@ export function AdaptiveDetailSurface({
               {children}
             </div>
             {footer ? (
-              <div className="sticky bottom-0 border-t border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-4">
+              <div className="sticky bottom-0 border-t border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 pt-3 pb-[calc(1rem+env(safe-area-inset-bottom,0px))]">
                 {footer}
               </div>
             ) : null}


### PR DESCRIPTION
## Summary

This PR fixes two mobile-specific layout issues in the KYC and Settings UI, improving responsive behavior and iOS safe-area handling.

## Issues

1. **Badge Overflow:** Long dynamic requirement names under "Information needed" could expand the layout beyond the viewport, causing horizontal overflow on narrow screens.
2. **iOS Footer Overlap:** Sticky action footers inside `AdaptiveDetailSurface` could overlap with the iOS home-swipe indicator due to insufficient bottom safe-area spacing.

## Changes

- Added `max-w-full` to the `Badge` wrapper and `truncate` to the badge text so long identifiers stay within the available width and display with an ellipsis.
- Updated the `AdaptiveDetailSurface` footer with `env(safe-area-inset-bottom)` padding to keep sticky actions above the iOS home indicator.

## UX Impact

- Long dynamic badges no longer break or cause horizontal scrolling on small screens.
- Mobile sticky action buttons now respect the device's bottom safe area, providing a cleaner and safer experience on modern iPhones.

## Verification

- Tested long requirement names on narrow mobile viewports.
- Verified badge text truncates correctly without horizontal overflow.
- Verified sticky footer actions remain above the iOS home indicator.
- Confirmed no changes to the underlying KYC or Settings logic.