### PR TITLE
fix(location): tell people what to do when a Circle share has no recipients

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7003,9 +7003,7 @@ export function OneLocationAgentPageContent({
           (target) => target.recipient.userId,
         );
         if (!recipientUserIds.length) {
-          throw new Error(
-            "No current Circle members are ready to receive encrypted location.",
-          );
+          throw new Error("Add members to your Circle");
         }
         setSelectedShareCircleSelection(selection);
         setNamedCircleShareContext({


### PR DESCRIPTION
> ~~"No current Circle members are ready to receive encrypted location."~~
> **"Add members to your Circle"**

The old line described the system's state in the system's vocabulary and left the reader to work out their move. The new one names the move.

## ⚠️ One case where the new line gives the wrong advice

Worth a decision, not just a review. This toast fires whenever `selection.ready` is empty, and [`resolveCircleRecipientSelection`](hushh-webapp/lib/one-location/circle-recipient-selection.ts) empties it for **three** different reasons:

| Exclusion reason | Means | Is "Add members" the right advice? |
|---|---|---|
| `self` | you are the only member | ✅ yes |
| `phone_verification_needed` | member hasn't verified their phone | ❌ no |
| `location_setup_needed` | member has no location keys yet | ❌ no |

A Circle with five members who haven't finished location setup will now be told to **add more people** — which won't help, and sends them to do the one thing that can't fix it.

`selection.excluded` already carries the reason for every excluded member, so branching is cheap:

```ts
const onlySelf = selection.excluded.every((e) => e.reason === "self");
throw new Error(
  onlySelf
    ? "Add members to your Circle"
    : "No one in this Circle can receive location yet",
);
```

I've left that out deliberately — it's a copy decision, and the request was for this specific string. Happy to add it in a follow-up, or now if you want it.

## Verification

- 116 tests pass in `one-location-agent-page.test.tsx`
- ESLint clean; typecheck clean
- No test referenced the old string

Closes #5856
