### PR TITLE
fix(location): shorten a spoken refusal to one thing worth hearing

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -8861,7 +8861,7 @@ export function OneLocationAgentPageContent({
       if (openFlow === "share" && shareReadySelectedRecipients.length === 0) {
         return {
           reason:
-            "Nobody is picked for this share yet, so starting it will refuse. The share needs a person chosen before it can run.",
+            "No one is chosen for this share yet. Pick who to share with.",
           remedyActionId: "location.select_share_recipient",
         };
       }


### PR DESCRIPTION
> ~~"Nobody is picked for this share yet, so starting it will refuse. The share needs a person chosen before it can run."~~
>
> **"No one is chosen for this share yet. Pick who to share with."**

21 words → 12.

## Why this is worse than it looks on the page

This field is **spoken aloud**. `VoiceSurfaceDeadEnd` says so in its own contract:

> *"`reason` is spoken aloud, so it must be safe to say and must describe the situation rather than name any person."*

So the old line is two sentences saying the same thing twice, read to someone who has just been refused and is waiting to hear what to do.

**"starting it will refuse"** and **"before it can run"** are the system narrating its own mechanics. The person doesn't need to be told a refusal happened — they just heard one. They need the missing piece and the next move, which is now the entire line: state, then remedy.

The remedy stays machine-addressable through `remedyActionId: "location.select_share_recipient"`, unchanged.

## Same problem, not touched

The sibling dead end a few lines above is also spoken, also long, and also explains the schema rather than the step:

> *"There is no one to share location with yet: sharing needs a connection or a circle member, and this account has neither."*

Left alone because the request was for the one string. Worth the same pass.

## Verification

- 375 tests pass across the voice suites and `one-location-agent-page`
- The 8 failures are `action-usage-memory.test.ts`, a pre-existing baseline failure unrelated to this change
- ESLint clean; typecheck clean

Closes #5859
