### PR TITLE
feat(contacts): Google Contacts for the browsers that have no address book

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -74,6 +74,15 @@ tests/test_capability_health.py
 tests/test_managed_vertex_readiness_script.py
 tests/test_verify_uat_release.py
 
+# The privacy property contact sync is built around, as code instead of prose.
+#
+# A raw phone number belonging to somebody who is NOT a Hushh user must never
+# reach a Hushh server. Adding Google Contacts is ~20 lines if the backend calls
+# the People API — it reuses the working OAuth refresh path and needs no client
+# id, no JS origins, no Capacitor gate. It would read as a simplification in
+# review. This is what makes it a failing test instead of a judgement call.
+tests/test_contacts_never_reach_the_server.py
+
 # One Location Circles, and the migration guards that protect them.
 #
 # Every file below was written to lock a behaviour that had already broken
@@ -90,12 +99,3 @@ tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
 tests/test_pool_acquire_is_bounded.py
-
-# The privacy property contact sync is built around, as code instead of prose.
-#
-# A raw phone number belonging to somebody who is NOT a Hushh user must never
-# reach a Hushh server. Adding Google Contacts is ~20 lines if the backend calls
-# the People API — it reuses the working OAuth refresh path and needs no client
-# id, no JS origins, no Capacitor gate. It would read as a simplification in
-# review. This is what makes it a failing test instead of a judgement call.
-tests/test_contacts_never_reach_the_server.py

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -67,13 +67,6 @@ tests/test_ria_dossier_mail_contract.py
 tests/test_ria_claim_location.py
 tests/test_ria_brochure_profile.py
 
-# Release-gate classification. These guard the rule that a third-party outage
-# must not block a healthy release, and that a candidate defect still must.
-tests/test_dependency_health_classifier.py
-tests/test_capability_health.py
-tests/test_managed_vertex_readiness_script.py
-tests/test_verify_uat_release.py
-
 # The privacy property contact sync is built around, as code instead of prose.
 #
 # A raw phone number belonging to somebody who is NOT a Hushh user must never
@@ -82,6 +75,13 @@ tests/test_verify_uat_release.py
 # id, no JS origins, no Capacitor gate. It would read as a simplification in
 # review. This is what makes it a failing test instead of a judgement call.
 tests/test_contacts_never_reach_the_server.py
+
+# Release-gate classification. These guard the rule that a third-party outage
+# must not block a healthy release, and that a candidate defect still must.
+tests/test_dependency_health_classifier.py
+tests/test_capability_health.py
+tests/test_managed_vertex_readiness_script.py
+tests/test_verify_uat_release.py
 
 # One Location Circles, and the migration guards that protect them.
 #

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -90,3 +90,12 @@ tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
 tests/test_pool_acquire_is_bounded.py
+
+# The privacy property contact sync is built around, as code instead of prose.
+#
+# A raw phone number belonging to somebody who is NOT a Hushh user must never
+# reach a Hushh server. Adding Google Contacts is ~20 lines if the backend calls
+# the People API — it reuses the working OAuth refresh path and needs no client
+# id, no JS origins, no Capacitor gate. It would read as a simplification in
+# review. This is what makes it a failing test instead of a judgement call.
+tests/test_contacts_never_reach_the_server.py

--- a/consent-protocol/tests/test_contacts_never_reach_the_server.py
+++ b/consent-protocol/tests/test_contacts_never_reach_the_server.py
@@ -1,0 +1,125 @@
+"""The one property contact sync is built around, as code instead of prose.
+
+A raw phone number belonging to somebody who is **not** a Hushh user must never
+reach a Hushh server. The device normalizes to E.164, hashes on-device, and
+sends only `{hash, last4}`; `match_marketplace_contacts` persists nothing, so a
+contact who does not match leaves no trace anywhere.
+
+Until this file, that property lived only in comments
+(`lib/marketplace/contact-matching.ts:13-18`,
+`lib/contacts/phone-normalization.ts:1-19`). Comments do not fail a build.
+
+The specific thing being guarded: adding Google Contacts as a source for web is
+about twenty lines if the backend calls the People API — it reuses
+`GoogleConnectionService.access_token`, needs no public client id, no JS
+origins, and no Capacitor gate. It would read as a simplification in review. It
+also puts the phone number of every non-user in somebody's address book onto our
+servers. This test is what turns that from a judgement call into a failing test.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Directories that make up the deployed backend. Tests and scripts are excluded
+#: on purpose — this file itself names the forbidden host, and a fixture may
+#: legitimately need to.
+_SERVER_TREES = ("hushh_mcp", "api", "mcp_modules")
+
+
+def _server_python_files() -> list[Path]:
+    files: list[Path] = []
+    for tree in _SERVER_TREES:
+        root = REPO_ROOT / tree
+        if not root.is_dir():
+            continue
+        files.extend(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    return files
+
+
+def test_no_server_module_talks_to_the_people_api():
+    """The backend must not read anybody's Google address book.
+
+    The scope declaration is allowed to exist -- `google_connection_service.py`
+    is the single source of truth for what each Google service means, and the
+    browser reads that string to ask for the same thing. What is forbidden is a
+    server-side CALL: the moment one exists, non-users' phone numbers are on our
+    infrastructure and the entire design collapses into "we upload your contacts".
+    """
+
+    offenders: list[str] = []
+    for path in _server_python_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "people.googleapis.com" not in text:
+            continue
+        offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        "A backend module references the Google People API: "
+        + ", ".join(offenders)
+        + ". Contact reads happen in the browser so a non-user's phone number "
+        "never reaches a Hushh server. See tests/test_contacts_never_reach_the_server.py."
+    )
+
+
+def test_the_contacts_scope_is_declared_but_never_exchanged_for_a_token():
+    """`contacts` may be a declared GoogleService. It may not be an authenticated caller.
+
+    `GoogleConnectionService.access_token(service=...)` returns an account-wide
+    Google token -- the refresh grant carries `include_granted_scopes: "true"`,
+    so it accumulates every scope the user has ever granted, including Calendar
+    write. Nothing may request one for contacts.
+    """
+
+    service_path = REPO_ROOT / "hushh_mcp" / "services" / "google_connection_service.py"
+    source = service_path.read_text(encoding="utf-8")
+
+    # The declaration is expected, and is what the browser flow reads.
+    assert '"contacts"' in source, (
+        "the contacts scope declaration disappeared -- the browser flow reads it "
+        "as the source of truth for which scope to request"
+    )
+
+    callers: list[str] = []
+    for path in _server_python_files():
+        if path == service_path:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "access_token" not in text:
+            continue
+        for match in re.finditer(r"access_token\s*\(([^)]*)\)", text, re.S):
+            if "contacts" in match.group(1):
+                callers.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not callers, (
+        "Something asks for a Google access token scoped to contacts: "
+        + ", ".join(callers)
+        + ". That token is account-wide, and the contacts read belongs in the browser."
+    )
+
+
+def test_the_match_endpoint_still_stores_nothing():
+    """No write on the matching path, so a non-user leaves no trace.
+
+    Guarded at the source rather than behaviourally because the endpoint has no
+    DB harness: the assertion is that the function body contains no statement
+    that could write. A future INSERT here would be the other way this property
+    is lost -- not by reading more, but by remembering what was read.
+    """
+
+    import inspect
+
+    from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+    source = inspect.getsource(RIAIAMService.match_marketplace_contacts)
+    lowered = source.lower()
+
+    for statement in ("insert into", "update ", "delete from"):
+        assert statement not in lowered, (
+            f"match_marketplace_contacts contains {statement!r}. The matching "
+            "path persists nothing; a contact who is not a Hushh user must "
+            "leave no trace."
+        )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (

--- a/docs/guides/google-contacts-enable.md
+++ b/docs/guides/google-contacts-enable.md
@@ -1,0 +1,197 @@
+# Switching on Google Contacts for web contact sync
+
+The code shipped **dark**. `googleContactsAvailability()` returns `"unconfigured"`
+whenever `NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID` is empty, which it is in every
+environment — so web, iOS and Android behave exactly as they did before. This
+file is the rest of the work, and none of it is code.
+
+Everything below needs GCP permissions that an ordinary developer credential does
+not carry. Verified 2026-08-24 with `testIamPermissions` against both
+`hushh-pda` and `hushh-pda-uat`: a normal member account holds
+`resourcemanager.projects.get` and nothing else on this path — no
+`serviceusage.services.enable`, no `secretmanager.secrets.create`, no
+`secretmanager.versions.add`, not even `secretmanager.versions.access`. Secret
+*names* list fine, which reads like access and is not. Run these as a member of
+`gcp-admins@hushh.ai`.
+
+## Order matters, and getting it wrong breaks every frontend deploy
+
+Step 3 creates the secret. Step 4 makes `frontend.cloudbuild.yaml` reference it.
+Cloud Build resolves every `availableSecrets` entry before the build starts, so a
+reference to a secret that does not exist yet fails the build — in all three
+environments, on every branch, whether or not it touches contacts. **Do not merge
+the step 4 diff until step 3 has run in all three projects.**
+
+This is the same ordering rule as R1 in the `safe-changes` skill, in its
+build-time form.
+
+---
+
+## Step 1 — Read the consent screen before changing anything
+
+The UAT backend env file on the deploy host carries a **localhost** OAuth
+callback, in a deployed environment. That is what a consent screen still in
+*Testing* looks like. (The file is untracked by design, so this is a thing to go
+and read, not a line to cite.)
+
+If it is in Testing, then today **no Google scope reaches a real user** — Gmail
+included — and only allowlisted test accounts work. Turning contacts on does not
+change that. But publishing the screen, whenever that happens, means a first
+production submission that necessarily includes the restricted `gmail.readonly`
+scope and its CASA assessment. Contacts did not create that debt; it is simply
+the feature that makes you look at it.
+
+Dogfooding is not blocked either way. Add the tester accounts and the flow works.
+
+```
+https://console.cloud.google.com/apis/credentials/consent?project=hushh-pda
+```
+
+Read it. Do not publish it as part of this change.
+
+## Step 2 — Enable the People API
+
+Per project, all three:
+
+```bash
+for p in hushh-pda hushh-pda-uat hushh-pda-dev; do
+  gcloud services enable people.googleapis.com --project="$p"
+done
+
+# prove it
+for p in hushh-pda hushh-pda-uat hushh-pda-dev; do
+  printf '%-16s ' "$p"
+  gcloud services list --enabled --project="$p" \
+    --filter="config.name=people.googleapis.com" --format='value(config.name)'
+done
+```
+
+Three lines of `people.googleapis.com`, or the browser gets a 403 that looks
+exactly like a consent failure.
+
+## Step 3 — A dedicated browser OAuth client, then the secret
+
+**Create a new Web application client. Do not add JavaScript origins to the Gmail
+client.** Same Cloud project, so it inherits the already-configured consent screen
+and starts no new verification — but a separate client id, so a mistake in the
+contacts origins cannot reach the client Gmail and Calendar authenticate through.
+That client is listed in the `safe-changes` shared-credential table for a reason.
+
+Console → Credentials → Create credentials → OAuth client ID → **Web application**.
+
+Authorized JavaScript origins — origins only, no paths, no trailing slash:
+
+```
+https://one.hushh.ai
+https://uat.one.hushh.ai
+https://dev.one.hushh.ai
+http://localhost:3000
+```
+
+No redirect URIs. The Google Identity Services token flow does not use one.
+
+Native is deliberately absent. `capacitor.config.ts` sets `iosScheme: "App"`, so
+the iOS shell origin is `App://localhost`; Google will not accept a non-https
+custom scheme, and native already has the real address book through the
+first-party plugin. `googleContactsAvailability()` returns `"unconfigured"` on
+native unconditionally, so nothing there ever asks.
+
+Then create the secret — same value in all three projects, because a client id is
+public and ships inside browser JavaScript:
+
+```bash
+CLIENT_ID='<the new client id>.apps.googleusercontent.com'
+
+for p in hushh-pda hushh-pda-uat hushh-pda-dev; do
+  gcloud secrets create NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID \
+    --project="$p" --replication-policy=automatic 2>/dev/null || true
+  printf '%s' "$CLIENT_ID" | gcloud secrets versions add \
+    NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID --project="$p" --data-file=-
+done
+```
+
+`printf` rather than `echo`: a trailing newline inside the secret becomes a
+trailing newline in the client id, and Google rejects it with a message that
+never mentions whitespace.
+
+Verify all three before going near step 4:
+
+```bash
+for p in hushh-pda hushh-pda-uat hushh-pda-dev; do
+  printf '%-16s ' "$p"
+  gcloud secrets versions access latest \
+    --secret=NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID --project="$p" | tail -c 30
+  echo
+done
+```
+
+No IAM grant is needed here. `roles/secretmanager.secretAccessor` is held at
+project level in each project, so a new secret is readable by that project's
+runtimes the moment it exists. That is only true because all three copies are
+same-project — a cross-project reference would need an explicit per-secret grant
+and would fail silently without one.
+
+## Step 4 — The build plumbing
+
+Only after step 3 shows a value in all three.
+
+`deploy/frontend.cloudbuild.yaml`, three edits:
+
+```yaml
+# 1. in the docker build args, beside the other NEXT_PUBLIC_GOOGLE_* lines
+          --build-arg NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=$$NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_VAL \
+
+# 2. in that step's secretEnv list
+      "NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_VAL",
+
+# 3. in availableSecrets
+    - versionName: projects/$PROJECT_ID/secrets/NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID/versions/latest
+      env: "NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_VAL"
+```
+
+**Do not add it to `required_vars`.** That list hard-fails the build on an empty
+value. Contacts is a fallback that is allowed to be off, and the two Maps keys
+are already precedent for a `NEXT_PUBLIC_` value that is wired but not required.
+
+`hushh-webapp/Dockerfile`, beside the other `NEXT_PUBLIC_GOOGLE_*` pair:
+
+```dockerfile
+ARG NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID
+ENV NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID
+```
+
+Both lines are needed. `ARG` alone reaches the build and not the bundle: Next.js
+reads `process.env` at build time, so without the `ENV` line the value is
+silently empty and the feature stays dark with no error anywhere.
+
+Finally add the name to `scripts/ops/verify-env-secrets-parity.py`, so a project
+missing the secret is a CI failure rather than one environment where the button
+quietly does nothing.
+
+## Step 5 — Prove it end to end
+
+```bash
+python3 scripts/ops/verify-env-secrets-parity.py --project hushh-pda-uat
+```
+
+Then in a **desktop** browser on `https://uat.one.hushh.ai` — desktop
+specifically, because that is the surface with no Contact Picker at all and
+therefore the only one where this path is reachable:
+
+1. Open the contacts step. The Google fallback offers itself.
+2. The consent sheet appears, scoped to `contacts.readonly` and nothing else.
+3. Matches come back; DevTools → Network shows `people.googleapis.com` called
+   **from the browser**, and no request to our API carrying a phone number.
+
+That last check is the whole design. If a People API call ever shows up in
+backend logs, `consent-protocol/tests/test_contacts_never_reach_the_server.py`
+should have failed the build first — treat that as a bug in the test rather than
+a tolerable shortcut.
+
+## What stays unverified
+
+Steps 1 and 3 are console actions with no read-back that proves *intent*. The
+origins list can be correct while the consent screen is still in Testing, and
+nothing in CI can tell those apart. The end-to-end check in step 5 on a real
+desktop browser is the only thing that closes the gap, and it cannot be
+automated — the consent sheet needs a human.

--- a/docs/guides/google-contacts-enable.md
+++ b/docs/guides/google-contacts-enable.md
@@ -14,6 +14,31 @@ not carry. Verified 2026-08-24 with `testIamPermissions` against both
 *names* list fine, which reads like access and is not. Run these as a member of
 `gcp-admins@hushh.ai`.
 
+## Visual Map
+
+Where the client id travels, and the one edge that must not be reversed.
+
+```mermaid
+flowchart TD
+    C["OAuth client<br/>(new Web client, same project)"] -->|"step 3"| SM["Secret Manager<br/>NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID<br/>x3 projects"]
+    SM -->|"step 4: availableSecrets"| CB["frontend.cloudbuild.yaml"]
+    CB -->|"--build-arg"| DA["Dockerfile ARG"]
+    DA -->|"ENV"| DE["Dockerfile ENV"]
+    DE -->|"read at build time"| NB["Next.js bundle<br/>process.env"]
+    NB --> AV["googleContactsAvailability()"]
+    AV -->|"empty -> unconfigured"| DARK["feature stays dark<br/>(today, every environment)"]
+    AV -->|"set -> connectable"| GIS["Google Identity Services<br/>token in browser memory"]
+    GIS --> PA["people.googleapis.com<br/>called FROM THE BROWSER"]
+    PA -.->|"never"| SRV["our servers"]
+
+    SM -.->|"step 4 before step 3 =<br/>every frontend build fails,<br/>all 3 envs, every branch"| CB
+```
+
+The dotted edge back into `frontend.cloudbuild.yaml` is the failure mode this
+document is ordered around. The dotted edge into "our servers" is the one the
+whole design exists to prevent, and it is enforced by a test rather than by
+this diagram.
+
 ## Order matters, and getting it wrong breaks every frontend deploy
 
 Step 3 creates the secret. Step 4 makes `frontend.cloudbuild.yaml` reference it.

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -427,6 +427,31 @@ vi.mock("@/lib/services/connections-service", () => ({
   },
 }));
 
+// Google Contacts is the fallback for browsers with no address book. Both
+// modules stay inert by default -- `mockGoogleAvailability` returns
+// "unconfigured", which is what a build without NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID
+// reports, so every test in this file behaves exactly as it did before unless it
+// opts in.
+let mockGoogleAvailability: () => string = () => "unconfigured";
+const mockRequestGoogleContactsToken = vi.fn(async () => "google-token");
+const mockGooglePeopleContactSource = vi.fn(() => vi.fn());
+
+vi.mock("@/lib/contacts/google-people-source", () => ({
+  googleContactsAvailability: () => mockGoogleAvailability(),
+  googlePeopleContactSource: (...args: unknown[]) =>
+    mockGooglePeopleContactSource(...(args as [])),
+}));
+
+// Only the part that talks to Google is replaced. `isGoogleContactsConsentCancelled`
+// comes through untouched on purpose: it IS the contract under test, and a
+// hand-written copy here would keep passing after the real one broke.
+vi.mock("@/lib/contacts/google-contacts-token", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/contacts/google-contacts-token")
+  >()),
+  requestGoogleContactsToken: () => mockRequestGoogleContactsToken(),
+}));
+
 vi.mock("sonner", () => {
   const toast = vi.fn();
   return {
@@ -956,6 +981,12 @@ describe("OneLocationAgentPage", () => {
       algorithm: "ECDH-P256-AES256-GCM",
     });
     mockRegisterKey.mockResolvedValue({});
+    // Back to what a build with no NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID reports,
+    // so one opted-in test cannot leak the Google branch into the next.
+    mockGoogleAvailability = () => "unconfigured";
+    mockRequestGoogleContactsToken.mockReset();
+    mockRequestGoogleContactsToken.mockResolvedValue("google-token");
+    mockGooglePeopleContactSource.mockReset();
     mockGetPermissionState.mockReset();
     mockGetPermissionState.mockResolvedValue({
       state: "granted",
@@ -5059,6 +5090,48 @@ describe("OneLocationAgentPage", () => {
         invite_candidate_count: 7,
       }),
     );
+  });
+
+  it("treats a closed Google consent sheet as a shrug, not a failure", async () => {
+    // The Google fallback is the only contact source on desktop and iOS Safari,
+    // and it is reached through a consent sheet the person can simply close.
+    // That path had no handling: the rejection fell into the same catch as a
+    // real failure, so changing your mind produced a red error toast, left the
+    // card stuck on "scanning", and recorded an analytics row saying the sync
+    // had failed. The device picker has read AbortError as a shrug since it
+    // shipped; this makes the two agree.
+    mockGoogleAvailability = () => "connectable";
+    const cancelled = new Error("Google contact access was cancelled.");
+    cancelled.name = "AbortError";
+    mockRequestGoogleContactsToken.mockRejectedValueOnce(cancelled);
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "People" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Find contacts/i }),
+    );
+
+    await waitFor(() =>
+      expect(mockRequestGoogleContactsToken).toHaveBeenCalled(),
+    );
+
+    // Nothing was read, so nothing may be sent -- a cancelled consent sheet
+    // must not fall through to a device read that would also fail here.
+    expect(mockSyncOneLocationContactSignals).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    // Not reported as a failed sync either. An analytics row that counts every
+    // dismissal as an error makes the feature look broken in the dashboard.
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      "one_location_contact_signal_synced",
+      expect.objectContaining({ result: "error" }),
+    );
+    // And the button is usable again rather than stuck mid-scan.
+    expect(
+      await screen.findByRole("button", { name: /Find contacts/i }),
+    ).toBeTruthy();
   });
 
   it("creates an approval-first invite path for contacts who are not One users", async () => {

--- a/hushh-webapp/__tests__/lib/marketplace/contact-matching.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/contact-matching.test.ts
@@ -10,6 +10,73 @@ vi.mock("@/lib/capacitor", () => ({
   },
 }));
 
+/**
+ * The injected-source cases. Google Contacts feeds the SAME pipeline as the
+ * device address book — normalization, dedupe, mobile-first ordering, the 1000
+ * cap and the hashing all have exactly one implementation, and these pin that
+ * a second source does not get a second copy of any of it.
+ */
+describe("buildMarketplaceContactLookups with an injected source", () => {
+  const googleResult = {
+    contacts: [
+      { id: "g1", displayName: "Asha", phoneNumbers: ["98765 43210"] },
+      { id: "g2", displayName: "Asha again", phoneNumbers: ["+91 98765 43210"] },
+      { id: "g3", displayName: "Landline", phoneNumbers: ["+91 11 2345 6789"] },
+    ],
+    sourcePlatform: "google" as const,
+    defaultRegion: null,
+    limited: false,
+    truncated: false,
+    totalAvailable: 3,
+  };
+
+  it("dedupes across the source exactly as it does for the device book", async () => {
+    const source = vi.fn(async () => googleResult);
+    const result = await buildMarketplaceContactLookups({
+      accountPhoneNumber: "+919000000000",
+      source,
+    });
+
+    // Two spellings of one number collapse to one digest.
+    const digests = new Set(result.lookups.map((l) => l.hash));
+    expect(digests.size).toBe(result.lookups.length);
+    expect(result.sourcePlatform).toBe("google");
+    expect(result.limited).toBe(false);
+  });
+
+  it("sends the source only the limit, and nothing else", async () => {
+    // A source has no business receiving the account phone number or the abort
+    // signal. Both stay on this side of the seam.
+    const source = vi.fn(async () => googleResult);
+    await buildMarketplaceContactLookups({
+      limit: 42,
+      accountPhoneNumber: "+919000000000",
+      source,
+    });
+    expect(source).toHaveBeenCalledWith({ limit: 42 });
+  });
+
+  it("still hashes on this side, never trusting the source for a digest", async () => {
+    const source = vi.fn(async () => googleResult);
+    const result = await buildMarketplaceContactLookups({
+      accountPhoneNumber: "+919000000000",
+      source,
+    });
+    for (const lookup of result.lookups) {
+      expect(lookup.hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("propagates truncation from the source", async () => {
+    const source = vi.fn(async () => ({ ...googleResult, truncated: true }));
+    const result = await buildMarketplaceContactLookups({
+      accountPhoneNumber: "+919000000000",
+      source,
+    });
+    expect(result.truncated).toBe(true);
+  });
+});
+
 describe("marketplace contact matching", () => {
   beforeEach(() => {
     readContactsMock.mockReset();

--- a/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
@@ -191,3 +191,54 @@ describe("one location contact signals", () => {
     await expect(openContactPermissionSettings()).resolves.toBe(false);
   });
 });
+
+describe("one location contact signals — an injected source", () => {
+  it("does not run the device pre-flight, which would refuse the browser it exists for", async () => {
+    // `assertContactsReadable` asks the Capacitor plugin whether the DEVICE can
+    // read contacts. On a desktop browser the honest answer is `unavailable` —
+    // and that is exactly the platform where reading Google Contacts is the
+    // whole point. Left in front of an injected source it would refuse the one
+    // case this feature exists to serve.
+    mockGetPermissionState.mockResolvedValue({ state: "unavailable" });
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      totalContacts: 2,
+      sourcePlatform: "google",
+      region: "IN",
+      limited: false,
+      truncated: false,
+      lookups: [{ hash: "d".repeat(64), last4: "1234", displayName: "Asha" }],
+    });
+    mockMatchMarketplaceContacts.mockResolvedValue([]);
+
+    const source = vi.fn(async () => ({
+      contacts: [],
+      sourcePlatform: "google" as const,
+      defaultRegion: null,
+      limited: false,
+      truncated: false,
+      totalAvailable: 0,
+    }));
+
+    const result = await syncOneLocationContactSignals({
+      idToken: "id-token",
+      accountPhoneNumber: "+919000000000",
+      source,
+    });
+
+    expect(result.sourcePlatform).toBe("google");
+    expect(mockBuildMarketplaceContactLookups).toHaveBeenCalledWith(
+      expect.objectContaining({ source }),
+    );
+  });
+
+  it("still runs the pre-flight for the device address book", async () => {
+    // The guard has to stay for the default path — a denied device permission
+    // is a real, actionable state with its own copy and its own remedy.
+    mockGetPermissionState.mockResolvedValue({ state: "denied" });
+
+    await expect(
+      syncOneLocationContactSignals({ idToken: "id-token" }),
+    ).rejects.toMatchObject({ failure: "denied" });
+    expect(mockBuildMarketplaceContactLookups).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-sync-outcome.test.ts
@@ -108,3 +108,52 @@ describe("describeContactSyncOutcome", () => {
     expect(outcome.title).toBe("1 of the 1 contact you shared is on Hushh");
   });
 });
+
+describe("describeContactSyncOutcome — a Google read is a whole read", () => {
+  // Google Contacts is read in the browser through the People API, so it
+  // returns the entire address book rather than a hand-picked subset. The
+  // partial-read copy and its remedies must not apply to it.
+  const googleBase = {
+    ...base,
+    sourcePlatform: "google" as const,
+    limited: false,
+  };
+
+  it("never offers the remedy that widens a partial read", () => {
+    // "Check more" re-runs the picker. After a Google sync that action would
+    // return the identical set and teach the person the button does nothing.
+    // The web + limited combination is what routes to `pick_more`, and a
+    // Google read is neither.
+    const outcome = describeContactSyncOutcome({
+      ...googleBase,
+      matchedUserIds: ["a"],
+      totalContacts: 200,
+    });
+
+    expect(outcome.remedy).not.toBe("pick_more");
+    expect(outcome.remedy).not.toBe("open_settings");
+  });
+
+  it("does not scope the count to what was shared", () => {
+    // "3 of the 40 contacts you shared" is true of a picker and false of a
+    // whole-address-book read.
+    const outcome = describeContactSyncOutcome({
+      ...googleBase,
+      matchedUserIds: ["a", "b", "c"],
+      totalContacts: 200,
+    });
+
+    expect(outcome.title).toBe("3 people added as a contact signal.");
+    expect(outcome.title).not.toContain("you shared");
+  });
+
+  it("reports an empty Google read without implying a narrowed one", () => {
+    const outcome = describeContactSyncOutcome({
+      ...googleBase,
+      totalContacts: 40,
+    });
+
+    expect(outcome.title).toBe("No One users matched from this contact scan.");
+    expect(outcome.title).not.toContain("you shared");
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -133,6 +133,12 @@ function BodyPortal({ children }: { children: ReactNode }) {
 
 import { HushhContacts } from "@/lib/capacitor";
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
+import {
+  googleContactsAvailability,
+  googlePeopleContactSource,
+} from "@/lib/contacts/google-people-source";
+import { requestGoogleContactsToken } from "@/lib/contacts/google-contacts-token";
+import type { MarketplaceContactSource } from "@/lib/marketplace/contact-matching";
 import { isWeb } from "@/lib/capacitor/platform";
 import { apiErrorCode } from "@/lib/services/api-client";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
@@ -371,12 +377,6 @@ import {
   DRIVE_ETA_MIN_RECOMPUTE_MOVE_METERS,
 } from "@/lib/one-location/eta-recompute";
 import { getApiBaseUrl } from "@/lib/services/api-service";
-import {
-  googleContactsAvailability,
-  googlePeopleContactSource,
-} from "@/lib/contacts/google-people-source";
-import { requestGoogleContactsToken } from "@/lib/contacts/google-contacts-token";
-import type { MarketplaceContactSource } from "@/lib/marketplace/contact-matching";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import {
   buildCircleInviteShareText,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -371,6 +371,12 @@ import {
   DRIVE_ETA_MIN_RECOMPUTE_MOVE_METERS,
 } from "@/lib/one-location/eta-recompute";
 import { getApiBaseUrl } from "@/lib/services/api-service";
+import {
+  googleContactsAvailability,
+  googlePeopleContactSource,
+} from "@/lib/contacts/google-people-source";
+import { requestGoogleContactsToken } from "@/lib/contacts/google-contacts-token";
+import type { MarketplaceContactSource } from "@/lib/marketplace/contact-matching";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import {
   buildCircleInviteShareText,
@@ -6376,8 +6382,39 @@ export function OneLocationAgentPageContent({
 
     try {
       const idToken = await auth.user.getIdToken();
+      // Google Contacts, only where there is no address book to read.
+      //
+      // `navigator.contacts.select` ships enabled by default in Chrome on
+      // Android and nowhere else — iOS Safari has it behind a flag, no desktop
+      // browser has it at all. On those, this control had nothing to read and
+      // said so. A Google account is not a device capability, so it works
+      // everywhere a browser does.
+      //
+      // Deliberately a fallback rather than a second button. The device book is
+      // the better source when it exists: it is the person's actual phone
+      // contacts rather than whichever of them Google happens to hold, and it
+      // needs no consent sheet. This only fires where the alternative is
+      // nothing at all, and only when the build is configured for it —
+      // `googleContactsAvailability()` is "unconfigured" without
+      // NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID, which keeps the feature invisible
+      // until the console work behind it is finished.
+      let googleSource: MarketplaceContactSource | undefined;
+      if (googleContactsAvailability() === "connectable") {
+        const deviceState = await HushhContacts.getPermissionState().catch(
+          () => null,
+        );
+        if (!deviceState || deviceState.state === "unavailable") {
+          // Must run inside the click that started this: acquiring the token
+          // can open a consent sheet, and a browser blocks a popup no gesture
+          // asked for.
+          googleSource = googlePeopleContactSource(
+            await requestGoogleContactsToken(),
+          );
+        }
+      }
       const result = await syncOneLocationContactSignals({
         idToken,
+        ...(googleSource ? { source: googleSource } : {}),
         // Tells the normalizer which region a bare "9876543210" belongs to.
         // Without it every 10-digit contact was read as North American.
         accountPhoneNumber: auth.user.phoneNumber,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -137,7 +137,10 @@ import {
   googleContactsAvailability,
   googlePeopleContactSource,
 } from "@/lib/contacts/google-people-source";
-import { requestGoogleContactsToken } from "@/lib/contacts/google-contacts-token";
+import {
+  isGoogleContactsConsentCancelled,
+  requestGoogleContactsToken,
+} from "@/lib/contacts/google-contacts-token";
 import type { MarketplaceContactSource } from "@/lib/marketplace/contact-matching";
 import { isWeb } from "@/lib/capacitor/platform";
 import { apiErrorCode } from "@/lib/services/api-client";
@@ -6373,6 +6376,11 @@ export function OneLocationAgentPageContent({
       return;
     }
 
+    // Kept so a cancelled consent sheet can put the card back exactly as it
+    // was. "scanning" is set below before anything can be cancelled, and
+    // leaving it there would strand the card mid-scan forever.
+    const statusBeforeSync = contactSignal.status;
+
     setBusy("contactSync");
     setContactSignal((current) => ({
       ...current,
@@ -6407,9 +6415,22 @@ export function OneLocationAgentPageContent({
           // Must run inside the click that started this: acquiring the token
           // can open a consent sheet, and a browser blocks a popup no gesture
           // asked for.
-          googleSource = googlePeopleContactSource(
-            await requestGoogleContactsToken(),
-          );
+          try {
+            googleSource = googlePeopleContactSource(
+              await requestGoogleContactsToken(),
+            );
+          } catch (error) {
+            // Closing the sheet is a choice, not a failure -- the same reading
+            // the device picker has always given an AbortError. Anything else
+            // is a real failure and still belongs in the catch below.
+            if (!isGoogleContactsConsentCancelled(error)) throw error;
+            setContactSignal((current) => ({
+              ...current,
+              status: statusBeforeSync,
+              error: null,
+            }));
+            return;
+          }
         }
       }
       const result = await syncOneLocationContactSignals({

--- a/hushh-webapp/eslint.config.mjs
+++ b/hushh-webapp/eslint.config.mjs
@@ -137,6 +137,13 @@ export default [
       "lib/mail/**/*",
       // SSE streaming components use fetch() for EventSource polyfill
       "components/kai/debate-stream-view.tsx",
+      // Google People API, called from the browser ON PURPOSE. Routing this
+      // through our own server is exactly what the module exists to avoid: the
+      // server would then see the raw phone number of every contact who is NOT
+      // a Hushh user. The token is browser-held and our infrastructure never
+      // touches it. Enforced from the other side by
+      // consent-protocol/tests/test_contacts_never_reach_the_server.py.
+      "lib/contacts/google-people-source.ts",
     ],
     rules: {
       "no-restricted-syntax": "off",

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -880,7 +880,17 @@ export type HushhContactRecord = {
 
 export type HushhContactsReadResult = {
   contacts: HushhContactRecord[];
-  sourcePlatform: "web" | "ios" | "android" | "native";
+  /**
+   * Where the contacts came from.
+   *
+   * `google` is not a platform in the Capacitor sense — it is a different
+   * ACCOUNT on the same platform, read in the browser through the People API.
+   * It is a member here because everything downstream keys off this field, and
+   * folding a Google read into `web` would route it to the partial-read remedy
+   * ("Check more"), whose action re-runs the picker and returns the identical
+   * set.
+   */
+  sourcePlatform: "web" | "ios" | "android" | "native" | "google";
   /**
    * ISO-3166 alpha-2 region the device believes it is in (SIM, then network,
    * then locale). National-format contact numbers are meaningless without it —

--- a/hushh-webapp/lib/contacts/__tests__/google-people-source.test.ts
+++ b/hushh-webapp/lib/contacts/__tests__/google-people-source.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  googleContactsAvailability,
+  googlePeopleContactSource,
+} from "../google-people-source";
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: () => mockIsNative(),
+}));
+
+let mockIsNative = () => false;
+
+/**
+ * The ingress mirror of the egress guards in `contact-signals.test.ts`.
+ *
+ * Those assert nothing phone-shaped leaves the sync toward the screen. These
+ * assert nothing but a `HushhContactsReadResult` leaves this module toward the
+ * hashing pipeline — and that the request itself asks Google for the minimum it
+ * can be asked for.
+ */
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
+
+function respondWith(...pages: unknown[]) {
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (url: string) => {
+    calls.push(String(url));
+    const body = pages[Math.min(calls.length - 1, pages.length - 1)];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as unknown as Response;
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { calls, fetchMock };
+}
+
+beforeEach(() => {
+  mockIsNative = () => false;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_CLIENT_ID === undefined) {
+    delete process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID = ORIGINAL_CLIENT_ID;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("googleContactsAvailability", () => {
+  it("is unconfigured without a client id, so the feature is simply absent", () => {
+    delete process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
+    expect(googleContactsAvailability()).toBe("unconfigured");
+  });
+
+  it("is connectable on the web once a client id exists", () => {
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID = "test-client.apps.googleusercontent.com";
+    expect(googleContactsAvailability()).toBe("connectable");
+  });
+
+  it("is unconfigured inside the native shell even with a client id", () => {
+    // `capacitor.config.ts` sets `iosScheme: "App"`, so the page origin in the
+    // iOS shell is `App://localhost`. Google will not accept a non-https custom
+    // scheme as an Authorized JavaScript Origin and GIS will not initialise —
+    // and native already has the real address book through the plugin, so there
+    // is nothing to fall back to.
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID = "test-client.apps.googleusercontent.com";
+    mockIsNative = () => true;
+    expect(googleContactsAvailability()).toBe("unconfigured");
+  });
+});
+
+describe("googlePeopleContactSource", () => {
+  it("asks Google for the two fields the pipeline actually reads, and no more", async () => {
+    const { calls } = respondWith({ connections: [], totalPeople: 0 });
+    await googlePeopleContactSource("tok")({ limit: 500 });
+
+    const url = new URL(calls[0]);
+    expect(url.searchParams.get("personFields")).toBe("names,phoneNumbers");
+    // Photos, addresses and organisations belong to people who are not our
+    // users. There is no reason to receive them.
+    expect(url.searchParams.get("personFields")).not.toContain("photos");
+    expect(url.searchParams.get("personFields")).not.toContain("addresses");
+    // Saved contacts only — not merged profiles Google infers from mail
+    // traffic. Somebody emailed once is not somebody you meant to share.
+    expect(url.searchParams.get("sources")).toBe("READ_SOURCE_TYPE_CONTACT");
+  });
+
+  it("never asks for a sync token", async () => {
+    // A sync token is a durable handle to somebody's address book, and there is
+    // nowhere in this design to keep one — nothing here is persisted.
+    const { calls } = respondWith({ connections: [] });
+    await googlePeopleContactSource("tok")({ limit: 500 });
+    expect(calls[0]).not.toContain("requestSyncToken");
+  });
+
+  it("sends the token as a bearer header and never in the URL", async () => {
+    const { calls, fetchMock } = respondWith({ connections: [] });
+    await googlePeopleContactSource("secret-token")({ limit: 500 });
+
+    expect(calls[0]).not.toContain("secret-token");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.Authorization,
+    ).toBe("Bearer secret-token");
+  });
+
+  it("passes the typed number through, not Google's canonical form", async () => {
+    // `phone-normalization.ts` exists so both sides of the hash reach
+    // byte-identical E.164 through ONE implementation. Google's parser and
+    // libphonenumber-js need not agree at the edges, and the moment they
+    // disagree the digest misses silently and the person is told nobody
+    // matched. The normalizer sees what the user typed.
+    respondWith({
+      connections: [
+        {
+          resourceName: "people/1",
+          names: [{ displayName: "Asha" }],
+          phoneNumbers: [
+            { value: "98765 43210", canonicalForm: "+919876543210" },
+          ],
+        },
+      ],
+    });
+
+    const result = await googlePeopleContactSource("tok")({ limit: 500 });
+    expect(result.contacts[0].phoneNumbers).toEqual(["98765 43210"]);
+  });
+
+  it("falls back to the canonical form only when there is no typed value", async () => {
+    respondWith({
+      connections: [
+        {
+          resourceName: "people/2",
+          names: [{ displayName: "Only Canonical" }],
+          phoneNumbers: [{ value: "", canonicalForm: "+919876500000" }],
+        },
+      ],
+    });
+
+    const result = await googlePeopleContactSource("tok")({ limit: 500 });
+    // Still goes THROUGH the normalizer downstream, never around it.
+    expect(result.contacts[0].phoneNumbers).toEqual(["+919876500000"]);
+  });
+
+  it("reports google, unlimited, and no region", async () => {
+    respondWith({
+      connections: [
+        {
+          resourceName: "people/3",
+          names: [{ displayName: "Someone" }],
+          phoneNumbers: [{ value: "+919876543210" }],
+        },
+      ],
+      totalPeople: 1,
+    });
+
+    const result = await googlePeopleContactSource("tok")({ limit: 500 });
+
+    expect(result.sourcePlatform).toBe("google");
+    // A People read is the whole address book, not a hand-picked subset. This
+    // flag is the sole gate on the partial-read copy and its "Check more"
+    // remedy, whose action would re-read and return the identical set.
+    expect(result.limited).toBe(false);
+    // Null, not the browser locale — and strictly better than the picker path.
+    // A US-locale browser must not override an Indian account's own verified
+    // number when deciding what `9876543210` means.
+    expect(result.defaultRegion).toBeNull();
+  });
+
+  it("drops contacts with no phone number", async () => {
+    respondWith({
+      connections: [
+        { resourceName: "a", names: [{ displayName: "Has" }], phoneNumbers: [{ value: "+911" }] },
+        { resourceName: "b", names: [{ displayName: "None" }], phoneNumbers: [] },
+        { resourceName: "c", names: [{ displayName: "Blank" }], phoneNumbers: [{ value: "  " }] },
+      ],
+    });
+
+    const result = await googlePeopleContactSource("tok")({ limit: 500 });
+    // A contact with no number cannot produce a digest, so carrying it would
+    // only inflate the count reported back to the person.
+    expect(result.contacts).toHaveLength(1);
+  });
+
+  it("follows pages and reports truncation honestly", async () => {
+    respondWith(
+      {
+        connections: [
+          { resourceName: "a", names: [{ displayName: "One" }], phoneNumbers: [{ value: "+911" }] },
+        ],
+        nextPageToken: "page-2",
+        totalPeople: 2,
+      },
+      {
+        connections: [
+          { resourceName: "b", names: [{ displayName: "Two" }], phoneNumbers: [{ value: "+912" }] },
+        ],
+        totalPeople: 2,
+      },
+    );
+
+    const result = await googlePeopleContactSource("tok")({ limit: 500 });
+    expect(result.contacts).toHaveLength(2);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("says so when the token has expired rather than reporting an empty book", async () => {
+    // An empty result and a refused one look identical downstream — one says
+    // "nobody you know is here", which is a lie.
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    await expect(
+      googlePeopleContactSource("stale")({ limit: 500 }),
+    ).rejects.toThrow(/expired|connect again/i);
+  });
+
+  it("returns nothing but a read result — no raw response, no token", async () => {
+    respondWith({
+      connections: [
+        {
+          resourceName: "people/9",
+          names: [{ displayName: "Asha" }],
+          phoneNumbers: [{ value: "+919876543210", canonicalForm: "+919876543210" }],
+        },
+      ],
+      nextPageToken: null,
+      totalPeople: 1,
+    });
+
+    const result = await googlePeopleContactSource("super-secret")({ limit: 500 });
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain("super-secret");
+    expect(serialized).not.toContain("canonicalForm");
+    expect(serialized).not.toContain("nextPageToken");
+    expect(Object.keys(result).sort()).toEqual(
+      [
+        "contacts",
+        "defaultRegion",
+        "limited",
+        "sourcePlatform",
+        "totalAvailable",
+        "truncated",
+      ].sort(),
+    );
+  });
+});

--- a/hushh-webapp/lib/contacts/google-contacts-token.ts
+++ b/hushh-webapp/lib/contacts/google-contacts-token.ts
@@ -1,0 +1,151 @@
+/**
+ * A browser-held Google access token, scoped to reading contacts and nothing else.
+ *
+ * Uses Google Identity Services' implicit token flow, which never involves our
+ * servers: the token is minted in the browser, lives in this module's memory,
+ * and is discarded. That is the whole reason this file exists rather than an
+ * endpoint that vends one.
+ *
+ * WHY NOT ASK OUR BACKEND FOR A TOKEN. `GoogleConnectionService.access_token`
+ * exists and works, and it is the wrong tool. It refreshes with no `scope`
+ * parameter, and `start()` sets `include_granted_scopes: "true"` — so the
+ * single stored refresh token accumulates the union of every scope the person
+ * has ever granted. For anyone who connected Calendar with `manage`, that token
+ * carries `calendar.events` WRITE. Handing it to JavaScript hands the browser
+ * the ability to create, move and cancel that person's real meetings, in order
+ * to read their address book. Narrowing on the refresh grant fails open: if
+ * Google ignores the narrowed scope you get a broader token, not an error.
+ *
+ * The scope string below is the one already declared server-side in
+ * `google_connection_service.py`. That declaration stays the source of truth
+ * for what "contacts" means; this file asks for the same thing.
+ */
+
+const GIS_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
+const CONTACTS_SCOPE = "https://www.googleapis.com/auth/contacts.readonly";
+
+type TokenResponse = { access_token?: string; error?: string };
+type TokenClient = { requestAccessToken: () => void };
+type GoogleIdentityServices = {
+  accounts?: {
+    oauth2?: {
+      initTokenClient: (config: {
+        client_id: string;
+        scope: string;
+        callback: (response: TokenResponse) => void;
+        error_callback?: (error: { type?: string }) => void;
+      }) => TokenClient;
+    };
+  };
+};
+
+function gis(): GoogleIdentityServices | null {
+  const candidate = (globalThis as Record<string, unknown>).google;
+  return (candidate as GoogleIdentityServices) ?? null;
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadGis(): Promise<void> {
+  if (gis()?.accounts?.oauth2) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    if (typeof document === "undefined") {
+      reject(new Error("Google sign-in is only available in a browser."));
+      return;
+    }
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${GIS_SCRIPT_SRC}"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener(
+        "error",
+        () => reject(new Error("Could not reach Google sign-in.")),
+        { once: true },
+      );
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = GIS_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener(
+      "error",
+      () => reject(new Error("Could not reach Google sign-in.")),
+      { once: true },
+    );
+    document.head.appendChild(script);
+  }).catch((error) => {
+    // A failed load must not poison every later attempt.
+    scriptPromise = null;
+    throw error;
+  });
+
+  return scriptPromise;
+}
+
+/**
+ * Ask Google for a contacts-scoped access token.
+ *
+ * MUST be called from a user gesture — the flow can open a consent popup, and
+ * browsers block popups that no click asked for.
+ *
+ * The token is returned rather than stored. The caller uses it for one read and
+ * lets it go: there is no refresh token on this path, nothing is written to
+ * `localStorage` or `sessionStorage` (the house rule — see
+ * `lib/calendar/calendar-oauth-journey.ts`, which stores only the literal "1"),
+ * and a 401 mid-read means asking again, which is silent once consent is
+ * already granted.
+ */
+export async function requestGoogleContactsToken(): Promise<string> {
+  const clientId = String(
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID || "",
+  ).trim();
+  if (!clientId) {
+    throw new Error("Google contacts are not available in this build.");
+  }
+
+  await loadGis();
+  const oauth2 = gis()?.accounts?.oauth2;
+  if (!oauth2) {
+    throw new Error("Could not reach Google sign-in.");
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const client = oauth2.initTokenClient({
+      client_id: clientId,
+      scope: CONTACTS_SCOPE,
+      callback: (response) => {
+        if (settled) return;
+        settled = true;
+        const token = String(response?.access_token || "").trim();
+        if (token) {
+          resolve(token);
+          return;
+        }
+        reject(new Error("Google contact access was not granted."));
+      },
+      error_callback: (error) => {
+        if (settled) return;
+        settled = true;
+        // Closing the consent sheet is a choice, not a failure. Reported with a
+        // recognisable name so the caller can stay silent about it, the same
+        // way an AbortError from the device picker is treated.
+        const closed =
+          error?.type === "popup_closed" || error?.type === "popup_failed_to_open";
+        const failure = new Error(
+          closed
+            ? "Google contact access was cancelled."
+            : "Could not open Google sign-in.",
+        );
+        failure.name = closed ? "AbortError" : "Error";
+        reject(failure);
+      },
+    });
+    client.requestAccessToken();
+  });
+}

--- a/hushh-webapp/lib/contacts/google-contacts-token.ts
+++ b/hushh-webapp/lib/contacts/google-contacts-token.ts
@@ -88,6 +88,24 @@ function loadGis(): Promise<void> {
 }
 
 /**
+ * Did the person close the consent sheet rather than fail to open it?
+ *
+ * Lives here because this file is what decides it: `error_callback` stamps
+ * `name = "AbortError"` on a dismissal specifically so a caller can tell the
+ * two apart. Callers that re-derive the rule by string-matching the message
+ * break the first time the wording changes.
+ *
+ * Cancelling is a choice, not a failure. The device picker has read it that
+ * way since it shipped (`contacts-web.ts` returns an empty read on
+ * `AbortError`); without this the Google path reported a shrug as a red error
+ * toast and an analytics row saying the sync failed.
+ */
+export function isGoogleContactsConsentCancelled(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return (error as { name?: unknown }).name === "AbortError";
+}
+
+/**
  * Ask Google for a contacts-scoped access token.
  *
  * MUST be called from a user gesture — the flow can open a consent popup, and

--- a/hushh-webapp/lib/contacts/google-people-source.ts
+++ b/hushh-webapp/lib/contacts/google-people-source.ts
@@ -1,0 +1,211 @@
+/**
+ * Google Contacts as a source for contact sync, read in the browser.
+ *
+ * WHY THIS EXISTS: the W3C Contact Picker (`navigator.contacts.select`) ships
+ * enabled by default only in Chrome on Android. iOS Safari has it behind a
+ * flag; no desktop browser has it at all. So on most of the web, contact sync
+ * has nothing to read. A Google account is not a device capability — it works
+ * in every browser — which is what makes it the right second source.
+ *
+ * THE INVARIANT THIS MODULE EXISTS TO PRESERVE, AND MUST NOT BREAK:
+ *
+ *   The People API is called ONLY from browser JavaScript, with a token our
+ *   servers never see. A raw phone number belonging to somebody who is not a
+ *   Hushh user must never reach a Hushh server. There is no server-side People
+ *   API client and there must never be one. No response from this module is
+ *   cached or persisted anywhere.
+ *
+ * A backend implementation is about twenty lines and would reuse the working
+ * OAuth refresh path — it will look like a simplification in review. It also
+ * puts the phone number of every non-user in somebody's address book onto our
+ * infrastructure, which is the one thing this whole design is arranged to
+ * prevent. `consent-protocol/tests/test_contacts_never_reach_the_server.py`
+ * fails the build if anyone tries.
+ *
+ * Everything read here is handed straight to `buildMarketplaceContactLookups`,
+ * which normalizes, dedupes and hashes on-device exactly as it does for the
+ * device address book. There is one copy of that pipeline on purpose.
+ */
+
+import type { HushhContactsReadResult } from "@/lib/capacitor";
+import { isNative } from "@/lib/capacitor/platform";
+import type { MarketplaceContactSource } from "@/lib/marketplace/contact-matching";
+
+const PEOPLE_CONNECTIONS_URL =
+  "https://people.googleapis.com/v1/people/me/connections";
+
+/**
+ * Exactly the two fields the pipeline consumes.
+ *
+ * `contact-matching.ts` reads `displayName` and `phoneNumbers` and nothing
+ * else — `HushhContactRecord.emailAddresses` is declared and never used. Asking
+ * for photos, addresses or organisations would be collecting data we have no
+ * use for, from people who are not our users.
+ */
+const PERSON_FIELDS = "names,phoneNumbers";
+
+/**
+ * Contacts the person actually saved, not merged "other contacts" profiles
+ * Google infers from mail traffic. Someone emailed once is not someone you
+ * meant to share.
+ */
+const READ_SOURCE = "READ_SOURCE_TYPE_CONTACT";
+
+/** Google's maximum for this endpoint. */
+const PAGE_SIZE = 1000;
+
+/**
+ * Pages are bounded rather than followed to exhaustion. The pipeline caps at
+ * 1000 lookups anyway (`MAX_PHONE_LOOKUPS`), so walking a 20,000-contact
+ * account to the end would spend the person's quota to build a list that is
+ * then discarded.
+ */
+const MAX_PAGES = 5;
+
+export type GoogleContactsAvailability = "connectable" | "unconfigured";
+
+type PeoplePhone = { value?: string | null; canonicalForm?: string | null };
+type PeopleName = { displayName?: string | null };
+type PeoplePerson = {
+  resourceName?: string | null;
+  names?: PeopleName[];
+  phoneNumbers?: PeoplePhone[];
+};
+type PeopleConnectionsResponse = {
+  connections?: PeoplePerson[];
+  nextPageToken?: string | null;
+  totalPeople?: number | null;
+};
+
+/**
+ * Whether this build can offer a Google connection at all.
+ *
+ * Synchronous and deliberately NOT a `HushhContactsPermissionState`. That state
+ * is a device fact answered by a plugin, and the onboarding gate treats any
+ * failure to answer it as "hide the contacts step"
+ * (`app/one/location/page.tsx`). Google availability is an ACCOUNT fact and
+ * needs a network round trip to establish, so folding it in would let a slow
+ * response hide the contacts step on a phone whose picker works perfectly.
+ *
+ * Native returns `unconfigured` on purpose. `capacitor.config.ts` sets
+ * `iosScheme: "App"`, so inside the iOS shell the page origin is
+ * `App://localhost` — Google will not accept a non-https custom scheme as an
+ * Authorized JavaScript Origin, and Google Identity Services will not
+ * initialise there. Native already has the real address book through the
+ * first-party plugin, so there is nothing to fall back to.
+ */
+export function googleContactsAvailability(): GoogleContactsAvailability {
+  if (typeof window === "undefined") return "unconfigured";
+  if (isNative()) return "unconfigured";
+  const clientId = String(
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID || "",
+  ).trim();
+  return clientId ? "connectable" : "unconfigured";
+}
+
+function displayNameOf(person: PeoplePerson): string | null {
+  const named = (person.names ?? []).find((name) =>
+    String(name?.displayName || "").trim(),
+  );
+  return named?.displayName?.trim() || null;
+}
+
+/**
+ * The number string to normalize, chosen deliberately.
+ *
+ * Google returns `canonicalForm` (its own E.164) beside `value` (whatever the
+ * person typed). Using `canonicalForm` is the obvious shortcut and it is wrong:
+ * `lib/contacts/phone-normalization.ts` exists so BOTH sides of the hash reach
+ * byte-identical E.164 through ONE implementation. Google's parser and
+ * `libphonenumber-js` need not agree at the edges, and the moment they disagree
+ * the digest misses silently and the person is told nobody matched.
+ *
+ * `canonicalForm` is used only when `value` is empty, and even then it goes
+ * THROUGH the normalizer, never around it.
+ */
+function phoneStringsOf(person: PeoplePerson): string[] {
+  return (person.phoneNumbers ?? [])
+    .map((phone) => {
+      const typed = String(phone?.value || "").trim();
+      if (typed) return typed;
+      return String(phone?.canonicalForm || "").trim();
+    })
+    .filter(Boolean);
+}
+
+/**
+ * A source that reads the signed-in Google account's saved contacts.
+ *
+ * The token is passed in rather than fetched here: acquiring it is a UI concern
+ * (it needs a user gesture and can show a consent sheet), and keeping the two
+ * apart means this module can be tested with a plain string.
+ */
+export function googlePeopleContactSource(token: string): MarketplaceContactSource {
+  return async ({ limit }) => {
+    const contacts: HushhContactsReadResult["contacts"] = [];
+    let pageToken: string | null = null;
+    let pages = 0;
+    let totalPeople = 0;
+    let hasMore = false;
+
+    do {
+      const url = new URL(PEOPLE_CONNECTIONS_URL);
+      url.searchParams.set("personFields", PERSON_FIELDS);
+      url.searchParams.set("pageSize", String(PAGE_SIZE));
+      url.searchParams.set("sources", READ_SOURCE);
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+      // Deliberately no `requestSyncToken`. A sync token is a durable handle to
+      // somebody's address book, and there is nowhere in this design to keep
+      // one — nothing here is persisted.
+
+      const response = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        throw new Error(
+          response.status === 401 || response.status === 403
+            ? "Google contact access expired. Connect again to keep going."
+            : "Could not read your Google contacts. Try again in a moment.",
+        );
+      }
+
+      const payload = (await response.json()) as PeopleConnectionsResponse;
+      totalPeople = Number(payload.totalPeople || 0) || totalPeople;
+
+      for (const person of payload.connections ?? []) {
+        const phoneNumbers = phoneStringsOf(person);
+        // A contact with no number cannot produce a digest, so carrying it
+        // would only inflate the count reported back to the person.
+        if (!phoneNumbers.length) continue;
+        contacts.push({
+          id: String(person.resourceName || "") || null,
+          displayName: displayNameOf(person),
+          phoneNumbers,
+        });
+      }
+
+      pageToken = String(payload.nextPageToken || "") || null;
+      pages += 1;
+      hasMore = Boolean(pageToken);
+    } while (pageToken && pages < MAX_PAGES && contacts.length < limit);
+
+    return {
+      contacts: contacts.slice(0, limit),
+      sourcePlatform: "google",
+      // Null, not the browser locale — and this is strictly better than the
+      // device-picker path. `resolveContactPhoneRegion` takes the first of
+      // device region, the account's own verified number, then locale. The web
+      // picker passes a locale, so a US-locale browser overrides an Indian
+      // account's own number, which is exactly the bug
+      // `phone-normalization.ts` was written to kill. Passing null lets the
+      // account's real number decide.
+      defaultRegion: null,
+      // A People read is the whole address book, not a hand-picked subset. This
+      // flag is the sole gate on the partial-read copy and its "Check more"
+      // remedy, which would re-run the read and return the identical set.
+      limited: false,
+      truncated: hasMore || contacts.length > limit,
+      totalAvailable: totalPeople || contacts.length,
+    };
+  };
+}

--- a/hushh-webapp/lib/marketplace/contact-matching.ts
+++ b/hushh-webapp/lib/marketplace/contact-matching.ts
@@ -55,6 +55,24 @@ async function sha256Hex(value: string): Promise<string> {
     .join("");
 }
 
+/**
+ * Where a batch of contacts comes from.
+ *
+ * The device address book is the default and stays the default. This exists so
+ * a second source — Google Contacts, read in the browser — can feed the same
+ * normalize/dedupe/hash pipeline instead of growing a parallel one. Everything
+ * that keeps a raw phone number off our servers lives below this line, and
+ * there has to be exactly one copy of it.
+ *
+ * Deliberately a function returning the whole `HushhContactsReadResult` rather
+ * than a bare array of records: the pipeline reads `defaultRegion`,
+ * `sourcePlatform`, `limited` and `truncated` off the result, and every one of
+ * those is a judgement only the source is qualified to make.
+ */
+export type MarketplaceContactSource = (options: {
+  limit: number;
+}) => Promise<HushhContactsReadResult>;
+
 export async function buildMarketplaceContactLookups(options?: {
   limit?: number;
   /**
@@ -63,8 +81,16 @@ export async function buildMarketplaceContactLookups(options?: {
    */
   accountPhoneNumber?: string | null;
   signal?: AbortSignal;
+  /** Defaults to the device address book through the Capacitor plugin. */
+  source?: MarketplaceContactSource;
 }): Promise<MarketplaceContactLookupResult> {
-  const result = await HushhContacts.readContacts({
+  // The default forwards exactly `{ limit }` and nothing else — the existing
+  // test asserts that call shape as an exact object match, and it is the right
+  // assertion: a source has no business receiving the account phone number or
+  // the abort signal, both of which stay on this side of the seam.
+  const read: MarketplaceContactSource =
+    options?.source ?? ((forwarded) => HushhContacts.readContacts(forwarded));
+  const result = await read({
     limit: options?.limit ?? 500,
   });
   options?.signal?.throwIfAborted();

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import { HushhContacts, type HushhContactsPermissionState } from "@/lib/capacitor";
-import { buildMarketplaceContactLookups } from "@/lib/marketplace/contact-matching";
+import {
+  buildMarketplaceContactLookups,
+  type MarketplaceContactSource,
+} from "@/lib/marketplace/contact-matching";
 import {
   RiaService,
   type MarketplaceContactMatch,
@@ -34,7 +37,7 @@ export type OneLocationContactSignalResult = {
   matchedUserIds: string[];
   totalContacts: number;
   inviteCandidateCount: number;
-  sourcePlatform: "web" | "ios" | "android" | "native";
+  sourcePlatform: "web" | "ios" | "android" | "native" | "google";
   /** Region used to read national-format contact numbers, for diagnostics. */
   region: string | null;
   /**
@@ -88,6 +91,7 @@ export async function syncOneLocationContactSignals({
   contactLimit = 5000,
   matchLimit = 100,
   signal,
+  source,
 }: {
   idToken: string;
   /**
@@ -98,13 +102,30 @@ export async function syncOneLocationContactSignals({
   contactLimit?: number;
   matchLimit?: number;
   signal?: AbortSignal;
+  /**
+   * Where to read contacts from. Omitted means the device address book.
+   *
+   * Supplied for Google Contacts, which is read in the browser through the
+   * People API and is the only contact source available at all on iOS Safari
+   * and on desktop.
+   */
+  source?: MarketplaceContactSource;
 }): Promise<OneLocationContactSignalResult> {
-  await assertContactsReadable();
+  // The device-permission pre-flight applies to the device address book and to
+  // nothing else. `assertContactsReadable` asks the Capacitor plugin whether it
+  // can read, and on a desktop browser the honest answer is `unavailable` —
+  // which is exactly the platform where a Google read is the whole point.
+  // Left in front of an injected source, it would refuse the one case this
+  // exists to serve.
+  if (!source) {
+    await assertContactsReadable();
+  }
 
   const lookupResult = await buildMarketplaceContactLookups({
     limit: contactLimit,
     accountPhoneNumber,
     signal,
+    ...(source ? { source } : {}),
   });
 
   if (lookupResult.lookups.length === 0) {


### PR DESCRIPTION
Ships **dark**. `googleContactsAvailability()` returns `"unconfigured"` without `NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID`, which is set in **no environment** — so behaviour on web, iOS and Android is byte-identical to today until the console work behind it is done.

## The gap it closes

`navigator.contacts.select` ships enabled by default in **Chrome on Android and nowhere else**. iOS Safari has it behind a flag; no desktop browser has it at all. On those, "Find contacts" had nothing to read and correctly said so — the onboarding step removed itself entirely.

A Google account is not a device capability. It works everywhere a browser does.

## The People API is called from the browser, never from us

A token minted by Google Identity Services, held in module memory, used for one read, discarded. Our servers never see it and never see a contact.

**The alternative is genuinely tempting and that is the danger.** A backend implementation is ~20 lines, reuses the working OAuth refresh path, and needs no public client id, no JS origins, no Capacitor gate. It would read as a *simplification* in review. It also puts the phone number of **every non-user in somebody's address book** onto our infrastructure.

So the invariant is now a test. `consent-protocol/tests/test_contacts_never_reach_the_server.py` asserts:
- no backend module references `people.googleapis.com`
- nothing asks `GoogleConnectionService.access_token` for the contacts scope
- the matching path still contains no `INSERT`/`UPDATE`/`DELETE`

Until now that property lived only in comments, and comments do not fail a build.

**Why not `access_token` specifically.** It refreshes with **no `scope` parameter** while `start()` sets `include_granted_scopes: "true"` — so the stored refresh token accumulates the union of every scope the person ever granted. Anyone who connected Calendar with `manage` has `calendar.events` **write** in that token. Handing it to JavaScript to read an address book hands the browser the ability to cancel their real meetings. Narrowing on the refresh grant *fails open*: if Google ignores the narrowed scope you get a broader token, not an error.

## One pipeline, not two

`buildMarketplaceContactLookups` gained one optional `source`. Normalization, dedupe, mobile-first ordering, the 1000 cap and the hashing are untouched and still have exactly one implementation.

Three details that are load-bearing and not obvious:

| | |
|---|---|
| `defaultRegion: null` | **Better** than the picker path, not merely different. The web picker passes a browser locale, so a US-locale browser overrides an Indian account's own verified number when deciding what `9876543210` means — the exact bug `phone-normalization.ts` was written to kill. Null lets the account's real number win. |
| `limited: false` | A People read is the whole address book. That flag is the sole gate on the partial-read copy and its **"Check more"** remedy, whose action would re-read and return the identical set. |
| `canonicalForm` **unused** | Google returns its own E.164 beside the typed value. Using it is the obvious shortcut and it is wrong: both sides of the hash must reach byte-identical E.164 through **one** implementation. Google's parser and libphonenumber-js need not agree at the edges, and the moment they disagree the digest misses silently and the person is told nobody matched. |

## A fallback, not a second button

It fires only where the device address book is unavailable. The device book stays primary — it is the person's actual phone contacts rather than whichever of them Google happens to hold, and it needs no consent sheet. **No control is added to any screen.**

Native returns `"unconfigured"` unconditionally: `capacitor.config.ts` sets `iosScheme: "App"`, so the shell origin is `App://localhost`, which Google will not accept as an Authorized JavaScript Origin — and native already has the real address book.

## Verification

| | |
|---|---|
| New `google-people-source.test.ts` | **13 passed** |
| New `test_contacts_never_reach_the_server.py` | **3 passed** |
| `verify:one-location` | **430 passed** (16 files) |
| `__tests__/lib` + `lib/contacts` + `lib/capacitor/plugins` | **616 passed** (82 files) |
| `tsc --noEmit`, `eslint`, `ruff` | clean |

The new tests pin the request shape itself: `personFields` is exactly `names,phoneNumbers` (no photos, no addresses — those belong to people who are not our users), `sources=READ_SOURCE_TYPE_CONTACT` (saved contacts, not profiles Google infers from mail traffic), `requestSyncToken` is never sent (a durable handle to an address book we have nowhere to keep), the token never appears in a URL, and nothing but a `HushhContactsReadResult` leaves the module.

## Three human steps before it can be switched on — none of them code

1. **Read the OAuth consent-screen publishing status for `hushh-pda`.** `deploy/.env.backend.uat:144` is a **localhost** callback in a deployed UAT env, which is what a screen still in *Testing* looks like. If so, nothing ships to real users on any Google scope today — Gmail included — and turning contacts on means a first production submission that necessarily includes restricted `gmail.readonly` and its CASA assessment. Contacts did not cause that debt but is what makes you pay it. **Either way the feature works today for allowlisted test users**, so dogfooding is not blocked.
2. **Enable `people.googleapis.com`** and register **Authorized JavaScript Origins** on the OAuth client. Keep the browser client in the same Cloud project — a separate project restarts consent-screen verification from zero.
3. **Plumb `NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID`** through Secret Manager, `frontend.cloudbuild.yaml`, the Dockerfile `ARG`/`ENV`, and `verify-env-secrets-parity.py` — or parity CI will not catch a miss and a user will find a dead button.

One commit is the recurring `ruff format` drift in `test_one_adk_live_protocol.py` — fifth time this session, not this branch's code, and the pre-commit hook blocks every commit until it is flattened.


---

## Added after review of the finished flow

**Closing the consent sheet no longer reports a failure.** The sheet can be
closed, and that path had no handling: the rejection landed in the same catch as
a real failure, so changing your mind produced a red error toast, a card stuck on
"scanning", and an analytics row saying the sync failed. Desktop and iOS Safari
have no Contact Picker at all, so Google is not a nicety there — it is the only
contact source those browsers have, which makes its consent sheet the single most
likely place for somebody to back out.

`isGoogleContactsConsentCancelled` ships beside the code that creates the
condition, because `error_callback` stamps `name = "AbortError"` on a dismissal
precisely so a caller can tell the two apart. Only a cancellation is swallowed;
anything else still rethrows.

Verified failing before the fix, not merely passing after — reverting the
try/catch produces `expected "vi.fn()" to not be called at all, but actually been
called 1 times` on `toast.error`. The page test mocks only the Google call and
pulls the predicate through `importOriginal`, so the real one is exercised rather
than a copy that would keep passing after it broke.

**`docs/guides/google-contacts-enable.md`** now carries the three console steps
in runnable form, with the ordering hazard first: Cloud Build resolves every
`availableSecrets` entry before the build starts, so referencing the secret
before creating it fails the frontend build in all three environments, on every
branch. The access note in it is measured rather than assumed —
`testIamPermissions` against `hushh-pda` and `hushh-pda-uat` returns
`resourcemanager.projects.get` and nothing else for an ordinary member
credential, while secret *names* still list fine, which reads like access and is
not.
