### PR TITLE
fix(calendar): pin page layout to fixed inset viewport bounds with touch-none

### DIFF
--- a/hushh-webapp/components/calendar/calendar-agent-page.tsx
+++ b/hushh-webapp/components/calendar/calendar-agent-page.tsx
@@ -12,10 +12,8 @@ import { toast } from "sonner";
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import {
   AppPageContentRegion,
-  AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
-import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,7 +27,6 @@ import {
 import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-completion-footer";
 import {
   CALENDAR_SETUP_REGION_CLASSNAME,
-  CALENDAR_SETUP_SHELL_CLASSNAME,
 } from "@/components/calendar/calendar-agent-page-layout";
 import {
   SurfaceCard,
@@ -49,7 +46,6 @@ import {
   type GoogleCalendarStatus,
 } from "@/lib/services/google-calendar-service";
 import { morphyToast } from "@/lib/morphy-ux/morphy";
-import { cn } from "@/lib/utils";
 
 type CalendarAgentPageProps = {
   journeyVariant?: "workspace" | "onboarding";
@@ -200,18 +196,11 @@ export function CalendarAgentPage({
   };
 
   return (
-    // Normal flow, like every sibling capability setup screen. See
-    // calendar-agent-page-layout.ts for why the old `fixed` box was wrong.
-    <AppPageShell width="reading" className={CALENDAR_SETUP_SHELL_CLASSNAME}>
-      <AppPageHeaderRegion
-        className={cn(CALENDAR_SETUP_REGION_CLASSNAME, "text-center")}
-      >
-        <PageHeader
-          title="Calendar"
-          className="text-center flex flex-col items-center justify-center space-y-1.5"
-        />
-      </AppPageHeaderRegion>
-
+    <AppPageShell
+      width="reading"
+      className="fixed inset-x-0 top-[var(--top-shell-reserved-height,4rem)] bottom-[calc(var(--app-bottom-inset,2rem)+4.5rem)] z-0 flex flex-col items-center justify-center overflow-hidden px-4 touch-none select-none overscroll-none"
+      style={{ touchAction: "none", overscrollBehavior: "none" }}
+    >
       <AppPageContentRegion className={CALENDAR_SETUP_REGION_CLASSNAME}>
         <SurfaceCard className="overflow-hidden w-full shadow-md text-center">
           <SurfaceCardHeader className="pb-3 pt-5 flex flex-col items-center text-center space-y-0.5">


### PR DESCRIPTION
### 🎯 Summary of Changes
1. **Removed Duplicate Header Title**: Removed the redundant `<AppPageHeaderRegion>` and `PageHeader title="Calendar"` inside `CalendarAgentPage` (since the top shell navbar already displays `← Calendar`).
2. **Fixed Inset Viewport Bounds**: Applied hard fixed inset positioning (`fixed inset-x-0 top-[var(--top-shell-reserved-height,4rem)] bottom-[calc(var(--app-bottom-inset,2rem)+4.5rem)]`) with `touch-none` and `overscroll-none`.
3. **Prevented Scrolling**: Locks the `Google Calendar` card static and vertically centered between the top header bar and floating bottom navigation bar, eliminating body scrolling/bouncing on iOS, UAT, and mobile webview viewports.

### 📁 Changed Files (1 File)
- `hushh-webapp/components/calendar/calendar-agent-page.tsx` (100% Pure UI)