### PR TITLE
fix(trusted-device): open Hermes enrollment to all signed-in accounts

### DIFF
--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -114,15 +114,10 @@ class TrustedDeviceVaultHandoffRequest(BaseModel):
         return value
 
 
-def _trusted_device_allowlist() -> set[str]:
-    return {
-        value.strip()
-        for value in str(os.getenv("HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST") or "").split(",")
-        if value.strip()
-    }
-
-
 async def _trusted_device_guard(user_id: str | None = None) -> None:
+    # user_id is retained for call-site compatibility; enrollment no longer
+    # depends on per-account rollout membership.
+    del user_id
     if not trusted_devices_enabled():
         raise HTTPException(
             status_code=404,
@@ -131,45 +126,12 @@ async def _trusted_device_guard(user_id: str | None = None) -> None:
                 "message": "Trusted-device authorization is not enabled.",
             },
         )
-    allowlist = _trusted_device_allowlist()
-    if not allowlist:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "TRUSTED_DEVICE_NOT_ALLOWED",
-                "message": "Trusted-device enrollment is not available for this account.",
-            },
-        )
-    # The unauthenticated PKCE exchange is guarded by possession of the
-    # one-time code and verifier; the allowlist was enforced when that code was
-    # created. Every signed-in entrypoint fails closed when rollout membership
-    # is absent or does not match.
-    if not user_id:
-        return
-    if user_id in allowlist:
-        return
-
-    allowed_emails = {value.lower() for value in allowlist if "@" in value}
-    firebase_email = ""
-    if allowed_emails:
-        app = get_firebase_auth_app()
-        if app is not None:
-            try:
-                from firebase_admin import auth as firebase_auth
-
-                record = await run_in_threadpool(firebase_auth.get_user, user_id, app=app)
-                if bool(getattr(record, "email_verified", False)):
-                    firebase_email = str(getattr(record, "email", "") or "").strip().lower()
-            except Exception:
-                logger.exception("trusted_device.allowlist_identity_lookup_failed")
-    if firebase_email not in allowed_emails:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "TRUSTED_DEVICE_NOT_ALLOWED",
-                "message": "This account is not in the trusted-device rollout.",
-            },
-        )
+    # Enrollment is open to every signed-in account once the feature is enabled.
+    # The remaining controls still apply per request: the kill switch above, the
+    # browser-session identity check in _verify_browser_enrollment_identity, the
+    # verified-email requirement enforced at exchange, and the PKCE-bound
+    # one-time code. The former per-account rollout allowlist has been removed.
+    return
 
 
 def _raise_trusted_device_error(exc: TrustedDeviceError) -> None:

--- a/consent-protocol/tests/test_trusted_device_routes.py
+++ b/consent-protocol/tests/test_trusted_device_routes.py
@@ -192,41 +192,23 @@ async def test_device_owner_capability_closes_revocation_issuance_race(
 
 
 @pytest.mark.asyncio
-async def test_signed_in_trusted_device_rollout_fails_closed_without_allowlist(
+async def test_signed_in_trusted_device_guard_allows_any_account_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Enrollment is open to every signed-in account once the feature is enabled;
+    # the per-account rollout allowlist has been removed.
     monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: set())
-
-    with pytest.raises(HTTPException) as raised:
-        await account._trusted_device_guard("user-1")
-
-    assert raised.value.status_code == 403
-    assert raised.value.detail["code"] == "TRUSTED_DEVICE_NOT_ALLOWED"
-
-
-@pytest.mark.asyncio
-async def test_signed_in_trusted_device_rollout_accepts_exact_uid(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"user-1", "other-user"})
 
     await account._trusted_device_guard("user-1")
 
 
 @pytest.mark.asyncio
-async def test_pkce_exchange_guard_fails_closed_without_rollout_allowlist(
+async def test_pkce_exchange_guard_allows_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: set())
 
-    with pytest.raises(HTTPException) as raised:
-        await account._trusted_device_guard()
-
-    assert raised.value.status_code == 403
-    assert raised.value.detail["code"] == "TRUSTED_DEVICE_NOT_ALLOWED"
+    await account._trusted_device_guard()
 
 
 @pytest.mark.asyncio
@@ -367,32 +349,6 @@ def test_trusted_device_vault_handoff_accepts_only_bounded_ciphertext() -> None:
 
 
 @pytest.mark.asyncio
-async def test_email_rollout_entry_requires_verified_firebase_email(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from firebase_admin import auth as firebase_auth
-
-    class _Record:
-        email = "owner@example.com"
-        email_verified = False
-
-    async def _run_in_threadpool(function, *args, **kwargs):
-        return function(*args, **kwargs)
-
-    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"user-1"})
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"owner@example.com"})
-    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
-    monkeypatch.setattr(account, "get_firebase_auth_app", lambda: object())
-    monkeypatch.setattr(firebase_auth, "get_user", lambda *_args, **_kwargs: _Record())
-
-    with pytest.raises(HTTPException) as raised:
-        await account._trusted_device_guard("user-1")
-
-    assert raised.value.status_code == 403
-
-
-@pytest.mark.asyncio
 async def test_trusted_device_exchange_identity_uses_verified_firebase_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -453,7 +409,6 @@ async def test_trusted_device_exchange_returns_server_verified_account_email(
         return function(*args, **kwargs)
 
     monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
-    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"user-1"})
     monkeypatch.setattr(account, "TrustedDeviceService", _Service)
     monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
     monkeypatch.setattr(account, "get_firebase_auth_app", lambda: object())


### PR DESCRIPTION
## What
Remove the per-account rollout allowlist from the Hermes trusted-device approval guard so any signed-in, Firebase-verified account can enroll a device once the feature is enabled.

## Why
The allowlist (`HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST`) was a UAT rollout gate that pinned enrollment to a single reviewer account. It was never intended as a permanent access control and blocks general use. This opens enrollment to all authenticated users.

## What still guards the flow
- Kill switch `HUSSH_TRUSTED_DEVICE_ENABLED` (master on/off; UAT-only, default off in prod).
- Browser-session identity check rejects a device session approving another device.
- Verified-email requirement enforced at exchange.
- PKCE-bound one-time code.

## Changes
- `account.py`: simplify `_trusted_device_guard` to the kill-switch check; remove `_trusted_device_allowlist`.
- `test_trusted_device_routes.py`: replace allowlist-behavior tests with open-enrollment tests.

## Follow-ups (separate)
- Remove the now-unused allowlist env plumbing once this ships.
- Pre-existing ruff wrap-style drift in `tests/test_one_adk_live_protocol.py` (unrelated; flagged by the local all-files hook, not this change).

## Verification
- `tests/test_trusted_device_routes.py`: 15 passed.
- `ruff check` clean on changed files.