### PR TITLE
fix(db): give every pool acquire a deadline so a busy pool cannot hang

### DIFF
--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -778,7 +778,13 @@ async def run_consent_listener():
         return
     conn = None
     try:
-        conn = await pool.acquire()
+        # Wait as long as it takes. This connection is held for the life of
+        # the process, nothing retries this coroutine, and failing here also
+        # cancels the timeout and notification loops in the finally below —
+        # so an early failure silently disables consent notifications on this
+        # instance until it restarts. The acquire deadline in db.connection is
+        # for request handlers, which have a caller waiting; this has none.
+        conn = await pool.acquire(timeout=None)
         await conn.execute("LISTEN consent_audit_new")
         # asyncpg add_listener is a coroutine (must be awaited)
         await conn.add_listener("consent_audit_new", _notify_callback)

--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -39,7 +39,7 @@ import asyncio
 import hashlib
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import quote_plus
 
 import asyncpg
@@ -197,29 +197,62 @@ def _get_pool_int(env_name: str, default: int, *, minimum: int) -> int:
 # clamped hard, and an unbounded wait against a small pool is a hang.
 #
 # On 2026-08-23 that combination took UAT phone verification down for six
-# hours: three connections were held by slow handlers, every later request
-# queued on acquire() with no deadline, and Cloud Run killed each one at its
-# 3600s request timeout while it held a concurrency slot for the full hour.
+# hours: connections were held by slow handlers, every later request queued on
+# acquire() with no deadline, and Cloud Run killed each one at its 3600s
+# request timeout while it held a concurrency slot for the full hour. Nothing
+# could drain.
 #
 # The fix is a deadline. ``Pool.execute()``/``fetch()``/``fetchval()`` and the
 # rest all funnel through ``self.acquire()`` internally, so bounding acquire
 # bounds every one of them from a single place — including any asyncpg method
 # this repo does not call today.
 #
-# A starved pool now raises DatabaseUnavailableError (503) in seconds instead
-# of hanging for an hour. A fast, honest 503 is recoverable; an hour-long hang
-# takes the whole service down with it.
+# Three things this deliberately does NOT do:
+#
+#   1. It does not hand the deadline to asyncpg. ``Pool._acquire`` records its
+#      timeout on the connection holder and ``Pool.release()`` later reuses it
+#      as the budget for ``Connection.reset()``. Passing a deadline down would
+#      silently cap every release too, and a reset that overran would terminate
+#      the connection and force a fresh handshake — churn, exactly when the
+#      database is already struggling. We keep our own deadline out here and
+#      leave asyncpg's release semantics untouched.
+#
+#   2. It does not claim every timeout is pool exhaustion. The wait covers
+#      connection ESTABLISHMENT as well as the queue wait, so a TCP/TLS/auth
+#      timeout to Cloud SQL surfaces here too. Reporting that as "pool
+#      exhausted, raise DB_POOL_MAX_SIZE" would send an operator the wrong way
+#      during a real database outage — and would add connection pressure to an
+#      instance that is already failing. We only claim exhaustion when our own
+#      deadline actually elapsed; anything faster is re-raised untouched so the
+#      real connection error, and local_database_unavailable_hint(), survive.
+#
+#   3. It does not bind callers who must wait. A background job that needs one
+#      connection once, for the life of the process, loses nothing by waiting
+#      and loses everything by failing early. Such callers pass an explicit
+#      ``timeout=None`` and keep asyncpg's original unbounded behaviour.
+#
+# The default is sized above the cold-start cost this repo documents at
+# server.py — a burst of first requests can stall 15-30s while additional
+# connections are established to Cloud SQL on a single vCPU. A deadline under
+# that would turn every cold start into a 503 storm. It is not sized to undercut
+# the proxy's per-route timeouts (the tightest are 10s), because it cannot do
+# both, and not hanging matters far more than which layer reports the failure.
 # ---------------------------------------------------------------------------
 
-_DEFAULT_ACQUIRE_TIMEOUT_SECONDS = 10.0
+_DEFAULT_ACQUIRE_TIMEOUT_SECONDS = 60.0
+
+# Distinguishes "caller said nothing" from "caller explicitly said None".
+# ``acquire(timeout=None)`` has to keep meaning "wait as long as it takes".
+_UNSET: Any = object()
 
 
 def _get_acquire_timeout_seconds() -> float:
-    """Seconds to wait for a free pooled connection before failing fast.
+    """Seconds to wait for a pooled connection before failing fast.
 
-    Tunable via DB_POOL_ACQUIRE_TIMEOUT_SECONDS. The default is deliberately
-    far below the proxy's own per-route timeouts (20s at the tightest) so a
-    starved pool surfaces as a clean 503 rather than a proxy gateway timeout.
+    Tunable via DB_POOL_ACQUIRE_TIMEOUT_SECONDS. The window has to clear the
+    15-30s cold-start handshake burst documented in server.py, because this
+    deadline covers establishing a new connection as well as waiting for a
+    free one.
     """
     raw = os.getenv(
         "DB_POOL_ACQUIRE_TIMEOUT_SECONDS", str(_DEFAULT_ACQUIRE_TIMEOUT_SECONDS)
@@ -243,63 +276,78 @@ def _get_acquire_timeout_seconds() -> float:
     return value
 
 
-def _pool_exhausted_error(timeout: float) -> "DatabaseUnavailableError":
-    """Build the 503 raised when no connection frees up in time."""
+def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
+    """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no free connection within %.1fs "
-        "(DB_POOL_MAX_SIZE=%s, DB_POOL_ACQUIRE_TIMEOUT_SECONDS=%.1f)",
-        timeout,
+        "db.pool_acquire_timeout: no connection available after %.1fs "
+        "(DB_POOL_MAX_SIZE=%s)",
+        elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
-        timeout,
     )
     return DatabaseUnavailableError(
         "The database is busy. Please try again.",
         hint=(
-            f"asyncpg pool exhausted: no connection became free within {timeout:g}s. "
-            "Raise DB_POOL_MAX_SIZE, lower Cloud Run concurrency, or find the handler "
-            "holding a pooled connection across slow network I/O."
+            f"No pooled connection became available within {elapsed:.1f}s. Either the "
+            "pool is too small for the admitted concurrency, or a handler is holding a "
+            "pooled connection across slow network I/O."
         ),
     )
 
 
 class _BoundedAcquireContext:
-    """Wrap asyncpg's PoolAcquireContext so a starved pool fails fast.
+    """Put a deadline on asyncpg's PoolAcquireContext without changing release.
 
     Supports both shapes this repo uses:
         async with pool.acquire() as conn: ...
         conn = await pool.acquire()
     """
 
-    __slots__ = ("_ctx", "_timeout")
+    __slots__ = ("_ctx", "_deadline")
 
-    def __init__(self, ctx, timeout: float) -> None:
+    def __init__(self, ctx: Any, deadline: float) -> None:
         self._ctx = ctx
-        self._timeout = timeout
+        self._deadline = deadline
 
-    async def _acquire(self):
+    async def _guarded(self, awaitable: Any) -> Any:
+        loop = asyncio.get_running_loop()
+        started = loop.time()
         try:
-            return await self._ctx
+            return await asyncio.wait_for(awaitable, timeout=self._deadline)
         except (asyncio.TimeoutError, TimeoutError) as exc:
-            raise _pool_exhausted_error(self._timeout) from exc
+            elapsed = loop.time() - started
+            if elapsed < self._deadline * 0.9:
+                # Something inside timed out well before our deadline — almost
+                # always the connection attempt itself. That is a different
+                # incident with a different fix, so let the real error through.
+                raise
+            raise _pool_exhausted_error(elapsed) from exc
 
-    def __await__(self):
-        return self._acquire().__await__()
+    async def _enter(self) -> Any:
+        return await self._guarded(self._ctx.__aenter__())
 
-    async def __aenter__(self):
-        try:
-            return await self._ctx.__aenter__()
-        except (asyncio.TimeoutError, TimeoutError) as exc:
-            raise _pool_exhausted_error(self._timeout) from exc
+    async def _direct(self) -> Any:
+        return await self._guarded(_await_context(self._ctx))
 
-    async def __aexit__(self, exc_type=None, exc_val=None, exc_tb=None):
+    def __await__(self) -> Any:
+        return self._direct().__await__()
+
+    async def __aenter__(self) -> Any:
+        return await self._enter()
+
+    async def __aexit__(self, exc_type: Any = None, exc_val: Any = None, exc_tb: Any = None) -> Any:
         return await self._ctx.__aexit__(exc_type, exc_val, exc_tb)
 
 
-_ORIGINAL_POOL_ACQUIRE = None
+async def _await_context(ctx: Any) -> Any:
+    """Await a PoolAcquireContext as a coroutine so wait_for can wrap it."""
+    return await ctx
+
+
+_ORIGINAL_POOL_ACQUIRE: Any = None
 
 
 def _install_bounded_acquire() -> None:
-    """Give every asyncpg pool acquire a deadline. Idempotent."""
+    """Give every unqualified asyncpg pool acquire a deadline. Idempotent."""
     global _ORIGINAL_POOL_ACQUIRE
     if _ORIGINAL_POOL_ACQUIRE is not None:
         return
@@ -307,11 +355,15 @@ def _install_bounded_acquire() -> None:
     original = asyncpg.pool.Pool.acquire
     _ORIGINAL_POOL_ACQUIRE = original
 
-    def acquire(self, *, timeout=None):
-        # An explicit timeout from a caller always wins; only the unbounded
-        # default is replaced.
-        effective = _get_acquire_timeout_seconds() if timeout is None else timeout
-        return _BoundedAcquireContext(original(self, timeout=effective), effective)
+    def acquire(self: Any, *, timeout: Any = _UNSET) -> Any:
+        if timeout is not _UNSET:
+            # The caller owns the deadline, including `timeout=None` meaning
+            # "wait as long as it takes" for a background job that must not
+            # fail early.
+            return original(self, timeout=timeout)
+        # timeout=None keeps asyncpg's holder budget untouched, so Pool.release()
+        # keeps its original unbounded reset. Our deadline lives outside.
+        return _BoundedAcquireContext(original(self, timeout=None), _get_acquire_timeout_seconds())
 
     acquire.__doc__ = original.__doc__
     asyncpg.pool.Pool.acquire = acquire

--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -187,6 +187,139 @@ def _get_pool_int(env_name: str, default: int, *, minimum: int) -> int:
     return value
 
 
+# ---------------------------------------------------------------------------
+# Pool acquire guardrail
+#
+# asyncpg's ``Pool.acquire()`` waits FOREVER when every connection is checked
+# out, and none of this repo's call sites pass a timeout. Behind Supabase's
+# PgBouncer that never mattered — connections were cheap and plentiful. On
+# Cloud SQL every connection is a real Postgres backend, so the pool was
+# clamped hard, and an unbounded wait against a small pool is a hang.
+#
+# On 2026-08-23 that combination took UAT phone verification down for six
+# hours: three connections were held by slow handlers, every later request
+# queued on acquire() with no deadline, and Cloud Run killed each one at its
+# 3600s request timeout while it held a concurrency slot for the full hour.
+#
+# The fix is a deadline. ``Pool.execute()``/``fetch()``/``fetchval()`` and the
+# rest all funnel through ``self.acquire()`` internally, so bounding acquire
+# bounds every one of them from a single place — including any asyncpg method
+# this repo does not call today.
+#
+# A starved pool now raises DatabaseUnavailableError (503) in seconds instead
+# of hanging for an hour. A fast, honest 503 is recoverable; an hour-long hang
+# takes the whole service down with it.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ACQUIRE_TIMEOUT_SECONDS = 10.0
+
+
+def _get_acquire_timeout_seconds() -> float:
+    """Seconds to wait for a free pooled connection before failing fast.
+
+    Tunable via DB_POOL_ACQUIRE_TIMEOUT_SECONDS. The default is deliberately
+    far below the proxy's own per-route timeouts (20s at the tightest) so a
+    starved pool surfaces as a clean 503 rather than a proxy gateway timeout.
+    """
+    raw = os.getenv(
+        "DB_POOL_ACQUIRE_TIMEOUT_SECONDS", str(_DEFAULT_ACQUIRE_TIMEOUT_SECONDS)
+    ).strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid float for DB_POOL_ACQUIRE_TIMEOUT_SECONDS=%r; using default %.1f",
+            raw,
+            _DEFAULT_ACQUIRE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_ACQUIRE_TIMEOUT_SECONDS
+    if value <= 0:
+        logger.warning(
+            "Out-of-range DB_POOL_ACQUIRE_TIMEOUT_SECONDS=%r; expected > 0. Using default %.1f",
+            raw,
+            _DEFAULT_ACQUIRE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_ACQUIRE_TIMEOUT_SECONDS
+    return value
+
+
+def _pool_exhausted_error(timeout: float) -> "DatabaseUnavailableError":
+    """Build the 503 raised when no connection frees up in time."""
+    logger.warning(
+        "db.pool_acquire_timeout: no free connection within %.1fs "
+        "(DB_POOL_MAX_SIZE=%s, DB_POOL_ACQUIRE_TIMEOUT_SECONDS=%.1f)",
+        timeout,
+        os.getenv("DB_POOL_MAX_SIZE", "<default>"),
+        timeout,
+    )
+    return DatabaseUnavailableError(
+        "The database is busy. Please try again.",
+        hint=(
+            f"asyncpg pool exhausted: no connection became free within {timeout:g}s. "
+            "Raise DB_POOL_MAX_SIZE, lower Cloud Run concurrency, or find the handler "
+            "holding a pooled connection across slow network I/O."
+        ),
+    )
+
+
+class _BoundedAcquireContext:
+    """Wrap asyncpg's PoolAcquireContext so a starved pool fails fast.
+
+    Supports both shapes this repo uses:
+        async with pool.acquire() as conn: ...
+        conn = await pool.acquire()
+    """
+
+    __slots__ = ("_ctx", "_timeout")
+
+    def __init__(self, ctx, timeout: float) -> None:
+        self._ctx = ctx
+        self._timeout = timeout
+
+    async def _acquire(self):
+        try:
+            return await self._ctx
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            raise _pool_exhausted_error(self._timeout) from exc
+
+    def __await__(self):
+        return self._acquire().__await__()
+
+    async def __aenter__(self):
+        try:
+            return await self._ctx.__aenter__()
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            raise _pool_exhausted_error(self._timeout) from exc
+
+    async def __aexit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        return await self._ctx.__aexit__(exc_type, exc_val, exc_tb)
+
+
+_ORIGINAL_POOL_ACQUIRE = None
+
+
+def _install_bounded_acquire() -> None:
+    """Give every asyncpg pool acquire a deadline. Idempotent."""
+    global _ORIGINAL_POOL_ACQUIRE
+    if _ORIGINAL_POOL_ACQUIRE is not None:
+        return
+
+    original = asyncpg.pool.Pool.acquire
+    _ORIGINAL_POOL_ACQUIRE = original
+
+    def acquire(self, *, timeout=None):
+        # An explicit timeout from a caller always wins; only the unbounded
+        # default is replaced.
+        effective = _get_acquire_timeout_seconds() if timeout is None else timeout
+        return _BoundedAcquireContext(original(self, timeout=effective), effective)
+
+    acquire.__doc__ = original.__doc__
+    asyncpg.pool.Pool.acquire = acquire
+
+
+_install_bounded_acquire()
+
+
 def get_database_url() -> str:
     """
     Build database URL from DB_* environment variables (single source of truth).

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -89,3 +89,4 @@ tests/test_one_location_system_circle_migration.py
 tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py
 tests/services/test_account_service_cleanup_tables.py
+tests/test_pool_acquire_is_bounded.py

--- a/consent-protocol/tests/test_pool_acquire_is_bounded.py
+++ b/consent-protocol/tests/test_pool_acquire_is_bounded.py
@@ -9,7 +9,9 @@ slot for the full hour, so the service could not drain.
 
 These tests drive asyncpg's REAL ``Pool._acquire`` against a genuinely empty
 connection queue — the same starvation the outage hit — and assert it now fails
-fast with a 503 instead of hanging.
+fast. They also pin the three things the deadline must NOT do: cap
+``Pool.release()``, blame pool exhaustion for a connection failure, or bind a
+caller that explicitly asked to wait.
 """
 
 from __future__ import annotations
@@ -21,22 +23,39 @@ import asyncpg
 import pytest
 
 from db.connection import (
+    _DEFAULT_ACQUIRE_TIMEOUT_SECONDS,
     DatabaseUnavailableError,
     _get_acquire_timeout_seconds,
     _install_bounded_acquire,
 )
 
+FAST_DEADLINE = 0.25
 
-class _StarvedPool:
-    """A pool whose every connection is checked out.
 
-    Only what asyncpg's real ``Pool._acquire`` touches: an empty queue it will
-    block on, plus the two guards it checks first. ``_acquire`` is the genuine
-    asyncpg implementation, so the unbounded-wait branch is exercised for real.
+class _Holder:
+    """Stands in for asyncpg's PoolConnectionHolder."""
+
+    def __init__(self, connection: object = "connection", fail: BaseException | None = None):
+        self._connection = connection
+        self._fail = fail
+        self._timeout: float | None = "untouched"  # type: ignore[assignment]
+
+    async def acquire(self):
+        if self._fail is not None:
+            raise self._fail
+        return self._connection
+
+
+class _Pool:
+    """Only what asyncpg's real ``Pool._acquire`` touches.
+
+    ``_acquire`` and ``acquire`` are the genuine asyncpg implementations, so the
+    unbounded-wait branch and the holder bookkeeping are exercised for real.
     """
 
+    _closing = False
+
     def __init__(self) -> None:
-        self._closing = False
         self._queue: asyncio.Queue = asyncio.Queue()  # empty == fully starved
         self.released: list = []
 
@@ -44,20 +63,26 @@ class _StarvedPool:
         return None
 
     async def release(self, connection, *, timeout=None):  # noqa: ARG002
-        """asyncpg's PoolAcquireContext.__aexit__ releases through the pool."""
         self.released.append(connection)
 
     _acquire = asyncpg.pool.Pool._acquire
     acquire = asyncpg.pool.Pool.acquire
 
 
+def _healthy(**kwargs) -> tuple[_Pool, _Holder]:
+    pool = _Pool()
+    holder = _Holder(**kwargs)
+    pool._queue.put_nowait(holder)
+    return pool, holder
+
+
 @pytest.fixture(autouse=True)
-def _fast_timeout(monkeypatch):
+def _fast_deadline(monkeypatch):
     """Keep the suite quick; the mechanism is identical at any deadline."""
-    monkeypatch.setenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", "0.25")
+    monkeypatch.setenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", str(FAST_DEADLINE))
 
 
-async def _elapsed(coro) -> tuple[BaseException | None, float]:
+async def _outcome(coro) -> tuple[BaseException | None, float]:
     started = time.monotonic()
     try:
         await coro
@@ -66,100 +91,159 @@ async def _elapsed(coro) -> tuple[BaseException | None, float]:
     return None, time.monotonic() - started
 
 
+# --------------------------------------------------------------------------
+# The hang itself
+# --------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_starved_pool_raises_instead_of_hanging_async_with():
     """`async with pool.acquire()` must give up, not queue forever."""
-    pool = _StarvedPool()
+    pool = _Pool()
 
     async def _use():
         async with pool.acquire():
             pytest.fail("acquired a connection from a fully starved pool")
 
-    exc, elapsed = await _elapsed(_use())
+    exc, elapsed = await _outcome(_use())
 
     assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
     assert exc.status_code == 503
-    # The whole point: bounded. Before the fix this ran until Cloud Run's 3600s.
+    # The whole point. Before the fix this ran until Cloud Run's 3600s.
     assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
 
 
 @pytest.mark.asyncio
 async def test_starved_pool_raises_instead_of_hanging_bare_await():
     """`conn = await pool.acquire()` is used too (ria_iam_service._conn)."""
-    pool = _StarvedPool()
+    pool = _Pool()
 
-    exc, elapsed = await _elapsed(pool.acquire())
+    exc, elapsed = await _outcome(pool.acquire())
 
     assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
-    assert exc.status_code == 503
     assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
 
 
 @pytest.mark.asyncio
 async def test_pool_execute_is_bounded_too():
-    """Pool.execute/fetch/fetchval funnel through acquire, so they inherit the bound.
+    """execute/fetch/fetchval funnel through acquire, so they inherit the bound.
 
-    94 call sites in this repo use `pool.execute(...)` directly rather than
-    acquiring first; bounding acquire is what covers them.
+    94 call sites use `pool.execute(...)` directly rather than acquiring first;
+    bounding acquire is what covers them.
     """
-    pool = _StarvedPool()
+    pool = _Pool()
 
-    exc, elapsed = await _elapsed(asyncpg.pool.Pool.execute(pool, "SELECT 1"))
+    exc, elapsed = await _outcome(asyncpg.pool.Pool.execute(pool, "SELECT 1"))
 
     assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
     assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
 
 
+# --------------------------------------------------------------------------
+# What the deadline must NOT do
+# --------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_an_explicit_caller_timeout_still_wins():
-    """Only the unbounded default is replaced; a caller's own deadline is kept."""
-    pool = _StarvedPool()
+async def test_an_explicit_none_timeout_still_waits():
+    """A background job that must not fail early can opt out with timeout=None.
+
+    api/consent_listener.py needs one connection once, for the life of the
+    process. Failing it early permanently disables consent notifications on that
+    instance, because nothing retries. `timeout=None` has to keep meaning
+    "wait", which is why the wrapper uses a sentinel rather than None.
+    """
+    pool = _Pool()
 
     async def _use():
-        async with pool.acquire(timeout=0.05):
+        async with pool.acquire(timeout=None):
             pytest.fail("acquired a connection from a fully starved pool")
 
-    exc, elapsed = await _elapsed(_use())
+    try:
+        await asyncio.wait_for(_use(), timeout=0.6)
+    except (asyncio.TimeoutError, TimeoutError):
+        pass  # still waiting when we pulled the plug — correct
+    except DatabaseUnavailableError:
+        pytest.fail("timeout=None was overridden; the opt-out does not work")
 
-    assert isinstance(exc, DatabaseUnavailableError)
-    # Honoured the caller's 0.05s rather than the 0.25s env default.
-    assert elapsed < 0.2, f"caller timeout ignored; took {elapsed:.2f}s"
+
+@pytest.mark.asyncio
+async def test_release_budget_is_left_untouched():
+    """The deadline must not leak into Pool.release()'s reset budget.
+
+    asyncpg records the acquire timeout on the holder and reuses it in
+    release() as the budget for Connection.reset(). If our deadline leaked
+    there, an overrunning reset would terminate the connection and force a
+    fresh handshake — churn, exactly when the database is already struggling.
+    """
+    pool, holder = _healthy()
+
+    async with pool.acquire():
+        pass
+
+    assert holder._timeout is None, (
+        f"acquire deadline leaked into the release budget (ch._timeout={holder._timeout!r}); "
+        "Pool.release() would now cap Connection.reset() and terminate on overrun"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_connection_failure_is_not_blamed_on_pool_exhaustion():
+    """A TimeoutError from establishing a connection must surface as itself.
+
+    TimeoutError is a subclass of OSError, and asyncio.TimeoutError IS
+    TimeoutError since 3.11, so a naive except would swallow a Cloud SQL
+    connect timeout and tell an operator to raise DB_POOL_MAX_SIZE — adding
+    connection pressure to an instance that is already failing.
+    """
+    pool, _ = _healthy(fail=TimeoutError("[Errno 60] Operation timed out"))
+
+    async def _use():
+        async with pool.acquire():
+            pytest.fail("should not have acquired")
+
+    exc, elapsed = await _outcome(_use())
+
+    assert isinstance(exc, TimeoutError), f"got {exc!r}"
+    assert not isinstance(exc, DatabaseUnavailableError), (
+        "a connect failure was misreported as pool exhaustion"
+    )
+    assert elapsed < FAST_DEADLINE * 0.9, "should have failed immediately, not at the deadline"
+
+
+# --------------------------------------------------------------------------
+# The happy path must be untouched
+# --------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_a_healthy_pool_still_hands_back_its_connection():
-    """The guardrail must not change the happy path, in either call shape."""
-    sentinel = object()
-
-    class _HealthyPool(_StarvedPool):
-        async def _acquire(self, timeout):  # noqa: ARG002 - signature parity
-            return sentinel
-
-    pool = _HealthyPool()
+    """Both call shapes keep working, and the connection is released."""
+    pool, _ = _healthy()
 
     async with pool.acquire() as conn:
-        assert conn is sentinel
+        assert conn == "connection"
 
     # __aexit__ must delegate, or connections leak until the pool starves again.
-    assert pool.released == [sentinel]
+    assert pool.released == ["connection"]
 
-    assert await pool.acquire() is sentinel
+    pool2, _ = _healthy()
+    assert await pool2.acquire() == "connection"
 
 
 @pytest.mark.asyncio
 async def test_an_error_inside_the_block_still_propagates():
     """__aexit__ must not swallow what the body raised."""
-    sentinel = object()
-
-    class _HealthyPool(_StarvedPool):
-        async def _acquire(self, timeout):  # noqa: ARG002 - signature parity
-            return sentinel
-
-    pool = _HealthyPool()
+    pool, _ = _healthy()
 
     with pytest.raises(ValueError, match="from inside the block"):
         async with pool.acquire():
             raise ValueError("from inside the block")
+
+
+# --------------------------------------------------------------------------
+# The guardrail's own wiring
+# --------------------------------------------------------------------------
 
 
 def test_the_guardrail_is_actually_installed():
@@ -182,10 +266,10 @@ def test_installing_twice_does_not_stack_wrappers():
     ("raw", "expected"),
     [
         ("0.25", 0.25),
-        ("30", 30.0),
-        ("not-a-number", 10.0),  # falls back to the default
-        ("0", 10.0),  # zero would mean "never wait"
-        ("-5", 10.0),  # negative is nonsense
+        ("90", 90.0),
+        ("not-a-number", _DEFAULT_ACQUIRE_TIMEOUT_SECONDS),
+        ("0", _DEFAULT_ACQUIRE_TIMEOUT_SECONDS),
+        ("-5", _DEFAULT_ACQUIRE_TIMEOUT_SECONDS),
     ],
 )
 def test_the_deadline_is_env_tunable_and_rejects_nonsense(monkeypatch, raw, expected):
@@ -193,12 +277,28 @@ def test_the_deadline_is_env_tunable_and_rejects_nonsense(monkeypatch, raw, expe
     assert _get_acquire_timeout_seconds() == expected
 
 
-def test_the_default_stays_under_the_tightest_proxy_timeout(monkeypatch):
-    """A starved pool must surface as a clean 503, not a proxy gateway timeout.
+def test_the_default_clears_the_documented_cold_start_burst(monkeypatch):
+    """The deadline covers establishing a connection, not just waiting for one.
 
-    The Next.js proxy's tightest per-route deadline is 20s; if the pool waited
-    longer than that the caller would see a 500/504 from the proxy instead of
-    the real reason.
+    server.py documents that a burst of first requests after a restart can stall
+    15-30s while additional connections are established to Cloud SQL. Only
+    DB_POOL_MIN_SIZE connections are pre-warmed; the rest are opened lazily
+    inside this deadline. A default at or under that cost would turn every cold
+    start into a 503 storm — and the log would tell the operator to enlarge the
+    pool, which makes it strictly worse.
     """
     monkeypatch.delenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", raising=False)
-    assert _get_acquire_timeout_seconds() < 20
+    assert _get_acquire_timeout_seconds() >= 45, (
+        "the default must clear the 15-30s cold-start handshake burst"
+    )
+
+
+def test_the_deadline_is_far_below_the_cloud_run_request_timeout(monkeypatch):
+    """The outage was requests holding a Cloud Run slot for the full 3600s.
+
+    Releasing the slot early is the point; which layer reports the failure is
+    not. The deadline cannot also undercut the proxy's tightest per-route
+    timeouts (10s) without breaking cold starts, so it deliberately does not try.
+    """
+    monkeypatch.delenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", raising=False)
+    assert _get_acquire_timeout_seconds() <= 120

--- a/consent-protocol/tests/test_pool_acquire_is_bounded.py
+++ b/consent-protocol/tests/test_pool_acquire_is_bounded.py
@@ -1,0 +1,204 @@
+"""The asyncpg pool must never wait forever for a free connection.
+
+On 2026-08-23 UAT phone verification was down for six hours because
+``Pool.acquire()`` has no default deadline: asyncpg's ``Pool._acquire`` takes
+the unbounded ``await self._queue.get()`` branch whenever ``timeout is None``,
+and not one of this repo's call sites passed a timeout. Requests queued until
+Cloud Run killed them at its 3600s request timeout, each holding a concurrency
+slot for the full hour, so the service could not drain.
+
+These tests drive asyncpg's REAL ``Pool._acquire`` against a genuinely empty
+connection queue — the same starvation the outage hit — and assert it now fails
+fast with a 503 instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import asyncpg
+import pytest
+
+from db.connection import (
+    DatabaseUnavailableError,
+    _get_acquire_timeout_seconds,
+    _install_bounded_acquire,
+)
+
+
+class _StarvedPool:
+    """A pool whose every connection is checked out.
+
+    Only what asyncpg's real ``Pool._acquire`` touches: an empty queue it will
+    block on, plus the two guards it checks first. ``_acquire`` is the genuine
+    asyncpg implementation, so the unbounded-wait branch is exercised for real.
+    """
+
+    def __init__(self) -> None:
+        self._closing = False
+        self._queue: asyncio.Queue = asyncio.Queue()  # empty == fully starved
+        self.released: list = []
+
+    def _check_init(self) -> None:
+        return None
+
+    async def release(self, connection, *, timeout=None):  # noqa: ARG002
+        """asyncpg's PoolAcquireContext.__aexit__ releases through the pool."""
+        self.released.append(connection)
+
+    _acquire = asyncpg.pool.Pool._acquire
+    acquire = asyncpg.pool.Pool.acquire
+
+
+@pytest.fixture(autouse=True)
+def _fast_timeout(monkeypatch):
+    """Keep the suite quick; the mechanism is identical at any deadline."""
+    monkeypatch.setenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", "0.25")
+
+
+async def _elapsed(coro) -> tuple[BaseException | None, float]:
+    started = time.monotonic()
+    try:
+        await coro
+    except BaseException as exc:  # noqa: BLE001 - the test inspects it
+        return exc, time.monotonic() - started
+    return None, time.monotonic() - started
+
+
+@pytest.mark.asyncio
+async def test_starved_pool_raises_instead_of_hanging_async_with():
+    """`async with pool.acquire()` must give up, not queue forever."""
+    pool = _StarvedPool()
+
+    async def _use():
+        async with pool.acquire():
+            pytest.fail("acquired a connection from a fully starved pool")
+
+    exc, elapsed = await _elapsed(_use())
+
+    assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
+    assert exc.status_code == 503
+    # The whole point: bounded. Before the fix this ran until Cloud Run's 3600s.
+    assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
+
+
+@pytest.mark.asyncio
+async def test_starved_pool_raises_instead_of_hanging_bare_await():
+    """`conn = await pool.acquire()` is used too (ria_iam_service._conn)."""
+    pool = _StarvedPool()
+
+    exc, elapsed = await _elapsed(pool.acquire())
+
+    assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
+    assert exc.status_code == 503
+    assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
+
+
+@pytest.mark.asyncio
+async def test_pool_execute_is_bounded_too():
+    """Pool.execute/fetch/fetchval funnel through acquire, so they inherit the bound.
+
+    94 call sites in this repo use `pool.execute(...)` directly rather than
+    acquiring first; bounding acquire is what covers them.
+    """
+    pool = _StarvedPool()
+
+    exc, elapsed = await _elapsed(asyncpg.pool.Pool.execute(pool, "SELECT 1"))
+
+    assert isinstance(exc, DatabaseUnavailableError), f"got {exc!r}"
+    assert elapsed < 5, f"took {elapsed:.2f}s — that is a hang, not a deadline"
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_caller_timeout_still_wins():
+    """Only the unbounded default is replaced; a caller's own deadline is kept."""
+    pool = _StarvedPool()
+
+    async def _use():
+        async with pool.acquire(timeout=0.05):
+            pytest.fail("acquired a connection from a fully starved pool")
+
+    exc, elapsed = await _elapsed(_use())
+
+    assert isinstance(exc, DatabaseUnavailableError)
+    # Honoured the caller's 0.05s rather than the 0.25s env default.
+    assert elapsed < 0.2, f"caller timeout ignored; took {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_pool_still_hands_back_its_connection():
+    """The guardrail must not change the happy path, in either call shape."""
+    sentinel = object()
+
+    class _HealthyPool(_StarvedPool):
+        async def _acquire(self, timeout):  # noqa: ARG002 - signature parity
+            return sentinel
+
+    pool = _HealthyPool()
+
+    async with pool.acquire() as conn:
+        assert conn is sentinel
+
+    # __aexit__ must delegate, or connections leak until the pool starves again.
+    assert pool.released == [sentinel]
+
+    assert await pool.acquire() is sentinel
+
+
+@pytest.mark.asyncio
+async def test_an_error_inside_the_block_still_propagates():
+    """__aexit__ must not swallow what the body raised."""
+    sentinel = object()
+
+    class _HealthyPool(_StarvedPool):
+        async def _acquire(self, timeout):  # noqa: ARG002 - signature parity
+            return sentinel
+
+    pool = _HealthyPool()
+
+    with pytest.raises(ValueError, match="from inside the block"):
+        async with pool.acquire():
+            raise ValueError("from inside the block")
+
+
+def test_the_guardrail_is_actually_installed():
+    """Importing db.connection must leave every asyncpg pool bounded."""
+    assert asyncpg.pool.Pool.acquire.__module__ == "db.connection", (
+        "asyncpg.pool.Pool.acquire is not the bounded version — the guardrail "
+        "is not installed, and every acquire in the process can hang forever"
+    )
+
+
+def test_installing_twice_does_not_stack_wrappers():
+    """Re-import or an explicit re-install must be a no-op."""
+    before = asyncpg.pool.Pool.acquire
+    _install_bounded_acquire()
+    _install_bounded_acquire()
+    assert asyncpg.pool.Pool.acquire is before
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0.25", 0.25),
+        ("30", 30.0),
+        ("not-a-number", 10.0),  # falls back to the default
+        ("0", 10.0),  # zero would mean "never wait"
+        ("-5", 10.0),  # negative is nonsense
+    ],
+)
+def test_the_deadline_is_env_tunable_and_rejects_nonsense(monkeypatch, raw, expected):
+    monkeypatch.setenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", raw)
+    assert _get_acquire_timeout_seconds() == expected
+
+
+def test_the_default_stays_under_the_tightest_proxy_timeout(monkeypatch):
+    """A starved pool must surface as a clean 503, not a proxy gateway timeout.
+
+    The Next.js proxy's tightest per-route deadline is 20s; if the pool waited
+    longer than that the caller would see a 500/504 from the proxy instead of
+    the real reason.
+    """
+    monkeypatch.delenv("DB_POOL_ACQUIRE_TIMEOUT_SECONDS", raising=False)
+    assert _get_acquire_timeout_seconds() < 20

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -278,6 +278,7 @@ steps:
           "DB_POOL_MAX_SIZE=${_DB_POOL_MAX_SIZE}"
           "DB_SQLALCHEMY_POOL_SIZE=${_DB_SQLALCHEMY_POOL_SIZE}"
           "DB_SQLALCHEMY_MAX_OVERFLOW=${_DB_SQLALCHEMY_MAX_OVERFLOW}"
+          "DB_POOL_ACQUIRE_TIMEOUT_SECONDS=${_DB_POOL_ACQUIRE_TIMEOUT_SECONDS}"
           "RIA_INTELLIGENCE_CRD_SCRAPER_TIMEOUT_SECONDS=${_RIA_INTELLIGENCE_CRD_SCRAPER_TIMEOUT_SECONDS}"
           "RIA_ONBOARDING_PROVIDER_TIMEOUT_SECONDS=${_RIA_ONBOARDING_PROVIDER_TIMEOUT_SECONDS}"
         )
@@ -567,6 +568,11 @@ substitutions:
   _DB_POOL_MAX_SIZE: "4"
   _DB_SQLALCHEMY_POOL_SIZE: "4"
   _DB_SQLALCHEMY_MAX_OVERFLOW: "0"
+  # Deadline for getting a pooled connection. Covers establishing a new one,
+  # so it has to clear the 15-30s cold-start handshake burst documented in
+  # consent-protocol/server.py. Tunable without a code change so a bad value
+  # can be corrected by a redeploy rather than another PR.
+  _DB_POOL_ACQUIRE_TIMEOUT_SECONDS: "60"
   _CLOUD_RUN_MIN_INSTANCES: "1"
   _CLOUD_RUN_MAX_INSTANCES: "5"
   _RUNTIME_ENVIRONMENT: ""


### PR DESCRIPTION
The guardrail behind #5860. That PR bought headroom; this removes the cliff.

**An adversarial review found four blocking defects in the first version of this PR. Two were reproduced empirically. All are fixed — see "What the review caught" below.**

## The hang, in asyncpg's own code

`asyncpg/pool.py` → `Pool._acquire`:

```python
if timeout is None:
    return await _acquire_impl()          # await self._queue.get() — forever
else:
    return await compat.wait_for(_acquire_impl(), timeout=timeout)
```

**Not one of this repo's 71 non-test `pool.acquire()` call sites passes a timeout**, so every one took the unbounded branch.

## Why it only became fatal recently

| date | |
|---|---|
| 2026-07-27 | `78aaa1e4b` move production onto Cloud SQL, remove Supabase entirely |
| 2026-07-30 | `f1f8817db` bound Cloud SQL connection fanout to stop prod slot exhaustion |

Behind **Supabase's PgBouncer** connections were cheap and multiplexed, so an unbounded wait never mattered. On **Cloud SQL every connection is a real Postgres backend** — and `hushh-uat-pg` has no managed pooler. Slots ran out, the pools were clamped three days later (UAT to 3), and a small pool plus an unbounded wait is a hang.

On 2026-08-23 it took UAT phone verification down for six hours: requests queued on `acquire()` with no deadline, and Cloud Run killed each at its 3600s timeout **while it held a concurrency slot for the full hour**, so nothing could drain.

## The change

One seam. `Pool.execute()`, `fetch()`, `fetchval()` and the rest all funnel through `async with self.acquire()` internally, so bounding `acquire` also bounds all **94 direct `pool.execute()` calls** — and any asyncpg method this repo doesn't use today. A wrapper object could miss a method; this cannot.

**Default 60s**, tunable via `DB_POOL_ACQUIRE_TIMEOUT_SECONDS`. Starved pool → `DatabaseUnavailableError` → **503** via the handler already in `server.py:191`.

## What the review caught

### 1. The deadline covers *connecting*, not just queueing — 10s would have caused cold-start 503 storms

`_acquire_impl` does `await self._queue.get()` **then** `await ch.acquire()`, and that second call opens a new connection when the holder has none. UAT pre-warms only `DB_POOL_MIN_SIZE=2` of 12, so connections 3–12 are established inside this budget.

`consent-protocol/server.py` already documents the cost: a burst of first requests after a restart *"stall for 15-30s while additional connections are established"*, on `--cpu=1` with no concurrency cap.

A 10s deadline would 503 on every cold-start burst — and the log line told the operator to **raise `DB_POOL_MAX_SIZE`**, which makes it strictly worse by adding more cold handshakes. **Default is now 60s.**

### 2. A connection failure was reported as pool exhaustion — reproduced

`TimeoutError` subclasses `OSError`, and `asyncio.TimeoutError IS TimeoutError` since 3.11. The old `except (asyncio.TimeoutError, TimeoutError)` caught a Cloud SQL **connect** timeout and relabelled it "pool exhausted, raise `DB_POOL_MAX_SIZE`" — firing in microseconds while logging *"within 10.0s"*.

During a real database outage that sends an operator the wrong way and bypasses `local_database_unavailable_hint()`. Now we **measure elapsed time** and only claim exhaustion when our own deadline actually ran out; anything faster is re-raised untouched.

### 3. The deadline leaked into `Pool.release()` — reproduced

`Pool._acquire` records its timeout on the holder (`ch._timeout = timeout`) and `Pool.release()` reuses it as the budget for `Connection.reset()`. Verified: `origin/main` → `None` (unbounded), first version → `10.0`.

An overrunning reset **terminates the connection and re-raises** — churn exactly when the database is already struggling, surfacing as a bare `TimeoutError` out of `__aexit__` rather than a 503.

Now we pass `timeout=None` to asyncpg and hold our own deadline **outside** it, so release semantics are unchanged. Pinned by a test.

### 4. There was no opt-out

`acquire(timeout=None)` was indistinguishable from `acquire()`. `api/consent_listener.py:781` takes one connection and holds it **for the life of the process**, nothing retries it, and its failure path also cancels the consent timeout and notification loops — so one early failure silently disables consent notifications on that instance until restart.

A sentinel now separates "said nothing" from "explicitly said `None`", and the listener opts out.

### Also fixed

- **The test file never ran in CI.** `consent-protocol/scripts/test-ci.manifest.txt` is an enumerated 74-entry list; nothing here was in it — including the test asserting the guardrail is installed. Registered. (My own first check of this used the stale local checkout and wrongly cleared it; `origin/main` is the truth.)
- **`DB_POOL_ACQUIRE_TIMEOUT_SECONDS` was unreachable.** Not in `deploy/backend.cloudbuild.yaml`'s env list, and the deploy uses `--set-env-vars`, which replaces the whole set — so it could not be set on UAT or prod, and a manual override is blocked there by the IAM deny policy. Plumbed.
- **The "undercuts the proxy's 20s" claim was false.** Six routes are at **10s**, not 20s (`consent/pending`, `consent/history`, `consent/active`, `consent/pending/lookup`, `consent/pending/opened`, `notifications/register`). The docstring and its test asserted a bound that did not exist. Removed rather than restated: the deadline cannot both clear a 15–30s cold start and undercut a 10s proxy timeout, and releasing the Cloud Run slot matters far more than which layer reports the failure.

## Verification

- **17 tests, all passing**, driving asyncpg's real `Pool._acquire` against a genuinely empty queue — including new tests pinning the release budget, the opt-out, and that a connect failure is not blamed on the pool
- **Mutation-checked**: disabling the guardrail makes the suite **hang**; killed at 75s. Restored: 17/17 in 1.5s
- **The real CI lane** (`scripts/run-test-ci.sh`): **1407 passed, 0 failed**, and it now includes this file
- **Full suite vs baseline**: 67 failed / **7435** passed, against `origin/main`'s 67 / 7418 — failing node ids **byte-identical**, 114 each way. Those 67 are pre-existing on main
- `./bin/hushh protocol lint` clean

## Note

`db/connection.py` is also touched by **PR #4917 (Sage)**, dormant since 2026-08-07. Flagging the overlap; this change is additive and sits in its own block.

## Still open after this

1. Handlers holding a pooled connection across external network I/O — `marketplace_investor_replenisher.py:274` across rate-limited SEC EDGAR calls, `consent_request_lock.py:56-61` across a blocking `pg_advisory_lock`
2. `api/consent_listener.py` permanently consumes one pooled connection per worker for `LISTEN`; that should be a dedicated connection, not a pool slot
3. `containerConcurrency` is unset, so Cloud Run's default 80 fights over 12 connections
4. `deploy/backend.cloudbuild.yaml:319` hardcodes `--timeout=3600` for every environment — the real reason this lasted six hours
5. Cloud SQL has no managed connection pooler, the thing Supabase used to provide