### PR TITLE
style(consent-protocol): make the subtree ruff-format-clean so pushes work again

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -279,8 +279,7 @@ def _get_acquire_timeout_seconds() -> float:
 def _pool_exhausted_error(elapsed: float) -> "DatabaseUnavailableError":
     """Build the 503 raised when our own acquire deadline actually elapsed."""
     logger.warning(
-        "db.pool_acquire_timeout: no connection available after %.1fs "
-        "(DB_POOL_MAX_SIZE=%s)",
+        "db.pool_acquire_timeout: no connection available after %.1fs (DB_POOL_MAX_SIZE=%s)",
         elapsed,
         os.getenv("DB_POOL_MAX_SIZE", "<default>"),
     )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -97,18 +97,24 @@ async def test_close_quietly_swallows_a_close_failure_on_an_already_gone_client(
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "developer_api",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "developer_api",
+            }
+        ),
+        uid="user_1",
     )
 
     assert mode == "byok"
@@ -120,20 +126,26 @@ async def test_runtime_bootstrap_accepts_only_the_authenticated_byok_frame():
 
 @pytest.mark.asyncio
 async def test_runtime_bootstrap_accepts_a_vertex_api_key_only_with_explicit_endpoint_metadata():
-    mode, credential, transport, project, location, _resume, _voice = (
-        await _receive_runtime_bootstrap(
-            _BootstrapSocket(
-                {
-                    "type": "runtime_bootstrap",
-                    "runtime_credential_mode": "byok",
-                    "runtime_credential": "test-key",
-                    "runtime_credential_transport": "vertex_api_key",
-                    "runtime_vertex_project": "customer-vertex-project",
-                    "runtime_vertex_location": "us-central1",
-                }
-            ),
-            uid="user_1",
-        )
+    (
+        mode,
+        credential,
+        transport,
+        project,
+        location,
+        _resume,
+        _voice,
+    ) = await _receive_runtime_bootstrap(
+        _BootstrapSocket(
+            {
+                "type": "runtime_bootstrap",
+                "runtime_credential_mode": "byok",
+                "runtime_credential": "test-key",
+                "runtime_credential_transport": "vertex_api_key",
+                "runtime_vertex_project": "customer-vertex-project",
+                "runtime_vertex_location": "us-central1",
+            }
+        ),
+        uid="user_1",
     )
 
     assert (mode, credential, transport, project, location) == (


### PR DESCRIPTION
Two files on `main` fail `ruff format --check`, and between them they block **every push from every branch in this repo** — including branches with no Python in them.

| File | Drift | Came from |
|---|---|---|
| `consent-protocol/db/connection.py` | acquire-timeout warning split across two adjacent string literals | #5869 |
| `consent-protocol/tests/test_one_adk_live_protocol.py` | seven-name tuple unpack the formatter wants one-per-line | pre-existing |

Neither is a behaviour change.

### Why this is not cosmetic

`consent-protocol/ops/monorepo/pre-push.sh:293` runs:

```sh
"$LINT_PYTHON" -m ruff format --check .
```

over the **whole subtree**, unscoped. One drifted file anywhere under `consent-protocol/` fails the push of any branch. That is the state `main` has been in.

### Verification

- `ruff format --check .` → `972 files already formatted` (was `1 file would be reformatted`)
- `ruff check .` → `All checks passed!`
- `pytest tests/test_one_adk_live_protocol.py` → **46 passed** after the reformat
- Local ruff is `0.15.11`, the version pinned in `requirements-dev.txt:26` — so this is not a version-skew artefact

### The thing actually worth fixing, separately

CI merged both of these while the local hook rejects them. So the backend lint lane is either not running `ruff format --check` at all, or running it scoped to changed paths while the hook runs it unscoped. As long as those two disagree, a green `main` can keep blocking every developer's push, and this PR will be needed again. Filing that as its own issue rather than widening this one.