### PR TITLE
fix(ria): normalize iOS safe-area clearance

### DIFF
--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -177,7 +177,6 @@ export default function RiaClientsPage() {
     <AppPageShell
       as="main"
       width="expanded"
-      className="pb-24 sm:pb-28"
       nativeTest={{
         routeId: "/ria/clients",
         marker: "native-route-ria-clients",

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2293,7 +2293,6 @@ export default function RiaPicksPage() {
     <AppPageShell
       as="main"
       width="expanded"
-      className="pb-16 sm:pb-24"
       nativeTest={{
         routeId: "/ria/picks",
         marker: "native-route-ria-picks",

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -82,7 +82,7 @@ export function RiaPageShell({
       as="main"
       fitContent
       width={width}
-      className={cn("pb-24 sm:pb-28", className)}
+      className={className}
       nativeTest={nativeTest}
     >
       <AppPageHeaderRegion className={cn("pt-2 sm:pt-3", headerClassName)}>


### PR DESCRIPTION
## Summary

Fixes inconsistent iOS safe-area spacing in the shared RIA bottom chrome.

## Problem

RIA Profile, Clients, and Picks must maintain predictable separation between scrollable content, Talk to One, bottom navigation, and the iOS safe-area region across iPhone viewport sizes.

## Root Cause

The shared bottom chrome safe-area system already measures the fixed Talk to One plus Navbar stack and exposes it through `--bottom-chrome-stack-height` / `--app-scroll-bottom-pad`. Standard RIA pages were still adding large route-local bottom padding on top of that shared scroll-root clearance, which could duplicate the reserved bottom space and make spacing inconsistent.

## Fix

Removed the standard RIA page-level bottom padding overrides so Profile, Clients, and Picks rely on the shared measured bottom shell plus the normal `AppPageShell` reading gap.

## Scope

UI/UX / frontend layout only.

No changes to:

* backend
* APIs
* authentication
* data fetching
* business logic
* routing
* Talk to One functionality
* Navbar functionality

## Action Item

Action Item: #5874

Fixes #5874

## QA

* [x] Shared bottom clearance mechanism inspected
* [x] Profile bottom content uses shared clearance
* [x] Clients bottom content uses shared clearance
* [x] Picks bottom content uses shared clearance
* [x] 320, 375, 390, 430, 768, 1024, and 1440 layout contract widths verified
* [x] safe-area spacing stays centralized in shared shell tokens
* [x] no clipping regression in focused bottom-clearance contract
* [x] no horizontal overflow regression in focused bottom-clearance contract
* [x] Talk to One unchanged
* [x] Navbar unchanged
