### PR TITLE
fix(ria): prevent Picks mobile overflow

### DIFF
--- a/hushh-webapp/__tests__/components/data-table.test.tsx
+++ b/hushh-webapp/__tests__/components/data-table.test.tsx
@@ -123,4 +123,25 @@ describe("DataTable", () => {
     expect(searchInput.getAttribute("placeholder")).toBe("Search records");
     expect(searchInput.getAttribute("aria-hidden")).toBeNull();
   });
+
+  it("renders an opt-in mobile card list while keeping the desktop table shell", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(2)}
+        enableSearch={false}
+        renderMobileCard={(row) => (
+          <article data-testid="mobile-row-card">{row.name}</article>
+        )}
+      />,
+    );
+
+    expect(screen.getAllByTestId("mobile-row-card")).toHaveLength(2);
+    expect(
+      document.querySelector('[data-slot="data-table-mobile-list"]'),
+    ).toBeTruthy();
+    expect(
+      document.querySelector('[data-slot="surface-data-table-shell"]'),
+    ).toHaveClass("hidden", "md:block");
+  });
 });

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -450,6 +450,71 @@ function EmptyMyListState() {
   );
 }
 
+function TopPickMobileCard({ row }: { row: RiaPickRow }) {
+  return (
+    <SurfaceCard>
+      <SurfaceCardContent className="space-y-3 p-4">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold tracking-tight text-foreground">
+              {row.ticker || "—"}
+            </p>
+            <p className="mt-0.5 break-words text-sm text-foreground">
+              {row.company_name || "—"}
+            </p>
+            <p className="mt-0.5 break-words text-xs text-muted-foreground">
+              {row.sector || "—"}
+            </p>
+          </div>
+          <div className="shrink-0">
+            <TierBadge tier={row.tier} />
+          </div>
+        </div>
+        <p className="break-words text-xs leading-5 text-muted-foreground">
+          {row.investment_thesis || "—"}
+        </p>
+      </SurfaceCardContent>
+    </SurfaceCard>
+  );
+}
+
+function AvoidMobileCard({ row }: { row: RiaAvoidRow }) {
+  return (
+    <SurfaceCard>
+      <SurfaceCardContent className="space-y-3 p-4">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold tracking-tight text-foreground">
+                {row.ticker || "—"}
+              </p>
+              <p className="mt-0.5 break-words text-sm text-foreground">
+                {row.company_name || "—"}
+              </p>
+              <p className="mt-0.5 break-words text-xs text-muted-foreground">
+                {row.sector || "—"}
+              </p>
+            </div>
+            <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground">
+              {row.category || "Avoid"}
+            </span>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <p className="break-words text-xs leading-5 text-muted-foreground">
+            {row.why_avoid || "—"}
+          </p>
+          {row.note ? (
+            <p className="break-words border-t border-border/30 pt-2 text-xs leading-5 text-muted-foreground">
+              {row.note}
+            </p>
+          ) : null}
+        </div>
+      </SurfaceCardContent>
+    </SurfaceCard>
+  );
+}
+
 function InlineValidationBanner({ errors }: { errors: string[] }) {
   if (errors.length === 0) return null;
   return (
@@ -1668,7 +1733,7 @@ export default function RiaPicksPage() {
         accessorKey: "investment_thesis",
         header: "Thesis",
         cell: ({ row }) => (
-          <p className="max-w-[360px] text-xs leading-5 text-muted-foreground">
+          <p className="max-w-[360px] whitespace-normal break-words text-xs leading-5 text-muted-foreground">
             {row.original.investment_thesis || "—"}
           </p>
         ),
@@ -1709,7 +1774,7 @@ export default function RiaPicksPage() {
         accessorKey: "why_avoid",
         header: "Reason",
         cell: ({ row }) => (
-          <p className="max-w-[380px] text-xs leading-5 text-muted-foreground">
+          <p className="max-w-[380px] whitespace-normal break-words text-xs leading-5 text-muted-foreground">
             {row.original.why_avoid || "—"}
           </p>
         ),
@@ -1718,7 +1783,7 @@ export default function RiaPicksPage() {
         accessorKey: "note",
         header: "Note",
         cell: ({ row }) => (
-          <p className="max-w-[260px] text-xs leading-5 text-muted-foreground">
+          <p className="max-w-[260px] whitespace-normal break-words text-xs leading-5 text-muted-foreground">
             {row.original.note || "—"}
           </p>
         ),
@@ -2679,6 +2744,7 @@ export default function RiaPicksPage() {
                     stickyHeader
                     tableContainerClassName="w-full"
                     tableClassName="w-full min-w-[640px]"
+                    renderMobileCard={(row) => <TopPickMobileCard row={row} />}
                   />
                 </div>
               ) : null}
@@ -2747,6 +2813,7 @@ export default function RiaPicksPage() {
                     stickyHeader
                     tableContainerClassName="w-full"
                     tableClassName="w-full min-w-[700px]"
+                    renderMobileCard={(row) => <AvoidMobileCard row={row} />}
                   />
                 </div>
               ) : null}

--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -101,6 +101,10 @@ interface DataTableProps<TData, TValue> {
   enableSearch?: boolean;
   tableContainerClassName?: string;
   tableClassName?: string;
+  renderMobileCard?: (
+    row: TData,
+    context: { index: number; tableRow: Row<TData> },
+  ) => React.ReactNode;
   density?: "default" | "compact";
   stickyHeader?: boolean;
 }
@@ -121,6 +125,7 @@ export function DataTable<TData, TValue>({
   enableSearch = true,
   tableContainerClassName,
   tableClassName,
+  renderMobileCard,
   density = "default",
   stickyHeader = false,
 }: DataTableProps<TData, TValue>) {
@@ -293,9 +298,26 @@ export function DataTable<TData, TValue>({
         </div>
       )}
 
+      {renderMobileCard ? (
+        <div className="grid gap-3 md:hidden" data-slot="data-table-mobile-list">
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row, index) => (
+              <React.Fragment key={row.id}>
+                {renderMobileCard(row.original, { index, tableRow: row })}
+              </React.Fragment>
+            ))
+          ) : (
+            <div className="rounded-[var(--app-card-radius-compact)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-8 text-center text-sm text-muted-foreground shadow-[var(--app-card-shadow-standard)]">
+              No results found.
+            </div>
+          )}
+        </div>
+      ) : null}
+
       <div
         className={cn(
           surfaceDataTableShellClassName,
+          renderMobileCard && "hidden md:block",
           resolvedTableShellClassName,
         )}
         data-slot="surface-data-table-shell"


### PR DESCRIPTION
## Description
In RIA → Picks, some controls and content do not fit correctly on narrow mobile viewports.

Certain sections can clip, overflow horizontally, or preserve a desktop-oriented layout that does not adapt cleanly to smaller iPhone-sized screens.

This is a frontend UI/UX responsive-layout issue only.

## Steps To Reproduce
1. Open RIA → Picks.
2. Use a narrow mobile/iPhone viewport such as:
   - 440 × 956
   - 393 × 852
   - 375 × 812
3. Navigate through the Picks controls/content.
4. Observe the responsive behavior of segmented controls, table/content sections, labels, and horizontal spacing.
5. Check whether any content is clipped, extends beyond the viewport, or requires unintended horizontal scrolling.

## Expected Behavior
All Picks controls and content should fit cleanly within narrow mobile viewports.

The responsive layout should:
- avoid unintended horizontal overflow
- avoid clipped text/content
- preserve readable spacing
- keep controls fully accessible
- maintain the existing visual hierarchy
- adapt desktop-oriented layouts appropriately for mobile

The fix must remain frontend UI/UX only and must not modify Picks data, APIs, business logic, filtering logic, ranking logic, or backend behavior.

## Environment
- OS: iOS / iPhone viewport emulation
- Browser: Safari / Chrome DevTools device emulation
- Application: Hushh One UAT
- Area: RIA → Picks
- Viewports:
  - 440 × 956
  - 393 × 852
  - 375 × 812
- Node Version: Use current project Node version