### PR TITLE
Fix UAT advisory Vertex probe parsing

### DIFF
--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -91,6 +91,16 @@ def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None
     assert "gcloud services describe" not in backend_build
 
 
+def test_backend_vertex_advisory_probe_parses_pretty_json_verdict() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+
+    assert "PROBE_LINE=\"${probe_line}\" python - <<'PY'" in backend_build
+    assert 'marker = "managed_vertex_probe_result"' in backend_build
+    assert "json.loads(payload)" in backend_build
+    assert 'verdict.get("classification")' in backend_build
+    assert 'sed -n \'s/.*"classification":"' not in backend_build
+
+
 def test_cross_project_vertex_fallback_is_dev_or_exact_uat_bridge_only() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
     uat_workflow = _read(".github/workflows/deploy-uat.yml")

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -440,8 +440,22 @@ steps:
           done
         fi
         echo "Probe execution: ${execution_name:-unknown}"
-        classification="$(printf '%s' "${probe_line}" \
-          | sed -n 's/.*"classification":"\([a-z_]*\)".*/\1/p' | head -1)"
+        classification="$(
+          PROBE_LINE="${probe_line}" python - <<'PY'
+        import json
+        import os
+
+        line = os.environ.get("PROBE_LINE", "")
+        marker = "managed_vertex_probe_result"
+        payload = line.split(marker, 1)[1].strip() if marker in line else line
+        try:
+            verdict = json.loads(payload)
+        except json.JSONDecodeError:
+            print("")
+        else:
+            print(str(verdict.get("classification") or ""))
+        PY
+        )"
 
         if [[ "${classification}" == "provider_unavailable" ]]; then
           echo "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"


### PR DESCRIPTION
## Summary
- parse managed Vertex readiness verdict JSON with Python instead of whitespace-sensitive sed
- keep provider_unavailable readiness failures advisory when the probe output contains pretty JSON
- add deploy-contract coverage for the parser guardrail

## Linked PR / Action Items
- **Merged PR**: [#5882](https://github.com/hushh-labs/hushh-research/pull/5882)

## Verification
- cd consent-protocol && uv run python -m pytest tests/test_uat_deploy_no_traffic_contract.py -q
- git diff --check

Fixes #5879