### PR TITLE
fix(auth): recover vault and phone onboarding races

### DIFF
--- a/hushh-webapp/__tests__/app/home-auth-entry.test.tsx
+++ b/hushh-webapp/__tests__/app/home-auth-entry.test.tsx
@@ -1,18 +1,20 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
   resolveAfterLogin: vi.fn(),
   getIdToken: vi.fn(),
+  getIdTokenWithRetry: vi.fn(),
   user: { uid: "returning_user" } as { uid: string } | null,
   loading: false,
   phoneNumber: "+15555550100" as string | null,
+  search: "",
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mocks.replace, push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => new URLSearchParams(mocks.search),
 }));
 
 vi.mock("@/lib/firebase/auth-context", () => ({
@@ -28,7 +30,10 @@ vi.mock("@/lib/services/post-auth-route-service", () => ({
 }));
 
 vi.mock("@/lib/services/auth-service", () => ({
-  AuthService: { getIdToken: mocks.getIdToken },
+  AuthService: {
+    getIdToken: mocks.getIdToken,
+    getIdTokenWithRetry: mocks.getIdTokenWithRetry,
+  },
 }));
 
 vi.mock("@/components/onboarding/IntroStep", () => ({
@@ -57,10 +62,13 @@ describe("authenticated root entry", () => {
     mocks.replace.mockReset();
     mocks.resolveAfterLogin.mockReset();
     mocks.getIdToken.mockReset();
+    mocks.getIdTokenWithRetry.mockReset();
     mocks.user = { uid: "returning_user" };
     mocks.loading = false;
     mocks.phoneNumber = "+15555550100";
+    mocks.search = "";
     mocks.getIdToken.mockResolvedValue("redacted-id-token");
+    mocks.getIdTokenWithRetry.mockResolvedValue("redacted-id-token");
     mocks.resolveAfterLogin.mockResolvedValue("/one");
   });
 
@@ -81,5 +89,37 @@ describe("authenticated root entry", () => {
     await Promise.resolve();
     expect(mocks.resolveAfterLogin).toHaveBeenCalledTimes(1);
     expect(mocks.replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the bounded-retry token fetch, not a single-shot read, for a deep link (e.g. a referral redirect)", async () => {
+    // A Firebase session can still be restoring a frame after a fresh
+    // sign-in or a referral redirect lands here with `redirect` set. A
+    // single null token read used to fail this resolution outright and
+    // show "Unable to verify setup progress." Routing through
+    // getIdTokenWithRetry (rather than the bare getIdToken) is what gives
+    // that restoration a bounded retry before this screen gives up.
+    mocks.search = "redirect=%2Fr%2Ffriend-code";
+    mocks.resolveAfterLogin.mockResolvedValue("/r/friend-code");
+    mocks.getIdTokenWithRetry.mockResolvedValue("redacted-id-token");
+
+    render(<Home />);
+
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/r/friend-code"),
+    );
+    expect(mocks.getIdTokenWithRetry).toHaveBeenCalledTimes(1);
+    expect(mocks.getIdToken).not.toHaveBeenCalled();
+    expect(screen.queryByText(/unable to verify setup progress/i)).toBeNull();
+  });
+
+  it("still shows the retry screen when the bounded retry genuinely exhausts (no session, not a race)", async () => {
+    mocks.getIdTokenWithRetry.mockResolvedValue(null);
+
+    render(<Home />);
+
+    expect(
+      await screen.findByText(/unable to verify setup progress/i),
+    ).toBeTruthy();
+    expect(mocks.resolveAfterLogin).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -15,11 +15,16 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/register-phone",
 }));
 
-function renderPhoneVerificationFlow(options?: { startRejects?: boolean }) {
+function renderPhoneVerificationFlow(options?: {
+  startRejects?: boolean;
+  confirmVerification?: ReturnType<typeof vi.fn>;
+}) {
   const startVerification = options?.startRejects
     ? vi.fn().mockRejectedValue(new Error("provider unavailable"))
     : vi.fn().mockResolvedValue({ autoVerified: false });
-  const confirmVerification = vi.fn().mockResolvedValue({ uid: "user_1" });
+  const confirmVerification =
+    options?.confirmVerification ??
+    vi.fn().mockResolvedValue({ uid: "user_1" });
   const onCompleted = vi.fn();
 
   render(
@@ -36,6 +41,14 @@ function renderPhoneVerificationFlow(options?: { startRejects?: boolean }) {
     confirmVerification,
     onCompleted,
   };
+}
+
+async function reachCodeStep(startVerification: ReturnType<typeof vi.fn>) {
+  const phoneInput = screen.getByRole("textbox", { name: "Phone number" });
+  fireEvent.change(phoneInput, { target: { value: "6505550101" } });
+  fireEvent.submit(phoneInput.closest("form")!);
+  await waitFor(() => expect(startVerification).toHaveBeenCalledTimes(1));
+  return screen.findByRole("textbox", { name: "One-time code" });
 }
 
 async function selectIndiaOnce() {
@@ -340,5 +353,108 @@ describe("PhoneVerificationFlow country selector", () => {
       (screen.getByRole("textbox", { name: "One-time code" }) as HTMLInputElement)
         .value,
     ).toBe("");
+  });
+
+  it("clears stale OTP digits on resend so the newest verification session wins", async () => {
+    const { startVerification } = renderPhoneVerificationFlow();
+    const codeInput = (await reachCodeStep(
+      startVerification,
+    )) as HTMLInputElement;
+
+    fireEvent.change(codeInput, { target: { value: "111111" } });
+    expect(codeInput.value).toBe("111111");
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend code" }));
+
+    await waitFor(() => expect(startVerification).toHaveBeenCalledTimes(2));
+    expect(startVerification).toHaveBeenLastCalledWith("+16505550101", {
+      resendCode: true,
+    });
+    await waitFor(() => expect(codeInput.value).toBe(""));
+  });
+
+  it("clears the OTP input when the code has expired, keeping the person on the OTP screen with Resend available", async () => {
+    const confirmVerification = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(
+          new Error("This verification code has expired. Please request a new code."),
+          { code: "code-expired" },
+        ),
+      );
+    const { startVerification } = renderPhoneVerificationFlow({
+      confirmVerification,
+    });
+    const codeInput = (await reachCodeStep(
+      startVerification,
+    )) as HTMLInputElement;
+
+    fireEvent.change(codeInput, { target: { value: "222222" } });
+    fireEvent.submit(codeInput.closest("form")!);
+
+    await waitFor(() => expect(confirmVerification).toHaveBeenCalledWith("222222"));
+    await waitFor(() => expect(codeInput.value).toBe(""));
+    // Stays on the OTP screen (not bounced back to the phone step) and no
+    // second SMS was auto-sent.
+    expect(screen.getByRole("button", { name: "Resend code" })).toBeTruthy();
+    expect(startVerification).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a wrong OTP in place instead of clearing it, so a typo can be fixed", async () => {
+    const confirmVerification = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(
+          new Error(
+            "That verification code is incorrect. Please check the code and try again.",
+          ),
+          { code: "invalid-verification-code" },
+        ),
+      );
+    const { startVerification } = renderPhoneVerificationFlow({
+      confirmVerification,
+    });
+    const codeInput = (await reachCodeStep(
+      startVerification,
+    )) as HTMLInputElement;
+
+    fireEvent.change(codeInput, { target: { value: "333333" } });
+    fireEvent.submit(codeInput.closest("form")!);
+
+    await waitFor(() =>
+      expect(confirmVerification).toHaveBeenCalledWith("333333"),
+    );
+    expect(codeInput.value).toBe("333333");
+  });
+
+  it("does not fire a second verify request while one is still in flight", async () => {
+    let resolveConfirm: (value: { uid: string }) => void = () => {};
+    const confirmVerification = vi.fn(
+      () =>
+        new Promise<{ uid: string }>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    const { startVerification } = renderPhoneVerificationFlow({
+      confirmVerification,
+    });
+    const codeInput = (await reachCodeStep(
+      startVerification,
+    )) as HTMLInputElement;
+    fireEvent.change(codeInput, { target: { value: "444444" } });
+
+    const verifyButton = screen.getByRole("button", {
+      name: "Verify and continue",
+    });
+    fireEvent.click(verifyButton);
+    fireEvent.click(verifyButton);
+    // A Resend click while the verify request is still in flight must not
+    // start a second, competing network request either.
+    fireEvent.click(screen.getByRole("button", { name: "Resend code" }));
+
+    await waitFor(() => expect(confirmVerification).toHaveBeenCalledTimes(1));
+    expect(startVerification).toHaveBeenCalledTimes(1);
+
+    resolveConfirm({ uid: "user_1" });
   });
 });

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -281,6 +281,49 @@ describe("AuthService native custom-token continuity", () => {
   });
 });
 
+describe("AuthService.getIdTokenWithRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+    mockAuth.currentUser = null;
+  });
+
+  it("returns the token immediately when the session is already restored", async () => {
+    mockAuth.currentUser = {
+      getIdToken: vi.fn().mockResolvedValue("ready-token"),
+    } as any;
+
+    await expect(AuthService.getIdTokenWithRetry()).resolves.toBe(
+      "ready-token",
+    );
+    expect(mockAuth.currentUser.getIdToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once after a short wait when the session is still restoring", async () => {
+    const getIdToken = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce("restored-token");
+    mockAuth.currentUser = { getIdToken } as any;
+
+    const result = await AuthService.getIdTokenWithRetry({ delayMs: 1 });
+
+    expect(result).toBe("restored-token");
+    expect(getIdToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the bounded retry instead of looping forever", async () => {
+    mockAuth.currentUser = null;
+
+    const result = await AuthService.getIdTokenWithRetry({
+      retries: 1,
+      delayMs: 1,
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
 describe("AuthService.restoreNativeSession", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
@@ -734,6 +777,78 @@ describe("AuthService.restoreNativeSession", () => {
       message: "This phone number is already linked to your account.",
       code: "phone-already-linked-to-current-user",
     });
+  });
+
+  it("normalizes an expired OTP into stable, user-facing copy", async () => {
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+    const verifyPhoneNumber = vi.fn().mockResolvedValue("verification-id");
+    mockPhoneAuthProvider.mockImplementation(function () {
+      return { verifyPhoneNumber };
+    });
+    mockAuth.currentUser = { uid: "web-user", phoneNumber: null } as any;
+    vi.mocked(PhoneAuthProvider.credential).mockReturnValue(
+      "phone-credential" as any,
+    );
+    vi.mocked(linkWithCredential).mockRejectedValue({
+      code: "auth/code-expired",
+      message: "Firebase: Error (auth/code-expired).",
+    });
+
+    await expect(
+      AuthService.confirmPhoneLinkVerification({
+        verificationCode: "123456",
+        verificationId: "link-verification-id",
+      }),
+    ).rejects.toMatchObject({
+      code: "code-expired",
+      message: "This verification code has expired. Please request a new code.",
+    });
+  });
+
+  it("normalizes an incorrect OTP into stable, user-facing copy", async () => {
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+    mockAuth.currentUser = { uid: "web-user", phoneNumber: null } as any;
+    vi.mocked(PhoneAuthProvider.credential).mockReturnValue(
+      "phone-credential" as any,
+    );
+    vi.mocked(linkWithCredential).mockRejectedValue({
+      code: "auth/invalid-verification-code",
+      message: "Firebase: Error (auth/invalid-verification-code).",
+    });
+
+    await expect(
+      AuthService.confirmPhoneLinkVerification({
+        verificationCode: "000000",
+        verificationId: "link-verification-id",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid-verification-code",
+      message:
+        "That verification code is incorrect. Please check the code and try again.",
+    });
+  });
+
+  it("normalizes a raw Firebase error out of getPhoneClaimIdToken instead of leaking it to the UI", async () => {
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+    vi.mocked(PhoneAuthProvider.credential).mockReturnValue(
+      "phone-credential" as any,
+    );
+    vi.mocked(signInWithCredential).mockRejectedValue({
+      code: "auth/code-expired",
+      message: "Firebase: Error (auth/code-expired).",
+    });
+
+    await expect(
+      AuthService.getPhoneClaimIdToken({
+        verificationCode: "123456",
+        verificationId: "claim-verification-id",
+      }),
+    ).rejects.toMatchObject({
+      code: "code-expired",
+      message: "This verification code has expired. Please request a new code.",
+    });
+    // Cleanup must still run even though the sign-in itself failed.
+    expect(firebaseSignOut).toHaveBeenCalledWith(mockPhoneClaimAuth);
   });
 
   it("recognizes UAT phone test verification ids without treating them as local dev ids", () => {

--- a/hushh-webapp/__tests__/services/vault-service-check.test.ts
+++ b/hushh-webapp/__tests__/services/vault-service-check.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetIdToken, mockBootstrapState, sessionStore } = vi.hoisted(() => ({
+  mockGetIdToken: vi.fn(),
+  mockBootstrapState: vi.fn(),
+  sessionStore: new Map<string, string>(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
+vi.mock("@/lib/capacitor", () => ({
+  HushhVault: {},
+  HushhAuth: {},
+  HushhConsent: {},
+}));
+
+vi.mock("@/lib/services/auth-service", () => ({
+  AuthService: {
+    getIdToken: mockGetIdToken,
+  },
+}));
+
+vi.mock("@/lib/firebase/config", () => ({
+  auth: { currentUser: null },
+}));
+
+vi.mock("@/lib/services/cache-service", () => ({
+  CacheService: {
+    getInstance: () => ({
+      get: () => undefined,
+      set: () => undefined,
+      invalidate: () => undefined,
+      subscribe: () => () => undefined,
+    }),
+  },
+  CACHE_KEYS: {
+    VAULT_CHECK: (userId: string) => `vault_check_${userId}`,
+    PRE_VAULT_BOOTSTRAP: (userId: string) => `pre_vault_bootstrap_${userId}`,
+  },
+}));
+
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: {
+    onVaultStateChanged: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    bootstrapState: mockBootstrapState,
+  },
+}));
+
+vi.mock("@/lib/vault/passphrase-key", () => ({
+  createVaultWithPassphrase: vi.fn(),
+  unlockVaultWithPassphrase: vi.fn(),
+  unlockVaultWithRecoveryKey: vi.fn(),
+}));
+
+vi.mock("@/lib/vault/passkey-rp", () => ({
+  resolvePasskeyRpId: () => null,
+}));
+
+vi.mock("@/lib/services/api-client", () => ({
+  apiJson: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/request-timeouts", () => ({
+  resolveSlowRequestTimeoutMs: (ms: number) => ms,
+}));
+
+vi.mock("@/lib/utils/session-storage", () => ({
+  getLocalItem: () => null,
+  getSessionItem: (key: string) => sessionStore.get(key) ?? null,
+  setSessionItem: (key: string, value: string) => {
+    sessionStore.set(key, value);
+  },
+  removeSessionItem: (key: string) => {
+    sessionStore.delete(key);
+  },
+}));
+
+import {
+  VaultAuthSessionNotReadyError,
+  VaultService,
+} from "@/lib/services/vault-service";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("VaultService.checkVault (web) — session-restore / 401 handling", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStore.clear();
+    VaultService.invalidateVaultStateCache();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("waits briefly for a still-restoring session, then fails closed instead of guessing hasVault=false", async () => {
+    mockGetIdToken.mockResolvedValue(null);
+
+    await expect(
+      VaultService.checkVault("user-restoring"),
+    ).rejects.toBeInstanceOf(VaultAuthSessionNotReadyError);
+
+    // Bounded: one immediate read plus exactly one retry after the short
+    // wait -- never an unbounded loop -- before giving up.
+    expect(mockGetIdToken).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("force-refreshes the token and retries exactly once after a 401", async () => {
+    mockGetIdToken.mockImplementation((forceRefresh?: boolean) =>
+      Promise.resolve(forceRefresh ? "fresh-token" : "stale-token"),
+    );
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }))
+      .mockResolvedValueOnce(jsonResponse(200, { hasVault: true }));
+
+    await expect(VaultService.checkVault("user-401-retry")).resolves.toBe(
+      true,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = fetchMock.mock.calls[1]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders.Authorization).toBe("Bearer stale-token");
+    expect(secondHeaders.Authorization).toBe("Bearer fresh-token");
+    expect(mockGetIdToken).toHaveBeenCalledWith(true);
+  });
+
+  it("does not collapse a genuine failure into hasVault=false when no fallback state exists", async () => {
+    mockGetIdToken.mockImplementation((forceRefresh?: boolean) =>
+      Promise.resolve(forceRefresh ? "fresh-token" : "stale-token"),
+    );
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }))
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+    mockBootstrapState.mockRejectedValue(new Error("backend unreachable"));
+
+    await expect(
+      VaultService.checkVault("user-genuine-failure"),
+    ).rejects.toBeTruthy();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/hushh-webapp/app/page.tsx
+++ b/hushh-webapp/app/page.tsx
@@ -78,7 +78,11 @@ function HomeContent() {
     let cancelled = false;
 
     void (async () => {
-      const idToken = await AuthService.getIdToken();
+      // A Firebase session can still be restoring a few frames after a fresh
+      // sign-in or a referral redirect. A single null read here used to fail
+      // this whole resolution hard ("Unable to verify setup progress"); wait
+      // briefly and retry once before treating it as a genuine sign-out.
+      const idToken = await AuthService.getIdTokenWithRetry();
       if (!idToken) {
         throw new Error("Native session did not provide an ID token.");
       }

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -373,11 +373,13 @@ export function PhoneVerificationFlow({
     mode === "link" && currentPhoneNumber ? "linked" : "phone",
   );
   const [busy, setBusy] = useState(false);
-  // State updates do not land until after the current event. These refs keep
-  // an Enter keypress and a pointer activation from starting two auth attempts
-  // in the same turn.
-  const startVerificationAttemptRef = useRef(false);
-  const confirmVerificationAttemptRef = useRef(false);
+  // State updates do not land until after the current event. `busy` alone
+  // cannot gate this: two different actions (Verify and Resend) fired in the
+  // same render both read the same stale `busy=false` before either commits
+  // its `setBusy(true)`. One shared ref -- set synchronously the instant an
+  // attempt starts -- closes that cross-action race, not just same-action
+  // double-clicks.
+  const phoneFlowInFlightRef = useRef(false);
 
   useEffect(() => {
     const nextFields = derivePhoneFields(currentPhoneNumber);
@@ -618,7 +620,7 @@ export function PhoneVerificationFlow({
       resendCode = false,
       phoneNumberOverride?: string,
     ): Promise<StartVerificationOutcome> => {
-      if (busy || startVerificationAttemptRef.current) {
+      if (busy || phoneFlowInFlightRef.current) {
         return "busy";
       }
       const normalizedPhone = (
@@ -654,7 +656,7 @@ export function PhoneVerificationFlow({
         return "already_linked";
       }
 
-      startVerificationAttemptRef.current = true;
+      phoneFlowInFlightRef.current = true;
       setBusy(true);
       try {
         const result = await startVerification(normalizedPhone, { resendCode });
@@ -677,6 +679,12 @@ export function PhoneVerificationFlow({
         }
 
         setSubmittedPhoneNumber(normalizedPhone);
+        // A resend replaces the verification session outright (auth-context
+        // already discards the previous verificationId before starting this
+        // one). Any digits the user typed against the OLD code are stale the
+        // instant a new one exists -- keeping them invites confirming the
+        // wrong session.
+        setVerificationCode("");
         setStep("code");
         morphyToast.success(
           resendCode
@@ -705,7 +713,7 @@ export function PhoneVerificationFlow({
         );
         return "failed";
       } finally {
-        startVerificationAttemptRef.current = false;
+        phoneFlowInFlightRef.current = false;
         setBusy(false);
       }
     },
@@ -794,11 +802,11 @@ export function PhoneVerificationFlow({
         }
         return "invalid";
       }
-      if (busy || confirmVerificationAttemptRef.current) {
+      if (busy || phoneFlowInFlightRef.current) {
         return "busy";
       }
 
-      confirmVerificationAttemptRef.current = true;
+      phoneFlowInFlightRef.current = true;
       setBusy(true);
       try {
         const verifiedUser = await confirmVerification(normalizedCode);
@@ -829,6 +837,15 @@ export function PhoneVerificationFlow({
             phoneNumber: submittedPhoneNumber,
           });
         }
+        // An expired code can never succeed by resubmitting the same digits,
+        // so clear the input and leave the person on the OTP screen with
+        // Resend available. A wrong code stays in place -- it may be a typo
+        // worth fixing, not a dead session -- and no SMS is auto-sent either
+        // way; Resend remains an explicit tap.
+        const errorCode = String((error as { code?: unknown })?.code ?? "");
+        if (errorCode === "code-expired") {
+          setVerificationCode("");
+        }
         if (options.notify) {
           morphyToast.error(
             error instanceof Error
@@ -838,7 +855,7 @@ export function PhoneVerificationFlow({
         }
         return "failed";
       } finally {
-        confirmVerificationAttemptRef.current = false;
+        phoneFlowInFlightRef.current = false;
         setBusy(false);
       }
     },

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -22,7 +22,10 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { VaultService } from "@/lib/services/vault-service";
+import {
+  VaultAuthSessionNotReadyError,
+  VaultService,
+} from "@/lib/services/vault-service";
 import { downloadTextFile } from "@/lib/utils/native-download";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,7 +44,6 @@ import { VaultMethodPromptLocalService } from "@/lib/services/vault-method-promp
 import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
 import { checkPrfSupport } from "@/lib/vault/prf-auth";
 import { copyToClipboard } from "@/lib/utils/clipboard";
-import { reloadWindow } from "@/lib/utils/browser-navigation";
 import {
   toInvestorLoading,
   toInvestorMessage,
@@ -145,6 +147,8 @@ export function VaultFlow({
   const [step, setStep] = useState<VaultStep>("checking");
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isRestoringSession, setIsRestoringSession] = useState(false);
+  const [checkAttempt, setCheckAttempt] = useState(0);
   const [passphrase, setPassphrase] = useState("");
   const [confirmPassphrase, setConfirmPassphrase] = useState("");
   const [recoveryKey, setRecoveryKey] = useState<string>("");
@@ -370,8 +374,12 @@ export function VaultFlow({
 
   // Initial Vault Status Check
   useEffect(() => {
-    const checkStatus = async () => {
+    let cancelled = false;
+    const MAX_SESSION_RESTORE_ATTEMPTS = 3;
+
+    const checkStatus = async (restoreAttempt = 0) => {
       try {
+        setIsRestoringSession(false);
         // Start the vault-state read in parallel with the existence check so a
         // cold backend pays a single round-trip latency instead of two
         // sequential cold calls (which made the first unlock feel slow). The
@@ -456,7 +464,26 @@ export function VaultFlow({
         }
         setStep("unlock");
       } catch (err) {
+        // A Firebase session still restoring is not a Vault failure -- it is
+        // evidence we asked before a token existed. Show a transient
+        // "restoring" state and retry a bounded number of times instead of
+        // surfacing a hard failure for what is, in most cases, a race that
+        // resolves within a second.
+        if (
+          err instanceof VaultAuthSessionNotReadyError &&
+          restoreAttempt < MAX_SESSION_RESTORE_ATTEMPTS
+        ) {
+          if (cancelled) return;
+          setIsRestoringSession(true);
+          setError(null);
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          if (cancelled) return;
+          await checkStatus(restoreAttempt + 1);
+          return;
+        }
+
         console.error("Vault status check failed:", err);
+        setIsRestoringSession(false);
         const errorCode =
           typeof (err as { code?: unknown } | null | undefined)?.code === "string"
             ? (err as { code: string }).code
@@ -472,8 +499,17 @@ export function VaultFlow({
         }
       }
     };
-    checkStatus();
-  }, [allowVaultCreation, nativeTestConfig.vaultPassphrase, shouldPreferPassphraseUnlock, user.uid]);
+    void checkStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    allowVaultCreation,
+    checkAttempt,
+    nativeTestConfig.vaultPassphrase,
+    shouldPreferPassphraseUnlock,
+    user.uid,
+  ]);
 
   useLayoutEffect(() => {
     if (step !== "unlock") {
@@ -994,7 +1030,14 @@ export function VaultFlow({
               </div>
               <p className="text-muted-foreground">{error}</p>
               <Button
-                onClick={reloadWindow}
+                onClick={() => {
+                  // A clean restart of the whole check, not a page reload:
+                  // re-enter "checking" and re-run the effect from scratch
+                  // rather than dragging a stale error/step across a retry.
+                  setError(null);
+                  setIsRestoringSession(false);
+                  setCheckAttempt((attempt) => attempt + 1);
+                }}
                 variant="none"
                 className="border border-input bg-background hover:bg-accent hover:text-accent-foreground"
               >
@@ -1006,7 +1049,15 @@ export function VaultFlow({
       );
     }
 
-    return <HushhLoader label={toInvestorLoading("VAULT")} />;
+    return (
+      <HushhLoader
+        label={
+          isRestoringSession
+            ? "Restoring your session…"
+            : toInvestorLoading("VAULT")
+        }
+      />
+    );
   }
 
   return (

--- a/hushh-webapp/components/vault/vault-lock-guard.tsx
+++ b/hushh-webapp/components/vault/vault-lock-guard.tsx
@@ -198,7 +198,6 @@ export function VaultLockGuard({ children }: VaultLockGuardProps) {
         }
       } catch (error) {
         if (
-          isNativePlatform &&
           error instanceof VaultAuthSessionNotReadyError &&
           nativeVaultCheckAttempt < 2
         ) {

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -111,6 +111,26 @@ export class AuthService {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  /**
+   * Bounded token fetch that tolerates a Firebase session still restoring
+   * (common a few frames after a fresh Google/Apple sign-in or a referral
+   * redirect). One short wait-and-retry only -- never an unbounded loop --
+   * so a genuinely signed-out caller still fails fast.
+   */
+  static async getIdTokenWithRetry(options?: {
+    retries?: number;
+    delayMs?: number;
+  }): Promise<string | null> {
+    const retries = options?.retries ?? 1;
+    const delayMs = options?.delayMs ?? 400;
+    let token = await this.getIdToken();
+    for (let attempt = 0; !token && attempt < retries; attempt += 1) {
+      await this.pause(delayMs);
+      token = await this.getIdToken();
+    }
+    return token;
+  }
+
   private static getLocalDevPhoneTestConfig(): {
     phoneNumber: string;
     verificationCode: string;
@@ -1159,6 +1179,8 @@ export class AuthService {
     try {
       const result = await signInWithCredential(phoneClaimAuth, credential);
       claimToken = await result.user.getIdToken(true);
+    } catch (error) {
+      throw this.normalizePhoneVerificationError(error, "link_confirm");
     } finally {
       await firebaseSignOut(phoneClaimAuth).catch(() => undefined);
     }
@@ -1314,6 +1336,20 @@ export class AuthService {
       return this.createPhoneVerificationError(
         code,
         "Use Change phone number to replace the current number.",
+      );
+    }
+
+    if (code === "code-expired") {
+      return this.createPhoneVerificationError(
+        code,
+        "This verification code has expired. Please request a new code.",
+      );
+    }
+
+    if (code === "invalid-verification-code") {
+      return this.createPhoneVerificationError(
+        code,
+        "That verification code is incorrect. Please check the code and try again.",
       );
     }
 

--- a/hushh-webapp/lib/services/vault-service.ts
+++ b/hushh-webapp/lib/services/vault-service.ts
@@ -864,17 +864,41 @@ export class VaultService {
         console.log("🌐 [VaultService] Using API for checkVault");
         const url = this.getApiUrl(`/api/vault/check?userId=${userId}`);
 
-        const authToken = await this.getFirebaseToken();
-        const headers: HeadersInit = {};
-        if (authToken) {
-          headers["Authorization"] = `Bearer ${authToken}`;
+        // A Firebase session can still be restoring a few frames after a
+        // fresh sign-in. Do not issue an unauthenticated check in that
+        // window -- its 401 is not evidence that no vault exists -- so wait
+        // briefly and retry once before treating the token as genuinely
+        // absent (fail-closed below via VaultAuthSessionNotReadyError).
+        let authToken = await this.getFirebaseToken();
+        if (!authToken) {
+          await this.sleep(400);
+          authToken = await this.getFirebaseToken();
         }
 
-        try {
-          const response = await fetch(url, {
-            headers,
+        const fetchWithToken = (token: string) =>
+          fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
             signal: AbortSignal.timeout(resolveSlowRequestTimeoutMs(20_000)),
           });
+
+        try {
+          if (!authToken) {
+            throw new VaultAuthSessionNotReadyError();
+          }
+
+          let response = await fetchWithToken(authToken);
+          if (response.status === 401) {
+            // The token we sent may have just expired or not yet reflect a
+            // freshly restored session. Force a refresh and retry exactly
+            // once -- a second 401 after a forced refresh is a genuine auth
+            // failure, not a race, and must fail closed below.
+            const refreshedToken = await AuthService.getIdToken(true).catch(
+              () => null,
+            );
+            if (refreshedToken) {
+              response = await fetchWithToken(refreshedToken);
+            }
+          }
           if (!response.ok) {
             const payload = await response.json().catch(() => undefined);
             const message =
@@ -900,6 +924,9 @@ export class VaultService {
           const data = await response.json();
           hasVault = data.hasVault;
         } catch (error) {
+          if (error instanceof VaultAuthSessionNotReadyError) {
+            throw error;
+          }
           const fallbackHasVault = await this.resolveVaultCheckFallback(userId);
           if (fallbackHasVault === null) {
             console.error("❌ [VaultService] checkVault failed:", error);


### PR DESCRIPTION
Linked issue: hushh-labs/hushh-research#5884

## Problem

P0 login/onboarding regression affecting new referral users and existing users:

- transient Firebase session restoration could cause Vault bootstrap to fail
- referral/deep-link entry could fail when the Firebase token was temporarily unavailable
- Vault `401` had no token-refresh recovery
- expired/invalid phone OTP errors leaked raw Firebase messages
- resend/verify interactions could retain stale OTP/session state

## Fix

- added bounded Firebase ID-token restoration retry (`AuthService.getIdTokenWithRetry`)
- Vault check now waits for auth readiness before checking
- Vault `401` force-refreshes the token and retries once
- transient restoration shows a recovery state instead of an immediate fatal error
- Vault "Try Again" reruns the actual status check instead of reloading the page
- the web Vault guard now handles session-restoration retries (previously native-only)
- the post-auth resolver (`app/page.tsx`) uses the retry-aware token resolution
- normalized `auth/code-expired` and `auth/invalid-verification-code` into stable, user-facing copy
- `getPhoneClaimIdToken()` now goes through the same error normalization
- expired OTP clears the input while keeping the user on the verification screen; a wrong OTP is left in place
- resend replaces stale OTP/session state
- a single in-flight guard prevents duplicate verify/resend requests (including cross-action races)

## Existing verified users

Current routing already treats backend `phoneVerified=true` as authoritative and waits when state is unknown. The suspected existing-user phone re-verification regression was not reproducible in the current code (re-verified directly against this repo's actual `components/auth/phone-mandate-guard.tsx`, which independently treats backend phone-verified state as authoritative and treats "unknown" as "wait," not "unverified"), so no speculative routing change was made. Existing behavior is protected by the test suite.

## Verification

- TypeScript (`tsc --noEmit`): pass
- ESLint (`--max-warnings=0`) on all changed files: pass
- Targeted auth/Vault/phone/onboarding tests: 90/90 pass
- CI: all checks green (DCO, Secret Scan, PR Base Policy, Base Freshness Gate, Merge Fidelity Gate, Governance, Upstream Sync, Preflight Gate, Integration, CI Status Gate, Web Core, Web Targeted Contracts)
- UAT manual verification: **confirmed by requester (2026-08-24)**

## Scope note

This branch is built directly off `hushh-labs/hushh-research:main` and contains only the 10 files listed below — no pre-existing unrelated work from other in-flight branches is included.