### PR TITLE
fix(deploy): resolve UAT contacts config in Cloud SDK

### DIFF
--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -2,7 +2,61 @@
 # Deploy to: Cloud Run (service name configurable via substitutions)
 
 steps:
-  # Step 1: Build Docker image with runtime-specific environment variables (using Secrets)
+  # Step 1: Resolve the environment-specific Google Contacts browser client.
+  #
+  # The Docker Cloud Builder image intentionally contains only the Docker CLI;
+  # it does not contain gcloud. Resolve the optional Secret Manager value in a
+  # Cloud SDK step, then hand the public client id to the Docker step through
+  # Cloud Build's ephemeral /workspace volume.
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+
+        google_contacts_client_id_file="/workspace/.google-contacts-client-id"
+        google_contacts_secret_error="$$(mktemp)"
+        trap 'rm -f "$${google_contacts_secret_error}"' EXIT
+
+        : > "$${google_contacts_client_id_file}"
+        chmod 600 "$${google_contacts_client_id_file}"
+
+        # Google Contacts rolls out one environment at a time. A missing value
+        # is a hard UAT failure; production/dev remain dark until their own
+        # explicit OAuth client setup is complete.
+        if gcloud secrets versions access latest \
+          --secret=NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID \
+          --project="$PROJECT_ID" \
+          > "$${google_contacts_client_id_file}" \
+          2> "$${google_contacts_secret_error}"; then
+          GOOGLE_CONTACTS_CLIENT_ID_VAL="$$(tr -d '\r\n' < "$${google_contacts_client_id_file}")"
+          if [[ -z "$${GOOGLE_CONTACTS_CLIENT_ID_VAL}" ]]; then
+            echo "Google Contacts OAuth client configuration is empty."
+            exit 1
+          fi
+          case "$${GOOGLE_CONTACTS_CLIENT_ID_VAL}" in
+            *.apps.googleusercontent.com) ;;
+            *)
+              echo "Google Contacts OAuth client configuration is invalid."
+              exit 1
+              ;;
+          esac
+          printf '%s' "$${GOOGLE_CONTACTS_CLIENT_ID_VAL}" \
+            > "$${google_contacts_client_id_file}"
+        elif grep -Eq '(^|[[:space:]])NOT_FOUND(:|[[:space:]])' "$${google_contacts_secret_error}" \
+          && [[ "${_DEPLOY_ENV}" == "uat" ]]; then
+            echo "Missing UAT Google Contacts OAuth client configuration."
+            exit 1
+        elif grep -Eq '(^|[[:space:]])NOT_FOUND(:|[[:space:]])' "$${google_contacts_secret_error}"; then
+          echo "Google Contacts is not configured for ${_DEPLOY_ENV}; keeping the browser fallback dark."
+        else
+          echo "Unable to access Google Contacts OAuth client configuration."
+          exit 1
+        fi
+    id: "resolve-google-contacts-client-config"
+
+  # Step 2: Build Docker image with runtime-specific environment variables (using Secrets)
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"
     args:
@@ -29,43 +83,13 @@ steps:
           fi
         done
 
-        # Google Contacts rolls out one environment at a time. Fetching this
-        # public OAuth client id from the current project keeps every client and
-        # Authorized JavaScript Origin isolated. A missing value is a hard UAT
-        # failure; production/dev remain dark until their own explicit setup.
-        # A top-level availableSecrets entry cannot be conditional and would
-        # make those environments fail before this step even starts.
-        GOOGLE_CONTACTS_CLIENT_ID_VAL=""
-        google_contacts_secret_error="$(mktemp)"
-        trap 'rm -f "${google_contacts_secret_error}"' EXIT
-        if gcloud secrets describe NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID \
-          --project="$PROJECT_ID" >/dev/null 2>"${google_contacts_secret_error}"; then
-          GOOGLE_CONTACTS_CLIENT_ID_VAL="$$(
-            gcloud secrets versions access latest \
-              --secret=NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID \
-              --project="$PROJECT_ID"
-          )"
-          if [[ -z "$${GOOGLE_CONTACTS_CLIENT_ID_VAL}" ]]; then
-            echo "Google Contacts OAuth client configuration is empty."
-            exit 1
-          fi
-          case "$${GOOGLE_CONTACTS_CLIENT_ID_VAL}" in
-            *.apps.googleusercontent.com) ;;
-            *)
-              echo "Google Contacts OAuth client configuration is invalid."
-              exit 1
-              ;;
-          esac
-        elif grep -Eqi 'NOT_FOUND|not found' "${google_contacts_secret_error}" \
-          && [[ "${_DEPLOY_ENV}" == "uat" ]]; then
-            echo "Missing UAT Google Contacts OAuth client configuration."
-            exit 1
-        elif grep -Eqi 'NOT_FOUND|not found' "${google_contacts_secret_error}"; then
-          echo "Google Contacts is not configured for ${_DEPLOY_ENV}; keeping the browser fallback dark."
-        else
-          echo "Unable to inspect Google Contacts OAuth client configuration."
+        google_contacts_client_id_file="/workspace/.google-contacts-client-id"
+        if [[ ! -f "$${google_contacts_client_id_file}" ]]; then
+          echo "Google Contacts OAuth client resolver artifact is missing."
           exit 1
         fi
+        GOOGLE_CONTACTS_CLIENT_ID_VAL="$$(cat "$${google_contacts_client_id_file}")"
+        trap 'rm -f "$${google_contacts_client_id_file}"' EXIT
 
         # Registry layer cache (buildx, mode=max): caches the npm ci + next build layers
         # so an unchanged package-lock turns dependency install into a cache hit. First
@@ -180,7 +204,7 @@ steps:
         "${cmd[@]}"
     id: "deploy-frontend"
 
-# NOTE: no top-level `images:` block — `docker buildx build --push` (Step 1) already
+# NOTE: no top-level `images:` block — `docker buildx build --push` (Step 2) already
 # pushes every tag. Listing images here would make Cloud Build re-push from the local
 # daemon, which is empty under the buildx docker-container driver, and fail.
 

--- a/scripts/ci/runtime-contract-check.sh
+++ b/scripts/ci/runtime-contract-check.sh
@@ -28,6 +28,42 @@ if ! grep -q 'DEVELOPER_API_URL=BACKEND_URL:latest' "$frontend_cloudbuild"; then
   exit 1
 fi
 
+# The Docker Cloud Builder image does not ship gcloud. Google Contacts client
+# resolution must stay in a Cloud SDK step and pass only the public client id to
+# the Docker step through Cloud Build's ephemeral workspace.
+google_contacts_lookup_step="$(
+  awk '
+    /name: "gcr.io\/google.com\/cloudsdktool\/cloud-sdk"/ { current_step = "cloud-sdk" }
+    /name: "gcr.io\/cloud-builders\/docker"/ { current_step = "docker" }
+    /gcloud secrets versions access latest/ {
+      print current_step
+      exit
+    }
+  ' "$frontend_cloudbuild"
+)"
+if [ "$google_contacts_lookup_step" != "cloud-sdk" ]; then
+  echo "❌ Google Contacts Secret Manager lookup must run in a Cloud SDK step, not the Docker builder."
+  exit 1
+fi
+
+if grep -q "NOT_FOUND|not found" "$frontend_cloudbuild"; then
+  echo "❌ Google Contacts secret handling must not treat generic 'not found' text as a Secret Manager NOT_FOUND status."
+  exit 1
+fi
+
+google_contacts_artifact_refs="$(
+  grep -c '/workspace/.google-contacts-client-id' "$frontend_cloudbuild" || true
+)"
+if [ "$google_contacts_artifact_refs" -lt 2 ]; then
+  echo "❌ Google Contacts client resolution must hand off through the ephemeral Cloud Build workspace."
+  exit 1
+fi
+
+if ! grep -q -- '--build-arg "NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=' "$frontend_cloudbuild"; then
+  echo "❌ frontend Cloud Build must pass NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID to the web image."
+  exit 1
+fi
+
 for association_secret in \
   APPLE_TEAM_ID \
   NEXT_PUBLIC_IOS_BUNDLE_ID \


### PR DESCRIPTION
## Summary
- resolve the Google Contacts browser OAuth client configuration in a Cloud SDK build step
- hand the public client ID to the Docker builder through Cloud Build's ephemeral workspace
- fail UAT closed for missing, empty, invalid, or inaccessible configuration while keeping unconfigured non-UAT environments dark
- add a runtime contract guard so Secret Manager access cannot drift back into the Docker-only builder

## Root cause
The first exact-SHA UAT rollout for #5875 failed safely in workflow run `32761674315` / Cloud Build `28cdb7e7-cabf-45ab-b654-2f2ed309256a`. The Docker Cloud Builder image contains Docker/buildx but not `gcloud`; the lookup therefore failed before the image build. A broad text matcher also risked classifying `command not found` as a missing secret.

The deployment workflow rolled back and retained the last-known-good UAT traffic allocation.

## Safety boundary
- touches only the frontend Cloud Build config and its static runtime contract
- does not change OAuth branding, scopes, clients, IAM, Cloud Run traffic, or production resources
- never prints the configured client ID from Secret Manager
- matches only the structured `NOT_FOUND` status; permission, API, or tooling errors fail closed
- preserves the existing buildx cache, push, no-traffic deploy, provenance, and promotion flow

## Verification
- runtime contract check passed repeatedly
- Cloud Build YAML parsed as three ordered steps
- embedded Bash for all three steps passed `bash -n`
- protected-pipeline/governance checks passed (Windows-only interpreter path/UTF-8 reruns included)
- client environment parity passed
- release migration and production posture contracts passed
- DCO sign-off verified
- gitleaks scanned the committed diff with no leaks; GitHub secret-scanning alerts: 0

Closes the UAT deployment blocker for #5875.