### PR TITLE
Polish One Location flows and One launcher

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5110,7 +5110,7 @@
     "one_specialist_tools": "e6e3e5388d1f1660d0f72c295fceb091116bbf66944f00b85454fa7d2c76d768",
     "route_index": "e554b21dcb393c9d6ba5160106afb40faafe759e99ce792bf4e1006abadc61d7",
     "route_layout": "9fdf440b9c771314317abcf6ac1d22d01fe25b8792860a0cb087bb933edf80b9",
-    "surface_map": "6cf4ef5f423eac4a0957b536f1474be5cb332b2a2bad1c1da69ac0dfe766b5ce",
+    "surface_map": "050728616159d81320bcf3ae60d38b26b6523e3ed4c560932ed8cdbc8afbfe1b",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
@@ -41,7 +41,7 @@ describe("canonical workspace hierarchy", () => {
     const finance = read("components/kai/kai-market-hub-page.tsx");
 
     expect(finance).toContain('width="reading"');
-    expect(finance).toContain('"relative !px-0"');
+    expect(finance).toContain('className="relative !px-0');
     expect(finance).toContain('panelInset="page"');
     expect(finance).not.toContain('style={{ "--one-gutter": "0px" }}');
   });

--- a/hushh-webapp/__tests__/components/capability-setup-tile.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-setup-tile.test.tsx
@@ -3,6 +3,7 @@ import { Mail } from "lucide-react";
 import { describe, expect, it, vi } from "vitest";
 
 import { CapabilitySetupTile } from "@/components/onboarding/setup/capability-setup-tile";
+import { lucideCapabilityIcon } from "@/lib/onboarding/one-capabilities";
 import {
   INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
   type InternalAppNavigationRequest,
@@ -28,13 +29,14 @@ describe("CapabilitySetupTile", () => {
     );
     render(
       <CapabilitySetupTile
+        capabilityId="gmail"
         title="Gmail"
         description="Bring in receipts."
         actionLabel="Connect Gmail"
         resumeActionLabel="Finish Gmail"
         href="/one/setup/gmail"
         voiceControlId="one_setup_tile_gmail"
-        icon={Mail}
+        icon={lucideCapabilityIcon(Mail)}
         tone="gmail"
         status={{
           id: "gmail",
@@ -54,6 +56,7 @@ describe("CapabilitySetupTile", () => {
       "one_setup_tile_gmail",
     );
     expect(row.querySelector(".morphy-ripple-host")).not.toBeNull();
+    expect(row.querySelector('[data-testid="one-agent-icon-gmail"]')).not.toBeNull();
     fireEvent.click(row);
 
     expect(navigationRequest).toEqual({
@@ -72,13 +75,14 @@ describe("CapabilitySetupTile", () => {
   it("keeps a capability-specific action visible while vault state resolves", () => {
     render(
       <CapabilitySetupTile
+        capabilityId="gmail"
         title="Connect Gmail"
         description="Bring in receipts."
         actionLabel="Connect Gmail"
         resumeActionLabel="Finish Gmail"
         href="/one/setup/gmail"
         voiceControlId="one_setup_tile_gmail"
-        icon={Mail}
+        icon={lucideCapabilityIcon(Mail)}
         tone="gmail"
         status={{
           id: "gmail",

--- a/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
+++ b/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
@@ -123,11 +123,15 @@ describe("the Requests sent list", () => {
     // fixture: re-adding the word here would not change the fixture and would
     // not turn it red. This assertion is what closes that gap, so the two are
     // load-bearing together, not redundant.
+    const pendingBranchStart = source.indexOf('request.status === "pending" ?');
+    expect(pendingBranchStart).toBeGreaterThan(-1);
+    const pendingBranchEnd = source.indexOf(
+      "requestStatusWord(request.status)",
+      pendingBranchStart,
+    );
+    expect(pendingBranchEnd).toBeGreaterThan(pendingBranchStart);
     const pendingBranch = source
-      .slice(
-        source.indexOf('request.status === "pending" ?'),
-        source.indexOf("requestStatusWord(request.status)"),
-      )
+      .slice(pendingBranchStart, pendingBranchEnd)
       // The comment explaining the decision says "Pending" itself.
       .replace(/^\s*\/\/.*$/gm, "");
     expect(pendingBranch.trim().length).toBeGreaterThan(0);

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { buildOneSetupCapabilityRoute, ROUTES } from "@/lib/navigation/routes";
 import type { CapabilityStatus } from "@/lib/services/capability-setup-state-service";
+import {
+  CACHE_KEYS,
+  CacheService,
+} from "@/lib/services/cache-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 
 function status(
@@ -30,23 +34,15 @@ function buildStatusMap(
   return map;
 }
 
-function countRosterMetrics(
-  container: HTMLElement,
-  value: string,
-  label: string,
-): number {
-  return Array.from(
-    container.querySelectorAll('span[data-ui-role="body-strong"]'),
-  ).filter(
-    (node) =>
-      node.textContent === value &&
-      node.nextElementSibling?.textContent === label,
-  ).length;
+function openAgentListView() {
+  fireEvent.click(screen.getByLabelText("Show agent list view"));
+  return screen.getByTestId("one-agents-list");
 }
 
 describe("OneDashboardPage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    CacheService.getInstance().clear();
   });
 
   it("keeps unfinished Finance actionable after root onboarding is dismissed", () => {
@@ -65,18 +61,36 @@ describe("OneDashboardPage", () => {
 
     // Root onboarding completion is not Finance completion. The resolver's
     // actionable state must still lead to the bounded Finance setup workspace.
-    const financeLink = screen.getByRole("link", { name: "Open Finance" });
+    const financeLink = screen.getByRole("link", { name: /^Open Finance/ });
     expect(financeLink.getAttribute("href")).toBe(
       buildOneSetupCapabilityRoute("finance"),
     );
   });
 
-  it("renders the primary One agent modes with route targets", () => {
+  it("renders the primary One agents as a direct premium app-icon launcher", () => {
+    const userId = "dashboard-launcher-user";
+    CacheService.getInstance().set(
+      CACHE_KEYS.KAI_MARKET_HOME_BASELINE(userId, 7),
+      {
+        movers: {
+          gainers: [{ symbol: "RFAI", change_pct: 355.6 }],
+        },
+      },
+    );
+    CacheService.getInstance().set(CACHE_KEYS.ONE_LOCATION_STATE(userId), {
+      ownerGrants: [{ status: "active" }],
+      receivedGrants: [{ status: "approved" }],
+    });
+    CacheService.getInstance().set(CACHE_KEYS.PKM_METADATA(userId), {
+      totalAttributes: 31,
+    });
+
     const { container } = render(
       <OneDashboardPage
         displayName="Kushal Trivedi"
+        userId={userId}
         capabilityStatusById={buildStatusMap({
-          finance: { state: "not-started", requiresUnlock: true },
+          finance: { state: "completed" },
           gmail: { state: "blocked", prerequisite: "oauth" },
           calendar: { state: "blocked", prerequisite: "oauth" },
           email: { state: "completed" },
@@ -90,19 +104,17 @@ describe("OneDashboardPage", () => {
     expect(screen.queryByText("Good to see you, Kushal.")).toBeNull();
     expect(screen.queryByText("Your private agent")).toBeNull();
     expect(screen.getByTestId("one-agents-section")).toBeTruthy();
-    expect(screen.getByTestId("one-agents-list")).toBeTruthy();
+    expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
+    expect(screen.queryByTestId("one-agents-list")).toBeNull();
     expect(container.textContent).not.toContain("Finish setup");
-    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
 
-    // Every dashboard tile enters the same static setup workspace as the hub.
-    // A resolved journey is redirected by that workspace to the normal product
-    // destination, so direct product routes never bypass first-run setup.
-    const financeLink = screen.getByRole("link", { name: "Open Finance" });
-    expect(financeLink.getAttribute("href")).toBe(
-      buildOneSetupCapabilityRoute("finance"),
-    );
-    const expectedProfileFormatIcons = [
+    const heading = screen.getByRole("heading", { name: "Agents (9)" });
+    expect(heading.textContent).toBe("Agents (9)");
+    expect(heading.querySelector(".sr-only")).toBeNull();
+
+    const expectedOrder = [
       "finance",
+      "location",
       "ria",
       "gmail",
       "calendar",
@@ -110,188 +122,109 @@ describe("OneDashboardPage", () => {
       "pkm",
       "consent",
       "connected-systems",
-      "location",
     ] as const;
-    for (const id of expectedProfileFormatIcons) {
+    const tiles = Array.from(
+      container.querySelectorAll('[data-testid^="one-agent-tile-"]'),
+    );
+    expect(tiles.map((tile) => tile.getAttribute("data-testid"))).toEqual(
+      expectedOrder.map((id) => `one-agent-tile-${id}`),
+    );
+
+    const grid = container.querySelector(
+      '[data-agent-roster-layout="app-icon-launcher-grid"]',
+    );
+    expect(grid).toBeTruthy();
+    expect(grid?.className).toContain("grid-cols-3");
+    expect(grid?.className).not.toContain("sm:grid-cols-[repeat(4");
+    expect(screen.getByTestId("one-agents-grid").className).not.toContain(
+      "bg-white",
+    );
+    expect(screen.getByTestId("one-agents-grid").className).not.toContain(
+      "rounded-[20px]",
+    );
+
+    const financeLink = screen.getByRole("link", {
+      name: /Open Finance, RFAI up 355\.6 percent/,
+    });
+    expect(financeLink.getAttribute("href")).toBe(ROUTES.KAI_HOME);
+    expect(
+      screen.getByRole("link", {
+        name: /Open Location, 2 live shares/,
+      }).getAttribute("href"),
+    ).toBe(ROUTES.ONE_LOCATION);
+    expect(
+      screen.getByRole("link", { name: /^Open Gmail/ }).getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("gmail"));
+    expect(
+      screen.getByRole("link", { name: /^Open Calendar/ }).getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("calendar"));
+    expect(
+      screen.getByRole("link", { name: /^Open KYC/ }).getAttribute("href"),
+    ).toBe(ROUTES.ONE_KYC);
+    expect(
+      screen.getByRole("link", { name: /^Open CRM/ }).getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("connected-systems"));
+    expect(
+      screen.getByRole("link", { name: /^Open Memory/ }).getAttribute("href"),
+    ).toBe(ROUTES.PKM);
+    expect(
+      screen.getByRole("link", { name: /^Open Consent/ }).getAttribute("href"),
+    ).toContain(ROUTES.CONSENTS);
+
+    for (const id of expectedOrder) {
       const icon = screen.getAllByTestId(`one-agent-icon-${id}`)[0];
       expect(icon).toBeTruthy();
       expect(icon).toHaveAttribute("data-agent-icon-kind", "lucide");
-      expect(icon.querySelector("svg")).toBeTruthy();
+      expect(icon.className).toContain("h-[68px]");
+      expect(icon.className).toContain("w-[68px]");
+      expect(icon.className).toContain("rounded-[18px]");
+      expect(icon.querySelector("svg")?.className.baseVal).toContain(
+        "!text-white",
+      );
     }
-    const financeIcon = screen.getAllByTestId("one-agent-icon-finance")[0];
-    expect(financeIcon).toHaveStyle({
-      "--agent-icon-profile-bg": "rgba(88, 86, 214, 0.16)",
-      "--agent-icon-profile-fg": "#5856D6",
-    });
-    // Palette slots are assigned by roster position, so this list must track
-    // ONE_CAPABILITIES order. Location moved from sixth to second, which shifts
-    // the five agents it passed by one slot each — a deliberate consequence of
-    // the reorder, not an incidental one: the palette exists to keep adjacent
-    // rows distinguishable, and that property is preserved.
-    const rosterPaletteOrder = [
-      "finance",
-      "location",
-      "ria",
-      "gmail",
-      "calendar",
-      "email",
-      "pkm",
-      "consent",
-      "connected-systems",
-    ] as const;
-    const rosterPaletteSlots = rosterPaletteOrder.map((id) =>
-      screen
-        .getAllByTestId(`one-agent-icon-${id}`)[0]
-        .getAttribute("data-agent-icon-palette-index"),
-    );
-    expect(rosterPaletteSlots).toEqual([
-      "0",
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-    ]);
-    const iconBackgrounds = Object.fromEntries(
-      rosterPaletteOrder.map((id) => [
-        id,
-        screen
-          .getAllByTestId(`one-agent-icon-${id}`)[0]
-          .style.getPropertyValue("--agent-icon-profile-bg"),
-      ]),
-    );
-    expect(iconBackgrounds.ria).toBe(iconBackgrounds.finance);
-    expect(iconBackgrounds.gmail).toBe(iconBackgrounds.location);
-    expect(iconBackgrounds.calendar).toBe(iconBackgrounds.location);
-    expect(iconBackgrounds.email).toBe(iconBackgrounds.location);
-    expect(iconBackgrounds["connected-systems"]).toBe(
-      iconBackgrounds.location,
-    );
-    expect(iconBackgrounds.pkm).toBe(iconBackgrounds.consent);
-    expect(new Set(Object.values(iconBackgrounds)).size).toBe(3);
-    expect(financeIcon.className).toContain(
-      "dark:bg-[var(--agent-icon-profile-bg-dark)]",
-    );
-    expect(financeIcon.querySelector("svg")?.className.baseVal).toContain(
-      "text-current",
-    );
-    expect(financeIcon.querySelector("svg")?.className.baseVal).not.toContain(
-      "dark:!text-[#1d1d1f]",
-    );
-    expect(financeIcon.querySelector(".backdrop-blur-\\[8px\\]")).toBeNull();
-    const riaLink = screen.getByRole("link", { name: "Open RIA" });
-    expect(riaLink.getAttribute("href")).toBe(
-      buildOneSetupCapabilityRoute("ria"),
-    );
-    // Agents model: the route link is a normal app-icon tile, not a large
-    // colored workflow card.
-    expect(financeLink.className).not.toContain("border-emerald-500");
-    expect(financeLink.getAttribute("style") ?? "").not.toContain("background");
-    expect(
-      screen.getByRole("link", { name: "Open Gmail" }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("gmail"));
-    expect(
-      screen.getByRole("link", { name: "Open Calendar" }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("calendar"));
-    expect(
-      screen.getByRole("link", { name: "Open KYC" }).getAttribute("href"),
-    ).toBe(ROUTES.ONE_KYC);
-    expect(
-      screen.getByRole("link", { name: "Open Location" }).getAttribute("href"),
-    ).toBe(ROUTES.ONE_LOCATION);
-    expect(
-      screen.getByRole("link", { name: "Open CRM" }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("connected-systems"));
 
-    // The roster shows a concise, numeric action KPI rather than generic
-    // progress words such as Ready, Open, or Explore.
-    expect(countRosterMetrics(container, "0", "actions")).toBe(2);
-    expect(
-      countRosterMetrics(container, "—", "checking"),
-    ).toBeGreaterThan(0);
+    expect(screen.getByText("RFAI")).toBeTruthy();
+    expect(screen.getByText("+355.6%")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("live")).toBeTruthy();
+    expect(screen.getByText("31")).toBeTruthy();
+    expect(screen.getByText("saved")).toBeTruthy();
+    expect(screen.queryByText("0 actions")).toBeNull();
+    expect(screen.queryByText("0 approvals waiting")).toBeNull();
+    expect(screen.queryByText("status not loaded")).toBeNull();
+    expect(screen.queryByText("Checking...")).toBeNull();
     expect(screen.queryByText("Ready")).toBeNull();
     expect(screen.queryByText("Explore")).toBeNull();
-    // Gmail and Calendar are first-class setup capabilities; Memory and
-    // Consent remain direct workspaces and do not inflate setup progress.
-    expect(container.querySelectorAll('a[aria-label^="Open "]').length).toBe(9);
-    expect(
-      screen.getByRole("link", { name: "Open Memory" }).getAttribute("href"),
-    ).toBe(ROUTES.PKM);
-    expect(
-      screen.getByRole("link", { name: "Open Consent" }).getAttribute("href"),
-    ).toContain(ROUTES.CONSENTS);
-    expect(
-      screen.queryByRole("link", { name: "Open Information Marketplace" }),
-    ).toBeNull();
-    expect(screen.queryByTestId("one-finish-setup")).toBeNull();
-    expect(screen.queryByText(/9 agents.*setup steps ready/i)).toBeNull();
+    expect(screen.getAllByTestId("one-agent-notification-badge").length).toBe(
+      4,
+    );
+    expect(screen.getByTestId("one-agent-live-dot")).toBeTruthy();
+    expect(container.querySelector(".material-ripple")).toBeNull();
     expect(screen.queryByRole("link", { name: "Open One Agent" })).toBeNull();
   });
 
-  it("reflects completed setup across all capabilities", () => {
-    const { container } = render(
-      <OneDashboardPage
-        displayName="Kushal Trivedi"
-        capabilityStatusById={buildStatusMap({
-          finance: { state: "completed" },
-          gmail: { state: "completed" },
-          calendar: { state: "completed" },
-          email: { state: "completed" },
-          location: { state: "completed" },
-          ria: { state: "completed" },
-          "connected-systems": { state: "completed" },
-        })}
-      />,
-    );
-
-    // Completed workspace setup is represented as an operational KPI rather
-    // than the generic Ready label.
-    expect(countRosterMetrics(container, "0", "actions")).toBe(7);
-    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
-    expect(screen.queryByText("Finish setup")).toBeNull();
-  });
-
-  it("renders authored setup actions instead of transient checking states", () => {
-    render(<OneDashboardPage displayName="Kushal Trivedi" />);
-    expect(screen.queryAllByText("Checking...")).toHaveLength(0);
-    expect(screen.queryByText("Connect Gmail")).toBeNull();
-    expect(
-      countRosterMetrics(document.body, "—", "checking"),
-    ).toBeGreaterThan(0);
-  });
-
-  it("renders the complete roster as a list first and keeps the grid available", () => {
-    const { container } = render(
+  it("defaults first-time visitors to grid and preserves a saved list view", () => {
+    const { unmount } = render(
       <OneDashboardPage displayName="Kushal Trivedi" />,
     );
 
-    expect(screen.getByTestId("one-agents-list")).toBeTruthy();
-    expect(screen.getByTestId("one-agent-list-row-finance")).toBeTruthy();
-    expect(
-      screen.getByRole("link", { name: "Open Finance" }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("finance"));
+    expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
     expect(screen.getByLabelText("Show agent grid view")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Show agent list view")).toHaveAttribute(
       "aria-pressed",
       "false",
     );
-    fireEvent.click(screen.getByLabelText("Show agent grid view"));
-    expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
-    expect(screen.getByTestId("one-agent-tile-finance")).toBeTruthy();
-    const grid = container.querySelector(
-      '[data-agent-roster-layout="grouped-icon-grid"]',
-    );
-    expect(grid?.className).toContain("grid-cols-[repeat(3,minmax(84px,1fr))]");
-    expect(grid?.className).not.toContain("sm:grid-cols-[repeat(4");
-  });
 
-  it("restores a saved list view without replaying a view-change animation", () => {
+    unmount();
     window.localStorage.setItem("hushh:one-agent-roster-view", "list");
+
     render(<OneDashboardPage displayName="Kushal Trivedi" />);
 
     expect(screen.getByTestId("one-agents-list")).toBeTruthy();
+    expect(screen.getByTestId("one-agent-list-row-finance")).toBeTruthy();
     expect(screen.getByTestId("one-agents-view-content")).not.toHaveClass(
       "motion-step-enter",
     );
@@ -300,17 +233,98 @@ describe("OneDashboardPage", () => {
     expect(screen.getByTestId("one-agents-view-content")).toHaveClass(
       "motion-step-enter",
     );
+    expect(window.localStorage.getItem("hushh:one-agent-roster-view")).toBe(
+      "grid",
+    );
   });
 
-  it("filters the local agent roster without opening a second global search surface", () => {
-    render(<OneDashboardPage displayName="Kushal Trivedi" />);
+  it("keeps list view available with the same routes and solid app identity", () => {
+    render(
+      <OneDashboardPage
+        displayName="Kushal Trivedi"
+        capabilityStatusById={buildStatusMap({
+          finance: { state: "not-started", requiresUnlock: true },
+          ria: { state: "in-progress" },
+        })}
+      />,
+    );
+
+    const list = openAgentListView();
+    expect(list).toBeTruthy();
+
+    const financeRow = screen.getByRole("link", { name: /^Open Finance/ });
+    expect(financeRow.getAttribute("href")).toBe(
+      buildOneSetupCapabilityRoute("finance"),
+    );
+    const financeIcon = screen.getAllByTestId("one-agent-icon-finance")[0];
+    expect(financeIcon.className).toContain("h-10");
+    expect(financeIcon.className).toContain("w-10");
+    expect(financeIcon.querySelector("svg")?.className.baseVal).toContain(
+      "!text-white",
+    );
+    expect(screen.getAllByTestId("one-agent-notification-badge").length).toBe(
+      2,
+    );
+  });
+
+  it("filters by title, description, metric value, and metric label without opening another search", () => {
+    const userId = "dashboard-search-user";
+    CacheService.getInstance().set(
+      CACHE_KEYS.KAI_MARKET_HOME_BASELINE(userId, 7),
+      {
+        movers: {
+          gainers: [{ symbol: "RFAI", change_pct: 12.25 }],
+        },
+      },
+    );
+    CacheService.getInstance().set(CACHE_KEYS.ONE_LOCATION_STATE(userId), {
+      ownerGrants: [{ status: "active" }],
+      receivedGrants: [],
+    });
+
+    render(
+      <OneDashboardPage displayName="Kushal Trivedi" userId={userId} />,
+    );
 
     fireEvent.change(screen.getByTestId("one-agents-search"), {
       target: { value: "location" },
     });
+    expect(screen.getByTestId("one-agent-tile-location")).toBeTruthy();
+    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
 
-    expect(screen.getByTestId("one-agent-list-row-location")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-list-row-finance")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    fireEvent.change(screen.getByTestId("one-agents-search"), {
+      target: { value: "receipt" },
+    });
+    expect(screen.getByTestId("one-agent-tile-gmail")).toBeTruthy();
+    expect(screen.queryByTestId("one-agent-tile-location")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    fireEvent.change(screen.getByTestId("one-agents-search"), {
+      target: { value: "RFAI" },
+    });
+    expect(screen.getByTestId("one-agent-tile-finance")).toBeTruthy();
+    expect(screen.queryByTestId("one-agent-tile-location")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    fireEvent.change(screen.getByTestId("one-agents-search"), {
+      target: { value: "live" },
+    });
+    expect(screen.getByTestId("one-agent-tile-location")).toBeTruthy();
+    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
+  });
+
+  it("shows a quiet empty state for unmatched search", () => {
+    render(<OneDashboardPage displayName="Kushal Trivedi" />);
+
+    fireEvent.change(screen.getByTestId("one-agents-search"), {
+      target: { value: "not an agent" },
+    });
+
+    expect(screen.getByTestId("one-agents-empty-state")).toBeTruthy();
+    expect(screen.getByText("No matching agents")).toBeTruthy();
+    expect(screen.getByText("Try another search.")).toBeTruthy();
+    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
   });
 
   it("shows the finance mover as a concise green percentage without redundant winner copy", () => {

--- a/hushh-webapp/__tests__/components/one-location-people-empty-connect-bridge.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-people-empty-connect-bridge.contract.test.ts
@@ -51,17 +51,25 @@ function peopleEmptyState(src: string): string {
 describe("link 1 — People search hands over to Connect", () => {
   const block = peopleEmptyState(HUB);
 
-  it("asks the question the person is actually asking", () => {
-    expect(block).toContain("Don't see who you're looking for?");
+  it("names the empty result plainly", () => {
+    expect(block).toContain("No matching people");
+    expect(block).toContain("Try another name.");
   });
 
   it("offers the way into Connect", () => {
     expect(block).toContain("action=");
-    expect(block).toContain("Manage connections in Connect");
+    expect(block).toContain("Manage connections");
+    expect(block).toContain(
+      'data-voice-control-id="one-location-empty-connect-bridge"',
+    );
   });
 
   it("offers the same bridge when there are no connections at all", () => {
-    expect(block).toContain("Add someone in Connect");
+    expect(block).toContain("addPeopleEmptyAction");
+    expect(HUB).toContain("Add people");
+    expect(HUB).toContain(
+      'data-voice-control-id="one-location-add-connections"',
+    );
   });
 
   it("routes through the hub's single Connect entry point", () => {
@@ -107,7 +115,7 @@ describe("the chain holds end to end", () => {
 
   it("every link points at the next one", () => {
     // 1 -> Connect
-    expect(peopleEmptyState(HUB)).toContain("Manage connections in Connect");
+    expect(peopleEmptyState(HUB)).toContain("Manage connections");
     expect(HUB).toContain("ROUTES.CONNECT");
     // 2 -> invite
     expect(CONNECT).toContain("Invite them to One");

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -107,9 +107,36 @@ describe("One setup hub terminal action contract", () => {
     expect(tile).toContain('aria-current={isCurrent ? "step" : undefined}');
   });
 
+  it("uses the canonical setup icon geometry instead of a setup-specific icon map", () => {
+    const tile = readFileSync(
+      join(
+        process.cwd(),
+        "components/onboarding/setup/capability-setup-tile.tsx",
+      ),
+      "utf8",
+    );
+    const icon = readFileSync(
+      join(process.cwd(), "components/app-ui/agent-section-icon.tsx"),
+      "utf8",
+    );
+
+    expect(tile).toContain("AgentSectionIcon");
+    expect(tile).toContain('size="setup"');
+    expect(icon).toContain("setup: {");
+    expect(icon).toContain('lucideSurface: "h-9 w-9 rounded-[10px]"');
+    expect(icon).toContain('lucide: "h-[19px] w-[19px]"');
+  });
+
   it("counts the mandatory AI access choice in the same progress projection as capability rows", () => {
     const source = readFileSync(
       join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(
+        process.cwd(),
+        "components/onboarding/setup/one-setup-hub.module.css",
+      ),
       "utf8",
     );
 
@@ -120,6 +147,13 @@ describe("One setup hub terminal action contract", () => {
     expect(source).toContain(
       "const done = progressSteps.filter((step) => step.complete).length",
     );
+    expect(source).toContain("className={styles.setupProgress}");
+    expect(source).toContain("{done} of {total} complete");
+    expect(source).toContain("className={styles.setupProgressTrack}");
+    expect(source).toContain("className={styles.setupProgressFill}");
+    expect(source).not.toContain("Array.from({ length: total })");
+    expect(styles).toContain(".setupProgressTrack");
+    expect(styles).not.toContain(".segmentedProgress");
     expect(source).not.toContain("masterSkipped");
     expect(source).not.toContain("const total = items.length");
   });
@@ -178,8 +212,8 @@ describe("One setup hub terminal action contract", () => {
     // `title` tooltip that used to carry the reason are gone -- the tooltip
     // never rendered on touch anyway, which is the only place that action ships.
     expect(footer).toContain("blocked?: boolean");
-    expect(footer).toContain(
-      "const isBlockedTappableAction =\n    blocked && !disabled && !busy && !isQuietSetupAction",
+    expect(footer).toMatch(
+      /const isBlockedTappableAction =\s+blocked && !disabled && !busy && !isQuietSetupAction/,
     );
     // One block, not a stacked description -- the two-line toast ceiling.
     expect(hub).toContain('toast.info("Choose your AI first."');

--- a/hushh-webapp/__tests__/lib/capability-setup-copy.test.ts
+++ b/hushh-webapp/__tests__/lib/capability-setup-copy.test.ts
@@ -1,4 +1,8 @@
 import { getCapabilitySetupCopy } from "@/lib/onboarding/capability-setup-copy";
+import {
+  ONE_CAPABILITIES,
+  ONE_SETUP_CAPABILITIES,
+} from "@/lib/onboarding/one-capabilities";
 import { describe, expect, it } from "vitest";
 
 describe("onboarding capability copy", () => {
@@ -15,7 +19,7 @@ describe("onboarding capability copy", () => {
     const location = getCapabilitySetupCopy("location");
 
     expect(location?.setupTitle).toBe("Set up location");
-    expect(location?.setupBlurb).toBe("Share where you are, when you want.");
+    expect(location?.setupBlurb).toBe("Share only when you choose.");
   });
 
   it("names the identity-check step in words, not an abbreviation", () => {
@@ -28,7 +32,7 @@ describe("onboarding capability copy", () => {
       actionLabel: "Set up KYC",
       resumeActionLabel: "Finish KYC",
     });
-    expect(email?.setupBlurb).toBe("One drafts the replies. You approve.");
+    expect(email?.setupBlurb).toBe("Verify with your approval.");
   });
 
   it("frames CRM setup as a connection the person approves", () => {
@@ -38,7 +42,19 @@ describe("onboarding capability copy", () => {
       setupTitle: "Connect your CRM",
       actionLabel: "Set up CRM",
     });
-    expect(connectedSystems?.setupBlurb).toBe("One finds your record. You approve.");
+    expect(connectedSystems?.setupBlurb).toBe("Find records with your approval.");
+  });
+
+  it("reuses the same launcher icon and tone registry for setup rows", () => {
+    for (const setupCapability of ONE_SETUP_CAPABILITIES) {
+      const launcherCapability = ONE_CAPABILITIES.find(
+        (candidate) => candidate.id === setupCapability.id,
+      );
+
+      expect(launcherCapability, setupCapability.id).toBeDefined();
+      expect(setupCapability.icon).toBe(launcherCapability?.icon);
+      expect(setupCapability.tone).toBe(launcherCapability?.tone);
+    }
   });
 
   it("keeps every setup row short enough to read at a glance", () => {

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -148,19 +148,21 @@ function AppShellFrame({ children }: ProvidersProps) {
     [shellPathname],
   );
   const routeLayoutMode = routeLayout.mode;
-  // Chrome visibility is a property of the ROUTE, not of the `?action=` flow
-  // open inside it. Every Location task flow keeps the shell's back control,
-  // breadcrumb and avatar.
+  // Chrome visibility is primarily route-owned. A small set of focused
+  // Location flows still keeps the top shell while clearing bottom chrome.
   const hidesPersistentChrome = routeLayout.persistentChrome === "none";
   const locationAction = String(searchParams?.get("action") || "").trim();
-  const focusedLocationSmsFlow =
+  const focusedLocationChromeFlow =
     shellPathname === ROUTES.ONE_LOCATION &&
-    (locationAction === "sos" || locationAction === "sms-contacts");
-  // Query-scoped Location flows may hide navigation, but the persistent Agent
-  // Bar must stay mounted so a live voice task can settle after navigation.
+    (locationAction === "sos" ||
+      locationAction === "sms-contacts" ||
+      locationAction === "create-circle" ||
+      locationAction === "circle-detail");
+  // Focused query-scoped Location flows clear the bottom command/navigation
+  // stack while keeping the top shell route context.
   const bottomChromeHidden = hidesPersistentChrome;
   const effectiveHideCommandBar =
-    chromeState.hideCommandBar || focusedLocationSmsFlow;
+    chromeState.hideCommandBar || focusedLocationChromeFlow;
   const topShellRouteProfile = useMemo(() => {
     const query = searchParams?.toString() ?? "";
     return resolveTopShellRouteProfile(
@@ -498,7 +500,7 @@ function AppShellFrame({ children }: ProvidersProps) {
                           <AppTopShell model={topShellModel} />
                         </Suspense>
                       ) : null}
-                      {!hidesPersistentChrome ? (
+                      {!hidesPersistentChrome && !effectiveHideCommandBar ? (
                         <Suspense fallback={null}>
                           <KaiCommandBarGlobal />
                         </Suspense>

--- a/hushh-webapp/components/app-ui/agent-section-icon.tsx
+++ b/hushh-webapp/components/app-ui/agent-section-icon.tsx
@@ -59,6 +59,14 @@ const ICON_SIZE_CLASS = {
     image: "h-full w-full object-contain",
     pixels: 40,
   },
+  setup: {
+    surface: "h-9 w-9",
+    lucideSurface: "h-9 w-9 rounded-[10px]",
+    imageSurface: "rounded-[10px]",
+    lucide: "h-[19px] w-[19px]",
+    image: "h-full w-full object-contain",
+    pixels: 40,
+  },
   roster: {
     surface: "h-10 w-10",
     lucideSurface: "h-10 w-10 rounded-[12px]",
@@ -91,6 +99,7 @@ const PROFILE_ICON_RADIUS_CLASS: Record<AgentSectionIconSize, string> = {
   launcher: "rounded-[17px] sm:rounded-[20px]",
   topbar: "rounded-[10px]",
   menu: "rounded-[11px]",
+  setup: "rounded-[10px]",
   roster: "rounded-[12px]",
   "roster-dashboard": "rounded-[14px]",
   "roster-lg": "rounded-[18px]",

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
-import { ChevronRight, Grid2X2, List, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { ChevronRight, Grid2X2, List, Search, X } from "lucide-react";
 
 import { AgentSectionIcon } from "@/components/app-ui/agent-section-icon";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
@@ -22,7 +22,6 @@ import { getCapabilitySetupCopy } from "@/lib/onboarding/capability-setup-copy";
 import { buildOneSetupCapabilityRoute } from "@/lib/navigation/routes";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
-import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import type { OneLocationState } from "@/lib/one-location/types";
 import type { KaiHomeInsightsV2, KaiHomeMover } from "@/lib/services/api-service";
 import { CACHE_KEYS, CacheService } from "@/lib/services/cache-service";
@@ -50,55 +49,8 @@ type OneAgentMode = {
 type AgentMetric = OneAgentMode["primaryMetric"];
 type AgentRosterView = "grid" | "list";
 type AgentMetricTone = "default" | "positive" | "accent" | "warning" | "muted";
-type DashboardAgentIconFamily = "indigo" | "blue" | "neutral";
-type DashboardAgentIconStyle = CSSProperties & {
-  "--agent-icon-profile-bg": string;
-  "--agent-icon-profile-fg": string;
-  "--agent-icon-profile-bg-dark": string;
-  "--agent-icon-profile-fg-dark": string;
-};
 
 const AGENT_ROSTER_VIEW_STORAGE_KEY = "hushh:one-agent-roster-view";
-const DASHBOARD_AGENT_ICON_FAMILY_BY_ID: Record<string, DashboardAgentIconFamily> = {
-  finance: "indigo",
-  ria: "indigo",
-  gmail: "blue",
-  calendar: "blue",
-  email: "blue",
-  location: "blue",
-  "connected-systems": "blue",
-  pkm: "neutral",
-  consent: "neutral",
-};
-
-const DASHBOARD_AGENT_ICON_STYLE_BY_FAMILY: Record<
-  DashboardAgentIconFamily,
-  DashboardAgentIconStyle
-> = {
-  indigo: {
-    "--agent-icon-profile-bg": "rgba(88, 86, 214, 0.16)",
-    "--agent-icon-profile-fg": "#5856D6",
-    "--agent-icon-profile-bg-dark": "rgba(94, 92, 230, 0.24)",
-    "--agent-icon-profile-fg-dark": "#A7A3FF",
-  },
-  blue: {
-    "--agent-icon-profile-bg": "rgba(0, 122, 255, 0.14)",
-    "--agent-icon-profile-fg": "var(--app-accent-deep)",
-    "--agent-icon-profile-bg-dark": "rgba(10, 132, 255, 0.24)",
-    "--agent-icon-profile-fg-dark": "var(--app-accent-bright)",
-  },
-  neutral: {
-    "--agent-icon-profile-bg": "#E5E5EA",
-    "--agent-icon-profile-fg": "#3A3A3C",
-    "--agent-icon-profile-bg-dark": "rgba(142, 142, 147, 0.28)",
-    "--agent-icon-profile-fg-dark": "#E5E5EA",
-  },
-};
-
-function dashboardAgentIconStyle(mode: OneAgentMode): DashboardAgentIconStyle {
-  const family = DASHBOARD_AGENT_ICON_FAMILY_BY_ID[mode.id] ?? "blue";
-  return DASHBOARD_AGENT_ICON_STYLE_BY_FAMILY[family];
-}
 
 /**
  * The roster only ever mounts client-side (its `/one` route renders a loader
@@ -109,14 +61,14 @@ function dashboardAgentIconStyle(mode: OneAgentMode): DashboardAgentIconStyle {
  * `/one`.
  */
 function readPersistedRosterView(): AgentRosterView {
-  if (typeof window === "undefined") return "list";
+  if (typeof window === "undefined") return "grid";
   try {
     const persisted = window.localStorage.getItem(
       AGENT_ROSTER_VIEW_STORAGE_KEY,
     );
-    return persisted === "grid" ? "grid" : "list";
+    return persisted === "list" ? "list" : "grid";
   } catch {
-    return "list";
+    return "grid";
   }
 }
 
@@ -397,6 +349,85 @@ function isZeroMetric(metric: AgentMetric): boolean {
   return Number(metric.value) === 0;
 }
 
+function positiveIntegerMetricValue(metric: AgentMetric): number | null {
+  const number = Number(metric.value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function isUnavailableMetric(metric: AgentMetric): boolean {
+  return metric.value === "—" || /status not loaded|checking/i.test(metric.label);
+}
+
+const ACTION_METRIC_LABELS = new Set([
+  "action",
+  "actions",
+  "review",
+  "reviews",
+  "request",
+  "requests",
+  "approval waiting",
+  "approvals waiting",
+]);
+
+function actionBadgeValue(mode: OneAgentMode): number | null {
+  const value = positiveIntegerMetricValue(mode.primaryMetric);
+  if (value === null) return null;
+  return ACTION_METRIC_LABELS.has(mode.primaryMetric.label.toLowerCase())
+    ? value
+    : null;
+}
+
+function locationLiveValue(mode: OneAgentMode): number | null {
+  if (mode.id !== "location") return null;
+  const value = positiveIntegerMetricValue(mode.primaryMetric);
+  return value === null ? null : value;
+}
+
+function shouldShowGridMetric(mode: OneAgentMode): boolean {
+  if (isUnavailableMetric(mode.primaryMetric)) return false;
+  if (actionBadgeValue(mode) !== null) return false;
+  if (mode.id === "location") return locationLiveValue(mode) !== null;
+  if (mode.id === "finance") return mode.primaryMetric.label.endsWith("%");
+  if (mode.id === "pkm") return !isZeroMetric(mode.primaryMetric);
+  if (mode.primaryMetric.label.includes("client")) {
+    return !isZeroMetric(mode.primaryMetric);
+  }
+  return false;
+}
+
+function shouldShowListMetric(mode: OneAgentMode): boolean {
+  if (isUnavailableMetric(mode.primaryMetric)) return false;
+  if (isZeroMetric(mode.primaryMetric)) return false;
+  if (actionBadgeValue(mode) !== null) return false;
+  return true;
+}
+
+function formatBadgeValue(value: number): string {
+  return value > 99 ? "99+" : String(value);
+}
+
+function formatA11yMetric(mode: OneAgentMode): string {
+  const badge = actionBadgeValue(mode);
+  if (badge !== null) {
+    return `, ${formatBadgeValue(badge)} ${mode.primaryMetric.label}`;
+  }
+  const live = locationLiveValue(mode);
+  if (live !== null) {
+    return `, ${live} live ${live === 1 ? "share" : "shares"}`;
+  }
+  if (isUnavailableMetric(mode.primaryMetric) || isZeroMetric(mode.primaryMetric)) {
+    return "";
+  }
+  if (mode.id === "finance" && mode.primaryMetric.label.endsWith("%")) {
+    const direction = mode.primaryMetric.label.startsWith("-") ? "down" : "up";
+    const percent = mode.primaryMetric.label
+      .replace(/^[+-]/, "")
+      .replace("%", " percent");
+    return `, ${mode.primaryMetric.value} ${direction} ${percent}`;
+  }
+  return `, ${mode.primaryMetric.value} ${mode.primaryMetric.label}`;
+}
+
 function resolveMetricTone(mode: OneAgentMode): AgentMetricTone {
   const metric = mode.primaryMetric;
   const isZero = isZeroMetric(metric);
@@ -464,6 +495,9 @@ function AgentMetric({
   const labelTone = isTopWinner ? "positive" : tone;
   const isGrid = align === "grid";
 
+  if (isGrid && !shouldShowGridMetric(mode)) return null;
+  if (!isGrid && !shouldShowListMetric(mode)) return null;
+
   return (
     <span
       data-testid={isTopWinner ? "one-finance-top-winner-kpi" : undefined}
@@ -510,6 +544,28 @@ function AgentMetric({
   );
 }
 
+function AgentNotificationBadge({ value }: { value: number }) {
+  return (
+    <span
+      data-testid="one-agent-notification-badge"
+      className="absolute -right-1.5 -top-1.5 z-20 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[#FF3B30] px-1 text-[11px] font-semibold leading-none text-white shadow-none"
+      aria-hidden
+    >
+      {formatBadgeValue(value)}
+    </span>
+  );
+}
+
+function AgentLiveDot() {
+  return (
+    <span
+      data-testid="one-agent-live-dot"
+      className="absolute -right-0.5 -top-0.5 z-20 h-3.5 w-3.5 rounded-full border-2 border-[color:var(--background)] bg-[#34C759]"
+      aria-hidden
+    />
+  );
+}
+
 function AgentGridItem({
   mode,
   className,
@@ -517,41 +573,47 @@ function AgentGridItem({
   mode: OneAgentMode;
   className?: string;
 }) {
+  const badgeValue = actionBadgeValue(mode);
+  const liveValue = locationLiveValue(mode);
+
   return (
     <Link
       href={mode.href}
-      aria-label={`Open ${mode.title}`}
+      aria-label={`Open ${mode.title}${formatA11yMetric(mode)}`}
       data-testid={`one-agent-tile-${mode.id}`}
       title={mode.description}
       className={cn(
-        "group relative flex min-h-[96px] min-w-0 w-full flex-col items-center justify-start gap-[7px] overflow-hidden rounded-[14px] px-1.5 py-2 text-center",
-        "transition-[background-color,transform] duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
-        "hover:bg-[rgba(120,120,128,.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/60 focus-visible:ring-inset active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
+        "group relative flex min-h-[108px] min-w-0 w-full flex-col items-center justify-start gap-2 rounded-[18px] px-1.5 py-1 text-center",
+        "transition-[background-color,opacity,transform] duration-150 ease-[var(--motion-ease-standard)]",
+        "hover:bg-[rgba(120,120,128,.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/60 active:scale-[0.97] active:opacity-80 motion-reduce:transition-none motion-reduce:active:scale-100",
         className,
       )}
     >
-      <AgentSectionIcon
-        id={mode.id}
-        icon={mode.icon}
-        tone={mode.tone}
-        paletteIndex={mode.paletteIndex}
-        isActive={mode.statusTone !== "muted"}
-        size="roster-dashboard"
-        treatment="profile"
-        glyphContrast="default"
-        className="relative z-10"
-        profileStyle={dashboardAgentIconStyle(mode)}
-      />
+      <span className="relative z-10 overflow-visible">
+        <AgentSectionIcon
+          id={mode.id}
+          icon={mode.icon}
+          tone={mode.tone}
+          paletteIndex={mode.paletteIndex}
+          isActive={mode.statusTone !== "muted"}
+          size="roster-lg"
+          treatment="default"
+        />
+        {badgeValue !== null ? (
+          <AgentNotificationBadge value={badgeValue} />
+        ) : liveValue !== null ? (
+          <AgentLiveDot />
+        ) : null}
+      </span>
       <span className="relative z-10 flex w-full min-w-0 flex-col items-center gap-[2px] text-center">
         <span
-          className="block w-full truncate text-center text-[14px] font-semibold leading-[18px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
+          className="block w-full truncate text-center text-[13px] font-semibold leading-[17px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
           data-ui-role="body-strong"
         >
           {mode.title}
         </span>
         <AgentMetric mode={mode} align="grid" />
       </span>
-      <MaterialRipple variant="blue" effect="fade" className="z-0" />
     </Link>
   );
 }
@@ -560,7 +622,7 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
   return (
     <Link
       href={mode.href}
-      aria-label={`Open ${mode.title}`}
+      aria-label={`Open ${mode.title}${formatA11yMetric(mode)}`}
       title={mode.description}
       data-testid={`one-agent-list-row-${mode.id}`}
       className={cn(
@@ -571,17 +633,22 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
       )}
     >
       <span className="relative z-10 flex items-center justify-center">
-        <AgentSectionIcon
-          id={mode.id}
-          icon={mode.icon}
-          tone={mode.tone}
-          paletteIndex={mode.paletteIndex}
-          isActive={mode.statusTone !== "muted"}
-          size="roster"
-          treatment="profile"
-          glyphContrast="default"
-          profileStyle={dashboardAgentIconStyle(mode)}
-        />
+        <span className="relative overflow-visible">
+          <AgentSectionIcon
+            id={mode.id}
+            icon={mode.icon}
+            tone={mode.tone}
+            paletteIndex={mode.paletteIndex}
+            isActive={mode.statusTone !== "muted"}
+            size="roster"
+            treatment="default"
+          />
+          {actionBadgeValue(mode) !== null ? (
+            <AgentNotificationBadge value={actionBadgeValue(mode) ?? 0} />
+          ) : locationLiveValue(mode) !== null ? (
+            <AgentLiveDot />
+          ) : null}
+        </span>
       </span>
       <span className="relative z-10 flex min-w-0 flex-col justify-center">
         <span
@@ -617,7 +684,6 @@ function AgentListRow({ mode }: { mode: OneAgentMode }) {
         aria-hidden
         className="pointer-events-none absolute bottom-0 left-16 right-4 h-px bg-[rgba(60,60,67,.12)] group-last/agent-list:hidden"
       />
-      <MaterialRipple variant="blue" effect="fade" className="z-0" />
     </Link>
   );
 }
@@ -716,7 +782,7 @@ export function OneAgentRoster({
     <section
       aria-labelledby="one-agents-heading"
       data-testid="one-agents-section"
-      className="mx-auto w-full max-w-[720px] pb-[calc(var(--app-bottom-fixed-ui,96px)+1.75rem)] md:pb-[calc(var(--app-bottom-fixed-ui,96px)+2rem)]"
+      className="mx-auto w-full max-w-[560px]"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <PageTitle
@@ -741,8 +807,18 @@ export function OneAgentRoster({
           aria-label="Search agents"
           data-ui-role="input-text"
           data-testid="one-agents-search"
-          className="h-11 w-full rounded-[14px] border border-[rgba(60,60,67,.12)] bg-white py-[11px] pl-11 pr-4 text-[15px] font-normal leading-5 text-[#1D1D1F] outline-none placeholder:text-[#8E8E93] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent)]/60 dark:bg-[#1C1C1E] dark:text-[#F5F5F7]"
+          className="h-[46px] w-full rounded-[15px] border border-transparent bg-white py-[12px] pl-11 pr-10 text-[15px] font-normal leading-5 text-[#1D1D1F] outline-none placeholder:text-[#8E8E93] focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent)]/55 dark:bg-[#1C1C1E] dark:text-[#F5F5F7]"
         />
+        {query ? (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onClick={() => setQuery("")}
+            className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-[#6E6E73] transition-colors hover:bg-[rgba(120,120,128,.12)] hover:text-[#1D1D1F] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/55"
+          >
+            <X className="h-4 w-4 [stroke-width:2]" aria-hidden />
+          </button>
+        ) : null}
       </label>
       <div
         key={view}
@@ -752,16 +828,29 @@ export function OneAgentRoster({
         {view === "grid" ? (
           <div
             data-testid="one-agents-grid"
-            className="overflow-hidden rounded-[20px] bg-white p-[18px] shadow-none dark:bg-[#1C1C1E]"
+            className="mx-auto w-full max-w-[552px] overflow-visible"
           >
             <div
-              data-agent-roster-layout="grouped-icon-grid"
-              className="grid w-full grid-cols-[repeat(3,minmax(84px,1fr))] justify-center gap-x-2 gap-y-5 min-[430px]:grid-cols-[repeat(3,minmax(96px,1fr))] sm:gap-x-3 sm:gap-y-6"
+              data-agent-roster-layout="app-icon-launcher-grid"
+              className="grid w-full grid-cols-3 justify-center gap-x-4 gap-y-5 overflow-visible min-[430px]:gap-x-6 sm:gap-x-7 sm:gap-y-6"
             >
               {visibleModes.map((mode) => (
                 <AgentGridItem key={mode.id} mode={mode} />
               ))}
             </div>
+            {visibleModes.length === 0 ? (
+              <div
+                data-testid="one-agents-empty-state"
+                className="py-10 text-center"
+              >
+                <p className="text-[17px] font-semibold leading-[22px] text-[#1D1D1F] dark:text-[#F5F5F7]">
+                  No matching agents
+                </p>
+                <p className="mt-1 text-[15px] font-normal leading-5 text-[#8E8E93]">
+                  Try another search.
+                </p>
+              </div>
+            ) : null}
           </div>
         ) : (
           <div

--- a/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
@@ -123,7 +123,7 @@ export function SetupNavigationTile({
           icon={icon}
           tone={tone}
           isActive={isComplete}
-          size="menu"
+          size="setup"
         />
       }
       title={title}
@@ -218,7 +218,7 @@ export function CapabilitySetupTile({
           icon={icon}
           tone={tone}
           isActive={isCapabilitySetupComplete(status)}
-          size="menu"
+          size="setup"
         />
       }
       title={title}

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.module.css
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.module.css
@@ -16,53 +16,79 @@
   line-height: 1.45 !important;
 }
 
-.segmentedProgress {
-  display: flex;
-  gap: 6px;
-  margin-bottom: 16px;
-}
-.segmentedProgress > span {
-  flex: 1 1 0%;
-  height: 4px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--foundation-hairline) 86%, transparent);
-  transition: background-color 200ms ease;
-}
-.segmentedProgress > span[data-filled="true"] {
-  background: var(--foundation-gold-deep);
+.setupProgress {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 24px;
 }
 
-/* Flat editorial checklist — drop the grouped-card chrome, keep inset hairlines. */
+.setupProgressLabel {
+  font-family: var(--font-app-text);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.125rem;
+  color: var(--muted-foreground);
+}
+
+.setupProgressTrack {
+  position: relative;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foundation-hairline) 82%, transparent);
+}
+
+.setupProgressFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--app-accent);
+  transition: width 160ms ease;
+}
+
+/* Focused checklist — one grouped white list with inset hairlines. */
 .flatChecklist {
   display: grid;
-  gap: 1rem;
+  gap: 1.125rem;
 }
 
 .flatChecklist [data-slot="settings-group-shell"] {
-  --settings-group-radius: 0px;
+  --settings-group-radius: 18px;
   border: 0;
-  background: transparent;
-  border-radius: 0;
-  overflow: visible;
+  background: var(--app-card-surface-default-solid);
+  border-radius: 18px;
+  box-shadow: none;
 }
-/* Rows read on the page background (no per-row mobile surface fill). */
-.flatChecklist [data-testid="settings-row"] {
-  background: transparent;
+
+.flatChecklist :global([data-slot="settings-group-heading"]) {
+  font-family: var(--font-app-text);
+  font-size: 0.8125rem !important;
+  font-weight: 400 !important;
+  line-height: 1.125rem !important;
+  letter-spacing: 0 !important;
+  color: var(--muted-foreground) !important;
 }
 
 .flatChecklist :global([data-slot="settings-row-title"]),
 .stepGroup :global([data-slot="settings-row-title"]) {
   font-family: var(--font-app-text);
-  font-size: 0.9375rem !important;
-  font-weight: 600 !important;
-  line-height: 1.25 !important;
+  font-size: 1.0625rem !important;
+  font-weight: 400 !important;
+  line-height: 1.375rem !important;
   letter-spacing: 0 !important;
 }
 
 .flatChecklist :global([data-slot="settings-row-description"]),
 .stepGroup :global([data-slot="settings-row-description"]) {
   font-size: 0.8125rem !important;
-  line-height: 1.42 !important;
+  line-height: 1.125rem !important;
+  color: var(--muted-foreground) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .setupProgressFill {
+    transition: none;
+  }
 }
 
 .stepHeader :global([data-slot="page-header-description"]) {

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -408,7 +408,8 @@ export function OneSetupHub() {
     <AppPageShell
       as="main"
       width="reading"
-      className="relative isolate"
+      fitContent
+      className="relative isolate max-w-[600px] pb-[calc(20px+env(safe-area-inset-bottom))]"
       nativeTest={{
         routeId: "/one/setup",
         marker: "native-route-one-setup",
@@ -475,19 +476,25 @@ export function OneSetupHub() {
           <>
             {total > 0 ? (
               <div
-                className={styles.segmentedProgress}
+                className={styles.setupProgress}
                 role="progressbar"
                 aria-valuemin={0}
                 aria-valuemax={total}
                 aria-valuenow={done}
                 aria-label={`${done} of ${total} set up`}
               >
-                {Array.from({ length: total }).map((_, index) => (
+                <div className={styles.setupProgressLabel}>
+                  {done} of {total} complete
+                </div>
+                <div className={styles.setupProgressTrack} aria-hidden>
                   <span
-                    key={index}
-                    data-filled={index < done ? "true" : undefined}
+                    className={styles.setupProgressFill}
+                    style={{
+                      width:
+                        total > 0 ? `${Math.round((done / total) * 100)}%` : "0%",
+                    }}
                   />
-                ))}
+                </div>
               </div>
             ) : null}
             <div className={styles.flatChecklist}>

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -16,7 +16,6 @@ import {
   CreateCircleFlow,
   JoinCircleFlow,
 } from "@/components/one-location/redesign/circles/named-circle-flows";
-import { CIRCLE_NAME_ACTION_CLASSNAME } from "@/components/one-location/redesign/circles/circle-name-row-layout";
 import { CIRCLE_MEMBER_MENU_CLASSNAME } from "@/components/one-location/redesign/circles/circle-member-row-layout";
 import { ROUTES } from "@/lib/navigation/routes";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
@@ -102,16 +101,16 @@ describe("named Circle flows", () => {
 
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByPlaceholderText("e.g. Meena Family"), {
+    fireEvent.change(screen.getByPlaceholderText("e.g. Family"), {
       target: { value: "Meena Family" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create circle" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Circle" }));
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith("Circle limit reached."),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Create circle" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Circle" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
     expect(onSubmit).toHaveBeenLastCalledWith("Meena Family", "family");
   });
@@ -120,8 +119,8 @@ describe("named Circle flows", () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
 
-    const create = screen.getByRole("button", { name: "Create circle" });
-    const input = screen.getByPlaceholderText("e.g. Meena Family");
+    const create = screen.getByRole("button", { name: "Create Circle" });
+    const input = screen.getByPlaceholderText("e.g. Family");
 
     // Nothing typed: the button is genuinely blocked, and it is painted as a
     // neutral fill rather than a half-opacity accent that still reads as live.
@@ -589,15 +588,15 @@ describe("named Circle flows", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Asha Meena Connected on One/i }),
+      screen.getByRole("button", { name: /Asha Meena/i }),
     );
     expect(
       screen.getByRole("button", {
-        name: /Asha Meena Connected on One/i,
+        name: /Asha Meena/i,
       }),
     ).toHaveAttribute("aria-pressed", "true");
     fireEvent.click(
-      screen.getByRole("button", { name: /Neel Shah Connected on One/i }),
+      screen.getByRole("button", { name: /Neel Shah/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 2 people" }));
 
@@ -655,20 +654,16 @@ describe("named Circle flows", () => {
     );
 
     expect(await screen.findByText("Friends")).toBeTruthy();
-    expect(screen.getByText(inviteCode.code)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add people" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Rotate code" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Replace code" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Delete circle" })).toBeNull();
     expect(screen.queryByLabelText("Circle name")).toBeNull();
     expect(screen.getByRole("button", { name: "Leave circle" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Copy" }).parentElement).toHaveClass(
-      "grid-cols-1",
-      "min-[360px]:grid-cols-2",
-    );
 
-    const inviteCard = screen.getByTestId("one-location-circle-invite-card");
-    fireEvent.click(within(inviteCard).getByRole("button", { name: "Copy" }));
-    fireEvent.click(within(inviteCard).getByRole("button", { name: "Share" }));
+    fireEvent.click(screen.getByRole("button", { name: /Invite code/i }));
+    expect(await screen.findByText(inviteCode.code)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Share invite" }));
     await waitFor(() => {
       expect(onCopyCode).toHaveBeenCalledWith(inviteCode.code);
       expect(onShareCode).toHaveBeenCalledWith(
@@ -680,7 +675,7 @@ describe("named Circle flows", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add people" }));
     fireEvent.click(
       await screen.findByRole("button", {
-        name: /Friend User Connected on One/i,
+        name: /Friend User/i,
       }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
@@ -717,10 +712,13 @@ describe("named Circle flows", () => {
       />,
     );
 
-    expect(await screen.findByText(currentCode.code)).toBeTruthy();
-    expect(screen.getByLabelText("Circle name")).toBeTruthy();
+    expect(await screen.findByText("Family")).toBeTruthy();
+    expect(screen.queryByLabelText("Circle name")).toBeNull();
     expect(screen.getByRole("button", { name: "Delete circle" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Rotate code" }));
+    fireEvent.click(screen.getByRole("button", { name: /Invite code/i }));
+    expect(await screen.findByText(currentCode.code)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Replace code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Replace code" }));
 
     await waitFor(() =>
       expect(onGenerateCode).toHaveBeenCalledWith("circle-1", true),
@@ -751,8 +749,9 @@ describe("named Circle flows", () => {
     );
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Refresh invite code" }),
+      await screen.findByRole("button", { name: /Invite code/i }),
     );
+    fireEvent.click(await screen.findByRole("button", { name: "Create code" }));
     await waitFor(() =>
       expect(onGenerateCode).toHaveBeenCalledWith("circle-1", true),
     );
@@ -786,13 +785,13 @@ describe("named Circle flows", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Add people" }),
     );
-    expect(await screen.findByText(/add 1 more person right now/i)).toBeTruthy();
+    expect(await screen.findByText("Asha Meena")).toBeTruthy();
 
     const asha = screen.getByRole("button", {
-      name: /Asha Meena Connected on One/i,
+      name: /Asha Meena/i,
     });
     const neel = screen.getByRole("button", {
-      name: /Neel Shah Connected on One/i,
+      name: /Neel Shah/i,
     });
     expect(asha).toHaveAttribute("aria-pressed", "false");
     fireEvent.click(asha);
@@ -870,7 +869,7 @@ describe("named Circle flows", () => {
       await screen.findByRole("button", { name: "Add people" }),
     );
     const asha = await screen.findByRole("button", {
-      name: /Asha Meena Connected on One/i,
+      name: /Asha Meena/i,
     });
     fireEvent.click(asha);
     fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
@@ -881,12 +880,17 @@ describe("named Circle flows", () => {
     expect(screen.queryByText("Asha Meena")).toBeNull();
     expect(await screen.findByText("Neel Shah")).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /Neel Shah Connected on One/i }),
+      screen.getByRole("button", { name: /Neel Shah/i }),
     ).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByRole("button", { name: "Select people" })).toBeDisabled();
+    expect(
+      within(screen.getByRole("dialog", { name: "Add people" })).getByRole(
+        "button",
+        { name: "Add people" },
+      ),
+    ).toBeDisabled();
   });
 
-  it("offers an inline Save only once the Circle name is edited, then shows the new name everywhere", async () => {
+  it("opens a quiet rename sheet, then shows the new name without refetching", async () => {
     const onRename = vi.fn(async (circleId: string, name: string) =>
       circle(circleId, name),
     );
@@ -900,12 +904,14 @@ describe("named Circle flows", () => {
       />,
     );
 
+    expect(await screen.findByText("Meena Family")).toBeTruthy();
+    expect(screen.queryByLabelText("Circle name")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     const input = (await screen.findByLabelText(
       "Circle name",
     )) as HTMLInputElement;
-    // Untouched: the trailing control is the edit affordance, never a write.
-    expect(screen.getByRole("button", { name: "Edit Circle name" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
 
     // Only an empty name blocks the write; one character is a name.
     fireEvent.change(input, { target: { value: "   " } });
@@ -926,47 +932,22 @@ describe("named Circle flows", () => {
     // Header, the delete confirmation copy and the add-people sheet all read the
     // renamed Circle without waiting for a refetch.
     expect(await screen.findByText("Meena Home")).toBeTruthy();
-    expect(input.value).toBe("Meena Home");
-    // Saved state collapses back to the edit affordance.
+    // Saved state closes the sheet back to the quiet edit affordance.
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
     );
+    expect(screen.queryByLabelText("Circle name")).toBeNull();
     expect(onLoad).toHaveBeenCalledTimes(1);
   });
 
-  it("gives Save and Edit one box, so the field never resizes mid-edit", async () => {
-    // QA: "Save CTA, not looking good". The cause was measurable. Save took
-    // `Button`'s `default` size, whose `min-h-[50px]` outlives an `h-11` --
-    // `h-` and `min-h-` are separate tailwind-merge groups -- so it rendered
-    // 50px against a 44px field. And because Save is wider than a pencil
-    // glyph, swapping one for the other resized the input on the first
-    // keystroke.
-    //
-    // JSDOM cannot see either of those; it applies no CSS. What it can prove is
-    // that both states are handed the one shared class string that
-    // `e2e/connect-circle-cta.layout.spec.ts` measured at 44px and a fixed
-    // width, on Chromium and on WebKit.
+  it("keeps rename controls out of the steady-state Circle detail page", async () => {
     const onLoad = vi.fn(async () => circle("circle-1", "Meena Family"));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    const input = (await screen.findByLabelText(
-      "Circle name",
-    )) as HTMLInputElement;
-
-    const edit = screen.getByRole("button", { name: "Edit Circle name" });
-    expect(edit.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
-
-    fireEvent.change(input, { target: { value: "Meena Home" } });
-    const save = screen.getByRole("button", { name: "Save" });
-    expect(save.className).toContain(CIRCLE_NAME_ACTION_CLASSNAME);
-
-    // The height override is only load-bearing with its `min-h` partner.
-    const tokens = new Set(CIRCLE_NAME_ACTION_CLASSNAME.split(/\s+/));
-    expect(tokens.has("h-11")).toBe(true);
-    expect(tokens.has("min-h-11")).toBe(true);
-
-    // A word alone. The check mark beside "Save" said the same thing twice and
-    // pulled the button's padding in through `has-[>svg]`.
+    expect(await screen.findByText("Meena Family")).toBeTruthy();
+    expect(screen.queryByLabelText("Circle name")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const save = await screen.findByRole("button", { name: "Save" });
     expect(save.querySelector("svg")).toBeNull();
     expect(save.textContent).toBe("Save");
   });
@@ -984,17 +965,23 @@ describe("named Circle flows", () => {
       />,
     );
 
+    await screen.findByText("Meena Family");
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     const input = (await screen.findByLabelText(
       "Circle name",
     )) as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: "Typed then abandoned" } });
     fireEvent.keyDown(input, { key: "Escape" });
-    expect(input.value).toBe("Meena Family");
+    await waitFor(() => expect(screen.queryByLabelText("Circle name")).toBeNull());
     expect(onRename).not.toHaveBeenCalled();
 
-    fireEvent.change(input, { target: { value: "Meena Home" } });
-    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const nextInput = (await screen.findByLabelText(
+      "Circle name",
+    )) as HTMLInputElement;
+    fireEvent.change(nextInput, { target: { value: "Meena Home" } });
+    fireEvent.keyDown(nextInput, { key: "Enter" });
     await waitFor(() =>
       expect(onRename).toHaveBeenCalledWith("circle-1", "Meena Home"),
     );
@@ -1285,6 +1272,13 @@ describe("named Circle flows", () => {
           phoneVerified: true,
           secureLocationReady: true,
         },
+        ...Array.from({ length: 7 }, (_, index) => ({
+          userId: `extra-user-${index}`,
+          displayName: `Circle Member ${index}`,
+          role: "member" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+        })),
       ],
     };
 
@@ -1296,7 +1290,7 @@ describe("named Circle flows", () => {
     );
 
     await screen.findByText("John Smith");
-    expect(screen.getByText("Owner (you)")).toBeInTheDocument();
+    expect(screen.getByText("You · Owner")).toBeInTheDocument();
 
     const search = screen.getByPlaceholderText("Search members");
 
@@ -1304,7 +1298,7 @@ describe("named Circle flows", () => {
     // case never matters, same contract as the Add People connection search.
     fireEvent.change(search, { target: { value: "JOH" } });
     expect(screen.getByText("John Smith")).toBeInTheDocument();
-    expect(screen.queryByText("Owner (you)")).not.toBeInTheDocument();
+    expect(screen.queryByText("You · Owner")).not.toBeInTheDocument();
 
     // Zero matches gets a real empty state, not a blank list.
     fireEvent.change(search, { target: { value: "zzz" } });
@@ -1314,7 +1308,7 @@ describe("named Circle flows", () => {
     // Clearing the query restores the original, unfiltered roster.
     fireEvent.change(search, { target: { value: "" } });
     expect(screen.getByText("John Smith")).toBeInTheDocument();
-    expect(screen.getByText("Owner (you)")).toBeInTheDocument();
+    expect(screen.getByText("You · Owner")).toBeInTheDocument();
     expect(screen.queryByText("No members found")).not.toBeInTheDocument();
   });
 
@@ -1359,14 +1353,12 @@ describe("named Circle flows", () => {
     expect(scrollRegion?.className).toContain("overflow-y-auto");
   });
 
-  it("shows the member search bar even for a single-member Circle", async () => {
+  it("keeps the member search bar hidden for a small Circle", async () => {
     const onLoad = vi.fn(async () => circle("circle-1", "Meena Family"));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    expect(
-      await screen.findByPlaceholderText("Search members"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Owner (you)")).toBeInTheDocument();
+    expect(await screen.findByText("You · Owner")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search members")).toBeNull();
   });
 
   it("closes the add-people sheet after inviting, for one person or many", async () => {
@@ -1400,7 +1392,7 @@ describe("named Circle flows", () => {
     // Single selection.
     fireEvent.click(await screen.findByRole("button", { name: "Add people" }));
     fireEvent.click(
-      await screen.findByRole("button", { name: /Asha Meena Connected on One/i }),
+      await screen.findByRole("button", { name: /Asha Meena/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
@@ -1410,16 +1402,16 @@ describe("named Circle flows", () => {
       ]),
     );
     await waitFor(() =>
-      expect(screen.queryByText("Add people to Meena Family")).toBeNull(),
+      expect(screen.queryByRole("dialog", { name: "Add people" })).toBeNull(),
     );
 
     // Multiple selection — reopening starts from a cleared selection.
     fireEvent.click(screen.getByRole("button", { name: "Add people" }));
     fireEvent.click(
-      await screen.findByRole("button", { name: /Asha Meena Connected on One/i }),
+      await screen.findByRole("button", { name: /Asha Meena/i }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: /Neel Shah Connected on One/i }),
+      screen.getByRole("button", { name: /Neel Shah/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 2 people" }));
 
@@ -1430,7 +1422,7 @@ describe("named Circle flows", () => {
       ]),
     );
     await waitFor(() =>
-      expect(screen.queryByText("Add people to Meena Family")).toBeNull(),
+      expect(screen.queryByRole("dialog", { name: "Add people" })).toBeNull(),
     );
   });
 
@@ -1460,14 +1452,14 @@ describe("named Circle flows", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Add people" }));
     fireEvent.click(
-      await screen.findByRole("button", { name: /Asha Meena Connected on One/i }),
+      await screen.findByRole("button", { name: /Asha Meena/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith("Circle capacity changed."),
     );
-    expect(screen.getByText("Add people to Meena Family")).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Add people" })).toBeTruthy();
   });
 
   it("closes invitation controls when server capability is revoked", async () => {
@@ -1522,7 +1514,7 @@ describe("named Circle flows", () => {
     );
     fireEvent.click(
       await screen.findByRole("button", {
-        name: /Friend User Connected on One/i,
+        name: /Friend User/i,
       }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add 1 person" }));
@@ -1533,7 +1525,7 @@ describe("named Circle flows", () => {
     expect(onLoad).toHaveBeenCalledTimes(2);
     expect(onLoadEligibleConnections).toHaveBeenCalledTimes(1);
   });
-  it("offers a system Circle's owner neither door, and says why", async () => {
+  it("offers a system Circle's owner neither destructive door", async () => {
     // The branch used to be a two-way `isOwner && !isSystem`, so the owner of
     // their own emergency Circle fell through to "Leave circle" -- which
     // `_end_membership` refuses with LOCATION_CIRCLE_OWNER_LEAVE_INVALID every
@@ -1564,10 +1556,9 @@ describe("named Circle flows", () => {
     expect(
       screen.queryByRole("button", { name: /Delete circle/i }),
     ).toBeNull();
-    // A sentence, not a disabled button: there is nothing to enable later.
     expect(
-      screen.getByText(/managed for you, so it can.t be left or deleted/i),
-    ).toBeTruthy();
+      screen.queryByText(/managed for you, so it can.t be left or deleted/i),
+    ).toBeNull();
   });
 
   it("still offers an ordinary Circle's owner the delete door", async () => {
@@ -1630,7 +1621,7 @@ describe("a Trusted Circle offers no control that cannot work", () => {
     vi.clearAllMocks();
   });
 
-  it("shows neither Delete nor Leave, and says why in its own words", async () => {
+  it("shows neither Delete nor Leave", async () => {
     // Trusted is deliberately NOT `is_system`, so the guard written for the SMS
     // Circle -- `isOwner && circle.isSystem` -- let it fall through to a Delete
     // button that the API and a database trigger both refuse.
@@ -1640,11 +1631,9 @@ describe("a Trusted Circle offers no control that cannot work", () => {
     await screen.findByText("Trusted");
     expect(screen.queryByRole("button", { name: /Delete circle/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Leave circle/i })).toBeNull();
-
-    // And not the SMS Circle's sentence, which promises a roster you can edit.
     expect(
-      screen.getByText(/Everyone you're connected to is in this Circle/i),
-    ).toBeTruthy();
+      screen.queryByText(/Everyone you're connected to is in this Circle/i),
+    ).toBeNull();
     expect(screen.queryByText(/choose who is in it/i)).toBeNull();
   });
 
@@ -1822,7 +1811,7 @@ describe("an impatient second tap never makes a second Circle", () => {
 
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByPlaceholderText("e.g. Meena Family"), {
+    fireEvent.change(screen.getByPlaceholderText("e.g. Family"), {
       target: { value: "Roommates" },
     });
     const create = screen.getByRole("button", { name: /create/i });
@@ -1844,7 +1833,7 @@ describe("an impatient second tap never makes a second Circle", () => {
       .mockResolvedValueOnce(undefined);
 
     render(<CreateCircleFlow busy={false} onSubmit={onSubmit} />);
-    fireEvent.change(screen.getByPlaceholderText("e.g. Meena Family"), {
+    fireEvent.change(screen.getByPlaceholderText("e.g. Family"), {
       target: { value: "Roommates" },
     });
     const create = screen.getByRole("button", { name: /create/i });
@@ -1856,7 +1845,7 @@ describe("an impatient second tap never makes a second Circle", () => {
   });
 });
 
-describe("an empty Circle is never a dead end", () => {
+describe("a Circle with only the current user stays compact", () => {
   function emptyCircle(
     systemKind: "trusted" | "sms" | null,
     canInvite = true,
@@ -1904,18 +1893,19 @@ describe("an empty Circle is never a dead end", () => {
     const onLoad = vi.fn(async () => emptyCircle("sms"));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    expect(await screen.findByText("No one's in this Circle yet")).toBeTruthy();
+    expect(await screen.findByText("You · Owner")).toBeTruthy();
+    expect(screen.queryByText("No one's in this Circle yet")).toBeNull();
     expect(screen.queryByText("Try a different name.")).toBeNull();
   });
 
-  it("points at the card that fills it, without a second identical button", async () => {
+  it("offers the Invite row without a second identical empty-state button", async () => {
     // A Circle you can add to already has an "Add people" card on this screen.
     // A second identical button is not a second option, it is the same one
     // twice -- and it made "Add people" ambiguous to anything looking for it.
     const onLoad = vi.fn(async () => emptyCircle("sms"));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    await screen.findByText("No one's in this Circle yet");
+    await screen.findByText("SMS Circle");
     expect(screen.getAllByRole("button", { name: /Add people/i })).toHaveLength(
       1,
     );
@@ -1924,25 +1914,24 @@ describe("an empty Circle is never a dead end", () => {
     ).toBeNull();
   });
 
-  it("sends you to find people when the Circle fills itself", async () => {
+  it("does not show manual add controls when the Circle fills itself", async () => {
     // Trusted's roster follows the connection, so there is nothing to add by
     // hand -- the way to fill it is to connect with somebody.
     const onLoad = vi.fn(async () => emptyCircle("trusted"));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    const find = await screen.findByTestId(
-      "one-location-circle-empty-find-people",
-    );
-    expect(find.getAttribute("href")).toContain("/one/connect");
-    // And no add-people card at all, because Trusted cannot be added to.
+    expect(await screen.findByText("Trusted")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Add people/i })).toBeNull();
+    expect(
+      screen.queryByTestId("one-location-circle-empty-find-people"),
+    ).toBeNull();
   });
 
-  it("still says what is going on when the reader cannot act", async () => {
+  it("keeps the owner row when the reader cannot act", async () => {
     const onLoad = vi.fn(async () => emptyCircle("sms", false));
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
-    expect(await screen.findByText("No one's in this Circle yet")).toBeTruthy();
+    expect(await screen.findByText("You · Owner")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Add people/i })).toBeNull();
   });
 

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -9,11 +9,8 @@ import {
   KeyRound,
   Loader2,
   LogOut,
-  Pencil,
   Plus,
-  RotateCw,
   Search,
-  Send,
   Share2,
   ShieldCheck,
   Trash2,
@@ -55,7 +52,6 @@ import { SectionLabel, TrailingValue } from "@/components/app-ui/typography";
 import {
   EmptyState,
   TaskFlowHeader,
-  TrustNoteCard,
 } from "@/components/one-location/redesign/primitives";
 import {
   CARD_SURFACE,
@@ -65,7 +61,6 @@ import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
-  CIRCLE_NAME_ACTION_CLASSNAME,
   CIRCLE_NAME_INPUT_CLASSNAME,
   CIRCLE_NAME_ROW_CLASSNAME,
 } from "@/components/one-location/redesign/circles/circle-name-row-layout";
@@ -109,18 +104,6 @@ const CIRCLES_EMPTY_STATE_WRAPPER =
   "[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)]";
 
 /**
- * The Circle detail screen's own cards -- rename, invite -- on the SAME
- * surface recipe as the Members list they sit above.
- *
- * They used to be hand-rolled: `rounded-[22px] border border-border shadow-sm`
- * against the grouped card's 24px radius, borderless fill and standard card
- * shadow. Three cards, two radii, two borders and two shadows down one
- * scroll, which is most of what "scattered" was describing. `CARD_SURFACE` is
- * the app-wide recipe `SettingsGroup` already renders, so there is now one.
- */
-const CIRCLE_DETAIL_CARD = cn(CARD_SURFACE, "p-4");
-
-/**
  * Leave / Delete circle.
  *
  * `variant="outline"` gave these a filled neutral slab with a red hairline and
@@ -131,17 +114,6 @@ const CIRCLE_DETAIL_CARD = cn(CARD_SURFACE, "p-4");
  */
 const CIRCLE_DESTRUCTIVE_ACTION =
   "h-12 w-full rounded-full text-[17px] font-semibold text-destructive hover:bg-destructive/10 hover:text-destructive";
-
-/**
- * "Generate invite code", "Refresh invite code", "Rotate code".
- *
- * All of them are alternatives to the card's one primary action, so they read
- * as one quiet tier: same height, same radius, accent label, no fill. Three
- * full-width neutral slabs in a column was the invite card's share of
- * "scattered".
- */
-const CIRCLE_INVITE_SECONDARY_ACTION =
-  "mt-2 h-11 w-full rounded-full font-semibold";
 
 /**
  * A circle is a group of trusted people, so its glyph carries the PEOPLE role
@@ -192,6 +164,11 @@ function circleInitials(value: string): string {
 export { othersCountLabel };
 
 const circleListMemberCountLabel = circleMemberCountLabel;
+
+function circleDetailMemberCountLabel(count: number): string {
+  if (count <= 1) return "Only you";
+  return `${count} people`;
+}
 
 function circleFlowErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message.trim()
@@ -509,22 +486,18 @@ export function CirclesSection({
 const CIRCLE_KIND_OPTIONS: {
   value: OneLocationCircleKind;
   label: string;
-  description: string;
 }[] = [
   {
     value: "family",
     label: "Family",
-    description: "Home, relatives and caregivers",
   },
   {
     value: "friends",
     label: "Friends",
-    description: "Friends, roommates and travel groups",
   },
   {
     value: "other",
     label: "Other",
-    description: "A custom trusted group",
   },
 ];
 
@@ -565,14 +538,10 @@ export function CreateCircleFlow({
 
   return (
     <div className="space-y-6" data-testid="one-location-create-circle-flow">
-      <TaskFlowHeader
-        eyebrow="People"
-        title="Create a circle"
-        description="Name the group."
-      />
+      <TaskFlowHeader title="Create Circle" />
 
       <label className="block space-y-2">
-        <span className="text-sm font-semibold text-foreground">
+        <span className="text-[15px] font-semibold leading-5 text-foreground">
           Circle name
         </span>
         <input
@@ -581,26 +550,18 @@ export function CreateCircleFlow({
           maxLength={80}
           autoComplete="off"
           spellCheck
-          placeholder="e.g. Meena Family"
-          className="h-12 w-full rounded-2xl border border-border bg-[color:var(--app-card-surface-default-solid)] px-4 text-base outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+          placeholder="e.g. Family"
+          className="h-[52px] w-full rounded-2xl border-0 bg-[color:var(--app-card-surface-default-solid)] px-4 text-[17px] leading-[22px] shadow-[var(--app-card-shadow-standard)] outline-none transition focus:border-[color:var(--app-accent)] focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
         />
       </label>
 
-      <SettingsGroup title="Circle type" separatorInset>
+      <SettingsGroup title="Type" separatorInset shellClassName="!rounded-[18px]">
         {CIRCLE_KIND_OPTIONS.map((option) => (
           <SettingsRow
             key={option.value}
-            // Stays on SettingsRow's own `icon` slot: that slot is what carries
-            // `data-slot="settings-row-icon"` (global CSS thins the glyph
-            // stroke through it), the `data-ui-role`/`data-icon-tone` hooks,
-            // and the group's density switch. A people tone is missing from the
-            // shared tone map, so the row keeps the tones it already had and
-            // the missing entry is recorded as deferred rather than worked
-            // around by re-implementing the slot here.
             icon={UsersRound}
-            iconTone={option.value === "family" ? "purple" : "blue"}
+            iconTone="gray"
             title={option.label}
-            description={option.description}
             trailing={
               kind === option.value ? (
                 <Check className="h-5 w-5 text-[color:var(--app-accent)]" />
@@ -612,11 +573,6 @@ export function CreateCircleFlow({
         ))}
       </SettingsGroup>
 
-      <TrustNoteCard
-        title="Connected, still private"
-        description="Members connect. Sharing stays explicit."
-      />
-
       <Button
         type="button"
         disabled={!canSubmit}
@@ -627,7 +583,7 @@ export function CreateCircleFlow({
           BLOCKED_CTA,
         )}
       >
-        Create circle
+        Create Circle
       </Button>
     </div>
   );
@@ -881,10 +837,14 @@ function CircleMemberRow({
   const canCancelRequest = Boolean(pendingLabel && onCancelRequest);
 
   const secondaryLine =
-    member.role === "owner"
-      ? "Circle owner"
+    isCurrentUser
+      ? member.role === "owner"
+        ? "You · Owner"
+        : "You"
+      : member.role === "owner"
+        ? "Owner"
       : member.secureLocationReady
-        ? "Ready for private sharing"
+        ? "Connected"
         : "Location setup needed";
   // The one second line that is asking for something rather than reporting.
   const secondaryNeedsSetup =
@@ -907,7 +867,6 @@ function CircleMemberRow({
           title={member.displayName}
         >
           {member.displayName}
-          {isCurrentUser ? " (you)" : ""}
         </p>
         <p
           className={cn(
@@ -1054,8 +1013,8 @@ function CircleMemberRow({
                 Remove {member.displayName}?
               </AlertDialogTitle>
               <AlertDialogDescription>
-                Circle shares with this member stop. Direct shares stay
-                unchanged.
+                Circle shares with {member.displayName} will stop. Direct
+                shares stay unchanged.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -1161,6 +1120,10 @@ export function CircleDetailFlow({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [circleName, setCircleName] = useState("");
   const [peopleSheetOpen, setPeopleSheetOpen] = useState(false);
+  const [renameSheetOpen, setRenameSheetOpen] = useState(false);
+  const [inviteCodeSheetOpen, setInviteCodeSheetOpen] = useState(false);
+  const [replaceCodeConfirmOpen, setReplaceCodeConfirmOpen] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
   const [eligibleConnections, setEligibleConnections] = useState<
     OneLocationCircleEligibleConnection[]
   >([]);
@@ -1283,17 +1246,10 @@ export function CircleDetailFlow({
   // One request in flight at a time: the roster re-renders from the reloaded
   // Circle, and two overlapping sends would leave the wrong row spinning.
   const [connectingUserId, setConnectingUserId] = useState<string | null>(null);
-  // Single source of truth for the member count shown on BOTH the "Your
-  // circles" list row and this detail subtitle: the number of OTHER people in
-  // the circle (everyone except the viewer). `circle.memberCount` from the
-  // backend includes the viewer, so the list row subtracts one; here we filter
-  // the loaded members by the current user id, which yields the same number.
-  // Excluding only the current user (not the owner role) keeps the two views
-  // in agreement for members viewing a circle they do not own.
-  const externalMembersCount = useMemo(
-    () => members.filter((member) => member.userId !== currentUserId).length,
-    [members, currentUserId],
-  );
+  // Circle Detail counts the rows it actually renders. The "Your circles" list
+  // still uses the other-member summary helper; this focused screen needs the
+  // visible roster count so the title and Members label never disagree.
+  const visibleMemberSummary = circleDetailMemberCountLabel(members.length);
 
   // Filters the already-loaded Members list client-side, same as the "Add
   // people" sheet's connection search — a circle's roster is small enough
@@ -1314,7 +1270,8 @@ export function CircleDetailFlow({
   // against the roster, because that is the list actually on screen.
   const memberCountLabel = memberSearch.trim()
     ? `${filteredMembers.length} of ${members.length}`
-    : othersCountLabel(externalMembersCount);
+    : visibleMemberSummary;
+  const showMemberSearch = members.length >= 8 || memberSearch.trim().length > 0;
 
   const filteredEligibleConnections = useMemo(
     () =>
@@ -1444,6 +1401,7 @@ export function CircleDetailFlow({
     }
     try {
       setInviteCode(await onGenerateCode(circle.id, rotate));
+      setReplaceCodeConfirmOpen(false);
     } catch (error) {
       toast.error(
         circleFlowErrorMessage(error, "Could not create an invite code."),
@@ -1451,23 +1409,31 @@ export function CircleDetailFlow({
     }
   };
 
+  const copyInviteCode = async (code: string) => {
+    await onCopyCode(code);
+    setCodeCopied(true);
+    window.setTimeout(() => setCodeCopied(false), 1600);
+  };
+
   // The rename is written server-side against the shared Circle row, so once it
   // resolves every member reads the new name on their next load. Reflect it
   // locally right away (header, delete/leave copy, "Add people to …") instead of
   // waiting for a refetch.
-  const renameCircle = async () => {
+  const renameCircle = async (): Promise<boolean> => {
     const nextName = circleName.trim();
     if (!circle || savingName || nextName.length < 1 || nextName === circle.name)
-      return;
+      return false;
     setSavingName(true);
     try {
       const updated = await onRename(circle.id, nextName);
       setCircle(updated);
       setCircleName(updated.name);
+      return true;
     } catch (error) {
       toast.error(
         circleFlowErrorMessage(error, "Could not rename this Circle."),
       );
+      return false;
     } finally {
       setSavingName(false);
     }
@@ -1515,18 +1481,9 @@ export function CircleDetailFlow({
     // heading margin, so the one gap on the page that mattered least -- the
     // one above "Members" -- was also the largest.
     <div className="space-y-5" data-testid="one-location-circle-detail-flow">
-      <TaskFlowHeader
-        eyebrow="Your circles"
-        title={circle?.name ?? "Circle"}
-        description={
-          circle
-            ? // Same line as the list row this screen was opened from, so the
-              // count does not change wording between the two. The kind is
-              // dropped here for the same reason it is dropped there.
-              othersCountLabel(externalMembersCount)
-            : "Loading Circle…"
-        }
-      />
+      {!circle ? (
+        <TaskFlowHeader title="Circle" description="Loading Circle…" />
+      ) : null}
 
       {loadError ? (
         <div
@@ -1552,203 +1509,258 @@ export function CircleDetailFlow({
 
       {circle ? (
         <>
-          {/* Renaming a Trusted Circle is withheld, the SMS Circle's is not.
-            *
-            * That is not an inconsistency. `ensure_sms_system_circle` says in
-            * so many words that its rename "heals our default, it does not
-            * overwrite a person's decision" -- the emergency roster is a list
-            * you curate, so its name is yours. A Trusted Circle's name is
-            * derived exactly like its roster is, and renaming it produced the
-            * one thing this move exists to end: the write landed and toasted
-            * success, then Connect went on calling it "Trusted" while Location
-            * showed the new name. One Circle, two names, in one app. */}
-          {isOwner && circle.systemKind !== "trusted" ? (
-            <div className={CIRCLE_DETAIL_CARD}>
-              <label
-                htmlFor={CIRCLE_NAME_INPUT_ID}
-                className="block text-sm font-semibold text-foreground"
+          <div className="flex items-start justify-between gap-4 px-1">
+            <TaskFlowHeader title={circle.name} description={visibleMemberSummary} />
+            {isOwner && circle.systemKind !== "trusted" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setCircleName(circle.name);
+                  setRenameSheetOpen(true);
+                  window.setTimeout(() => nameInputRef.current?.focus(), 80);
+                }}
+                className="h-11 rounded-full px-4 text-[color:var(--app-accent)] hover:bg-[color:var(--app-neutral-fill)] hover:text-[color:var(--app-accent-hover)]"
               >
-                Circle name
-              </label>
-              <div className={CIRCLE_NAME_ROW_CLASSNAME}>
-                <input
-                  id={CIRCLE_NAME_INPUT_ID}
-                  ref={nameInputRef}
-                  value={circleName}
-                  onChange={(event) => setCircleName(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      void renameCircle();
-                    } else if (event.key === "Escape" && circleNameDirty) {
-                      event.preventDefault();
-                      setCircleName(circle.name);
-                    }
-                  }}
-                  maxLength={80}
-                  autoComplete="off"
-                  className={CIRCLE_NAME_INPUT_CLASSNAME}
-                />
-                {circleNameDirty ? (
+                Edit
+              </Button>
+            ) : null}
+          </div>
+
+          {isOwner && circle.systemKind !== "trusted" ? (
+            <Sheet
+              open={renameSheetOpen}
+              onOpenChange={(open) => {
+                setRenameSheetOpen(open);
+                if (!open && circle) setCircleName(circle.name);
+              }}
+            >
+              <SheetContent
+                side="bottom"
+                aria-describedby={undefined}
+                className="mx-auto w-full rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:max-w-lg sm:px-6"
+              >
+                <SheetHeader className="text-left">
+                  <SheetTitle>Rename Circle</SheetTitle>
+                </SheetHeader>
+                <div className="mt-5 space-y-4">
+                  <label className="block space-y-2">
+                    <span className="text-[15px] font-semibold leading-5 text-foreground">
+                      Circle name
+                    </span>
+                    <div className={CIRCLE_NAME_ROW_CLASSNAME}>
+                      <input
+                        id={CIRCLE_NAME_INPUT_ID}
+                        ref={nameInputRef}
+                        value={circleName}
+                        onChange={(event) => setCircleName(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void renameCircle();
+                          } else if (event.key === "Escape") {
+                            event.preventDefault();
+                            setRenameSheetOpen(false);
+                            setCircleName(circle.name);
+                          }
+                        }}
+                        maxLength={80}
+                        autoComplete="off"
+                        className={CIRCLE_NAME_INPUT_CLASSNAME}
+                      />
+                    </div>
+                  </label>
+                  {circleNameDirty && trimmedCircleName.length < 1 ? (
+                    <p className="text-sm text-destructive">Enter a name.</p>
+                  ) : null}
                   <Button
                     type="button"
-                    size="sm"
                     disabled={!canSaveCircleName}
                     isLoading={savingName}
-                    onClick={() => void renameCircle()}
-                    className={CIRCLE_NAME_ACTION_CLASSNAME}
+                    onClick={() =>
+                      void renameCircle().then((saved) => {
+                        if (saved) setRenameSheetOpen(false);
+                      })
+                    }
+                    className={cn("h-12 w-full rounded-full text-base font-semibold", BLOCKED_CTA)}
                     data-testid="one-location-circle-name-save"
                   >
                     Save
                   </Button>
-                ) : (
                   <Button
                     type="button"
-                    size="sm"
-                    variant="outline"
-                    aria-label="Edit Circle name"
-                    onClick={() => nameInputRef.current?.focus()}
-                    className={CIRCLE_NAME_ACTION_CLASSNAME}
+                    variant="ghost"
+                    onClick={() => {
+                      setRenameSheetOpen(false);
+                      setCircleName(circle.name);
+                    }}
+                    className="h-11 w-full rounded-full"
                   >
-                    <Pencil className="h-4 w-4" />
+                    Cancel
                   </Button>
-                )}
-              </div>
-              <p className={cn(MUTED_TEXT, "mt-2")}>
-                {circleNameDirty && trimmedCircleName.length < 1
-                  ? "Enter a name."
-                  : circleNameDirty
-                    ? "Tap Save to rename."
-                    : "Circle members see this."}
-              </p>
-            </div>
+                </div>
+              </SheetContent>
+            </Sheet>
           ) : null}
 
-          {canInviteMembers ? (
-            <div
-              className={CIRCLE_DETAIL_CARD}
-              data-testid="one-location-circle-invite-card"
+          {canInviteMembers || canViewInviteCode ? (
+            <SettingsGroup
+              title="Invite"
+              separatorInset
+              shellClassName="!rounded-[18px]"
+              testId="one-location-circle-invite-card"
             >
-              <div className="flex items-start gap-3">
-                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
-                  <KeyRound className="h-5 w-5" />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-[15px] font-semibold leading-5 text-foreground">
-                    Invite people
-                  </p>
-                  {/* What the API actually permits.
-                    *
-                    * "Every Circle member can invite … or share the same
-                    * Circle code" was false on every kind: both
-                    * `create_member_invites` and `create_invite_code` refuse a
-                    * non-owner, this card only renders to the owner anyway,
-                    * and a product-managed Circle can never have a code at
-                    * all. The sentence tracked an old docstring rather than
-                    * the code, on the one screen whose job is to say who may
-                    * do what. */}
-                  <p className={cn(MUTED_TEXT, "mt-1")}>
-                    {canViewInviteCode
-                      ? "Only you can add an existing connection and share this Circle's code."
-                      : "Only you can add an existing connection. This Circle has no shareable code."}
-                  </p>
-                </div>
-              </div>
-              {/* The card's primary action, and the only filled control on the
-                  screen. It used to be `variant="outline"` -- the same neutral
-                  slab as "Generate invite code" directly beneath it, so two
-                  identical grey pills stacked with nothing saying which one
-                  the screen wanted pressed. */}
-              <Button
-                type="button"
-                disabled={busy}
-                onClick={openPeopleSheet}
-                className="mt-4 h-11 w-full rounded-full font-semibold"
+              {canInviteMembers ? (
+                <SettingsRow
+                  icon={Plus}
+                  iconTone="accent"
+                  title="Add people"
+                  chevron
+                  onClick={openPeopleSheet}
+                  disabled={busy}
+                  testId="one-location-circle-add-people-row"
+                />
+              ) : null}
+              {canViewInviteCode ? (
+                <SettingsRow
+                  icon={KeyRound}
+                  iconTone="gray"
+                  title="Invite code"
+                  trailing={inviteCode ? "Ready" : "Create"}
+                  chevron
+                  onClick={() => {
+                    setCodeCopied(false);
+                    setInviteCodeSheetOpen(true);
+                  }}
+                  disabled={busy}
+                  testId="one-location-circle-invite-code-row"
+                />
+              ) : null}
+            </SettingsGroup>
+          ) : null}
+
+          {canViewInviteCode ? (
+            <Sheet
+              open={inviteCodeSheetOpen}
+              onOpenChange={(open) => {
+                setInviteCodeSheetOpen(open);
+                if (!open) {
+                  setCodeCopied(false);
+                  setReplaceCodeConfirmOpen(false);
+                }
+              }}
+            >
+              <SheetContent
+                side="bottom"
+                aria-describedby={undefined}
+                className="mx-auto w-full rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:max-w-lg sm:px-6"
               >
-                <Plus className="mr-2 h-4 w-4" />
-                Add people
-              </Button>
-              {canViewInviteCode && inviteCode ? (
-                <div className="mt-4 rounded-[var(--app-radius-md)] bg-muted/55 p-4 text-center">
-                  <p className="break-all font-mono text-lg font-bold tracking-[0.08em] text-foreground min-[360px]:text-xl min-[360px]:tracking-[0.12em]">
-                    {inviteCode.code}
-                  </p>
-                  <p className={cn(MUTED_TEXT, "mt-2")}>
-                    Joining connects Circle members. Location and SMS stay
-                    private until each person chooses to share.
-                  </p>
-                  <div className="mt-3 grid grid-cols-1 gap-2 min-[360px]:grid-cols-2">
+                <SheetHeader className="text-left">
+                  <SheetTitle>Invite code</SheetTitle>
+                  {!inviteCode && !inviteCodeNeedsOwnerRotation ? (
+                    <SheetDescription>
+                      Create a code to invite someone to this Circle.
+                    </SheetDescription>
+                  ) : null}
+                </SheetHeader>
+                {inviteCode ? (
+                  <div className="mt-5 space-y-4">
+                    <div className="rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] p-5 text-center shadow-[var(--app-card-shadow-standard)]">
+                      <p className="break-all font-mono text-2xl font-bold tracking-[0.12em] text-foreground">
+                        {inviteCode.code}
+                      </p>
+                      <p className={cn(MUTED_TEXT, "mt-3")}>
+                        Joining does not share location.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void onShareCode(circle, inviteCode.code)}
+                      className="h-12 w-full rounded-full text-base font-semibold"
+                    >
+                      <Share2 className="mr-2 h-4 w-4" />
+                      Share invite
+                    </Button>
                     <Button
                       type="button"
                       variant="outline"
                       disabled={busy}
-                      onClick={() => void onCopyCode(inviteCode.code)}
-                      className="h-11 rounded-full"
+                      onClick={() => void copyInviteCode(inviteCode.code)}
+                      className="h-12 w-full rounded-full text-base font-semibold"
                     >
                       <Copy className="mr-2 h-4 w-4" />
-                      Copy
+                      {codeCopied ? "Copied" : "Copy code"}
                     </Button>
+                    {canRotateInviteCode ? (
+                      <AlertDialog
+                        open={replaceCodeConfirmOpen}
+                        onOpenChange={setReplaceCodeConfirmOpen}
+                      >
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={busy}
+                            className="h-11 w-full rounded-full"
+                          >
+                            Replace code
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent size="sm">
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>
+                              Replace invite code?
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                              The current code will stop working.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction
+                              disabled={busy}
+                              onClick={() => void generateCode(true)}
+                            >
+                              Replace code
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    ) : null}
+                  </div>
+                ) : inviteCodeNeedsOwnerRotation && !canRotateInviteCode ? (
+                  <div className="mt-5 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--app-card-shadow-standard)]">
+                    <p className="text-[17px] font-semibold leading-[22px] text-foreground">
+                      Invite code unavailable
+                    </p>
+                    <p className={cn(MUTED_TEXT, "mt-1")}>
+                      Ask the Circle owner for a new code.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="mt-5 space-y-3">
                     <Button
                       type="button"
                       disabled={busy}
-                      onClick={() =>
-                        void onShareCode(circle, inviteCode.code)
-                      }
-                      className="h-11 rounded-full"
+                      isLoading={busy}
+                      onClick={() => void generateCode(inviteCodeNeedsOwnerRotation)}
+                      className="h-12 w-full rounded-full text-base font-semibold"
                     >
-                      <Share2 className="mr-2 h-4 w-4" />
-                      Share
+                      Create code
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => setInviteCodeSheetOpen(false)}
+                      className="h-11 w-full rounded-full"
+                    >
+                      Cancel
                     </Button>
                   </div>
-                </div>
-              ) : canViewInviteCode && inviteCodeNeedsOwnerRotation ? (
-                canRotateInviteCode ? (
-                  /* Secondary to "Add people", so it is quiet -- accent label
-                     on no fill -- rather than a second neutral slab of the
-                     same size and weight. */
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    disabled={busy}
-                    isLoading={busy}
-                    onClick={() => void generateCode(true)}
-                    className={CIRCLE_INVITE_SECONDARY_ACTION}
-                  >
-                    <RotateCw className="mr-2 h-4 w-4" />
-                    Refresh invite code
-                  </Button>
-                ) : (
-                  <p className="mt-3 rounded-[var(--app-radius-md)] bg-muted/55 px-4 py-3 text-sm leading-5 text-muted-foreground">
-                    Ask the Circle owner to refresh the older invite code. It
-                    will appear here for every member as soon as they do.
-                  </p>
-                )
-              ) : canViewInviteCode ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  disabled={busy}
-                  isLoading={busy}
-                  onClick={() => void generateCode()}
-                  className={CIRCLE_INVITE_SECONDARY_ACTION}
-                >
-                  <KeyRound className="mr-2 h-4 w-4" />
-                  Generate invite code
-                </Button>
-              ) : null}
-              {inviteCode && canRotateInviteCode ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  isLoading={busy}
-                  onClick={() => void generateCode(true)}
-                  className={CIRCLE_INVITE_SECONDARY_ACTION}
-                >
-                  <RotateCw className="mr-2 h-4 w-4" />
-                  Rotate code
-                </Button>
-              ) : null}
-            </div>
+                )}
+              </SheetContent>
+            </Sheet>
           ) : null}
 
           <Sheet
@@ -1778,22 +1790,10 @@ export function CircleDetailFlow({
               // tapped slide off the top of the screen. They then type into a
               // field they cannot see.
               className="mx-auto flex max-h-[calc(88dvh-var(--kb-height,0px))] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
-            >
+              >
               <SheetHeader className="text-left">
-                <SheetTitle>Add people to {circle.name}</SheetTitle>
-                <SheetDescription>
-                  {/* No Circle sends invitations any more. Only existing
-                      connections can be picked here, and two people who are
-                      already connected have already agreed to know each other
-                      -- so the membership is written on tap and the person is
-                      notified. Saying "they join after accepting" would
-                      describe a step that no longer happens, on the screen
-                      where believing it means thinking you still have time to
-                      change your mind. */}
-                  {circle.isSystem
-                    ? "Choose existing connections. They are added straight away, so SMS alerts reach them immediately."
-                    : "Choose existing connections. They are added straight away and told you added them."}
-                </SheetDescription>
+                <SheetTitle>Add people</SheetTitle>
+                <SheetDescription>Choose connections.</SheetDescription>
               </SheetHeader>
 
               <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4">
@@ -1803,7 +1803,7 @@ export function CircleDetailFlow({
                   <input
                     value={peopleSearch}
                     onChange={(event) => setPeopleSearch(event.target.value)}
-                    placeholder="Search connections"
+                    placeholder="Search people"
                     className={cn(
                       LOCATION_SEARCH_INPUT_CLASSNAME,
                       "h-12 rounded-full bg-muted/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/70",
@@ -1835,15 +1835,7 @@ export function CircleDetailFlow({
                     <div className="space-y-4">
                       {remainingCapacity > 0 &&
                       filteredEligibleConnections.length ? (
-                        <SettingsGroup
-                          title="Your connections"
-                          description={
-                            remainingCapacity === 1
-                              ? "You can add 1 more person right now."
-                              : `You can add ${remainingCapacity} more people right now.`
-                          }
-                          testId="one-location-circle-eligible-connections"
-                        >
+                        <SettingsGroup testId="one-location-circle-eligible-connections">
                           {filteredEligibleConnections.map((connection) => {
                             const selected = selectedConnectionIds.has(
                               connection.userId,
@@ -1867,7 +1859,6 @@ export function CircleDetailFlow({
                                   </Avatar>
                                 }
                                 title={connection.displayName}
-                                description="Connected on One"
                                 ariaPressed={selected}
                                 disabled={!selected && selectionAtCapacity}
                                 trailing={
@@ -1915,8 +1906,8 @@ export function CircleDetailFlow({
                             remainingCapacity === 0
                               ? "Circle is full."
                               : peopleSearch.trim()
-                                ? "Try a different name."
-                                : "You can invite people to this Circle once you're connected to them — or share its code with anyone."
+                                ? undefined
+                                : undefined
                           }
                           // A sentence pointing at Connect, shown inside a
                           // sheet that covers Connect, with nothing to press.
@@ -1945,19 +1936,31 @@ export function CircleDetailFlow({
 
                       {pendingInvites.length ? (
                         <SettingsGroup
-                          title="Pending invitations"
-                          description="Cancel anytime before acceptance."
+                          title="Pending"
                         >
                           {pendingInvites.map((invite) => (
                             <SettingsRow
                               key={invite.id}
-                              icon={Send}
-                              // Awaiting acceptance is PENDING, not an action.
-                              iconTone="orange"
+                              leading={
+                                <Avatar className="h-10 w-10">
+                                  {invite.inviteePhotoUrl ? (
+                                    <AvatarImage
+                                      src={invite.inviteePhotoUrl}
+                                      alt=""
+                                    />
+                                  ) : null}
+                                  <AvatarFallback>
+                                    {circleInitials(
+                                      invite.inviteeDisplayName ||
+                                        "One connection",
+                                    )}
+                                  </AvatarFallback>
+                                </Avatar>
+                              }
                               title={
                                 invite.inviteeDisplayName || "One connection"
                               }
-                              description="Waiting for them to join"
+                              description="Waiting"
                               trailing={
                                 <Button
                                   type="button"
@@ -2000,7 +2003,7 @@ export function CircleDetailFlow({
                     ? `Add ${selectedConnectionIds.size} ${
                         selectedConnectionIds.size === 1 ? "person" : "people"
                       }`
-                    : "Select people"}
+                    : "Add people"}
                 </Button>
               </div>
             </SheetContent>
@@ -2031,7 +2034,7 @@ export function CircleDetailFlow({
               <TrailingValue>{memberCountLabel}</TrailingValue>
             </div>
 
-            {members.length ? (
+            {showMemberSearch ? (
               <label className="relative block">
                 <span className="sr-only">Search members</span>
                 <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -2113,56 +2116,6 @@ export function CircleDetailFlow({
               </div>
             )}
 
-            {/* Shown BESIDE the roster, not instead of it.
-              *
-              * The viewer is always in `filteredMembers`, so that list is
-              * never empty on a Circle they can see -- which is why the empty
-              * case used to be unreachable and a Circle holding nobody
-              * rendered one row (themselves) and nothing else. The question a
-              * person has there is "how do I put someone in this", and the
-              * screen did not answer it.
-              *
-              * Three Circles reach this state without being asked for: the SMS
-              * Circle and Trusted arrive on their own, and onboarding makes
-              * one more. So it is the first thing many people ever see here. */}
-            {!memberSearch.trim() && externalMembersCount === 0 ? (
-              <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
-                <EmptyState
-                  title="No one's in this Circle yet"
-                  description={
-                    circle.systemKind === "trusted"
-                      ? "Everyone you connect with lands here on its own. Connect with someone to start it off."
-                      : canInviteMembers
-                        ? "Add someone you're connected to, using the card above — or share this Circle's code."
-                        : "Its owner hasn't added anyone yet."
-                  }
-                  action={
-                    // Only where nothing else on the screen already offers the
-                    // way forward.
-                    //
-                    // A Circle you can add to already has an "Add people" card
-                    // right here, and a second identical button is not a
-                    // second option -- it is the same one twice, and it made
-                    // "Add people" ambiguous to anything looking for it.
-                    //
-                    // Trusted is the case with no card at all: its roster
-                    // follows the connection, so it cannot be added to by hand
-                    // and the way to fill it is to connect with somebody.
-                    circle.systemKind === "trusted" ? (
-                      <Link
-                        href={`${ROUTES.CONNECT}?tab=all`}
-                        data-testid="one-location-circle-empty-find-people"
-                        className={cn(
-                          buttonVariants({ variant: "outline", size: "sm" }),
-                        )}
-                      >
-                        Find people
-                      </Link>
-                    ) : undefined
-                  }
-                />
-              </div>
-            ) : null}
           </section>
 
           {/* A system Circle (today: SMS Contacts) is provisioned by the product
@@ -2171,32 +2124,7 @@ export function CircleDetailFlow({
               rename, invite, remove. The API and a database trigger refuse the
               delete too; this only keeps the person from being offered
               something that cannot happen. */}
-          {!canDeleteCircle && !canLeaveCircle ? (
-            // Neither door, and the reader is told why.
-            //
-            // The branch below used to be a two-way `isOwner && !isSystem`, so
-            // this person fell through to "Leave circle" -- which
-            // `_end_membership` refuses with LOCATION_CIRCLE_OWNER_LEAVE_INVALID
-            // every single time. The only control at the bottom of their own
-            // emergency Circle was one that could not work.
-            //
-            // A sentence rather than a disabled button: there is nothing to
-            // enable later, and a greyed control invites a press and a guess.
-            <p className={cn(MUTED_TEXT, "px-1 pt-1")}>
-              {circle.systemKind === "trusted" ? (
-                <>
-                  Everyone you&apos;re connected to is in this Circle, so it
-                  can&apos;t be left or deleted. To take somebody out,
-                  disconnect from them.
-                </>
-              ) : (
-                <>
-                  This Circle is managed for you, so it can&apos;t be left or
-                  deleted. You can still rename it and choose who is in it.
-                </>
-              )}
-            </p>
-          ) : canDeleteCircle ? (
+          {canDeleteCircle ? (
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button
@@ -2210,9 +2138,12 @@ export function CircleDetailFlow({
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Delete {circle.name}?</AlertDialogTitle>
+                  <AlertDialogTitle>
+                    Delete “{circle.name}”?
+                  </AlertDialogTitle>
                   <AlertDialogDescription>
-                    This deletes the Circle for everyone. Circle shares stop.
+                    This removes the Circle for everyone. Circle shares will
+                    stop. Direct shares stay unchanged.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -2225,12 +2156,12 @@ export function CircleDetailFlow({
                     onClick={() => void deleteCircle()}
                     className="h-11 w-full sm:w-auto"
                   >
-                    Delete circle
+                    Delete Circle
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-          ) : (
+          ) : canLeaveCircle ? (
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button
@@ -2245,9 +2176,12 @@ export function CircleDetailFlow({
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Leave {circle.name}?</AlertDialogTitle>
+                  <AlertDialogTitle>
+                    Leave “{circle.name}”?
+                  </AlertDialogTitle>
                   <AlertDialogDescription>
-                    Circle shares with you stop. Direct shares stay unchanged.
+                    Circle shares with you will stop. Direct shares stay
+                    unchanged.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -2260,12 +2194,12 @@ export function CircleDetailFlow({
                     onClick={() => void leaveCircle()}
                     className="h-11 w-full sm:w-auto"
                   >
-                    Leave circle
+                    Leave Circle
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-          )}
+          ) : null}
         </>
       ) : !loadError ? (
         <div className="flex min-h-40 items-center justify-center rounded-[var(--app-card-radius-standard,24px)] bg-muted/35">

--- a/hushh-webapp/e2e/one-agent-directory-ui.spec.ts
+++ b/hushh-webapp/e2e/one-agent-directory-ui.spec.ts
@@ -7,9 +7,12 @@ const hasReviewerEnv = Boolean(
 );
 
 const viewports = [
+  { width: 320, height: 568 },
+  { width: 375, height: 667 },
   { width: 390, height: 844 },
   { width: 430, height: 932 },
   { width: 768, height: 1024 },
+  { width: 1024, height: 768 },
   { width: 1440, height: 900 },
 ] as const;
 
@@ -40,55 +43,93 @@ test.describe("first post-login Agent Directory visual contract", () => {
   );
 
   for (const viewport of viewports) {
-    test(`keeps the Apple grouped-list contract at ${viewport.width}x${viewport.height}`, async ({
+    test(`keeps the premium app-icon launcher contract at ${viewport.width}x${viewport.height}`, async ({
       page,
     }) => {
       await page.setViewportSize(viewport);
       await openOneDirectory(page);
 
       await expect(
-        page.getByRole("heading", { name: "Agents (7)" }),
+        page.getByRole("heading", { name: "Agents (9)" }),
       ).toBeVisible();
       await expect(page.getByTestId("one-agents-search")).toBeVisible();
-      await expect(page.getByTestId("one-agents-list")).toBeVisible();
+      await expect(page.getByTestId("one-agents-grid")).toBeVisible();
 
       const metrics = await page.evaluate(() => {
         const foundation = document.querySelector(".foundation-public-ambient");
         const foundationStyle = foundation
           ? getComputedStyle(foundation)
           : null;
-        const title = document
-          .querySelector("#one-agents-heading span:first-child");
+        const section = document.querySelector(
+          '[data-testid="one-agents-section"]',
+        );
+        const sectionRect = section?.getBoundingClientRect();
+        const title = document.querySelector("#one-agents-heading");
         const titleStyle = title ? getComputedStyle(title) : null;
         const search = document.querySelector(
           '[data-testid="one-agents-search"]',
         );
         const searchStyle = search ? getComputedStyle(search) : null;
-        const list = document.querySelector('[data-testid="one-agents-list"]');
-        const listStyle = list ? getComputedStyle(list) : null;
-        const rows = Array.from(
-          document.querySelectorAll('[data-testid^="one-agent-list-row-"]'),
+        const grid = document.querySelector('[data-testid="one-agents-grid"]');
+        const layout = document.querySelector(
+          '[data-agent-roster-layout="app-icon-launcher-grid"]',
         );
-        const metricRightEdges = rows.map((row) => {
-          const metric = row.querySelector('[data-ui-role="body-strong"]')
-            ?.parentElement;
-          return Math.round(metric?.getBoundingClientRect().right ?? 0);
+        const tileElements = Array.from(
+          document.querySelectorAll('[data-testid^="one-agent-tile-"]'),
+        );
+        const iconElements = Array.from(
+          document.querySelectorAll('[data-testid^="one-agent-icon-"]'),
+        );
+        const tiles = tileElements.map((tile) => {
+          const rect = tile.getBoundingClientRect();
+          return {
+            id: tile.getAttribute("data-testid"),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          };
         });
-        const rowHeights = rows.map((row) =>
-          Math.round(row.getBoundingClientRect().height),
-        );
+        const icons = iconElements.map((icon) => {
+          const rect = icon.getBoundingClientRect();
+          const style = getComputedStyle(icon);
+          return {
+            id: icon.getAttribute("data-testid"),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+            radius: style.borderRadius,
+          };
+        });
+        const horizontalOverflow =
+          document.documentElement.scrollWidth > window.innerWidth + 1;
+        const gridRect = grid?.getBoundingClientRect();
+        const badges = Array.from(
+          document.querySelectorAll(
+            '[data-testid="one-agent-notification-badge"], [data-testid="one-agent-live-dot"]',
+          ),
+        ).map((badge) => {
+          const rect = badge.getBoundingClientRect();
+          return {
+            left: Math.floor(rect.left),
+            right: Math.ceil(rect.right),
+            top: Math.floor(rect.top),
+            bottom: Math.ceil(rect.bottom),
+          };
+        });
         return {
           foundationBackgroundImage: foundationStyle?.backgroundImage,
           foundationBackgroundColor: foundationStyle?.backgroundColor,
           titleFontSize: titleStyle?.fontSize,
           titleFontWeight: titleStyle?.fontWeight,
           titleLineHeight: titleStyle?.lineHeight,
+          sectionWidth: Math.round(sectionRect?.width ?? 0),
           searchHeight: Math.round(search?.getBoundingClientRect().height ?? 0),
           searchRadius: searchStyle?.borderRadius,
-          listRadius: listStyle?.borderRadius,
-          rowCount: rows.length,
-          rowHeights,
-          metricRightEdges,
+          gridClassName: layout?.className,
+          gridWidth: Math.round(gridRect?.width ?? 0),
+          tileCount: tiles.length,
+          tiles,
+          icons,
+          horizontalOverflow,
+          badges,
         };
       });
 
@@ -96,12 +137,27 @@ test.describe("first post-login Agent Directory visual contract", () => {
       expect(metrics.titleFontSize).toBe("34px");
       expect(metrics.titleFontWeight).toBe("700");
       expect(metrics.titleLineHeight).toBe("41px");
-      expect(metrics.searchHeight).toBe(52);
-      expect(metrics.searchRadius).toBe("16px");
-      expect(metrics.listRadius).toBe("22px");
-      expect(metrics.rowCount).toBe(7);
-      expect(metrics.rowHeights.every((height) => height >= 64)).toBe(true);
-      expect(new Set(metrics.metricRightEdges).size).toBe(1);
+      expect(metrics.sectionWidth).toBeLessThanOrEqual(560);
+      expect(metrics.searchHeight).toBeGreaterThanOrEqual(44);
+      expect(metrics.searchHeight).toBeLessThanOrEqual(46);
+      expect(metrics.searchRadius).toBe("15px");
+      expect(metrics.gridClassName).toContain("grid-cols-3");
+      expect(metrics.gridWidth).toBeLessThanOrEqual(552);
+      expect(metrics.tileCount).toBe(9);
+      expect(metrics.tiles.every((tile) => tile.height >= 100)).toBe(true);
+      expect(metrics.icons.every((icon) => icon.width >= 60)).toBe(true);
+      expect(metrics.icons.every((icon) => icon.height >= 60)).toBe(true);
+      expect(
+        metrics.icons.every((icon) =>
+          ["18px", "17px", "16px"].includes(icon.radius),
+        ),
+      ).toBe(true);
+      expect(metrics.horizontalOverflow).toBe(false);
+      for (const badge of metrics.badges) {
+        expect(badge.left).toBeGreaterThanOrEqual(0);
+        expect(badge.right).toBeLessThanOrEqual(viewport.width);
+        expect(badge.top).toBeGreaterThanOrEqual(0);
+      }
     });
   }
 });

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -5996,7 +5996,18 @@
           "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
         }
       },
-      "native": null,
+      "native": {
+        "route": "/one/profile/preferences/voice/examples",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fpreferences%2Fvoice%2Fexamples",
+        "expectedMarker": "native-route-profile",
+        "expectedRoute": "/one/profile/preferences/voice/examples",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded"
+        ]
+      },
       "shell": {
         "app_page_shell": false,
         "page_header": false,
@@ -6116,7 +6127,18 @@
           "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
         }
       },
-      "native": null,
+      "native": {
+        "route": "/one/profile/referrals",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Freferrals",
+        "expectedMarker": "native-route-profile",
+        "expectedRoute": "/one/profile/referrals",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded"
+        ]
+      },
       "shell": {
         "app_page_shell": false,
         "page_header": false,
@@ -8947,5 +8969,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "851edda753c1e992d76970c01771c9285105a2f1252c38e6805bfed982323b01"
+  "content_sha256": "94be8dd8b779f0c4116c978cdc0634dd3333bb46fec92f69d493b755779cf13e"
 }

--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -77,7 +77,7 @@ const SETUP_COPY_BY_ID: Record<
 > = {
   finance: {
     setupTitle: "Set up your money",
-    setupBlurb: "See how your money is doing.",
+    setupBlurb: "See your money clearly.",
     actionLabel: "Set up Finance",
     resumeActionLabel: "Finish Finance",
     introPremise: "Access your finances in one place.",
@@ -118,7 +118,7 @@ const SETUP_COPY_BY_ID: Record<
     // "KYC" is an abbreviation nobody meets for the first time and understands.
     // The row now says what actually happens; the destination keeps the name.
     setupTitle: "Identity checks",
-    setupBlurb: "One drafts the replies. You approve.",
+    setupBlurb: "Verify with your approval.",
     actionLabel: "Set up KYC",
     resumeActionLabel: "Finish KYC",
     introPremise: "Replies, ready when you are.",
@@ -130,7 +130,7 @@ const SETUP_COPY_BY_ID: Record<
   },
   location: {
     setupTitle: "Set up location",
-    setupBlurb: "Share where you are, when you want.",
+    setupBlurb: "Share only when you choose.",
     actionLabel: "Choose location",
     resumeActionLabel: "Finish location",
     introPremise: "Be easier to reach when it matters.",
@@ -143,7 +143,7 @@ const SETUP_COPY_BY_ID: Record<
   },
   ria: {
     setupTitle: "Set up your advisor profile",
-    setupBlurb: "Verify once. Get your advisor workspace.",
+    setupBlurb: "Build your advisor workspace.",
     actionLabel: "Verify RIA",
     resumeActionLabel: "Finish RIA",
     introPremise: "A workspace built for your practice.",
@@ -180,7 +180,7 @@ const SETUP_COPY_BY_ID: Record<
   },
   "connected-systems": {
     setupTitle: "Connect your CRM",
-    setupBlurb: "One finds your record. You approve.",
+    setupBlurb: "Find records with your approval.",
     actionLabel: "Set up CRM",
     resumeActionLabel: "Finish CRM",
     introPremise: "Start with the record you already have.",

--- a/hushh-webapp/native-route-inventory.json
+++ b/hushh-webapp/native-route-inventory.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-08-02",
-  "total_routes": 114,
-  "native_required_routes": 99,
+  "total_routes": 116,
+  "native_required_routes": 101,
   "excluded_routes": 10,
   "routes": [
     {
@@ -896,6 +896,18 @@
       ]
     },
     {
+      "route": "/one/profile/preferences/voice/examples",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fpreferences%2Fvoice%2Fexamples",
+      "expectedMarker": "native-route-profile",
+      "expectedRoute": "/one/profile/preferences/voice/examples",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded"
+      ]
+    },
+    {
       "route": "/one/profile/receipts",
       "classification": "native-required-functional",
       "legacyAlias": true,
@@ -908,6 +920,18 @@
         "loaded",
         "empty-valid",
         "unavailable-valid"
+      ]
+    },
+    {
+      "route": "/one/profile/referrals",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Freferrals",
+      "expectedMarker": "native-route-profile",
+      "expectedRoute": "/one/profile/referrals",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Restyled the `/one` agent roster into a centered 3x3 app-icon launcher with solid canonical agent icons.
- Kept all nine agents, order, routes, search, grid/list toggle, persisted preference, metrics, and accessibility semantics.
- Reworked grid metrics into badges/live/info treatments and removed the extra grid card/bottom reservation from the roster.

## Verification
- `npm test -- --run __tests__/components/one-dashboard-page.test.tsx` ✅
- `npx eslint components/dashboard/one-agent-roster.tsx __tests__/components/one-dashboard-page.test.tsx e2e/one-agent-directory-ui.spec.ts --max-warnings=0` ✅
- `npx playwright test e2e/one-agent-directory-ui.spec.ts --reporter=line` skipped as expected without reviewer auth env.
- `npm run typecheck` currently blocked by unrelated untracked local file `hushh-webapp/app/one-location-menu-visual-preview/page.tsx`.