### PR TITLE
fix(finance): remove overflow-hidden and max-h height constraints on workspace panels to prevent bottom card clipping

### DIFF
--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -21,7 +21,6 @@ import { KaiPreviewRouter } from "@/components/kai/views/kai-preview-router";
 import { KaiAnalysisPageContent } from "@/app/one/kai/analysis/page";
 import { scheduleFinanceWorkspaceWarmup } from "@/lib/kai/finance-workspace-warmup";
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
-import { cn } from "@/lib/utils";
 
 const FINANCE_TAB_DEFINITION = TOP_SHELL_TAB_REGISTRY.finance;
 type PortfolioTab = (typeof FINANCE_TAB_DEFINITION.tabs)[number]["value"];

--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -97,12 +97,8 @@ export function KaiMarketHubPage() {
     <AppPageShell
       as="div"
       fitContent
-
       width="reading"
-      className={cn(
-        "relative !px-0",
-        visibleTab !== "market" && "overflow-hidden max-h-[calc(100dvh-var(--app-top-content-offset,84px))]"
-      )}
+      className="relative !px-0"
       data-finance-workspace="true"
       nativeTest={{
         routeId: KAI_MARKET_PATH,
@@ -121,13 +117,13 @@ export function KaiMarketHubPage() {
         heightMode="active"
         viewportMinHeight="0"
       >
-        <div className="h-full w-full">
+        <div className="w-full">
           <AppPageContentRegion>
             <KaiPreviewRouter />
           </AppPageContentRegion>
         </div>
-        <div className="h-full w-full overflow-hidden">
-          <AppPageContentRegion className="h-full overflow-hidden">
+        <div className="w-full">
+          <AppPageContentRegion>
             <KaiFlow
               userId={user.uid}
               mode="dashboard"
@@ -136,8 +132,8 @@ export function KaiMarketHubPage() {
             />
           </AppPageContentRegion>
         </div>
-        <div className="h-full w-full overflow-hidden">
-          <AppPageContentRegion className="h-full overflow-hidden">
+        <div className="w-full">
+          <AppPageContentRegion>
             <KaiAnalysisPageContent />
           </AppPageContentRegion>
         </div>


### PR DESCRIPTION
## Summary of Changes
This PR resolves an issue in the Finance workspace where stock preview and analysis cards were cut off at the bottom of the container card on Desktop and Mobile views.

- **File Modified:** `hushh-webapp/components/kai/kai-market-hub-page.tsx`
- **Change:** Removed `max-h-[calc(100dvh-var(--app-top-content-offset,84px))]` from `AppPageShell` and removed `h-full overflow-hidden` wrapper styles on `SwipeViews` tab panels.

## Scope & Impact
- **Pure Layout Fix:** Strictly 1 file modified (layout CSS classes in `kai-market-hub-page.tsx`).
- **Zero Risk:** No backend, data fetching, or state logic touched.

## How to Verify
1. Run local dev server (`npm run dev`).
2. Open `http://localhost:3000/one/kai?tab=analysis`.
3. View the stock preview card (`MSFT preview`).
4. Verify that the bottom card (`Cloud + AI dominance, recurring revenue`) is fully visible with complete rounded borders on Desktop and Mobile width screens.