### PR TITLE
fix(finance): remove redundant 148px bottom padding on market tab view to eliminate blank space

### DIFF
--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -2219,7 +2219,7 @@ export function KaiMarketPreviewView() {
           `}
         </style>
       ) : null}
-      <div className="flex-1 pb-[calc(148px+env(safe-area-inset-bottom))] pt-0">
+      <div className="flex-1 pb-6 pt-0">
         <KaiWorkspaceHeader
           workspace="market"
           title="Market"


### PR DESCRIPTION
## Summary of Changes
This PR eliminates the massive empty black space at the bottom of the `Finance > Market` tab when scrolling past the `Sector rotation` section.

- **File Modified:** `hushh-webapp/components/kai/views/kai-market-preview-view.tsx`
- **Change:** Changed `pb-[calc(148px+env(safe-area-inset-bottom))]` to `pb-6` on the main wrapper container of `KaiMarketPreviewView`.

## Scope & Impact
- **Pure UI Layout Fix:** Strictly 1 file modified (layout CSS padding in `kai-market-preview-view.tsx`).
- **Isolated Commit:** 1 single commit branched directly off `origin/main`.
- **Zero Risk:** No backend or state logic affected.

## How to Verify
1. Run `npm run dev` locally.
2. Open `http://localhost:3000/one/kai?tab=market`.
3. Scroll down past `Sector rotation`.
4. Verify that the bottom blank space is gone and the card ends cleanly with standard padding above the floating bar.