### PR TITLE
fix(finance): collapse import streams on error and add bottom clearance to prevent card clipping

### DIFF
--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -97,7 +97,7 @@ export function KaiMarketHubPage() {
       as="div"
       fitContent
       width="reading"
-      className="relative !px-0"
+      className="relative !px-0 pb-20 sm:pb-24"
       data-finance-workspace="true"
       nativeTest={{
         routeId: KAI_MARKET_PATH,

--- a/hushh-webapp/components/kai/views/import-progress-view.tsx
+++ b/hushh-webapp/components/kai/views/import-progress-view.tsx
@@ -142,8 +142,8 @@ export function ImportProgressView({
   onBackToDashboard,
   className,
 }: ImportProgressViewProps) {
-  const [streamExpanded, setStreamExpanded] = useState<boolean>(() => true);
-  const [holdingsExpanded, setHoldingsExpanded] = useState<boolean>(() => true);
+  const [streamExpanded, setStreamExpanded] = useState<boolean>(() => stage !== "error");
+  const [holdingsExpanded, setHoldingsExpanded] = useState<boolean>(() => stage !== "error");
 
   const hasMeasuredProgress = useMemo(
     () => typeof progressPct === "number" && Number.isFinite(progressPct) && progressPct > 0,


### PR DESCRIPTION
## Summary of Changes
Fixes bottom card clipping on `Finance > Portfolio` import progress view when error states occur.

- **Files Modified (Pure UI):**
  - `hushh-webapp/components/kai/views/import-progress-view.tsx`: Set default `streamExpanded` to `stage !== "error"` so error messages & action buttons (`Retry Import`, `Back`) jump directly into view.
  - `hushh-webapp/components/kai/kai-market-hub-page.tsx`: Added `pb-20 sm:pb-24` padding to `AppPageShell` for safe bottom clearance above the floating command bar.

## Scope & Safety
- **100% UI Only:** Only layout padding & component collapse state modified.
- **Zero Business Logic Touched:** No backend, API, or data processing code changed.

## How to Verify
1. Open `http://localhost:3000/one/kai?tab=portfolio`.
2. Upload a statement that triggers the error state.
3. Verify that the red error banner, `Retry Import`, and `Back` buttons are 100% visible with full rounded borders above the floating command bar.