### PR TITLE
feat(voice): direct backend read access for Location and Connect data

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Literal
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -680,6 +680,82 @@ async def _execute_backend_direct_mutation(
         return f"Cancelled your connection request to {name}."
 
     raise AssertionError(f"{action_id} is in BACKEND_DIRECT_ACTION_IDS with no execution branch")
+
+
+async def _read_tool_user_id(tool_context: ToolContext) -> tuple[str | None, dict[str, Any] | None]:
+    """Shared auth gate for the backend-direct read tools below.
+
+    Same re-validated check the backend-direct mutations use
+    (``_verify_backend_direct_authorization``) -- these tools return
+    consent-scoped personal and location data, so they get the real
+    VAULT_OWNER re-validation, not a lighter signed-in-only check.
+    """
+    authorized, user_id, reason = await _verify_backend_direct_authorization(tool_context)
+    if not authorized:
+        return None, {"status": "blocked", "message": reason}
+    return user_id, None
+
+
+async def list_my_location_circles(tool_context: ToolContext) -> dict[str, Any]:
+    """List the person's own Location circles: name, kind, and role in each.
+
+    Reads live from the backend, not from whatever the current screen has
+    published -- safe to call from anywhere, any time.
+    """
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    circles = OneLocationCircleService().list_circles(user_id=user_id)
+    return {"status": "ok", "circles": circles}
+
+
+async def list_my_location_shares(tool_context: ToolContext) -> dict[str, Any]:
+    """List who the person is currently sharing their live location with."""
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    shares = OneLocationAgentService().list_active_owner_grants(owner_user_id=user_id)
+    return {"status": "ok", "shares": shares}
+
+
+async def list_location_shared_with_me(tool_context: ToolContext) -> dict[str, Any]:
+    """List who is currently sharing their live location with this person."""
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    shares = OneLocationAgentService().list_active_recipient_grants(recipient_user_id=user_id)
+    return {"status": "ok", "shares": shares}
+
+
+async def list_pending_location_requests(tool_context: ToolContext) -> dict[str, Any]:
+    """List location access requests waiting on this person's approve/decline."""
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    requests = OneLocationAgentService().list_pending_owner_requests(owner_user_id=user_id)
+    return {"status": "ok", "requests": requests}
+
+
+async def list_my_connections(tool_context: ToolContext) -> dict[str, Any]:
+    """List the person's Connect connections."""
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    connections = ConnectionsService().list_connections(user_id=user_id)
+    return {"status": "ok", "connections": connections}
+
+
+async def list_pending_connection_requests(
+    tool_context: ToolContext,
+    direction: Literal["incoming", "outgoing"] = "incoming",
+) -> dict[str, Any]:
+    """List pending Connect requests. "incoming" = waiting on this person to accept;
+    "outgoing" = this person's own asks still waiting on someone else."""
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    requests = ConnectionsService().list_requests(user_id=user_id, direction=direction)
+    return {"status": "ok", "requests": requests}
 
 
 async def run_app_action(

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -57,6 +57,12 @@ from hushh_mcp.one_adk.action_tools import (
     continue_app_goal,
     journey_for_specialist_request,
     list_app_actions,
+    list_location_shared_with_me,
+    list_my_connections,
+    list_my_location_circles,
+    list_my_location_shares,
+    list_pending_connection_requests,
+    list_pending_location_requests,
     run_app_action,
     start_app_goal,
 )
@@ -1392,6 +1398,14 @@ def _one_roster_tools(*, specialist_model: Any | None = None) -> list:
     connections, connected systems, consent) are plain function
     tools that call the existing governed adk_bridge handlers.
 
+    The Location/Connect `list_*` read tools and `run_app_action`'s
+    BACKEND_DIRECT_ACTION_IDS mutations are the deliberate line for what may
+    depend on the frontend at all: navigation (`open_screen`,
+    `start_app_goal`, `route.*`) is frontend-triggered because there's no
+    backend concept of "which screen is open" -- everything else here reads
+    or writes the real backend data directly, so a frontend screen rewrite
+    can never silently break what these tools return or do.
+
     Uses GoogleSearchTool(bypass_multi_tools_limit=True) rather than the bare
     google_search function-tool. Binding Gemini's native google_search
     directly alongside this many custom function/agent tools in the SAME
@@ -1436,6 +1450,12 @@ def _one_roster_tools(*, specialist_model: Any | None = None) -> list:
         ask_location_agent,
         ask_connected_systems_agent,
         ask_consent_agent,
+        list_my_location_circles,
+        list_my_location_shares,
+        list_location_shared_with_me,
+        list_pending_location_requests,
+        list_my_connections,
+        list_pending_connection_requests,
         calendar_summary,
         calendar_events,
         calendar_availability,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -7663,6 +7663,30 @@ class OneLocationAgentService:
         )
         return [payload for row in rows if (payload := self._grant_payload(row))]
 
+    def list_active_recipient_grants(self, *, recipient_user_id: str) -> list[dict[str, Any]]:
+        """Who is currently sharing their location with me -- see list_active_owner_grants.
+
+        The received-side twin: same narrow-read reasoning, just the other
+        half of the grant relationship (scoped by recipient, joined to the
+        owner's identity instead of the recipient's).
+        """
+        rows = self._execute_many(
+            """
+            SELECT
+              g.*,
+              o.display_name AS owner_display_name,
+              o.phone_number AS owner_phone_number
+            FROM one_location_share_grants g
+            LEFT JOIN actor_identity_cache o ON o.user_id = g.owner_user_id
+            WHERE g.recipient_user_id = :recipient_user_id
+              AND g.status = 'active'
+            ORDER BY g.created_at DESC
+            LIMIT 50
+            """,
+            {"recipient_user_id": recipient_user_id},
+        )
+        return [payload for row in rows if (payload := self._grant_payload(row))]
+
     def list_pending_owner_requests(self, *, owner_user_id: str) -> list[dict[str, Any]]:
         """The owner's own pending access requests -- see list_active_owner_grants."""
         rows = self._execute_many(

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -818,6 +818,39 @@ def test_list_active_owner_grants_is_scoped_to_this_owner_and_active_status(
     assert out[0]["recipientDisplayName"] == "Friend"
 
 
+def test_list_active_recipient_grants_is_scoped_to_this_recipient_and_active_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The received-side twin of list_active_owner_grants, for "who is sharing
+    # their location with me" -- scoped by recipient, joined to the owner's
+    # identity rather than the recipient's.
+    svc = OneLocationAgentService()
+    captured: dict[str, object] = {}
+
+    def fake_execute_many(sql: str, params: dict | None = None) -> list[dict]:
+        captured["sql"] = sql
+        captured["params"] = params
+        return [
+            {
+                "id": "grant-1",
+                "owner_user_id": "friend",
+                "recipient_user_id": "me",
+                "owner_display_name": "Friend",
+                "status": "active",
+                "metadata": "{}",
+            }
+        ]
+
+    monkeypatch.setattr(svc, "_execute_many", fake_execute_many)
+    out = svc.list_active_recipient_grants(recipient_user_id="me")
+    assert "g.recipient_user_id = :recipient_user_id" in captured["sql"]
+    assert "g.status = 'active'" in captured["sql"]
+    assert captured["params"] == {"recipient_user_id": "me"}
+    assert len(out) == 1
+    assert out[0]["id"] == "grant-1"
+    assert out[0]["ownerDisplayName"] == "Friend"
+
+
 def test_list_pending_owner_requests_is_scoped_to_this_owner_and_pending_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -35,6 +35,12 @@ from hushh_mcp.one_adk.action_tools import (
     _navigation_journey_definition,
     continue_app_goal,
     list_app_actions,
+    list_location_shared_with_me,
+    list_my_connections,
+    list_my_location_circles,
+    list_my_location_shares,
+    list_pending_connection_requests,
+    list_pending_location_requests,
     run_app_action,
     start_app_goal,
 )
@@ -1759,6 +1765,179 @@ class TestBackendDirectConnectionActions:
             )
         assert result["status"] == "failed"
         assert "no pending request" in result["message"].lower()
+
+
+class TestBackendDirectLocationReadTools:
+    """list_my_location_circles / list_my_location_shares /
+    list_location_shared_with_me / list_pending_location_requests -- plain
+    root-agent tools, no specialist detour, no dependency on anything the
+    frontend published. Each test's state carries only STATE_USER_ID/
+    STATE_CONSENT_TOKEN -- no hussh:screen, no hussh:voice_context at all --
+    which is itself the proof these tools need nothing from the frontend."""
+
+    def _authorized_state(self) -> dict:
+        return {STATE_USER_ID: "user_1", STATE_CONSENT_TOKEN: "token_1"}
+
+    def _auth_patch(self):
+        return patch(
+            "hushh_mcp.one_adk.action_tools.validate_token_with_db",
+            new=AsyncMock(return_value=(True, None, SimpleNamespace(user_id="user_1"))),
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_my_location_circles_reads_live_from_the_service(self):
+        state = self._authorized_state()
+        assert _STATE_SCREEN not in state
+        with (
+            self._auth_patch(),
+            patch.object(
+                OneLocationCircleService,
+                "list_circles",
+                autospec=True,
+                return_value=[{"id": "c1", "name": "Family"}],
+            ) as list_mock,
+        ):
+            result = await list_my_location_circles(_tool_context(state))
+        assert result["status"] == "ok"
+        assert result["circles"] == [{"id": "c1", "name": "Family"}]
+        assert list_mock.call_args.kwargs == {"user_id": "user_1"}
+
+    @pytest.mark.asyncio
+    async def test_list_my_location_shares_reads_active_owner_grants(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                OneLocationAgentService,
+                "list_active_owner_grants",
+                autospec=True,
+                return_value=[{"id": "g1", "recipientDisplayName": "Roopmann"}],
+            ) as grants_mock,
+        ):
+            result = await list_my_location_shares(_tool_context(state))
+        assert result["status"] == "ok"
+        assert result["shares"][0]["recipientDisplayName"] == "Roopmann"
+        assert grants_mock.call_args.kwargs == {"owner_user_id": "user_1"}
+
+    @pytest.mark.asyncio
+    async def test_list_location_shared_with_me_reads_active_recipient_grants(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                OneLocationAgentService,
+                "list_active_recipient_grants",
+                autospec=True,
+                return_value=[{"id": "g2", "ownerDisplayName": "Friend"}],
+            ) as grants_mock,
+        ):
+            result = await list_location_shared_with_me(_tool_context(state))
+        assert result["status"] == "ok"
+        assert result["shares"][0]["ownerDisplayName"] == "Friend"
+        assert grants_mock.call_args.kwargs == {"recipient_user_id": "user_1"}
+
+    @pytest.mark.asyncio
+    async def test_list_pending_location_requests_reads_pending_owner_requests(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                OneLocationAgentService,
+                "list_pending_owner_requests",
+                autospec=True,
+                return_value=[{"id": "r1", "requesterDisplayName": "Asker"}],
+            ) as requests_mock,
+        ):
+            result = await list_pending_location_requests(_tool_context(state))
+        assert result["status"] == "ok"
+        assert result["requests"][0]["requesterDisplayName"] == "Asker"
+        assert requests_mock.call_args.kwargs == {"owner_user_id": "user_1"}
+
+    @pytest.mark.asyncio
+    async def test_refuses_without_a_consent_token(self):
+        state = {STATE_USER_ID: "user_1"}  # no STATE_CONSENT_TOKEN
+        with patch.object(OneLocationCircleService, "list_circles", autospec=True) as list_mock:
+            result = await list_my_location_circles(_tool_context(state))
+        assert result["status"] == "blocked"
+        list_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_token_fails_revalidation(self):
+        state = self._authorized_state()
+        with (
+            patch(
+                "hushh_mcp.one_adk.action_tools.validate_token_with_db",
+                new=AsyncMock(return_value=(False, "expired", None)),
+            ),
+            patch.object(OneLocationCircleService, "list_circles", autospec=True) as list_mock,
+        ):
+            result = await list_my_location_circles(_tool_context(state))
+        assert result["status"] == "blocked"
+        list_mock.assert_not_called()
+
+
+class TestBackendDirectConnectionReadTools:
+    """list_my_connections / list_pending_connection_requests."""
+
+    def _authorized_state(self) -> dict:
+        return {STATE_USER_ID: "user_1", STATE_CONSENT_TOKEN: "token_1"}
+
+    def _auth_patch(self):
+        return patch(
+            "hushh_mcp.one_adk.action_tools.validate_token_with_db",
+            new=AsyncMock(return_value=(True, None, SimpleNamespace(user_id="user_1"))),
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_my_connections_reads_live_from_the_service(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                ConnectionsService,
+                "list_connections",
+                autospec=True,
+                return_value=[{"connectionId": "cx1", "displayName": "Sarah"}],
+            ) as list_mock,
+        ):
+            result = await list_my_connections(_tool_context(state))
+        assert result["status"] == "ok"
+        assert result["connections"][0]["displayName"] == "Sarah"
+        assert list_mock.call_args.kwargs == {"user_id": "user_1"}
+
+    @pytest.mark.asyncio
+    async def test_list_pending_connection_requests_defaults_to_incoming(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                ConnectionsService, "list_requests", autospec=True, return_value=[]
+            ) as requests_mock,
+        ):
+            result = await list_pending_connection_requests(_tool_context(state))
+        assert result["status"] == "ok"
+        assert requests_mock.call_args.kwargs == {"user_id": "user_1", "direction": "incoming"}
+
+    @pytest.mark.asyncio
+    async def test_list_pending_connection_requests_accepts_outgoing(self):
+        state = self._authorized_state()
+        with (
+            self._auth_patch(),
+            patch.object(
+                ConnectionsService, "list_requests", autospec=True, return_value=[]
+            ) as requests_mock,
+        ):
+            result = await list_pending_connection_requests(_tool_context(state), "outgoing")
+        assert result["status"] == "ok"
+        assert requests_mock.call_args.kwargs == {"user_id": "user_1", "direction": "outgoing"}
+
+    @pytest.mark.asyncio
+    async def test_refuses_without_a_consent_token(self):
+        state = {STATE_USER_ID: "user_1"}  # no STATE_CONSENT_TOKEN
+        with patch.object(ConnectionsService, "list_connections", autospec=True) as list_mock:
+            result = await list_my_connections(_tool_context(state))
+        assert result["status"] == "blocked"
+        list_mock.assert_not_called()
 
 
 class TestSettledActionJourneys:

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5107,7 +5107,7 @@
     "cache_manifest": "4de3513e5a3f846d1f2ec45e92a62d67c8ca716908cecb67ca0dc796d21b0d4f",
     "data_plane": "ea69e0d26bd9bdd7ad525a3bceb7561902f26d23addc5757a8a90dd78cfe15fc",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "d1d1ddc7dbc5a9fe49142f6102951d2f0d479b40d280e449f4eeaee3b551d0c5",
+    "one_specialist_tools": "6423d3f0d3d0f1c505dad1a013456f456ccb938823f799fc36c313cfbb49f5ec",
     "route_index": "b66b81a4399465e4a9220e22cfa379991e76db2538173496f8acf7d1beb99c2a",
     "route_layout": "9fdf440b9c771314317abcf6ac1d22d01fe25b8792860a0cb087bb933edf80b9",
     "surface_map": "050728616159d81320bcf3ae60d38b26b6523e3ed4c560932ed8cdbc8afbfe1b",


### PR DESCRIPTION
## Summary

Stacked on #5934 (backend-direct mutations). Same principle, applied to reads: "the frontend keeps changing, so no functionality should depend on it — only 'navigate to' should trigger the frontend, and the voice agent should read data from the backend that's actually streaming it, not from the frontend."

Adds six plain root-agent tools that read straight from the same service layer the mutations already call:

- `list_my_location_circles` → `OneLocationCircleService.list_circles`
- `list_my_location_shares` → `OneLocationAgentService.list_active_owner_grants`
- `list_location_shared_with_me` → new `OneLocationAgentService.list_active_recipient_grants`
- `list_pending_location_requests` → `OneLocationAgentService.list_pending_owner_requests`
- `list_my_connections` → `ConnectionsService.list_connections`
- `list_pending_connection_requests(direction)` → `ConnectionsService.list_requests`

## Why this shape

Investigated where the model's picture of app data currently comes from. Two existing mechanisms, both frontend-dependent in different ways:

1. **`app_context`/`hussh:voice_context`** — the browser's WebSocket frame, assembled by ~6,000 lines of frontend orchestration (`gemini-live-client.ts`, `agent-runtime-context.tsx`, `screen-context-builder.ts`, `voice-surface-metadata.ts`) across **29 independent screen call sites**. This is the exact drift surface this session's mutation work already traced real bugs back to.
2. **`ask_location_agent`/`ask_consent_agent`** — a working, genuinely backend-direct nested Gemini tool-calling loop (`LocationChatService`/`ConnectionsChatService`, confirmed via their own docstring: they deliberately bypass a broken ADK wrapper and call Gemini directly). But it costs a full extra LLM round trip per question, and specialist *admission* itself still reads frontend-published `route_family`/`screen`.

A cleaner precedent already exists and already ships: the Calendar tools (`hushh_mcp/agents/calendar/tools.py` — `calendar_summary`, `calendar_events`) are plain functions, no specialist detour, no frontend dependency beyond session-level `hussh:user_id`. This PR follows that exact shape for Location/Connect, with one difference: auth reuses `_verify_backend_direct_authorization` (the full re-validated `VAULT_OWNER` consent-token check the mutations use) rather than Calendar's lighter signed-in-only check, since circles/grants/connections are consent-scoped personal and location data.

None of the six tools touch `available_action_ids`/`screen`/`concepts` at all — same carve-out the backend-direct mutations already get from the screen-reachability guard, just for a new class of tool that never goes through `run_app_action` in the first place.

Also adds `list_active_recipient_grants` (who is sharing *their* location with me) — the one narrow read genuinely missing, mirroring `list_active_owner_grants`/`list_pending_owner_requests` added earlier this session, for the same reason: avoid a third voice-triggered path through `list_state`'s ten parallel sections just to answer one question.

**Scoped to Location + Connect only** (confirmed with the user before building) — the two domains already converted to backend-direct mutations. Email/KYC/Connected Systems/RIA reads are a deliberately separate, later pass.

Addresses #5677

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pytest tests/test_one_adk_agent_tree.py tests/services/test_one_location_agent_service.py tests/services/test_one_location_circle_service.py tests/services/test_connections_service.py` — 448/448 passing (14 new: 6 tool happy-paths + 3 auth-refusal tests + 1 new service-layer test for `list_active_recipient_grants`, plus the 4 pre-existing specialist-turn/agent-tree contract tests unaffected)
- [x] Every `patch.object(...)` on a real service method uses `autospec=True`
- [x] Governed artifact regenerated: `runtime-topology-index.v1.json`'s `one_specialist_tools` hash (content-hashes `action_tools.py`/`agent_tree.py`)
- [x] Zero regressions
