### PR TITLE
feat(ria): add frontend voice navigation actions

### DIFF
--- a/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
+++ b/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
@@ -14477,6 +14477,349 @@
       }
     },
     {
+      "action_id": "ria.clients.show_connected",
+      "surface_id": "ria_clients",
+      "label": "Show Connected Clients",
+      "aliases": [
+        "only connected",
+        "show connected clients",
+        "show connected investors",
+        "switch to connected",
+        "open connected roster"
+      ],
+      "search_keywords": [
+        "connected",
+        "connected clients",
+        "connected investors",
+        "client roster"
+      ],
+      "meaning": "Switches the clients screen to the connected investor roster.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_connected"
+      },
+      "control_ids": [
+        "ria_clients_show_connected"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_connected",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_connected",
+            "label": "Show Connected Clients",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.show_around_you",
+      "surface_id": "ria_clients",
+      "label": "Show Around You",
+      "aliases": [
+        "who is around me",
+        "show people around me",
+        "show around you",
+        "switch to around you",
+        "open nearby records",
+        "show nearby prospects"
+      ],
+      "search_keywords": [
+        "around you",
+        "around me",
+        "nearby",
+        "prospects",
+        "public records"
+      ],
+      "meaning": "Switches the clients screen to public-association records near the advisor's selected place.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_around_you"
+      },
+      "control_ids": [
+        "ria_clients_show_around_you"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx",
+        "hushh-webapp/components/ria/nearby/nearby-around-you.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_around_you",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_around_you",
+            "label": "Show Around You",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.search_client",
+      "surface_id": "ria_clients",
+      "label": "Search Connected Clients",
+      "aliases": [
+        "find client",
+        "find investor",
+        "search client",
+        "search connected clients",
+        "find john"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "client",
+        "investor",
+        "connected"
+      ],
+      "meaning": "Filters the connected investor roster by a spoken client name or identifier.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.search_client"
+      },
+      "control_ids": [
+        "ria_clients_search"
+      ],
+      "state_exposure": [
+        "visible connected client names",
+        "visible connected client relationship states"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/clients"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.search_client",
+        "required_inputs": [
+          {
+            "name": "clientName",
+            "prompt": "Which client should I search for?",
+            "required": true,
+            "slot": "clientName",
+            "resolver": "spoken_person_name"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "clientName": "spoken_person_name"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search connected clients",
+            "failure_behavior": "stop",
+            "action_id": "ria.clients.search_client",
+            "settlement_target": {
+              "route": "/ria/clients",
+              "screen": "ria_clients"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "ria.clients.nearby_shortlist_record",
       "surface_id": "ria_clients",
       "label": "Shortlist Nearby Record",
@@ -15814,6 +16157,131 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/ria/picks?category=avoid",
+              "screen": "ria_picks"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.picks.search_ticker",
+      "surface_id": "ria_picks",
+      "label": "Search Ticker In Picks",
+      "aliases": [
+        "find ticker",
+        "find AAPL",
+        "search ticker",
+        "search for ticker",
+        "find stock",
+        "search picks"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "ticker",
+        "symbol",
+        "stock",
+        "picks"
+      ],
+      "meaning": "Filters the current RIA Picks table by a spoken ticker symbol.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/picks"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.picks.search_ticker"
+      },
+      "control_ids": [
+        "ria_picks_search_ticker"
+      ],
+      "state_exposure": [
+        "visible RIA picks rows"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/picks"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.picks.search_ticker",
+        "required_inputs": [
+          {
+            "name": "ticker",
+            "prompt": "Which ticker should I search for?",
+            "required": true,
+            "slot": "ticker",
+            "resolver": "ticker_symbol"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "ticker": "ticker_symbol"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search ticker in Picks",
+            "failure_behavior": "stop",
+            "action_id": "ria.picks.search_ticker",
+            "settlement_target": {
+              "route": "/ria/picks",
               "screen": "ria_picks"
             }
           }

--- a/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
+++ b/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
@@ -5861,6 +5861,9 @@
       "canonical_screen": "ria_clients",
       "voice_contract_file": "app/ria/clients/page.voice-action-contract.json",
       "action_ids": [
+        "ria.clients.search_client",
+        "ria.clients.show_around_you",
+        "ria.clients.show_connected",
         "ria.clients.switch_to_nearby",
         "route.ria_clients"
       ],
@@ -6109,6 +6112,7 @@
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
         "ria.picks.open_view_debate",
+        "ria.picks.search_ticker",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4841,6 +4841,9 @@
       "semantic_routes": [],
       "voice": {
         "action_ids": [
+          "ria.clients.search_client",
+          "ria.clients.show_around_you",
+          "ria.clients.show_connected",
           "ria.clients.switch_to_nearby",
           "route.ria_clients"
         ],
@@ -4984,6 +4987,7 @@
           "ria.picks.open_source_kai",
           "ria.picks.open_source_my",
           "ria.picks.open_view_debate",
+          "ria.picks.search_ticker",
           "route.ria_picks"
         ],
         "delegate_agent_ids": [],
@@ -5147,21 +5151,21 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "4da0727c2fdeadb78bc4650914827d77ad085c72dbfebff7e1f1baa2e89c07a1",
+    "action_gateway": "19a770f16c2daf29ab8de595e6b778e9cd1170d055e9797cc6d977e20d7fc73a",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
     "cache_manifest": "13a2f556b7ea2ebbcf7729c5ba7dfa8875a79d8dd4a37df2b8dc2471ca544879",
     "data_plane": "e54c50888114e8ec012180b6eb142335164d429494a7cab7a084a1ab0df64e84",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "91046655f19b6c84fa76f27faa3309b7f28887aec26cae65e2b3fa6843f389e4",
-    "route_index": "eb051f176332f390083c5e270b7dcc494994a68352b741c16b1765efdc63243e",
+    "route_index": "8e5fd4cc293f1752df5608d3ef005ac4d13285bb520813865cc68162c238b9e9",
     "route_layout": "178064ac4f170604e1014eb9eb87fad2aae55c1a9a7039dbd34c4b20ea51704b",
-    "surface_map": "956b3a9d00d47795f6e1102e87f8817d75097f5a0e5e1f5b9b2d1db9969da6f0",
+    "surface_map": "8d7e17c7d51f8e7abb3a5ca238e652a0e0f3414863ac33607bc7d5341a28c57b",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
   "summary": {
     "a2a_scope_gated_agents": 5,
-    "actions": 185,
+    "actions": 189,
     "agents": 19,
     "aliases": 3,
     "decision_required": 2,

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -14477,6 +14477,349 @@
       }
     },
     {
+      "action_id": "ria.clients.show_connected",
+      "surface_id": "ria_clients",
+      "label": "Show Connected Clients",
+      "aliases": [
+        "only connected",
+        "show connected clients",
+        "show connected investors",
+        "switch to connected",
+        "open connected roster"
+      ],
+      "search_keywords": [
+        "connected",
+        "connected clients",
+        "connected investors",
+        "client roster"
+      ],
+      "meaning": "Switches the clients screen to the connected investor roster.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_connected"
+      },
+      "control_ids": [
+        "ria_clients_show_connected"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_connected",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_connected",
+            "label": "Show Connected Clients",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.show_around_you",
+      "surface_id": "ria_clients",
+      "label": "Show Around You",
+      "aliases": [
+        "who is around me",
+        "show people around me",
+        "show around you",
+        "switch to around you",
+        "open nearby records",
+        "show nearby prospects"
+      ],
+      "search_keywords": [
+        "around you",
+        "around me",
+        "nearby",
+        "prospects",
+        "public records"
+      ],
+      "meaning": "Switches the clients screen to public-association records near the advisor's selected place.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_around_you"
+      },
+      "control_ids": [
+        "ria_clients_show_around_you"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx",
+        "hushh-webapp/components/ria/nearby/nearby-around-you.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_around_you",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_around_you",
+            "label": "Show Around You",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.search_client",
+      "surface_id": "ria_clients",
+      "label": "Search Connected Clients",
+      "aliases": [
+        "find client",
+        "find investor",
+        "search client",
+        "search connected clients",
+        "find john"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "client",
+        "investor",
+        "connected"
+      ],
+      "meaning": "Filters the connected investor roster by a spoken client name or identifier.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.search_client"
+      },
+      "control_ids": [
+        "ria_clients_search"
+      ],
+      "state_exposure": [
+        "visible connected client names",
+        "visible connected client relationship states"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/clients"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.search_client",
+        "required_inputs": [
+          {
+            "name": "clientName",
+            "prompt": "Which client should I search for?",
+            "required": true,
+            "slot": "clientName",
+            "resolver": "spoken_person_name"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "clientName": "spoken_person_name"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search connected clients",
+            "failure_behavior": "stop",
+            "action_id": "ria.clients.search_client",
+            "settlement_target": {
+              "route": "/ria/clients",
+              "screen": "ria_clients"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "ria.clients.nearby_shortlist_record",
       "surface_id": "ria_clients",
       "label": "Shortlist Nearby Record",
@@ -15814,6 +16157,131 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/ria/picks?category=avoid",
+              "screen": "ria_picks"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.picks.search_ticker",
+      "surface_id": "ria_picks",
+      "label": "Search Ticker In Picks",
+      "aliases": [
+        "find ticker",
+        "find AAPL",
+        "search ticker",
+        "search for ticker",
+        "find stock",
+        "search picks"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "ticker",
+        "symbol",
+        "stock",
+        "picks"
+      ],
+      "meaning": "Filters the current RIA Picks table by a spoken ticker symbol.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/picks"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.picks.search_ticker"
+      },
+      "control_ids": [
+        "ria_picks_search_ticker"
+      ],
+      "state_exposure": [
+        "visible RIA picks rows"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/picks"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.picks.search_ticker",
+        "required_inputs": [
+          {
+            "name": "ticker",
+            "prompt": "Which ticker should I search for?",
+            "required": true,
+            "slot": "ticker",
+            "resolver": "ticker_symbol"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "ticker": "ticker_symbol"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search ticker in Picks",
+            "failure_behavior": "stop",
+            "action_id": "ria.picks.search_ticker",
+            "settlement_target": {
+              "route": "/ria/picks",
               "screen": "ria_picks"
             }
           }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -5861,6 +5861,9 @@
       "canonical_screen": "ria_clients",
       "voice_contract_file": "app/ria/clients/page.voice-action-contract.json",
       "action_ids": [
+        "ria.clients.search_client",
+        "ria.clients.show_around_you",
+        "ria.clients.show_connected",
         "ria.clients.switch_to_nearby",
         "route.ria_clients"
       ],
@@ -6109,6 +6112,7 @@
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
         "ria.picks.open_view_debate",
+        "ria.picks.search_ticker",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",

--- a/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
@@ -81,6 +81,50 @@ describe("executeAgentGatewayAction", () => {
     });
   });
 
+  it("executes generated RIA route actions through browser navigation", async () => {
+    const router = { push: vi.fn() };
+
+    for (const [actionId, target, screenAfter] of [
+      ["route.ria_profile", "/ria/profile", "profile_regulatory"],
+      ["route.ria_clients", "/ria/clients", "ria_clients"],
+      ["route.ria_picks", "/ria/picks", "ria_picks"],
+    ] as const) {
+      router.push.mockClear();
+      const result = await executeAgentGatewayAction({
+        actionId,
+        allowedActionIds: ["route.ria_profile"],
+        userId: "user_1",
+        router,
+        appRuntimeState: runtimeState({
+          route: {
+            pathname: "/ria/profile",
+            screen: "profile_regulatory",
+            subview: null,
+          },
+          persona: {
+            active: "ria",
+            primary_nav: "ria",
+            available: ["ria", "investor"],
+            transition_target: null,
+            ria_switch_available: true,
+            ria_setup_available: false,
+          },
+        }),
+        hasPortfolioData: true,
+        busyOperations: {},
+        setAnalysisParams: vi.fn(),
+      });
+
+      expect(router.push).toHaveBeenCalledWith(target);
+      expect(result).toMatchObject({
+        status: "started",
+        actionId,
+        routeAfter: target,
+        screenAfter,
+      });
+    }
+  });
+
   it("keeps global route actions blocked behind an active blocking layer", async () => {
     const router = { push: vi.fn() };
 

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -829,6 +829,70 @@ describe("buildStructuredScreenContext", () => {
 
   // ── Array bounds coverage added below the existing suite ─────────────────
 
+  it("keeps RIA sibling route actions in the live context on profile and crowded tabs", () => {
+    window.history.pushState({}, "", "/ria/profile");
+
+    const profileContext = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/ria/profile", "profile_regulatory"),
+      voiceContext: {},
+    });
+
+    expect(profileContext.screen_metadata.available_action_ids).toEqual(
+      expect.arrayContaining([
+        "route.ria_profile",
+        "route.ria_clients",
+        "route.ria_picks",
+      ]),
+    );
+
+    clearVoiceSurfaceMetadata("test_surface");
+    window.history.pushState({}, "", "/ria/picks");
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "ria_picks",
+      title: "RIA Picks",
+      controls: [
+        ...Array.from({ length: ACTION_ID_SCREEN_SEGMENT_CAP }, (_, index) => ({
+          id: `ria_picks_local_${index + 1}`,
+          label: `Local picks action ${index + 1}`,
+          actionId:
+            index === 0
+              ? "ria.picks.search_ticker"
+              : index === 1
+                ? "ria.picks.open_category_avoid"
+                : "ria.picks.open_source_my",
+        })),
+        {
+          id: "ria_route_tab_profile",
+          label: "Profile",
+          actionId: "route.ria_profile",
+        },
+        {
+          id: "ria_route_tab_clients",
+          label: "Clients",
+          actionId: "route.ria_clients",
+        },
+        {
+          id: "ria_route_tab_picks",
+          label: "Picks",
+          actionId: "route.ria_picks",
+        },
+      ],
+    });
+
+    const picksContext = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/ria/picks", "ria_picks"),
+      voiceContext: {},
+    });
+
+    expect(picksContext.screen_metadata.available_action_ids).toEqual(
+      expect.arrayContaining([
+        "route.ria_profile",
+        "route.ria_clients",
+        "route.ria_picks",
+      ]),
+    );
+  });
+
   it("clamps oversized voice_aliases on control definitions", () => {
     publishVoiceSurfaceMetadata("test_surface", {
       controls: [

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, Loader2, UserRound } from "lucide-react";
+import { ChevronRight, Loader2, Search, UserRound } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
@@ -19,9 +19,11 @@ import {
 import { NearbyAroundYou } from "@/components/ria/nearby/nearby-around-you";
 import { SettingsGroup, SettingsSegmentedTabs } from "@/components/profile/settings-ui";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { useAuth } from "@/hooks/use-auth";
-import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { Button } from "@/lib/morphy-ux/button";
+import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { buildRiaClientWorkspaceRoute, ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
@@ -68,6 +70,7 @@ export default function RiaClientsPage() {
   // Session-only: an advisor lands on their roster, and prospecting is a
   // deliberate second step rather than the default view.
   const [view, setView] = useState<ClientsView>("connected");
+  const [clientSearchQuery, setClientSearchQuery] = useState("");
 
   const clientsResource = useStaleResource<RiaClientListResponse>({
     cacheKey: user?.uid ? `ria_clients_connected_${user.uid}` : "ria_clients_guest",
@@ -103,6 +106,62 @@ export default function RiaClientsPage() {
     },
     [connectedClients, injectedTestClient]
   );
+  const visibleClientItems = useMemo(() => {
+    const query = clientSearchQuery.trim().toLowerCase();
+    if (!query) return clientItems;
+    return clientItems.filter((client) =>
+      [
+        client.investor_display_name,
+        client.investor_email,
+        client.investor_secondary_label,
+        client.investor_user_id,
+      ].some((value) => String(value || "").toLowerCase().includes(query))
+    );
+  }, [clientItems, clientSearchQuery]);
+  useLocalOnboardingActionHandler(
+    "ria.clients.show_connected",
+    () => {
+      setView("connected");
+      return {
+        status: "succeeded",
+        summary: "Showing connected investors.",
+        data: { view: "connected" },
+      };
+    },
+    { enabled: riaCapability === "switch" }
+  );
+  useLocalOnboardingActionHandler(
+    "ria.clients.show_around_you",
+    () => {
+      setView("nearby");
+      return {
+        status: "succeeded",
+        summary: "Showing people around you.",
+        data: { view: "nearby" },
+      };
+    },
+    { enabled: riaCapability === "switch" }
+  );
+  useLocalOnboardingActionHandler(
+    "ria.clients.search_client",
+    (slots) => {
+      const clientName = String(slots.clientName || slots.query || "").trim().slice(0, 80);
+      if (!clientName) {
+        return {
+          status: "blocked",
+          summary: "Which client should I search for?",
+        };
+      }
+      setView("connected");
+      setClientSearchQuery(clientName);
+      return {
+        status: "succeeded",
+        summary: `Searching connected clients for ${clientName}.`,
+        data: { view: "connected" },
+      };
+    },
+    { enabled: riaCapability === "switch" }
+  );
   const voiceSurfaceMetadata = useMemo(
     () => ({
       screenId: "ria_clients",
@@ -116,6 +175,13 @@ export default function RiaClientsPage() {
       ],
       controls: [
         {
+          id: "ria_route_tab_profile",
+          label: "Profile",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_profile",
+        },
+        {
           id: "ria_route_tab_clients",
           label: "Clients",
           type: "tab",
@@ -123,12 +189,43 @@ export default function RiaClientsPage() {
           actionId: "route.ria_clients",
         },
         {
+          id: "ria_route_tab_picks",
+          label: "Picks",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_picks",
+        },
+        {
           id: "ria_clients_browse_marketplace",
           label: "Browse the marketplace",
           type: "button",
           actionId: "route.ria_marketplace_connect",
         },
-        ...clientItems.slice(0, 8).map((client, index) => ({
+        {
+          id: "ria_clients_show_connected",
+          label: "Connected",
+          type: "tab",
+          state: view === "connected" ? "active" : "available",
+          actionId: "ria.clients.show_connected",
+          voiceAliases: ["only connected", "show connected clients", "connected investors"],
+        },
+        {
+          id: "ria_clients_show_around_you",
+          label: "Around you",
+          type: "tab",
+          state: view === "nearby" ? "active" : "available",
+          actionId: "ria.clients.show_around_you",
+          voiceAliases: ["around me", "who is around me", "people around you"],
+        },
+        {
+          id: "ria_clients_search",
+          label: "Search clients",
+          type: "search",
+          state: clientSearchQuery ? "active" : "available",
+          actionId: "ria.clients.search_client",
+          voiceAliases: ["find client", "search client", "find investor"],
+        },
+        ...visibleClientItems.slice(0, 8).map((client, index) => ({
           id: `ria_clients_client_row_${index + 1}`,
           label: client.investor_display_name || client.investor_email || "Investor",
           type: "button",
@@ -137,17 +234,20 @@ export default function RiaClientsPage() {
         })),
       ],
       activeTab: "clients",
-      visibleModules: ["Connected investors"],
-      selectedObjects: clientItems
+      visibleModules: [view === "nearby" ? "People around you" : "Connected investors"],
+      selectedObjects: visibleClientItems
         .slice(0, 8)
         .map((client) => client.investor_display_name || client.investor_email || client.investor_user_id)
         .filter((value): value is string => Boolean(value)),
       screenMetadata: {
         connected_client_count: clientItems.length,
+        visible_client_count: visibleClientItems.length,
         loading: clientsResource.loading,
+        clients_view: view,
+        search_active: Boolean(clientSearchQuery.trim()),
       },
     }),
-    [clientItems, clientsResource.loading]
+    [clientItems.length, clientSearchQuery, clientsResource.loading, view, visibleClientItems]
   );
   usePublishVoiceSurfaceMetadata(voiceSurfaceMetadata);
 
@@ -194,9 +294,9 @@ export default function RiaClientsPage() {
           title={
             <span className="inline-flex flex-wrap items-center gap-2">
               {RIA_COPY.clients.title}
-              {view === "connected" && clientItems.length > 0 ? (
+              {view === "connected" && visibleClientItems.length > 0 ? (
                 <Badge variant="secondary" className="text-[10px]">
-                  {clientItems.length}
+                  {visibleClientItems.length}
                 </Badge>
               ) : null}
             </span>
@@ -251,8 +351,43 @@ export default function RiaClientsPage() {
                   {RIA_COPY.clients.browse}
                 </Button>
               </div>
+            ) : visibleClientItems.length === 0 ? (
+              <div className="space-y-3 px-4 py-8 text-center">
+                <div className="relative mx-auto max-w-sm">
+                  <Search
+                    className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    type="search"
+                    value={clientSearchQuery}
+                    onChange={(event) => setClientSearchQuery(event.target.value)}
+                    placeholder="Search connected clients"
+                    className="pl-9"
+                    aria-label="Search connected clients"
+                  />
+                </div>
+                <p className="text-sm text-muted-foreground">No connected clients match that search.</p>
+              </div>
             ) : (
-              clientItems.map((client, index) => (
+              <>
+                <div className="px-4 pt-4">
+                  <div className="relative">
+                    <Search
+                      className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                    <Input
+                      type="search"
+                      value={clientSearchQuery}
+                      onChange={(event) => setClientSearchQuery(event.target.value)}
+                      placeholder="Search connected clients"
+                      className="pl-9"
+                      aria-label="Search connected clients"
+                    />
+                  </div>
+                </div>
+              {visibleClientItems.map((client, index) => (
                 <button
                   key={client.id}
                   type="button"
@@ -298,7 +433,8 @@ export default function RiaClientsPage() {
                   </div>
                   <MaterialRipple variant="none" effect="fade" className="z-0" />
                 </button>
-              ))
+              ))}
+              </>
             )}
           </SettingsGroup>
           )}

--- a/hushh-webapp/app/ria/clients/page.voice-action-contract.json
+++ b/hushh-webapp/app/ria/clients/page.voice-action-contract.json
@@ -174,6 +174,199 @@
       "speaker_persona": "one"
     },
     {
+      "action_id": "ria.clients.show_connected",
+      "label": "Show Connected Clients",
+      "meaning": "Switches the clients screen to the connected investor roster.",
+      "aliases": [
+        "only connected",
+        "show connected clients",
+        "show connected investors",
+        "switch to connected",
+        "open connected roster"
+      ],
+      "search_keywords": [
+        "connected",
+        "connected clients",
+        "connected investors",
+        "client roster"
+      ],
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_connected"
+      },
+      "control_ids": [
+        "ria_clients_show_connected"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "speaker_persona": "one"
+    },
+    {
+      "action_id": "ria.clients.show_around_you",
+      "label": "Show Around You",
+      "meaning": "Switches the clients screen to public-association records near the advisor's selected place.",
+      "aliases": [
+        "who is around me",
+        "show people around me",
+        "show around you",
+        "switch to around you",
+        "open nearby records",
+        "show nearby prospects"
+      ],
+      "search_keywords": [
+        "around you",
+        "around me",
+        "nearby",
+        "prospects",
+        "public records"
+      ],
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_around_you"
+      },
+      "control_ids": [
+        "ria_clients_show_around_you"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "hushh-webapp/app/ria/clients/page.tsx",
+        "hushh-webapp/components/ria/nearby/nearby-around-you.tsx"
+      ],
+      "speaker_persona": "one"
+    },
+    {
+      "action_id": "ria.clients.search_client",
+      "label": "Search Connected Clients",
+      "meaning": "Filters the connected investor roster by a spoken client name or identifier.",
+      "aliases": [
+        "find client",
+        "find investor",
+        "search client",
+        "search connected clients",
+        "find john"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "client",
+        "investor",
+        "connected"
+      ],
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.search_client"
+      },
+      "control_ids": [
+        "ria_clients_search"
+      ],
+      "state_exposure": [
+        "visible connected client names",
+        "visible connected client relationship states"
+      ],
+      "goal": {
+        "goal_id": "goal.ria.clients.search_client",
+        "slot_schema": {
+          "clientName": "spoken_person_name"
+        },
+        "required_inputs": [
+          {
+            "name": "clientName",
+            "slot": "clientName",
+            "resolver": "spoken_person_name",
+            "prompt": "Which client should I search for?",
+            "required": true
+          }
+        ],
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.search_client",
+            "label": "Search connected clients",
+            "settlement_target": {
+              "route": "/ria/clients",
+              "screen": "ria_clients"
+            }
+          }
+        ]
+      },
+      "docs_references": [
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "speaker_persona": "one"
+    },
+    {
       "action_id": "ria.clients.nearby_shortlist_record",
       "label": "Shortlist Nearby Record",
       "meaning": "Represents the shortlist control on an opened public-association record. Choosing a specific record stays manual until voice carries a selected record id.",

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -55,6 +55,7 @@ import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { Button } from "@/lib/morphy-ux/button";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { useVault } from "@/lib/vault/vault-context";
 import {
@@ -1398,6 +1399,7 @@ export default function RiaPicksPage() {
   const [packageSaving, setPackageSaving] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [picksSearchQuery, setPicksSearchQuery] = useState("");
   const [showIssuesOnly, setShowIssuesOnly] = useState(false);
   const [focusedIssueRowId, setFocusedIssueRowId] = useState<string | null>(null);
   const [draftPackage, setDraftPackage] = useState<DraftPickPackage | null>(null);
@@ -1465,6 +1467,27 @@ export default function RiaPicksPage() {
       });
     },
     [router, searchParams]
+  );
+  useLocalOnboardingActionHandler(
+    "ria.picks.search_ticker",
+    (slots) => {
+      const ticker = String(slots.ticker || slots.query || "").trim().toUpperCase().slice(0, 12);
+      if (!ticker) {
+        return {
+          status: "blocked",
+          summary: "Which ticker should I search for?",
+        };
+      }
+      setPicksSearchQuery(ticker);
+      setCategory("top-picks");
+      updatePicksRouteState({ category: "top-picks", view: null });
+      return {
+        status: "succeeded",
+        summary: `Searching Picks for ${ticker}.`,
+        data: { ticker },
+      };
+    },
+    { enabled: riaCapability === "switch" }
   );
 
   const picksResource = useStaleResource<{
@@ -2208,6 +2231,20 @@ export default function RiaPicksPage() {
       ],
       controls: [
         {
+          id: "ria_route_tab_profile",
+          label: "Profile",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_profile",
+        },
+        {
+          id: "ria_route_tab_clients",
+          label: "Clients",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_clients",
+        },
+        {
           id: "ria_route_tab_picks",
           label: "Picks",
           type: "tab",
@@ -2248,6 +2285,14 @@ export default function RiaPicksPage() {
           type: "tab",
           state: !isDebateView && category === "screening" ? "active" : "available",
           actionId: "ria.picks.open_category_screening",
+        },
+        {
+          id: "ria_picks_search_ticker",
+          label: "Search ticker",
+          type: "search",
+          state: picksSearchQuery ? "active" : "available",
+          actionId: "ria.picks.search_ticker",
+          voiceAliases: ["find ticker", "search ticker", "find AAPL"],
         },
         {
           id: "ria_picks_view_debate",
@@ -2313,6 +2358,7 @@ export default function RiaPicksPage() {
         editing,
         upload_open: uploadOpen,
         has_unsaved_changes: hasUnsavedChanges,
+        search_active: Boolean(picksSearchQuery.trim()),
         vault_unlocked: isVaultUnlocked,
         validation_issue_count: validationIssues.length,
         kai_top_pick_count: kaiRows.length,
@@ -2328,6 +2374,7 @@ export default function RiaPicksPage() {
       kaiRows.length,
       myTopPicks.length,
       packageSaving,
+      picksSearchQuery,
       savingToMyList,
       source,
       sourceTitle,
@@ -2738,6 +2785,8 @@ export default function RiaPicksPage() {
                     searchKey="ticker"
                     globalSearchKeys={["ticker", "company_name", "sector", "tier", "investment_thesis"]}
                     searchPlaceholder={`Search ${sourceTitle.toLowerCase()} by ticker, company, sector, or tier`}
+                    searchValue={picksSearchQuery}
+                    onSearchValueChange={setPicksSearchQuery}
                     initialPageSize={10}
                     pageSizeOptions={[10, 20, 30]}
                     density="compact"
@@ -2807,6 +2856,8 @@ export default function RiaPicksPage() {
                     searchKey="ticker"
                     globalSearchKeys={["ticker", "company_name", "sector", "category", "why_avoid", "note"]}
                     searchPlaceholder="Search avoid list by ticker, company, category, or reason"
+                    searchValue={picksSearchQuery}
+                    onSearchValueChange={setPicksSearchQuery}
                     initialPageSize={10}
                     pageSizeOptions={[10, 20, 30]}
                     density="compact"

--- a/hushh-webapp/app/ria/picks/page.voice-action-contract.json
+++ b/hushh-webapp/app/ria/picks/page.voice-action-contract.json
@@ -255,6 +255,89 @@
       "speaker_persona": "kai"
     },
     {
+      "action_id": "ria.picks.search_ticker",
+      "label": "Search Ticker In Picks",
+      "meaning": "Filters the current RIA Picks table by a spoken ticker symbol.",
+      "aliases": [
+        "find ticker",
+        "find AAPL",
+        "search ticker",
+        "search for ticker",
+        "find stock",
+        "search picks"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "ticker",
+        "symbol",
+        "stock",
+        "picks"
+      ],
+      "reachability": {
+        "routes": [
+          "/ria/picks"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.picks.search_ticker"
+      },
+      "control_ids": [
+        "ria_picks_search_ticker"
+      ],
+      "state_exposure": [
+        "visible RIA picks rows"
+      ],
+      "goal": {
+        "goal_id": "goal.ria.picks.search_ticker",
+        "slot_schema": {
+          "ticker": "ticker_symbol"
+        },
+        "required_inputs": [
+          {
+            "name": "ticker",
+            "slot": "ticker",
+            "resolver": "ticker_symbol",
+            "prompt": "Which ticker should I search for?",
+            "required": true
+          }
+        ],
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.picks.search_ticker",
+            "label": "Search ticker in Picks",
+            "settlement_target": {
+              "route": "/ria/picks",
+              "screen": "ria_picks"
+            }
+          }
+        ]
+      },
+      "docs_references": [
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "speaker_persona": "kai"
+    },
+    {
       "action_id": "ria.picks.open_category_screening",
       "label": "Show Screening Rules",
       "meaning": "Switches the picks route state to screening rules.",

--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -91,6 +91,8 @@ interface DataTableProps<TData, TValue> {
   filterKey?: string;
   filterOptions?: { label: string; value: string }[];
   filterPlaceholder?: string;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
   onRowClick?: (
     row: TData,
     event: React.MouseEvent<HTMLTableRowElement> | React.KeyboardEvent<HTMLTableRowElement>,
@@ -118,6 +120,8 @@ export function DataTable<TData, TValue>({
   filterKey,
   filterOptions,
   filterPlaceholder = "Filter...",
+  searchValue,
+  onSearchValueChange,
   onRowClick,
   initialPageSize = 8,
   pageSizeOptions = [8, 16, 24],
@@ -135,13 +139,23 @@ export function DataTable<TData, TValue>({
   );
   const [searchTerm, setSearchTerm] = React.useState("");
   const [globalFilter, setGlobalFilter] = React.useState("");
+  const resolvedSearchTerm = searchValue ?? searchTerm;
+  const setResolvedSearchTerm = React.useCallback(
+    (value: string) => {
+      if (searchValue === undefined) {
+        setSearchTerm(value);
+      }
+      onSearchValueChange?.(value);
+    },
+    [onSearchValueChange, searchValue],
+  );
 
   React.useEffect(() => {
     const timer = setTimeout(() => {
-      setGlobalFilter(searchTerm);
+      setGlobalFilter(resolvedSearchTerm);
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchTerm]);
+  }, [resolvedSearchTerm]);
 
   const normalizedSearchKeys = React.useMemo(
     () =>
@@ -253,8 +267,8 @@ export function DataTable<TData, TValue>({
                 autoCorrect="off"
                 autoCapitalize="off"
                 placeholder={searchPlaceholder}
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
+                value={resolvedSearchTerm}
+                onChange={(e) => setResolvedSearchTerm(e.target.value)}
                 className="pl-9 cursor-text"
                 aria-label="Search table"
               />

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -53,6 +53,7 @@ import { ProseMarkdown } from "@/components/research/prose-markdown";
 import { useAuth } from "@/hooks/use-auth";
 import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import {
   RiaService,
   type RiaDossier,
@@ -900,6 +901,67 @@ export function RiaProfileSection({
 
   const currentLicenseNumber = getProfileRiaRefreshLicenseNumber(status);
   const verified = isRiaVerified(status?.verification_status);
+  const voiceSurfaceMetadata = useMemo(
+    () => ({
+      screenId: "profile_regulatory",
+      title: "RIA Profile",
+      purpose: "Advisor profile management and verification details.",
+      sections: [
+        {
+          id: "ria_profile_verification",
+          title: "Verification",
+        },
+        {
+          id: "ria_profile_manage",
+          title: "RIA profile",
+        },
+      ],
+      controls: [
+        {
+          id: "ria_route_tab_profile",
+          label: "Profile",
+          type: "tab",
+          state: "active",
+          actionId: "route.ria_profile",
+        },
+        {
+          id: "ria_route_tab_clients",
+          label: "Clients",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_clients",
+        },
+        {
+          id: "ria_route_tab_picks",
+          label: "Picks",
+          type: "tab",
+          state: "available",
+          actionId: "route.ria_picks",
+        },
+        {
+          id: "ria_profile_edit_services",
+          label: "Edit profile",
+          type: "button",
+          state: editOpen ? "active" : "available",
+          actionId: "ria.profile.edit_services",
+        },
+      ],
+      activeTab: "profile",
+      visibleModules: ["Verification", "Regulatory profile", "RIA profile"],
+      busyOperations: [
+        ...(saving ? ["ria_profile_saving"] : []),
+        ...(deleting ? ["ria_profile_deleting"] : []),
+        ...(refreshingLicense ? ["ria_profile_refreshing_license"] : []),
+      ],
+      screenMetadata: {
+        profile_exists: status?.exists !== false,
+        verified,
+        edit_open: editOpen,
+      },
+    }),
+    [deleting, editOpen, refreshingLicense, saving, status?.exists, verified],
+  );
+  usePublishVoiceSurfaceMetadata(voiceSurfaceMetadata);
   const secRecordMetadata = useMemo(
     () => resolveSecRecordMetadata(status),
     [status],

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -14477,6 +14477,349 @@
       }
     },
     {
+      "action_id": "ria.clients.show_connected",
+      "surface_id": "ria_clients",
+      "label": "Show Connected Clients",
+      "aliases": [
+        "only connected",
+        "show connected clients",
+        "show connected investors",
+        "switch to connected",
+        "open connected roster"
+      ],
+      "search_keywords": [
+        "connected",
+        "connected clients",
+        "connected investors",
+        "client roster"
+      ],
+      "meaning": "Switches the clients screen to the connected investor roster.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_connected"
+      },
+      "control_ids": [
+        "ria_clients_show_connected"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_connected",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_connected",
+            "label": "Show Connected Clients",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.show_around_you",
+      "surface_id": "ria_clients",
+      "label": "Show Around You",
+      "aliases": [
+        "who is around me",
+        "show people around me",
+        "show around you",
+        "switch to around you",
+        "open nearby records",
+        "show nearby prospects"
+      ],
+      "search_keywords": [
+        "around you",
+        "around me",
+        "nearby",
+        "prospects",
+        "public records"
+      ],
+      "meaning": "Switches the clients screen to public-association records near the advisor's selected place.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.show_around_you"
+      },
+      "control_ids": [
+        "ria_clients_show_around_you"
+      ],
+      "state_exposure": [
+        "selected clients view"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx",
+        "hushh-webapp/components/ria/nearby/nearby-around-you.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "The mounted action reports its browser-observed outcome."
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.show_around_you",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.clients.show_around_you",
+            "label": "Show Around You",
+            "failure_behavior": "stop"
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.clients.search_client",
+      "surface_id": "ria_clients",
+      "label": "Search Connected Clients",
+      "aliases": [
+        "find client",
+        "find investor",
+        "search client",
+        "search connected clients",
+        "find john"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "client",
+        "investor",
+        "connected"
+      ],
+      "meaning": "Filters the connected investor roster by a spoken client name or identifier.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/clients"
+        ],
+        "screens": [
+          "ria_clients"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.clients.search_client"
+      },
+      "control_ids": [
+        "ria_clients_search"
+      ],
+      "state_exposure": [
+        "visible connected client names",
+        "visible connected client relationship states"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/clients/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/clients"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.clients.search_client",
+        "required_inputs": [
+          {
+            "name": "clientName",
+            "prompt": "Which client should I search for?",
+            "required": true,
+            "slot": "clientName",
+            "resolver": "spoken_person_name"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "clientName": "spoken_person_name"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search connected clients",
+            "failure_behavior": "stop",
+            "action_id": "ria.clients.search_client",
+            "settlement_target": {
+              "route": "/ria/clients",
+              "screen": "ria_clients"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "ria.clients.nearby_shortlist_record",
       "surface_id": "ria_clients",
       "label": "Shortlist Nearby Record",
@@ -15814,6 +16157,131 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/ria/picks?category=avoid",
+              "screen": "ria_picks"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "ria.picks.search_ticker",
+      "surface_id": "ria_picks",
+      "label": "Search Ticker In Picks",
+      "aliases": [
+        "find ticker",
+        "find AAPL",
+        "search ticker",
+        "search for ticker",
+        "find stock",
+        "search picks"
+      ],
+      "search_keywords": [
+        "find",
+        "search",
+        "ticker",
+        "symbol",
+        "stock",
+        "picks"
+      ],
+      "meaning": "Filters the current RIA Picks table by a spoken ticker symbol.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/picks"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "RIA onboarding must be complete."
+        ],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "ria.picks.search_ticker"
+      },
+      "control_ids": [
+        "ria_picks_search_ticker"
+      ],
+      "state_exposure": [
+        "visible RIA picks rows"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/picks"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.picks.search_ticker",
+        "required_inputs": [
+          {
+            "name": "ticker",
+            "prompt": "Which ticker should I search for?",
+            "required": true,
+            "slot": "ticker",
+            "resolver": "ticker_symbol"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {
+          "ticker": "ticker_symbol"
+        },
+        "workflow_steps": [
+          {
+            "type": "action",
+            "label": "Search ticker in Picks",
+            "failure_behavior": "stop",
+            "action_id": "ria.picks.search_ticker",
+            "settlement_target": {
+              "route": "/ria/picks",
               "screen": "ria_picks"
             }
           }

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -5861,6 +5861,9 @@
       "canonical_screen": "ria_clients",
       "voice_contract_file": "app/ria/clients/page.voice-action-contract.json",
       "action_ids": [
+        "ria.clients.search_client",
+        "ria.clients.show_around_you",
+        "ria.clients.show_connected",
         "ria.clients.switch_to_nearby",
         "route.ria_clients"
       ],
@@ -6109,6 +6112,7 @@
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
         "ria.picks.open_view_debate",
+        "ria.picks.search_ticker",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -8416,6 +8416,9 @@
       "voice_action_contract_ids": [
         "ria.clients.nearby_shortlist_record",
         "ria.clients.open_client_workspace",
+        "ria.clients.search_client",
+        "ria.clients.show_around_you",
+        "ria.clients.show_connected",
         "ria.clients.switch_to_nearby",
         "route.ria_clients"
       ],
@@ -8737,6 +8740,7 @@
         "ria.picks.open_source_my",
         "ria.picks.open_view_debate",
         "ria.picks.save_package",
+        "ria.picks.search_ticker",
         "ria.picks.start_edit_package",
         "ria.picks.upload_csv_replace_top_picks",
         "route.ria_picks"
@@ -9055,5 +9059,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "2ef0768ebc2426dc0abc74b160663f48fc9d9a8919d6c21390cd4b0407600739"
+  "content_sha256": "92ccac7b0e74e4695dbde641d59883f81e4729a89bd2921261933704ae258fb8"
 }

--- a/hushh-webapp/lib/agent/agent-action-runtime.ts
+++ b/hushh-webapp/lib/agent/agent-action-runtime.ts
@@ -17,6 +17,7 @@ import {
   evaluateKaiActionAvailability,
   getKaiActionById,
 } from "@/lib/voice/kai-action-gateway";
+import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
 import { resolveNavigationJourney } from "@/lib/voice/navigation-journey";
 import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import type { VoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
@@ -587,6 +588,7 @@ export async function executeAgentGatewayAction(
   }
 
   if (action.execution_target.path === "route") {
+    const destination = deriveVoiceRouteScreen(action.execution_target.target);
     input.router.push(action.execution_target.target);
     return buildResult({
       status: "started",
@@ -595,7 +597,8 @@ export async function executeAgentGatewayAction(
       routeBefore: routeBefore.pathname,
       routeAfter: action.execution_target.target,
       screenBefore: routeBefore.screen,
-      resultSummary: `${action.label} opened in Finance.`,
+      screenAfter: destination.screen,
+      resultSummary: `${action.label} opened.`,
       data: {
         target: action.execution_target.target,
         goal_id: action.goal.goal_id,

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -82,6 +82,27 @@ export const GLOBAL_NAV_ACTION_IDS: readonly string[] = [
   "route.consents",
   "route.profile_connected_systems",
 ];
+
+const RIA_ROUTE_NAV_ACTION_IDS: readonly string[] = [
+  "route.ria_profile",
+  "route.ria_clients",
+  "route.ria_picks",
+];
+
+const SCREEN_FAMILY_NAV_ACTION_IDS: Record<string, readonly string[]> = {
+  profile_regulatory: RIA_ROUTE_NAV_ACTION_IDS,
+  ria_clients: RIA_ROUTE_NAV_ACTION_IDS,
+  ria_picks: RIA_ROUTE_NAV_ACTION_IDS,
+};
+
+function isScreenFamilyNavigationAction(
+  screen: string | null,
+  actionId: string,
+): boolean {
+  return Boolean(
+    screen && SCREEN_FAMILY_NAV_ACTION_IDS[screen]?.includes(actionId),
+  );
+}
 export const ARRAY_DIMENSION_CAP_ERROR =
   "CONSTRAINT_VIOLATION_DIMENSION_OVERFLOW";
 export const INVALID_ARRAY_TYPE_ERROR = "INVALID_ARRAY_TYPE";
@@ -587,6 +608,9 @@ function prioritizeAvailableActionIds(
       }
       return 4;
     }
+    if (isScreenFamilyNavigationAction(screen, actionId)) {
+      return action.execution_target.path === "route" ? 0 : 1;
+    }
     if (screen && action.reachability.screens.includes(screen)) {
       // Among the actions this screen owns, the ones that cannot be reached
       // any other way come first, and within those, the ones tied to
@@ -646,7 +670,10 @@ function prioritizeAvailableActionIds(
   ).items;
   if (!includeGlobalNavigation) return screenSegment;
   const combined = [...screenSegment];
-  for (const navId of GLOBAL_NAV_ACTION_IDS) {
+  for (const navId of [
+    ...(screen ? SCREEN_FAMILY_NAV_ACTION_IDS[screen] || [] : []),
+    ...GLOBAL_NAV_ACTION_IDS,
+  ]) {
     if (combined.length >= AVAILABLE_ACTION_IDS_CAP) break;
     if (combined.includes(navId)) continue;
     if (!getKaiActionById(navId)) continue;


### PR DESCRIPTION
## Summary

Adds structured RIA natural-language action coverage to the existing Talk to One / One ADK action pipeline.

Natural-language requests are resolved through the existing generated action gateway and mounted local handlers, not a new client-side planner.

## Initial Capabilities

* RIA Profile navigation
* RIA Clients navigation
* Connected / Around You selection
* connected client search
* RIA Picks navigation
* Top Picks / Avoid selection
* ticker search in Picks
* safe manual-only handling for dynamic client workspace actions
* safe UNKNOWN / unsupported fallback through bounded generated action discovery

## Architecture

Natural language
-> One ADK semantic head
-> `list_app_actions`
-> exact generated `action_id`
-> `run_app_action` / local handler
-> existing authorized UI behavior and browser settlement

## Safety

The model cannot execute arbitrary application operations. RIA actions remain allowlisted in generated contracts, and dynamic or mutating flows remain manual-only or gated by the existing browser/action runtime.

Authentication, authorization, RIA persona gates, client/workspace business rules, and financial/business logic are unchanged.

## Tests

* `uv run pytest -q tests/test_one_adk_agent_tree.py`
* `npm.cmd run typecheck`
* `npm.cmd run verify:voice-gateway`
* `npm.cmd run verify:design-system`
* `npm.cmd run verify:docs`
* `npm.cmd run verify:cache`
* `npx.cmd eslint app/ria/clients/page.tsx app/ria/picks/page.tsx components/app-ui/data-table.tsx __tests__/voice/kai-action-gateway.test.ts --max-warnings=0`
* `npx.cmd vitest run __tests__/voice/kai-action-gateway.test.ts`
* `git diff --check`

## Action Item

Action Item: #5940

Fixes #5940
