### PR TITLE
fix(voice): stop stranding a confirm that needs a tap-only setting

### DIFF
--- a/hushh-webapp/__tests__/lib/agent/confirmation-tap-policy.test.ts
+++ b/hushh-webapp/__tests__/lib/agent/confirmation-tap-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { requiresHardTapConfirmation } from "@/lib/agent/confirmation-tap-policy";
+
+describe("requiresHardTapConfirmation", () => {
+  it("is always true for trusted_activation_required, regardless of the tap setting", () => {
+    const action = {
+      activation_policy: "trusted_activation_required" as const,
+      execution_policy: "confirm_required" as const,
+    };
+    expect(requiresHardTapConfirmation(action, false)).toBe(true);
+    expect(requiresHardTapConfirmation(action, true)).toBe(true);
+  });
+
+  it("is true for confirm_required only when the person turned on require_tap_confirmation", () => {
+    const action = {
+      activation_policy: "none" as const,
+      execution_policy: "confirm_required" as const,
+    };
+    expect(requiresHardTapConfirmation(action, true)).toBe(true);
+    expect(requiresHardTapConfirmation(action, false)).toBe(false);
+  });
+
+  it("is never true for allow_direct, even with the setting on", () => {
+    // The tap preference only ever adds a confirmation to actions the
+    // contract already calls risky -- it must never turn a hands-free action
+    // into one that silently waits for a tap nobody was told to expect.
+    const action = {
+      activation_policy: "none" as const,
+      execution_policy: "allow_direct" as const,
+    };
+    expect(requiresHardTapConfirmation(action, true)).toBe(false);
+    expect(requiresHardTapConfirmation(action, false)).toBe(false);
+  });
+
+  it("is false when there is no pending action at all", () => {
+    expect(requiresHardTapConfirmation(null, true)).toBe(false);
+    expect(requiresHardTapConfirmation(undefined, true)).toBe(false);
+  });
+});

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -49,6 +49,7 @@ import {
 import { AGENT_CONVERSATION_REQUEST_EVENT } from "@/lib/agent/agent-voice-settings";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { validateMorphyAxAssessment } from "@/lib/morphy-ax";
+import { snapKaiBottomChromeVisible } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
 import {
   KAI_MARKET_PATH,
@@ -303,6 +304,15 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const [retryNonce, setRetryNonce] = useState(0);
   const [pendingConfirmation, setPendingConfirmation] =
     useState<PendingVoiceConfirmation | null>(null);
+  // A confirm raised purely from a spoken turn -- no physical tap -- mounts
+  // this dialog wherever the bottom chrome's auto-hide progress currently
+  // sits. Without this, a card raised while the chrome was scrolled away
+  // stayed translated off-screen with nothing bringing it back, the same
+  // defect app-bottom-shell.tsx already prevents for a real tap via
+  // onPointerDownCapture.
+  useEffect(() => {
+    if (pendingConfirmation) snapKaiBottomChromeVisible();
+  }, [pendingConfirmation]);
   // The journey approval lives in module scope, not component state: it has
   // to survive the navigation it exists to span, and a ref does not survive a
   // remount. See lib/voice/journey-approval-grant.ts.
@@ -1932,6 +1942,19 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const pendingConfirmationPlanSteps = pendingConfirmation?.plan?.steps ?? [];
   const pendingActionNeedsTrustedActivation =
     pendingAction?.activation_policy === "trusted_activation_required";
+  // Broader than trusted activation: also true when a confirm_required
+  // action needs a hard tap only because of the person's own
+  // require_tap_confirmation setting (lib/agent/confirmation-tap-policy.ts).
+  // requiresHardTapConfirmation() is the one place that decision is already
+  // made correctly (agent-bar.tsx:1342 uses it to decide whether to keep the
+  // confirmation pending for a tap); without this second check, a card in
+  // that state rendered "say yes to continue" with no Cancel/Authorize
+  // buttons at all -- a real dead end, since a spoken yes never settles it.
+  const pendingActionNeedsHardTap = requiresHardTapConfirmation(
+    pendingAction,
+    runtime?.oneVoiceContextSnapshot.voice_settings.require_tap_confirmation ===
+      true,
+  );
   const pendingActionLabel = pendingAction?.label || "Continue this action";
 
   // The specific reason (mic blocked, no device, setup timeout) now lives in
@@ -2219,9 +2242,11 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
             {pendingActionNeedsTrustedActivation
               ? "This tap opens the provider window and keeps One active here."
-              : pendingConfirmationPlanSteps.length > 1
-                ? "Sensitive values stay hidden. Say yes to run these steps, or no to cancel."
-                : "Sensitive values stay hidden. Say yes to run this, or no to cancel."}
+              : pendingActionNeedsHardTap
+                ? "Sensitive values stay hidden. Tap Authorize to continue, or Cancel."
+                : pendingConfirmationPlanSteps.length > 1
+                  ? "Sensitive values stay hidden. Say yes to run these steps, or no to cancel."
+                  : "Sensitive values stay hidden. Say yes to run this, or no to cancel."}
           </p>
           {/* Every step is named before anything runs, so one approval is a
               list the person can read rather than an open-ended permission. */}
@@ -2249,12 +2274,12 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           ) : null}
           {pendingConfirmation.nudgedAt ? (
             <p className="mt-2 text-[12px] font-medium text-muted-foreground/80">
-              {pendingActionNeedsTrustedActivation
+              {pendingActionNeedsHardTap
                 ? "Still there? Tap the button above or Cancel when you're ready."
                 : "Still there? Say yes to continue or no to cancel."}
             </p>
           ) : null}
-          {pendingActionNeedsTrustedActivation ? (
+          {pendingActionNeedsHardTap ? (
             <div className="mt-4 grid grid-cols-2 gap-2">
               <button
                 type="button"

--- a/hushh-webapp/components/agent/voice-action-card.tsx
+++ b/hushh-webapp/components/agent/voice-action-card.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { User } from "lucide-react";
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 
 import { resolveLocalOnboardingHandler } from "@/lib/agent/local-onboarding-actions";
+import { snapKaiBottomChromeVisible } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import {
   clearVoiceCard,
   readVoiceCard,
@@ -64,6 +65,13 @@ export function VoiceActionCard() {
   const disambiguation = card?.kind === "choice" ? card : null;
   const [runningId, setRunningId] = useState<string | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+
+  // This card is always raised from a spoken turn, never a tap, so it can
+  // arrive while the bottom chrome is scrolled away. See the matching effect
+  // on pendingConfirmation in agent-bar.tsx for the same reasoning.
+  useEffect(() => {
+    if (card) snapKaiBottomChromeVisible();
+  }, [card]);
 
   const choose = useCallback(
     async (candidate: VoiceDisambiguationCandidate) => {


### PR DESCRIPTION
## Summary

Fixes a diagnosed voice bug: a confirmation requiring a hard tap purely because of the person's own "require tap confirmation" Voice setting rendered with no way to tap-confirm it at all.

Root cause: `pendingActionNeedsTrustedActivation` (`agent-bar.tsx:1933-1934`) only checked `activation_policy === "trusted_activation_required"` — the *platform* reason for a hard tap (a provider popup can only open during a fresh gesture). It ignored the *chosen* reason: `confirm_required` + the person's own `require_tap_confirmation` preference. `requiresHardTapConfirmation()` in `confirmation-tap-policy.ts` already makes this exact decision correctly elsewhere in the same file (line ~1342, deciding whether to keep a confirmation pending for a tap rather than settling a spoken yes) — this dialog's button-render gate was the one place still asking the narrower question, so a confirm in that state showed "say yes to continue" with **no Cancel/Authorize buttons rendered at all**. A spoken yes was never going to settle it either (that's the whole point of the setting), so it was a genuine dead end, not just unclear copy.

Fix: split into two checks. `pendingActionNeedsTrustedActivation` stays narrow, still gating the provider-popup-specific copy ("opens the provider window..."). A new `pendingActionNeedsHardTap`, backed by the same already-tested-in-production function, now gates whether the buttons render at all, with its own copy for the tap-required-by-setting case ("Tap Authorize to continue, or Cancel").

Also fixed, found while investigating the same bug report's "confirm doesn't scroll into view" half: neither this dialog nor `VoiceActionCard`'s `choice`/`confirm` cards ever called `snapKaiBottomChromeVisible()` on mount, unlike `app-bottom-shell.tsx`'s own `onPointerDownCapture` handler. A card raised purely from a spoken turn (no physical tap to trigger that handler) could render while the bottom chrome sat auto-hidden from earlier scrolling — translated off-screen with nothing bringing it back. Both surfaces now snap the chrome visible when their card first becomes active.

Addresses #5677

## Test plan

- [x] Added the first test coverage for `requiresHardTapConfirmation()` (`__tests__/lib/agent/confirmation-tap-policy.test.ts`) — it had none despite already being relied on in production
- [x] `eslint` / `tsc --noEmit` clean
- [x] `npx vitest run __tests__/lib/agent/ __tests__/voice/` — 271/271 passing
- [x] Confirmed 3 unrelated pre-existing failures elsewhere (`navbar-agent-trigger.contract.test.ts`, `top-app-bar.contract.test.ts`) are present on clean `main` too, not caused by this change (verified via `git stash`)
