### PR TITLE
feat(voice): give backend-direct actions a visible result on screen

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -395,22 +395,53 @@ async def _run_backend_direct_action(
     except _BackendDirectError as exc:
         record_failed_action(session_id, clean_id, fingerprint, exc.message)
         logger.info("one_adk_action_decision action=%s status=failed reason=%s", clean_id, exc.code)
+        _park_action_result_directive(tool_context, clean_id, status="failed", message=exc.message)
         return {"status": "failed", "message": exc.message}
     except Exception:  # noqa: BLE001 - the model must be told something failed, not why internally
         record_failed_action(session_id, clean_id, fingerprint, "unexpected_error")
         logger.exception(
             "one_adk_action_decision action=%s status=failed reason=unexpected", clean_id
         )
-        return {
-            "status": "failed",
-            "message": f"{label} did not go through. Try again in a moment.",
-        }
+        failure_message = f"{label} did not go through. Try again in a moment."
+        _park_action_result_directive(
+            tool_context, clean_id, status="failed", message=failure_message
+        )
+        return {"status": "failed", "message": failure_message}
 
     record_completed_action(session_id, clean_id, fingerprint)
     logger.info("one_adk_action_decision action=%s status=completed backend_direct=true", clean_id)
+    _park_action_result_directive(
+        tool_context, clean_id, status="completed", message=result_message
+    )
     return {
         "status": "completed",
         "message": result_message,
+    }
+
+
+def _park_action_result_directive(
+    tool_context: ToolContext,
+    action_id: str,
+    *,
+    status: Literal["completed", "failed"],
+    message: str,
+) -> None:
+    """Give a backend-direct mutation the same on-screen visibility any other
+    action already gets, without a browser round trip.
+
+    A BACKEND_DIRECT_ACTION_IDS mutation already knows its true outcome by
+    the time this runs -- there is nothing for the browser to execute or
+    settle back, unlike a `kind: "action"` directive. This rides the exact
+    same turn-boundary `hussh:pending_directive` -> `clientDirective`
+    delivery every other directive already uses (adk_live.py), just a kind
+    the browser renders as an already-terminal step instead of dispatching
+    to a local handler. adk_live.py's settlement-tracking/GC bookkeeping
+    must treat this kind as never awaiting a settlement -- there is nothing
+    for the browser to report back.
+    """
+    tool_context.state[f"{_STATE_PENDING_DIRECTIVE}:{action_id}:result"] = {
+        "kind": "action_result",
+        "payload": {"actionId": action_id, "status": status, "message": message},
     }
 
 

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -1104,7 +1104,10 @@ def test_every_backend_direct_action_id_still_exists_in_the_action_gateway() -> 
 class TestBackendDirectCircleActions:
     """location.leave_circle / location.delete_circle bypass the client
     directive entirely and mutate through OneLocationCircleService directly.
-    No client_directive should ever be parked for these two."""
+    The only directive parked for either is the terminal action_result kind
+    (see _park_action_result_directive) -- there is no client_directive
+    asking the browser to execute anything, since the mutation already
+    happened here."""
 
     def _authorized_state(self) -> dict:
         return {STATE_USER_ID: "user_1", STATE_CONSENT_TOKEN: "token_1"}
@@ -1113,7 +1116,7 @@ class TestBackendDirectCircleActions:
         return (True, None, SimpleNamespace(user_id=user_id))
 
     @pytest.mark.asyncio
-    async def test_leave_circle_executes_directly_and_parks_nothing(self):
+    async def test_leave_circle_executes_directly_and_parks_only_the_result(self):
         state = self._authorized_state()
         with (
             patch(
@@ -1137,7 +1140,18 @@ class TestBackendDirectCircleActions:
         # positional arg -- assert on the keyword args a real caller used.
         leave_mock.assert_called_once()
         assert leave_mock.call_args.kwargs == {"user_id": "user_1", "circle_id": "c1"}
-        assert not any(k.startswith(f"{_STATE_PENDING_DIRECTIVE}:") for k in state)
+        # No {kind: "action"} directive asking the browser to execute
+        # anything -- only the terminal result, so it never enters the
+        # issue()/settlement/GC machinery a real "action" directive would.
+        directive_keys = [k for k in state if k.startswith(f"{_STATE_PENDING_DIRECTIVE}:")]
+        assert directive_keys == [f"{_STATE_PENDING_DIRECTIVE}:location.leave_circle:result"]
+        parked = state[directive_keys[0]]
+        assert parked["kind"] == "action_result"
+        assert parked["payload"] == {
+            "actionId": "location.leave_circle",
+            "status": "completed",
+            "message": result["message"],
+        }
 
     @pytest.mark.asyncio
     async def test_delete_circle_executes_directly(self):
@@ -1269,6 +1283,10 @@ class TestBackendDirectCircleActions:
         ):
             first = await run_app_action("location.leave_circle", {"circle": "family"}, ctx)
             assert first["status"] == "failed"
+            parked = state[f"{_STATE_PENDING_DIRECTIVE}:location.leave_circle:result"]
+            assert parked["kind"] == "action_result"
+            assert parked["payload"]["status"] == "failed"
+            assert parked["payload"]["actionId"] == "location.leave_circle"
             second = await run_app_action("location.leave_circle", {"circle": "family"}, ctx)
         assert second["status"] == "already_failed"
 

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5107,7 +5107,7 @@
     "cache_manifest": "4de3513e5a3f846d1f2ec45e92a62d67c8ca716908cecb67ca0dc796d21b0d4f",
     "data_plane": "ea69e0d26bd9bdd7ad525a3bceb7561902f26d23addc5757a8a90dd78cfe15fc",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "6423d3f0d3d0f1c505dad1a013456f456ccb938823f799fc36c313cfbb49f5ec",
+    "one_specialist_tools": "9ad859a204ac90df2ce37b856c5206e0e1e0cf36c3521f26a4ef4f18ee8f9227",
     "route_index": "b66b81a4399465e4a9220e22cfa379991e76db2538173496f8acf7d1beb99c2a",
     "route_layout": "9fdf440b9c771314317abcf6ac1d22d01fe25b8792860a0cb087bb933edf80b9",
     "surface_map": "050728616159d81320bcf3ae60d38b26b6523e3ed4c560932ed8cdbc8afbfe1b",

--- a/hushh-webapp/__tests__/lib/interaction-intent-coordinator.test.ts
+++ b/hushh-webapp/__tests__/lib/interaction-intent-coordinator.test.ts
@@ -207,6 +207,59 @@ describe("InteractionIntentCoordinator", () => {
     expect(withoutGoal.goalId).toBeNull();
   });
 
+  it("renders a backend-direct action_result directive as an already-terminal run", () => {
+    // Mirrors exactly what agent-bar.tsx's `kind === "action_result"` branch
+    // does: no directiveId (nothing to settle), start then immediately move
+    // to the terminal phase the backend already computed.
+    const coordinator = new InteractionIntentCoordinator();
+    const run = coordinator.startActionRun({
+      actionId: "connect.remove_connection",
+      label: "Remove connection",
+      source: "voice",
+      message: "Removed Roopmann. They can no longer be picked for location sharing.",
+    });
+    expect(run.directiveId).toBeNull();
+    expect(run.phase).toBe("acknowledged");
+
+    const updated = coordinator.updateActionRun(run.id, {
+      phase: "completed",
+      message: "Removed Roopmann. They can no longer be picked for location sharing.",
+    });
+
+    expect(updated).toMatchObject({
+      id: run.id,
+      phase: "completed",
+      message: "Removed Roopmann. They can no longer be picked for location sharing.",
+    });
+    expect(updated?.completedAtMs).not.toBeNull();
+    // No active run left to show a spinner for -- it settled immediately,
+    // same as any other terminal run.
+    expect(coordinator.getActiveActionRun()).toBeNull();
+    // But it stays in the rolling snapshot VoiceWalkthroughPanel reads, so
+    // the person still sees what happened, not a card that vanished.
+    expect(coordinator.getActionRunsSnapshot()).toContainEqual(
+      expect.objectContaining({ id: run.id, phase: "completed" }),
+    );
+  });
+
+  it("renders a failed action_result the same way, with the failure message visible", () => {
+    const coordinator = new InteractionIntentCoordinator();
+    const run = coordinator.startActionRun({
+      actionId: "location.approve_request",
+      label: "Approve request",
+      source: "voice",
+      message: "That request is no longer pending.",
+    });
+
+    const updated = coordinator.updateActionRun(run.id, {
+      phase: "failed",
+      message: "That request is no longer pending.",
+    });
+
+    expect(updated?.phase).toBe("failed");
+    expect(updated?.message).toBe("That request is no longer pending.");
+  });
+
   it("cancels non-terminal interaction work on background without owning vault state", () => {
     const coordinator = new InteractionIntentCoordinator();
     const cancelNavigation = vi.fn();

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -690,6 +690,40 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           console.warn("[AgentBar] Rejected legacy direct navigation directive.");
           return;
         }
+        if (event.directive.kind === "action_result") {
+          // Backend-direct: the mutation already ran server-side before this
+          // arrived (_park_action_result_directive in action_tools.py), so
+          // there is nothing to execute and nothing to settle back -- unlike
+          // a `kind: "action"` directive, this only needs to become visible.
+          // No directiveId/contextRevision binding either, for the same
+          // reason: there is no settlement round trip to bind one to.
+          const actionId =
+            typeof event.directive.payload?.actionId === "string"
+              ? event.directive.payload.actionId
+              : null;
+          const message =
+            typeof event.directive.payload?.message === "string"
+              ? event.directive.payload.message
+              : null;
+          if (!actionId || !message) {
+            console.warn("[AgentBar] Rejected malformed action_result directive.");
+            return;
+          }
+          const resultPhase =
+            event.directive.payload?.status === "failed" ? "failed" : "completed";
+          const action = getKaiActionById(actionId);
+          const run = appInteractionCoordinator.startActionRun({
+            actionId,
+            label: action?.label ?? actionId,
+            source: "voice",
+            message,
+          });
+          appInteractionCoordinator.updateActionRun(run.id, {
+            phase: resultPhase,
+            message,
+          });
+          return;
+        }
         if (event.directive.kind === "action") {
           const actionId =
             typeof event.directive.payload?.actionId === "string"


### PR DESCRIPTION
## Summary

Stacked on #5941 (backend-direct reads). PR-2 of the backend-direct initiative: the 10 backend-direct mutations (#5934) mutate correctly but leave nothing on screen — their outcome reaches only the model, as a tool result, never the browser.

Investigated whether a genuine mid-flight push channel exists on the voice WebSocket to build a real multi-phase progress card on: **it doesn't**. Every `clientDirective` is one-shot, correlated to a model turn boundary (park → issue → forward → browser executes → settle); the only backend-initiated async push anywhere in the codebase (`sse.py`'s consent-notification channel) is unrelated infrastructure, never wired into this socket. Building one would be a large, separate effort — and unnecessary right now: all 10 current backend-direct actions complete in a single synchronous DB call, so there's no real in-progress phase to show yet. That belongs to share/request location (not touched here).

What's actually missing is smaller: **the outcome the backend already computed never becomes a visible UI event.** `_run_backend_direct_action` now parks a new `action_result` directive kind on both the completed and failed paths, riding the *exact same* `hussh:pending_directive` → `clientDirective` delivery every other directive already uses — no new WebSocket message type, no new push channel.

Confirmed `adk_live.py` needs **zero changes**: its `issue()`/settlement/GC bookkeeping (the `directives_to_issue` loop) is already scoped to `directive.get("kind") == "action"` specifically. Any other kind — which today already includes the specialist `select`/`confirm`/`navigate` directives — flows straight through as an opaque forward with no settlement tracking. That property already existed; `action_result` is just a new value landing in the same already-correct branch.

`agent-bar.tsx` gets one new branch for `kind === "action_result"`: no `directiveId`/`contextRevision` binding (nothing to settle), just an already-terminal `ActionRun` via the existing start-then-immediately-update-to-terminal sequence, rendered by `VoiceWalkthroughPanel` exactly like any other step — no changes needed there, it was already just re-rendering off a mutable external store.

Addresses #5677

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pytest tests/test_one_adk_agent_tree.py tests/test_one_adk_live_protocol.py` — 187/187 passing, including updated/new assertions on the parked `action_result` directive's exact shape for both the completed (`leave_circle`) and failed (service-exception) paths
- [x] `tsc --noEmit` / `eslint` clean
- [x] New coordinator-level tests (`interaction-intent-coordinator.test.ts`) proving the exact start→terminal-update sequence the new branch performs produces a correctly-shaped, already-terminal run that still surfaces in the rolling snapshot `VoiceWalkthroughPanel` reads
- [x] `npx vitest run __tests__/lib/ __tests__/voice/` — 852/852 passing
- [x] Governed artifact regenerated: `runtime-topology-index.v1.json`
