### PR TITLE
fix(location): ensure personal circles render above SMS Circle in Share flow

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -4087,7 +4087,9 @@ function ShareFlow({
           separatorInset
           className="[&>div:first-child]:mt-0"
         >
-          {shareableCircles.map((circle) => {
+          {[...shareableCircles]
+            .sort((a, b) => (a.name === "SMS Circle" ? 1 : b.name === "SMS Circle" ? -1 : 0))
+            .map((circle) => {
             const selected =
               vm.selectedShareCircleSelection?.circle.id === circle.id &&
               shareCircleFullySelected;


### PR DESCRIPTION

#### Summary of Changes

* **Circle Order Alignment:** Updated the circle selection list in `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (the "Who can see you?" / Share Location subview) to sort personal circles to the top.
* **UAT Parity:** Ensured the user's personal circles appear first while system/emergency groups (`SMS Circle`) stay at the bottom, matching the exact hierarchy used in the People tab and UAT.
* **Non-Destructive:** Retained existing selection state logic, click handlers, accessibility labels, and voice control identifiers without modifying underlying data structures.

---

#### Verification & Testing

* [x] **Unit & Contract Tests:** Ran `npx vitest run one-location` from `hushh-webapp` (all tests passing).
* [x] **Simulator Visual Check:** Verified in the iOS Simulator (iPhone 17 Pro) that personal circles render at the top when entering the **Share location** flow.
* [x] **Parity Check:** Matched visual hierarchy against `[https://uat.one.hushh.ai/one](https://uat.one.hushh.ai/one)`.

---

#### Checklist

* [x] Commit is signed off (`-s` / DCO compliant).
* [x] Branch is rebased and up to date with latest `origin/main`.
* [x] No unintended styling, logic, or bundle changes.