### PR TITLE
fix(referrals): stop referral counters from capping at 50

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_referral_service.py
+++ b/consent-protocol/hushh_mcp/services/one_referral_service.py
@@ -213,6 +213,17 @@ def get_referral_summary(user_id: str) -> dict:
     required_minutes = policy.required_active_seconds // 60
 
     with get_db_connection() as connection:
+        all_statuses = connection.execute(
+            text(
+                """
+                SELECT r.status
+                  FROM one_referral_relationships r
+                 WHERE r.referrer_user_id = :uid
+                """
+            ),
+            {"uid": user_id},
+        ).fetchall()
+
         rows = connection.execute(
             text(
                 """
@@ -237,9 +248,12 @@ def get_referral_summary(user_id: str) -> dict:
             {"uid": user_id},
         ).fetchall()
 
-    qualified = sum(1 for row in rows if row.status == QUALIFIED)
-    in_progress = sum(1 for row in rows if public_status(row.status) == "In progress")
-    under_review = sum(1 for row in rows if public_status(row.status) == "Under review")
+    # Counts must cover every referral relationship, not just the 50 shown in
+    # the Recent list below — a referrer with 63 referrals still sees 63
+    # counted, even though only 50 render as rows.
+    qualified = sum(1 for row in all_statuses if row.status == QUALIFIED)
+    in_progress = sum(1 for row in all_statuses if public_status(row.status) == "In progress")
+    under_review = sum(1 for row in all_statuses if public_status(row.status) == "Under review")
 
     referrals = []
     for row in rows:

--- a/consent-protocol/tests/services/test_one_referral_service_summary.py
+++ b/consent-protocol/tests/services/test_one_referral_service_summary.py
@@ -1,0 +1,133 @@
+"""Regression coverage for the referral counter 50-row cap.
+
+`get_referral_summary()` used to compute `qualified_count`, `in_progress_count`
+and `under_review_count` from the same 50-row window that backs the Recent
+list. A referrer with more than 50 referral relationships saw counters that
+silently stopped climbing at 50, even though the underlying relationships kept
+growing. These tests pin the fix: the counters must reflect every relationship
+the referrer owns, while the Recent list stays bounded at 50.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hushh_mcp.services import one_referral_service
+
+USER_ID = "user_referrer_123"
+NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+def _policy_row():
+    return SimpleNamespace(
+        version=1,
+        program_enabled=True,
+        new_users_only=True,
+        attribution_window_days=30,
+        qualification_window_days=7,
+        required_active_seconds=900,
+        minimum_meaningful_events=3,
+        eligible_agent_keys=(),
+        heartbeat_interval_seconds=30,
+        max_credit_per_heartbeat_secs=30,
+        recent_interaction_window_secs=60,
+        max_reporting_gap_seconds=90,
+    )
+
+
+def _code_row():
+    return SimpleNamespace(slug="ada-1234", normalized_slug="ada-1234", created_at=NOW)
+
+
+def _relationship_row(status: str):
+    return SimpleNamespace(
+        status=status,
+        created_at=NOW,
+        qualified_at=None,
+        credited_seconds=0,
+        meaningful_events=0,
+    )
+
+
+def _conn_with_relationships(all_statuses: list[str]):
+    """A fake connection whose responses depend on which query is issued.
+
+    The counting query and the detail query both select from
+    `one_referral_relationships`, so they are told apart by whether the SQL
+    text carries the LATERAL join that only the detail query uses.
+    """
+    all_rows = [SimpleNamespace(status=s) for s in all_statuses]
+    detail_rows = [_relationship_row(s) for s in all_statuses[:50]]
+
+    def execute(query, params=None):
+        sql = str(query)
+        if "one_referral_policies" in sql:
+            return _Result([_policy_row()])
+        if "one_referral_codes" in sql:
+            return _Result([_code_row()])
+        if "one_referral_relationships" in sql:
+            if "LATERAL" in sql:
+                return _Result(detail_rows)
+            return _Result(all_rows)
+        raise AssertionError(f"unexpected query: {sql}")
+
+    conn = MagicMock()
+    conn.execute.side_effect = execute
+    return conn
+
+
+@contextmanager
+def _db(conn):
+    yield conn
+
+
+def test_counters_are_not_capped_at_the_fifty_row_recent_limit():
+    # 63 total referrals: 60 in progress (an "In progress" status), 3 qualified.
+    statuses = ["qualified"] * 3 + ["attributed"] * 60
+    conn = _conn_with_relationships(statuses)
+
+    with patch.object(one_referral_service, "get_db_connection", side_effect=lambda: _db(conn)):
+        summary = one_referral_service.get_referral_summary(USER_ID)
+
+    assert summary["in_progress_count"] == 60
+    assert summary["qualified_count"] == 3
+    assert len(summary["referrals"]) == 50
+
+
+def test_under_review_count_is_not_capped_either():
+    statuses = ["under_review"] * 55 + ["qualified"] * 2
+    conn = _conn_with_relationships(statuses)
+
+    with patch.object(one_referral_service, "get_db_connection", side_effect=lambda: _db(conn)):
+        summary = one_referral_service.get_referral_summary(USER_ID)
+
+    assert summary["under_review_count"] == 55
+    assert summary["qualified_count"] == 2
+    assert len(summary["referrals"]) == 50
+
+
+def test_counts_and_recent_list_agree_when_under_the_cap():
+    statuses = ["qualified", "attributed", "under_review"]
+    conn = _conn_with_relationships(statuses)
+
+    with patch.object(one_referral_service, "get_db_connection", side_effect=lambda: _db(conn)):
+        summary = one_referral_service.get_referral_summary(USER_ID)
+
+    assert summary["qualified_count"] == 1
+    assert summary["in_progress_count"] == 1
+    assert summary["under_review_count"] == 1
+    assert len(summary["referrals"]) == 3


### PR DESCRIPTION
## Summary
- `get_referral_summary()` computed `qualified_count` / `in_progress_count` / `under_review_count` from the same 50-row `LIMIT` used for the Recent referral list, so counters silently stopped climbing at 50 even when the referrer had more relationships.
- Split the query: a lightweight status-only query now covers every `one_referral_relationships` row for the referrer to compute counts; the existing `ORDER BY r.created_at DESC LIMIT 50` detail query still backs the Recent list unchanged.
- No change to attribution, eligibility, qualification, engagement, privacy rules, `public_status()` mapping, or the API response shape.

Fixes #5956

## Test plan
- [x] Added `tests/services/test_one_referral_service_summary.py` covering the issue's exact scenario (63 total referrals, 60 in progress, 3 qualified) asserting `in_progress_count == 60`, `qualified_count == 3`, `len(referrals) == 50`, plus an `under_review_count` case and a below-cap parity case.
- [x] `pytest -k referral` — 92 passed, no regressions.
- [x] `mypy hushh_mcp/services/one_referral_service.py` — no issues.
- [x] Verified live: ran the real `get_referral_summary()` behind the real FastAPI route (auth dependency overridden, DB layer replaced with the same 63-referral fixture) and hit `GET /api/one/referrals/summary` — response confirmed `qualified_count: 3, in_progress_count: 60, under_review_count: 0, referrals: 50 rows`.