### PR TITLE
fix(voice): make mypy actually check the two services action_tools.py calls directly

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -1081,6 +1081,8 @@ async def list_my_location_shares(tool_context: ToolContext) -> dict[str, Any]:
     user_id, blocked = await _read_tool_user_id(tool_context)
     if blocked is not None:
         return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     shares = OneLocationAgentService().list_active_owner_grants(owner_user_id=user_id)
     return {"status": "ok", "shares": shares}
 
@@ -1090,6 +1092,8 @@ async def list_location_shared_with_me(tool_context: ToolContext) -> dict[str, A
     user_id, blocked = await _read_tool_user_id(tool_context)
     if blocked is not None:
         return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     shares = OneLocationAgentService().list_active_recipient_grants(recipient_user_id=user_id)
     return {"status": "ok", "shares": shares}
 
@@ -1099,6 +1103,8 @@ async def list_pending_location_requests(tool_context: ToolContext) -> dict[str,
     user_id, blocked = await _read_tool_user_id(tool_context)
     if blocked is not None:
         return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     requests = OneLocationAgentService().list_pending_owner_requests(owner_user_id=user_id)
     return {"status": "ok", "requests": requests}
 
@@ -1108,6 +1114,8 @@ async def list_my_connections(tool_context: ToolContext) -> dict[str, Any]:
     user_id, blocked = await _read_tool_user_id(tool_context)
     if blocked is not None:
         return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     connections = ConnectionsService().list_connections(user_id=user_id)
     return {"status": "ok", "connections": connections}
 
@@ -1121,6 +1129,8 @@ async def list_pending_connection_requests(
     user_id, blocked = await _read_tool_user_id(tool_context)
     if blocked is not None:
         return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     requests = ConnectionsService().list_requests(user_id=user_id, direction=direction)
     return {"status": "ok", "requests": requests}
 

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -12,7 +12,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 from uuid import UUID
 
 from sqlalchemy import text
@@ -37,6 +37,17 @@ from hushh_mcp.types import AgentID, UserID
 from mcp_modules.log_redaction import redact_log_field, redact_log_value
 
 logger = logging.getLogger(__name__)
+
+# hushh_mcp.operons.* is still quarantined from mypy (follow_imports=skip),
+# so UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE erases to Any on import, and
+# any `x == UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE` comparison then
+# infers as Any too -- silently defeating the bool return type of every
+# function that returns one directly. A same-name `cast()` reassignment
+# does NOT fix this: mypy joins a module global's type across every static
+# binding of that name in the file, so the import's Any keeps winning at
+# every OTHER function's usage site even after a local reassignment. A
+# distinct name sidesteps that join entirely.
+_UNTIL_STOPPED_DURATION_MODE: str = cast(str, UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE)
 
 # Capability scope minted into the per-grant HCT consent token. Live-location
 # viewing is the authority the recipient device exercises when reading
@@ -615,7 +626,10 @@ def _identity_notification_label(
     # email rung. Same ladder, one read instead of two.
     from hushh_mcp.services.requester_identity import label_from_identity_row
 
-    return label_from_identity_row(row, fallback=fallback)
+    # requester_identity is itself still quarantined from mypy
+    # (hushh_mcp.services.* follow_imports=skip), so its otherwise-correct
+    # `-> str` return erases to Any here even though the value is real.
+    return cast(str, label_from_identity_row(row, fallback=fallback))
 
 
 def _notification_safe_data(data: dict[str, Any]) -> dict[str, Any]:
@@ -722,7 +736,7 @@ def _classify_share_kind(reason: str | None) -> str:
 
 
 def _is_until_stopped_share(duration_mode: str | None) -> bool:
-    return duration_mode == UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE
+    return duration_mode == _UNTIL_STOPPED_DURATION_MODE
 
 
 def _resolve_share_duration(
@@ -811,7 +825,9 @@ def _remaining_label(expires_at: Any, *, now: datetime | None = None) -> str:
     remaining = (parsed - (now or _utcnow())).total_seconds()
     if remaining <= 0:
         return ""
-    return format_duration_label(remaining / 3600.0)
+    # format_duration_label lives in the still-quarantined operons.location
+    # module, so its real `-> str` return erases to Any without this cast.
+    return cast(str, format_duration_label(remaining / 3600.0))
 
 
 def _access_ask_summary(
@@ -876,7 +892,7 @@ def _share_duration_change_direction(
 def _grant_expires_at_is_past(row: dict[str, Any]) -> bool:
     expires_at_raw = row.get("expires_at")
     if expires_at_raw is None:
-        return str(row.get("duration_mode") or "") != UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE
+        return str(row.get("duration_mode") or "") != _UNTIL_STOPPED_DURATION_MODE
     expires_at = _parse_datetime(expires_at_raw, field_name="expires_at")
     return expires_at <= _utcnow()
 
@@ -884,7 +900,7 @@ def _grant_expires_at_is_past(row: dict[str, Any]) -> bool:
 def _payload_expires_at_is_past(grant: dict[str, Any]) -> bool:
     expires_at_raw = grant.get("expiresAt")
     if not expires_at_raw:
-        return str(grant.get("durationMode") or "") != UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE
+        return str(grant.get("durationMode") or "") != _UNTIL_STOPPED_DURATION_MODE
     expires_at = _parse_datetime(expires_at_raw, field_name="expiresAt")
     return expires_at <= _utcnow()
 
@@ -1489,10 +1505,16 @@ class OneLocationAgentService:
 
         if not owner_user_id:
             return ""
-        return label_from_identity_row(
-            self._identity_row(owner_user_id),
-            allow_email_handle=False,
-            fallback="",
+        # See _identity_notification_label: requester_identity is still
+        # quarantined from mypy, so its real `-> str` return erases to Any
+        # without this cast.
+        return cast(
+            str,
+            label_from_identity_row(
+                self._identity_row(owner_user_id),
+                allow_email_handle=False,
+                fallback="",
+            ),
         )
 
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:
@@ -2477,7 +2499,9 @@ class OneLocationAgentService:
             "capabilityScopes": _loads_json(row.get("capability_scopes")) or [],
             "durationMode": duration_mode,
             "durationHours": (
-                float(row.get("duration_hours")) if row.get("duration_hours") is not None else None
+                float(duration_hours_raw)
+                if (duration_hours_raw := row.get("duration_hours")) is not None
+                else None
             ),
             "expiresAt": _iso(row.get("expires_at")),
             "createdAt": _iso(row.get("created_at")),
@@ -3786,11 +3810,14 @@ class OneLocationAgentService:
         # Privacy gate: a user who turned marketplace visibility OFF
         # (marketplace_public_profiles.is_discoverable = FALSE) disappears from
         # the directory too, UNLESS the owner has an explicit trusted edge.
-        return self.search_directory_candidates(
-            owner_user_id=owner_user_id,
-            page=1,
-            limit=limit,
-        )["items"]
+        return cast(
+            "list[dict[str, Any]]",
+            self.search_directory_candidates(
+                owner_user_id=owner_user_id,
+                page=1,
+                limit=limit,
+            )["items"],
+        )
 
     def search_directory_candidates(
         self,
@@ -5025,6 +5052,7 @@ class OneLocationAgentService:
             "recipient_display_name": recipient.get("display_name"),
             "recipient_phone_number": recipient.get("phone_number"),
         }
+        row: dict[str, Any] | None
         if enforce_connection:
             row = self._create_enforced_grant_row(
                 owner_user_id=owner_user_id,
@@ -5079,8 +5107,15 @@ class OneLocationAgentService:
                 """,
                 grant_params,
             )
-        grant = self._grant_payload(row)
-        if not grant:
+        # Named distinctly from the early-return `grant` above: that one is
+        # this same function's own recursive result once the writer guard is
+        # held, this one is the row this call itself just wrote. Both are
+        # real dict[str, Any] payloads -- reusing one name across the two
+        # would make mypy infer the type from whichever assignment it sees
+        # first and flag the other as incompatible (the same class of issue
+        # UNTIL_STOPPED_LOCATION_SHARE_DURATION_MODE's join hit above).
+        created_grant = self._grant_payload(row)
+        if not created_grant:
             raise OneLocationAgentError(
                 "LOCATION_GRANT_CREATE_FAILED",
                 "Could not create the location share.",
@@ -5092,7 +5127,7 @@ class OneLocationAgentService:
                 owner_user_id=owner_user_id,
                 actor_user_id=owner_user_id,
                 recipient_user_id=recipient_user_id,
-                grant_id=grant["id"],
+                grant_id=created_grant["id"],
                 event_type="location_share_created",
                 metadata={
                     "duration_hours": _duration_metadata_value(duration),
@@ -5113,14 +5148,14 @@ class OneLocationAgentService:
         # stored so a recipient is never told a location is available too early.
         if not _key_writer_guarded and reason != "request_approved" and resolved_kind != "sos":
             self._send_location_share_created_notification(
-                grant=grant,
+                grant=created_grant,
                 owner_user_id=owner_user_id,
                 recipient_user_id=recipient_user_id,
                 duration=_duration_metadata_value(duration),
                 reason=reason,
                 resolved_kind=resolved_kind,
             )
-        return grant
+        return created_grant
 
     def create_grant_with_initial_envelope(
         self,
@@ -5795,8 +5830,14 @@ class OneLocationAgentService:
                 **envelope_fields,
             },
         )
-        envelope_payload = self._envelope_payload(row)
-        if not envelope_payload:
+        # Named distinctly from the early-return `envelope_payload` above:
+        # that one is this same function's own recursive result once the
+        # writer guard is held, this one is the row this call itself just
+        # wrote. Reusing one name across the two would make mypy infer the
+        # type from whichever assignment it sees first and flag the other as
+        # incompatible (see create_grant's grant/created_grant above).
+        stored_envelope = self._envelope_payload(row)
+        if not stored_envelope:
             raise OneLocationAgentError(
                 "LOCATION_ENVELOPE_STORE_FAILED",
                 "Could not store the encrypted envelope.",
@@ -5808,17 +5849,17 @@ class OneLocationAgentService:
             SET latest_envelope_id = CAST(:envelope_id AS UUID), updated_at = NOW()
             WHERE id = CAST(:grant_id AS UUID)
             """,
-            {"grant_id": grant_id, "envelope_id": envelope_payload["id"]},
+            {"grant_id": grant_id, "envelope_id": stored_envelope["id"]},
         )
         self._insert_event(
             owner_user_id=owner_user_id,
             actor_user_id=owner_user_id,
-            recipient_user_id=envelope_payload["recipientUserId"],
+            recipient_user_id=stored_envelope["recipientUserId"],
             grant_id=grant_id,
-            envelope_id=envelope_payload["id"],
+            envelope_id=stored_envelope["id"],
             event_type="location_envelope_updated",
             metadata={
-                "source_platform": envelope_payload["sourcePlatform"],
+                "source_platform": stored_envelope["sourcePlatform"],
                 "recipient_key_id": recipient_key_id,
             },
         )
@@ -5831,7 +5872,7 @@ class OneLocationAgentService:
                 "grant": self._grant_payload(
                     {
                         **grant_row,
-                        "latest_envelope_id": envelope_payload["id"],
+                        "latest_envelope_id": stored_envelope["id"],
                     }
                 )
                 or {"id": grant_id, "expiresAt": _iso(grant_row.get("expires_at"))},
@@ -5844,15 +5885,15 @@ class OneLocationAgentService:
             if _key_writer_guarded:
                 # Deferred: the caller sends it after the write commits and
                 # records the outcome there.
-                envelope_payload["_post_commit_notification"] = notification_args
+                stored_envelope["_post_commit_notification"] = notification_args
             else:
                 # Direct route path (POST .../envelopes), which is the one
                 # runSosPanic drives. Record reachability so the sender can be
                 # told which contacts the alert actually reached.
-                envelope_payload["recipientAlerted"] = (
+                stored_envelope["recipientAlerted"] = (
                     self._send_location_share_created_notification(**notification_args)
                 )
-        return envelope_payload
+        return stored_envelope
 
     def view_latest_envelope(
         self, *, recipient_user_id: str, grant_id: str, allow_empty: bool = False
@@ -7760,8 +7801,8 @@ class OneLocationAgentService:
                 "share_kind": revoked_share_kind or "standard",
             },
         )
-        notification_user_id = (
-            recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
+        notification_user_id = str(
+            (recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")) or ""
         )
         self._send_metadata_notification(
             user_id=notification_user_id,
@@ -7904,8 +7945,8 @@ class OneLocationAgentService:
                 "counterpart_label": recipient_label,
             },
         )
-        notification_user_id = (
-            recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
+        notification_user_id = str(
+            (recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")) or ""
         )
         self._send_metadata_notification(
             user_id=notification_user_id,
@@ -8397,12 +8438,18 @@ class OneLocationAgentService:
                 "Refresh and review this request.",
                 status_code=422,
             )
-        if automatic and int(auto_approve_rule_version) < 1:
-            raise OneLocationAgentError(
-                "LOCATION_AUTO_APPROVE_RULE_INVALID",
-                "Auto-approve is unavailable. Review this request.",
-                status_code=422,
-            )
+        if automatic:
+            # The `automatic and ... is None` raise above already guarantees
+            # this; mypy can't chain that proof across two separate
+            # if-statements without narrowing the value directly.
+            if auto_approve_rule_version is None:
+                raise AssertionError("automatic approval reached with no rule version")
+            if int(auto_approve_rule_version) < 1:
+                raise OneLocationAgentError(
+                    "LOCATION_AUTO_APPROVE_RULE_INVALID",
+                    "Auto-approve is unavailable. Review this request.",
+                    status_code=422,
+                )
         if automatic and (duration_hours is not None or duration_mode is not None):
             raise OneLocationAgentError(
                 "LOCATION_AUTO_APPROVE_DURATION_OVERRIDE_INVALID",
@@ -8463,6 +8510,11 @@ class OneLocationAgentService:
             automatic_circle_id: str | None = None
             automatic_enabled_at: datetime | None = None
             if automatic:
+                # See the `automatic and ... is None` raise earlier in this
+                # function -- same invariant, re-checked because it doesn't
+                # carry across this closure's own `if automatic:` scope.
+                if auto_approve_rule_version is None:
+                    raise AssertionError("automatic approval reached with no rule version")
                 automatic_preference = self._lock_current_auto_approve_preference(
                     user_id=owner_user_id,
                     expected_rule_version=int(auto_approve_rule_version),
@@ -8590,7 +8642,9 @@ class OneLocationAgentService:
                 request_id=request_id,
                 event_type="location_access_approved",
                 metadata={
-                    "duration_hours": granted_hours,
+                    # data is an FCM payload (str values only) -- stringify the
+                    # float duration rather than pass it through raw.
+                    "duration_hours": str(granted_hours) if granted_hours is not None else None,
                     "duration_mode": granted_mode,
                     "counterpart_label": requester_label,
                     "owner_label": owner_label,
@@ -8639,7 +8693,9 @@ class OneLocationAgentService:
                 "grant_id": grant["id"],
                 "owner_user_id": owner_user_id,
                 "owner_display_label": owner_label,
-                "duration_hours": granted_hours,
+                # data is an FCM payload (str values only) -- stringify the
+                # float duration rather than pass it through raw.
+                "duration_hours": str(granted_hours) if granted_hours is not None else None,
                 "duration_mode": granted_mode,
                 "expires_at": grant.get("expiresAt"),
                 "is_extension": "true" if was_extension else None,
@@ -8710,7 +8766,9 @@ class OneLocationAgentService:
                 "request_id": request_id,
                 "owner_user_id": owner_user_id,
                 "owner_display_label": owner_label,
-                "requested_duration_hours": denied_hours,
+                # data is an FCM payload (str values only) -- stringify the
+                # float duration rather than pass it through raw.
+                "requested_duration_hours": str(denied_hours) if denied_hours is not None else None,
                 "requested_duration_mode": denied_mode,
                 "is_extension": "true" if was_extension else None,
             },

--- a/consent-protocol/pyproject.toml
+++ b/consent-protocol/pyproject.toml
@@ -177,6 +177,21 @@ module = [
 ]
 follow_imports = "skip"
 
+# hushh_mcp/one_adk/action_tools.py calls these two services' methods
+# directly (backend-direct voice actions bypassing the @hushh_tool layer,
+# e.g. create_grant, request_access, list_verified_recipients,
+# search_directory, create_request), so a signature change there is a real,
+# silent break for action_tools.py -- not just debt local to the service.
+# More specific overrides win over the hushh_mcp.services.* wildcard above,
+# so this un-skips exactly these two modules as import dependencies without
+# adding them to `files` as scan targets or touching the wildcard itself.
+[[tool.mypy.overrides]]
+module = [
+    "hushh_mcp.services.one_location_agent_service",
+    "hushh_mcp.services.connections_service",
+]
+follow_imports = "normal"
+
 [tool.bandit]
 exclude_dirs = ["tests", "__pycache__"]
 skips = ["B101"]  # Skip assert warnings

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5107,7 +5107,7 @@
     "cache_manifest": "4de3513e5a3f846d1f2ec45e92a62d67c8ca716908cecb67ca0dc796d21b0d4f",
     "data_plane": "ea69e0d26bd9bdd7ad525a3bceb7561902f26d23addc5757a8a90dd78cfe15fc",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "37822099f9a179215b789f41b915ae1c2898947a8086995b5d668ac5d348b92a",
+    "one_specialist_tools": "91046655f19b6c84fa76f27faa3309b7f28887aec26cae65e2b3fa6843f389e4",
     "route_index": "b66b81a4399465e4a9220e22cfa379991e76db2538173496f8acf7d1beb99c2a",
     "route_layout": "9fdf440b9c771314317abcf6ac1d22d01fe25b8792860a0cb087bb933edf80b9",
     "surface_map": "050728616159d81320bcf3ae60d38b26b6523e3ed4c560932ed8cdbc8afbfe1b",


### PR DESCRIPTION
## Summary

Stacked on #5953. First half of the "make it stable and consistent" drift-safety work requested for the backend-direct voice actions from #5946/#5948/#5949/#5953.

`action_tools.py`'s backend-direct actions call `OneLocationAgentService`/`ConnectionsService` methods directly — `create_grant`, `request_access`, `list_verified_recipients`, `search_directory`, `create_request`, and more — bypassing the `@hushh_tool` layer. That's a real coupling: a renamed or retyped parameter on either service silently breaks `action_tools.py` with no CI signal until it fails at runtime.

Investigated whether extending the existing `runtime-topology-index.v1.json` governed-artifact check (the mechanism `one_specialist_tools` already uses to catch drift in `action_tools.py` itself) could cover this too — it can't. That mechanism is a whole-file SHA-256 staleness check, structurally identical to a lockfile: it fails when a hashed file changed and nobody re-ran the generator, not when a caller's assumptions about a callee's signature became wrong. A dev who renames a parameter and dutifully reruns the generator gets a "not stale" green hash with the bug still present.

What actually catches this today, and already runs as a real blocking CI step (`Protocol (Python)` → `CI Status Gate`, via `scripts/ci/backend-check.sh`'s `mypy` invocation): mypy. It's just been structurally blind to this specific class of bug, because `hushh_mcp.services.*` — including both services `action_tools.py` calls directly — is wildcard-quarantined (`follow_imports = "skip"`) in `pyproject.toml`, a leftover from gradual typing adoption.

This PR adds one more-specific override for exactly `one_location_agent_service` and `connections_service` (more-specific overrides win over the wildcard, so nothing else is un-skipped) and fixes everything that surfaced. Verified the mechanism actually works before trusting it: renaming `create_grant`'s `recipient_user_id` parameter locally reproduces the exact `call-arg` error CI would now catch.

Un-skipping surfaced 21 pre-existing errors, all fixed here — none are new code, all were already-broken invariants mypy just couldn't see:

- **5 real gaps at `action_tools.py`'s own existing read-tool call sites** (`list_active_owner_grants`, `list_active_recipient_grants`, `list_pending_owner_requests`, `list_connections`, `list_requests`) — the shared `_read_tool_user_id` helper widened its return to `str | None` even though `_verify_backend_direct_authorization`'s real return type guarantees a non-empty `str` whenever authorization succeeds. Narrowed with an explicit check at each site instead of trusting the wider type silently.
- **16 pre-existing type gaps inside `one_location_agent_service.py` itself**: `Any` leaking in from other still-quarantined modules (`operons.location.policy`, `services.requester_identity`) at call and comparison sites; two cases where `create_grant` and `store_encrypted_envelope` each reused the same variable name for two genuinely different values, so mypy inferred the type from whichever assignment it saw first and flagged the other (renamed to `created_grant`/`stored_envelope`); a `float` duration passed raw into an FCM `data` payload that's contractually `str`-only; and two auto-approve invariants that don't carry their narrowing across separate `if`-statements.

Addresses #5677

## Test plan

- [x] `mypy --config-file pyproject.toml --ignore-missing-imports` (the exact CI invocation) — clean across all 105 checked source files, was 21 errors before this PR
- [x] `ruff check` / `ruff format --check` clean on both touched files — every fix uses `raise AssertionError(...)` rather than a bare `assert` (S101 forbids `assert` in production code; matches the existing `action_tools.py:1049` idiom)
- [x] `pytest tests/test_one_adk_agent_tree.py tests/services/ tests/test_fabric_routes.py tests/test_feed_events_dedupe_approved_share_migration.py tests/test_one_location_routes.py` — all green (2030/2030 relevant tests). The only failures anywhere in the broader suite are pre-existing and unrelated: `test_one_location_list_state_resilience.py` needs a live local Cloud SQL proxy tunnel this sandbox doesn't have running, and `test_vault_keys_service_pure_helpers.py::TestNormalizeIntMsOrNone` hits a genuine, pre-existing bug in `vault_keys_service.py` (`_normalize_int_ms_or_none` is missing its body — an apparent merge artifact left its `try/return int(value)` block as dead code inside the *next* function instead) — confirmed unrelated to this PR's diff and reported separately, not touched here since it's out of scope for a drift-safety fix
- [x] Confirmed the mechanism actually catches the bug it exists for: locally renamed `create_grant`'s `recipient_user_id` parameter with these changes in place, reran mypy, got the exact `call-arg` failure CI would now raise; reverted before committing
