### PR TITLE
feat(voice): bump to Voice Engine 1.4, drop "version" from the settings header

### DIFF
--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -23,7 +23,7 @@ describe("VoicePreferencesPanel", () => {
     expect(screen.getByRole("heading", { name: "One" })).toBeInTheDocument();
     expect(
       screen.getByText(
-        `Voice engine version ${VOICE_ENGINE_VERSION} — powered by Gemini Live`,
+        `Voice engine ${VOICE_ENGINE_VERSION} — powered by Gemini Live`,
       ),
     ).toBeInTheDocument();
   });

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -44,7 +44,7 @@ function VoiceHeader() {
         One
       </h1>
       <PageSubtitle className="text-muted-foreground">
-        Voice engine version {VOICE_ENGINE_VERSION} — powered by Gemini Live
+        Voice engine {VOICE_ENGINE_VERSION} — powered by Gemini Live
       </PageSubtitle>
     </div>
   );

--- a/hushh-webapp/lib/agent/voice-engine-changelog.ts
+++ b/hushh-webapp/lib/agent/voice-engine-changelog.ts
@@ -5,7 +5,7 @@
  * VOICE_ENGINE_VERSION in the same PR, so the version shown in the settings
  * header always matches the changelog under it.
  */
-export const VOICE_ENGINE_VERSION = "1.3";
+export const VOICE_ENGINE_VERSION = "1.4";
 
 export type VoiceEngineChangelogEntry = {
   version: string;
@@ -16,6 +16,20 @@ export type VoiceEngineChangelogEntry = {
 };
 
 export const VOICE_ENGINE_CHANGELOG: readonly VoiceEngineChangelogEntry[] = [
+  {
+    version: "1.4",
+    date: "2026-08-25",
+    title: "These actions now run the moment you ask",
+    description:
+      "Sharing your location, sending a connection request, stopping a share, and approving or declining a request used to need you on the right screen first. They now run directly and show what happened, from anywhere in the app.",
+  },
+  {
+    version: "1.4",
+    date: "2026-08-25",
+    title: "Say it once, for everyone",
+    description:
+      "Sharing your location, asking someone for theirs, and sending a connection request now understand more than one name in the same sentence -- \"share my location with Alex and Sam for 2 hours\" works in one turn, the same way adding people to a Circle already did.",
+  },
   {
     version: "1.3",
     date: "2026-08-23",


### PR DESCRIPTION
## Summary

Bumps `VOICE_ENGINE_VERSION` to `1.4` and adds two changelog entries for today's shipped work (the backend-direct/multi-person Location and Connect stack: #5934, #5941, #5945, #5946, #5948, #5949, #5953, #5960). The internal mypy drift-safety fix (#5958) and its guardrail test (#5962) aren't user-facing, so they don't get a changelog entry.

Also drops "version" from the Voice Settings header: "Voice engine version 1.4" → "Voice engine 1.4".

Addresses #5677

## Test plan

- [x] `npx vitest run __tests__/components/voice-preferences-panel.test.tsx __tests__/components/voice-changelog-page.test.tsx` — 12/12 passing
- [x] `npx tsc --noEmit` / `npx eslint` clean
- [x] Grepped for any other "engine version" UI text — the settings header was the only rendered occurrence; the changelog page only uses `entry.version` as a React key, never displayed
