### PR TITLE
fix(finance): align portfolio review pagination and metrics layout across UAT and iOS views

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -452,11 +452,11 @@ export function DataTable<TData, TValue>({
       </div>
 
       {hasMultiplePages && (
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
           <div
             aria-live="polite"
             aria-atomic="true"
-            className="flex w-full flex-nowrap items-center justify-between gap-3 text-xs text-muted-foreground sm:text-sm"
+            className="flex w-full items-center justify-between gap-3 text-xs text-muted-foreground sm:w-auto sm:justify-start sm:text-sm"
             data-slot="data-table-range-controls"
           >
             <DropdownMenu>
@@ -464,7 +464,7 @@ export function DataTable<TData, TValue>({
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-8 min-w-[64px] justify-between px-2 text-xs sm:min-w-[80px] sm:px-3 sm:text-sm"
+                  className="h-8 min-w-[64px] justify-between px-2 text-xs sm:min-w-[72px] sm:px-2.5 sm:text-sm"
                   data-no-route-swipe
                   aria-label="Rows per page"
                 >
@@ -489,13 +489,13 @@ export function DataTable<TData, TValue>({
           </div>
 
           <div
-            className="flex w-full flex-nowrap items-center justify-between gap-3"
+            className="flex w-full items-center justify-between gap-3 sm:w-auto sm:justify-end"
             data-slot="data-table-page-controls"
           >
-            <Pagination className="mx-0 w-auto justify-end">
+            <Pagination className="mx-0 w-auto">
               <PaginationContent
                 data-no-route-swipe
-                className="flex-wrap gap-y-1"
+                className="flex-nowrap gap-1"
               >
                 <PaginationItem>
                   <PaginationPrevious
@@ -518,7 +518,7 @@ export function DataTable<TData, TValue>({
                   item === "ellipsis" ? (
                     <PaginationItem
                       key={`ellipsis-${index}`}
-                      className="hidden sm:flex"
+                      className="hidden md:flex"
                     >
                       <PaginationEllipsis />
                     </PaginationItem>
@@ -526,7 +526,7 @@ export function DataTable<TData, TValue>({
                     <PaginationItem
                       key={item}
                       className={
-                        item === currentPage ? undefined : "hidden sm:flex"
+                        item === currentPage ? undefined : "hidden md:flex"
                       }
                     >
                       <PaginationLink

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -2065,9 +2065,9 @@ export function PortfolioReviewView({
                 )}
               </div>
 
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 pt-6 border-t border-primary/10">
-                <div className="min-w-0 text-center sm:text-left sm:pl-4">
-                  <p className="text-[1.35rem] font-medium sm:text-[1.5rem]">{activeHoldings.length}</p>
+              <div className="grid grid-cols-3 gap-2 pt-6 border-t border-primary/10">
+                <div className="min-w-0 text-left pl-2 sm:pl-4">
+                  <p className="text-lg font-semibold sm:text-xl">{activeHoldings.length}</p>
                   <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Assets</p>
                 </div>
                 <div className="min-w-0 flex flex-col items-center justify-center">
@@ -2084,12 +2084,12 @@ export function PortfolioReviewView({
                   >
                     {riskBucket}
                   </Badge>
-                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground mt-2">Portfolio Risk</p>
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground mt-1.5">Portfolio Risk</p>
                 </div>
-                <div className="min-w-0 text-center sm:text-right sm:pr-4">
+                <div className="min-w-0 text-right pr-2 sm:pr-4">
                   <p
                     className={cn(
-                      "max-w-full text-[20px] font-medium leading-none tracking-normal tabular-nums whitespace-nowrap sm:text-[22px]",
+                      "max-w-full text-base font-semibold leading-none tracking-normal tabular-nums truncate sm:text-lg",
                       liveCashBalance < 0
                         ? "text-red-500 dark:text-red-400"
                         : "text-foreground"
@@ -2099,7 +2099,7 @@ export function PortfolioReviewView({
                       {formatCurrencyCompact(liveCashBalance)}
                     </span>
                   </p>
-                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Cash</p>
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground mt-1.5">Cash</p>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary of Changes
Aligns pagination controls and summary metrics on the `Portfolio Review` screen across Desktop UAT and Mobile iOS views.

- **Data Table Pagination (`data-table.tsx`):** Realigned flex child containers (`w-full sm:w-auto`) so page numbers, range labels, and arrow controls sit in 1 clean row on Desktop UAT and stack neatly on Mobile iOS.
- **Metrics Grid (`portfolio-review-view.tsx`):** Adjusted Cash metric spacing and truncation to prevent text collision with Portfolio Risk badges.

## Verification
1. Run `npm run dev` and open `http://localhost:3000/one/kai?tab=portfolio`.
2. Inspect `Review Portfolio` screen on Desktop (UAT wide view) and Mobile (iOS narrow view).
3. Verify pagination controls and metrics card are 100% aligned with zero text overlap.