### PR TITLE
fix(ci): exclude dynamic route /r/** from capacitor static export

### DIFF
--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -63,7 +63,7 @@
     "smoke:analytics:uat": "node ./scripts/testing/run-uat-analytics-smoke.mjs",
     "audit:cache-coherence": "node ./scripts/architecture/audit-cache-coherence.mjs --check",
     "audit:ui-surfaces": "node ./scripts/architecture/audit-ui-surfaces.mjs",
-    "cap:build": "npx cross-env CAPACITOR_BUILD=true next build --webpack --debug-build-paths \"app/**/page.tsx,!app/api/**\"",
+    "cap:build": "npx cross-env CAPACITOR_BUILD=true next build --webpack --debug-build-paths \"app/**/page.tsx,!app/api/**,!app/r/**\"",
     "cap:sync:android": "npx cross-env CAPACITOR_PLATFORM=android npx cap sync android",
     "cap:sync:ios": "npx cross-env CAPACITOR_PLATFORM=ios npx cap sync ios",
     "ios:run": "npm run cap:build && npm run cap:sync:ios && npx cap run ios",


### PR DESCRIPTION
## Summary

Fixes the Capacitor static build failure in the iOS TestFlight CI pipeline caused by the dynamic `/r/[slug]` route.

## Issue

The newly added `/r/[slug]` route does not define `generateStaticParams()`, causing Next.js static export to fail when building the native Capacitor bundle.

## Changes Made

* Updated the `cap:build` script in `package.json`.
* Added `!app/r/**` to `--debug-build-paths` to exclude the referral route from the Capacitor static export.
* This keeps the `/r/**` web route available while preventing it from being included in the native iOS static bundle.

## Verification

* [x] Ran `npm run cap:build` locally.
* [x] Next.js static export completed successfully.
* [x] Confirmed the Capacitor build no longer fails because of `/r/[slug]`.
* [x] No changes made to the referral route logic or existing application behavior.
