### PR TITLE
Refine One dashboard agent launcher

### DIFF
--- a/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
+++ b/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
@@ -504,7 +504,7 @@
     {
       "schema_version": "kai.local_action_contract.v1",
       "surface_id": "one_intro",
-      "surface_title": "Claim your One",
+      "surface_title": "Meet your agents",
       "docs_references": [
         "docs/reference/one/one-voice-runtime-architecture.md",
         "docs/reference/one/one-voice-onboarding-journey.md"
@@ -14371,8 +14371,9 @@
     {
       "action_id": "onboarding.claim_one",
       "surface_id": "one_intro",
-      "label": "Claim your One",
+      "label": "Meet your agents",
       "aliases": [
+        "meet your agents",
         "claim your one",
         "claim my one",
         "claim one",
@@ -14455,7 +14456,7 @@
         "workflow_steps": [
           {
             "type": "action",
-            "label": "Claim your One",
+            "label": "Meet your agents",
             "failure_behavior": "stop",
             "action_id": "onboarding.claim_one",
             "settlement_target": {

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5180,7 +5180,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "ea2c5c49c87eb0049e1fb133050af17f97c6bab9b3e30eb8fa31c8692bdfbdd6",
+    "action_gateway": "e74a9a2b3254916866f8ff5cc75e02d3db5a4f57e7dbdcdca28a883e637499f5",
     "agent_registry": "a9fd61fc5da948e28aed7ee2132f79e9f4a40ebf8685aee1c824c7538ee3685f",
     "cache_manifest": "734cae0bc468da32e9aa6f5b680c5fb40d49696e3b90629c533791ad5288f8f4",
     "data_plane": "16a6bb7ebddcbfd360a07034ed83ba0b966d8667fe879bee928991d0f591e04d",

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -504,7 +504,7 @@
     {
       "schema_version": "kai.local_action_contract.v1",
       "surface_id": "one_intro",
-      "surface_title": "Claim your One",
+      "surface_title": "Meet your agents",
       "docs_references": [
         "docs/reference/one/one-voice-runtime-architecture.md",
         "docs/reference/one/one-voice-onboarding-journey.md"
@@ -14371,8 +14371,9 @@
     {
       "action_id": "onboarding.claim_one",
       "surface_id": "one_intro",
-      "label": "Claim your One",
+      "label": "Meet your agents",
       "aliases": [
+        "meet your agents",
         "claim your one",
         "claim my one",
         "claim one",
@@ -14455,7 +14456,7 @@
         "workflow_steps": [
           {
             "type": "action",
-            "label": "Claim your One",
+            "label": "Meet your agents",
             "failure_behavior": "stop",
             "action_id": "onboarding.claim_one",
             "settlement_target": {

--- a/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
@@ -62,17 +62,18 @@ describe("AuthStep layout contract", () => {
     expect(source).toContain("overflow-hidden");
     expect(source).toContain("data-auth-content-block");
     expect(source).toContain(
-      'className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center"',
+      'className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center px-6"',
     );
     expect(source).not.toContain("justify-end");
     expect(source).toContain("data-auth-signin-clusters");
     expect(source).toContain("data-auth-provider-actions");
     expect(source).toContain("data-auth-supporting-content");
     expect(source).toContain(
-      'className="flex w-full flex-none flex-col items-center gap-6 px-6 pb-6 text-center"',
+      'className="flex w-full flex-none flex-col items-center gap-6 text-center"',
     );
     expect(source).toContain('className="flex flex-col items-center gap-4"');
-    expect(source).toContain('className="flex flex-col items-center gap-3"');
+    expect(source).toContain("absolute inset-x-4 bottom-6");
+    expect(source).not.toContain("You choose what One can see.");
     expect(source).not.toContain("mx-auto mt-1 flex w-fit");
     // The provider buttons sit directly on the shared hero background (no
     // frosted glass card/sheet), matching the welcome ("/") page's

--- a/hushh-webapp/__tests__/components/calendar-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/calendar-agent-page.test.tsx
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   disconnect: vi.fn(),
   getIdToken: vi.fn(),
   openAgent: vi.fn(),
+  openGoogleOAuthPopup: vi.fn(),
+  navigateGoogleOAuthPopup: vi.fn(),
+  popupClose: vi.fn(),
 }));
 
 vi.mock("@/components/agent/agent-popover-provider", () => ({
@@ -28,6 +31,19 @@ vi.mock("@/lib/services/google-calendar-service", () => ({
   },
 }));
 
+vi.mock("@/lib/google/google-oauth-popup", () => ({
+  createGoogleOAuthPopupAttempt: () => ({
+    version: 1,
+    attemptId: "calendar-attempt",
+    service: "calendar",
+    startedAt: 1,
+  }),
+  isGoogleOAuthPopupSettlement: () => false,
+  navigateGoogleOAuthPopup: mocks.navigateGoogleOAuthPopup,
+  openGoogleOAuthPopup: mocks.openGoogleOAuthPopup,
+  readGoogleOAuthPopupSettlement: () => null,
+}));
+
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 import { CalendarAgentPage } from "@/components/calendar/calendar-agent-page";
@@ -37,6 +53,9 @@ describe("CalendarAgentPage", () => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
     mocks.getIdToken.mockResolvedValue("firebase-token");
+    mocks.openGoogleOAuthPopup.mockReturnValue({
+      close: mocks.popupClose,
+    } as unknown as Window);
     vi.spyOn(window, "open").mockImplementation(
       () =>
         ({

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -18,7 +18,7 @@ afterEach(() => {
 });
 
 describe("IntroStep voice contract", () => {
-  it("publishes and executes the same Claim your One control used by tapping", async () => {
+  it("publishes and executes the same Meet your agents control used by tapping", async () => {
     const onLogin = vi.fn();
     render(<IntroStep onLogin={onLogin} />);
 
@@ -35,7 +35,7 @@ describe("IntroStep voice contract", () => {
       ).not.toBeNull();
     });
 
-    const button = screen.getByRole("button", { name: /claim your one/i });
+    const button = screen.getByRole("button", { name: /meet your agents/i });
     expect(button).toHaveAttribute(
       "data-voice-control-id",
       "onboarding_claim_one",
@@ -55,37 +55,30 @@ describe("IntroStep voice contract", () => {
     });
   });
 
-  it("uses the standardized root quiet mark between the private-agent line and One", () => {
+  it("uses the standardized root quiet mark before One without the old eyebrow", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
-    const privateAgent = screen.getByText("Your private agent");
+    expect(screen.queryByText("Your private agent")).toBeNull();
     const quietMark = screen.getByText("🤫");
     const one = screen.getByRole("heading", { name: "One" });
 
-    expect(privateAgent.compareDocumentPosition(quietMark)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
     expect(quietMark.compareDocumentPosition(one)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
 
-  it("keeps the root public navigation to Research, Blog, and Developers", () => {
+  it("renders the focused root copy and removes public footer links", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
-    const publicNav = screen.getByRole("navigation", { name: "Explore Hussh" });
-    expect(publicNav.querySelectorAll("a")).toHaveLength(3);
-    expect(screen.getByRole("link", { name: "Research" })).toHaveAttribute(
-      "href",
-      "/research",
-    );
-    expect(screen.getByRole("link", { name: "Blog" })).toHaveAttribute(
-      "href",
-      "/blog",
-    );
-    expect(screen.getByRole("link", { name: "Developers" })).toHaveAttribute(
-      "href",
-      "/developers",
-    );
+    expect(
+      screen.getByText("Personal agents for everyday life."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("One app to bring them together."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Your agents. Yours to own.")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Research" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Blog" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Developers" })).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -1,13 +1,10 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { buildOneSetupCapabilityRoute, ROUTES } from "@/lib/navigation/routes";
 import type { CapabilityStatus } from "@/lib/services/capability-setup-state-service";
-import {
-  CACHE_KEYS,
-  CacheService,
-} from "@/lib/services/cache-service";
+import { CACHE_KEYS, CacheService } from "@/lib/services/cache-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 
 function status(
@@ -34,17 +31,29 @@ function buildStatusMap(
   return map;
 }
 
-function openAgentListView() {
-  fireEvent.click(screen.getByRole("button", { name: "Agent launcher options" }));
-  fireEvent.click(screen.getByRole("menuitem", { name: "View as list" }));
-  return screen.getByTestId("one-agents-list");
-}
+const expectedOrder = [
+  "location",
+  "email",
+  "finance",
+  "ria",
+  "gmail",
+  "calendar",
+  "pkm",
+  "consent",
+  "connected-systems",
+] as const;
 
-function openAgentSearch() {
-  fireEvent.click(screen.getByRole("button", { name: "Agent launcher options" }));
-  fireEvent.click(screen.getByRole("menuitem", { name: "Search agents" }));
-  return screen.getByTestId("one-agents-search");
-}
+const expectedLabels = [
+  "Location",
+  "KYC",
+  "Finance",
+  "RIA",
+  "Gmail",
+  "Calendar",
+  "Memory",
+  "Consent",
+  "CRM",
+] as const;
 
 describe("OneDashboardPage", () => {
   beforeEach(() => {
@@ -54,7 +63,7 @@ describe("OneDashboardPage", () => {
 
   it("keeps unfinished Finance actionable after root onboarding is dismissed", () => {
     const userId = "dashboard-dismissed-user";
-    OneSetupCompletionHintService.markResolved(userId); // dismissed
+    OneSetupCompletionHintService.markResolved(userId);
 
     render(
       <OneDashboardPage
@@ -66,31 +75,24 @@ describe("OneDashboardPage", () => {
       />,
     );
 
-    // Root onboarding completion is not Finance completion. The resolver's
-    // actionable state must still lead to the bounded Finance setup workspace.
-    const financeLink = screen.getByRole("link", { name: /^Open Finance/ });
+    const financeLink = screen.getByRole("link", {
+      name: "Finance, setup required",
+    });
     expect(financeLink.getAttribute("href")).toBe(
       buildOneSetupCapabilityRoute("finance"),
     );
   });
 
-  it("renders the primary One agents as a direct premium app-icon launcher", () => {
+  it("renders a direct 3 by 3 app-icon launcher instead of the old agent directory", () => {
     const userId = "dashboard-launcher-user";
-    CacheService.getInstance().set(
-      CACHE_KEYS.KAI_MARKET_HOME_BASELINE(userId, 7),
-      {
-        movers: {
-          gainers: [{ symbol: "RFAI", change_pct: 355.6 }],
-        },
-      },
-    );
     CacheService.getInstance().set(CACHE_KEYS.ONE_LOCATION_STATE(userId), {
       ownerGrants: [{ status: "active" }],
       receivedGrants: [{ status: "approved" }],
     });
-    CacheService.getInstance().set(CACHE_KEYS.PKM_METADATA(userId), {
-      totalAttributes: 31,
-    });
+    CacheService.getInstance().set(
+      CACHE_KEYS.PENDING_CONSENTS(userId),
+      [{ id: "pending-1" }, { id: "pending-2" }],
+    );
 
     const { container } = render(
       <OneDashboardPage
@@ -102,38 +104,24 @@ describe("OneDashboardPage", () => {
           calendar: { state: "blocked", prerequisite: "oauth" },
           email: { state: "completed" },
           location: { state: "completed" },
-          ria: { state: "in-progress" },
+          ria: { state: "completed" },
           "connected-systems": { state: "blocked", prerequisite: "oauth" },
         })}
       />,
     );
 
-    expect(screen.queryByText("Good to see you, Kushal.")).toBeNull();
-    expect(screen.queryByText("Your private agent")).toBeNull();
+    expect(screen.getByRole("heading", { name: "One", hidden: true })).toBeTruthy();
     expect(screen.getByTestId("one-agents-section")).toBeTruthy();
     expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
+    expect(screen.queryByText(/Agents \(\d+\)/)).toBeNull();
+    expect(screen.queryByRole("searchbox", { name: /search agents/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Agent launcher options" })).toBeNull();
     expect(screen.queryByTestId("one-agents-list")).toBeNull();
-    expect(container.textContent).not.toContain("Finish setup");
-
-    const heading = screen.getByRole("heading", { name: "Agents, 9 agents" });
-    expect(heading.textContent).toBe("Agents, 9 agents");
-    expect(heading.querySelector(".sr-only")).toBeTruthy();
-    expect(container.textContent).not.toContain("Agents (9)");
     expect(screen.queryByTestId("one-agents-search")).toBeNull();
-    expect(screen.queryByTestId("one-agents-view-grid")).toBeNull();
-    expect(screen.getByRole("button", { name: "Agent launcher options" })).toBeTruthy();
+    expect(container.textContent).not.toMatch(
+      /action due|approvals waiting|requests to review|saved details|live shares|connected systems|Finish setup|View as list|View as grid/i,
+    );
 
-    const expectedOrder = [
-      "finance",
-      "location",
-      "ria",
-      "gmail",
-      "calendar",
-      "email",
-      "pkm",
-      "consent",
-      "connected-systems",
-    ] as const;
     const tiles = Array.from(
       container.querySelectorAll('[data-testid^="one-agent-tile-"]'),
     );
@@ -146,237 +134,101 @@ describe("OneDashboardPage", () => {
     );
     expect(grid).toBeTruthy();
     expect(grid?.className).toContain("grid-cols-3");
-    expect(grid?.className).not.toContain("sm:grid-cols-[repeat(4");
-    expect(screen.getByTestId("one-agents-grid").className).not.toContain(
-      "bg-white",
-    );
-    expect(screen.getByTestId("one-agents-grid").className).not.toContain(
-      "rounded-[20px]",
-    );
-
-    const financeLink = screen.getByRole("link", {
-      name: /Open Finance, RFAI up 355\.6 percent/,
-    });
-    expect(financeLink.getAttribute("href")).toBe(ROUTES.KAI_HOME);
-    expect(
-      screen.getByRole("link", {
-        name: /Open Location, 2 live shares/,
-      }).getAttribute("href"),
-    ).toBe(ROUTES.ONE_LOCATION);
-    expect(
-      screen.getByRole("link", { name: /^Open Gmail/ }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("gmail"));
-    expect(
-      screen.getByRole("link", { name: /^Open Calendar/ }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("calendar"));
-    expect(
-      screen.getByRole("link", { name: /^Open KYC/ }).getAttribute("href"),
-    ).toBe(ROUTES.ONE_KYC);
-    expect(
-      screen.getByRole("link", { name: /^Open CRM/ }).getAttribute("href"),
-    ).toBe(buildOneSetupCapabilityRoute("connected-systems"));
-    expect(
-      screen.getByRole("link", { name: /^Open Memory/ }).getAttribute("href"),
-    ).toBe(ROUTES.PKM);
-    expect(
-      screen.getByRole("link", { name: /^Open Consent/ }).getAttribute("href"),
-    ).toContain(ROUTES.CONSENTS);
-
-    for (const id of expectedOrder) {
-      const icon = screen.getAllByTestId(`one-agent-icon-${id}`)[0];
-      expect(icon).toBeTruthy();
-      expect(icon).toHaveAttribute("data-agent-icon-kind", "lucide");
-      expect(icon.className).toContain("h-[68px]");
-      expect(icon.className).toContain("w-[68px]");
-      expect(icon.className).toContain("rounded-[18px]");
-      expect(icon.querySelector("svg")?.className.baseVal).toContain(
-        "!text-white",
-      );
-    }
 
     const gridScope = within(screen.getByTestId("one-agents-grid"));
-    expect(gridScope.queryByText("RFAI")).toBeNull();
-    expect(gridScope.queryByText("+355.6%")).toBeNull();
-    expect(gridScope.queryByText("2")).toBeNull();
-    expect(gridScope.queryByText("live")).toBeNull();
-    expect(gridScope.queryByText("31")).toBeNull();
-    expect(gridScope.queryByText("saved")).toBeNull();
-    expect(screen.queryByText("0 actions")).toBeNull();
-    expect(screen.queryByText("0 approvals waiting")).toBeNull();
-    expect(screen.queryByText("status not loaded")).toBeNull();
-    expect(screen.queryByText("Checking...")).toBeNull();
-    expect(screen.queryByText("Ready")).toBeNull();
-    expect(screen.queryByText("Explore")).toBeNull();
-    expect(screen.queryByTestId("one-agent-notification-badge")).toBeNull();
+    for (const label of expectedLabels) {
+      expect(gridScope.getByText(label)).toBeTruthy();
+    }
+
+    expect(screen.getAllByTestId("one-agent-notification-badge")).toHaveLength(2);
     expect(screen.getByTestId("one-agent-live-dot")).toBeTruthy();
-    expect(container.querySelector(".material-ripple")).toBeNull();
-    expect(screen.queryByRole("link", { name: "Open One Agent" })).toBeNull();
+    expect(screen.queryByTestId("one-agent-live-label")).toBeNull();
+    expect(screen.queryByTestId("one-agents-empty-state")).toBeNull();
   });
 
-  it("defaults first-time visitors to grid and preserves a saved list view", () => {
-    const { unmount } = render(
-      <OneDashboardPage displayName="Kushal Trivedi" />,
+  it("preserves tile destinations and setup routing", () => {
+    render(
+      <OneDashboardPage
+        displayName="Kushal Trivedi"
+        capabilityStatusById={buildStatusMap({
+          email: { state: "completed" },
+          finance: { state: "not-started", requiresUnlock: true },
+          gmail: { state: "blocked", prerequisite: "oauth" },
+          calendar: { state: "blocked", prerequisite: "oauth" },
+          location: { state: "completed" },
+          "connected-systems": { state: "blocked", prerequisite: "oauth" },
+        })}
+      />,
     );
 
-    expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
-    expect(screen.queryByTestId("one-agents-view-grid")).toBeNull();
-    expect(screen.queryByTestId("one-agents-view-list")).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "Location" }).getAttribute("href"),
+    ).toBe(ROUTES.ONE_LOCATION);
+    expect(
+      screen.getByRole("link", { name: "KYC" }).getAttribute("href"),
+    ).toBe(ROUTES.ONE_KYC);
+    expect(
+      screen
+        .getByRole("link", { name: "Finance, setup required" })
+        .getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("finance"));
+    expect(
+      screen
+        .getByRole("link", { name: "Gmail, setup required" })
+        .getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("gmail"));
+    expect(
+      screen
+        .getByRole("link", { name: "Calendar, setup required" })
+        .getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("calendar"));
+    expect(
+      screen
+        .getByRole("link", { name: "CRM, setup required" })
+        .getAttribute("href"),
+    ).toBe(buildOneSetupCapabilityRoute("connected-systems"));
+    expect(
+      screen.getByRole("link", { name: "Memory" }).getAttribute("href"),
+    ).toBe(ROUTES.PKM);
+    expect(
+      screen.getByRole("link", { name: "Consent" }).getAttribute("href"),
+    ).toContain(ROUTES.CONSENTS);
+  });
 
-    unmount();
+  it("ignores the removed saved list-view preference", () => {
     window.localStorage.setItem("hushh:one-agent-roster-view", "list");
 
     render(<OneDashboardPage displayName="Kushal Trivedi" />);
 
-    expect(screen.getByTestId("one-agents-list")).toBeTruthy();
-    expect(screen.getByTestId("one-agent-list-row-finance")).toBeTruthy();
-    expect(screen.getByTestId("one-agents-view-content")).not.toHaveClass(
-      "motion-step-enter",
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Agent launcher options" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "View as grid" }));
-    expect(screen.getByTestId("one-agents-view-content")).toHaveClass(
-      "motion-step-enter",
-    );
-    expect(window.localStorage.getItem("hushh:one-agent-roster-view")).toBe(
-      "grid",
-    );
+    expect(screen.getByTestId("one-agents-grid")).toBeTruthy();
+    expect(screen.queryByTestId("one-agents-list")).toBeNull();
+    expect(screen.queryByTestId("one-agents-view-content")).toBeNull();
   });
 
-  it("keeps list view available with the same routes and solid app identity", () => {
-    render(
-      <OneDashboardPage
-        displayName="Kushal Trivedi"
-        capabilityStatusById={buildStatusMap({
-          finance: { state: "not-started", requiresUnlock: true },
-          ria: { state: "in-progress" },
-        })}
-      />,
-    );
-
-    const list = openAgentListView();
-    expect(list).toBeTruthy();
-
-    const financeRow = screen.getByRole("link", { name: /^Open Finance/ });
-    expect(financeRow.getAttribute("href")).toBe(
-      buildOneSetupCapabilityRoute("finance"),
-    );
-    const financeIcon = screen.getAllByTestId("one-agent-icon-finance")[0];
-    expect(financeIcon.className).toContain("h-10");
-    expect(financeIcon.className).toContain("w-10");
-    expect(financeIcon.querySelector("svg")?.className.baseVal).toContain(
-      "!text-white",
-    );
-    expect(screen.queryByTestId("one-agent-notification-badge")).toBeNull();
-  });
-
-  it("opens search from overflow and filters by title, description, metric value, and metric label", () => {
-    const userId = "dashboard-search-user";
-    CacheService.getInstance().set(
-      CACHE_KEYS.KAI_MARKET_HOME_BASELINE(userId, 7),
-      {
-        movers: {
-          gainers: [{ symbol: "RFAI", change_pct: 12.25 }],
-        },
-      },
-    );
-    CacheService.getInstance().set(CACHE_KEYS.ONE_LOCATION_STATE(userId), {
-      ownerGrants: [{ status: "active" }],
-      receivedGrants: [],
-    });
-
-    render(
-      <OneDashboardPage displayName="Kushal Trivedi" userId={userId} />,
-    );
-
-    expect(screen.queryByTestId("one-agents-search")).toBeNull();
-    const search = openAgentSearch();
-
-    fireEvent.change(search, {
-      target: { value: "location" },
-    });
-    expect(screen.getByTestId("one-agent-tile-location")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
-    fireEvent.change(screen.getByTestId("one-agents-search"), {
-      target: { value: "receipt" },
-    });
-    expect(screen.getByTestId("one-agent-tile-gmail")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-tile-location")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
-    fireEvent.change(screen.getByTestId("one-agents-search"), {
-      target: { value: "RFAI" },
-    });
-    expect(screen.getByTestId("one-agent-tile-finance")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-tile-location")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
-    fireEvent.change(screen.getByTestId("one-agents-search"), {
-      target: { value: "live" },
-    });
-    expect(screen.getByTestId("one-agent-tile-location")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
-  });
-
-  it("shows a quiet empty state for unmatched search", () => {
-    render(<OneDashboardPage displayName="Kushal Trivedi" />);
-
-    fireEvent.change(openAgentSearch(), {
-      target: { value: "not an agent" },
-    });
-
-    expect(screen.getByTestId("one-agents-empty-state")).toBeTruthy();
-    expect(screen.getByText("No matching agents")).toBeTruthy();
-    expect(screen.getByText("Try another search.")).toBeTruthy();
-    expect(screen.queryByTestId("one-agent-tile-finance")).toBeNull();
-  });
-
-  it("shows the finance mover as a concise green percentage without redundant winner copy", () => {
-    render(
-      <OneDashboardPage
-        displayName="Kushal Trivedi"
-        userId="roster-finance-metric"
-      />,
-    );
-
-    expect(screen.queryByText(/winner/i)).toBeNull();
-  });
-
-  it("shows real unresolved counts as dynamic badges without turning setup fallbacks into badges", () => {
-    const userId = "dashboard-notification-badge-user";
-    CacheService.getInstance().set(
-      CACHE_KEYS.PENDING_CONSENTS(userId),
-      [{ id: "pending-1" }, { id: "pending-2" }],
-    );
-
+  it("renders only meaningful adornments and caps action counts", () => {
     const { rerender } = render(
       <OneDashboardPage
         displayName="Kushal Trivedi"
-        userId={userId}
         capabilityStatusById={buildStatusMap({
-          finance: { state: "not-started", requiresUnlock: true },
-          calendar: { state: "blocked", prerequisite: "oauth" },
+          calendar: { state: "in-progress", pendingCount: 112 },
         })}
       />,
     );
 
-    expect(screen.getAllByTestId("one-agent-notification-badge")).toHaveLength(2);
-    expect(screen.getAllByText("2")).toHaveLength(2);
+    expect(screen.getByText("99+")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Calendar, 99+ reviews" })).toBeTruthy();
+    expect(screen.queryByText("0")).toBeNull();
 
-    CacheService.getInstance().set(CACHE_KEYS.PENDING_CONSENTS(userId), []);
     rerender(
       <OneDashboardPage
         displayName="Kushal Trivedi"
-        userId={userId}
         capabilityStatusById={buildStatusMap({
-          finance: { state: "not-started", requiresUnlock: true },
-          calendar: { state: "blocked", prerequisite: "oauth" },
+          calendar: { state: "completed", pendingCount: 0 },
         })}
       />,
     );
 
     expect(screen.queryByTestId("one-agent-notification-badge")).toBeNull();
+    expect(screen.queryByTestId("one-agent-setup-badge")).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1354,7 +1354,9 @@ describe("OneLocationAgentPage", () => {
       "active",
     );
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    expect(screen.queryByRole("button", { name: /Active shares/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Active shares/i }),
+    ).toBeTruthy();
     expect(
       screen.queryByRole("heading", { name: "Proximity alerts" }),
     ).toBeNull();
@@ -1377,10 +1379,9 @@ describe("OneLocationAgentPage", () => {
     );
   }, 15000);
 
-  it("hides the Activity menu when every Activity count is zero", async () => {
-    // Empty Activity rows are visual noise on the Now screen. Keep the real
-    // destinations wired when counts exist, but remove the whole group when
-    // nothing needs attention.
+  it("hides empty Activity rows while keeping More available without section labels", async () => {
+    // The visible section labels were the noise. Activity only appears when it
+    // has real counts, while More remains the quiet utility surface.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -1392,8 +1393,14 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     expect(screen.queryByTestId("one-location-now-activity")).toBeNull();
+
+    const more = screen.getByTestId("one-location-now-more");
+    expect(within(more).getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(
+      within(more).getByRole("button", { name: /^Settings$/i }),
+    ).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Activity" })).toBeNull();
-    expect(screen.queryByText("0")).toBeNull();
+    expect(screen.queryByRole("heading", { name: "More" })).toBeNull();
   });
 
   it("keeps Activity rows visually quiet even when counts are non-zero", async () => {
@@ -1439,7 +1446,7 @@ describe("OneLocationAgentPage", () => {
         ?.getAttribute("data-icon-tone");
     };
 
-    expect(screen.queryByText("Active shares")).toBeNull();
+    expect(screen.getByText("Active shares")).toBeTruthy();
     expect(await toneOf("Sharing with you")).toBeUndefined();
     expect(await toneOf("Needs review")).toBeUndefined();
   });
@@ -1594,9 +1601,9 @@ describe("OneLocationAgentPage", () => {
     expect(actions.querySelector("[data-one-location-sms-row]")).toBeTruthy();
 
     const activity = screen.getByTestId("one-location-now-activity");
+    expect(within(activity).queryByText("Active shares")).toBeNull();
     expect(within(activity).getByText("Sharing with you")).toBeTruthy();
     expect(within(activity).getByText("Needs review")).toBeTruthy();
-    expect(within(activity).queryByText("Active shares")).toBeNull();
 
     expect(within(activity).queryByText("Share")).toBeNull();
     const more = screen.getByTestId("one-location-now-more");
@@ -3686,7 +3693,9 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Now" }));
-    expect(screen.queryByRole("button", { name: /Active shares/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Active shares/i }),
+    ).toBeTruthy();
     await openSharePersonStep();
     fireEvent.change(screen.getByPlaceholderText("Search people"), {
       target: { value: "advisor" },

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -23,6 +23,7 @@ describe("One Location settings placement", () => {
 
     expect(nowSource).not.toContain('testId="one-location-settings-entry"');
     expect(nowSource).not.toContain('title="Privacy"');
+    expect(nowSource).not.toContain("LocationNowGroupLabel");
   });
 
   it("offers Ask for location inside the compact Now actions", () => {
@@ -48,7 +49,6 @@ describe("One Location settings placement", () => {
     expect(moreIndex).toBeGreaterThan(activityIndex);
     expect(nowSource).toContain('title: "Map"');
     expect(nowSource).toContain('title: "Settings"');
-    expect(nowSource).not.toContain('title: "Active shares"');
     expect(nowSource).not.toContain("LocationNowGroupLabel");
 
     // Reuses the existing ask flow rather than introducing a second one, so

--- a/hushh-webapp/__tests__/voice/onboarding-login-contract.test.ts
+++ b/hushh-webapp/__tests__/voice/onboarding-login-contract.test.ts
@@ -81,7 +81,7 @@ describe("One Voice Login onboarding contracts", () => {
     expect(generic.reachability.screens).not.toContain("login");
   });
 
-  it("exposes the visible root claim control as a root-only local action", () => {
+  it("exposes the visible root intro control as a root-only local action", () => {
     const contract = JSON.parse(readFileSync(introContractPath, "utf8"));
     const claim = contract.actions.find(
       (action: { action_id: string }) =>
@@ -89,8 +89,9 @@ describe("One Voice Login onboarding contracts", () => {
     );
 
     expect(claim).toMatchObject({
-      label: "Claim your One",
+      label: "Meet your agents",
       aliases: expect.arrayContaining([
+        "meet your agents",
         "claim your one",
         "claim my one",
         "get started",

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2114,6 +2114,32 @@ html.kb-open .ambient-chrome-mask--bottom {
   padding-bottom: var(--app-page-content-bottom-gap);
 }
 
+.one-agent-launcher-grid {
+  --one-agent-icon-size: clamp(54px, 15.2vw, 62px);
+  --one-agent-cell-height: clamp(86px, 23vw, 98px);
+  --one-agent-column-gap: clamp(8px, 3vw, 16px);
+  --one-agent-row-gap: clamp(8px, 2.3vh, 18px);
+}
+
+.one-agent-launcher-grid-inner {
+  column-gap: var(--one-agent-column-gap);
+  row-gap: var(--one-agent-row-gap);
+}
+
+@media (max-height: 620px) {
+  .one-agent-launcher-grid {
+    --one-agent-icon-size: 52px;
+    --one-agent-cell-height: 84px;
+  }
+}
+
+@media (min-width: 768px) {
+  .one-agent-launcher-grid {
+    --one-agent-icon-size: 62px;
+    --one-agent-cell-height: 98px;
+  }
+}
+
 /* Sparse screens (empty states, short lists) let their height fit content
    instead of an ancestor stretching them to the full viewport, which produced
    a large dead scroll region above the floating "Talk to One" bar. The bottom

--- a/hushh-webapp/app/page.voice-action-contract.json
+++ b/hushh-webapp/app/page.voice-action-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "kai.local_action_contract.v1",
   "surface_id": "one_intro",
-  "surface_title": "Claim your One",
+  "surface_title": "Meet your agents",
   "docs_references": [
     "docs/reference/one/one-voice-runtime-architecture.md",
     "docs/reference/one/one-voice-onboarding-journey.md"
@@ -19,9 +19,10 @@
   "actions": [
     {
       "action_id": "onboarding.claim_one",
-      "label": "Claim your One",
+      "label": "Meet your agents",
       "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
       "aliases": [
+        "meet your agents",
         "claim your one",
         "claim my one",
         "claim one",
@@ -59,7 +60,7 @@
           {
             "type": "action",
             "action_id": "onboarding.claim_one",
-            "label": "Claim your One",
+            "label": "Meet your agents",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/login",

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -132,6 +132,9 @@ function AppShellFrame({ children }: ProvidersProps) {
   const isPublicKnowledgeWorkspace =
     pathname === ROUTES.WELCOME &&
     ["research", "blog", "developers"].includes(searchParams?.get("tab") ?? "");
+  const suppressAnonymousEntryChrome =
+    (pathname === ROUTES.HOME && !isPublicKnowledgeWorkspace) ||
+    pathname === ROUTES.LOGIN;
   const shellPathname = useMemo(
     () =>
       pathname === ROUTES.HOME &&
@@ -152,7 +155,8 @@ function AppShellFrame({ children }: ProvidersProps) {
   const routeLayoutMode = routeLayout.mode;
   // Chrome visibility is primarily route-owned. A small set of focused
   // Location flows still keeps the top shell while clearing bottom chrome.
-  const hidesPersistentChrome = routeLayout.persistentChrome === "none";
+  const hidesPersistentChrome =
+    routeLayout.persistentChrome === "none" || suppressAnonymousEntryChrome;
   const locationAction = String(searchParams?.get("action") || "").trim();
   const focusedLocationChromeFlow =
     shellPathname === ROUTES.ONE_LOCATION &&

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRight, Grid2X2, List, MoreHorizontal, Search, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 
-import { AgentSectionIcon } from "@/components/app-ui/agent-section-icon";
-import { PageTitle } from "@/components/app-ui/typography";
 import {
   getOneSetupCapability,
   isOneCapabilityEnabled,
   ONE_CAPABILITIES,
-  type OneCapabilityIcon,
-  type OneCapabilityTone,
 } from "@/lib/onboarding/one-capabilities";
 import {
   getCapabilityStatusDisplay,
@@ -29,52 +25,129 @@ import type { PersonalKnowledgeModelMetadata } from "@/lib/services/personal-kno
 import type { RiaHomeResponse } from "@/lib/services/ria-service";
 import { cn } from "@/lib/utils";
 
+type AgentMetric = {
+  value: string;
+  label: string;
+};
+
 type OneAgentMode = {
   id: string;
   title: string;
-  description: string;
   href: string;
-  icon: OneCapabilityIcon;
-  statusTone: CapabilityStatusTone;
-  primaryMetric: {
-    value: string;
-    label: string;
-  };
-  paletteIndex: number;
-  tone: OneCapabilityTone;
-  isExploreOnly: boolean;
+  primaryMetric: AgentMetric;
+  status?: CapabilityStatus;
 };
 
-type AgentMetric = OneAgentMode["primaryMetric"];
-type AgentRosterView = "grid" | "list";
-type AgentMetricTone = "default" | "positive" | "accent" | "warning" | "muted";
-type AgentLauncherState = {
-  notificationCount: number | null;
-  isLive: boolean;
-  informationalMetric: AgentMetric | null;
+type AgentHomeStatus =
+  | { kind: "action"; count: number; label: string }
+  | { kind: "live"; count: number }
+  | { kind: "setup" }
+  | { kind: "none" };
+
+type AgentGlyphKey =
+  | "location"
+  | "kyc"
+  | "finance"
+  | "ria"
+  | "gmail"
+  | "calendar"
+  | "memory"
+  | "consent"
+  | "crm";
+
+type AgentHomeDefinition = {
+  id: string;
+  label: string;
+  order: number;
+  surface: string;
+  glyph: AgentGlyphKey;
+  glyphClassName?: string;
+  surfaceClassName?: string;
 };
 
-const AGENT_ROSTER_VIEW_STORAGE_KEY = "hushh:one-agent-roster-view";
+const ONE_HOME_AGENT_DEFINITIONS: readonly AgentHomeDefinition[] = [
+  {
+    id: "location",
+    label: "Location",
+    order: 0,
+    surface: "var(--app-accent)",
+    glyph: "location",
+  },
+  {
+    id: "email",
+    label: "KYC",
+    order: 1,
+    surface: "#32ADE6",
+    glyph: "kyc",
+  },
+  {
+    id: "finance",
+    label: "Finance",
+    order: 2,
+    surface: "#5E5CE6",
+    glyph: "finance",
+  },
+  {
+    id: "ria",
+    label: "RIA",
+    order: 3,
+    surface: "#AF52DE",
+    glyph: "ria",
+  },
+  {
+    id: "gmail",
+    label: "Gmail",
+    order: 4,
+    surface: "#FFFFFF",
+    glyph: "gmail",
+    glyphClassName: "text-[#EA4335]",
+    surfaceClassName: "ring-black/[0.08]",
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    order: 5,
+    surface: "var(--app-accent)",
+    glyph: "calendar",
+  },
+  {
+    id: "pkm",
+    label: "Memory",
+    order: 6,
+    surface: "#30B0C7",
+    glyph: "memory",
+  },
+  {
+    id: "consent",
+    label: "Consent",
+    order: 7,
+    surface: "#636366",
+    glyph: "consent",
+  },
+  {
+    id: "connected-systems",
+    label: "CRM",
+    order: 8,
+    surface: "#3A7CA5",
+    glyph: "crm",
+  },
+] as const;
 
-/**
- * The roster only ever mounts client-side (its `/one` route renders a loader
- * until auth resolves, so it never server-renders with content). Reading the
- * persisted preference synchronously in the state initializer therefore has
- * no hydration-mismatch risk and lets the very first paint already be the
- * remembered view - eliminating a brief default-view flip on every return to
- * `/one`.
- */
-function readPersistedRosterView(): AgentRosterView {
-  if (typeof window === "undefined") return "grid";
-  try {
-    const persisted = window.localStorage.getItem(
-      AGENT_ROSTER_VIEW_STORAGE_KEY,
-    );
-    return persisted === "list" ? "list" : "grid";
-  } catch {
-    return "grid";
-  }
-}
+const ONE_HOME_DEFINITION_BY_ID = new Map(
+  ONE_HOME_AGENT_DEFINITIONS.map((definition) => [
+    definition.id,
+    definition,
+  ]),
+);
+
+const ACTION_METRIC_LABELS = new Set([
+  "review",
+  "reviews",
+  "request",
+  "requests",
+  "approval waiting",
+  "approvals waiting",
+]);
 
 function positiveNumber(value: unknown): number | null {
   const number = Number(value);
@@ -95,10 +168,6 @@ function countCollection(value: unknown): number | null {
 
 function canonicalMarketPayload(userId: string): KaiHomeInsightsV2 | null {
   const cache = CacheService.getInstance();
-  // The roster describes the overall market leader, not the newest arbitrary
-  // symbol-scoped Finance response. A holdings/analysis cache can arrive after
-  // the baseline and contain a different, partial universe; choosing by last
-  // write made the `/one` KPI jump or show an unrelated percentage.
   return (
     cache.peek<KaiHomeInsightsV2>(
       CACHE_KEYS.KAI_MARKET_HOME_BASELINE(userId, 7),
@@ -122,10 +191,6 @@ function isPositiveMover(
   );
 }
 
-/**
- * Read-only cache metrics for the One roster. These never trigger a fetch and
- * only expose existing, non-sensitive workspace summaries.
- */
 export function resolveCachedAgentMetrics(
   userId: string | null | undefined,
 ): Record<string, AgentMetric> {
@@ -136,12 +201,8 @@ export function resolveCachedAgentMetrics(
   const market = canonicalMarketPayload(userId);
   const topMover = (market?.movers?.gainers ?? [])
     .filter(isPositiveMover)
-    .sort(
-      (left, right) => right.change_pct - left.change_pct,
-    )[0];
-  const moverSymbol = String(topMover?.symbol ?? "")
-    .trim()
-    .toUpperCase();
+    .sort((left, right) => right.change_pct - left.change_pct)[0];
+  const moverSymbol = String(topMover?.symbol ?? "").trim().toUpperCase();
   if (moverSymbol) {
     metrics.finance = {
       value: moverSymbol,
@@ -185,7 +246,7 @@ export function resolveCachedAgentMetrics(
     ).length;
     metrics.location = {
       value: String(liveShares),
-      label: liveShares === 1 ? "live" : "live",
+      label: "live",
     };
   }
 
@@ -237,10 +298,40 @@ function useCachedAgentMetrics(
     });
   }, [userId]);
 
-  // `revision` is deliberately read so cache events cause a fresh, read-only
-  // projection without introducing a second cache mirror for this list.
   void revision;
   return resolveCachedAgentMetrics(userId);
+}
+
+function resolvePrimaryMetric({
+  capabilityId,
+  status,
+}: {
+  capabilityId: string;
+  status?: CapabilityStatus;
+}): AgentMetric {
+  if (capabilityId === "consent") {
+    if (!status || status.state === "unknown") {
+      return { value: "0", label: "requests" };
+    }
+    const pendingConsentCount = status.pendingCount;
+    return {
+      value: String(pendingConsentCount),
+      label: pendingConsentCount === 1 ? "request" : "requests",
+    };
+  }
+
+  if (!status || status.state === "unknown") {
+    return { value: "0", label: "none" };
+  }
+
+  if (status.pendingCount > 0) {
+    return {
+      value: String(status.pendingCount),
+      label: status.pendingCount === 1 ? "review" : "reviews",
+    };
+  }
+
+  return { value: "0", label: "none" };
 }
 
 function buildModes(
@@ -251,106 +342,57 @@ function buildModes(
   return ONE_CAPABILITIES.filter(
     (capability) =>
       capability.isVisibleOnRoster !== false &&
-      isOneCapabilityEnabled(capability),
-  ).map((capability, paletteIndex) => {
-    const setupCapability = getOneSetupCapability(capability.id);
-    const status = statusById[capability.id];
-    const copy = setupCapability
-      ? getCapabilitySetupCopy(capability.id)
-      : undefined;
-    const display =
-      setupCapability && copy
-        ? status
-          ? getCapabilityStatusDisplay(status, {
-              isExploreOnly: capability.isExploreOnly,
-              actionLabel: copy.actionLabel,
-              resumeActionLabel: copy.resumeActionLabel,
-            })
-          : { label: copy.actionLabel, tone: "action" as CapabilityStatusTone }
-        : {
-            label: capability.isExploreOnly ? "Explore" : "Open",
-            tone: "action" as CapabilityStatusTone,
-          };
+      isOneCapabilityEnabled(capability) &&
+      ONE_HOME_DEFINITION_BY_ID.has(capability.id),
+  )
+    .map((capability) => {
+      const setupCapability = getOneSetupCapability(capability.id);
+      const status = statusById[capability.id];
+      const copy = setupCapability
+        ? getCapabilitySetupCopy(capability.id)
+        : undefined;
+      const display =
+        setupCapability && copy
+          ? status
+            ? getCapabilityStatusDisplay(status, {
+                isExploreOnly: capability.isExploreOnly,
+                actionLabel: copy.actionLabel,
+                resumeActionLabel: copy.resumeActionLabel,
+              })
+            : { label: copy.actionLabel, tone: "action" as CapabilityStatusTone }
+          : {
+              label: capability.isExploreOnly ? "Explore" : "Open",
+              tone: "action" as CapabilityStatusTone,
+            };
 
-    const isActionable =
-      "isActionable" in display ? (display as any).isActionable : true;
-    const opensSetup = Boolean(
-      setupCapability &&
-        isActionable &&
-        (!setupDismissed || capability.id === "finance"),
-    );
+      const isActionable =
+        "isActionable" in display ? (display as any).isActionable : true;
+      const opensSetup = Boolean(
+        setupCapability &&
+          isActionable &&
+          (!setupDismissed || capability.id === "finance"),
+      );
 
-    const primaryMetric =
-      cachedMetrics[capability.id] ??
-      resolvePrimaryMetric({
-        capabilityId: capability.id,
+      return {
+        id: capability.id,
+        title: capability.title,
+        href: opensSetup
+          ? buildOneSetupCapabilityRoute(capability.id)
+          : capability.href,
+        primaryMetric:
+          cachedMetrics[capability.id] ??
+          resolvePrimaryMetric({
+            capabilityId: capability.id,
+            status,
+          }),
         status,
-      });
-
-    return {
-      id: capability.id,
-      title: capability.title,
-      description: capability.description,
-      // Root onboarding dismissal normally opens the product workspace.
-      // Finance remains an exception while its own resolver says setup is
-      // actionable: root completion or Skip is not Finance completion.
-      href: opensSetup
-        ? buildOneSetupCapabilityRoute(capability.id)
-        : capability.href,
-      icon: capability.icon,
-      statusTone: display.tone,
-      primaryMetric,
-      paletteIndex,
-      tone: capability.tone,
-      isExploreOnly: capability.isExploreOnly === true,
-    };
-  });
-}
-
-/**
- * The roster's compact KPI is deliberately derived from an already-resolved
- * capability state. Cache-backed workspace summaries take precedence when
- * available; this fallback never invents product activity.
- */
-function resolvePrimaryMetric({
-  capabilityId,
-  status,
-}: {
-  capabilityId: string;
-  status?: CapabilityStatus;
-}): OneAgentMode["primaryMetric"] {
-  if (capabilityId === "consent") {
-    if (!status || status.state === "unknown") {
-      return { value: "—", label: "checking" };
-    }
-    const pendingConsentCount = status.pendingCount;
-    return {
-      value: String(pendingConsentCount),
-      label: pendingConsentCount === 1 ? "request" : "requests",
-    };
-  }
-
-  if (!status || status.state === "unknown") {
-    return { value: "—", label: "status not loaded" };
-  }
-
-  if (status.pendingCount > 0) {
-    return {
-      value: String(status.pendingCount),
-      label: status.pendingCount === 1 ? "review" : "reviews",
-    };
-  }
-
-  const actionsDue =
-    status.state === "completed" || status.state === "skipped" ? 0 : 1;
-  return {
-    value: String(actionsDue),
-    label: actionsDue === 1 ? "action" : "actions",
-  };
-}
-
-function isZeroMetric(metric: AgentMetric): boolean {
-  return Number(metric.value) === 0;
+      };
+    })
+    .sort((left, right) => {
+      const leftOrder = ONE_HOME_DEFINITION_BY_ID.get(left.id)?.order ?? 99;
+      const rightOrder = ONE_HOME_DEFINITION_BY_ID.get(right.id)?.order ?? 99;
+      return leftOrder - rightOrder;
+    });
 }
 
 function positiveIntegerMetricValue(metric: AgentMetric): number | null {
@@ -358,18 +400,9 @@ function positiveIntegerMetricValue(metric: AgentMetric): number | null {
   return Number.isInteger(number) && number > 0 ? number : null;
 }
 
-function isUnavailableMetric(metric: AgentMetric): boolean {
-  return metric.value === "—" || /status not loaded|checking/i.test(metric.label);
+function formatBadgeValue(value: number): string {
+  return value > 99 ? "99+" : String(value);
 }
-
-const ACTION_METRIC_LABELS = new Set([
-  "review",
-  "reviews",
-  "request",
-  "requests",
-  "approval waiting",
-  "approvals waiting",
-]);
 
 function actionBadgeValue(mode: OneAgentMode): number | null {
   const value = positiveIntegerMetricValue(mode.primaryMetric);
@@ -385,414 +418,233 @@ function locationLiveValue(mode: OneAgentMode): number | null {
   return value === null ? null : value;
 }
 
-function launcherState(mode: OneAgentMode): AgentLauncherState {
-  const notificationCount = actionBadgeValue(mode);
-  const isLive = locationLiveValue(mode) !== null;
-  return {
-    notificationCount,
-    isLive,
-    informationalMetric:
-      notificationCount === null && !isUnavailableMetric(mode.primaryMetric)
-        ? mode.primaryMetric
-        : null,
-  };
-}
-
-function shouldShowGridMetric(mode: OneAgentMode): boolean {
-  if (isUnavailableMetric(mode.primaryMetric)) return false;
-  if (actionBadgeValue(mode) !== null) return false;
-  if (mode.id === "location") return locationLiveValue(mode) !== null;
-  if (mode.id === "finance") return mode.primaryMetric.label.endsWith("%");
-  if (mode.id === "pkm") return !isZeroMetric(mode.primaryMetric);
-  if (mode.primaryMetric.label.includes("client")) {
-    return !isZeroMetric(mode.primaryMetric);
-  }
-  return false;
-}
-
-function shouldShowListMetric(mode: OneAgentMode): boolean {
-  if (isUnavailableMetric(mode.primaryMetric)) return false;
-  if (isZeroMetric(mode.primaryMetric)) return false;
-  if (actionBadgeValue(mode) !== null) return false;
-  return true;
-}
-
-function formatBadgeValue(value: number): string {
-  return value > 99 ? "99+" : String(value);
-}
-
-function formatA11yMetric(mode: OneAgentMode): string {
-  const badge = actionBadgeValue(mode);
-  if (badge !== null) {
-    return `, ${formatBadgeValue(badge)} ${mode.primaryMetric.label}`;
-  }
-  const live = locationLiveValue(mode);
-  if (live !== null) {
-    return `, ${live} live ${live === 1 ? "share" : "shares"}`;
-  }
-  if (isUnavailableMetric(mode.primaryMetric) || isZeroMetric(mode.primaryMetric)) {
-    return "";
-  }
-  if (mode.id === "finance" && mode.primaryMetric.label.endsWith("%")) {
-    const direction = mode.primaryMetric.label.startsWith("-") ? "down" : "up";
-    const percent = mode.primaryMetric.label
-      .replace(/^[+-]/, "")
-      .replace("%", " percent");
-    return `, ${mode.primaryMetric.value} ${direction} ${percent}`;
-  }
-  return `, ${mode.primaryMetric.value} ${mode.primaryMetric.label}`;
-}
-
-function resolveMetricTone(mode: OneAgentMode): AgentMetricTone {
-  const metric = mode.primaryMetric;
-  const isZero = isZeroMetric(metric);
-
-  if (metric.value === "—") return "muted";
-
-  if (mode.id === "finance") {
-    return metric.label.endsWith("%") ? "default" : "muted";
+function resolveAgentHomeStatus(mode: OneAgentMode): AgentHomeStatus {
+  const actionCount = actionBadgeValue(mode);
+  if (actionCount !== null) {
+    return { kind: "action", count: actionCount, label: mode.primaryMetric.label };
   }
 
-  if (mode.id === "location") {
-    return isZero ? "muted" : "accent";
+  const liveCount = locationLiveValue(mode);
+  if (liveCount !== null) {
+    return { kind: "live", count: liveCount };
   }
 
-  if (mode.id === "pkm") {
-    return "default";
+  const hasReliableSetupState =
+    mode.status &&
+    mode.status.state !== "unknown" &&
+    mode.status.state !== "completed" &&
+    mode.status.state !== "skipped" &&
+    getOneSetupCapability(mode.id);
+
+  return hasReliableSetupState ? { kind: "setup" } : { kind: "none" };
+}
+
+function formatTileAccessibleName(mode: OneAgentMode): string {
+  const status = resolveAgentHomeStatus(mode);
+  const definition = ONE_HOME_DEFINITION_BY_ID.get(mode.id);
+  const label = definition?.label ?? mode.title;
+
+  if (status.kind === "action") {
+    return `${label}, ${formatBadgeValue(status.count)} ${status.label}`;
   }
-
-  if (
-    mode.id === "ria" ||
-    mode.id === "email" ||
-    mode.id === "consent" ||
-    mode.id === "connected-systems"
-  ) {
-    return isZero ? "muted" : "warning";
+  if (status.kind === "live") {
+    return `${label}, live sharing active`;
   }
-
-  return mode.statusTone === "muted" ? "muted" : "default";
+  if (status.kind === "setup") {
+    return `${label}, setup required`;
+  }
+  return label;
 }
 
-function metricValueClassName(tone: AgentMetricTone): string {
-  if (tone === "positive") return "text-[#34C759]";
-  if (tone === "accent") return "text-[color:var(--app-accent-deep)]";
-  if (tone === "warning") return "text-[#FF9500]";
-  if (tone === "muted") return "text-[#8E8E93]";
-  return "text-[#1D1D1F] dark:text-[#F5F5F7]";
-}
-
-function metricLabelClassName(tone: AgentMetricTone): string {
-  if (tone === "positive") return "text-[#34C759]";
-  if (tone === "accent") return "text-[color:var(--app-accent-deep)]";
-  if (tone === "warning") return "text-[#8E8E93]";
-  if (tone === "muted") return "text-[#8E8E93]";
-  return "text-[#8E8E93]";
-}
-
-function AgentMetric({
-  mode,
-  compact = false,
-  align = "right",
-}: {
-  mode: OneAgentMode;
-  compact?: boolean;
-  /**
-   * `left`/`right` are the list-view alignments. `grid` is the dashboard card:
-   * one centered line — value + label together at a smaller size — that never
-   * wraps or clips (labels shrink to fit; see the 11px label class below).
-   */
-  align?: "right" | "left" | "grid";
-}) {
-  const isTopWinner =
-    mode.id === "finance" && mode.primaryMetric.label.endsWith("%");
-  const tone = resolveMetricTone(mode);
-  const valueTone = isTopWinner ? "default" : tone;
-  const labelTone = isTopWinner ? "positive" : tone;
-  const isGrid = align === "grid";
-
-  if (isGrid && !shouldShowGridMetric(mode)) return null;
-  if (!isGrid && !shouldShowListMetric(mode)) return null;
-
-  return (
-    <span
-      data-testid={isTopWinner ? "one-finance-top-winner-kpi" : undefined}
-      className={cn(
-        "inline-flex w-full min-w-0 items-baseline gap-1",
-        isGrid
-          ? "justify-center whitespace-nowrap text-center"
-          : align === "left"
-            ? "justify-start text-left"
-            : "text-right",
-        !isGrid &&
-          (compact
-            ? "max-w-full flex-wrap justify-center"
-            : align === "left"
-              ? "flex-wrap"
-              : "justify-end whitespace-nowrap"),
-      )}
-    >
-      <span
-        data-ui-role="body-strong"
-        className={cn(
-          "shrink-0 tabular-nums font-semibold tracking-normal",
-          isGrid ? "text-[11px] leading-4" : "text-[15px] leading-5",
-          metricValueClassName(valueTone),
-        )}
-      >
-        {mode.primaryMetric.value}
-      </span>
-      <span
-        data-ui-role="trailing-value"
-        className={cn(
-          "min-w-0 font-normal tracking-normal",
-          isGrid ? "truncate text-[11px] leading-4" : "text-[15px] leading-5",
-          !isGrid &&
-            (compact
-              ? "whitespace-normal text-center [overflow-wrap:anywhere]"
-              : "truncate"),
-          metricLabelClassName(labelTone),
-        )}
-      >
-        {mode.primaryMetric.label}
-      </span>
-    </span>
-  );
-}
-
-function AgentNotificationBadge({ value }: { value: number }) {
-  return (
-    <span
-      data-testid="one-agent-notification-badge"
-      className="absolute -right-1.5 -top-1.5 z-20 inline-flex min-h-[19px] min-w-[19px] items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[#FF3B30] px-1 text-[11px] font-semibold leading-none text-white shadow-none"
-      aria-hidden
-    >
-      {formatBadgeValue(value)}
-    </span>
-  );
-}
-
-function AgentLiveDot() {
-  return (
-    <span
-      data-testid="one-agent-live-dot"
-      className="absolute -bottom-0.5 -right-0.5 z-20 h-3.5 w-3.5 rounded-full border-2 border-[color:var(--background)] bg-[#34C759]"
-      aria-hidden
-    />
-  );
-}
-
-function AgentGridItem({
-  mode,
+function AgentHomeGlyph({
+  glyph,
   className,
 }: {
-  mode: OneAgentMode;
+  glyph: AgentGlyphKey;
   className?: string;
 }) {
-  const state = launcherState(mode);
+  const common = {
+    className: cn("h-[46%] w-[46%]", className),
+    viewBox: "0 0 24 24",
+    fill: "currentColor",
+    "aria-hidden": true,
+  } as const;
 
-  return (
-    <Link
-      href={mode.href}
-      aria-label={`Open ${mode.title}${formatA11yMetric(mode)}`}
-      data-testid={`one-agent-tile-${mode.id}`}
-      title={mode.description}
-      className={cn(
-        "group relative flex min-h-[94px] min-w-0 w-full flex-col items-center justify-start gap-2 rounded-[18px] px-1 py-0.5 text-center",
-        "transition-[background-color,opacity,transform] duration-150 ease-[var(--motion-ease-standard)]",
-        "hover:bg-[rgba(120,120,128,.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/60 active:scale-[0.97] active:opacity-80 motion-reduce:transition-none motion-reduce:active:scale-100",
-        className,
-      )}
-    >
-      <span className="relative z-10 overflow-visible">
-        <AgentSectionIcon
-          id={mode.id}
-          icon={mode.icon}
-          tone={mode.tone}
-          paletteIndex={mode.paletteIndex}
-          isActive={mode.statusTone !== "muted"}
-          size="roster-lg"
-          treatment="default"
-        />
-        {state.notificationCount !== null ? (
-          <AgentNotificationBadge value={state.notificationCount} />
-        ) : null}
-        {state.isLive ? (
-          <AgentLiveDot />
-        ) : null}
-      </span>
-      <span className="relative z-10 flex w-full min-w-0 flex-col items-center gap-[2px] text-center">
-        <span
-          className="block w-full truncate text-center text-[13px] font-semibold leading-[17px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
-          data-ui-role="body-strong"
-        >
-          {mode.title}
-        </span>
-      </span>
-    </Link>
-  );
+  switch (glyph) {
+    case "location":
+      return (
+        <svg {...common}>
+          <path d="M12 2.6c-4.1 0-7.1 3.1-7.1 7.2 0 5 5.5 10.5 6.6 11.5.3.3.7.3 1 0 1.1-1 6.6-6.5 6.6-11.5 0-4.1-3-7.2-7.1-7.2Zm0 10.1a2.9 2.9 0 1 1 0-5.8 2.9 2.9 0 0 1 0 5.8Z" />
+        </svg>
+      );
+    case "kyc":
+      return (
+        <svg {...common}>
+          <path d="M4.5 5.2c0-1.1.9-2 2-2h11c1.1 0 2 .9 2 2v13.6c0 1.1-.9 2-2 2h-11c-1.1 0-2-.9-2-2V5.2Zm2.6 3.3h5.4v-2H7.1v2Zm.2 9.3h5.1c-.3-1.7-1.3-2.7-2.6-2.7s-2.2 1-2.5 2.7Zm2.5-4a2.4 2.4 0 1 0 0-4.8 2.4 2.4 0 0 0 0 4.8Zm5.2.1 1.5 1.5 3-3-1.2-1.2-1.8 1.8-.6-.6-.9 1Z" />
+        </svg>
+      );
+    case "finance":
+      return (
+        <svg {...common}>
+          <path d="M4.2 17.8h15.6c.5 0 .9.4.9.9s-.4.9-.9.9H4.2a.9.9 0 0 1 0-1.8Zm1.2-4.5 4-4c.3-.3.8-.3 1.1 0l2.3 2.2 5.1-5.1h-2.1a.9.9 0 0 1 0-1.8h4.2c.5 0 .9.4.9.9v4.2a.9.9 0 0 1-1.8 0V7.7l-5.7 5.7c-.3.3-.8.3-1.1 0l-2.3-2.2-3.4 3.4a.9.9 0 0 1-1.2-1.3Z" />
+        </svg>
+      );
+    case "ria":
+      return (
+        <svg {...common}>
+          <path d="M8.8 11.3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm-6 7.3c.7-3.8 2.8-5.7 6-5.7 2.2 0 3.9.9 4.9 2.6.3.5 0 1.1-.6 1.2-.7.2-1.2.7-1.3 1.4-.1.6-.6 1.1-1.2 1.1H3.5c-.5 0-.8-.2-.7-.6Zm12.2.8h5.2c.7 0 1.2-.5 1.2-1.2v-3.7c0-.7-.5-1.2-1.2-1.2H15c-.7 0-1.2.5-1.2 1.2v3.7c0 .7.5 1.2 1.2 1.2Zm.8-7h3.6v-.6c0-.5-.4-.9-.9-.9h-1.8c-.5 0-.9.4-.9.9v.6Z" />
+        </svg>
+      );
+    case "gmail":
+      return (
+        <svg {...common} className={cn("h-[44%] w-[50%]", className)}>
+          <path d="M4.8 6h14.4c1 0 1.8.8 1.8 1.8v8.4c0 1-.8 1.8-1.8 1.8H4.8c-1 0-1.8-.8-1.8-1.8V7.8C3 6.8 3.8 6 4.8 6Zm.5 2.2v7.6h13.4V8.2L12 13.1 5.3 8.2Zm1.4-.7 5.3 3.9 5.3-3.9H6.7Z" />
+        </svg>
+      );
+    case "calendar":
+      return (
+        <svg {...common}>
+          <path d="M7.3 2.8c.6 0 1 .4 1 1v1h7.4v-1a1 1 0 1 1 2 0v1h.5c1.4 0 2.6 1.2 2.6 2.6v10.7c0 1.4-1.2 2.6-2.6 2.6H5.8c-1.4 0-2.6-1.2-2.6-2.6V7.4c0-1.4 1.2-2.6 2.6-2.6h.5v-1c0-.6.4-1 1-1Zm11.5 7H5.2v8.3c0 .3.3.6.6.6h12.4c.3 0 .6-.3.6-.6V9.8Zm-8.5 3.1h3.5c.5 0 .9.4.9.9v1.9c0 .5-.4.9-.9.9h-3.5a.9.9 0 0 1-.9-.9v-1.9c0-.5.4-.9.9-.9Z" />
+        </svg>
+      );
+    case "memory":
+      return (
+        <svg {...common}>
+          <path d="M8.3 3.6c-1.7 0-3 1.2-3.1 2.8a3.5 3.5 0 0 0-.7 6 3.3 3.3 0 0 0 3.1 4.7h.2a2.8 2.8 0 0 0 5.2 1.2V5.1a3.1 3.1 0 0 0-4.7-1.5Zm7.4 0A3.1 3.1 0 0 0 11 5.1v13.2a2.8 2.8 0 0 0 5.2-1.2h.2a3.3 3.3 0 0 0 3.1-4.7 3.5 3.5 0 0 0-.7-6 3.1 3.1 0 0 0-3.1-2.8Zm2.6 6.3 1 .5-1 .5-.5 1-.5-1-1-.5 1-.5.5-1 .5 1Z" />
+        </svg>
+      );
+    case "consent":
+      return (
+        <svg {...common}>
+          <path d="M7.3 10.7V7.3a1 1 0 0 1 2 0v4.4h.8V5.5a1 1 0 1 1 2 0v6.2h.8V6.6a1 1 0 1 1 2 0v5.1h.8V8.2a1 1 0 1 1 2 0v6.2c0 4-2.4 6.5-6.1 6.5-2.8 0-4.8-1.3-6.3-4.2l-1.2-2.3a1.2 1.2 0 0 1 2.1-1.1l1 1.9v-4.5Zm7.8 6.5 1.6 1.6 3.4-3.4-1.1-1.1-2.3 2.3-.8-.8-.8 1.4Z" />
+        </svg>
+      );
+    case "crm":
+      return (
+        <svg {...common}>
+          <path d="M6 3.3h10.6c1 0 1.8.8 1.8 1.8v13.8c0 1-.8 1.8-1.8 1.8H6c-1 0-1.8-.8-1.8-1.8V5.1c0-1 .8-1.8 1.8-1.8Zm1.9 4.1h6.8V5.8H7.9v1.6Zm2.4 7.1c-1.7 0-2.9 1.1-3.3 3h8c-.4-1.9-1.7-3-3.4-3h-1.3Zm.6-1.2a2.3 2.3 0 1 0 0-4.6 2.3 2.3 0 0 0 0 4.6Zm7.9-5.7h1V6.2h-1v1.4Zm0 3.6h1V9.8h-1v1.4Zm0 3.6h1v-1.4h-1v1.4Z" />
+        </svg>
+      );
+  }
 }
 
-function AgentListRow({ mode }: { mode: OneAgentMode }) {
-  const state = launcherState(mode);
-  return (
-    <Link
-      href={mode.href}
-      aria-label={`Open ${mode.title}${formatA11yMetric(mode)}`}
-      title={mode.description}
-      data-testid={`one-agent-list-row-${mode.id}`}
-      className={cn(
-        "group/agent-row relative grid min-h-[58px] w-full grid-cols-[40px_minmax(0,1fr)_minmax(84px,auto)_14px] items-center gap-x-3 overflow-hidden px-3.5 text-left outline-none",
-        "transition-colors duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
-        "hover:bg-[rgba(120,120,128,.08)] active:bg-[rgba(120,120,128,.12)]",
-        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-      )}
-    >
-      <span className="relative z-10 flex items-center justify-center">
-        <span className="relative overflow-visible">
-          <AgentSectionIcon
-            id={mode.id}
-            icon={mode.icon}
-            tone={mode.tone}
-            paletteIndex={mode.paletteIndex}
-            isActive={mode.statusTone !== "muted"}
-            size="roster"
-            treatment="default"
-          />
-          {state.notificationCount !== null ? (
-            <AgentNotificationBadge value={state.notificationCount} />
-          ) : null}
-          {state.isLive ? (
-            <AgentLiveDot />
-          ) : null}
-        </span>
-      </span>
-      <span className="relative z-10 flex min-w-0 flex-col justify-center">
-        <span
-          data-ui-role="row-label"
-          className="ui-text-row-label min-w-0 truncate"
-        >
-          {mode.title}
-        </span>
-        {/*
-          The description was carried on every capability but rendered only as a
-          `title` attribute — a hover tooltip, which does not exist on a phone.
-          A roster of nine one-word labels asks the reader to already know what
-          each agent does, and the one people do not find is the one whose name
-          explains least.
-        */}
-        {mode.description ? (
-          <span
-            data-ui-role="row-description"
-            className="min-w-0 truncate text-[12px] leading-[16px] text-[#6E6E73] dark:text-[#98989D]"
-          >
-            {mode.description}
-          </span>
-        ) : null}
-      </span>
-      <span className="relative z-10 flex min-w-0 max-w-[132px] justify-end">
-        <AgentMetric mode={mode} />
-      </span>
-      <ChevronRight
-        aria-hidden
-        className="relative z-10 h-4 w-4 text-[#C7C7CC] [stroke-width:1.7]"
-      />
+function AgentHomeStatusAdornment({ status }: { status: AgentHomeStatus }) {
+  if (status.kind === "action") {
+    return (
       <span
+        data-testid="one-agent-notification-badge"
+        className="absolute -right-1.5 -top-1.5 z-20 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-destructive)] px-1 text-[11px] font-semibold leading-none text-white"
         aria-hidden
-        className="pointer-events-none absolute bottom-0 left-16 right-4 h-px bg-[rgba(60,60,67,.12)] group-last/agent-list:hidden"
+      >
+        {formatBadgeValue(status.count)}
+      </span>
+    );
+  }
+
+  if (status.kind === "live") {
+    return (
+      <span
+        data-testid="one-agent-live-dot"
+        className="absolute -right-1 -top-1 z-20 h-[10px] w-[10px] rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-success)]"
+        aria-hidden
       />
+    );
+  }
+
+  if (status.kind === "setup") {
+    return (
+      <span
+        data-testid="one-agent-setup-badge"
+        className="absolute -right-1 -top-1 z-20 inline-flex h-[17px] w-[17px] items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-accent)] text-white"
+        aria-hidden
+      >
+        <svg className="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" aria-hidden>
+          <path
+            d="M6 2.1v7.8M2.1 6h7.8"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth="1.8"
+          />
+        </svg>
+      </span>
+    );
+  }
+
+  return null;
+}
+
+function AgentHomeIcon({
+  definition,
+  status,
+}: {
+  definition: AgentHomeDefinition;
+  status: AgentHomeStatus;
+}) {
+  return (
+    <span className="relative inline-flex overflow-visible">
+      <span
+        data-testid={`one-agent-icon-${definition.id}`}
+        className={cn(
+          "inline-flex h-[var(--one-agent-icon-size)] w-[var(--one-agent-icon-size)] items-center justify-center rounded-[25%] text-white",
+          "shadow-[0_1px_2px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.05)] ring-1 ring-white/25",
+          definition.surfaceClassName,
+        )}
+        style={{ backgroundColor: definition.surface }}
+        aria-hidden
+      >
+        <AgentHomeGlyph
+          glyph={definition.glyph}
+          className={definition.glyphClassName}
+        />
+      </span>
+      <AgentHomeStatusAdornment status={status} />
+    </span>
+  );
+}
+
+function AgentLauncherItem({ mode }: { mode: OneAgentMode }) {
+  const definition = ONE_HOME_DEFINITION_BY_ID.get(mode.id);
+  if (!definition) return null;
+
+  const status = resolveAgentHomeStatus(mode);
+  const accessibleName = formatTileAccessibleName(mode);
+
+  return (
+    <Link
+      href={mode.href}
+      aria-label={accessibleName}
+      data-testid={`one-agent-tile-${mode.id}`}
+      className={cn(
+        "group flex min-h-[var(--one-agent-cell-height)] min-w-0 flex-col items-center justify-center gap-2 rounded-[18px] px-1.5 py-2 text-center outline-none",
+        "transition-[background-color,opacity,transform] duration-150 ease-[var(--motion-ease-standard)]",
+        "hover:bg-[rgba(120,120,128,.08)] focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] active:opacity-90 motion-reduce:transition-none",
+      )}
+    >
+      <span className="transition-transform duration-[120ms] ease-[var(--motion-ease-standard)] group-active:scale-[0.95] motion-reduce:transition-none motion-reduce:group-active:scale-100">
+        <AgentHomeIcon definition={definition} status={status} />
+      </span>
+      <span
+        data-ui-role="body-strong"
+        className="block max-w-full whitespace-nowrap text-center text-[13px] font-semibold leading-[17px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
+      >
+        {definition.label}
+      </span>
     </Link>
   );
 }
 
-function AgentRosterOverflowMenu({
-  value,
-  onChange,
-  onSearch,
-}: {
-  value: AgentRosterView;
-  onChange: (next: AgentRosterView) => void;
-  onSearch: () => void;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const nextView = value === "grid" ? "list" : "grid";
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const closeOnOutside = (event: MouseEvent | TouchEvent) => {
-      const target = event.target;
-      if (target instanceof Node && rootRef.current?.contains(target)) return;
-      setIsOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setIsOpen(false);
-    };
-
-    document.addEventListener("mousedown", closeOnOutside);
-    document.addEventListener("touchstart", closeOnOutside);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("mousedown", closeOnOutside);
-      document.removeEventListener("touchstart", closeOnOutside);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [isOpen]);
-
-  const runMenuAction = (action: () => void) => {
-    action();
-    setIsOpen(false);
-  };
-
+function AgentLauncherGrid({ children }: { children: ReactNode }) {
   return (
-    <div ref={rootRef} className="relative shrink-0">
-      <button
-        type="button"
-        aria-label="Agent launcher options"
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        data-testid="one-agents-overflow-trigger"
-        onClick={() => setIsOpen((open) => !open)}
-        className={cn(
-          "inline-flex h-9 w-9 items-center justify-center rounded-full text-[#1D1D1F]",
-          "transition-[background-color,opacity,transform] duration-150 hover:bg-[rgba(120,120,128,.12)] active:scale-[0.96] active:opacity-80",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/55 dark:text-[#F5F5F7]",
-        )}
+    <div
+      data-testid="one-agents-grid"
+      className="one-agent-launcher-grid mx-auto w-full max-w-[390px] overflow-visible px-0"
+    >
+      <div
+        data-agent-roster-layout="app-icon-launcher-grid"
+        className="one-agent-launcher-grid-inner grid w-full grid-cols-3 justify-items-center overflow-visible"
       >
-        <MoreHorizontal className="h-[21px] w-[21px] [stroke-width:2]" aria-hidden />
-      </button>
-      {isOpen ? (
-        <div
-          role="menu"
-          data-testid="one-agents-overflow-menu"
-          className="absolute right-0 top-11 z-30 w-[188px] overflow-hidden rounded-[14px] border border-[rgba(60,60,67,.10)] bg-white py-1 shadow-[0_12px_30px_rgba(0,0,0,.16)] dark:border-white/10 dark:bg-[#1C1C1E]"
-        >
-          <button
-            type="button"
-            role="menuitem"
-            data-testid="one-agents-search-open"
-            onClick={() => runMenuAction(onSearch)}
-            className="flex min-h-11 w-full items-center gap-2.5 px-3 text-left text-[15px] font-medium leading-5 text-[#1D1D1F] transition-colors hover:bg-[rgba(120,120,128,.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent)]/55 dark:text-[#F5F5F7]"
-          >
-            <Search className="h-4 w-4 text-[#6E6E73] [stroke-width:1.8]" aria-hidden />
-            <span>Search agents</span>
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            data-testid={`one-agents-view-${nextView}`}
-            onClick={() => runMenuAction(() => onChange(nextView))}
-            className="flex min-h-11 w-full items-center gap-2.5 px-3 text-left text-[15px] font-medium leading-5 text-[#1D1D1F] transition-colors hover:bg-[rgba(120,120,128,.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent)]/55 dark:text-[#F5F5F7]"
-          >
-            {nextView === "list" ? (
-              <List className="h-4 w-4 text-[#6E6E73] [stroke-width:1.8]" aria-hidden />
-            ) : (
-              <Grid2X2 className="h-4 w-4 text-[#6E6E73] [stroke-width:1.8]" aria-hidden />
-            )}
-            <span>{nextView === "list" ? "View as list" : "View as grid"}</span>
-          </button>
-        </div>
-      ) : null}
+        {children}
+      </div>
     </div>
   );
 }
@@ -812,149 +664,19 @@ export function OneAgentRoster({
           ?.setupCompleted === true),
   );
   const modes = buildModes(capabilityStatusById, cachedMetrics, setupDismissed);
-  const [view, setView] = useState<AgentRosterView>(readPersistedRosterView);
-  const [animateViewChange, setAnimateViewChange] = useState(false);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const visibleModes = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return modes;
-    return modes.filter((mode) =>
-      [
-        mode.title,
-        mode.description,
-        mode.primaryMetric.value,
-        mode.primaryMetric.label,
-      ]
-        .join(" ")
-        .toLowerCase()
-        .includes(normalized),
-    );
-  }, [modes, query]);
-
-  const selectView = (next: AgentRosterView) => {
-    if (next === view) return;
-    setAnimateViewChange(true);
-    setView(next);
-    try {
-      window.localStorage.setItem(AGENT_ROSTER_VIEW_STORAGE_KEY, next);
-    } catch {
-      // Storage can be disabled without blocking a local display change.
-    }
-  };
-
-  const closeSearch = () => {
-    setQuery("");
-    setIsSearchOpen(false);
-  };
 
   return (
     <section
-      aria-labelledby="one-agents-heading"
+      aria-label="One agents"
       data-testid="one-agents-section"
-      className="mx-auto w-full max-w-[560px]"
+      className="mx-auto flex w-full max-w-[430px] flex-col justify-center"
     >
-      <div className="mb-6 flex min-h-11 items-center justify-between gap-3">
-        {isSearchOpen ? (
-          <>
-            <label className="relative block min-w-0 flex-1">
-              <Search
-                className="pointer-events-none absolute left-4 top-1/2 h-[17px] w-[17px] -translate-y-1/2 text-[#8E8E93] [stroke-width:1.8]"
-                aria-hidden="true"
-              />
-              <input
-                type="search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search agents"
-                aria-label="Search agents"
-                autoFocus
-                data-ui-role="input-text"
-                data-testid="one-agents-search"
-                className="h-11 w-full rounded-[14px] border border-transparent bg-white py-[12px] pl-11 pr-10 text-[15px] font-normal leading-5 text-[#1D1D1F] outline-none placeholder:text-[#8E8E93] focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent)]/55 dark:bg-[#1C1C1E] dark:text-[#F5F5F7]"
-              />
-              {query ? (
-                <button
-                  type="button"
-                  aria-label="Clear search"
-                  onClick={() => setQuery("")}
-                  className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-[#1D1D1F] transition-colors hover:bg-[rgba(120,120,128,.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/55 dark:text-[#F5F5F7]"
-                >
-                  <X className="h-4 w-4 [stroke-width:2]" aria-hidden />
-                </button>
-              ) : null}
-            </label>
-            <button
-              type="button"
-              onClick={closeSearch}
-              className="h-11 shrink-0 rounded-full px-1.5 text-[17px] font-medium leading-[22px] text-[color:var(--app-accent)] transition-opacity active:opacity-65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]/55"
-            >
-              Cancel
-            </button>
-          </>
-        ) : (
-          <>
-            <PageTitle
-              as="h1"
-              id="one-agents-heading"
-              className="min-w-0 whitespace-nowrap"
-              aria-label={`Agents, ${modes.length} agents`}
-            >
-              {/* Legacy design gate marker: Agents ({modes.length}) */}
-              Agents
-              <span className="sr-only">, {modes.length} agents</span>
-            </PageTitle>
-            <AgentRosterOverflowMenu
-              value={view}
-              onChange={selectView}
-              onSearch={() => setIsSearchOpen(true)}
-            />
-          </>
-        )}
-      </div>
-      <div
-        key={view}
-        data-testid="one-agents-view-content"
-        className={animateViewChange ? "motion-step-enter" : undefined}
-      >
-        {view === "grid" ? (
-          <div
-            data-testid="one-agents-grid"
-            className="mx-auto w-full max-w-[552px] overflow-visible"
-          >
-            <div
-              data-agent-roster-layout="app-icon-launcher-grid"
-              className="grid w-full grid-cols-3 justify-center gap-x-5 gap-y-7 overflow-visible min-[430px]:gap-x-6"
-            >
-              {visibleModes.map((mode) => (
-                <AgentGridItem key={mode.id} mode={mode} />
-              ))}
-            </div>
-            {visibleModes.length === 0 ? (
-              <div
-                data-testid="one-agents-empty-state"
-                className="py-10 text-center"
-              >
-                <p className="text-[17px] font-semibold leading-[22px] text-[#1D1D1F] dark:text-[#F5F5F7]">
-                  No matching agents
-                </p>
-                <p className="mt-1 text-[15px] font-normal leading-5 text-[#8E8E93]">
-                  Try another search.
-                </p>
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div
-            data-testid="one-agents-list"
-            className="group/agent-list overflow-hidden rounded-[20px] bg-white shadow-none dark:bg-[#1C1C1E]"
-          >
-            {visibleModes.map((mode) => (
-              <AgentListRow key={mode.id} mode={mode} />
-            ))}
-          </div>
-        )}
-      </div>
+      <h1 className="sr-only">One</h1>
+      <AgentLauncherGrid>
+        {modes.map((mode) => (
+          <AgentLauncherItem key={mode.id} mode={mode} />
+        ))}
+      </AgentLauncherGrid>
     </section>
   );
 }

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1059,19 +1059,17 @@ export function AuthStep({
       </button>
 
       <div
-        className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center"
+        className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center px-6"
         style={{
           height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
           minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
         }}
         data-auth-content-block
       >
-        {/* Center the complete sign-in group as one visual block while the
-            fixed Back control remains independently anchored above it. The
-            clusters use one deliberate rhythm: identity, provider actions,
-            then the consent and legal context. */}
+        {/* Center the sign-in group as one visual block while the fixed Back
+            control and legal footer remain independently anchored. */}
         <div
-          className="flex w-full flex-none flex-col items-center gap-6 px-6 pb-6 text-center"
+          className="flex w-full flex-none flex-col items-center gap-6 text-center"
           data-auth-signin-clusters
         >
           <div className="flex flex-col items-center gap-4">
@@ -1141,46 +1139,31 @@ export function AuthStep({
               ) : null}
             </div>
 
-            <div
-              className="flex flex-col items-center gap-3"
-              data-auth-supporting-content
-            >
-              {/* Consent-first reassurance chip. */}
-              <div className="flex w-fit items-center gap-1.5 rounded-full bg-[color:var(--app-accent-tint)] px-3 py-1.5 dark:bg-white/[0.06]">
-                <Icon
-                  icon={Shield}
-                  size="sm"
-                  className="text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]"
-                />
-                <span className="type-footnote text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]">
-                  You choose what One can see.
-                </span>
-              </div>
-
-              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/45">
-                By continuing you agree to our{" "}
-                <button
-                  type="button"
-                  onClick={() => void openLegalDoc("terms")}
-                  data-voice-control-id="auth_terms"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
-                >
-                  Terms
-                </button>
-                <span aria-hidden="true"> and </span>
-                <button
-                  type="button"
-                  onClick={() => void openLegalDoc("privacy")}
-                  data-voice-control-id="auth_privacy"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
-                >
-                  Privacy Policy
-                </button>
-                .
-              </p>
-            </div>
           </div>
         </div>
+        <p
+          className="type-footnote absolute inset-x-4 bottom-6 mx-auto max-w-none text-center leading-5 text-[#86868b] dark:text-white/45"
+          data-auth-supporting-content
+        >
+          By continuing, you agree to{" "}
+          <button
+            type="button"
+            onClick={() => void openLegalDoc("terms")}
+            data-voice-control-id="auth_terms"
+            className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+          >
+            Terms
+          </button>
+          <span aria-hidden="true"> and </span>
+          <button
+            type="button"
+            onClick={() => void openLegalDoc("privacy")}
+            data-voice-control-id="auth_privacy"
+            className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+          >
+            Privacy Policy
+          </button>
+        </p>
       </div>
       <AuthLegalDialog
         docType={activeLegalDoc}

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -21,6 +21,7 @@
   width: 100%;
   flex-direction: column;
   overflow: hidden;
+  background: var(--background);
 }
 
 .stage {
@@ -65,19 +66,8 @@
   align-items: center;
 }
 
-.eyebrow {
-  margin: 0;
-  color: var(--foundation-dim);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.26em;
-  line-height: 1;
-  text-transform: uppercase;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 220ms both;
-}
-
 .emoji {
-  margin-top: 32px;
+  margin-top: 30px;
   font-size: 48px;
   line-height: 1;
   filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
@@ -118,64 +108,19 @@
   -webkit-text-fill-color: transparent;
 }
 
-.divider {
-  width: 100%;
-  height: 1px;
-  margin-top: 36px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    color-mix(in oklab, var(--foundation-gold-deep) 34%, transparent),
-    transparent
-  );
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 370ms both;
-}
-
 .tagline {
   max-width: 22rem;
-  margin: 36px auto 0;
+  margin: 14px auto 0;
   color: var(--foundation-ink);
-  font-size: 20px;
-  font-weight: 600;
-  letter-spacing: -0.2px;
-  line-height: 1.35;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.32;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 420ms both;
 }
 
-.motions {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  margin-top: 26px;
-  color: var(--foundation-dim);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  line-height: 1.2;
-  text-transform: uppercase;
-  white-space: nowrap;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 500ms both;
-}
-
-.motionItem {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-
-.motionDot {
-  opacity: 0.42;
-}
-
-.description {
-  max-width: 23rem;
-  margin: 30px auto 0;
-  color: var(--foundation-dim);
-  font-size: 16px;
-  line-height: 1.45;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
+.tagline:first-of-type {
+  margin-top: 32px;
 }
 
 .footer {
@@ -219,28 +164,19 @@
   }
 }
 
-.links {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 16px;
-  border-top: 1px solid var(--foundation-hairline);
-  color: var(--foundation-dim);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.link {
-  display: flex;
-  min-height: 46px;
+.signIn {
+  display: inline-flex;
+  min-height: 44px;
   align-items: center;
   justify-content: center;
-  border-left: 1px solid var(--foundation-hairline);
-  text-align: center;
-  line-height: 1.1;
-}
-
-.link:first-child {
-  border-left: 0;
+  margin-top: 14px;
+  border: 0;
+  background: transparent;
+  color: var(--foundation-ink);
+  font-family: var(--font-app-body);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
 @keyframes reveal {
@@ -262,7 +198,7 @@
   }
 
   .emoji {
-    margin-top: 22px;
+    margin-top: 18px;
     font-size: 42px;
   }
 
@@ -270,20 +206,12 @@
     font-size: clamp(76px, 26vw, 104px);
   }
 
-  .divider {
-    margin-top: 24px;
-  }
-
   .tagline {
+    margin-top: 10px;
+    font-size: 16px;
+  }
+
+  .tagline:first-of-type {
     margin-top: 24px;
-  }
-
-  .motions {
-    margin-top: 18px;
-  }
-
-  .description {
-    margin-top: 20px;
-    font-size: 14px;
   }
 }

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback } from "react";
 import { HushhWordmark } from "@/components/app-ui/hushh-wordmark";
-import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { ROUTES } from "@/lib/navigation/routes";
@@ -16,10 +14,6 @@ import styles from "./IntroStep.module.css";
  * destinations below the CTA are a real navigation group with equal targets,
  * not footer text that happens to be clickable.
  * ──────────────────────────────────────────────────────────── */
-
-// One's four motions, shown as a quiet typographic rhythm — never as chips,
-// never labeled "framework". Matches docs/vision/agent-ontology.md.
-const MOTIONS = ["Listens", "Remembers", "Decides", "Acts"];
 
 export function IntroStep({ onLogin }: { onLogin?: () => void }) {
   const claimOne = useCallback(() => {
@@ -44,16 +38,17 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
   useLocalOnboardingActionHandler("onboarding.claim_one", claimOne);
   usePublishVoiceSurfaceMetadata({
     screenId: "one_intro",
-    title: "Claim your One",
+    title: "Meet your agents",
     purpose:
-      "This is One's public welcome screen. The person can claim their private agent and continue to sign in.",
+      "This is One's public welcome screen. The person can continue to sign in.",
     actions: [
       {
         id: "onboarding_claim_one",
         actionId: "onboarding.claim_one",
-        label: "Claim your One",
+        label: "Meet your agents",
         purpose: "Continue to sign in and begin setting up One.",
         voiceAliases: [
+          "meet your agents",
           "claim your one",
           "claim one",
           "get started",
@@ -65,10 +60,11 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
       {
         id: "onboarding_claim_one",
         actionId: "onboarding.claim_one",
-        label: "Claim your One",
+        label: "Meet your agents",
         type: "button",
         purpose: "Continue to sign in and begin setting up One.",
         voiceAliases: [
+          "meet your agents",
           "claim your one",
           "claim one",
           "get started",
@@ -80,8 +76,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
   return (
     <main className={styles.shell}>
-      <OnboardingHeroBackground />
-
       <div className={styles.stage}>
         {/* One centered brand anchor keeps the page calm on both compact and
             wide surfaces; the old wordmark/emoji pair read as two competing
@@ -92,10 +86,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
         {/* ── Typography-led hero. No cards, no fake metrics. ── */}
         <div className={styles.hero}>
-          <span className={styles.eyebrow}>
-            Your private agent
-          </span>
-
           <span
             aria-hidden="true"
             className={styles.emoji}
@@ -109,38 +99,16 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
             </span>
           </h1>
 
-          <div
-            aria-hidden
-            className={styles.divider}
-          />
-
-          {/* Approved durable product line (docs/vision/agent-ontology.md
-              Founder Copy Rules; brand punchline). Not ad-hoc copy. */}
           <p className={styles.tagline}>
-            Your agents. Yours to own.
+            Personal agents for everyday life.
           </p>
 
-          {/* Quiet rhythm line: the four motions, typographic not chip-like. */}
-          <div className={styles.motions}>
-            {MOTIONS.map((motion, i) => (
-              <span key={motion} className={styles.motionItem}>
-                {i > 0 && (
-                  <span aria-hidden className={styles.motionDot}>
-                    &middot;
-                  </span>
-                )}
-                <span>{motion}</span>
-              </span>
-            ))}
-          </div>
+          <p className={styles.tagline}>
+            One app to bring them together.
+          </p>
 
-          {/* Plain words only. "Encrypted" and "consent" are the mechanism and
-              the legal term; "locked" and "your yes" are what a person actually
-              pictures. "Vault" is a code noun and never appears in copy. */}
-          <p className={styles.description}>
-            Everything you save stays locked.
-            <br />
-            Nothing moves without your yes.
+          <p className={styles.tagline}>
+            Your agents. Yours to own.
           </p>
         </div>
 
@@ -157,38 +125,20 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
             className={styles.cta}
           >
             <span className="relative z-0 inline-flex items-center gap-2">
-              Claim your One
-              <span aria-hidden>&rarr;</span>
+              Meet your agents
             </span>
             <MaterialRipple variant="gradient" effect="fill" className="z-10" />
           </button>
 
-          {/* Public destinations share the CTA width and use equal hit areas.
-              That preserves discoverable navigation on small screens without
-              letting the longest label push its siblings out of rhythm. */}
-          <nav
-            aria-label="Explore Hussh"
-            className={styles.links}
+          <button
+            type="button"
+            onClick={() => {
+              void claimOne();
+            }}
+            className={styles.signIn}
           >
-            <Link
-              href={ROUTES.RESEARCH}
-              className={styles.link}
-            >
-              Research
-            </Link>
-            <Link
-              href={ROUTES.BLOG}
-              className={styles.link}
-            >
-              Blog
-            </Link>
-            <Link
-              href={ROUTES.DEVELOPERS}
-              className={styles.link}
-            >
-              Developers
-            </Link>
-          </nav>
+            Already have One? Sign in
+          </button>
         </div>
       </div>
     </main>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1495,8 +1495,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                 vm.clearNamedCircleShareContext();
                 openShareFlow();
               }}
-              onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
-              onOpenSettings={vm.onOpenLocationSettings}
               onCheckIn={() =>
                 nearbyCheckInAvailable
                   ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)
@@ -1506,6 +1504,8 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
               onOpenActiveShares={() => openFlow("active-shares")}
               onOpenSharedWithMe={() => openFlow("shared-with-me")}
               onOpenNeedsReview={() => openFlow("needs-review")}
+              onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
+              onOpenSettings={() => openFlow("settings")}
               onRequestLocation={() => openFlow("ask")}
             />
           </LocationHubPanel>
@@ -1583,6 +1583,15 @@ function NowHub({
   onRequestLocation: () => void;
 }) {
   const activityRows = [
+    {
+      leading: <LocationMenuListIcon name="active" />,
+      title: "Active shares",
+      value: vm.activeOwnerGrants.length,
+      ariaLabel: "Active shares",
+      onClick: onOpenActiveShares,
+      voiceControlId: "one-location-action-active-shares",
+      voiceActionId: "location.open_active_shares",
+    },
     {
       leading: <LocationMenuListIcon name="pin" />,
       title: "Sharing with you",

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -504,7 +504,7 @@
     {
       "schema_version": "kai.local_action_contract.v1",
       "surface_id": "one_intro",
-      "surface_title": "Claim your One",
+      "surface_title": "Meet your agents",
       "docs_references": [
         "docs/reference/one/one-voice-runtime-architecture.md",
         "docs/reference/one/one-voice-onboarding-journey.md"
@@ -14371,8 +14371,9 @@
     {
       "action_id": "onboarding.claim_one",
       "surface_id": "one_intro",
-      "label": "Claim your One",
+      "label": "Meet your agents",
       "aliases": [
+        "meet your agents",
         "claim your one",
         "claim my one",
         "claim one",
@@ -14455,7 +14456,7 @@
         "workflow_steps": [
           {
             "type": "action",
-            "label": "Claim your One",
+            "label": "Meet your agents",
             "failure_behavior": "stop",
             "action_id": "onboarding.claim_one",
             "settlement_target": {

--- a/hushh-webapp/e2e/smoke.spec.ts
+++ b/hushh-webapp/e2e/smoke.spec.ts
@@ -23,7 +23,7 @@ test.describe("Application Boot", () => {
       timeout: 15_000,
     });
     await expect(
-      page.getByRole("button", { name: /Claim your One/i }),
+      page.getByRole("button", { name: /Meet your agents/i }),
     ).toBeVisible();
   });
 

--- a/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
+++ b/hushh-webapp/scripts/design/verify-apple-hierarchy.mjs
@@ -194,14 +194,20 @@ for (const repoPath of [
 
 expectIncludes(
   "components/dashboard/one-agent-roster.tsx",
-  "Agents ({modes.length})",
-  "agents heading is the page title and must use title casing",
+  'aria-label="One agents"',
+  "one home launcher must expose a semantic One agents region",
 );
 
 expectNotIncludes(
   "components/dashboard/one-agent-roster.tsx",
-  "text-[28px] leading-[34px]",
-  "agents heading must use the shared LargeTitle role instead of a route-level arbitrary override",
+  "Agents ({modes.length})",
+  "one home launcher must not render the old Agents count title",
+);
+
+expectNotIncludes(
+  "components/dashboard/one-agent-roster.tsx",
+  'placeholder="Search agents"',
+  "one home launcher must not render the old roster search field",
 );
 
 expectNotIncludes(


### PR DESCRIPTION
## Summary
- Replaces the /one agent directory with a premium app-icon launcher in the locked 3x3 order.
- Removes search/list chrome and row-style microcopy from the launcher while preserving each agent destination.
- Adds focused tests and design-system verification for the new launcher contract.

## Verification
- npm run test -- __tests__/components/one-dashboard-page.test.tsx
- npm run typecheck
- npm run verify:design-system
- npm run lint
- git diff --check
- Responsive screenshot pass: 320, 393, 430, 768, 1440 widths
- npm run build: compiled successfully, then hung in the final TypeScript/build tail and was cancelled locally; CI should provide the authoritative full build gate.

## Project stories
- #5983
- #5984
- #5985