### PR TITLE
feat: polish delivered Gmail email formatting

### DIFF
--- a/consent-protocol/hushh_mcp/services/gmail_delivery_service.py
+++ b/consent-protocol/hushh_mcp/services/gmail_delivery_service.py
@@ -50,6 +50,26 @@ _ACTION_TTL_SECONDS = 10 * 60
 _EMAIL_RE = re.compile(r"^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$")
 _CRLF_RE = re.compile(r"[\r\n]")
 
+_EMAIL_AGENT_INTRO_PHRASES = (
+    "explain features of the email agent",
+    "demonstrate the core features of the gmail agent",
+)
+_EMAIL_AGENT_INTRO_BODY = """Hi,
+
+## Meet your Hushh Email Agent
+
+Thanks for giving it a try. Here’s what I can help with:
+
+- **Draft polished emails** from a short request
+- **Keep recipients organised** across To, Cc, and Bcc
+- **Surface useful Gmail context** for receipts and inbox questions
+- **Keep you in control** — every message stays editable until you choose Send
+
+You can ask One to write, refine, or explain an email whenever you need it.
+
+Best,
+Hushh"""
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -57,6 +77,11 @@ def _utcnow() -> datetime:
 
 def _text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _is_email_agent_intro_instruction(instruction: str) -> bool:
+    normalized = " ".join(instruction.lower().split())
+    return any(phrase in normalized for phrase in _EMAIL_AGENT_INTRO_PHRASES)
 
 
 @dataclass(frozen=True)
@@ -268,7 +293,7 @@ class GmailDeliveryService:
             raise GmailDeliveryError(
                 "DRAFT_INVALID", "Email drafting returned an invalid draft.", status_code=502
             )
-        return {
+        draft = {
             "to": [str(item).strip() for item in value.get("to", []) if str(item).strip()],
             "cc": [str(item).strip() for item in value.get("cc", []) if str(item).strip()],
             "bcc": [str(item).strip() for item in value.get("bcc", []) if str(item).strip()],
@@ -278,6 +303,10 @@ class GmailDeliveryService:
                 str(item).strip() for item in value.get("missing_details", []) if str(item).strip()
             ],
         }
+        if _is_email_agent_intro_instruction(instruction):
+            draft["subject"] = "Meet your Hushh Email Agent"
+            draft["body"] = _EMAIL_AGENT_INTRO_BODY
+        return draft
 
     async def prepare(
         self, *, user_id: str, draft_payload: dict[str, Any], idempotency_key: str

--- a/consent-protocol/hushh_mcp/services/gmail_owner_html.py
+++ b/consent-protocol/hushh_mcp/services/gmail_owner_html.py
@@ -12,6 +12,16 @@ _ALLOWED_TAGS = frozenset(
 _VOID_TAGS = frozenset({"br"})
 _DISCARDED_TAGS = frozenset({"script", "style", "iframe", "object", "embed", "form", "svg", "math"})
 _MAX_HTML_CHARS = 50_000
+_BLOCK_STYLE_VALUES = {
+    "h1": frozenset({"margin:0 0 18px;font-size:24px;line-height:1.25"}),
+    "h2": frozenset({"margin:0 0 14px;font-size:20px;line-height:1.3"}),
+    "h3": frozenset({"margin:0 0 12px;font-size:16px;line-height:1.4"}),
+    "ul": frozenset({"margin:0 0 16px;padding-left:24px"}),
+    "ol": frozenset({"margin:0 0 16px;padding-left:24px"}),
+    "li": frozenset({"margin:0 0 8px"}),
+    "blockquote": frozenset({"margin:0 0 16px;padding-left:16px;color:#5f6368"}),
+}
+_PARAGRAPH_STYLE = "margin:0 0 16px;line-height:1.6"
 
 
 def _safe_href(value: str) -> str | None:
@@ -28,10 +38,20 @@ def _safe_href(value: str) -> str | None:
     return href
 
 
-def _safe_alignment_style(value: str) -> str | None:
-    normalized = "".join(value.lower().split())
-    if normalized in {"text-align:left", "text-align:center", "text-align:right"}:
+def _safe_block_style(tag: str, value: str) -> str | None:
+    normalized = " ".join(value.lower().split())
+    normalized = normalized.replace(": ", ":").replace(" ;", ";").replace("; ", ";")
+    if normalized in _BLOCK_STYLE_VALUES.get(tag, frozenset()):
         return normalized
+    if tag == "p":
+        if normalized == _PARAGRAPH_STYLE:
+            return normalized
+        for alignment in ("left", "center", "right"):
+            if normalized == f"{_PARAGRAPH_STYLE};text-align:{alignment}":
+                return normalized
+            # Preserve the alignment-only input accepted before rich delivery styling.
+            if normalized == f"text-align:{alignment}":
+                return normalized
     return None
 
 
@@ -55,11 +75,11 @@ class _GmailOwnerHtmlSanitizer(HTMLParser):
                 f'<a href="{html.escape(safe_href, quote=True)}">' if safe_href else "<a>"
             )
             return
-        if tag in {"p", "h1", "h2", "h3"}:
+        if tag in {"p", "h1", "h2", "h3", "ul", "ol", "li", "blockquote"}:
             style = next(
                 (value for name, value in attrs if name.lower() == "style" and value), None
             )
-            safe_style = _safe_alignment_style(style) if style else None
+            safe_style = _safe_block_style(tag, style) if style else None
             if safe_style:
                 self.parts.append(f'<{tag} style="{safe_style}">')
                 return

--- a/consent-protocol/tests/services/test_gmail_delivery_service.py
+++ b/consent-protocol/tests/services/test_gmail_delivery_service.py
@@ -8,8 +8,10 @@ import httpx
 import pytest
 
 from hushh_mcp.services.gmail_delivery_service import (
+    _EMAIL_AGENT_INTRO_BODY,
     GmailDeliveryError,
     GmailDeliveryService,
+    _is_email_agent_intro_instruction,
     _message_for,
     normalize_draft,
 )
@@ -180,6 +182,36 @@ def test_rich_email_html_is_sanitized_and_sent_as_multipart_alternative():
     assert rendered.get_content_type() == "multipart/alternative"
     assert rendered.get_body(preferencelist=("plain",)).get_content().strip() == "Message"
     assert rendered.get_body(preferencelist=("html",)).get_content().strip() == draft.html_body
+
+
+def test_delivery_keeps_only_the_reviewed_email_block_styles():
+    draft = normalize_draft(
+        {
+            **_envelope(),
+            "html_body": (
+                '<h2 style="margin: 0 0 14px; font-size: 20px; line-height: 1.3">Welcome</h2>'
+                '<ul style="margin:0 0 16px;padding-left:24px"><li style="margin:0 0 8px">First</li></ul>'
+                '<p style="margin:0 0 16px;line-height:1.6;text-align:center">Centered</p>'
+                '<p style="color:red">discarded style</p>'
+            ),
+        }
+    )
+
+    assert draft.html_body == (
+        '<h2 style="margin:0 0 14px;font-size:20px;line-height:1.3">Welcome</h2>'
+        '<ul style="margin:0 0 16px;padding-left:24px"><li style="margin:0 0 8px">First</li></ul>'
+        '<p style="margin:0 0 16px;line-height:1.6;text-align:center">Centered</p>'
+        "<p>discarded style</p>"
+    )
+
+
+def test_email_agent_intro_template_has_real_email_structure():
+    assert _is_email_agent_intro_instruction(
+        "Can you send an email to 'person@example.com', In the email explain features of the email agent."
+    )
+    assert not _is_email_agent_intro_instruction("Explain email agent features in a chat reply.")
+    assert "\n\n- **Draft polished emails**" in _EMAIL_AGENT_INTRO_BODY
+    assert _EMAIL_AGENT_INTRO_BODY.endswith("Best,\nHushh")
 
 
 def test_html_only_edit_changes_the_reviewed_envelope_hmac(monkeypatch):

--- a/hushh-webapp/components/agent/__tests__/email-rich-text.test.tsx
+++ b/hushh-webapp/components/agent/__tests__/email-rich-text.test.tsx
@@ -21,7 +21,13 @@ describe("Email rich text", () => {
       "https://example.com/report",
     );
     expect(richEmailHtmlFromMarkdown(body)).toBe(
-      '<h2>Update</h2><p><strong>Important</strong> details are <em>ready</em>.</p><blockquote>Please review before Friday.</blockquote><p style="text-align:center"><a href="https://example.com/report">Open the report</a></p>',
+      '<h2 style="margin:0 0 14px;font-size:20px;line-height:1.3">Update</h2><p style="margin:0 0 16px;line-height:1.6"><strong>Important</strong> details are <em>ready</em>.</p><blockquote style="margin:0 0 16px;padding-left:16px;color:#5f6368">Please review before Friday.</blockquote><p style="margin:0 0 16px;line-height:1.6;text-align:center"><a href="https://example.com/report">Open the report</a></p>',
+    );
+  });
+
+  it("uses real list markup and spacing for Gmail delivery", () => {
+    expect(richEmailHtmlFromMarkdown("Hi,\n\n- **First** benefit\n- Second benefit\n\nBest,\nHushh")).toContain(
+      '<ul style="margin:0 0 16px;padding-left:24px"><li style="margin:0 0 8px"><strong>First</strong> benefit</li><li style="margin:0 0 8px">Second benefit</li></ul>',
     );
   });
 

--- a/hushh-webapp/components/agent/email-rich-text.tsx
+++ b/hushh-webapp/components/agent/email-rich-text.tsx
@@ -80,6 +80,18 @@ function formattingIcon(action: FormattingAction) {
 const LINK_RE = /^\[([^\]]+)\]\(((?:https?:\/\/|mailto:)[^)\s]+)\)$/i;
 const INLINE_TOKEN_RE = /(\[[^\]]+\]\((?:https?:\/\/|mailto:)[^)\s]+\)|\*\*[^*]+\*\*|\*[^*]+\*|\+\+[^+]+\+\+)/g;
 
+// Inline styles are intentional: the delivery HTML is rendered by Gmail and
+// cannot rely on the application's Tailwind classes.
+const EMAIL_BLOCK_STYLES = {
+  h1: "margin:0 0 18px;font-size:24px;line-height:1.25",
+  h2: "margin:0 0 14px;font-size:20px;line-height:1.3",
+  h3: "margin:0 0 12px;font-size:16px;line-height:1.4",
+  list: "margin:0 0 16px;padding-left:24px",
+  listItem: "margin:0 0 8px",
+  paragraph: "margin:0 0 16px;line-height:1.6",
+  quote: "margin:0 0 16px;padding-left:16px;color:#5f6368",
+} as const;
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -237,23 +249,23 @@ export function richEmailHtmlFromMarkdown(value: string): string {
   return parseBlocks(value)
     .map((block) => {
       if (block.kind === "heading") {
-        return `<h${block.level}>${inlineHtml(block.text)}</h${block.level}>`;
+        return `<h${block.level} style="${EMAIL_BLOCK_STYLES[`h${block.level}`]}">${inlineHtml(block.text)}</h${block.level}>`;
       }
       if (block.kind === "list") {
         const tag = block.ordered ? "ol" : "ul";
-        return `<${tag}>${block.items
-          .map((item) => `<li>${inlineHtml(item)}</li>`)
+        return `<${tag} style="${EMAIL_BLOCK_STYLES.list}">${block.items
+          .map((item) => `<li style="${EMAIL_BLOCK_STYLES.listItem}">${inlineHtml(item)}</li>`)
           .join("")}</${tag}>`;
       }
       if (block.kind === "quote") {
-        return `<blockquote>${block.lines.map(inlineHtml).join("<br>")}</blockquote>`;
+        return `<blockquote style="${EMAIL_BLOCK_STYLES.quote}">${block.lines.map(inlineHtml).join("<br>")}</blockquote>`;
       }
       if (block.kind === "aligned") {
-        return `<p style="text-align:${block.alignment}">${block.lines
+        return `<p style="${EMAIL_BLOCK_STYLES.paragraph};text-align:${block.alignment}">${block.lines
           .map(inlineHtml)
           .join("<br>")}</p>`;
       }
-      return `<p>${block.lines.map(inlineHtml).join("<br>")}</p>`;
+      return `<p style="${EMAIL_BLOCK_STYLES.paragraph}">${block.lines.map(inlineHtml).join("<br>")}</p>`;
     })
     .join("");
 }


### PR DESCRIPTION
Summary: deliver structured, spaced Gmail HTML for rich email drafts; make the Try Email Agent intro a polished email with headings and feature bullets; retain strict server-side style allowlisting. Verification: focused frontend rich-text and draft-card tests, frontend lint/typecheck, Gmail delivery pytest, and focused mypy all pass.