### PR TITLE
feat(trusted-device): sync status, self-status liveness, and remote-revoke seal telemetry

### DIFF
--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -32,6 +32,15 @@ def _auth_error(detail: str) -> HTTPException:
     )
 
 
+# Reasons that are themselves machine codes the trusted-device native runtime
+# branches on (authoritative revoke -> seal vs transient DB outage -> retry).
+# These are surfaced verbatim as the 401 detail; every other failure reason
+# stays the generic message so we never leak why a token failed.
+_TRUSTED_DEVICE_AUTH_CODES = frozenset(
+    {"TRUSTED_DEVICE_REVOKED", "TRUSTED_DEVICE_STATUS_UNCONFIRMED"}
+)
+
+
 def _extract_token(
     value: Optional[str] | Any,
     *,
@@ -220,6 +229,8 @@ async def require_vault_owner_token(
 
     if not valid or not token_obj:
         logger.warning("Token validation failed: %s", reason)
+        if reason in _TRUSTED_DEVICE_AUTH_CODES:
+            raise _auth_error(reason)
         raise _auth_error("Token validation failed.")
 
     return _token_data_dict(token, token_obj)
@@ -245,6 +256,8 @@ def require_consent_scope(required_scope: str | ConsentScope):
 
         if not valid or not token_obj:
             logger.warning("Scoped token validation failed for %s: %s", required_scope, reason)
+            if reason in _TRUSTED_DEVICE_AUTH_CODES:
+                raise _auth_error(reason)
             raise _auth_error("Token validation failed.")
 
         return _token_data_dict(token, token_obj)

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import secrets
+import time
 from typing import Any, Literal
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
@@ -355,6 +356,84 @@ async def list_trusted_devices(firebase_uid: str = Depends(require_firebase_auth
     # removed. The authenticated user can only list their own device records.
     devices = await run_in_threadpool(TrustedDeviceService().list_devices, user_id=firebase_uid)
     return {"devices": devices}
+
+
+@router.get("/trusted-devices/{device_id}/status")
+async def trusted_device_status(
+    device_id: str,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Own-device liveness read for the native Hermes runtime.
+
+    Firebase-authed: the device keeps a user-level Firebase session after
+    revoke, so a device-token gate would be unreachable exactly when the answer
+    is 'revoked'. Fail-closed: a DB error is a 503, never a defaulted 'active'.
+    Grants nothing; every vault call still gates on the device-bound owner token
+    re-checked against is_trusted_device_active.
+    """
+    try:
+        status = await run_in_threadpool(
+            TrustedDeviceService().device_status,
+            user_id=firebase_uid,
+            device_id=device_id,
+        )
+    except Exception:
+        logger.exception("trusted_device.status_lookup_failed")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "TRUSTED_DEVICE_STATUS_UNAVAILABLE",
+                "message": "Trusted-device status is temporarily unavailable.",
+            },
+        ) from None
+    if status is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "TRUSTED_DEVICE_UNKNOWN",
+                "message": "No such trusted device for this account.",
+            },
+        )
+    return {**status, "server_time_ms": int(time.time() * 1000)}
+
+
+@router.post("/trusted-devices/{device_id}/seal-ack")
+async def trusted_device_seal_ack(
+    device_id: str,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Advisory seal confirmation from the native runtime after a remote revoke.
+
+    Firebase-authed only, with NO device signature: the device P-256 key is
+    zeroized during seal, so a post-seal signature is unsatisfiable and a static
+    one would be replayable. The ack is device-reported telemetry, never proof
+    of sealing and never authorization. The server stamps its own sealed_at, can
+    only stamp an already-revoked row, and enforcement never consults sealed_at.
+    """
+    try:
+        result = await run_in_threadpool(
+            TrustedDeviceService().seal_device,
+            user_id=firebase_uid,
+            device_id=device_id,
+        )
+    except Exception:
+        logger.exception("trusted_device.seal_ack_failed")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "TRUSTED_DEVICE_STATUS_UNAVAILABLE",
+                "message": "Trusted-device status is temporarily unavailable.",
+            },
+        ) from None
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "TRUSTED_DEVICE_UNKNOWN",
+                "message": "No such trusted device for this account.",
+            },
+        )
+    return result
 
 
 @router.post("/trusted-devices/{device_id}/challenge")

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Annotated, Any, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Response, status
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, ValidationError
 
 from api.middleware import require_vault_owner_token
@@ -30,6 +31,7 @@ from hushh_mcp.services.pkm_mutation_contracts import (
     validate_mutation_plan_for_write,
 )
 from hushh_mcp.services.pkm_upgrade_service import get_pkm_upgrade_service
+from hushh_mcp.services.trusted_device_service import TrustedDeviceService
 
 logger = logging.getLogger(__name__)
 
@@ -1373,7 +1375,28 @@ async def get_device_sync_events(
         after_cursor=after_cursor,
         limit=limit,
     )
-    return PkmDeviceSyncResponse.model_validate(payload)
+    response = PkmDeviceSyncResponse.model_validate(payload)
+
+    # Best-effort: stamp this device's last sync so settings can show real sync
+    # state. Swallowed on failure so a stamp problem never fails the read.
+    # require_vault_owner_token already re-checked is_trusted_device_active, so
+    # only an active device reaches here and a stamp cannot resurrect a revoked
+    # one.
+    agent_id = str(token_data.get("agent_id") or "")
+    if agent_id.startswith("device:"):
+        device_id = agent_id.removeprefix("device:")
+        if device_id:
+            try:
+                await run_in_threadpool(
+                    TrustedDeviceService().record_sync,
+                    user_id=user_id,
+                    device_id=device_id,
+                    cursor=response.next_cursor,
+                )
+            except Exception:
+                logger.warning("trusted_device.record_sync_failed", exc_info=True)
+
+    return response
 
 
 @router.post("/reconcile/{user_id}", response_model=ReconcilePkmResponse)

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 175,
+  "expected_migration_version": 176,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_pkm_domain_summary",
@@ -986,7 +986,10 @@
       "status",
       "created_at",
       "last_used_at",
-      "revoked_at"
+      "revoked_at",
+      "last_synced_at",
+      "last_sync_cursor",
+      "sealed_at"
     ],
     "trusted_device_challenges": [
       "challenge_id",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 175,
+  "expected_migration_version": 176,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",
@@ -1364,7 +1364,10 @@
       "status",
       "created_at",
       "last_used_at",
-      "revoked_at"
+      "revoked_at",
+      "last_synced_at",
+      "last_sync_cursor",
+      "sealed_at"
     ],
     "trusted_device_challenges": [
       "challenge_id",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 175,
+  "expected_migration_version": 176,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",
@@ -1364,7 +1364,10 @@
       "status",
       "created_at",
       "last_used_at",
-      "revoked_at"
+      "revoked_at",
+      "last_synced_at",
+      "last_sync_cursor",
+      "sealed_at"
     ],
     "trusted_device_challenges": [
       "challenge_id",

--- a/consent-protocol/db/migrations/176_trusted_device_sync_state.sql
+++ b/consent-protocol/db/migrations/176_trusted_device_sync_state.sql
@@ -1,0 +1,30 @@
+-- Trusted-device sync-state and seal telemetry.
+--
+-- Additive columns on trusted_devices that record when a device last pulled the
+-- PKM device-sync channel (last_synced_at, last_sync_cursor) and when the native
+-- Hermes runtime reported it sealed its local replica after a remote revoke
+-- (sealed_at). All three are metadata-only BIGINT epoch/cursor values: no
+-- credential, no vault material, no plaintext, no access grant. They drive the
+-- settings sync-status display and close the remote-revoke audit loop; the
+-- enforcement layer never gates on any of them.
+--
+-- The trusted-device tri-state (active / revoked / needs_reinit) stays DERIVED:
+-- the server persists only the existing active|revoked status CHECK from
+-- 121_trusted_devices.sql, and needs_reinit is a native-local condition. This
+-- migration therefore does NOT touch the status CHECK constraint.
+
+BEGIN;
+
+ALTER TABLE trusted_devices
+  ADD COLUMN IF NOT EXISTS last_synced_at BIGINT,
+  ADD COLUMN IF NOT EXISTS last_sync_cursor BIGINT,
+  ADD COLUMN IF NOT EXISTS sealed_at BIGINT;
+
+COMMENT ON COLUMN trusted_devices.last_synced_at IS
+  'Epoch ms of this device''s last PKM device-sync pull. Metadata only; drives the settings sync-status display. NULL until the device first syncs.';
+COMMENT ON COLUMN trusted_devices.last_sync_cursor IS
+  'High-water PKM device-sync cursor last served to this device. Metadata only; not an access grant.';
+COMMENT ON COLUMN trusted_devices.sealed_at IS
+  'Epoch ms the native runtime reported it sealed its local replica after a remote revoke. Advisory device-reported telemetry only; enforcement never gates on it.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/176_trusted_device_sync_state.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/176_trusted_device_sync_state.rollback.sql
@@ -1,0 +1,14 @@
+-- Rollback for 176_trusted_device_sync_state.sql.
+--
+-- Drops the additive sync-state / seal telemetry columns from trusted_devices.
+-- Safe under replay; the columns are metadata-only and carry no credential or
+-- vault material, so dropping them loses only display/audit telemetry.
+
+BEGIN;
+
+ALTER TABLE trusted_devices
+  DROP COLUMN IF EXISTS last_synced_at,
+  DROP COLUMN IF EXISTS last_sync_cursor,
+  DROP COLUMN IF EXISTS sealed_at;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -147,7 +147,8 @@
     "171_google_gmail_send_actions.sql",
     "172_gmail_combined_send_permission.sql",
     "173_gmail_owner_approved_delivery.sql",
-    "175_contact_sync_connection_provenance.sql"
+    "175_contact_sync_connection_provenance.sql",
+    "176_trusted_device_sync_state.sql"
   ],
   "environment_overlays": {
     "uat": [
@@ -248,7 +249,8 @@
       "165_one_referral_program.sql",
       "167_one_referral_realtime_notify.sql",
       "169_one_location_auto_approve_preferences.sql",
-      "175_contact_sync_connection_provenance.sql"
+      "175_contact_sync_connection_provenance.sql",
+      "176_trusted_device_sync_state.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -418,7 +418,7 @@ async def validate_token_with_db(
                         "(fingerprint=%s)",
                         _token_fingerprint(token_str),
                     )
-                    return False, "Trusted device is not active", None
+                    return False, "TRUSTED_DEVICE_REVOKED", None
     except Exception as e:
         # DB is unreachable — apply fail-closed policy based on token scope.
         # VAULT_OWNER tokens get a short grace period to avoid locking users
@@ -435,7 +435,7 @@ async def validate_token_with_db(
             )
             return (
                 False,
-                "Trusted device revocation status could not be confirmed (DB unavailable)",
+                "TRUSTED_DEVICE_STATUS_UNCONFIRMED",
                 None,
             )
         if is_vault_owner:

--- a/consent-protocol/hushh_mcp/services/trusted_device_service.py
+++ b/consent-protocol/hushh_mcp/services/trusted_device_service.py
@@ -103,6 +103,14 @@ class TrustedDeviceStore(Protocol):
 
     def touch_device(self, *, user_id: str, device_id: str, now_ms: int) -> None: ...
 
+    def record_sync(
+        self, *, user_id: str, device_id: str, cursor: int | None, now_ms: int
+    ) -> None: ...
+
+    def get_device_status(self, *, user_id: str, device_id: str) -> dict[str, Any] | None: ...
+
+    def seal_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool: ...
+
     def audit(
         self,
         *,
@@ -245,7 +253,10 @@ class PostgresTrustedDeviceStore:
     def list_devices(self, *, user_id: str) -> list[dict[str, Any]]:
         return (
             self._db.table("trusted_devices")
-            .select("device_id,device_name,platform,status,created_at,last_used_at,revoked_at")
+            .select(
+                "device_id,device_name,platform,status,created_at,last_used_at,"
+                "revoked_at,last_synced_at,last_sync_cursor,sealed_at"
+            )
             .eq("user_id", user_id)
             .order("created_at", desc=True)
             .execute()
@@ -330,6 +341,43 @@ class PostgresTrustedDeviceStore:
             .eq("status", "active")
             .execute()
         )
+
+    def record_sync(self, *, user_id: str, device_id: str, cursor: int | None, now_ms: int) -> None:
+        updates: dict[str, Any] = {"last_synced_at": now_ms}
+        if cursor is not None:
+            updates["last_sync_cursor"] = cursor
+        (
+            self._db.table("trusted_devices")
+            .update(updates)
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .eq("status", "active")
+            .execute()
+        )
+
+    def get_device_status(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        rows = (
+            self._db.table("trusted_devices")
+            .select("device_id,status,revoked_at,last_synced_at,sealed_at")
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return rows[0] if rows else None
+
+    def seal_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool:
+        result = self._db.execute_raw(
+            """UPDATE trusted_devices
+               SET sealed_at = :now_ms
+               WHERE user_id = :user_id AND device_id = :device_id
+                 AND status = 'revoked' AND sealed_at IS NULL
+               RETURNING device_id""",
+            {"user_id": user_id, "device_id": device_id, "now_ms": now_ms},
+        )
+        return bool(result.data)
 
     def audit(
         self,
@@ -420,6 +468,13 @@ def _safe_device(row: dict[str, Any]) -> dict[str, Any]:
         "created_at": int(row.get("created_at") or 0),
         "last_used_at": int(row["last_used_at"]) if row.get("last_used_at") else None,
         "revoked_at": int(row["revoked_at"]) if row.get("revoked_at") else None,
+        "last_synced_at": (
+            int(row["last_synced_at"]) if row.get("last_synced_at") is not None else None
+        ),
+        "last_sync_cursor": (
+            int(row["last_sync_cursor"]) if row.get("last_sync_cursor") is not None else None
+        ),
+        "sealed_at": int(row["sealed_at"]) if row.get("sealed_at") is not None else None,
     }
 
 
@@ -617,6 +672,76 @@ class TrustedDeviceService:
                 created_at=now_ms,
             )
         return revoked
+
+    def device_status(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        """Own-device liveness read for the native runtime.
+
+        Returns the caller's own device status and revocation/sync metadata, or
+        None when no such row exists (mapped to a uniform 404 at the route so an
+        unknown or foreign device_id cannot be enumerated). Never returns a
+        capability or vault material; enforcement is unaffected.
+        """
+        if not _DEVICE_ID_RE.fullmatch(device_id):
+            return None
+        row = self._store.get_device_status(user_id=user_id, device_id=device_id)
+        if not row:
+            return None
+        return {
+            "device_id": device_id,
+            "status": str(row.get("status") or "revoked"),
+            "revoked_at": int(row["revoked_at"]) if row.get("revoked_at") else None,
+            "last_synced_at": (int(row["last_synced_at"]) if row.get("last_synced_at") else None),
+        }
+
+    def record_sync(self, *, user_id: str, device_id: str, cursor: int | None = None) -> None:
+        """Stamp last_synced_at (and the high-water cursor) for an active device.
+
+        Best-effort telemetry: callers must swallow failures so a stamp problem
+        never fails the device-sync read that triggered it. Only active devices
+        are updated, so a revoked device can never be resurrected by a stamp.
+        """
+        if not _DEVICE_ID_RE.fullmatch(device_id):
+            return
+        self._store.record_sync(
+            user_id=user_id, device_id=device_id, cursor=cursor, now_ms=_now_ms()
+        )
+
+    def seal_device(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        """Record the native runtime's advisory seal confirmation after a remote
+        revoke. One-way and idempotent: it can only stamp sealed_at on an
+        already-revoked row and can never flip a device back to active. Returns
+        the device status with sealed_at, or None when there is no such device.
+
+        Enforcement never consults sealed_at; this closes the audit loop only.
+        """
+        if not _DEVICE_ID_RE.fullmatch(device_id):
+            return None
+        row = self._store.get_device_status(user_id=user_id, device_id=device_id)
+        if not row:
+            return None
+        if str(row.get("status")) != "revoked":
+            return {
+                "device_id": device_id,
+                "status": str(row.get("status") or "active"),
+                "sealed_at": int(row["sealed_at"]) if row.get("sealed_at") else None,
+            }
+        now_ms = _now_ms()
+        newly_sealed = self._store.seal_device(user_id=user_id, device_id=device_id, now_ms=now_ms)
+        if newly_sealed:
+            self._store.audit(
+                user_id=user_id,
+                device_id=device_id,
+                event_type="device_sealed",
+                created_at=now_ms,
+                metadata={"advisory": True, "reason": "remote_revoke"},
+            )
+            sealed_at: int | None = now_ms
+        else:
+            existing = self._store.get_device_status(user_id=user_id, device_id=device_id)
+            sealed_at = (
+                int(existing["sealed_at"]) if existing and existing.get("sealed_at") else None
+            )
+        return {"device_id": device_id, "status": "revoked", "sealed_at": sealed_at}
 
     def create_challenge(self, *, user_id: str, device_id: str) -> dict[str, Any]:
         device = self._store.get_active_device(user_id=user_id, device_id=device_id)

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -118,3 +118,5 @@ tests/test_pool_acquire_is_bounded.py
 # manifest is the only pytest invocation in any lane -- so a guard absent from
 # it is decoration.
 tests/test_contact_discovery_hardening.py
+tests/test_trusted_device_routes.py
+tests/quality/test_revocation_persistence.py

--- a/consent-protocol/tests/quality/test_revocation_persistence.py
+++ b/consent-protocol/tests/quality/test_revocation_persistence.py
@@ -345,7 +345,7 @@ async def test_device_owner_token_requires_active_device():
         )
 
     assert valid is False
-    assert reason == "Trusted device is not active"
+    assert reason == "TRUSTED_DEVICE_REVOKED"
     assert result is None
 
 
@@ -372,5 +372,5 @@ async def test_device_owner_token_fails_closed_when_device_status_is_unavailable
         )
 
     assert valid is False
-    assert reason == "Trusted device revocation status could not be confirmed (DB unavailable)"
+    assert reason == "TRUSTED_DEVICE_STATUS_UNCONFIRMED"
     assert result is None

--- a/consent-protocol/tests/test_trusted_device_routes.py
+++ b/consent-protocol/tests/test_trusted_device_routes.py
@@ -7,7 +7,10 @@ import pytest
 from fastapi import HTTPException
 
 from api.routes import account, consent
-from hushh_mcp.services.trusted_device_service import TrustedDeviceError
+from hushh_mcp.services.trusted_device_service import (
+    TrustedDeviceError,
+    TrustedDeviceService,
+)
 
 
 class _FakeTrustedDeviceService:
@@ -434,3 +437,269 @@ async def test_trusted_device_exchange_returns_server_verified_account_email(
         "account_email": "owner@example.com",
         "replaced_device_id": None,
     }
+
+
+# --- Sync-state, self-status, and seal-ack (migration 176) ---
+
+_SYNC_DEV = "tdv_" + ("b" * 32)
+
+
+class _FakeSyncStore:
+    """Minimal in-memory store for the sync-state service methods."""
+
+    def __init__(self, rows: dict[tuple[str, str], dict[str, Any]] | None = None) -> None:
+        self.rows = rows or {}
+        self.audited: list[dict[str, Any]] = []
+
+    def get_device_status(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        return self.rows.get((user_id, device_id))
+
+    def record_sync(self, *, user_id: str, device_id: str, cursor: int | None, now_ms: int) -> None:
+        row = self.rows.get((user_id, device_id))
+        if row and row.get("status") == "active":
+            row["last_synced_at"] = now_ms
+            if cursor is not None:
+                row["last_sync_cursor"] = cursor
+
+    def seal_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool:
+        row = self.rows.get((user_id, device_id))
+        if row and row.get("status") == "revoked" and not row.get("sealed_at"):
+            row["sealed_at"] = now_ms
+            return True
+        return False
+
+    def audit(self, *, user_id, device_id, event_type, created_at, metadata=None) -> None:
+        self.audited.append({"event_type": event_type, "metadata": metadata})
+
+
+def test_device_status_reports_active_with_sync_metadata() -> None:
+    store = _FakeSyncStore(
+        {("u1", _SYNC_DEV): {"status": "active", "revoked_at": None, "last_synced_at": 111}}
+    )
+    status = TrustedDeviceService(store=store).device_status(user_id="u1", device_id=_SYNC_DEV)
+    assert status == {
+        "device_id": _SYNC_DEV,
+        "status": "active",
+        "revoked_at": None,
+        "last_synced_at": 111,
+    }
+
+
+def test_device_status_is_scoped_and_unknown_is_none() -> None:
+    store = _FakeSyncStore({("u1", _SYNC_DEV): {"status": "active"}})
+    svc = TrustedDeviceService(store=store)
+    assert svc.device_status(user_id="u1", device_id="tdv_" + ("c" * 32)) is None
+    # A foreign caller cannot read another user's device (own-device scoping).
+    assert svc.device_status(user_id="u2", device_id=_SYNC_DEV) is None
+
+
+def test_seal_device_is_one_way_and_idempotent() -> None:
+    store = _FakeSyncStore({("u1", _SYNC_DEV): {"status": "revoked", "sealed_at": None}})
+    svc = TrustedDeviceService(store=store)
+    first = svc.seal_device(user_id="u1", device_id=_SYNC_DEV)
+    assert first is not None and first["status"] == "revoked"
+    assert first["sealed_at"] is not None
+    # Idempotent: a second ack returns the same sealed_at and audits only once.
+    second = svc.seal_device(user_id="u1", device_id=_SYNC_DEV)
+    assert second is not None and second["sealed_at"] == first["sealed_at"]
+    assert [a["event_type"] for a in store.audited] == ["device_sealed"]
+
+
+def test_seal_device_never_touches_active_device() -> None:
+    store = _FakeSyncStore({("u1", _SYNC_DEV): {"status": "active", "sealed_at": None}})
+    svc = TrustedDeviceService(store=store)
+    result = svc.seal_device(user_id="u1", device_id=_SYNC_DEV)
+    assert result is not None and result["status"] == "active"
+    assert result["sealed_at"] is None
+    assert store.rows[("u1", _SYNC_DEV)]["status"] == "active"
+    assert store.audited == []
+
+
+def test_seal_device_unknown_is_none() -> None:
+    assert (
+        TrustedDeviceService(store=_FakeSyncStore()).seal_device(user_id="u1", device_id=_SYNC_DEV)
+        is None
+    )
+
+
+def test_record_sync_stamps_active_and_swallows_bad_id() -> None:
+    store = _FakeSyncStore({("u1", _SYNC_DEV): {"status": "active"}})
+    svc = TrustedDeviceService(store=store)
+    svc.record_sync(user_id="u1", device_id=_SYNC_DEV, cursor=42)
+    assert store.rows[("u1", _SYNC_DEV)]["last_synced_at"] is not None
+    assert store.rows[("u1", _SYNC_DEV)]["last_sync_cursor"] == 42
+    # A malformed device id is a silent no-op, never an exception.
+    svc.record_sync(user_id="u1", device_id="not-a-device", cursor=1)
+
+
+@pytest.mark.asyncio
+async def test_status_route_maps_none_to_unknown_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    class _Svc:
+        def device_status(self, **_kwargs: Any) -> None:
+            return None
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    with pytest.raises(HTTPException) as raised:
+        await account.trusted_device_status(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert raised.value.status_code == 404
+    assert raised.value.detail["code"] == "TRUSTED_DEVICE_UNKNOWN"
+
+
+@pytest.mark.asyncio
+async def test_status_route_returns_status_and_server_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    class _Svc:
+        def device_status(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "device_id": _SYNC_DEV,
+                "status": "revoked",
+                "revoked_at": 5,
+                "last_synced_at": None,
+            }
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    result = await account.trusted_device_status(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert result["status"] == "revoked"
+    assert isinstance(result["server_time_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_status_route_db_error_fails_closed_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        raise RuntimeError("db down")
+
+    class _Svc:
+        def device_status(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "active"}
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    with pytest.raises(HTTPException) as raised:
+        await account.trusted_device_status(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert raised.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_seal_ack_route_maps_none_to_unknown_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    class _Svc:
+        def seal_device(self, **_kwargs: Any) -> None:
+            return None
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    with pytest.raises(HTTPException) as raised:
+        await account.trusted_device_seal_ack(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert raised.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_seal_ack_route_first_ack_stamps_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    store = _FakeSyncStore({("u1", _SYNC_DEV): {"status": "revoked", "sealed_at": None}})
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: TrustedDeviceService(store=store))
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    first = await account.trusted_device_seal_ack(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert first["status"] == "revoked" and first["sealed_at"] is not None
+    second = await account.trusted_device_seal_ack(device_id=_SYNC_DEV, firebase_uid="u1")
+    assert second["sealed_at"] == first["sealed_at"]
+    # Audited exactly once across the two acks.
+    assert [a["event_type"] for a in store.audited] == ["device_sealed"]
+
+
+@pytest.mark.asyncio
+async def test_device_sync_stamps_record_sync_only_for_device_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routes import pkm_routes_shared
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    calls: list[dict[str, Any]] = []
+
+    class _RecSvc:
+        def record_sync(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    class _FakePkm:
+        async def list_device_sync_events(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"events": [], "next_cursor": 7}
+
+    monkeypatch.setattr(pkm_routes_shared, "get_pkm_service", lambda: _FakePkm())
+    monkeypatch.setattr(pkm_routes_shared, "TrustedDeviceService", lambda: _RecSvc())
+    monkeypatch.setattr(pkm_routes_shared, "run_in_threadpool", _run_in_threadpool)
+
+    dev = "tdv_" + ("d" * 32)
+    resp = await pkm_routes_shared.get_device_sync_events(
+        user_id="u1",
+        after_cursor=0,
+        limit=100,
+        token_data={"user_id": "u1", "agent_id": f"device:{dev}"},
+    )
+    assert resp.next_cursor == 7
+    assert calls == [{"user_id": "u1", "device_id": dev, "cursor": 7}]
+
+    # A non-device caller is never stamped.
+    calls.clear()
+    await pkm_routes_shared.get_device_sync_events(
+        user_id="u1",
+        after_cursor=0,
+        limit=100,
+        token_data={"user_id": "u1", "agent_id": "browser"},
+    )
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_device_sync_stamp_failure_does_not_fail_the_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routes import pkm_routes_shared
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    class _RaisingSvc:
+        def record_sync(self, **_kwargs: Any) -> None:
+            raise RuntimeError("stamp boom")
+
+    class _FakePkm:
+        async def list_device_sync_events(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"events": [], "next_cursor": 3}
+
+    monkeypatch.setattr(pkm_routes_shared, "get_pkm_service", lambda: _FakePkm())
+    monkeypatch.setattr(pkm_routes_shared, "TrustedDeviceService", lambda: _RaisingSvc())
+    monkeypatch.setattr(pkm_routes_shared, "run_in_threadpool", _run_in_threadpool)
+
+    dev = "tdv_" + ("e" * 32)
+    resp = await pkm_routes_shared.get_device_sync_events(
+        user_id="u1",
+        after_cursor=0,
+        limit=100,
+        token_data={"user_id": "u1", "agent_id": f"device:{dev}"},
+    )
+    # The read still succeeds even though the best-effort stamp raised.
+    assert resp.next_cursor == 3

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -1215,7 +1215,7 @@
       "id": "trusted_device_registry",
       "lifecycle_status": "current",
       "owner": "iam-consent-governance",
-      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used tracking, and revocation through TrustedDeviceService."
+      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used and last-synced tracking, revocation, and advisory remote-revoke seal telemetry through TrustedDeviceService."
     },
     {
       "data_class": "workflow_state",
@@ -5150,7 +5150,7 @@
     "action_gateway": "4da0727c2fdeadb78bc4650914827d77ad085c72dbfebff7e1f1baa2e89c07a1",
     "agent_registry": "ee0eeb9ba4cdc177301df5ed35e03b93cdc8d116f4249d7ba6eb69b1362559a5",
     "cache_manifest": "13a2f556b7ea2ebbcf7729c5ba7dfa8875a79d8dd4a37df2b8dc2471ca544879",
-    "data_plane": "b7e681a7b0681e5d132313116490db2b7b802f77785a6147d629cf04ff9914a3",
+    "data_plane": "e54c50888114e8ec012180b6eb142335164d429494a7cab7a084a1ab0df64e84",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "91046655f19b6c84fa76f27faa3309b7f28887aec26cae65e2b3fa6843f389e4",
     "route_index": "eb051f176332f390083c5e270b7dcc494994a68352b741c16b1765efdc63243e",

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -569,10 +569,10 @@
       "exact_tables": [
         "trusted_devices"
       ],
-      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used tracking, and revocation through TrustedDeviceService.",
+      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used and last-synced tracking, revocation, and advisory remote-revoke seal telemetry through TrustedDeviceService.",
       "retention_policy": "Retain active device registrations while the account exists; retain revoked metadata only for bounded security review before compaction.",
       "deletion_behavior": "Delete all device rows on account deletion; explicit device revocation immediately disables new challenges and records the revocation timestamp.",
-      "trust_boundary": "Public P-256 device keys and device metadata only; never private keys, Firebase tokens, vault passphrases, vault keys, decrypted PKM, or developer credentials.",
+      "trust_boundary": "Public P-256 device keys and device metadata only, including PKM device-sync cursors and remote-revoke seal timestamps; never private keys, Firebase tokens, vault passphrases, vault keys, decrypted PKM, or developer credentials.",
       "plaintext_posture": "metadata_only",
       "expected_row_growth": "low_per_user"
     },

--- a/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
+++ b/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
@@ -192,13 +192,45 @@ recompute; they never silently overwrite newer information.
 | Remote vault persists but local envelope fails | Report remote creation and re-enroll with the passphrase |
 | Keychain unavailable or locked | Fail closed without local envelope |
 | Source Library custody missing with existing ciphertext | Fail closed as recovery/rebuild required; never generate a replacement secret |
-| Device revoked | Block refresh, owner-capability issuance, unlock recovery, and writes |
+| Device revoked (remote) | Firebase refresh survives revoke; the server cascades owner-token revocation so capability mint, unlock recovery, and writes fail closed. The native runtime learns via the self-status poll or a 401 `TRUSTED_DEVICE_REVOKED` and then seals (see Remote Revocation and Seal). |
 | PKM compatibility validation fails | Keep the bridge locked and update client/server contract |
 
 Disconnect revokes the remote device, removes the native connector
 registration, deletes the local envelope and ciphertext replica, removes
 related Keychain entries and the local Source Library plane, and clears in-memory credentials. Hosted MCP and
 existing vault wrappers remain unchanged.
+
+### Remote Revocation and Seal
+
+Revoking a device from the browser settings surface (DELETE
+`/api/account/trusted-devices/{device_id}`) is server-authoritative but does not
+push to the device. It flips the row to `revoked`, cascades the device-bound
+`vault.owner` tokens, and stops server-side sync, so every vault call then fails
+closed. It does NOT touch the Firebase session: per-device Firebase revocation
+is impossible, so the device keeps a user-level Firebase refresh credential and
+can always learn its own fate. Security rests on the invariant that Firebase-uid
+auth alone never grants vault data or capability; every vault-touching endpoint
+still gates on the device-bound `vault.owner` token re-checked against
+`is_trusted_device_active`.
+
+The native runtime detects a remote revoke and seals its local replica:
+
+- Detector. Poll `GET /api/account/trusted-devices/{device_id}/status`
+  (Firebase-authed) on a cadence and on foreground/wake before resuming sync. It
+  returns `active` or `revoked` (200), `TRUSTED_DEVICE_UNKNOWN` (404), or 503 on
+  a DB error, never a defaulted `active`. Also branch on the device-sync 401
+  machine code: `TRUSTED_DEVICE_REVOKED` is authoritative (seal);
+  `TRUSTED_DEVICE_STATUS_UNCONFIRMED` is a transient DB outage (retry, never
+  seal). A 404 is `needs_reinit` (quarantine ciphertext, do not erase).
+- Seal (on confirmed revoke, ordered and idempotent). Stop the sync loop,
+  zeroize in-memory credentials, delete the local envelope and ciphertext
+  replica, remove Keychain entries, surface the state to the user, then
+  `POST /api/account/trusted-devices/{device_id}/seal-ack`.
+- Ack. Seal-ack is Firebase-authed with NO device signature (the P-256 key is
+  zeroized during seal, so a post-seal signature is unsatisfiable and a static
+  one would be replayable). It is advisory telemetry only: the server records
+  `sealed_at`, never gates enforcement on it, and can only stamp an
+  already-revoked row.
 
 ## UAT Verification
 


### PR DESCRIPTION
## What
Phase 1 backend of the Hermes trusted-device lifecycle northstar: a real sync status the settings surface can show, a fail-closed self-status liveness read the native runtime polls, and advisory seal telemetry that closes the remote-revoke audit loop.

## Changes
- **Migration 176** (additive): `last_synced_at`, `last_sync_cursor`, `sealed_at` on `trusted_devices` (metadata-only, no status CHECK change) + rollback + manifest (ordered + iam) + 3 schema contracts at 176 + data-plane contract.
- **`GET /api/account/trusted-devices/{id}/status`** — Firebase-authed own-device liveness read: `active|revoked`, 404 `TRUSTED_DEVICE_UNKNOWN`, 503 fail-closed on DB error (never a defaulted `active`). Grants nothing.
- **`POST /api/account/trusted-devices/{id}/seal-ack`** — advisory telemetry, Firebase-authed, NO device signature (P-256 key is zeroized during seal). One-way idempotent; can only stamp an already-revoked row; enforcement never gates on `sealed_at`.
- **`record_sync`** stamped best-effort in the device-sync handler (active devices only, never double-stamped, swallowed on failure).
- **Dual 401 machine codes**: `TRUSTED_DEVICE_REVOKED` (native seals) vs `TRUSTED_DEVICE_STATUS_UNCONFIRMED` (transient DB outage, native retries), surfaced verbatim by the middleware.
- **Enrollment doc**: corrected the false 'block refresh on revoke' (Firebase refresh survives revoke) and documented the remote-revocation/seal contract.

## Enforcement backbone unchanged
Every vault call still gates on the device-bound owner token re-checked against `is_trusted_device_active`; revoke still cascades owner tokens; DB-down still fails closed. The new columns/endpoints are additive and never gate enforcement.

## Verification
- `db verify-release-contract`: aligned at 176.
- `data-model-audit`: 0 unclassified, 0 failures.
- `docs verify`: green.
- Full `run-test-ci.sh`: passed (11 new + 2 updated trusted-device tests; auth-core regression check clean).
- `ruff`: clean. Adversarially reviewed (3-lane + synthesis): ship verdict, zero blockers.

## Scope
Phase 1 of the northstar. Phase 2 (frontend sync-status settings surface) and Phase 3 (native seal in `hushh-one-hermes-agent`, a separate repo) follow. Tracked on Hussh Action Items #79.