### PR TITLE
feat(navbar): rename the Search tab to "Ask One"

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
+++ b/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
@@ -81,7 +81,7 @@ describe("Navbar bottom utilities", () => {
       within(routeNav)
         .getAllByRole("radio")
         .map((radio) => radio.textContent?.trim()),
-    ).toEqual(["One", "Connect", "Feed", "Search"]);
+    ).toEqual(["One", "Connect", "Feed", "Ask One"]);
     expect(screen.queryByRole("radio", { name: "Profile" })).toBeNull();
     unmount();
   });
@@ -129,7 +129,7 @@ describe("Navbar bottom utilities", () => {
       within(screen.getByRole("radiogroup", { name: "Route navigation" }))
         .getAllByRole("radio")
         .map((radio) => radio.textContent?.trim()),
-    ).toEqual(["One", "Connect", "Feed", "Search"]);
+    ).toEqual(["One", "Connect", "Feed", "Ask One"]);
     expect(
       screen.queryByRole("radiogroup", { name: "Workspace navigation" }),
     ).toBeNull();

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -169,7 +169,7 @@ const BOTTOM_NAV_OPTION_META: Record<
   },
   search: {
     value: "search",
-    label: "Search",
+    label: "Ask One",
     icon: MagnifyingGlass,
     activeIcon: FilledMagnifyingGlassIcon,
     dataTourId: "nav-search",


### PR DESCRIPTION
## What

The bottom-nav pill that opens the search route now reads **Ask One** instead of **Search**.

## Why

"Search" frames One as a search box; the interaction is asking your agent. This is the terminology change requested for the UAT nav (`uat.one.hushh.ai`).

## Scope

- `hushh-webapp/components/navbar.tsx` — `BOTTOM_NAV_OPTION_META.search.label`
- `hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx` — the two bottom-nav label assertions

Route key, path, and `dataTourId` intentionally stay `search` / `nav-search`; renaming those would break existing links and product-tour targeting.

## Verification

`npx vitest run __tests__/components/navbar-bottom-nav.test.tsx` → 10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)