### PR TITLE
feat(trusted-device): enriched sync-status settings surface (Phase 2)

### DIFF
--- a/hushh-webapp/__tests__/trusted-device-sync-display.test.ts
+++ b/hushh-webapp/__tests__/trusted-device-sync-display.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeTime } from "@/lib/format/relative-time";
+import {
+  deriveSyncDisplay,
+  SEAL_CONFIRM_WINDOW_MS,
+} from "@/lib/trusted-device/sync-display";
+
+const NOW = 1_700_000_000_000;
+
+describe("deriveSyncDisplay", () => {
+  it("shows an active device's real last-sync time", () => {
+    const d = deriveSyncDisplay(
+      { status: "active", last_synced_at: NOW - 3_600_000 },
+      NOW,
+    );
+    expect(d.tone).toBe("active");
+    expect(d.label).toMatch(/^Active · last synced /);
+  });
+
+  it("shows 'not yet synced' for an active device that never synced", () => {
+    const d = deriveSyncDisplay({ status: "active", last_synced_at: null }, NOW);
+    expect(d).toEqual({ label: "Active · not yet synced", tone: "neutral" });
+  });
+
+  it("reports a sealed device as reported, never asserts sealing as fact", () => {
+    const d = deriveSyncDisplay(
+      { status: "revoked", sealed_at: NOW - 60_000 },
+      NOW,
+    );
+    expect(d.tone).toBe("muted");
+    expect(d.label).toMatch(/^Revoked · device reported sealed /);
+    expect(d.label).not.toContain("vault sealed");
+  });
+
+  it("awaits seal confirmation inside the bounded window", () => {
+    const d = deriveSyncDisplay(
+      { status: "revoked", sealed_at: null, revoked_at: NOW - 1000 },
+      NOW,
+    );
+    expect(d).toEqual({
+      label: "Revoked · awaiting device seal confirmation",
+      tone: "neutral",
+    });
+  });
+
+  it("degrades to an honest 'seal unconfirmed' past the window", () => {
+    const d = deriveSyncDisplay(
+      {
+        status: "revoked",
+        sealed_at: null,
+        revoked_at: NOW - SEAL_CONFIRM_WINDOW_MS - 1000,
+      },
+      NOW,
+    );
+    expect(d).toEqual({ label: "Revoked · seal unconfirmed", tone: "muted" });
+  });
+
+  it("renders an unclassifiable status as unavailable, never a false 'stopped'", () => {
+    const d = deriveSyncDisplay({ status: "mystery" }, NOW);
+    expect(d).toEqual({ label: "Sync status unavailable", tone: "muted" });
+    expect(d.label).not.toMatch(/stopped|revoked/i);
+  });
+
+  it("is reload-stable for the same (fields, nowMs)", () => {
+    const fields = { status: "active" as const, last_synced_at: NOW - 5000 };
+    expect(deriveSyncDisplay(fields, NOW)).toEqual(
+      deriveSyncDisplay(fields, NOW),
+    );
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns empty for null/undefined so callers can branch", () => {
+    expect(formatRelativeTime(null, NOW)).toBe("");
+    expect(formatRelativeTime(undefined, NOW)).toBe("");
+  });
+
+  it("collapses very recent times to 'just now'", () => {
+    expect(formatRelativeTime(NOW - 5000, NOW)).toBe("just now");
+  });
+
+  it("formats a past time relative to now", () => {
+    expect(formatRelativeTime(NOW - 3 * 3_600_000, NOW)).toMatch(/ago/);
+  });
+});

--- a/hushh-webapp/app/one/profile/security/devices/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/page.tsx
@@ -21,8 +21,13 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
+import { formatRelativeTime } from "@/lib/format/relative-time";
 import { ROUTES } from "@/lib/navigation/routes";
 import { ApiService } from "@/lib/services/api-service";
+import {
+  deriveSyncDisplay,
+  type SyncTone,
+} from "@/lib/trusted-device/sync-display";
 
 interface TrustedDevice {
   device_id: string;
@@ -31,7 +36,18 @@ interface TrustedDevice {
   status: "active" | "revoked";
   created_at: number;
   last_used_at: number | null;
+  // Added by migration 176; optional so an older payload still type-checks and
+  // falls through to the honest "unavailable" / "not yet synced" states.
+  revoked_at?: number | null;
+  last_synced_at?: number | null;
+  sealed_at?: number | null;
 }
+
+const _SYNC_TONE_CLASS: Record<SyncTone, string> = {
+  active: "text-foreground",
+  neutral: "text-foreground",
+  muted: "text-muted-foreground",
+};
 
 export default function TrustedDevicesPage() {
   const { user } = useAuth();
@@ -82,6 +98,8 @@ export default function TrustedDevicesPage() {
     }
   }
 
+  const nowMs = Date.now();
+
   return (
     <AppPageShell
       as="main"
@@ -108,35 +126,53 @@ export default function TrustedDevicesPage() {
         ) : null}
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         <div className="space-y-3">
-          {devices.map((device) => (
-            <article
-              className="flex items-center gap-4 rounded-2xl border bg-card p-4"
-              key={device.device_id}
-            >
-              <div className="flex size-10 items-center justify-center rounded-xl bg-muted">
-                <Laptop className="size-5" aria-hidden />
-              </div>
-              <div className="min-w-0 flex-1">
-                <h2 className="truncate text-sm font-medium">
-                  {device.device_name}
-                </h2>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {device.status === "active" ? "Active" : "Revoked"} ·{" "}
-                  {device.platform}
-                </p>
-              </div>
-              {device.status === "active" ? (
-                <Button
-                  aria-label={`Revoke ${device.device_name}`}
-                  onClick={() => setPendingRevocation(device)}
-                  size="icon"
-                  variant="ghost"
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              ) : null}
-            </article>
-          ))}
+          {devices.map((device) => {
+            const sync = deriveSyncDisplay(device, nowMs);
+            const connected = formatRelativeTime(device.created_at, nowMs);
+            const lastActive = formatRelativeTime(device.last_used_at, nowMs);
+            const meta = [
+              device.platform,
+              connected ? `Connected ${connected}` : "",
+              lastActive ? `Last active ${lastActive}` : "",
+            ]
+              .filter(Boolean)
+              .join(" · ");
+            return (
+              <article
+                className="flex items-center gap-4 rounded-2xl border bg-card p-4"
+                key={device.device_id}
+              >
+                <div className="flex size-10 items-center justify-center rounded-xl bg-muted">
+                  <Laptop className="size-5" aria-hidden />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h2 className="truncate text-sm font-medium">
+                    {device.device_name}
+                  </h2>
+                  <p
+                    className={`mt-1 truncate text-xs font-medium ${_SYNC_TONE_CLASS[sync.tone]}`}
+                  >
+                    {sync.label}
+                  </p>
+                  {meta ? (
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {meta}
+                    </p>
+                  ) : null}
+                </div>
+                {device.status === "active" ? (
+                  <Button
+                    aria-label={`Unlink ${device.device_name}`}
+                    onClick={() => setPendingRevocation(device)}
+                    size="icon"
+                    variant="ghost"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                ) : null}
+              </article>
+            );
+          })}
           {!loading && devices.length === 0 ? (
             <p className="rounded-2xl border border-dashed p-8 text-center text-sm text-muted-foreground">
               No trusted devices are connected.
@@ -152,12 +188,14 @@ export default function TrustedDevicesPage() {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Revoke this trusted device?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Unlink {pendingRevocation?.device_name || "this device"}?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              {pendingRevocation?.device_name || "This device"} will immediately
-              lose access to new owner capabilities and Personal information writes.
-              Reconnecting requires browser approval and local vault setup
-              again.
+              This device will stop syncing immediately, and its local copy of
+              your vault will be sealed on the device. Reconnecting requires
+              approving it again in your browser and setting up the local vault
+              from scratch.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -169,7 +207,7 @@ export default function TrustedDevicesPage() {
                 if (pendingRevocation) void revoke(pendingRevocation.device_id);
               }}
             >
-              {revoking ? "Revoking…" : "Revoke device"}
+              {revoking ? "Unlinking…" : "Unlink device"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/hushh-webapp/lib/format/relative-time.ts
+++ b/hushh-webapp/lib/format/relative-time.ts
@@ -1,0 +1,33 @@
+const _rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+const _UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 365 * 24 * 3600],
+  ["month", 30 * 24 * 3600],
+  ["week", 7 * 24 * 3600],
+  ["day", 24 * 3600],
+  ["hour", 3600],
+  ["minute", 60],
+  ["second", 1],
+];
+
+/**
+ * Format an epoch-ms timestamp as a short relative string ("2 hours ago",
+ * "just now"). `nowMs` is passed in so callers stay reload-stable and testable
+ * rather than depending on a hidden clock. Returns "" for null/undefined so a
+ * caller can branch on emptiness (e.g. render "not yet synced").
+ */
+export function formatRelativeTime(
+  epochMs: number | null | undefined,
+  nowMs: number = Date.now(),
+): string {
+  if (epochMs == null || !Number.isFinite(epochMs)) return "";
+  const deltaMs = epochMs - nowMs;
+  const absSec = Math.abs(deltaMs) / 1000;
+  if (absSec < 45) return "just now";
+  for (const [unit, secs] of _UNITS) {
+    if (absSec >= secs || unit === "second") {
+      return _rtf.format(Math.round(deltaMs / 1000 / secs), unit);
+    }
+  }
+  return "just now";
+}

--- a/hushh-webapp/lib/trusted-device/sync-display.ts
+++ b/hushh-webapp/lib/trusted-device/sync-display.ts
@@ -1,0 +1,71 @@
+import { formatRelativeTime } from "@/lib/format/relative-time";
+
+/** The subset of a trusted-device row that drives the sync-status display. */
+export interface DeviceSyncFields {
+  status: "active" | "revoked" | string;
+  created_at?: number | null;
+  last_used_at?: number | null;
+  revoked_at?: number | null;
+  last_synced_at?: number | null;
+  sealed_at?: number | null;
+}
+
+export type SyncTone = "active" | "neutral" | "muted";
+
+export interface SyncDisplay {
+  label: string;
+  tone: SyncTone;
+}
+
+/**
+ * Bounded window separating "awaiting device seal confirmation" from the honest
+ * terminal "seal unconfirmed". Loosely tied to the native detector cadence.
+ */
+export const SEAL_CONFIRM_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Client-derived sync display from the raw server fields. The server emits only
+ * status and timestamps and never a display verdict, so all UI state is derived
+ * here and stays reload-stable given the same (fields, nowMs). It is
+ * deliberately honest:
+ *  - never claims a device is sealed as fact, only "device reported sealed";
+ *  - never relabels last_used_at (a capability mint) as a sync;
+ *  - renders anything it cannot classify as "unavailable", never a false
+ *    "stopped" or "revoked".
+ */
+export function deriveSyncDisplay(
+  device: DeviceSyncFields,
+  nowMs: number,
+): SyncDisplay {
+  if (device.status === "active") {
+    if (device.last_synced_at != null) {
+      return {
+        label: `Active · last synced ${formatRelativeTime(device.last_synced_at, nowMs)}`,
+        tone: "active",
+      };
+    }
+    return { label: "Active · not yet synced", tone: "neutral" };
+  }
+
+  if (device.status === "revoked") {
+    if (device.sealed_at != null) {
+      return {
+        label: `Revoked · device reported sealed ${formatRelativeTime(device.sealed_at, nowMs)}`,
+        tone: "muted",
+      };
+    }
+    const sinceRevoke =
+      device.revoked_at != null
+        ? nowMs - device.revoked_at
+        : Number.POSITIVE_INFINITY;
+    if (sinceRevoke <= SEAL_CONFIRM_WINDOW_MS) {
+      return {
+        label: "Revoked · awaiting device seal confirmation",
+        tone: "neutral",
+      };
+    }
+    return { label: "Revoked · seal unconfirmed", tone: "muted" };
+  }
+
+  return { label: "Sync status unavailable", tone: "muted" };
+}


### PR DESCRIPTION
## What
Phase 2 of the trusted-device lifecycle northstar: the settings surface now shows the **real sync state** from the fields Phase 1 (migration 176) added, and the unlink copy is honest about what happens on the device.

## Changes
- **`deriveSyncDisplay`** ([lib/trusted-device/sync-display.ts]): a pure, reload-stable client helper mapping raw `status` + timestamps to honest labels:
  - Active: `Active · last synced {rel}` / `Active · not yet synced`
  - Revoked: `awaiting device seal confirmation` (bounded window) → `seal unconfirmed` → `device reported sealed {rel}` (**never** asserted as fact)
  - Anything unclassifiable → `Sync status unavailable` (never a false "stopped"/"revoked")
- **Enriched device card**: sync status + `Connected {rel}` + `Last active {rel}` — `last_used_at` is labeled **"Last active"**, never "Last synced" (it's a capability mint, not a sync).
- **Honest unlink dialog**: "This device will stop syncing immediately, and its local copy of your vault will be sealed on the device."
- Shared **`lib/format/relative-time.ts`**.

## Boundaries kept
No new proxy route — the new fields fold into the existing `listTrustedDevices` payload. No `fetch` in components (stays in ApiService). Status conveyed by badge **text**, not color alone (WCAG).

## Verification
typecheck, eslint, `verify:service-boundary`, `verify:accent-tokens` all clean; **10 vitest cases** cover every user-facing state (synced, not-yet-synced, sealed, awaiting-seal, seal-unconfirmed, unavailable) and reload-stability. Degrades gracefully to "unavailable" against any payload without the new fields.

## Scope
Phase 2 of #6002. Phase 1 backend is live in UAT (endpoint mounted, revision in sync). Phase 3 (native seal) is the separate `hushh-one-hermes-agent` repo.