### PR TITLE
fix(location): un-nest replace invite code alert dialog from sheet

### DIFF
--- a/hushh-webapp/__tests__/components/calendar-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/calendar-agent-page.test.tsx
@@ -34,8 +34,19 @@ import { CalendarAgentPage } from "@/components/calendar/calendar-agent-page";
 
 describe("CalendarAgentPage", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     mocks.getIdToken.mockResolvedValue("firebase-token");
+    vi.spyOn(window, "open").mockImplementation(
+      () =>
+        ({
+          close: vi.fn(),
+          document: { title: "" },
+          focus: vi.fn(),
+          location: { replace: vi.fn() },
+          sessionStorage: { setItem: vi.fn() },
+        }) as unknown as Window,
+    );
   });
 
   it("requests management access in the single initial Calendar authorization", async () => {

--- a/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/connect-page-layout.contract.test.ts
@@ -37,12 +37,23 @@ describe("Connect page layout contract", () => {
       "utf8",
     );
 
-    const connectionRow = source.match(
-      /sortedConnections\.map[\s\S]*?<SettingsRow[\s\S]*?\/>/,
-    )?.[0];
-    expect(connectionRow, "the connections list still renders a SettingsRow").toBeTruthy();
-    expect(connectionRow).not.toMatch(/^\s*stackTrailingOnMobile\s*$/m);
-    expect(connectionRow).toContain("trailing=");
+    const connectionsMapStart = source.indexOf(
+      "sortedConnections.map((connection) => (",
+    );
+    const connectionsPagerStart = source.indexOf(
+      "{connectionsHasMore ?",
+      connectionsMapStart,
+    );
+    const connectionRows = source.slice(
+      connectionsMapStart,
+      connectionsPagerStart,
+    );
+    expect(
+      connectionRows,
+      "the connections list still renders a SettingsRow",
+    ).toContain("<SettingsRow");
+    expect(connectionRows).not.toMatch(/^\s*stackTrailingOnMobile\s*$/m);
+    expect(connectionRows).toContain("trailing=");
   });
 
   it("hard-gates Connect and the private agent on live in-memory vault state", () => {

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -796,13 +796,80 @@ describe("named Circle flows", () => {
     expect(screen.getByRole("button", { name: "Delete circle" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /Invite code/i }));
     expect(await screen.findByText(currentCode.code)).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Replace code" }));
-    fireEvent.click(screen.getByRole("button", { name: "Replace code" }));
+    const inviteCodeSheet = screen.getByRole("dialog", {
+      name: "Invite code",
+    });
+    fireEvent.click(
+      within(inviteCodeSheet).getByRole("button", { name: "Replace code" }),
+    );
+    const confirmDialog = await screen.findByRole("alertdialog", {
+      name: "Replace invite code?",
+    });
+    expect(confirmDialog.closest('[data-slot="sheet-content"]')).toBeNull();
+    expect(confirmDialog).toHaveClass("z-[714]");
+    expect(
+      document.querySelector('[data-slot="alert-dialog-overlay"]'),
+    ).toHaveClass("z-[713]");
+    fireEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Replace code" }),
+    );
 
     await waitFor(() =>
       expect(onGenerateCode).toHaveBeenCalledWith("circle-1", true),
     );
     expect(await screen.findByText(rotatedCode.code)).toBeTruthy();
+  });
+
+  it("dismisses only the replace-code confirmation and keeps the invite sheet close button responsive", async () => {
+    const currentCode = {
+      id: "code-1",
+      circleId: "circle-1",
+      code: "2345-6789-ABCD",
+      expiresAt: "2026-08-01T00:00:00Z",
+    };
+    const ownerCircle = {
+      ...circle("circle-1", "Family"),
+      activeInviteCode: currentCode,
+    };
+
+    render(
+      <CircleDetailFlow
+        circleId="circle-1"
+        {...detailProps(async () => ownerCircle)}
+      />,
+    );
+
+    expect(await screen.findByText("Family")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Invite code/i }));
+    expect(await screen.findByText(currentCode.code)).toBeTruthy();
+
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Invite code" })).getByRole(
+        "button",
+        { name: "Replace code" },
+      ),
+    );
+    const confirmDialog = await screen.findByRole("alertdialog", {
+      name: "Replace invite code?",
+    });
+    fireEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Cancel" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("alertdialog", { name: "Replace invite code?" }),
+      ).toBeNull();
+    });
+    const inviteCodeSheet = screen.getByRole("dialog", {
+      name: "Invite code",
+    });
+    fireEvent.click(
+      within(inviteCodeSheet).getByRole("button", { name: "Close" }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Invite code" })).toBeNull();
+    });
   });
 
   it("requires an explicit owner refresh for an unreadable legacy code", async () => {

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -1870,6 +1870,15 @@ export function CircleDetailFlow({
               <SheetContent
                 side="bottom"
                 aria-describedby={undefined}
+                onEscapeKeyDown={(event) => {
+                  if (replaceCodeConfirmOpen) event.preventDefault();
+                }}
+                onFocusOutside={(event) => {
+                  if (replaceCodeConfirmOpen) event.preventDefault();
+                }}
+                onPointerDownOutside={(event) => {
+                  if (replaceCodeConfirmOpen) event.preventDefault();
+                }}
                 className="mx-auto w-full rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:max-w-lg sm:px-6"
               >
                 <SheetHeader className="text-left">
@@ -1910,40 +1919,15 @@ export function CircleDetailFlow({
                       {codeCopied ? "Copied" : "Copy code"}
                     </Button>
                     {canRotateInviteCode ? (
-                      <AlertDialog
-                        open={replaceCodeConfirmOpen}
-                        onOpenChange={setReplaceCodeConfirmOpen}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={busy}
+                        onClick={() => setReplaceCodeConfirmOpen(true)}
+                        className="h-11 w-full rounded-full"
                       >
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            disabled={busy}
-                            className="h-11 w-full rounded-full"
-                          >
-                            Replace code
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent size="sm">
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>
-                              Replace invite code?
-                            </AlertDialogTitle>
-                            <AlertDialogDescription>
-                              The current code will stop working.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction
-                              disabled={busy}
-                              onClick={() => void generateCode(true)}
-                            >
-                              Replace code
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
+                        Replace code
+                      </Button>
                     ) : null}
                   </div>
                 ) : inviteCodeNeedsOwnerRotation && !canRotateInviteCode ? (
@@ -1980,6 +1964,35 @@ export function CircleDetailFlow({
                 )}
               </SheetContent>
             </Sheet>
+          ) : null}
+
+          {canViewInviteCode && canRotateInviteCode ? (
+            <AlertDialog
+              open={replaceCodeConfirmOpen}
+              onOpenChange={setReplaceCodeConfirmOpen}
+            >
+              <AlertDialogContent
+                size="sm"
+                overlayClassName="z-[713]"
+                className="z-[714]"
+              >
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Replace invite code?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    The current code will stop working.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={busy}
+                    onClick={() => void generateCode(true)}
+                  >
+                    Replace code
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           ) : null}
 
           <Sheet

--- a/hushh-webapp/components/ui/alert-dialog.tsx
+++ b/hushh-webapp/components/ui/alert-dialog.tsx
@@ -68,14 +68,16 @@ function AlertDialogOverlay({
 
 function AlertDialogContent({
   className,
+  overlayClassName,
   size = "default",
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm"
+  overlayClassName?: string
 }) {
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay className={overlayClassName} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         data-size={size}


### PR DESCRIPTION
### Summary 
* **Modal Architecture Fix:** Extracted the "Replace invite code?" `<AlertDialog>` out of `<SheetContent>` and placed it as a root-level sibling within `named-circle-flows.tsx`.
* **Resolved Deadlock:** Prevents competing Radix UI focus traps and backdrop layering collisions where the confirmation modal rendered trapped behind the active "Invite code" sheet, freezing user interactions and disabling the sheet's `X` close button.
* **Apple HIG Alignment:** Ensures modal overlays stack strictly above active sheets with clean dismissal behavior on "Cancel" and seamless code regeneration on "Replace code".

### Verification & Testing
* [x] **Unit Tests:** Ran `npx vitest run one-location` (all tests passing).
* [x] **Simulator Visual Check:** Verified in iOS Simulator (iPhone 17 Pro) that tapping "Replace code" brings the confirmation dialog to the front with active buttons.
* [x] **Dismissal Flow:** Verified that tapping "Cancel" safely dismisses the confirmation dialog and restores focus to the active invite sheet without freezing the UI.
* [x] **DCO Compliance:** Commit signed off with `-s`.