### PR TITLE
Polish One Location Apple UI system

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -723,7 +723,7 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(navigationHarness.replace).toHaveBeenCalledWith("/one/location", {
       scroll: false,
     });
-  });
+  }, 15000);
 
   it("keeps an empty people tray compact", async () => {
     experienceHarness.demoMode = false;

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
-  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+  return fs
+    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
+    .replace(/\r\n/g, "\n");
 }
 
 describe("Navbar bottom chrome contract", () => {

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1360,7 +1360,8 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /^Share location$/i }),
     ).toBeTruthy();
@@ -1374,7 +1375,7 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith(
       expect.objectContaining({ uid: "user_a" }),
     );
-  });
+  }, 15000);
 
   it("hides the Activity menu when every Activity count is zero", async () => {
     // Empty Activity rows are visual noise on the Now screen. Keep the real
@@ -1566,7 +1567,7 @@ describe("OneLocationAgentPage", () => {
       expect(cell.className).toContain("items-center");
       expect(cell.className).toContain("text-center");
       expect(cell.className).toContain("rounded-[16px]");
-      expect(cell.className).toContain("min-h-[100px]");
+      expect(cell.className).toContain("min-h-[96px]");
       expect(cell.className).toContain("px-5");
     });
     expect(
@@ -1598,11 +1599,14 @@ describe("OneLocationAgentPage", () => {
     expect(within(activity).queryByText("Active shares")).toBeNull();
 
     expect(within(activity).queryByText("Share")).toBeNull();
-    expect(screen.queryByTestId("one-location-now-more")).toBeNull();
+    const more = screen.getByTestId("one-location-now-more");
+    expect(within(more).getByText("Map")).toBeTruthy();
+    expect(within(more).getByText("Settings")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Activity" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "More" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(screen.queryByText("Check-In")).toBeNull();
     expect(screen.queryByText("Quick actions")).toBeNull();
   });
@@ -1620,7 +1624,7 @@ describe("OneLocationAgentPage", () => {
       name: "Location",
     });
     expect(headerActions.className).toContain("ml-auto");
-    expect(headerActions.className).toContain("items-center");
+    expect(headerActions.className).toContain("items-end");
     expect(headerActions.className).toContain("justify-center");
     // The actions column owns the switch and its compact visible status.
     const status = screen.getByTestId("one-location-header-status");
@@ -1634,8 +1638,9 @@ describe("OneLocationAgentPage", () => {
       "mt-1",
       "w-full",
       "whitespace-nowrap",
-      "text-center",
-      "text-[12px]",
+      "text-right",
+      "text-[13px]",
+      "leading-[18px]",
       "font-normal",
     );
     expect(status.textContent).toBe("Location off");
@@ -6365,7 +6370,7 @@ describe("OneLocationAgentPage", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
+  }, 15000);
 
   it("remembers the running share on the device, and only ids and times", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -16,20 +16,19 @@ const PROFILE_SOURCE = fs.readFileSync(
 );
 
 describe("One Location settings placement", () => {
-  it("keeps Settings out of the compact Now hub", () => {
+  it("keeps the old Settings entry out of the compact Now hub", () => {
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
     expect(nowSource).not.toContain('testId="one-location-settings-entry"');
-    expect(nowSource).not.toContain('title="Settings"');
     expect(nowSource).not.toContain('title="Privacy"');
   });
 
   it("offers Ask for location inside the compact Now actions", () => {
     // Request location is an action, not status or utility. The compact Now
-    // tab shows Ask, Check in, and SMS without dashboard section labels or a
-    // duplicated utility list.
+    // tab shows Ask, Check in, SMS, count-backed Activity rows, and the quiet
+    // More rows without dashboard section labels or the old active-shares row.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
@@ -42,10 +41,14 @@ describe("One Location settings placement", () => {
     const actionsIndex = nowSource.indexOf("LocationActionGrid");
     const requestIndex = nowSource.indexOf('title: "Ask for location"');
     const activityIndex = nowSource.indexOf("one-location-now-activity");
+    const moreIndex = nowSource.indexOf("one-location-now-more");
     expect(actionsIndex).toBeGreaterThan(-1);
     expect(requestIndex).toBeGreaterThan(actionsIndex);
     expect(activityIndex).toBeGreaterThan(requestIndex);
-    expect(nowSource).not.toContain("one-location-now-more");
+    expect(moreIndex).toBeGreaterThan(activityIndex);
+    expect(nowSource).toContain('title: "Map"');
+    expect(nowSource).toContain('title: "Settings"');
+    expect(nowSource).not.toContain('title: "Active shares"');
     expect(nowSource).not.toContain("LocationNowGroupLabel");
 
     // Reuses the existing ask flow rather than introducing a second one, so

--- a/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
@@ -4,6 +4,10 @@ import { AlertTriangle, Eye, Link as LinkIcon, MapPin, Share2 } from "lucide-rea
 
 import { Button } from "@/components/ui/button";
 import {
+  ButtonLabel,
+  RowDescription,
+} from "@/components/app-ui/typography";
+import {
   roleClasses,
   type SemanticRole,
 } from "@/lib/morphy-ux/tokens/semantic-roles";
@@ -58,13 +62,15 @@ export function ActionConfirmCard({
   return (
     <div
       data-testid="action-confirm-card"
-      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
+      className="rounded-[18px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-4 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
     >
       <div className="flex items-start gap-3">
         <span className={`mt-0.5 ${roleClasses(role).glyph}`}>
           <Icon className="h-5 w-5" aria-hidden />
         </span>
-        <p className="flex-1 text-sm font-medium">{action.summary}</p>
+        <RowDescription as="p" className="flex-1 text-[color:var(--app-label)]">
+          {action.summary}
+        </RowDescription>
       </div>
       <div className="mt-3 flex gap-2">
         <Button
@@ -75,8 +81,9 @@ export function ActionConfirmCard({
           variant={role === "danger" ? "destructive" : "default"}
           isLoading={busy}
           onClick={onConfirm}
+          className="ui-text-button-label"
         >
-          {CONFIRM_LABEL[action.type] ?? "Confirm"}
+          <ButtonLabel as="span">{CONFIRM_LABEL[action.type] ?? "Confirm"}</ButtonLabel>
         </Button>
         <Button
           data-testid="action-confirm-cancel"
@@ -84,8 +91,9 @@ export function ActionConfirmCard({
           variant="ghost"
           disabled={busy}
           onClick={onCancel}
+          className="ui-text-button-label"
         >
-          Cancel
+          <ButtonLabel as="span">Cancel</ButtonLabel>
         </Button>
       </div>
     </div>

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -30,6 +30,14 @@ import {
 import { cn } from "@/lib/utils";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+import {
+  FormLabel,
+  HelperText,
+  MediumRowLabel,
+  RowDescription,
+  RowLabel,
+  StatusText,
+} from "@/components/app-ui/typography";
 import { Button } from "@/components/ui/button";
 import { Avatar, StatusPill } from "./primitives";
 import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
@@ -108,18 +116,21 @@ export function TrustedPersonCard({
       <div className="flex items-center gap-3">
         <Avatar initials={initialsFrom(name)} />
         <div className="min-w-0 flex-1">
-          <p className="break-words text-[15px] font-semibold leading-5 text-foreground [overflow-wrap:anywhere] sm:text-[17px] sm:leading-[22px]">
+          <MediumRowLabel
+            as="p"
+            className="break-words [overflow-wrap:anywhere]"
+          >
             {name}
-          </p>
+          </MediumRowLabel>
           {subtitle ? (
-            <p
+            <RowDescription
               className={cn(
                 MUTED_TEXT,
                 "break-words [overflow-wrap:anywhere]",
               )}
             >
               {subtitle}
-            </p>
+            </RowDescription>
           ) : null}
         </div>
 
@@ -162,7 +173,7 @@ export function TrustedPersonCard({
             aria-label={actionAriaLabel}
             isLoading={actionBusy}
             disabled={actionDisabled}
-            className="h-8 shrink-0 rounded-full px-3.5 text-sm"
+            className="ui-text-button-label h-8 shrink-0 rounded-full px-3.5"
           >
             {actionLabel}
           </Button>
@@ -201,18 +212,20 @@ export function ActiveShareCard({
       <div className="flex items-center gap-3">
         <Avatar initials={initialsFrom(name)} />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-base font-semibold text-foreground">
+          <MediumRowLabel as="p" className="truncate">
             Sharing with {name}
-          </p>
-          <p className={cn(MUTED_TEXT, "truncate")}>{expiryLabel}</p>
+          </MediumRowLabel>
+          <RowDescription className={cn(MUTED_TEXT, "truncate")}>
+            {expiryLabel}
+          </RowDescription>
         </div>
         <StatusPill tone="live">Live</StatusPill>
       </div>
       {metaLabel ? (
-        <p className={cn(MUTED_TEXT, "flex items-center gap-1.5")}>
+        <RowDescription className={cn(MUTED_TEXT, "flex items-center gap-1.5")}>
           <Clock3 className="h-3.5 w-3.5" />
           {metaLabel}
-        </p>
+        </RowDescription>
       ) : null}
       <div className="grid grid-cols-2 gap-2">
         <Button
@@ -220,7 +233,7 @@ export function ActiveShareCard({
           size="sm"
           onClick={onStop}
           isLoading={stopBusy}
-          className="h-9 rounded-full text-sm"
+          className="ui-text-button-label h-9 rounded-full"
         >
           Stop sharing
         </Button>
@@ -230,7 +243,7 @@ export function ActiveShareCard({
             size="sm"
             onClick={onExtend}
             isLoading={extendBusy}
-            className="h-9 rounded-full text-sm"
+            className="ui-text-button-label h-9 rounded-full"
           >
             <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
             Extend
@@ -278,37 +291,38 @@ export function RequestCard({
       <div className="flex items-start gap-3">
         <Avatar initials={initialsFrom(name)} size={40} />
         <div className="min-w-0 flex-1">
-          <p className="text-[17px] font-semibold leading-[22px] text-foreground">
+          <MediumRowLabel as="p">
             {name}
-          </p>
-          <p className="mt-0.5 text-[15px] leading-5 text-muted-foreground">
+          </MediumRowLabel>
+          <RowDescription className={cn(MUTED_TEXT, "mt-0.5")}>
             {promptLine}
-          </p>
+          </RowDescription>
         </div>
       </div>
       {reason ? (
         <div className="mt-3 rounded-[12px] bg-[color:var(--app-card-surface-compact)] px-3 py-2.5">
-          <p className="text-[13px] font-medium leading-[18px] text-muted-foreground">
+          <FormLabel as="p" className={MUTED_TEXT}>
             Reason
-          </p>
-          <p className="mt-0.5 text-[15px] leading-5 text-foreground">
+          </FormLabel>
+          <RowLabel as="p" className="mt-0.5">
             {reason}
-          </p>
+          </RowLabel>
         </div>
       ) : null}
       {decided ? (
-        <p
+        <StatusText
+          as="p"
           role="status"
           className={cn(
-            "mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-full px-3 text-[14px] font-semibold leading-5",
+            "mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-full px-3",
             decision === "approved"
               ? "bg-[color:var(--app-success)]/12 text-[color:var(--app-success)]"
-              : "bg-[color:var(--app-neutral-fill-strong)] text-muted-foreground dark:bg-white/10",
+              : "bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-secondary-label)]",
           )}
         >
           <ShieldCheck className="h-4 w-4" aria-hidden />
           {decision === "approved" ? "Approved" : "Declined"}
-        </p>
+        </StatusText>
       ) : (
         <div className="mt-3.5 grid grid-cols-1 gap-2.5 min-[430px]:grid-cols-[0.82fr_1.18fr]">
           <Button
@@ -320,7 +334,7 @@ export function RequestCard({
             disabled={decided}
             // Deliberately not `isLoading`: the card has already answered. A
             // spinner here would reintroduce the wait it was pressed to remove.
-            className="order-1 h-11 rounded-full bg-[color:var(--app-accent)] text-[15px] font-semibold leading-5 text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 min-[430px]:order-2"
+            className="ui-text-button-label order-1 h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 min-[430px]:order-2"
           >
             {approveLabel}
           </Button>
@@ -331,7 +345,7 @@ export function RequestCard({
               onDecline();
             }}
             disabled={decided}
-            className="order-2 h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[15px] font-semibold leading-5 text-foreground hover:bg-[color:var(--app-neutral-fill-strong)]/80 dark:bg-white/10 min-[430px]:order-1"
+            className="ui-text-button-label order-2 h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80 min-[430px]:order-1"
           >
             Decline
           </Button>
@@ -446,19 +460,24 @@ export function SharedWithMeCard({
       <div className="flex items-start gap-3">
         <Avatar initials={initialsFrom(name)} size={40} />
         <div className="min-w-0 flex-1">
-          <p className="text-[17px] font-medium leading-[22px] text-foreground">
+          <RowLabel as="p">
             {name}
-          </p>
-          <p className={cn(MUTED_TEXT, "mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[13px] leading-[18px]")}>
+          </RowLabel>
+          <RowDescription
+            className={cn(
+              MUTED_TEXT,
+              "mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5",
+            )}
+          >
             {statusLine}
-          </p>
+          </RowDescription>
         </div>
       </div>
       {shareLanes}
       {address || addressLoading || coordinatesFallback ? (
         <div className="flex items-start gap-1.5">
           <MapPin
-            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[color:var(--app-tertiary-label)]"
             aria-hidden="true"
           />
           {addressLoading && !address ? (
@@ -467,9 +486,9 @@ export function SharedWithMeCard({
               aria-hidden="true"
             />
           ) : (
-            <p className={cn(MUTED_TEXT, "min-w-0 break-words text-sm")}>
+            <RowDescription className={cn(MUTED_TEXT, "min-w-0 break-words")}>
               {address ?? coordinatesFallback}
-            </p>
+            </RowDescription>
           )}
         </div>
       ) : null}
@@ -479,9 +498,10 @@ export function SharedWithMeCard({
           // as a problem. Nothing is wrong: the share is live and the first
           // point simply has not arrived. `aria-live="polite"` announces it
           // once without interrupting, which is what a status is.
-          <p
+          <RowDescription
+            as="p"
             aria-live="polite"
-            className={cn(MUTED_TEXT, "flex items-start gap-1.5 text-sm")}
+            className={cn(MUTED_TEXT, "flex items-start gap-1.5")}
           >
             <Clock3
               className="mt-0.5 h-3.5 w-3.5 shrink-0"
@@ -490,7 +510,7 @@ export function SharedWithMeCard({
             <span className="min-w-0 break-words">
               Waiting for their first update…
             </span>
-          </p>
+          </RowDescription>
         ) : (
           // Five hand-mixed hexes stood here. #ff9f0a is the iOS DARK-mode
           // orange used as a light-mode literal, and the 0.08 wash sat under
@@ -510,14 +530,15 @@ export function SharedWithMeCard({
                 className={cn("mt-0.5 h-4 w-4 shrink-0", warningRole.glyph)}
                 aria-hidden="true"
               />
-              <p
+              <HelperText
+                as="p"
                 className={cn(
-                  "min-w-0 break-words text-[12.5px] font-medium leading-snug [overflow-wrap:anywhere]",
+                  "min-w-0 break-words [overflow-wrap:anywhere]",
                   warningRole.glyph,
                 )}
               >
                 {viewStatus.message}
-              </p>
+              </HelperText>
             </div>
             {onAskReshare ? (
               <Button
@@ -540,7 +561,7 @@ export function SharedWithMeCard({
       {canTogglePreview ? (
         <button
           type="button"
-          className="inline-flex min-h-11 items-center gap-1.5 rounded-full text-[15px] font-semibold leading-[20px] text-[color:var(--app-accent)] transition-colors hover:text-[color:var(--app-accent-deep)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:opacity-60"
+          className="ui-text-button-label inline-flex min-h-11 items-center gap-1.5 rounded-full text-[color:var(--app-accent)] transition-colors hover:text-[color:var(--app-accent-deep)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:opacity-60"
           aria-label={
             isPreviewExpanded
               ? `Collapse shared location from ${name}`
@@ -582,14 +603,15 @@ export function SharedWithMeCard({
         </div>
       </div>
       {message ? (
-        <p
+        <RowDescription
+          as="p"
           className={cn(
             MUTED_TEXT,
-            "rounded-[12px] bg-[color:var(--app-neutral-fill)] px-3 py-2 text-[14px] leading-[19px]",
+            "rounded-[12px] bg-[color:var(--app-neutral-fill)] px-3 py-2",
           )}
         >
           “{message}”
-        </p>
+        </RowDescription>
       ) : null}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
         {canOpenMap ? (
@@ -597,7 +619,7 @@ export function SharedWithMeCard({
             asChild
             variant="ghost"
             size="sm"
-            className="h-11 rounded-full px-0 text-[15px] font-semibold text-[color:var(--app-accent)] hover:bg-transparent hover:text-[color:var(--app-accent-deep)]"
+            className="ui-text-button-label h-11 rounded-full px-0 text-[color:var(--app-accent)] hover:bg-transparent hover:text-[color:var(--app-accent-deep)]"
           >
             <a
               href={mapHref}
@@ -616,7 +638,7 @@ export function SharedWithMeCard({
             onClick={onRemove}
             disabled={removeBusy}
             aria-label={`Remove ${name} from Shared with me`}
-            className="inline-flex min-h-11 items-center justify-center rounded-full text-[15px] font-medium leading-[20px] text-[#FF3B30] transition-colors hover:text-[#D70015] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+            className="ui-text-button-label inline-flex min-h-11 items-center justify-center rounded-full text-[color:var(--app-destructive)] transition-colors hover:text-[color:var(--app-destructive)]/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
           >
             {removeBusy ? "Stopping…" : "Stop viewing"}
           </button>
@@ -685,28 +707,29 @@ export function TemporaryLinkCard({
         </span>
         <div className="min-w-0 flex-1">
           {title ? (
-            <p className="text-[17px] font-semibold leading-[22px] text-foreground">
+            <MediumRowLabel as="p">
               {title}
-            </p>
+            </MediumRowLabel>
           ) : null}
-          <p
+          <RowDescription
             className={cn(
-              "flex items-center gap-2 text-[15px] leading-5 text-muted-foreground",
+              MUTED_TEXT,
+              "flex items-center gap-2",
               title ? "mt-1" : "mt-0.5",
             )}
           >
             <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--app-success)]" />
             {statusLine}
-          </p>
-          <p className="mt-2 text-[15px] leading-5 text-muted-foreground">
+          </RowDescription>
+          <RowDescription className={cn(MUTED_TEXT, "mt-2")}>
             {description}
-          </p>
+          </RowDescription>
         </div>
       </div>
       <div className="grid grid-cols-1 gap-2 min-[340px]:grid-cols-2">
         <Button
           onClick={onShare}
-          className="h-12 rounded-[15px] bg-[color:var(--app-accent)] text-[15px] font-semibold leading-5 text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+          className="ui-text-button-label h-12 rounded-[15px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
         >
           <Share2 className="mr-1.5 h-4 w-4" />
           Share
@@ -716,7 +739,7 @@ export function TemporaryLinkCard({
           onClick={handleCopy}
           disabled={copyBusy}
           aria-busy={copyBusy || undefined}
-          className="h-12 rounded-[15px] text-[15px] font-semibold leading-5"
+          className="ui-text-button-label h-12 rounded-[15px]"
         >
           <Copy className="mr-1.5 h-4 w-4" />
           {copyBusy ? "Copying…" : copyLabel}
@@ -727,7 +750,7 @@ export function TemporaryLinkCard({
           type="button"
           onClick={onRevoke}
           disabled={revokeBusy}
-          className="min-h-11 w-full text-left text-[15px] font-semibold leading-5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+          className="ui-text-button-label min-h-11 w-full text-left text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
         >
           {revokeBusy ? "Revoking…" : "Revoke link"}
         </button>
@@ -763,11 +786,11 @@ export function DeviceReadinessCard({
 }) {
   const iconWrap =
     tone === "ready"
-      ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-300"
+      ? "bg-[color:var(--app-success)]/12 text-[color:var(--app-success)]"
       : tone === "warning"
-        ? "bg-amber-500/15 text-amber-600 dark:text-amber-300"
+        ? "bg-[color:var(--app-warning)]/12 text-[color:var(--app-warning)]"
         : tone === "blocked"
-          ? "bg-red-500/15 text-red-600 dark:text-red-300"
+          ? "bg-[color:var(--app-destructive)]/12 text-[color:var(--app-destructive)]"
           : "bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]";
   return (
     <div className="space-y-3">
@@ -785,8 +808,8 @@ export function DeviceReadinessCard({
           )}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-base font-semibold text-foreground">{title}</p>
-          <p className={MUTED_TEXT}>{description}</p>
+          <MediumRowLabel as="p">{title}</MediumRowLabel>
+          <RowDescription className={MUTED_TEXT}>{description}</RowDescription>
         </div>
       </div>
       <div className="grid gap-2">
@@ -796,7 +819,7 @@ export function DeviceReadinessCard({
             size="sm"
             onClick={onRefresh}
             isLoading={refreshBusy}
-            className="h-10 w-full rounded-full bg-[color:var(--app-accent)] text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+            className="ui-text-button-label h-10 w-full rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
           >
             {!refreshBusy ? <RefreshCw className="mr-2 h-4 w-4" /> : null}
             {refreshLabel}
@@ -808,7 +831,7 @@ export function DeviceReadinessCard({
             size="sm"
             onClick={onAction}
             isLoading={actionBusy}
-            className="h-10 w-full rounded-full text-sm"
+            className="ui-text-button-label h-10 w-full rounded-full"
           >
             {!actionBusy ? <ExternalLink className="mr-2 h-4 w-4" /> : null}
             {actionLabel}
@@ -832,12 +855,12 @@ export function ActivityReceiptCard({
 }) {
   return (
     <div className={cn(SUBCARD_SURFACE, "flex items-start gap-3 p-3")}>
-      <span className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-full bg-muted text-muted-foreground">
+      <span className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill)] text-[color:var(--app-secondary-label)]">
         <ShieldCheck className="h-3.5 w-3.5" />
       </span>
       <div className="min-w-0">
-        <p className="text-sm font-semibold text-foreground">{title}</p>
-        <p className={MUTED_TEXT}>{detail}</p>
+        <MediumRowLabel as="p">{title}</MediumRowLabel>
+        <RowDescription className={MUTED_TEXT}>{detail}</RowDescription>
       </div>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -40,7 +40,16 @@ import {
   filterPeopleByQuery,
   sortPeopleByName,
 } from "@/lib/one-location/people-search";
-import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
+import {
+  ButtonLabel,
+  HelperText,
+  MediumRowLabel,
+  PageSubtitle,
+  RowDescription,
+  SectionLabel as AppSectionLabel,
+  StatusText,
+  TrailingAction,
+} from "@/components/app-ui/typography";
 import {
   isCircleSelectionFullySelected,
   mergeRecipientsByUserId,
@@ -176,30 +185,33 @@ function ContactRow({
     >
       <span
         className={cn(
-          "flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full text-sm font-semibold",
+          "flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full",
           CONTACT_AVATAR_TONE,
         )}
         aria-hidden
       >
-        {initialsOf(label)}
+        <StatusText as="span">{initialsOf(label)}</StatusText>
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-start gap-1.5">
-          <span className="min-w-0 flex-1 truncate text-[16px] font-semibold text-foreground">
+          <MediumRowLabel as="span" className="min-w-0 flex-1 truncate">
             {label}
-          </span>
+          </MediumRowLabel>
           {fromContacts ? (
             <ContactSourceBadge className="mt-px shrink-0" />
           ) : null}
         </span>
         {completed ? (
-          <span className="block truncate text-[12px] text-emerald-600 dark:text-emerald-400">
+          <StatusText
+            as="span"
+            className="block truncate text-[color:var(--app-success)]"
+          >
             Already shared in this check-in
-          </span>
+          </StatusText>
         ) : !ready ? (
-          <span className="block truncate text-[13px] leading-[18px] text-[#8E8E93]">
+          <RowDescription as="span" className="block truncate">
             Hasn't set up sharing yet
-          </span>
+          </RowDescription>
         ) : null}
       </span>
       <span
@@ -530,9 +542,9 @@ export function CheckInFlow({
         <button
           type="button"
           onClick={close}
-          className="shrink-0 pt-1 text-[15px] text-[color:var(--app-accent)]"
+          className="shrink-0 pt-1 text-[color:var(--app-accent)]"
         >
-          Cancel
+          <TrailingAction as="span">Cancel</TrailingAction>
         </button>
       </div>
 
@@ -543,12 +555,12 @@ export function CheckInFlow({
         >
           <Shield className="mt-0.5 h-5 w-5 shrink-0 text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]" />
           <div>
-            <p className="text-[15px] font-semibold leading-5 text-foreground">
+            <MediumRowLabel as="p">
               Nearby and private sharing are separate
-            </p>
-            <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
+            </MediumRowLabel>
+            <PageSubtitle as="p" className="mt-1">
               Nearby sees your name only. Selected people get this share.
-            </p>
+            </PageSubtitle>
           </div>
         </section>
       ) : null}
@@ -558,7 +570,7 @@ export function CheckInFlow({
       <section className={cn(CARD, "overflow-hidden")}>
         <div className="flex items-center gap-3 px-4 py-[13px]">
           <div className="min-w-0 flex-1">
-            <p className="text-[16px] font-semibold text-foreground">
+            <MediumRowLabel as="p">
               {confirmedPoint
                 ? "Location confirmed for this share"
                 : point
@@ -566,14 +578,14 @@ export function CheckInFlow({
                     ? "Live location ready"
                     : "Location needs a refresh"
                   : "No location yet"}
-            </p>
-            <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
+            </MediumRowLabel>
+            <PageSubtitle as="p" className="mt-1">
               {point
                 ? confirmedPoint
                   ? `${accuracy ?? "Location found"} · Using the spot you confirmed`
                   : `${accuracy ?? "Location found"} · ${vm.formatDateTime(point.capturedAt)}`
                 : "Find your location to check in."}
-            </p>
+            </PageSubtitle>
           </div>
           <button
             type="button"
@@ -600,22 +612,22 @@ export function CheckInFlow({
           </button>
         </div>
         {point && !pointIsFresh ? (
-          <p className="px-4 pb-3 text-xs font-medium text-amber-700 dark:text-amber-300">
+          <HelperText className="px-4 pb-3 !text-[color:var(--app-warning)]">
             {confirmationExpired
               ? "That expired. Edit and confirm again."
               : "Refresh so the location you review is no more than one minute old."}
-          </p>
+          </HelperText>
         ) : null}
         {recipientKeyChanged ? (
-          <p className="px-4 pb-3 text-xs font-medium text-amber-700 dark:text-amber-300">
+          <HelperText className="px-4 pb-3 !text-[color:var(--app-warning)]">
             A selected person&apos;s secure key changed. Edit and reconfirm this
             private share.
-          </p>
+          </HelperText>
         ) : null}
         {vm.myLocationError ? (
-          <p className="px-4 pb-3 text-xs font-medium text-red-600 dark:text-red-300">
+          <HelperText className="px-4 pb-3 !text-[color:var(--app-destructive)]">
             {vm.myLocationError}
-          </p>
+          </HelperText>
         ) : null}
         {point ? (
           <div className="px-3 pb-3">
@@ -668,28 +680,28 @@ export function CheckInFlow({
                   <UsersRound className="h-[17px] w-[17px]" />
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[17px] font-normal leading-[22px] text-foreground">
+                  <MediumRowLabel as="span" className="block truncate">
                     {circle.name}
-                  </span>
-                  <span className="block text-[15px] leading-5 text-muted-foreground">
+                  </MediumRowLabel>
+                  <RowDescription as="span" className="block">
                     {selected
                       ? `${circleSelection.ready.length} ready now`
                       : circleMemberCountLabel(circle.memberCount)}
-                  </span>
+                  </RowDescription>
                 </span>
-                <span className="text-[13px] font-semibold leading-[18px] text-[color:var(--app-accent)]">
+                <TrailingAction as="span">
                   {circleLoadingId === circle.id
                     ? "Loading…"
                     : selected
                       ? "Selected"
                       : "Select all"}
-                </span>
+                </TrailingAction>
               </button>
             );
           })}
           {circleSelection ? (
             <>
-              <p className="border-t border-[color:var(--app-separator)] px-4 py-2.5 text-[15px] leading-[20px] text-[#8E8E93]">
+              <HelperText className="border-t border-[color:var(--app-separator)] px-4 py-2.5">
                 Current ready members only. Future members are not added to this
                 check-in.
                 {circleSelection.excluded.filter(
@@ -701,7 +713,7 @@ export function CheckInFlow({
                       ).length
                     } not ready.`
                   : ""}
-              </p>
+              </HelperText>
               {/* Grow this Circle in-context: invite an existing connection or
                   share the invite code, so a user can pull loved ones in right
                   before they check in — especially when few members are ready. */}
@@ -745,7 +757,7 @@ export function CheckInFlow({
           onChange={(event) => setSearch(event.target.value)}
           disabled={retryLocked}
           placeholder="Search contacts…"
-          className="min-w-0 flex-1 bg-transparent text-[15px] leading-5 text-foreground outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
+          className="ui-text-input-value min-w-0 flex-1 bg-transparent outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
         />
       </div>
       {filtered.length ? (
@@ -768,11 +780,13 @@ export function CheckInFlow({
         </div>
       ) : (
         <div
-          className={cn(CARD, "p-5 text-center text-sm text-muted-foreground")}
+          className={cn(CARD, "p-5 text-center")}
         >
-          {contacts.length === 0
-            ? "No contacts yet. Add people to your Circle."
-          : "No matching contacts."}
+          <PageSubtitle as="span">
+            {contacts.length === 0
+              ? "No contacts yet. Add people to your Circle."
+              : "No matching contacts."}
+          </PageSubtitle>
         </div>
       )}
       {completedRecipientIds.length > 0 ? (
@@ -780,13 +794,13 @@ export function CheckInFlow({
           className="mt-3 rounded-[12px] border border-[color:var(--app-success-border)] bg-[color:var(--app-success-tint)] px-4 py-3"
           data-testid="private-check-in-partial-success"
         >
-          <p className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+          <StatusText as="p" className="text-[color:var(--app-success)]">
             Shared with {completedRecipientIds.length}{" "}
             {completedRecipientIds.length === 1 ? "person" : "people"} already
-          </p>
-          <p className="mt-1 text-[15px] leading-[20px] text-[#8E8E93]">
+          </StatusText>
+          <PageSubtitle as="p" className="mt-1">
             Edits apply only to people still waiting.
-          </p>
+          </PageSubtitle>
         </section>
       ) : null}
 
@@ -808,14 +822,14 @@ export function CheckInFlow({
               retryLocked && "cursor-not-allowed opacity-60",
             )}
           >
-            {option.label}
+            <StatusText as="span">{option.label}</StatusText>
           </button>
         ))}
       </div>
-      <p className="mt-2 flex items-center gap-1.5 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
+      <PageSubtitle as="p" className="mt-2 flex items-center gap-1.5 px-1">
         <Shield className="h-3 w-3 shrink-0" strokeWidth={1.5} />
         Stops automatically.
-      </p>
+      </PageSubtitle>
 
       {/* MESSAGE — encrypted with the reviewed point for selected recipients. */}
       <SectionLabel>Message</SectionLabel>
@@ -828,25 +842,25 @@ export function CheckInFlow({
           disabled={retryLocked}
           rows={2}
           placeholder={DEFAULT_CHECK_IN_MESSAGE}
-          className="w-full resize-none bg-transparent text-[15px] leading-5 text-foreground outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
+          className="ui-text-input-value w-full resize-none bg-transparent outline-none placeholder:text-[color:var(--app-tertiary-label)] disabled:cursor-not-allowed"
         />
-        <p className="mt-2 text-right text-[12px] text-[color:var(--app-tertiary-label)]">
+        <HelperText className="mt-2 text-right !text-[color:var(--app-tertiary-label)]">
           {message.length}/{CHECK_IN_MESSAGE_MAX_LENGTH}
-        </p>
+        </HelperText>
       </div>
-      <p className="mb-[18px] mt-2 px-1 text-[15px] leading-[20px] text-[#8E8E93]">
+      <PageSubtitle as="p" className="mb-[18px] mt-2 px-1">
         {retryLocked
           ? "Encrypted. Sends again to the people it missed."
           : "Encrypted with your location."}
-      </p>
+      </PageSubtitle>
       {retryLocked ? (
         <button
           type="button"
-          className="mb-3 w-full rounded-full border border-black/[0.12] py-3 text-sm font-semibold text-foreground transition-colors hover:bg-black/[0.03] dark:border-white/[0.14] dark:hover:bg-white/[0.05]"
+          className="mb-3 w-full rounded-full border border-[color:var(--app-separator)] py-3 text-[color:var(--app-label)] transition-colors hover:bg-[color:var(--app-secondary-surface)]"
           disabled={busy}
           onClick={editAndReconfirm}
         >
-          Edit and confirm again
+          <ButtonLabel as="span">Edit and confirm again</ButtonLabel>
         </button>
       ) : null}
 
@@ -856,7 +870,7 @@ export function CheckInFlow({
         onClick={() => void submit()}
         disabled={!canSubmit || busy}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-full bg-[color:var(--app-accent)] py-4 text-[17px] font-medium text-[color:var(--app-accent-fg)] transition-opacity",
+          "flex w-full items-center justify-center gap-2 rounded-full bg-[color:var(--app-accent)] py-4 text-[color:var(--app-accent-fg)] transition-opacity",
           (!canSubmit || busy) && "opacity-50",
         )}
       >
@@ -865,23 +879,25 @@ export function CheckInFlow({
         ) : (
           <CheckCircle2 className="h-[18px] w-[18px]" strokeWidth={1.8} />
         )}
-        {point
-          ? recipientKeyChanged
-            ? "Their security key changed - confirm again"
-            : confirmationExpired
-            ? "Confirm your location again"
-            : !pointIsFresh
-            ? "Refresh your location first"
-            : selectedReadyCount > 0
-              ? entrySource === "nearby"
-                ? `Share location with ${selectedReadyCount} ${
-                    selectedReadyCount === 1 ? "person" : "people"
-                  }`
-                : `Check in with ${selectedReadyCount} ${
-                    selectedReadyCount === 1 ? "person" : "people"
-                  }`
-              : "Choose who to tell"
-          : "Get your location first"}
+        <ButtonLabel as="span">
+          {point
+            ? recipientKeyChanged
+              ? "Their security key changed - confirm again"
+              : confirmationExpired
+                ? "Confirm your location again"
+                : !pointIsFresh
+                  ? "Refresh your location first"
+                  : selectedReadyCount > 0
+                    ? entrySource === "nearby"
+                      ? `Share location with ${selectedReadyCount} ${
+                          selectedReadyCount === 1 ? "person" : "people"
+                        }`
+                      : `Check in with ${selectedReadyCount} ${
+                          selectedReadyCount === 1 ? "person" : "people"
+                        }`
+                    : "Choose who to tell"
+            : "Get your location first"}
+        </ButtonLabel>
       </button>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
@@ -326,5 +326,5 @@ describe("CircleInvitePeopleSheet", () => {
         invitees.slice(0, 20).map((invitee) => invitee.userId),
       ),
     );
-  });
+  }, 15000);
 });

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -191,7 +191,7 @@ describe("named Circle flows", () => {
     expect(retainedSearch).toHaveValue("nobody");
     fireEvent.change(retainedSearch, { target: { value: "" } });
     expect(screen.getByLabelText("Search members")).toHaveValue("");
-  });
+  }, 15000);
 
   it("creates a typed Circle and keeps a failed submission recoverable", async () => {
     const onSubmit = vi
@@ -1608,7 +1608,7 @@ describe("named Circle flows", () => {
         invitees.slice(0, 20).map((invitee) => invitee.userId),
       ),
     );
-  });
+  }, 15000);
 
   it("keeps the sheet open when sending fails so the selection can be retried", async () => {
     const onLoadEligibleConnections = vi.fn(async () => ({

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -300,7 +300,7 @@ export function CirclesSection({
           <DropdownMenuContent
             align="end"
             sideOffset={8}
-            className="w-[186px] rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1 shadow-[0_12px_28px_rgba(0,0,0,0.12)] dark:shadow-[var(--app-glass-shadow)]"
+            className="w-[186px] rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
           >
             <DropdownMenuItem
               onSelect={onCreate}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
@@ -77,7 +77,7 @@ export function ContactGroup({
 
 export function EmptyStateCard({ message }: { message: string }) {
   return (
-    <div className="flex min-h-[72px] w-full items-center justify-center rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-5 py-4 text-center text-[15px] font-normal leading-5 text-muted-foreground shadow-none transition-all duration-200 ease-out">
+    <div className="flex min-h-[72px] w-full items-center justify-center rounded-[var(--app-card-radius-compact)] bg-[color:var(--app-card-surface-default-solid)] px-5 py-4 text-center text-[15px] font-normal leading-5 text-[color:var(--app-secondary-label)] shadow-none transition-all duration-200 ease-out">
       <p className="max-w-[280px]">{message}</p>
     </div>
   );
@@ -125,7 +125,7 @@ export function ContactRowAction({
       onClick={onAdd}
       disabled={busy || !ready}
       aria-label={`Add ${label}`}
-      className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-muted-foreground"
+      className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-[color:var(--app-neutral-fill-strong)] disabled:text-[color:var(--app-tertiary-label)]"
     >
       {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : ready ? "Add" : "Setup"}
     </button>
@@ -159,7 +159,7 @@ export function ContactRow({
       <ContactAvatar label={label} />
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-start gap-1.5">
-          <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">
+          <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">
             {label}
           </span>
           {fromContacts ? (
@@ -167,7 +167,7 @@ export function ContactRow({
           ) : null}
         </span>
         {subtitle ? (
-          <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+          <span className="mt-0.5 block truncate text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]">
             {subtitle}
           </span>
         ) : null}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
@@ -61,7 +61,7 @@ export function SelectedContactsPill({
         onClick={onOpen}
         data-testid="sms-selected-pill"
         aria-label={"Review " + peoplePillLabel(count)}
-        className="press-scale flex h-11 max-w-full items-center gap-2 rounded-full bg-[color:var(--app-accent)] px-5 text-[15px] font-semibold text-[color:var(--app-accent-fg)] shadow-lg"
+        className="press-scale flex h-11 max-w-full items-center gap-2 rounded-full bg-[color:var(--app-accent)] px-5 text-[15px] font-semibold text-[color:var(--app-accent-fg)] shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
       >
         <UsersRound className="h-4 w-4 shrink-0" aria-hidden />
         <span className="truncate">{peoplePillLabel(count)}</span>
@@ -111,7 +111,7 @@ export function SelectedContactsSheet({
           <DrawerTitle className="text-[20px] font-semibold leading-[25px]">
             {peoplePillLabel(recipients.length)}
           </DrawerTitle>
-          <DrawerDescription className="text-[15px] leading-5 text-muted-foreground">
+          <DrawerDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
             They receive your SMS alerts. Remove anyone who should not.
           </DrawerDescription>
         </DrawerHeader>
@@ -156,7 +156,7 @@ export function SelectedContactsSheet({
                         ) : null}
                       </span>
                       {subtitle ? (
-                        <span className="mt-0.5 block truncate text-[13px] leading-4 text-muted-foreground">
+                        <span className="mt-0.5 block truncate text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]">
                           {subtitle}
                         </span>
                       ) : null}

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -79,7 +79,7 @@ export const DURATION_GRID_CLASS =
 export const DURATION_CELL_CLASS =
   "flex min-h-11 items-center justify-center whitespace-nowrap rounded-[14px] border px-2 text-center text-[15px] font-semibold leading-5 transition-colors touch-manipulation sm:px-4";
 export const DURATION_CELL_OFF_CLASS =
-  "border-border/70 bg-background text-foreground";
+  "border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] text-[color:var(--app-label)] hover:border-[color:var(--app-accent-ring)] hover:bg-[color:var(--app-neutral-fill-strong)]";
 export const DURATION_CELL_ON_CLASS =
   "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]";
 

--- a/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-wheel-picker.tsx
@@ -608,7 +608,7 @@ export function DurationWheelPicker({
             "min-h-11 rounded-full border px-4 text-sm font-medium transition-colors touch-manipulation",
             openEnded
               ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
-              : "border-border/70 bg-background text-foreground hover:border-[color:var(--app-accent-ring)]",
+              : "border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] text-[color:var(--app-label)] hover:border-[color:var(--app-accent-ring)] hover:bg-[color:var(--app-neutral-fill-strong)]",
           )}
         >
           Until I stop

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1539,7 +1539,7 @@ const PEOPLE_HEADER_ACTION =
 
 /** People-only grouped surface: compact geometry, shared semantic theme. */
 const PEOPLE_GROUP_SURFACE =
-  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)]";
+  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] dark:shadow-none";
 
 const LOCATION_GROUP_SURFACE =
   "overflow-hidden rounded-[16px] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
@@ -3226,7 +3226,7 @@ export function PeopleHub({
       <DropdownMenuContent
         align="end"
         forceMount
-        className="min-w-52 rounded-2xl border border-[color:var(--app-border,rgba(255,255,255,0.1))] bg-[color:var(--app-primary-surface)] p-1.5 shadow-xl dark:border-[color:var(--app-separator)] dark:shadow-[var(--app-glass-shadow)]"
+        className="min-w-52 rounded-2xl border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1.5 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
       >
         <DropdownMenuItem
           data-voice-control-id="one-location-find-contacts"
@@ -5077,7 +5077,7 @@ function AskFlow({
       {justSent ? (
         <div
           role="status"
-          className="flex items-start gap-2.5 rounded-[20px] border border-[color:var(--app-success)]/25 bg-white px-4 py-4 shadow-[0_14px_34px_rgba(15,23,42,0.08)]"
+          className="flex items-start gap-2.5 rounded-[20px] border border-[color:var(--app-success)]/25 bg-[color:var(--app-primary-surface)] px-4 py-4 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
         >
           <ShieldCheck className="mt-0.5 h-[19px] w-[19px] shrink-0 text-[color:var(--app-success)]" />
           <p className="text-[17px] font-medium leading-[22px] text-foreground">
@@ -5263,7 +5263,7 @@ function SelectedRecipientsRail({
           aria-label={ariaLabel ?? title}
           aria-roledescription="recipient summary"
           role="list"
-          className="flex min-h-14 items-center gap-3 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] px-4 py-3 shadow-[var(--app-card-shadow-standard)]"
+          className="flex min-h-14 items-center gap-3 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] px-4 py-3 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
         >
           <div className="flex shrink-0 -space-x-2" aria-hidden="true">
             {recipients.slice(0, 3).map((recipient) => {
@@ -5271,17 +5271,17 @@ function SelectedRecipientsRail({
               return (
                 <span
                   key={recipient.userId}
-                  className="flex h-9 w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-system-fill)] text-[13px] font-semibold text-muted-foreground"
+                  className="flex h-9 w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-surface)] text-[13px] font-semibold text-[color:var(--app-secondary-label)]"
                 >
                   {initialsFrom(label)}
                 </span>
               );
             })}
-            <span className="flex h-9 min-w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-system-fill)] px-2 text-[13px] font-semibold text-muted-foreground">
+            <span className="flex h-9 min-w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-surface)] px-2 text-[13px] font-semibold text-[color:var(--app-secondary-label)]">
               +{recipients.length - 3}
             </span>
           </div>
-          <div className="min-w-0 flex-1 text-[17px] leading-[22px] text-foreground">
+          <div className="min-w-0 flex-1 text-[17px] leading-[22px] text-[color:var(--app-label)]">
             {recipients.map((recipient) => (
               <span key={recipient.userId} className="sr-only">
                 {recipientLabel(recipient)}
@@ -5295,7 +5295,7 @@ function SelectedRecipientsRail({
           aria-label={ariaLabel ?? title}
           aria-roledescription="recipient summary"
           role="list"
-          className="divide-y divide-[color:var(--app-separator)] overflow-hidden rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)]"
+          className="divide-y divide-[color:var(--app-separator)] overflow-hidden rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
         >
           {recipients.map((recipient) => {
             const label = recipientLabel(recipient);
@@ -5306,7 +5306,7 @@ function SelectedRecipientsRail({
                 className="flex min-h-14 items-center gap-3 px-4 py-2.5"
               >
                 <ContactAvatar label={label} className="h-8 w-8 text-[13px]" />
-                <span className="flex min-w-0 flex-1 items-start gap-1.5 text-[17px] font-normal leading-[22px] text-foreground">
+                <span className="flex min-w-0 flex-1 items-start gap-1.5 text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">
                   <span className="min-w-0 flex-1 truncate">{label}</span>
                   {recipient.connectedFromContacts ? (
                     <ContactSourceBadge className="mt-px shrink-0" />

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -80,9 +80,17 @@ import { Switch } from "@/components/ui/switch";
 import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import {
+  ButtonLabel,
+  CardTitle,
+  FormLabel,
+  MediumRowLabel,
+  PageTitle,
+  PageSubtitle,
   RowDescription,
   RowLabel,
+  SectionLabel,
   SectionTitle,
+  TrailingValue,
 } from "@/components/app-ui/typography";
 import type {
   OneLocationAccessRequest,
@@ -802,7 +810,7 @@ function LocationHeaderStatus({ vm }: { vm: LocationHubViewModel }) {
     <span
       id={LOCATION_HEADER_STATUS_ID}
       data-testid="one-location-header-status"
-      className="mt-1 block w-full whitespace-nowrap text-center font-[family-name:var(--font-app-body)] text-[12px] font-normal leading-4 tracking-[-0.01em] text-[color:var(--app-secondary-label)]"
+      className="mt-1 block w-full whitespace-nowrap text-right font-[family-name:var(--font-app-body)] text-[13px] font-normal leading-[18px] tracking-[-0.01em] text-[color:var(--app-secondary-label)]"
     >
       {locationHeaderStatusText(vm)}
     </span>
@@ -826,7 +834,7 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
     <div
       role="group"
       aria-label="Location"
-      className="ml-auto flex h-[58px] w-[72px] shrink-0 flex-col items-center justify-center overflow-visible"
+      className="ml-auto flex min-h-[58px] w-[92px] shrink-0 flex-col items-end justify-center overflow-visible"
       data-testid="one-location-header-actions"
     >
       <Switch
@@ -864,6 +872,8 @@ const PEOPLE_LIST_SCROLL_CLASS =
   "space-y-5 overflow-visible md:max-h-[420px] md:space-y-3 md:overflow-y-auto md:overscroll-contain md:pr-1 md:[scrollbar-width:thin] md:[&::-webkit-scrollbar]:w-1.5 md:[&::-webkit-scrollbar-track]:bg-transparent md:[&::-webkit-scrollbar-thumb]:rounded-full md:[&::-webkit-scrollbar-thumb]:bg-black/15 dark:md:[&::-webkit-scrollbar-thumb]:bg-white/20";
 const FLOW_STEP_ONE_CLASSNAME =
   "mx-auto w-full max-w-[640px] space-y-5 pb-[calc(env(safe-area-inset-bottom)+1rem)]";
+const FLOW_STEP_CONFIRM_CLASSNAME =
+  "mx-auto w-full max-w-[560px] space-y-5 pb-[calc(var(--app-bottom-fixed-ui,96px)+1rem)]";
 const STICKY_FLOW_ACTION_CLASSNAME =
   "sticky bottom-0 z-20 -mx-1 bg-[linear-gradient(to_bottom,transparent,rgba(242,242,247,0.92)_24%,rgba(242,242,247,0.98))] px-1 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-3 dark:bg-[linear-gradient(to_bottom,transparent,color-mix(in_srgb,var(--background)_92%,transparent)_24%,var(--background))]";
 
@@ -1443,9 +1453,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     <div className="space-y-4 sm:space-y-5">
       <PageHeader
         title={
-          <span className="font-[family-name:var(--font-app-display)] text-[34px] font-bold leading-[41px] tracking-[-0.02em]">
+          <PageTitle as="span">
             Location
-          </span>
+          </PageTitle>
         }
         leading={<LocationHeaderIconTile />}
         accent="location"
@@ -1485,6 +1495,8 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                 vm.clearNamedCircleShareContext();
                 openShareFlow();
               }}
+              onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
+              onOpenSettings={vm.onOpenLocationSettings}
               onCheckIn={() =>
                 nearbyCheckInAvailable
                   ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)
@@ -1529,6 +1541,12 @@ const PEOPLE_HEADER_ACTION =
 const PEOPLE_GROUP_SURFACE =
   "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)]";
 
+const LOCATION_GROUP_SURFACE =
+  "overflow-hidden rounded-[16px] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
+
+const LOCATION_INTERACTIVE_SURFACE =
+  "bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
+
 function LocationHubPanel({ children }: { children: ReactNode }) {
   return (
     <div className="space-y-4 px-[var(--page-inline-gutter-standard)]">
@@ -1546,6 +1564,8 @@ function NowHub({
   onStartShare,
   onCheckIn,
   onSos,
+  onOpenMap,
+  onOpenSettings,
   onOpenActiveShares,
   onOpenSharedWithMe,
   onOpenNeedsReview,
@@ -1555,6 +1575,8 @@ function NowHub({
   onStartShare: () => void;
   onCheckIn: () => void;
   onSos: () => void;
+  onOpenMap: () => void;
+  onOpenSettings: () => void;
   onOpenActiveShares: () => void;
   onOpenSharedWithMe: () => void;
   onOpenNeedsReview: () => void;
@@ -1580,6 +1602,24 @@ function NowHub({
       voiceActionId: "location.open_needs_review",
     },
   ].filter((row) => row.value > 0);
+  const moreRows = [
+    {
+      leading: <LocationMenuListIcon name="map" />,
+      title: "Map",
+      ariaLabel: "Map",
+      onClick: onOpenMap,
+      voiceControlId: "one-location-action-map",
+      voiceActionId: "location.open_map",
+    },
+    {
+      leading: <LocationMenuListIcon name="settings" />,
+      title: "Settings",
+      ariaLabel: "Settings",
+      onClick: onOpenSettings,
+      voiceControlId: "one-location-action-settings",
+      voiceActionId: "location.open_settings",
+    },
+  ];
 
   return (
     <div className="space-y-3" data-testid="one-location-now-hub">
@@ -1681,6 +1721,21 @@ function NowHub({
           </LocationMenuListGroup>
         </div>
       ) : null}
+      <div className="pt-1">
+        <LocationMenuListGroup testId="one-location-now-more">
+          {moreRows.map((row) => (
+            <LocationMenuListRow
+              key={row.voiceControlId}
+              leading={row.leading}
+              title={row.title}
+              ariaLabel={row.ariaLabel}
+              onClick={row.onClick}
+              voiceControlId={row.voiceControlId}
+              voiceActionId={row.voiceActionId}
+            />
+          ))}
+        </LocationMenuListGroup>
+      </div>
     </div>
   );
 }
@@ -1696,7 +1751,7 @@ function LocationMenuListGroup({
     <div
       data-ui-role="grouped-card"
       data-testid={testId}
-      className="overflow-hidden rounded-[16px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.045),0_6px_16px_rgba(0,0,0,0.035)] ring-1 ring-inset ring-black/[0.035] dark:bg-[color:var(--app-primary-surface)] dark:shadow-none dark:ring-[color:var(--app-separator)]"
+      className={LOCATION_GROUP_SURFACE}
     >
       {children}
     </div>
@@ -1731,23 +1786,23 @@ function LocationMenuListRow({
       data-voice-label={ariaLabel}
       aria-label={ariaLabel}
       onClick={onClick}
-      className="flex min-h-14 w-full cursor-pointer items-center justify-between border-b border-[#e5e5ea]/80 px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] dark:border-[color:var(--app-separator)] dark:hover:bg-[color:var(--app-secondary-surface)]"
+      className="group flex min-h-14 w-full cursor-pointer items-center justify-between border-b border-[color:var(--app-separator)] px-4 py-2.5 text-left transition-colors last:border-b-0 hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]"
     >
       <span className="flex min-w-0 items-center gap-3">
         {leading}
-        <span className="min-w-0 text-[17px] font-normal leading-[22px] tracking-[-0.01em] text-[#1a1b1f] dark:text-[#f5f5f7]">
+        <RowLabel as="span" className="min-w-0">
           {title}
-        </span>
+        </RowLabel>
       </span>
       <span className="flex shrink-0 items-center gap-2">
         {typeof trailingValue === "number" ? (
-          <span className="min-w-4 text-right text-[16px] font-normal leading-[21px] tracking-[-0.01em] text-[#8e8e93] dark:text-[color:var(--app-secondary-label)]">
+          <TrailingValue as="span" className="min-w-4 text-right">
             {trailingValue}
-          </span>
+          </TrailingValue>
         ) : null}
         <ChevronRight
           aria-hidden="true"
-          className="h-5 w-5 shrink-0 text-[#c7c7cc] transition-transform group-active:translate-x-0.5 dark:text-[color:var(--app-tertiary-label)]"
+          className="h-5 w-5 shrink-0 text-[color:var(--app-tertiary-label)] transition-transform group-active:translate-x-0.5"
         />
       </span>
     </button>
@@ -1759,17 +1814,20 @@ function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
     <section aria-label="Share location" data-testid="one-location-now-primary">
       <div
         data-testid="one-location-share-row"
-        className="grid w-full gap-4 rounded-[20px] bg-white px-5 py-5 text-left shadow-[0_1px_2px_rgba(0,0,0,0.02),0_5px_16px_rgba(0,0,0,0.025)] ring-1 ring-inset ring-black/[0.025] dark:bg-[color:var(--app-primary-surface)] dark:shadow-none dark:ring-[color:var(--app-separator)] sm:grid-cols-[auto_minmax(0,1fr)_216px] sm:items-center sm:gap-6 sm:px-6 sm:py-6"
+        className={cn(
+          LOCATION_INTERACTIVE_SURFACE,
+          "grid w-full gap-4 rounded-[20px] px-5 py-5 text-left sm:grid-cols-[auto_minmax(0,1fr)_194px] sm:items-center sm:gap-5 sm:px-6 sm:py-5",
+        )}
       >
         <div className="flex min-w-0 items-center gap-4">
           <LocationSharePulseIcon />
           <span className="min-w-0 space-y-1">
-            <span className="block text-[20px] font-semibold leading-[25px] tracking-[-0.015em] text-[#1a1b1f] dark:text-[#f5f5f7]">
+            <CardTitle as="span" className="block">
               You&apos;re not sharing
-            </span>
-            <span className="block text-[15px] font-normal leading-5 tracking-[-0.01em] text-[#8e8e93] dark:text-[color:var(--app-secondary-label)]">
+            </CardTitle>
+            <PageSubtitle as="span" className="block">
               Choose a Circle or contact.
-            </span>
+            </PageSubtitle>
           </span>
         </div>
         <button
@@ -1779,9 +1837,9 @@ function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
           data-voice-label="Share location"
           aria-label="Share location"
           onClick={onClick}
-          className="inline-flex min-h-[52px] w-full items-center justify-center rounded-[16px] bg-[color:var(--app-accent)] px-5 font-[family-name:var(--font-app-body)] text-[17px] font-semibold leading-[22px] tracking-[-0.02em] text-white transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent)]/90 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:col-start-3"
+          className="inline-flex min-h-[47px] w-full items-center justify-center rounded-[15px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:col-start-3"
         >
-          Share location
+          <ButtonLabel as="span">Share location</ButtonLabel>
         </button>
       </div>
     </section>
@@ -1805,11 +1863,11 @@ function LocationSharePulseIcon() {
     <span
       aria-hidden="true"
       data-location-share-pulse-icon=""
-      className="relative inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[#eff6ff] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:bg-[color:var(--app-accent-tint)] dark:shadow-none sm:h-16 sm:w-16"
+      className="relative inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-16 sm:w-16"
     >
-      <span className="absolute inset-[13%] rounded-full bg-[#dcecff] dark:bg-[rgba(10,132,255,0.18)]" />
-      <span className="absolute inset-[28%] rounded-full bg-[#b9d7ff] dark:bg-[rgba(10,132,255,0.28)]" />
-      <span className="relative h-[25%] w-[25%] rounded-full bg-[color:var(--app-accent)] shadow-[0_0_0_4px_#ffffff,0_8px_16px_rgba(0,122,255,0.22)] dark:shadow-[0_0_0_4px_var(--app-primary-surface)]" />
+      <span className="absolute inset-[13%] rounded-full bg-[color:var(--app-accent-surface)]" />
+      <span className="absolute inset-[28%] rounded-full bg-[color:var(--app-accent)]/20" />
+      <span className="relative h-[25%] w-[25%] rounded-full bg-[color:var(--app-accent)] shadow-[0_0_0_4px_var(--app-primary-surface),0_8px_16px_rgba(0,122,255,0.18)] dark:shadow-[0_0_0_4px_var(--app-primary-surface)]" />
     </span>
   );
 }
@@ -1852,7 +1910,8 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             aria-label={item.ariaLabel}
             onClick={item.onClick}
             className={cn(
-              "group flex min-h-[100px] min-w-0 flex-col items-center justify-center gap-3 rounded-[16px] bg-white px-5 py-4 text-center shadow-[0_1px_2px_rgba(0,0,0,0.018),0_2px_7px_rgba(0,0,0,0.018)] ring-1 ring-inset ring-black/[0.025] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-gray-50 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] dark:bg-[color:var(--app-primary-surface)] dark:shadow-none dark:hover:bg-[color:var(--app-secondary-surface)] dark:ring-[color:var(--app-separator)]",
+              LOCATION_INTERACTIVE_SURFACE,
+              "group flex min-h-[96px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[16px] px-5 py-4 text-center transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-secondary-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]",
             )}
           >
             <span
@@ -1863,9 +1922,9 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
               {item.icon}
             </span>
             <span className="min-w-0">
-              <span className="block min-w-0 text-[17px] font-semibold leading-[22px] tracking-[-0.015em] text-[#1a1b1f] dark:text-[#f5f5f7]">
+              <ButtonLabel as="span" className="block min-w-0">
                 {item.title}
-              </span>
+              </ButtonLabel>
             </span>
           </button>
         ))}
@@ -1882,28 +1941,31 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
           data-voice-label={emergencyItem.ariaLabel}
           aria-label={emergencyItem.ariaLabel}
           onClick={emergencyItem.onClick}
-          className="group mt-3 flex min-h-[68px] w-full items-center justify-between gap-4 rounded-[16px] bg-[#fff7f7] px-5 py-3 text-left ring-1 ring-inset ring-[#ff3b30]/16 transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[#fff3f3] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#ff3b30]/40 dark:bg-[color:var(--app-destructive)]/10 dark:shadow-none dark:ring-[color:var(--app-destructive)]/30 dark:hover:bg-[color:var(--app-destructive)]/12"
+          className="group mt-3 flex min-h-[68px] w-full items-center justify-between gap-4 rounded-[16px] bg-[color:var(--app-destructive-tint)] px-5 py-3 text-left ring-1 ring-inset ring-[color:var(--app-destructive-border)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-destructive-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]"
         >
           <span className="flex min-w-0 items-center gap-4">
             <span
               aria-hidden
               data-one-location-action-icon=""
-              className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#ff3b30] text-white transition-transform group-active:scale-95"
+              className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
             >
               {emergencyItem.icon}
             </span>
             <span className="min-w-0">
-              <span className="block min-w-0 text-[17px] font-semibold leading-[22px] tracking-[-0.015em] text-[#1a1b1f] dark:text-[#f5f5f7]">
+              <RowLabel as="span" className="block min-w-0 font-semibold">
                 {emergencyItem.title}
-              </span>
-              <span className="mt-0.5 block min-w-0 text-[13px] font-normal leading-[18px] tracking-[-0.01em] text-[#ff3b30]">
+              </RowLabel>
+              <RowDescription
+                as="span"
+                className="mt-0.5 block min-w-0 !text-[color:var(--app-destructive)]"
+              >
                 {emergencyItem.subtitle}
-              </span>
+              </RowDescription>
             </span>
           </span>
           <ChevronRight
             aria-hidden="true"
-            className="h-5 w-5 shrink-0 text-[#ff3b30]/40"
+            className="h-5 w-5 shrink-0 text-[color:var(--app-destructive)]/45"
           />
         </button>
       ) : null}
@@ -2025,7 +2087,7 @@ function LocationMenuListIcon({ name }: { name: LocationMenuGlyphName }) {
   return (
     <span
       aria-hidden="true"
-      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#f2f2f7] text-[#6e6e73] dark:bg-[color:var(--app-secondary-surface)] dark:text-[color:var(--app-secondary-label)]"
+      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color:var(--app-secondary-surface)] text-[color:var(--app-secondary-label)]"
       data-location-menu-list-icon=""
     >
       <span className="inline-flex h-[18px] w-[18px] items-center justify-center">
@@ -2671,9 +2733,9 @@ function LocationSettingsFlow({
           <SettingsRow
             title="Emergency contacts"
             trailing={
-              <span className="text-[13px] font-normal leading-[18px] text-[color:var(--app-secondary-label)]">
+              <TrailingValue as="span">
                 {smsContactCount}
-              </span>
+              </TrailingValue>
             }
             onClick={onManageSmsContacts}
             chevron
@@ -2694,10 +2756,10 @@ function LocationSettingsFlow({
           showCloseButton={false}
         >
           <DialogHeader className="gap-1 text-left">
-            <DialogTitle className="text-[22px] font-semibold leading-[27px] tracking-[-0.01em] text-[color:var(--app-primary-label)]">
+            <DialogTitle className="ui-text-card-title">
               Auto-approve for
             </DialogTitle>
-            <DialogDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+            <DialogDescription className="ui-text-page-subtitle">
               Choose one.
             </DialogDescription>
           </DialogHeader>
@@ -2711,9 +2773,9 @@ function LocationSettingsFlow({
 
             {ownedCircles.length ? (
               <div className="space-y-2">
-                <p className="px-1 text-[15px] font-medium leading-5 text-[color:var(--app-secondary-label)]">
+                <SectionLabel as="p" className="px-1">
                   Circles
-                </p>
+                </SectionLabel>
                 <div className="overflow-hidden rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] ring-1 ring-[color:var(--app-separator)]">
                   {ownedCircles.map((circle) => {
                     const scope: AutoApproveScope = {
@@ -2737,7 +2799,7 @@ function LocationSettingsFlow({
           </div>
 
           {draftScope ? (
-            <p className="text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]">
+            <p className="ui-text-helper-text">
               {draftScope.kind === "all_contacts"
                 ? "New requests from current and future contacts will be approved automatically."
                 : `New requests from current and future members of ${
@@ -2748,7 +2810,7 @@ function LocationSettingsFlow({
               Requests already waiting still need your answer.
             </p>
           ) : (
-            <p className="text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]">
+            <p className="ui-text-helper-text">
               Requests already waiting still need your answer.
             </p>
           )}
@@ -2756,19 +2818,19 @@ function LocationSettingsFlow({
           <DialogFooter className="gap-2 sm:flex-col sm:justify-start">
             <Button
               type="button"
-              className="h-12 rounded-full text-[17px] font-semibold"
+              className="h-12 rounded-full"
               disabled={!draftScope}
               onClick={commitAutoApproveScope}
             >
-              {primaryScopeAction}
+              <ButtonLabel as="span">{primaryScopeAction}</ButtonLabel>
             </Button>
             <Button
               type="button"
               variant="ghost"
-              className="h-11 rounded-full text-[17px] font-semibold"
+              className="h-11 rounded-full"
               onClick={() => setScopeSheetOpen(false)}
             >
-              Cancel
+              <ButtonLabel as="span">Cancel</ButtonLabel>
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -2786,9 +2848,9 @@ function LocationSettingSection({
 }) {
   return (
     <section className="w-full">
-      <p className="mb-2 px-[6px] text-[13px] font-normal leading-[18px] text-[color:var(--app-secondary-label)]">
+      <SectionLabel as="p" className="mb-2 px-[6px]">
         {title}
-      </p>
+      </SectionLabel>
       {children}
     </section>
   );
@@ -2822,13 +2884,13 @@ function AutoApproveScopeOption({
       )}
     >
       <span className="min-w-0">
-        <span className="block truncate text-[17px] font-medium leading-[22px] text-[color:var(--app-primary-label)]">
+        <MediumRowLabel as="span" className="block truncate">
           {title}
-        </span>
+        </MediumRowLabel>
         {description ? (
-          <span className="block truncate text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+          <RowDescription as="span" className="block truncate">
             {description}
-          </span>
+          </RowDescription>
         ) : null}
       </span>
       <span
@@ -4133,7 +4195,7 @@ function ShareFlow({
       // Share confirm step rather than the shared flow root on purpose: that
       // root also carries SmsContactsFlow, whose 680/720 desktop widths are
       // deliberate and documented, plus two map previews.
-      <div className="mx-auto w-full max-w-[560px] space-y-6 pb-[calc(var(--app-bottom-content-clearance,7rem)+2rem)]">
+      <div className="mx-auto w-full max-w-[560px] space-y-5 pb-[calc(var(--app-bottom-fixed-ui,96px)+1rem)]">
         {/* No description: the summary card directly below states who can see
             you, for how long and when it ends. Repeating that in prose above it
             is the design explaining itself. */}
@@ -4161,12 +4223,12 @@ function ShareFlow({
                 8px gap under one and 10px under the other reads as a
                 mistake. */}
             <div className="space-y-2.5">
-              <label
+              <FormLabel
+                as="label"
                 htmlFor="one-location-share-note"
-                className="text-sm font-semibold text-foreground"
               >
                 Optional note
-              </label>
+              </FormLabel>
               <div className="relative">
                 <textarea
                   id="one-location-share-note"
@@ -4184,7 +4246,7 @@ function ShareFlow({
                         : undefined
                   }
                   placeholder="On my way to the meeting"
-                  className="block min-h-[92px] w-full resize-none rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-compact)] px-4 pb-8 pt-3.5 text-[17px] leading-[22px] text-foreground outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)] aria-invalid:border-destructive aria-invalid:focus:ring-destructive/30"
+                  className="ui-text-input-value block min-h-[92px] w-full resize-none rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] px-4 pb-8 pt-3.5 outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)] aria-invalid:border-[color:var(--app-destructive)] aria-invalid:focus:ring-[color:var(--app-destructive-border)]"
                 />
                 {showShareNoteCount ? (
                   <span
@@ -4899,7 +4961,7 @@ function AskFlow({
 
   if (step === "details") {
     return (
-      <div className="mx-auto w-full max-w-[560px] space-y-6 pb-[calc(var(--app-bottom-content-clearance,7rem)+5rem)]">
+      <div className={FLOW_STEP_CONFIRM_CLASSNAME}>
         <TaskFlowHeader eyebrow="Step 2 of 2" title="Ready to ask?" />
 
         <SectionCard className="p-5 sm:p-6">
@@ -4924,12 +4986,12 @@ function AskFlow({
             />
             {reason === "Other" ? (
               <div className="space-y-2.5">
-                <label
+                <FormLabel
+                  as="label"
                   htmlFor="one-location-ask-other-reason"
-                  className="text-sm font-semibold text-foreground"
                 >
                   Add reason
-                </label>
+                </FormLabel>
                 <textarea
                   id="one-location-ask-other-reason"
                   value={vm.requestMessage}
@@ -4944,7 +5006,7 @@ function AskFlow({
                   rows={2}
                   maxLength={ONE_LOCATION_REQUEST_REASON_MAX_LENGTH}
                   placeholder="What should they know?"
-                  className="block min-h-[88px] w-full resize-none rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-compact)] px-4 pb-8 pt-3.5 text-[17px] leading-[22px] text-foreground outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
+                  className="ui-text-input-value block min-h-[88px] w-full resize-none rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] px-4 pb-8 pt-3.5 outline-none focus:ring-2 focus:ring-[color:var(--app-accent-ring)]"
                 />
               </div>
             ) : null}

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -45,8 +45,8 @@ const TONE_STYLES: Record<QuickActionTone, { tile: string; icon: string }> = {
     icon: "text-[color:var(--app-accent-deep)]",
   },
   slate: {
-    tile: "bg-[#E5E5EA]",
-    icon: "text-[#6E6E73]",
+    tile: "bg-[color:var(--app-neutral-fill)]",
+    icon: "text-[color:var(--app-secondary-label)]",
   },
 };
 
@@ -97,7 +97,7 @@ export function QuickActionCard({
       data-voice-control-id={controlId}
       data-voice-action-id={voiceActionId}
       className={cn(
-        "group flex min-h-[132px] w-full min-w-0 flex-col items-center justify-center gap-3 rounded-[20px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-3 py-4 text-center shadow-[var(--app-card-shadow-standard)] transition-colors duration-150 dark:border-white/10",
+        "group flex min-h-[112px] w-full min-w-0 flex-col items-center justify-center gap-2.5 rounded-[18px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-3 py-3.5 text-center shadow-[var(--app-card-shadow-standard)] transition-colors duration-150 dark:shadow-none",
         isEmergency &&
           "bg-[color:var(--app-destructive)]/7 dark:bg-[color:var(--app-destructive)]/12",
         interactive

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -178,7 +178,7 @@ export function DurationSelector({
                   "h-9 rounded-full border px-4 transition-colors touch-manipulation",
                   active
                     ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
-                    : "border-border/70 bg-background text-foreground hover:border-[color:var(--app-accent-ring)]",
+                    : "border-[color:var(--app-separator)] bg-[color:var(--app-secondary-surface)] text-[color:var(--app-label)] hover:border-[color:var(--app-accent-ring)] hover:bg-[color:var(--app-neutral-fill-strong)]",
                 )}
               >
                 {option.label}

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -18,6 +18,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  FormLabel,
+  InputValue,
+  RowDescription,
+  RowLabel,
+} from "@/components/app-ui/typography";
 import { cn } from "@/lib/utils";
 import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
 import { DurationWheelPicker } from "./duration-wheel-picker";
@@ -25,7 +31,7 @@ import { DurationPresetPicker } from "./duration-presets";
 import type { DurationRung } from "./duration-presets";
 
 export const LOCATION_SEARCH_INPUT_CLASSNAME =
-  "h-11 w-full rounded-[14px] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] pl-10 pr-4 text-base text-foreground outline-none transition-shadow placeholder:text-muted-foreground focus:ring-2 focus:ring-inset focus:ring-[color:var(--app-accent-ring)] [&::-webkit-search-cancel-button]:appearance-none";
+  "ui-text-input-value h-11 w-full rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] pl-10 pr-4 text-[color:var(--app-label)] outline-none transition-shadow placeholder:text-[color:var(--app-tertiary-label)] focus:ring-2 focus:ring-inset focus:ring-[color:var(--app-accent-ring)] [&::-webkit-search-cancel-button]:appearance-none";
 
 /**
  * Mirrors the existing page DURATION_OPTIONS so the Select/menu values stay
@@ -106,9 +112,9 @@ export function DurationSelector({
         // far apart they read.
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
           {label ? (
-            <p id={labelId} className="text-sm font-semibold text-foreground">
+            <FormLabel as="p" id={labelId}>
               {label}
-            </p>
+            </FormLabel>
           ) : (
             <span aria-hidden />
           )}
@@ -140,9 +146,11 @@ export function DurationSelector({
           <SelectTrigger
             aria-label={label || "Duration"}
             aria-labelledby={label ? labelId : undefined}
-            className="h-11 w-full rounded-[14px] border-border/70 bg-[color:var(--app-card-surface-compact)] text-sm shadow-none"
+            className="h-11 w-full rounded-[14px] border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] shadow-none"
           >
-            <SelectValue />
+            <InputValue as="span">
+              <SelectValue />
+            </InputValue>
           </SelectTrigger>
           <SelectContent
             align="start"
@@ -167,7 +175,7 @@ export function DurationSelector({
                 aria-pressed={active}
                 onClick={() => onChange(option.value)}
                 className={cn(
-                  "h-9 rounded-full border px-4 text-sm font-medium transition-colors touch-manipulation",
+                  "h-9 rounded-full border px-4 transition-colors touch-manipulation",
                   active
                     ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
                     : "border-border/70 bg-background text-foreground hover:border-[color:var(--app-accent-ring)]",
@@ -213,7 +221,7 @@ export function LocationTypeSelector({
   return (
     <div className="space-y-2">
       {label ? (
-        <p className="text-sm font-semibold text-foreground">{label}</p>
+        <FormLabel as="p">{label}</FormLabel>
       ) : null}
       <div
         role="radiogroup"
@@ -237,12 +245,12 @@ export function LocationTypeSelector({
               )}
             >
               <span>
-                <span className="block text-sm font-semibold text-foreground">
+                <RowLabel as="span" className="block">
                   {option.title}
-                </span>
-                <span className={cn(MUTED_TEXT, "block")}>
+                </RowLabel>
+                <RowDescription as="span" className={cn(MUTED_TEXT, "block")}>
                   {option.description}
-                </span>
+                </RowDescription>
               </span>
               <span
                 className={cn(
@@ -294,11 +302,7 @@ export function ReasonChips({
   if (presentation === "select") {
     return (
       <div className="space-y-2">
-        {label ? (
-          <p id={labelId} className="text-sm font-semibold text-foreground">
-            {label}
-          </p>
-        ) : null}
+        {label ? <FormLabel as="p" id={labelId}>{label}</FormLabel> : null}
         <Select
           value={value ?? undefined}
           onValueChange={(next) => onChange(next as ReasonValue)}
@@ -306,9 +310,11 @@ export function ReasonChips({
           <SelectTrigger
             aria-label={label || "Reason"}
             aria-labelledby={label ? labelId : undefined}
-            className="h-11 w-full rounded-[14px] border-border/70 bg-[color:var(--app-card-surface-compact)] text-sm shadow-none"
+            className="h-11 w-full rounded-[14px] border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] shadow-none"
           >
-            <SelectValue placeholder={placeholder} />
+            <InputValue as="span">
+              <SelectValue placeholder={placeholder} />
+            </InputValue>
           </SelectTrigger>
           <SelectContent
             align="start"
@@ -329,7 +335,7 @@ export function ReasonChips({
   return (
     <div className="space-y-2">
       {label ? (
-        <p className="text-sm font-semibold text-foreground">{label}</p>
+        <FormLabel as="p">{label}</FormLabel>
       ) : null}
       <div className="grid grid-cols-2 gap-2">
         {REASON_CHIPS.map((reason) => {
@@ -340,12 +346,12 @@ export function ReasonChips({
               type="button"
               onClick={() => onChange(reason)}
               className={cn(
-                "h-10 rounded-[13px] px-3 text-sm font-semibold transition-colors touch-manipulation",
+                "h-10 rounded-[13px] px-3 transition-colors touch-manipulation",
                 active
                   ? "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
                   : "bg-[color:var(--app-secondary-system-fill)] text-foreground hover:bg-[color:var(--app-secondary-system-fill)]/80",
-              )}
-            >
+                )}
+              >
               {reason}
             </button>
           );
@@ -369,7 +375,7 @@ export function PersonSearchInput({
 }) {
   return (
     <div className="relative">
-      <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--app-tertiary-label)]" />
       <input
         type="search"
         aria-label={placeholder}

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -380,7 +380,7 @@ export function SmsContactsFlow({
             the tested one -- and only wider viewports re-centre it. */}
         <AlertDialogContent
           size="sm"
-          className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-[color:var(--app-card-surface-default-solid)] !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none md:!bottom-auto md:!top-1/2 md:!max-w-[400px] md:!-translate-y-1/2 md:!rounded-b-[24px] md:!pb-5 md:!shadow-xl"
+          className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-[color:var(--app-card-surface-default-solid)] !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none md:!bottom-auto md:!top-1/2 md:!max-w-[400px] md:!-translate-y-1/2 md:!rounded-b-[24px] md:!pb-5 md:!shadow-[var(--app-card-shadow-standard)] dark:md:!shadow-none"
         >
           <AlertDialogHeader className="!place-items-center !text-center sm:!place-items-center sm:!text-center">
             {/* The person being removed, not a warning about them. A solid
@@ -427,7 +427,7 @@ export function SmsContactsFlow({
             <AlertDialogCancel
               variant="secondary"
               disabled={removing}
-              className="!mt-0 !h-12 !rounded-full !border-0 !bg-[color:var(--app-neutral-fill-strong)] !text-[15px] !font-semibold !text-foreground hover:!bg-[color:var(--app-neutral-fill-strong)]/80 disabled:!opacity-60"
+              className="!mt-0 !h-12 !rounded-full !border-0 !bg-[color:var(--app-neutral-fill-strong)] !text-[15px] !font-semibold !text-[color:var(--app-label)] hover:!bg-[color:var(--app-neutral-fill-strong)]/80 disabled:!opacity-60"
             >
               Cancel
             </AlertDialogCancel>

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -22,6 +22,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  HelperText,
+  PageSubtitle,
+  RowDescription,
+  RowLabel,
+  StatusText,
+} from "@/components/app-ui/typography";
 import { cn } from "@/lib/utils";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
 import type {
@@ -341,7 +348,7 @@ export function SosPanel({
         : "Hold 2 seconds";
 
   const quickPill =
-    "press-scale flex h-11 flex-1 items-center justify-center rounded-xl border text-[15px] font-medium leading-5 transition-colors";
+    "ui-text-button-label press-scale flex h-11 flex-1 items-center justify-center rounded-xl border transition-colors";
 
   const callControl =
     emergencyStatus === "resolved" && emergency ? (
@@ -351,14 +358,14 @@ export function SosPanel({
           onClick={handleWindowsEmergencyCopy}
           data-testid="sos-emergency-actions"
           aria-label={`Copy ${emergency.number} emergency services (${emergency.countryName})`}
-          className="press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[17px] font-semibold leading-[22px] text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5"
+          className="ui-text-button-label press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5"
         >
           <Phone className="h-4 w-4" aria-hidden />
           <span className="min-w-0 flex-1 truncate">
             Call {emergency.number} · {emergency.countryName}
           </span>
           <ChevronRight
-            className="h-4 w-4 shrink-0 text-muted-foreground"
+            className="h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)]"
             aria-hidden
           />
         </button>
@@ -367,14 +374,14 @@ export function SosPanel({
           href={`tel:${emergency.number}`}
           data-testid="sos-emergency-actions"
           aria-label={`Call ${emergency.number} emergency services (${emergency.countryName})`}
-          className="press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[17px] font-semibold leading-[22px] text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5"
+          className="ui-text-button-label press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5"
         >
           <Phone className="h-4 w-4" aria-hidden />
           <span className="min-w-0 flex-1 truncate">
             Call {emergency.number} · {emergency.countryName}
           </span>
           <ChevronRight
-            className="h-4 w-4 shrink-0 text-muted-foreground"
+            className="h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)]"
             aria-hidden
           />
         </a>
@@ -392,7 +399,7 @@ export function SosPanel({
               ? "Finding local emergency number"
               : "Find local emergency number"
         }
-        className="press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[17px] font-semibold leading-[22px] text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5 disabled:cursor-wait disabled:opacity-70"
+        className="ui-text-button-label press-scale flex min-h-[50px] w-full items-center gap-3 rounded-[14px] bg-[color:var(--app-card-surface-default-solid)] px-4 text-left text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--app-destructive)]/5 disabled:cursor-wait disabled:opacity-70"
       >
         <Phone className="h-4 w-4" aria-hidden />
         <span className="min-w-0 flex-1 truncate">
@@ -408,7 +415,7 @@ export function SosPanel({
           <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
         ) : (
           <ChevronRight
-            className="h-4 w-4 shrink-0 text-muted-foreground"
+            className="h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)]"
             aria-hidden
           />
         )}
@@ -421,27 +428,27 @@ export function SosPanel({
       className="mx-auto flex w-full max-w-[560px] flex-col px-4 pb-6 pt-8 sm:px-0"
     >
       <header className="space-y-2">
-        <h1 className="text-[34px] font-bold leading-[41px] tracking-[-0.02em] text-foreground">
+        <h1 className="ui-text-page-title">
           Save My Soul
         </h1>
         {active ? (
-          <p className="text-[15px] leading-5 text-muted-foreground">
+          <PageSubtitle>
             {alertedSummary}
-          </p>
+          </PageSubtitle>
         ) : noReadyRecipients ? (
-          <p className="text-[15px] leading-5 text-muted-foreground">
+          <PageSubtitle>
             No emergency contacts
-          </p>
+          </PageSubtitle>
         ) : (
           <div className="flex items-center gap-3">
-            <p className="min-w-0 flex-1 truncate text-[15px] leading-5 text-muted-foreground">
+            <PageSubtitle className="min-w-0 flex-1 truncate">
               {recipientCountLabel} · Live location
-            </p>
+            </PageSubtitle>
             <button
               type="button"
               onClick={onEditContacts}
               aria-label="Edit emergency contacts"
-              className="press-scale -my-3 flex h-11 min-w-11 items-center justify-center rounded-full px-3 text-[15px] font-semibold leading-5 text-[color:var(--app-accent)]"
+              className="ui-text-button-label press-scale -my-3 flex h-11 min-w-11 items-center justify-center rounded-full px-3 text-[color:var(--app-accent)]"
             >
               Edit
             </button>
@@ -454,7 +461,7 @@ export function SosPanel({
           <button
             type="button"
             onClick={onEditContacts}
-            className="press-scale flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[color:var(--app-accent)] px-5 text-[17px] font-semibold leading-[22px] text-white"
+            className="ui-text-button-label press-scale flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)]"
           >
             Add emergency contacts
           </button>
@@ -468,20 +475,21 @@ export function SosPanel({
             </span>
             <p
               data-testid="sos-status-label"
-              className="mt-4 text-[17px] font-semibold leading-[22px] text-foreground"
+              className="ui-text-medium-row-label mt-4"
             >
               Alert active
             </p>
-            <p className="mt-1 text-[15px] leading-5 text-muted-foreground">
+            <RowDescription className="mt-1">
               {alertedSummary}
-            </p>
+            </RowDescription>
             {sentMessage ? (
-              <p
+              <RowLabel
+                as="p"
                 data-testid="sos-sent-message"
-                className="mt-4 max-w-full rounded-[14px] bg-[color:var(--sos-control-surface)] px-4 py-3 text-[15px] leading-5 text-foreground"
+                className="mt-4 max-w-full rounded-[14px] bg-[color:var(--sos-control-surface)] px-4 py-3"
               >
                 {sentMessage}
-              </p>
+              </RowLabel>
             ) : null}
             <span data-testid="sos-sent-face" className="sr-only">
               SENT
@@ -496,7 +504,7 @@ export function SosPanel({
             disabled={stopBusy}
             aria-label="Stop Save My Soul alert"
             data-testid="sos-cancel-alert"
-            className="press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-[16px] bg-[color:var(--sos-control-surface)] px-5 text-[17px] font-semibold leading-[22px] text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60"
+            className="ui-text-button-label press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-[16px] bg-[color:var(--sos-control-surface)] px-5 text-[color:var(--app-destructive)] transition-colors hover:bg-[color:var(--sos-control-surface-hover)] disabled:opacity-60"
           >
             {stopBusy ? (
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -554,37 +562,39 @@ export function SosPanel({
                 onFocus={() => setMessageFocused(true)}
                 onBlur={() => setMessageFocused(false)}
                 placeholder="Add message..."
-                className="h-full min-w-0 flex-1 rounded-[14px] bg-transparent px-4 pr-12 text-[16px] leading-[22px] text-foreground outline-none placeholder:text-[color:var(--sos-placeholder)]"
+                className="ui-text-input-value h-full min-w-0 flex-1 rounded-[14px] bg-transparent px-4 pr-12 text-[color:var(--app-label)] outline-none placeholder:text-[color:var(--sos-placeholder)]"
               />
               <ChevronRight
-                className="pointer-events-none absolute right-4 h-4 w-4 text-muted-foreground"
+                className="pointer-events-none absolute right-4 h-4 w-4 text-[color:var(--app-tertiary-label)]"
                 aria-hidden
               />
             </div>
             <div className="mt-1 flex min-h-5 items-baseline justify-between gap-3">
               {customMessageLimitExceeded ? (
-                <p
+                <HelperText
                   id="sos-short-message-error"
+                  as="p"
                   role="alert"
-                  className="text-[12px] text-[color:var(--app-destructive)]"
+                  className="text-[color:var(--app-destructive)]"
                 >
                   Message is too long
-                </p>
+                </HelperText>
               ) : (
                 <span />
               )}
               {showMessageCount ? (
-                <div
+                <HelperText
+                  as="div"
                   id="sos-short-message-count"
                   className={cn(
-                    "text-right text-[12px]",
+                    "text-right",
                     customMessageLimitExceeded
                       ? "text-[color:var(--app-destructive)]"
                       : "text-[color:var(--sos-label)]",
                   )}
                 >
                   {customMessageLength}/{ONE_LOCATION_SHARE_NOTE_MAX_LENGTH}
-                </div>
+                </HelperText>
               ) : null}
             </div>
           </div>
@@ -641,18 +651,19 @@ export function SosPanel({
                   disabled && "cursor-not-allowed opacity-65",
                 )}
               >
-                <span className="text-[42px] font-semibold tracking-[1px]">
+                <span className="font-[family-name:var(--font-app-body)] text-[42px] font-semibold leading-none tracking-normal">
                   SMS
                 </span>
               </button>
             </div>
 
-            <p
+            <StatusText
+              as="p"
               data-testid="sos-status-label"
-              className="mt-3 text-center text-[15px] font-medium leading-5 text-[color:var(--sos-label)]"
+              className="mt-3 text-center text-[color:var(--sos-label)]"
             >
               {statusLabel}
-            </p>
+            </StatusText>
           </div>
 
           <div className="mt-6">{callControl}</div>


### PR DESCRIPTION
## Summary
- Preserve the Location shell/header/nav while tightening the One Location visual system with shared typography/surface tokens.
- Restore the agreed Now menu composition: sharing status card, Ask for location, Check in, Save My Soul, conditional count rows, and always-available Map/Settings rows without section headings.
- Keep behavior/routes/handlers intact; update tests to match the current menu contract and long-running Location harness timing.

## Verification
- `npm run typecheck`
- `npm run verify:design-system`
- `git diff --check`
- `npm run verify:one-location -- --testTimeout=15000` (29 files, 619 tests passed; non-fatal JSDOM navigation warning emitted)