### PR TITLE
fix(finance): reset bottom spacing on tab transition

### DIFF
--- a/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/canonical-workspace-hierarchy.contract.test.ts
@@ -48,10 +48,21 @@ describe("canonical workspace hierarchy", () => {
 
   it("keeps Finance bottom chrome clearance owned by the shared scroll root", () => {
     const finance = read("components/kai/kai-market-hub-page.tsx");
+    const tabs = read("components/app-ui/top-shell-tabs.tsx");
 
     expect(finance).toContain('data-finance-workspace="true"');
     expect(finance).toContain('heightMode="active"');
+    expect(finance).toContain("holdHeightDuringTransition={false}");
     expect(finance).toContain('viewportMinHeight="0px"');
+    expect(finance).toContain("scrollAppToTop();");
+    expect(finance).toContain("resetKaiBottomChromeVisibility();");
+    expect(finance).not.toContain("router.replace(destination.href, { scroll: false })");
+    expect(tabs).toContain('const shouldResetScrollOnSelection = tabSet.id === "finance";');
+    expect(tabs).toContain("scrollAppToTop();");
+    expect(tabs).toContain("resetKaiBottomChromeVisibility();");
+    expect(tabs).toContain(
+      "shouldResetScrollOnSelection ? undefined : { scroll: false }",
+    );
     expect(finance).not.toContain('className="h-full w-full"');
     expect(finance).not.toContain("pb-32");
     expect(finance).not.toContain("pb-24");
@@ -61,7 +72,10 @@ describe("canonical workspace hierarchy", () => {
   });
 
   it("keeps Finance Portfolio and Analysis from adding route-local bottom reserves", () => {
-    const portfolio = read("components/kai/views/dashboard-master-view.tsx");
+    const portfolio = [
+      read("components/kai/kai-flow.tsx"),
+      read("components/kai/views/dashboard-master-view.tsx"),
+    ].join("\n");
     const analysis = [
       read("app/one/kai/analysis/page.tsx"),
       read("components/kai/views/analysis-summary-view.tsx"),
@@ -70,6 +84,9 @@ describe("canonical workspace hierarchy", () => {
     ].join("\n");
 
     expect(portfolio).not.toContain("pb-6");
+    expect(portfolio).not.toContain("h-full overflow-hidden");
     expect(analysis).not.toContain("pb-safe");
+    expect(analysis).not.toContain("h-full overflow-hidden");
+    expect(analysis).not.toContain("space-y-6 overflow-hidden");
   });
 });

--- a/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-tab-transition.contract.test.tsx
@@ -241,10 +241,12 @@ function LocationPager({
   activeValue,
   onSelectionChange,
   onSelectionCommit,
+  holdHeightDuringTransition = true,
 }: {
   activeValue: string;
   onSelectionChange?: (value: string) => void;
   onSelectionCommit?: (value: string) => void;
+  holdHeightDuringTransition?: boolean;
 }) {
   return (
     <SwipeViews
@@ -255,6 +257,7 @@ function LocationPager({
       onSelectionCommit={onSelectionCommit}
       viewportMinHeight="0px"
       heightMode="active"
+      holdHeightDuringTransition={holdHeightDuringTransition}
     >
       <div>Now panel</div>
       <div>People panel</div>
@@ -414,6 +417,52 @@ describe("Location tab transition — the viewport never clips a leaving panel",
     });
     expect(root).not.toHaveAttribute("data-swipe-views-height-settling");
     expect(root.style.height).toBe("520px");
+  });
+
+  it("releases the old height floor when route state catches up after a tab press", () => {
+    const view = render(<LocationPager activeValue="now" />);
+    const root = pagerRoot(view.container);
+    expect(root.style.height).toBe("1400px");
+
+    pressTab("people");
+    expect(embla.scrollTo).toHaveBeenCalledWith(1);
+    expect(root.style.height).toBe("1400px");
+
+    // WebKit can visually arrive before the query-backed activeValue reaches
+    // the pager, and then skip the scroll/settle beat the height-floor release
+    // previously depended on.
+    embla.offset = -SLIDE_WIDTH;
+    act(() => {
+      view.rerender(<LocationPager activeValue="people" />);
+    });
+
+    expect(root.style.height).toBe("520px");
+    expect(root).toHaveAttribute("data-swipe-views-height-settling", "true");
+  });
+
+  it("lets short route-backed workspaces opt out of holding a stale tall panel height", () => {
+    const view = render(
+      <LocationPager
+        activeValue="now"
+        holdHeightDuringTransition={false}
+      />,
+    );
+    const root = pagerRoot(view.container);
+    expect(root.style.height).toBe("1400px");
+
+    act(() => {
+      view.rerender(
+        <LocationPager
+          activeValue="people"
+          holdHeightDuringTransition={false}
+        />,
+      );
+    });
+
+    expect(root.style.height).toBe("520px");
+    expect(root).not.toHaveAttribute("data-swipe-views-height-settling");
+    expect(panels(view.container)[0]?.style.maxHeight).toBe("520px");
+    expect(panels(view.container)[0]?.style.overflow).toBe("hidden");
   });
 });
 

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1105,7 +1105,7 @@ export function KaiAnalysisPageContent() {
     <>
       {showWorkspace ? (
         <div
-          className="w-full min-w-0 max-w-full h-full overflow-hidden"
+          className="w-full min-w-0 max-w-full"
           data-testid={liveIntentReady ? "kai-analysis-active-run" : "kai-analysis-primary"}
         >
           <NativeTestBeacon
@@ -1306,7 +1306,7 @@ export function KaiAnalysisPageContent() {
           </AppPageContentRegion>
         </div>
       ) : !resolvingEntry ? (
-        <div className="w-full min-w-0 max-w-full h-full overflow-hidden" data-testid="kai-analysis-primary">
+        <div className="w-full min-w-0 max-w-full" data-testid="kai-analysis-primary">
           <NativeTestBeacon
             routeId={ROUTES.KAI_ANALYSIS}
             marker="native-route-kai-analysis"

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/lib/navigation/top-shell-tab-swipe-progress";
 import { useInteractionIntents } from "@/lib/interaction/interaction-intent-coordinator";
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
+import { resetKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
+import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import { cn } from "@/lib/utils";
 
 function topShellTabDomId(
@@ -78,6 +80,7 @@ export function TopShellTabs({
   const tabSwipeState = useTopShellTabSwipeState(tabSet.id);
   const indicatorTransform = `translate3d(calc(var(${topShellTabSwipePositionVariable(tabSet.id)}, ${activeIndex}) * 100%), 0, 0)`;
   const isLocationTabs = tabSet.id === "location";
+  const shouldResetScrollOnSelection = tabSet.id === "finance";
 
   const textRefs = useRef<Array<HTMLSpanElement | null>>([]);
   const [activeTextWidth, setActiveTextWidth] = useState(0);
@@ -130,17 +133,34 @@ export function TopShellTabs({
       beginRouteTransition(
         tab.href,
         () => {
+          if (shouldResetScrollOnSelection) {
+            scrollAppToTop();
+            resetKaiBottomChromeVisibility();
+          }
           if (navigationMode === "push") {
-            router.push(tab.href, { scroll: false });
+            router.push(
+              tab.href,
+              shouldResetScrollOnSelection ? undefined : { scroll: false },
+            );
             return;
           }
-          router.replace(tab.href, { scroll: false });
+          router.replace(
+            tab.href,
+            shouldResetScrollOnSelection ? undefined : { scroll: false },
+          );
         },
         "tap",
         transitionMode,
       );
     },
-    [navigationMode, router, selectedValue, tabSet, transitionMode],
+    [
+      navigationMode,
+      router,
+      selectedValue,
+      shouldResetScrollOnSelection,
+      tabSet,
+      transitionMode,
+    ],
   );
 
   return (

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -3746,7 +3746,7 @@ export function KaiFlow({
   }
 
   return (
-    <div className="flex w-full flex-col h-full overflow-hidden">
+    <div className="flex w-full flex-col">
       {/* State-based rendering */}
       {state === "import_required" && (
         <PortfolioImportView

--- a/hushh-webapp/components/kai/kai-market-hub-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-hub-page.tsx
@@ -21,6 +21,8 @@ import { KaiPreviewRouter } from "@/components/kai/views/kai-preview-router";
 import { KaiAnalysisPageContent } from "@/app/one/kai/analysis/page";
 import { scheduleFinanceWorkspaceWarmup } from "@/lib/kai/finance-workspace-warmup";
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
+import { resetKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
+import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 
 const FINANCE_TAB_DEFINITION = TOP_SHELL_TAB_REGISTRY.finance;
 type PortfolioTab = (typeof FINANCE_TAB_DEFINITION.tabs)[number]["value"];
@@ -52,7 +54,11 @@ export function KaiMarketHubPage() {
       return;
     beginRouteTransition(
       destination.href,
-      () => router.replace(destination.href, { scroll: false }),
+      () => {
+        scrollAppToTop();
+        resetKaiBottomChromeVisibility();
+        router.replace(destination.href);
+      },
       "tap",
       "contextual",
     );
@@ -60,6 +66,8 @@ export function KaiMarketHubPage() {
 
   useEffect(() => {
     setVisibleTab(activeTab);
+    scrollAppToTop();
+    resetKaiBottomChromeVisibility();
   }, [activeTab]);
 
   useEffect(() => {
@@ -113,6 +121,7 @@ export function KaiMarketHubPage() {
         onSelectionChange={(value) => setVisibleTab(value as PortfolioTab)}
         onSelectionCommit={(value) => setActiveTab(value as PortfolioTab)}
         heightMode="active"
+        holdHeightDuringTransition={false}
         panelInset="page"
         viewportMinHeight="0px"
       >

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -1138,7 +1138,7 @@ export function AnalysisHistoryDashboard({
 
   // ----- Populated state -----
   return (
-    <div className="w-full space-y-6 overflow-hidden">
+    <div className="w-full space-y-6">
       {/* Data Table */}
       <DataTable
         columns={columns}

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -192,6 +192,12 @@ interface SwipeViewsProps {
    * layout. Compact task panes can opt into the active pane's measured height.
    */
   heightMode?: "max" | "active";
+  /**
+   * Hold the outgoing pane's height while it slides away so tall content is
+   * not clipped mid-transition. Short route-backed workspaces can opt out when
+   * stale height is worse than clipping.
+   */
+  holdHeightDuringTransition?: boolean;
   className?: string;
 }
 
@@ -205,6 +211,7 @@ export function SwipeViews({
   panelInset = "none",
   viewportMinHeight = SWIPE_VIEWPORT_MIN_HEIGHT,
   heightMode = "max",
+  holdHeightDuringTransition = true,
   className,
 }: SwipeViewsProps) {
   const watchDrag = useCallback(
@@ -320,11 +327,14 @@ export function SwipeViews({
     // precisely in order to release the floor.
     if (measuredValueRef.current !== activeValue) {
       measuredValueRef.current = activeValue;
-      if (renderedHeightRef.current !== null) {
+      if (holdHeightDuringTransition && renderedHeightRef.current !== null) {
         heightFloorRef.current = Math.max(
           heightFloorRef.current ?? 0,
           renderedHeightRef.current,
         );
+        setHeightSettling(false);
+      } else {
+        heightFloorRef.current = null;
         setHeightSettling(false);
       }
     }
@@ -360,7 +370,7 @@ export function SwipeViews({
       if (frame) window.cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [activeValue, heightMode, heightSettleTick]);
+  }, [activeValue, heightMode, heightSettleTick, holdHeightDuringTransition]);
 
 
   // Embla measures the container and slides synchronously at init, but only
@@ -571,9 +581,17 @@ export function SwipeViews({
       scrollToSelection(emblaApi, targetIdx);
     } else if (!isDraggingRef.current && !hasMovedSincePointerDownRef.current) {
       setTopShellTabSwipeState(tabSetId, Math.max(0, targetIdx), false);
+      releaseHeightFloor();
     }
     lastReportedValueRef.current = activeValue;
-  }, [emblaApi, activeValue, options, scrollToSelection, tabSetId]);
+  }, [
+    emblaApi,
+    activeValue,
+    options,
+    releaseHeightFloor,
+    scrollToSelection,
+    tabSetId,
+  ]);
 
   // Publish selection at Embla's `select` point. Waiting for `settle` made
   // query-backed tabs look stale on iOS and delayed the visible panel state.
@@ -794,6 +812,13 @@ export function SwipeViews({
         {options.map((option, index) => {
           const isActive = index === activeIndex;
           const safeValue = option.value.replace(/[^a-zA-Z0-9_-]/g, "-");
+          const inactiveHeightClamp =
+            heightMode === "active" &&
+            !holdHeightDuringTransition &&
+            !isActive &&
+            activePanelHeight !== null
+              ? { maxHeight: activePanelHeight, overflow: "hidden" }
+              : null;
           return (
             <div
               key={option.value}
@@ -821,7 +846,10 @@ export function SwipeViews({
                 panelInset === "page" &&
                   "px-[var(--page-inline-gutter-standard)]",
               )}
-              style={{ minHeight: "inherit" }}
+              style={{
+                minHeight: "inherit",
+                ...inactiveHeightClamp,
+              }}
             >
               {/* Every panel stays mounted, so a backgrounded one must not
                   publish itself as the screen the person is on. */}


### PR DESCRIPTION
## Summary

Fixes the Finance tab-transition bottom spacing bug where repeatedly switching Market -> Portfolio or Market -> Analysis could leave a large empty scrollable tail on iOS.

## Root Cause

Finance query-tab navigation preserved the existing app scroll position while the destination tab was shorter. On iOS, returning to Market and then switching back to Portfolio or Analysis could keep the scroll root at the old Market depth, so the destination looked like it had a huge bottom gap.

The Finance panels also had route-local full-height/overflow clamps that made the pager more likely to retain stale panel height during transitions. The swipe pager height floor could also survive a route catch-up when WebKit skipped the usual scroll/settle beat.

## Fix

- Reset the shared app scroll root immediately when Finance tabs change.
- Reset Finance bottom-chrome hide progress on Finance tab changes.
- Let Finance tab navigation use the browser/router scroll reset path instead of forcing `scroll: false`.
- Remove full-height overflow clamps from Portfolio and Analysis route wrappers.
- Release the swipe pager height floor when route state catches up to the visual tab.
- Add regression coverage for Finance bottom clearance and iOS-style route catch-up.

## Scope

Frontend UI/layout only.

No backend, API, data-fetching, Finance calculations, authentication, authorization, Talk to One, bottom navigation, dependency, or package-lock changes.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run verify:design-system`
- `npm.cmd run verify:docs`
- `npm.cmd run verify:cache`
- `npx.cmd vitest run __tests__/components/one-location-tab-transition.contract.test.tsx __tests__/components/canonical-workspace-hierarchy.contract.test.ts __tests__/lib/kai-bottom-chrome-visibility.test.ts`
- `npx.cmd eslint components/app-ui/top-shell-tabs.tsx lib/morphy-ux/ui/swipe-views.tsx lib/navigation/kai-bottom-chrome-visibility.ts components/kai/kai-market-hub-page.tsx components/kai/kai-flow.tsx app/one/kai/analysis/page.tsx components/kai/views/analysis-history-dashboard.tsx __tests__/components/one-location-tab-transition.contract.test.tsx __tests__/components/canonical-workspace-hierarchy.contract.test.ts --max-warnings=0`
- `git diff --check`

Fixes #6012
