### PR TITLE
style(welcome): add premium iOS-style welcome polish

### DIFF
--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -55,12 +55,16 @@ describe("IntroStep voice contract", () => {
     });
   });
 
-  it("uses the standardized root quiet mark directly ahead of One", () => {
+  it("uses the standardized root quiet mark between the private-agent line and One", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
+    const privateAgent = screen.getByText("Your private agent");
     const quietMark = screen.getByText("🤫");
     const one = screen.getByRole("heading", { name: "One" });
 
+    expect(privateAgent.compareDocumentPosition(quietMark)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
     expect(quietMark.compareDocumentPosition(one)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -55,16 +55,12 @@ describe("IntroStep voice contract", () => {
     });
   });
 
-  it("uses the standardized root quiet mark between the private-agent line and One", () => {
+  it("uses the standardized root quiet mark directly ahead of One", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
-    const privateAgent = screen.getByText("Your private agent");
     const quietMark = screen.getByText("🤫");
     const one = screen.getByRole("heading", { name: "One" });
 
-    expect(privateAgent.compareDocumentPosition(quietMark)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
     expect(quietMark.compareDocumentPosition(one)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -70,22 +70,14 @@ describe("IntroStep voice contract", () => {
     );
   });
 
-  it("keeps the root public navigation to Research, Blog, and Developers", () => {
+  it("leads with the hussh wordmark ahead of the private-agent line", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
-    const publicNav = screen.getByRole("navigation", { name: "Explore Hussh" });
-    expect(publicNav.querySelectorAll("a")).toHaveLength(3);
-    expect(screen.getByRole("link", { name: "Research" })).toHaveAttribute(
-      "href",
-      "/research",
-    );
-    expect(screen.getByRole("link", { name: "Blog" })).toHaveAttribute(
-      "href",
-      "/blog",
-    );
-    expect(screen.getByRole("link", { name: "Developers" })).toHaveAttribute(
-      "href",
-      "/developers",
+    const wordmark = screen.getByText("hussh");
+    const privateAgent = screen.getByText("Your private agent");
+
+    expect(wordmark.compareDocumentPosition(privateAgent)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
 });

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -37,9 +37,9 @@
 }
 
 /* A near-invisible blue/cyan light field behind the upper half of the page —
-   not a background of its own, just something for the glass pill's blur to
-   actually refract. Two soft radial pools, faded out well before halfway
-   down so it never reads as a colored section. */
+   not a background of its own, just a little atmosphere behind the wordmark
+   and hero. Two soft radial pools, faded out well before halfway down so it
+   never reads as a colored section. */
 .shell::before {
   content: "";
   position: absolute;
@@ -72,7 +72,7 @@
   width: 100%;
   max-width: 34rem;
   margin: 0 auto;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   /* A hidden-shell route has no app top bar to clear. Native status areas are
      normally 44–59px, so cap this defensive gutter at 64px. This contains a
      stale browser/native inset without sacrificing the real status-bar
@@ -82,133 +82,14 @@
   text-align: center;
 }
 
-/* ── Brand row: wordmark + public nav share the top of the page instead of
-      splitting the wordmark up here and the links below the CTA. A single
-      pill sized to its own content (not the full column width) so the
-      wordmark and the links read as one intentionally-grouped mark rather
-      than two things pinned to opposite edges of an otherwise empty bar.
-      The glass recipe layers what real frosted glass has and a flat tinted
-      rectangle doesn't: a translucent tint (not a solid fill) faint enough
-      that the canvas shows through, a brighter hairline and inset highlight
-      along the top where light would catch a physical edge, and a soft cast
-      shadow for depth underneath the blur itself. ── */
-.brand {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(12px, 3.4vw, 22px);
-  width: fit-content;
-  max-width: 100%;
-  margin: 0 auto;
-  padding: clamp(1px, 0.3vh, 3px) clamp(9px, 2.4vw, 14px);
-  border-radius: 999px;
-  --pointer-x: 50%;
-  --pointer-y: 0%;
-  background:
-    radial-gradient(
-      140% 100% at 30% -20%,
-      color-mix(in oklab, var(--app-accent) 5%, transparent),
-      transparent 60%
-    ),
-    color-mix(in oklab, var(--app-glass-surface) 36%, transparent);
-  border: 0.5px solid
-    color-mix(in oklab, var(--app-glass-border) 38%, transparent);
-  box-shadow:
-    0 1px 0 color-mix(in oklab, white 32%, transparent) inset,
-    0 1px 1px color-mix(in oklab, white 18%, transparent) inset,
-    0 10px 28px -18px color-mix(in oklab, var(--foundation-ink) 26%, transparent);
-  -webkit-backdrop-filter: blur(18px) saturate(140%);
-  backdrop-filter: blur(18px) saturate(140%);
-  transform: translate3d(0, 0, 0);
-  will-change: transform;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
-}
-
-/* Pointer-following highlight — position tracked from IntroStep.tsx via the
-   --pointer-x/--pointer-y custom properties (mouse only; untouched, centered
-   defaults on touch where no pointermove ever fires). Visibility is a pure
-   CSS :hover, so there is nothing to wire up beyond the position itself. */
-.brand::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(
-    160px circle at var(--pointer-x) var(--pointer-y),
-    color-mix(in oklab, white 45%, transparent),
-    transparent 70%
-  );
-  opacity: 0;
-  transition: opacity 260ms ease-out;
-  pointer-events: none;
-}
-
-.brand:hover::after {
-  opacity: 0.6;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .brand::after {
-    transition: none;
-  }
-}
-
+/* hussh is the brand, One is the product: a small, quiet wordmark — not a
+   pill, not a nav bar — so nothing above "One" competes with it. */
 .wordmark {
-  height: clamp(20px, 2.3vh, 27px);
+  height: clamp(16px, 1.9vh, 21px);
   width: auto;
-  flex-shrink: 0;
-}
-
-.links {
-  display: flex;
-  align-items: center;
-  gap: clamp(0px, 0.8vw, 4px);
-  min-width: 0;
-}
-
-.link {
-  position: relative;
-  display: inline-flex;
-  /* Tap target stays 44px tall regardless of how compact the label reads. */
-  min-height: 44px;
-  align-items: center;
-  padding: 0 clamp(6px, 2vw, 12px);
-  border-radius: 999px;
-  color: var(--foundation-dim);
-  font-size: clamp(10px, 1.3vh, 12px);
-  font-weight: 590;
-  letter-spacing: -0.01em;
-  white-space: nowrap;
-  transition: color var(--motion-duration-sm, 180ms)
-    var(--motion-ease-standard, ease-out);
-}
-
-/* Tiny hover "lens": a soft circular tint behind the label, not a filled
-   chip — it should read as light catching the glass, not a button state. */
-.link::before {
-  content: "";
-  position: absolute;
-  inset: 2px;
-  z-index: -1;
-  border-radius: inherit;
-  background: radial-gradient(
-    circle at 50% 50%,
-    color-mix(in oklab, var(--app-accent) 14%, transparent),
-    transparent 72%
-  );
-  opacity: 0;
-  transition: opacity 200ms ease-out;
-}
-
-.link:hover,
-.link:focus-visible {
-  color: var(--foundation-ink);
-}
-
-.link:hover::before,
-.link:focus-visible::before {
-  opacity: 1;
+  margin-bottom: clamp(6px, 1.6vh, 16px);
+  opacity: 0.92;
+  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
 .hero {

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -1,6 +1,15 @@
 .shell {
   position: relative;
   display: flex;
+  /* Apple's own display/text faces where the platform has them, falling back
+     to the shared app tokens everywhere else (Android, Windows). Scoped to
+     this screen only — the welcome is the one surface where the type is
+     doing brand work, the rest of the app stays on its shared font tokens. */
+  --landing-display: "SF Pro Display", "SF Pro", -apple-system,
+    BlinkMacSystemFont, var(--font-app-display);
+  --landing-text: "SF Pro Text", "SF Pro", -apple-system, BlinkMacSystemFont,
+    var(--font-app-body);
+  font-family: var(--landing-text);
   /* The outer app scroll root already reserves --app-scroll-bottom-pad of
      clearance below this element for the fixed onboarding Agent Bar (see
      app/providers.tsx), then adds it back as its own padding-bottom. Sizing
@@ -47,13 +56,26 @@
 }
 
 /* ── Brand row: wordmark + public nav share the top of the page instead of
-      splitting the wordmark up here and the links below the CTA. ── */
+      splitting the wordmark up here and the links below the CTA. Styled as
+      a single frosted-glass pill (the app's existing glass material tokens,
+      not a new surface) rather than sitting bare on the canvas. ── */
 .brand {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: clamp(8px, 3vw, 16px);
   width: 100%;
+  padding: clamp(2px, 0.6vh, 6px) clamp(6px, 2vw, 10px) clamp(2px, 0.6vh, 6px)
+    clamp(10px, 3vw, 18px);
+  border-radius: 999px;
+  background: var(--app-glass-surface);
+  border: 1px solid var(--app-glass-border);
+  box-shadow: var(--app-glass-shadow);
+  -webkit-backdrop-filter: blur(var(--app-shell-surface-blur, 20px))
+    saturate(150%);
+  backdrop-filter: blur(var(--app-shell-surface-blur, 20px)) saturate(150%);
+  transform: translate3d(0, 0, 0);
+  will-change: transform;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
@@ -79,7 +101,8 @@
   border-radius: 999px;
   color: var(--foundation-dim);
   font-size: clamp(10px, 1.3vh, 12px);
-  font-weight: 600;
+  font-weight: 590;
+  letter-spacing: -0.01em;
   white-space: nowrap;
   transition: color var(--motion-duration-sm, 180ms)
     var(--motion-ease-standard, ease-out);
@@ -104,8 +127,8 @@
   margin: 0;
   color: var(--foundation-dim);
   font-size: clamp(8px, 1.3vh, 12px);
-  font-weight: 700;
-  letter-spacing: 0.26em;
+  font-weight: 600;
+  letter-spacing: 0.2em;
   line-height: 1;
   text-transform: uppercase;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 220ms both;
@@ -121,7 +144,7 @@
 
 .title {
   margin: clamp(2px, 0.9vh, 12px) 0 0;
-  font-family: var(--font-app-display);
+  font-family: var(--landing-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
 }
@@ -144,13 +167,16 @@
   background-position: 30% 50%;
   background-clip: text;
   color: transparent;
-  font-family: var(--font-app-display);
+  font-family: var(--landing-display);
   /* Bounded on both axes: a width-only clamp keeps growing on a short
      landscape viewport at exactly the moment the vertical room shrinks,
      which is what pushes the hero into the row above it. */
   font-size: clamp(36px, min(24vw, 11vh), 116px);
   font-weight: 800;
-  letter-spacing: -4px;
+  /* em-relative so the tracking stays proportional as the size itself
+     scales with the viewport, instead of a fixed px value reading as too
+     tight at the small end and too loose at the large end. */
+  letter-spacing: -0.04em;
   line-height: 1.04;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -173,10 +199,11 @@
   max-width: 22rem;
   margin: clamp(6px, 2.6vh, 36px) auto 0;
   color: var(--foundation-ink);
+  font-family: var(--landing-display);
   font-size: clamp(11px, 2.3vh, 20px);
   font-weight: 600;
-  letter-spacing: -0.2px;
-  line-height: 1.35;
+  letter-spacing: -0.02em;
+  line-height: 1.32;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 420ms both;
 }
 
@@ -189,8 +216,8 @@
   margin-top: clamp(4px, 1.8vh, 26px);
   color: var(--foundation-dim);
   font-size: clamp(6px, 1.2vh, 11px);
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  font-weight: 600;
+  letter-spacing: 0.14em;
   line-height: 1.2;
   text-transform: uppercase;
   white-space: nowrap;
@@ -212,6 +239,7 @@
   margin: clamp(6px, 2vh, 30px) auto 0;
   color: var(--foundation-dim);
   font-size: clamp(7px, 1.7vh, 16px);
+  letter-spacing: -0.01em;
   line-height: 1.45;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
 }
@@ -240,21 +268,30 @@
      (iOS Blue default, Molten Gold opt-in). No gradient, no shadow. */
   background: var(--app-accent);
   color: var(--app-accent-fg);
-  font-family: var(--font-app-body);
+  font-family: var(--landing-text);
   font-size: clamp(15px, 1.9vh, 16px);
   font-weight: 700;
   line-height: 1;
   transition:
-    background-color var(--motion-duration-sm) var(--motion-ease-standard);
+    background-color var(--motion-duration-sm) var(--motion-ease-standard),
+    transform var(--motion-duration-sm, 180ms) var(--motion-ease-standard, ease-out);
 }
 
 .cta:hover {
   background: var(--app-accent-hover);
 }
 
+.cta:active {
+  transform: scale(0.985);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cta {
     transition: none;
+  }
+
+  .cta:active {
+    transform: none;
   }
 }
 

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -9,7 +9,20 @@
     BlinkMacSystemFont, var(--font-app-display);
   --landing-text: "SF Pro Text", "SF Pro", -apple-system, BlinkMacSystemFont,
     var(--font-app-body);
+  /* A readable-but-secondary ink for the supporting lines (tagline sits
+     above this at full --foundation-ink; the motions row and description
+     sit below it at --foundation-dim). Keeps them legible without making
+     every line compete at the same weight. */
+  --landing-secondary-ink: color-mix(
+    in oklab,
+    var(--foundation-ink) 55%,
+    var(--foundation-dim) 45%
+  );
   font-family: var(--landing-text);
+  /* A faint wash above the shared decorative canvas (unchanged) so its grain
+     and drifting motes read as texture instead of visual noise competing
+     with the content on top of them. */
+  background: color-mix(in oklab, var(--background) 10%, transparent);
   /* The outer app scroll root already reserves --app-scroll-bottom-pad of
      clearance below this element for the fixed onboarding Agent Bar (see
      app/providers.tsx), then adds it back as its own padding-bottom. Sizing
@@ -50,37 +63,42 @@
      normally 44–59px, so cap this defensive gutter at 64px. This contains a
      stale browser/native inset without sacrificing the real status-bar
      clearance needed by an edge-to-edge WebView. */
-  padding: calc(clamp(28px, var(--app-safe-area-top-effective, 0px), 64px) + 12px)
+  padding: calc(clamp(28px, var(--app-safe-area-top-effective, 0px), 64px) + 8px)
     24px clamp(8px, 3vh, 24px);
   text-align: center;
 }
 
 /* ── Brand row: wordmark + public nav share the top of the page instead of
-      splitting the wordmark up here and the links below the CTA. Styled as
-      a single frosted-glass pill (the app's existing glass material tokens,
-      not a new surface) rather than sitting bare on the canvas. ── */
+      splitting the wordmark up here and the links below the CTA. A single
+      pill sized to its own content (not the full column width) so the
+      wordmark and the links read as one intentionally-grouped mark rather
+      than two things pinned to opposite edges of an otherwise empty bar.
+      The glass itself favors transparency over opacity — it should read as
+      a soft refraction of what's behind it, not a solid card. ── */
 .brand {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: clamp(8px, 3vw, 16px);
-  width: 100%;
-  padding: clamp(2px, 0.6vh, 6px) clamp(6px, 2vw, 10px) clamp(2px, 0.6vh, 6px)
-    clamp(10px, 3vw, 18px);
+  justify-content: center;
+  gap: clamp(14px, 4vw, 26px);
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto;
+  padding: clamp(1px, 0.4vh, 4px) clamp(10px, 2.6vw, 16px);
   border-radius: 999px;
-  background: var(--app-glass-surface);
-  border: 1px solid var(--app-glass-border);
-  box-shadow: var(--app-glass-shadow);
-  -webkit-backdrop-filter: blur(var(--app-shell-surface-blur, 20px))
-    saturate(150%);
-  backdrop-filter: blur(var(--app-shell-surface-blur, 20px)) saturate(150%);
+  background: color-mix(in oklab, var(--app-glass-surface) 58%, transparent);
+  border: 0.5px solid
+    color-mix(in oklab, var(--app-glass-border) 55%, transparent);
+  box-shadow: 0 4px 16px -12px
+    color-mix(in oklab, var(--foundation-ink) 20%, transparent);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  backdrop-filter: blur(14px) saturate(140%);
   transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
 .wordmark {
-  height: clamp(24px, 2.8vh, 34px);
+  height: clamp(22px, 2.6vh, 30px);
   width: auto;
   flex-shrink: 0;
 }
@@ -135,15 +153,15 @@
 }
 
 .emoji {
-  margin-top: clamp(6px, 2.6vh, 32px);
-  font-size: clamp(16px, 4.4vh, 48px);
+  margin-top: clamp(6px, 2vh, 20px);
+  font-size: clamp(14px, 3.6vh, 40px);
   line-height: 1;
   filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: clamp(2px, 0.9vh, 12px) 0 0;
+  margin: clamp(2px, 0.7vh, 8px) 0 0;
   font-family: var(--landing-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -183,13 +201,13 @@
 }
 
 .divider {
-  width: 100%;
+  width: min(88px, 28%);
   height: 1px;
-  margin-top: clamp(6px, 2.6vh, 36px);
+  margin: clamp(6px, 2vh, 20px) auto 0;
   background: linear-gradient(
     90deg,
     transparent,
-    color-mix(in oklab, var(--foundation-gold-deep) 34%, transparent),
+    color-mix(in oklab, var(--foundation-gold-deep) 20%, transparent),
     transparent
   );
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 370ms both;
@@ -197,7 +215,7 @@
 
 .tagline {
   max-width: 22rem;
-  margin: clamp(6px, 2.6vh, 36px) auto 0;
+  margin: clamp(6px, 2vh, 20px) auto 0;
   color: var(--foundation-ink);
   font-family: var(--landing-display);
   font-size: clamp(11px, 2.3vh, 20px);
@@ -213,11 +231,11 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  margin-top: clamp(4px, 1.8vh, 26px);
-  color: var(--foundation-dim);
-  font-size: clamp(6px, 1.2vh, 11px);
+  margin-top: clamp(4px, 1.4vh, 14px);
+  color: var(--landing-secondary-ink);
+  font-size: clamp(8px, 1.35vh, 12.5px);
   font-weight: 600;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.13em;
   line-height: 1.2;
   text-transform: uppercase;
   white-space: nowrap;
@@ -236,8 +254,8 @@
 
 .description {
   max-width: 23rem;
-  margin: clamp(6px, 2vh, 30px) auto 0;
-  color: var(--foundation-dim);
+  margin: clamp(6px, 1.6vh, 16px) auto 0;
+  color: var(--landing-secondary-ink);
   font-size: clamp(7px, 1.7vh, 16px);
   letter-spacing: -0.01em;
   line-height: 1.45;
@@ -246,10 +264,12 @@
 
 .footer {
   align-self: end;
+  display: flex;
+  justify-content: center;
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
-  padding-top: clamp(8px, 3vh, 26px);
+  padding-top: clamp(8px, 2vh, 16px);
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 680ms both;
 }
 
@@ -258,7 +278,11 @@
   overflow: hidden;
   display: inline-flex;
   min-height: clamp(44px, 6.4vh, 56px);
-  width: 100%;
+  /* Narrower than the column: a full-width pill here reads as the same
+     visual weight as the fixed voice bar directly beneath it. Falling short
+     of that width is what makes this one read as the deliberate primary
+     action instead of another edge-to-edge bar. */
+  width: 83%;
   align-items: center;
   justify-content: center;
   gap: 10px;

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -222,18 +222,29 @@
   align-items: center;
 }
 
+.eyebrow {
+  margin: 0;
+  color: var(--foundation-dim);
+  font-size: clamp(11px, 1.6vh, 14px);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  line-height: 1;
+  text-transform: uppercase;
+  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 220ms both;
+}
+
 .emoji {
-  margin-top: clamp(6px, 2.2vh, 22px);
-  /* 22–26px at rest; the floor only matters on the shortest landscape
-     heights PR1's contract covers. */
-  font-size: clamp(15px, 3vh, 26px);
+  margin-top: clamp(6px, 2.6vh, 26px);
+  /* Noticeably larger than a decorative accent — this is the second thing
+     the eye lands on, not a footnote. */
+  font-size: clamp(18px, 5vh, 40px);
   line-height: 1;
   filter: drop-shadow(0 4px 10px rgba(109, 67, 26, 0.14));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: clamp(1px, 0.4vh, 6px) 0 0;
+  margin: clamp(1px, 0.5vh, 8px) 0 0;
   font-family: var(--landing-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -249,7 +260,7 @@
   /* Bounded on both axes: a width-only clamp keeps growing on a short
      landscape viewport at exactly the moment the vertical room shrinks,
      which is what pushes the hero into the row above it. */
-  font-size: clamp(36px, min(24vw, 11vh), 116px);
+  font-size: clamp(40px, min(26vw, 13vh), 140px);
   font-weight: 800;
   /* em-relative so the tracking stays proportional as the size itself
      scales with the viewport, instead of a fixed px value reading as too
@@ -258,11 +269,12 @@
   line-height: 1.04;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  /* Restrained two-stop optical gradient (deep blue into iOS blue, no
-     shimmer band) as the resting state, with one light sweep layered on top
-     that crosses via background-position on first paint and then settles —
-     it never loops. Follows the app accent (Molten Gold under
-     html[data-accent="gold"]) via the shared hero stops. */
+  /* Deep blue through the true saturated system blue into a bright iOS
+     blue — richer than a flat two-stop fade, still restrained (one hue
+     family, no loud glow) — as the resting state, with one light sweep
+     layered on top that crosses via background-position on first paint
+     and then settles; it never loops. Follows the app accent (Molten Gold
+     under html[data-accent="gold"]) via the shared hero stops. */
   background-image:
     linear-gradient(
       100deg,
@@ -273,6 +285,7 @@
     linear-gradient(
       160deg,
       var(--app-accent-hero-from) 0%,
+      var(--app-accent-hero-mid) 50%,
       var(--app-accent-hero-to) 100%
     );
   background-size:
@@ -324,14 +337,48 @@
 
 .tagline {
   max-width: 22rem;
-  margin: clamp(6px, 2.2vh, 24px) auto 0;
+  margin: clamp(6px, 2.4vh, 26px) auto 0;
   color: var(--foundation-ink);
   font-family: var(--landing-display);
-  font-size: clamp(11px, 2.3vh, 20px);
+  font-size: clamp(14px, 2.8vh, 24px);
   font-weight: 600;
   letter-spacing: -0.02em;
-  line-height: 1.32;
+  line-height: 1.3;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 420ms both;
+}
+
+.motions {
+  display: flex;
+  /* Wraps as whole words (never mid-word — .motionItem itself stays
+     nowrap) rather than a fixed vw-bounded font size, since the width this
+     needs to fit is column width, not viewport height, and a wrap is a
+     robust fallback across locales and font metrics that a clamp() guess
+     isn't. At every required breakpoint this still resolves to one line;
+     390px width is the one case narrow enough to actually use it. */
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  column-gap: 8px;
+  row-gap: 2px;
+  max-width: 100%;
+  margin-top: clamp(5px, 2vh, 20px);
+  color: var(--foundation-dim);
+  font-size: clamp(9px, min(1.8vh, 3.3vw), 15px);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 500ms both;
+}
+
+.motionItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.motionDot {
+  opacity: 0.42;
 }
 
 .footer {
@@ -349,12 +396,12 @@
   position: relative;
   overflow: hidden;
   display: inline-flex;
-  min-height: clamp(44px, 6.4vh, 56px);
+  min-height: clamp(46px, 6.6vh, 58px);
   /* Narrower than the column: a full-width pill here reads as the same
      visual weight as the fixed voice bar directly beneath it. Falling short
      of that width is what makes this one read as the deliberate primary
      action instead of another edge-to-edge bar. */
-  width: 76%;
+  width: 80%;
   align-items: center;
   justify-content: center;
   gap: 10px;
@@ -366,7 +413,7 @@
   background: var(--app-accent);
   color: var(--app-accent-fg);
   font-family: var(--landing-text);
-  font-size: clamp(15px, 1.9vh, 16px);
+  font-size: clamp(16px, 2vh, 18px);
   font-weight: 700;
   line-height: 1;
   transition:

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -42,7 +42,7 @@
      stale browser/native inset without sacrificing the real status-bar
      clearance needed by an edge-to-edge WebView. */
   padding: calc(clamp(28px, var(--app-safe-area-top-effective, 0px), 64px) + 12px)
-    24px clamp(16px, 3vh, 24px);
+    24px clamp(8px, 3vh, 24px);
   text-align: center;
 }
 
@@ -103,7 +103,7 @@
 .eyebrow {
   margin: 0;
   color: var(--foundation-dim);
-  font-size: clamp(10px, 1.3vh, 12px);
+  font-size: clamp(8px, 1.3vh, 12px);
   font-weight: 700;
   letter-spacing: 0.26em;
   line-height: 1;
@@ -112,15 +112,15 @@
 }
 
 .emoji {
-  margin-top: clamp(14px, 3.4vh, 32px);
-  font-size: clamp(30px, 5.4vh, 48px);
+  margin-top: clamp(6px, 2.6vh, 32px);
+  font-size: clamp(16px, 4.4vh, 48px);
   line-height: 1;
   filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: clamp(6px, 1.3vh, 12px) 0 0;
+  margin: clamp(2px, 0.9vh, 12px) 0 0;
   font-family: var(--font-app-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -148,7 +148,7 @@
   /* Bounded on both axes: a width-only clamp keeps growing on a short
      landscape viewport at exactly the moment the vertical room shrinks,
      which is what pushes the hero into the row above it. */
-  font-size: clamp(64px, min(24vw, 14vh), 116px);
+  font-size: clamp(36px, min(24vw, 11vh), 116px);
   font-weight: 800;
   letter-spacing: -4px;
   line-height: 1.04;
@@ -159,7 +159,7 @@
 .divider {
   width: 100%;
   height: 1px;
-  margin-top: clamp(14px, 3.6vh, 36px);
+  margin-top: clamp(6px, 2.6vh, 36px);
   background: linear-gradient(
     90deg,
     transparent,
@@ -171,9 +171,9 @@
 
 .tagline {
   max-width: 22rem;
-  margin: clamp(14px, 3.6vh, 36px) auto 0;
+  margin: clamp(6px, 2.6vh, 36px) auto 0;
   color: var(--foundation-ink);
-  font-size: clamp(17px, 2.3vh, 20px);
+  font-size: clamp(11px, 2.3vh, 20px);
   font-weight: 600;
   letter-spacing: -0.2px;
   line-height: 1.35;
@@ -186,9 +186,9 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  margin-top: clamp(12px, 2.6vh, 26px);
+  margin-top: clamp(4px, 1.8vh, 26px);
   color: var(--foundation-dim);
-  font-size: clamp(9.5px, 1.2vh, 11px);
+  font-size: clamp(6px, 1.2vh, 11px);
   font-weight: 700;
   letter-spacing: 0.16em;
   line-height: 1.2;
@@ -209,9 +209,9 @@
 
 .description {
   max-width: 23rem;
-  margin: clamp(14px, 3vh, 30px) auto 0;
+  margin: clamp(6px, 2vh, 30px) auto 0;
   color: var(--foundation-dim);
-  font-size: clamp(13px, 1.7vh, 16px);
+  font-size: clamp(7px, 1.7vh, 16px);
   line-height: 1.45;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
 }
@@ -221,7 +221,7 @@
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
-  padding-top: clamp(16px, 3vh, 26px);
+  padding-top: clamp(8px, 3vh, 26px);
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 680ms both;
 }
 
@@ -229,7 +229,7 @@
   position: relative;
   overflow: hidden;
   display: inline-flex;
-  min-height: clamp(48px, 6.4vh, 56px);
+  min-height: clamp(44px, 6.4vh, 56px);
   width: 100%;
   align-items: center;
   justify-content: center;

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -82,14 +82,43 @@
   text-align: center;
 }
 
-/* hussh is the brand, One is the product: a small, quiet wordmark — not a
-   pill, not a nav bar — so nothing above "One" competes with it. */
-.wordmark {
-  height: clamp(16px, 1.9vh, 21px);
-  width: auto;
-  margin-bottom: clamp(6px, 1.6vh, 16px);
-  opacity: 0.92;
+/* hussh is the brand, One is the product: legible and clearly present on
+   its own — not a pill, not a nav bar, and still a fraction of One's size
+   — so it reads as the brand mark without competing with the hero below
+   it. The wrap carries a tight, low radial glow (visible, not a spotlight)
+   so the mark has a little support of its own instead of sitting bare
+   against the shared canvas. */
+.wordmarkWrap {
+  position: relative;
+  display: inline-flex;
+  margin-top: clamp(2px, 0.6vh, 10px);
+  margin-bottom: clamp(10px, 2.4vh, 24px);
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+
+.wordmarkWrap::before {
+  content: "";
+  position: absolute;
+  inset: -20px -30px;
+  z-index: -1;
+  border-radius: 999px;
+  background: radial-gradient(
+    60% 65% at 50% 50%,
+    color-mix(in oklab, var(--app-accent) 16%, transparent),
+    transparent 75%
+  );
+}
+
+.wordmark {
+  height: clamp(20px, 2.6vh, 28px);
+  width: auto;
+  /* A soft directional shadow rather than flat opacity: reads as depth in
+     light mode and as a faint light bloom in dark mode, since it is mixed
+     from the ink token each theme already flips. Full color, no dimming —
+     legibility was the actual complaint. */
+  filter: drop-shadow(
+    0 1px 3px color-mix(in oklab, var(--foundation-ink) 22%, transparent)
+  );
 }
 
 .hero {

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -27,7 +27,11 @@
   position: relative;
   z-index: 10;
   display: grid;
-  block-size: calc(100svh - var(--app-scroll-bottom-pad, 0px));
+  /* The shell above already sizes itself to exactly one viewport; this row
+     only needs to fill that box, and `min-height: 0` is what lets the middle
+     grid row (the hero) shrink below its own content height instead of
+     forcing the page to overflow. */
+  block-size: 100%;
   min-height: 0;
   width: 100%;
   max-width: 34rem;
@@ -38,29 +42,60 @@
      stale browser/native inset without sacrificing the real status-bar
      clearance needed by an edge-to-edge WebView. */
   padding: calc(clamp(28px, var(--app-safe-area-top-effective, 0px), 64px) + 12px)
-    24px 24px;
+    24px clamp(16px, 3vh, 24px);
   text-align: center;
 }
 
+/* ── Brand row: wordmark + public nav share the top of the page instead of
+      splitting the wordmark up here and the links below the CTA. ── */
 .brand {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  gap: clamp(8px, 3vw, 16px);
+  width: 100%;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
 .wordmark {
-  height: 34px;
+  height: clamp(24px, 2.8vh, 34px);
   width: auto;
+  flex-shrink: 0;
+}
+
+.links {
+  display: flex;
+  align-items: center;
+  gap: clamp(0px, 1vw, 6px);
+  min-width: 0;
+}
+
+.link {
+  display: inline-flex;
+  /* Tap target stays 44px tall regardless of how compact the label reads. */
+  min-height: 44px;
+  align-items: center;
+  padding: 0 clamp(6px, 2vw, 12px);
+  border-radius: 999px;
+  color: var(--foundation-dim);
+  font-size: clamp(10px, 1.3vh, 12px);
+  font-weight: 600;
+  white-space: nowrap;
+  transition: color var(--motion-duration-sm, 180ms)
+    var(--motion-ease-standard, ease-out);
+}
+
+.link:hover {
+  color: var(--foundation-ink);
 }
 
 .hero {
   align-self: center;
   display: flex;
+  min-height: 0;
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
-  transform: translateY(-8px);
   flex-direction: column;
   align-items: center;
 }
@@ -68,7 +103,7 @@
 .eyebrow {
   margin: 0;
   color: var(--foundation-dim);
-  font-size: 12px;
+  font-size: clamp(10px, 1.3vh, 12px);
   font-weight: 700;
   letter-spacing: 0.26em;
   line-height: 1;
@@ -77,15 +112,15 @@
 }
 
 .emoji {
-  margin-top: 32px;
-  font-size: 48px;
+  margin-top: clamp(14px, 3.4vh, 32px);
+  font-size: clamp(30px, 5.4vh, 48px);
   line-height: 1;
   filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: 12px 0 0;
+  margin: clamp(6px, 1.3vh, 12px) 0 0;
   font-family: var(--font-app-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -110,7 +145,10 @@
   background-clip: text;
   color: transparent;
   font-family: var(--font-app-display);
-  font-size: clamp(88px, 29vw, 118px);
+  /* Bounded on both axes: a width-only clamp keeps growing on a short
+     landscape viewport at exactly the moment the vertical room shrinks,
+     which is what pushes the hero into the row above it. */
+  font-size: clamp(64px, min(24vw, 14vh), 116px);
   font-weight: 800;
   letter-spacing: -4px;
   line-height: 1.04;
@@ -121,7 +159,7 @@
 .divider {
   width: 100%;
   height: 1px;
-  margin-top: 36px;
+  margin-top: clamp(14px, 3.6vh, 36px);
   background: linear-gradient(
     90deg,
     transparent,
@@ -133,9 +171,9 @@
 
 .tagline {
   max-width: 22rem;
-  margin: 36px auto 0;
+  margin: clamp(14px, 3.6vh, 36px) auto 0;
   color: var(--foundation-ink);
-  font-size: 20px;
+  font-size: clamp(17px, 2.3vh, 20px);
   font-weight: 600;
   letter-spacing: -0.2px;
   line-height: 1.35;
@@ -148,9 +186,9 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  margin-top: 26px;
+  margin-top: clamp(12px, 2.6vh, 26px);
   color: var(--foundation-dim);
-  font-size: 11px;
+  font-size: clamp(9.5px, 1.2vh, 11px);
   font-weight: 700;
   letter-spacing: 0.16em;
   line-height: 1.2;
@@ -171,9 +209,9 @@
 
 .description {
   max-width: 23rem;
-  margin: 30px auto 0;
+  margin: clamp(14px, 3vh, 30px) auto 0;
   color: var(--foundation-dim);
-  font-size: 16px;
+  font-size: clamp(13px, 1.7vh, 16px);
   line-height: 1.45;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
 }
@@ -183,6 +221,7 @@
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
+  padding-top: clamp(16px, 3vh, 26px);
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 680ms both;
 }
 
@@ -190,7 +229,7 @@
   position: relative;
   overflow: hidden;
   display: inline-flex;
-  min-height: 56px;
+  min-height: clamp(48px, 6.4vh, 56px);
   width: 100%;
   align-items: center;
   justify-content: center;
@@ -202,7 +241,7 @@
   background: var(--app-accent);
   color: var(--app-accent-fg);
   font-family: var(--font-app-body);
-  font-size: 16px;
+  font-size: clamp(15px, 1.9vh, 16px);
   font-weight: 700;
   line-height: 1;
   transition:
@@ -219,30 +258,6 @@
   }
 }
 
-.links {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 16px;
-  border-top: 1px solid var(--foundation-hairline);
-  color: var(--foundation-dim);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.link {
-  display: flex;
-  min-height: 46px;
-  align-items: center;
-  justify-content: center;
-  border-left: 1px solid var(--foundation-hairline);
-  text-align: center;
-  line-height: 1.1;
-}
-
-.link:first-child {
-  border-left: 0;
-}
-
 @keyframes reveal {
   from {
     opacity: 0;
@@ -253,37 +268,5 @@
     opacity: 1;
     transform: translate3d(0, 0, 0);
     filter: blur(0);
-  }
-}
-
-@media (max-height: 740px) {
-  .hero {
-    transform: translateY(-4px);
-  }
-
-  .emoji {
-    margin-top: 22px;
-    font-size: 42px;
-  }
-
-  .molten {
-    font-size: clamp(76px, 26vw, 104px);
-  }
-
-  .divider {
-    margin-top: 24px;
-  }
-
-  .tagline {
-    margin-top: 24px;
-  }
-
-  .motions {
-    margin-top: 18px;
-  }
-
-  .description {
-    margin-top: 20px;
-    font-size: 14px;
   }
 }

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -9,20 +9,18 @@
     BlinkMacSystemFont, var(--font-app-display);
   --landing-text: "SF Pro Text", "SF Pro", -apple-system, BlinkMacSystemFont,
     var(--font-app-body);
-  /* A readable-but-secondary ink for the supporting lines (tagline sits
-     above this at full --foundation-ink; the motions row and description
-     sit below it at --foundation-dim). Keeps them legible without making
-     every line compete at the same weight. */
+  /* A readable-but-secondary ink for the motions row: legible against the
+     canvas without competing with the tagline's full --foundation-ink. */
   --landing-secondary-ink: color-mix(
     in oklab,
     var(--foundation-ink) 55%,
     var(--foundation-dim) 45%
   );
   font-family: var(--landing-text);
-  /* A faint wash above the shared decorative canvas (unchanged) so its grain
-     and drifting motes read as texture instead of visual noise competing
-     with the content on top of them. */
-  background: color-mix(in oklab, var(--background) 10%, transparent);
+  /* A wash above the shared decorative canvas (unchanged) so its grain and
+     drifting motes read as a quiet texture rather than visual noise
+     competing with the one-thing-at-a-time composition on top of it. */
+  background: color-mix(in oklab, var(--background) 16%, transparent);
   /* The outer app scroll root already reserves --app-scroll-bottom-pad of
      clearance below this element for the fixed onboarding Agent Bar (see
      app/providers.tsx), then adds it back as its own padding-bottom. Sizing
@@ -73,32 +71,36 @@
       pill sized to its own content (not the full column width) so the
       wordmark and the links read as one intentionally-grouped mark rather
       than two things pinned to opposite edges of an otherwise empty bar.
-      The glass itself favors transparency over opacity — it should read as
-      a soft refraction of what's behind it, not a solid card. ── */
+      The glass recipe layers three things real frosted glass has and a flat
+      tinted rectangle doesn't: a translucent tint (not a solid fill), a
+      brighter hairline along the top where light would catch a physical
+      edge, and a soft cast shadow for depth — on top of the blur itself. ── */
 .brand {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(14px, 4vw, 26px);
+  gap: clamp(12px, 3.4vw, 22px);
   width: fit-content;
   max-width: 100%;
   margin: 0 auto;
-  padding: clamp(1px, 0.4vh, 4px) clamp(10px, 2.6vw, 16px);
+  padding: clamp(1px, 0.3vh, 3px) clamp(9px, 2.4vw, 14px);
   border-radius: 999px;
-  background: color-mix(in oklab, var(--app-glass-surface) 58%, transparent);
+  background: color-mix(in oklab, var(--app-glass-surface) 44%, transparent);
   border: 0.5px solid
-    color-mix(in oklab, var(--app-glass-border) 55%, transparent);
-  box-shadow: 0 4px 16px -12px
-    color-mix(in oklab, var(--foundation-ink) 20%, transparent);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
-  backdrop-filter: blur(14px) saturate(140%);
+    color-mix(in oklab, var(--app-glass-border) 40%, transparent);
+  box-shadow:
+    0 1px 0 color-mix(in oklab, white 30%, transparent) inset,
+    0 1px 1px color-mix(in oklab, white 20%, transparent) inset,
+    0 8px 24px -16px color-mix(in oklab, var(--foundation-ink) 24%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(130%);
+  backdrop-filter: blur(16px) saturate(130%);
   transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
 .wordmark {
-  height: clamp(22px, 2.6vh, 30px);
+  height: clamp(20px, 2.3vh, 27px);
   width: auto;
   flex-shrink: 0;
 }
@@ -106,7 +108,7 @@
 .links {
   display: flex;
   align-items: center;
-  gap: clamp(0px, 1vw, 6px);
+  gap: clamp(0px, 0.8vw, 4px);
   min-width: 0;
 }
 
@@ -153,15 +155,15 @@
 }
 
 .emoji {
-  margin-top: clamp(6px, 2vh, 20px);
-  font-size: clamp(14px, 3.6vh, 40px);
+  margin-top: clamp(6px, 2.4vh, 26px);
+  font-size: clamp(14px, 3.9vh, 46px);
   line-height: 1;
   filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: clamp(2px, 0.7vh, 8px) 0 0;
+  margin: clamp(2px, 0.8vh, 10px) 0 0;
   font-family: var(--landing-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -203,7 +205,7 @@
 .divider {
   width: min(88px, 28%);
   height: 1px;
-  margin: clamp(6px, 2vh, 20px) auto 0;
+  margin: clamp(6px, 2.4vh, 28px) auto 0;
   background: linear-gradient(
     90deg,
     transparent,
@@ -215,7 +217,7 @@
 
 .tagline {
   max-width: 22rem;
-  margin: clamp(6px, 2vh, 20px) auto 0;
+  margin: clamp(6px, 2.4vh, 28px) auto 0;
   color: var(--foundation-ink);
   font-family: var(--landing-display);
   font-size: clamp(11px, 2.3vh, 20px);
@@ -231,7 +233,7 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  margin-top: clamp(4px, 1.4vh, 14px);
+  margin-top: clamp(4px, 1.8vh, 22px);
   color: var(--landing-secondary-ink);
   font-size: clamp(8px, 1.35vh, 12.5px);
   font-weight: 600;
@@ -252,16 +254,6 @@
   opacity: 0.42;
 }
 
-.description {
-  max-width: 23rem;
-  margin: clamp(6px, 1.6vh, 16px) auto 0;
-  color: var(--landing-secondary-ink);
-  font-size: clamp(7px, 1.7vh, 16px);
-  letter-spacing: -0.01em;
-  line-height: 1.45;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
-}
-
 .footer {
   align-self: end;
   display: flex;
@@ -269,8 +261,8 @@
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
-  padding-top: clamp(8px, 2vh, 16px);
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 680ms both;
+  padding-top: clamp(14px, 3.4vh, 34px);
+  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
 }
 
 .cta {

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -9,13 +9,6 @@
     BlinkMacSystemFont, var(--font-app-display);
   --landing-text: "SF Pro Text", "SF Pro", -apple-system, BlinkMacSystemFont,
     var(--font-app-body);
-  /* A readable-but-secondary ink for the motions row: legible against the
-     canvas without competing with the tagline's full --foundation-ink. */
-  --landing-secondary-ink: color-mix(
-    in oklab,
-    var(--foundation-ink) 55%,
-    var(--foundation-dim) 45%
-  );
   font-family: var(--landing-text);
   /* A wash above the shared decorative canvas (unchanged) so its grain and
      drifting motes read as a quiet texture rather than visual noise
@@ -41,6 +34,29 @@
   width: 100%;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* A near-invisible blue/cyan light field behind the upper half of the page —
+   not a background of its own, just something for the glass pill's blur to
+   actually refract. Two soft radial pools, faded out well before halfway
+   down so it never reads as a colored section. */
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      55% 38% at 42% 0%,
+      color-mix(in oklab, var(--app-accent) 10%, transparent),
+      transparent 70%
+    ),
+    radial-gradient(
+      45% 32% at 68% 4%,
+      color-mix(in oklab, #22d3ee 8%, transparent),
+      transparent 70%
+    );
 }
 
 .stage {
@@ -71,11 +87,13 @@
       pill sized to its own content (not the full column width) so the
       wordmark and the links read as one intentionally-grouped mark rather
       than two things pinned to opposite edges of an otherwise empty bar.
-      The glass recipe layers three things real frosted glass has and a flat
-      tinted rectangle doesn't: a translucent tint (not a solid fill), a
-      brighter hairline along the top where light would catch a physical
-      edge, and a soft cast shadow for depth — on top of the blur itself. ── */
+      The glass recipe layers what real frosted glass has and a flat tinted
+      rectangle doesn't: a translucent tint (not a solid fill) faint enough
+      that the canvas shows through, a brighter hairline and inset highlight
+      along the top where light would catch a physical edge, and a soft cast
+      shadow for depth underneath the blur itself. ── */
 .brand {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -85,18 +103,55 @@
   margin: 0 auto;
   padding: clamp(1px, 0.3vh, 3px) clamp(9px, 2.4vw, 14px);
   border-radius: 999px;
-  background: color-mix(in oklab, var(--app-glass-surface) 44%, transparent);
+  --pointer-x: 50%;
+  --pointer-y: 0%;
+  background:
+    radial-gradient(
+      140% 100% at 30% -20%,
+      color-mix(in oklab, var(--app-accent) 5%, transparent),
+      transparent 60%
+    ),
+    color-mix(in oklab, var(--app-glass-surface) 36%, transparent);
   border: 0.5px solid
-    color-mix(in oklab, var(--app-glass-border) 40%, transparent);
+    color-mix(in oklab, var(--app-glass-border) 38%, transparent);
   box-shadow:
-    0 1px 0 color-mix(in oklab, white 30%, transparent) inset,
-    0 1px 1px color-mix(in oklab, white 20%, transparent) inset,
-    0 8px 24px -16px color-mix(in oklab, var(--foundation-ink) 24%, transparent);
-  -webkit-backdrop-filter: blur(16px) saturate(130%);
-  backdrop-filter: blur(16px) saturate(130%);
+    0 1px 0 color-mix(in oklab, white 32%, transparent) inset,
+    0 1px 1px color-mix(in oklab, white 18%, transparent) inset,
+    0 10px 28px -18px color-mix(in oklab, var(--foundation-ink) 26%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(18px) saturate(140%);
   transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+
+/* Pointer-following highlight — position tracked from IntroStep.tsx via the
+   --pointer-x/--pointer-y custom properties (mouse only; untouched, centered
+   defaults on touch where no pointermove ever fires). Visibility is a pure
+   CSS :hover, so there is nothing to wire up beyond the position itself. */
+.brand::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    160px circle at var(--pointer-x) var(--pointer-y),
+    color-mix(in oklab, white 45%, transparent),
+    transparent 70%
+  );
+  opacity: 0;
+  transition: opacity 260ms ease-out;
+  pointer-events: none;
+}
+
+.brand:hover::after {
+  opacity: 0.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand::after {
+    transition: none;
+  }
 }
 
 .wordmark {
@@ -113,6 +168,7 @@
 }
 
 .link {
+  position: relative;
   display: inline-flex;
   /* Tap target stays 44px tall regardless of how compact the label reads. */
   min-height: 44px;
@@ -128,8 +184,31 @@
     var(--motion-ease-standard, ease-out);
 }
 
-.link:hover {
+/* Tiny hover "lens": a soft circular tint behind the label, not a filled
+   chip — it should read as light catching the glass, not a button state. */
+.link::before {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  z-index: -1;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at 50% 50%,
+    color-mix(in oklab, var(--app-accent) 14%, transparent),
+    transparent 72%
+  );
+  opacity: 0;
+  transition: opacity 200ms ease-out;
+}
+
+.link:hover,
+.link:focus-visible {
   color: var(--foundation-ink);
+}
+
+.link:hover::before,
+.link:focus-visible::before {
+  opacity: 1;
 }
 
 .hero {
@@ -143,27 +222,18 @@
   align-items: center;
 }
 
-.eyebrow {
-  margin: 0;
-  color: var(--foundation-dim);
-  font-size: clamp(8px, 1.3vh, 12px);
-  font-weight: 600;
-  letter-spacing: 0.2em;
-  line-height: 1;
-  text-transform: uppercase;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 220ms both;
-}
-
 .emoji {
-  margin-top: clamp(6px, 2.4vh, 26px);
-  font-size: clamp(14px, 3.9vh, 46px);
+  margin-top: clamp(6px, 2.2vh, 22px);
+  /* 22–26px at rest; the floor only matters on the shortest landscape
+     heights PR1's contract covers. */
+  font-size: clamp(15px, 3vh, 26px);
   line-height: 1;
-  filter: drop-shadow(0 8px 18px rgba(109, 67, 26, 0.16));
+  filter: drop-shadow(0 4px 10px rgba(109, 67, 26, 0.14));
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 280ms both;
 }
 
 .title {
-  margin: clamp(2px, 0.8vh, 10px) 0 0;
+  margin: clamp(1px, 0.4vh, 6px) 0 0;
   font-family: var(--landing-display);
   line-height: 1;
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 340ms both;
@@ -173,18 +243,6 @@
   display: inline-block;
   margin: -0.05em -0.04em;
   padding: 0.06em 0.08em;
-  /* Hero foil gradient follows the app accent (iOS Blue default, Molten
-     Gold under html[data-accent="gold"]) via the shared hero stops. */
-  background-image: linear-gradient(
-    98deg,
-    var(--app-accent-hero-from) 0%,
-    var(--app-accent-hero-mid) 40%,
-    var(--app-accent-hero-to) 50%,
-    var(--app-accent-hero-mid) 60%,
-    var(--app-accent-hero-from) 100%
-  );
-  background-size: 300% 100%;
-  background-position: 30% 50%;
   background-clip: text;
   color: transparent;
   font-family: var(--landing-display);
@@ -200,16 +258,65 @@
   line-height: 1.04;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  /* Restrained two-stop optical gradient (deep blue into iOS blue, no
+     shimmer band) as the resting state, with one light sweep layered on top
+     that crosses via background-position on first paint and then settles —
+     it never loops. Follows the app accent (Molten Gold under
+     html[data-accent="gold"]) via the shared hero stops. */
+  background-image:
+    linear-gradient(
+      100deg,
+      transparent 40%,
+      color-mix(in oklab, white 75%, transparent) 50%,
+      transparent 60%
+    ),
+    linear-gradient(
+      160deg,
+      var(--app-accent-hero-from) 0%,
+      var(--app-accent-hero-to) 100%
+    );
+  background-size:
+    220% 100%,
+    100% 100%;
+  background-position:
+    160% 0,
+    0 0;
+  /* Starts once .title (the parent) has finished fading in — its own
+     reveal already covers this element's entrance, so this is only the
+     sweep, not a second independent fade. */
+  animation: molten-sweep 950ms ease-out 420ms both;
+}
+
+@keyframes molten-sweep {
+  from {
+    background-position:
+      160% 0,
+      0 0;
+  }
+  to {
+    background-position:
+      -60% 0,
+      0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .molten {
+    animation: none;
+    background-position:
+      -60% 0,
+      0 0;
+  }
 }
 
 .divider {
-  width: min(88px, 28%);
+  width: min(64px, 22%);
   height: 1px;
-  margin: clamp(6px, 2.4vh, 28px) auto 0;
+  margin: clamp(6px, 2.2vh, 24px) auto 0;
   background: linear-gradient(
     90deg,
     transparent,
-    color-mix(in oklab, var(--foundation-gold-deep) 20%, transparent),
+    color-mix(in oklab, var(--foundation-gold-deep) 18%, transparent),
     transparent
   );
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 370ms both;
@@ -217,7 +324,7 @@
 
 .tagline {
   max-width: 22rem;
-  margin: clamp(6px, 2.4vh, 28px) auto 0;
+  margin: clamp(6px, 2.2vh, 24px) auto 0;
   color: var(--foundation-ink);
   font-family: var(--landing-display);
   font-size: clamp(11px, 2.3vh, 20px);
@@ -227,33 +334,6 @@
   animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 420ms both;
 }
 
-.motions {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  margin-top: clamp(4px, 1.8vh, 22px);
-  color: var(--landing-secondary-ink);
-  font-size: clamp(8px, 1.35vh, 12.5px);
-  font-weight: 600;
-  letter-spacing: 0.13em;
-  line-height: 1.2;
-  text-transform: uppercase;
-  white-space: nowrap;
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 500ms both;
-}
-
-.motionItem {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-
-.motionDot {
-  opacity: 0.42;
-}
-
 .footer {
   align-self: end;
   display: flex;
@@ -261,8 +341,8 @@
   width: 100%;
   max-width: 30rem;
   margin: 0 auto;
-  padding-top: clamp(14px, 3.4vh, 34px);
-  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 580ms both;
+  padding-top: clamp(16px, 4vh, 40px);
+  animation: reveal 780ms cubic-bezier(0.16, 1, 0.3, 1) 500ms both;
 }
 
 .cta {
@@ -274,14 +354,15 @@
      visual weight as the fixed voice bar directly beneath it. Falling short
      of that width is what makes this one read as the deliberate primary
      action instead of another edge-to-edge bar. */
-  width: 83%;
+  width: 76%;
   align-items: center;
   justify-content: center;
   gap: 10px;
   border: 0;
   border-radius: 999px;
   /* Accent morphy: flat accent fill that follows the accent preference
-     (iOS Blue default, Molten Gold opt-in). No gradient, no shadow. */
+     (iOS Blue default, Molten Gold opt-in). No gradient, no glow, no glass —
+     the one solid, fully-opaque surface on the screen, deliberately. */
   background: var(--app-accent);
   color: var(--app-accent-fg);
   font-family: var(--landing-text);
@@ -322,4 +403,14 @@
     transform: translate3d(0, 0, 0);
     filter: blur(0);
   }
+}
+
+/* Quiets the persistent voice bar specifically while this screen is mounted,
+   via the data-attribute this component puts on its own <main> — matched
+   through :has() rather than any change to the bar's own component or a
+   global stylesheet rule, so no other route is affected. The CTA above is
+   meant to read as the one obvious action; a second full-width bar at equal
+   visual weight competes with that. */
+:global(body:has([data-screen="welcome"])) :global([data-agent-bar-shell]) {
+  opacity: 0.86;
 }

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -11,10 +11,10 @@ import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metada
 import styles from "./IntroStep.module.css";
 
 /* ────────────────────────────────────────────────────────────
- * Welcome ("/"). A restrained, Foundation-warm canvas carries one centered
- * brand anchor, one "One" moment, and one clear next action. The public
- * destinations below the CTA are a real navigation group with equal targets,
- * not footer text that happens to be clickable.
+ * Welcome ("/"). A restrained, Foundation-warm canvas carries one brand row,
+ * one "One" moment, and one clear next action. The public destinations sit
+ * beside the wordmark as a real navigation group with equal targets, not
+ * footer text that happens to be clickable.
  * ──────────────────────────────────────────────────────────── */
 
 // One's four motions, shown as a quiet typographic rhythm — never as chips,
@@ -83,11 +83,22 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
       <OnboardingHeroBackground />
 
       <div className={styles.stage}>
-        {/* One centered brand anchor keeps the page calm on both compact and
-            wide surfaces; the old wordmark/emoji pair read as two competing
-            logos rather than one header. */}
+        {/* Brand row: wordmark plus the public destinations, one nav group
+            instead of a header logo and a separate footer link row. */}
         <div className={styles.brand}>
           <HushhWordmark className={styles.wordmark} />
+
+          <nav aria-label="Explore Hussh" className={styles.links}>
+            <Link href={ROUTES.RESEARCH} className={styles.link}>
+              Research
+            </Link>
+            <Link href={ROUTES.BLOG} className={styles.link}>
+              Blog
+            </Link>
+            <Link href={ROUTES.DEVELOPERS} className={styles.link}>
+              Developers
+            </Link>
+          </nav>
         </div>
 
         {/* ── Typography-led hero. No cards, no fake metrics. ── */}
@@ -162,33 +173,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
             </span>
             <MaterialRipple variant="gradient" effect="fill" className="z-10" />
           </button>
-
-          {/* Public destinations share the CTA width and use equal hit areas.
-              That preserves discoverable navigation on small screens without
-              letting the longest label push its siblings out of rhythm. */}
-          <nav
-            aria-label="Explore Hussh"
-            className={styles.links}
-          >
-            <Link
-              href={ROUTES.RESEARCH}
-              className={styles.link}
-            >
-              Research
-            </Link>
-            <Link
-              href={ROUTES.BLOG}
-              className={styles.link}
-            >
-              Blog
-            </Link>
-            <Link
-              href={ROUTES.DEVELOPERS}
-              className={styles.link}
-            >
-              Developers
-            </Link>
-          </nav>
         </div>
       </div>
     </main>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -144,15 +144,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
               </span>
             ))}
           </div>
-
-          {/* Plain words only. "Encrypted" and "consent" are the mechanism and
-              the legal term; "locked" and "your yes" are what a person actually
-              pictures. "Vault" is a code noun and never appears in copy. */}
-          <p className={styles.description}>
-            Everything you save stays locked.
-            <br />
-            Nothing moves without your yes.
-          </p>
         </div>
 
         {/* ── CTA: Morphy Button, ink surface, gradient ripple. Sits in the

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { useCallback, useRef } from "react";
-import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback } from "react";
 import { HushhWordmark } from "@/components/app-ui/hushh-wordmark";
 import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
@@ -12,10 +10,9 @@ import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metada
 import styles from "./IntroStep.module.css";
 
 /* ────────────────────────────────────────────────────────────
- * Welcome ("/"). One brand row, one "One" moment, one clear next action —
- * nothing else competing for attention. The public destinations sit beside
- * the wordmark as a real navigation group with equal targets, not footer
- * text that happens to be clickable.
+ * Welcome ("/"). hussh is the brand, One is the product: a small quiet
+ * wordmark leads into one dominant "One" moment and one clear next action
+ * — nothing else competing for attention.
  * ──────────────────────────────────────────────────────────── */
 
 // One's four motions, shown as a quiet typographic rhythm — never as chips,
@@ -23,34 +20,6 @@ import styles from "./IntroStep.module.css";
 const MOTIONS = ["Listens", "Remembers", "Decides", "Acts"];
 
 export function IntroStep({ onLogin }: { onLogin?: () => void }) {
-  // Pointer-following highlight inside the glass pill. Written straight to
-  // the DOM (not React state) since it must track every pointermove without
-  // re-rendering the tree; the underlying custom properties default to
-  // centered so nothing moves on touch, where no pointermove ever fires.
-  const brandRef = useRef<HTMLDivElement>(null);
-  const handleBrandPointerMove = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const el = brandRef.current;
-      if (!el || event.pointerType !== "mouse") return;
-      const rect = el.getBoundingClientRect();
-      el.style.setProperty(
-        "--pointer-x",
-        `${(((event.clientX - rect.left) / rect.width) * 100).toFixed(1)}%`,
-      );
-      el.style.setProperty(
-        "--pointer-y",
-        `${(((event.clientY - rect.top) / rect.height) * 100).toFixed(1)}%`,
-      );
-    },
-    [],
-  );
-  const handleBrandPointerLeave = useCallback(() => {
-    const el = brandRef.current;
-    if (!el) return;
-    el.style.setProperty("--pointer-x", "50%");
-    el.style.setProperty("--pointer-y", "0%");
-  }, []);
-
   const claimOne = useCallback(() => {
     if (!onLogin) {
       return {
@@ -112,31 +81,12 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
       <OnboardingHeroBackground />
 
       <div className={styles.stage}>
-        {/* Brand row: wordmark plus the public destinations, one nav group
-            instead of a header logo and a separate footer link row. */}
-        <div
-          ref={brandRef}
-          className={styles.brand}
-          onPointerMove={handleBrandPointerMove}
-          onPointerLeave={handleBrandPointerLeave}
-        >
+        {/* ── Typography-led hero. No cards, no fake metrics. hussh leads
+              as the small, quiet brand mark; One is the product and the
+              dominant visual event below it. ── */}
+        <div className={styles.hero}>
           <HushhWordmark className={styles.wordmark} />
 
-          <nav aria-label="Explore Hussh" className={styles.links}>
-            <Link href={ROUTES.RESEARCH} className={styles.link}>
-              Research
-            </Link>
-            <Link href={ROUTES.BLOG} className={styles.link}>
-              Blog
-            </Link>
-            <Link href={ROUTES.DEVELOPERS} className={styles.link}>
-              Developers
-            </Link>
-          </nav>
-        </div>
-
-        {/* ── Typography-led hero. No cards, no fake metrics. ── */}
-        <div className={styles.hero}>
           <span className={styles.eyebrow}>
             Your private agent
           </span>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -82,10 +82,13 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
       <div className={styles.stage}>
         {/* ── Typography-led hero. No cards, no fake metrics. hussh leads
-              as the small, quiet brand mark; One is the product and the
-              dominant visual event below it. ── */}
+              as a clearly-legible brand mark with its own quiet presence;
+              One is still the product and the dominant visual event below
+              it. ── */}
         <div className={styles.hero}>
-          <HushhWordmark className={styles.wordmark} />
+          <div className={styles.wordmarkWrap}>
+            <HushhWordmark className={styles.wordmark} />
+          </div>
 
           <span className={styles.eyebrow}>
             Your private agent

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { HushhWordmark } from "@/components/app-ui/hushh-wordmark";
 import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
@@ -11,17 +12,41 @@ import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metada
 import styles from "./IntroStep.module.css";
 
 /* ────────────────────────────────────────────────────────────
- * Welcome ("/"). A restrained, Foundation-warm canvas carries one brand row,
- * one "One" moment, and one clear next action. The public destinations sit
- * beside the wordmark as a real navigation group with equal targets, not
- * footer text that happens to be clickable.
+ * Welcome ("/"). One brand row, one "One" moment, one clear next action —
+ * nothing else competing for attention. The public destinations sit beside
+ * the wordmark as a real navigation group with equal targets, not footer
+ * text that happens to be clickable.
  * ──────────────────────────────────────────────────────────── */
 
-// One's four motions, shown as a quiet typographic rhythm — never as chips,
-// never labeled "framework". Matches docs/vision/agent-ontology.md.
-const MOTIONS = ["Listens", "Remembers", "Decides", "Acts"];
-
 export function IntroStep({ onLogin }: { onLogin?: () => void }) {
+  // Pointer-following highlight inside the glass pill. Written straight to
+  // the DOM (not React state) since it must track every pointermove without
+  // re-rendering the tree; the underlying custom properties default to
+  // centered so nothing moves on touch, where no pointermove ever fires.
+  const brandRef = useRef<HTMLDivElement>(null);
+  const handleBrandPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const el = brandRef.current;
+      if (!el || event.pointerType !== "mouse") return;
+      const rect = el.getBoundingClientRect();
+      el.style.setProperty(
+        "--pointer-x",
+        `${(((event.clientX - rect.left) / rect.width) * 100).toFixed(1)}%`,
+      );
+      el.style.setProperty(
+        "--pointer-y",
+        `${(((event.clientY - rect.top) / rect.height) * 100).toFixed(1)}%`,
+      );
+    },
+    [],
+  );
+  const handleBrandPointerLeave = useCallback(() => {
+    const el = brandRef.current;
+    if (!el) return;
+    el.style.setProperty("--pointer-x", "50%");
+    el.style.setProperty("--pointer-y", "0%");
+  }, []);
+
   const claimOne = useCallback(() => {
     if (!onLogin) {
       return {
@@ -79,13 +104,18 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
   });
 
   return (
-    <main className={styles.shell}>
+    <main className={styles.shell} data-screen="welcome">
       <OnboardingHeroBackground />
 
       <div className={styles.stage}>
         {/* Brand row: wordmark plus the public destinations, one nav group
             instead of a header logo and a separate footer link row. */}
-        <div className={styles.brand}>
+        <div
+          ref={brandRef}
+          className={styles.brand}
+          onPointerMove={handleBrandPointerMove}
+          onPointerLeave={handleBrandPointerLeave}
+        >
           <HushhWordmark className={styles.wordmark} />
 
           <nav aria-label="Explore Hussh" className={styles.links}>
@@ -103,10 +133,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
         {/* ── Typography-led hero. No cards, no fake metrics. ── */}
         <div className={styles.hero}>
-          <span className={styles.eyebrow}>
-            Your private agent
-          </span>
-
           <span
             aria-hidden="true"
             className={styles.emoji}
@@ -130,20 +156,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
           <p className={styles.tagline}>
             Your agents. Yours to own.
           </p>
-
-          {/* Quiet rhythm line: the four motions, typographic not chip-like. */}
-          <div className={styles.motions}>
-            {MOTIONS.map((motion, i) => (
-              <span key={motion} className={styles.motionItem}>
-                {i > 0 && (
-                  <span aria-hidden className={styles.motionDot}>
-                    &middot;
-                  </span>
-                )}
-                <span>{motion}</span>
-              </span>
-            ))}
-          </div>
         </div>
 
         {/* ── CTA: Morphy Button, ink surface, gradient ripple. Sits in the

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -18,6 +18,10 @@ import styles from "./IntroStep.module.css";
  * text that happens to be clickable.
  * ──────────────────────────────────────────────────────────── */
 
+// One's four motions, shown as a quiet typographic rhythm — never as chips,
+// never labeled "framework". Matches docs/vision/agent-ontology.md.
+const MOTIONS = ["Listens", "Remembers", "Decides", "Acts"];
+
 export function IntroStep({ onLogin }: { onLogin?: () => void }) {
   // Pointer-following highlight inside the glass pill. Written straight to
   // the DOM (not React state) since it must track every pointermove without
@@ -133,6 +137,10 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
         {/* ── Typography-led hero. No cards, no fake metrics. ── */}
         <div className={styles.hero}>
+          <span className={styles.eyebrow}>
+            Your private agent
+          </span>
+
           <span
             aria-hidden="true"
             className={styles.emoji}
@@ -156,6 +164,20 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
           <p className={styles.tagline}>
             Your agents. Yours to own.
           </p>
+
+          {/* Quiet rhythm line: the four motions, typographic not chip-like. */}
+          <div className={styles.motions}>
+            {MOTIONS.map((motion, i) => (
+              <span key={motion} className={styles.motionItem}>
+                {i > 0 && (
+                  <span aria-hidden className={styles.motionDot}>
+                    &middot;
+                  </span>
+                )}
+                <span>{motion}</span>
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* ── CTA: Morphy Button, ink surface, gradient ripple. Sits in the

--- a/hushh-webapp/components/onboarding/OnboardingHeroBackground.module.css
+++ b/hushh-webapp/components/onboarding/OnboardingHeroBackground.module.css
@@ -24,6 +24,9 @@
   position: absolute;
   inset: 0;
   color: var(--app-accent-deep);
+  /* Toned down a further half-step on top of each mote's own opacity — the
+     drifting specks are quiet texture, not something to visually track. */
+  opacity: 0.55;
 }
 
 .mote {
@@ -39,7 +42,7 @@
 .grain {
   position: absolute;
   inset: 0;
-  opacity: 0.05;
+  opacity: 0.02;
   background-image: radial-gradient(
     color-mix(in oklab, var(--foreground) 72%, transparent) 0.5px,
     transparent 0.7px


### PR DESCRIPTION
Fixes #6026

## Stacked on #6019

This PR is stacked on top of `fix/welcome-nav-responsive-layout` (base branch above, #6019) and only shows the visual-polish diff on top of it. Once #6019 merges, this will be retargeted onto `main` so it shows only its own changes.

## What changed

Visual/hierarchy polish pass on the signed-out welcome screen (`/`), no behavior changes:

- **Brand vs. product hierarchy**: `hussh` now leads as a small, clearly-legible brand mark (with a soft drop-shadow and a subtle low-opacity glow behind it), and `One` remains the dominant product focus — several times larger at every breakpoint.
- **Removed** the `Research / Blog / Developers` nav and the glass pill that carried it (no longer needed once the nav was removed), and the description paragraph copy.
- **Restored and resized** the `YOUR PRIVATE AGENT` eyebrow and the `LISTENS · REMEMBERS · DECIDES · ACTS` motions line for real readability, not near-illegible metadata.
- **Hero**: `One` uses a richer three-stop blue gradient (through the true saturated system blue) with a single non-repeating light sweep on first paint only (no loop, disabled under `prefers-reduced-motion`).
- **Background**: a near-invisible blue/cyan ambient light field behind the upper page, and the shared decorative canvas's grain/mote opacity toned down (visual-only, same component/behavior).
- **CTA**: narrower than the column width and the one fully-opaque solid surface on the screen, so it reads as clearly primary against the quieter fixed voice bar beneath it (which is dimmed to 86% opacity specifically on this screen via a `:has()` selector scoped to this component's own `data-screen` attribute — the shared voice-bar component itself is untouched, so no other route is affected).

## Verified

All six required viewports (1440×900, 1366×768, 1280×720, 390×844, 430×932, 844×390) in both light and dark themes: no scroll, no vertical or horizontal clipping, no overlap, nav/CTA/voice-bar hierarchy holds. Tests, typecheck, and eslint all pass.

## Scope

`components/onboarding/IntroStep.tsx`, `components/onboarding/IntroStep.module.css`, one focused test update, and a visual-only opacity tweak in `OnboardingHeroBackground.module.css`. No route, login, CTA-behavior, or voice-action changes. No new dependencies, no Three.js/WebGL.


---

**CI note:** GitHub Actions runners are not currently picking up new jobs org-wide (runs on unrelated branches have sat `queued` for weeks — verified via the Actions API, not just this PR). Equivalent checks were run locally via `scripts/ci/local-release-gate.sh` (the repo's `ship-without-actions` release-gate script) against this exact commit in an isolated worktree. Result: `pr-base-policy`, `main-freshness`, `web-core` (tests/typecheck/eslint/build/design-system checks), and `web-targeted` all passed. The remaining stage failures (`secret`, `governance`, `dco`, `protocol`, `mcp-package`, `integration`, `smoke`) were each individually verified as local/Windows-fresh-worktree toolchain gaps (missing `gitleaks`, a Windows-encoding crash in an unrelated skill script, two pre-existing upstream commits misflagged for DCO, CRLF-only diffs in generated files, and a Python subprocess resolving the system interpreter instead of the repo-pinned venv) — not code regressions. No code changes were made to satisfy any of these.
