### PR TITLE
fix(kai): fix analysis history not opening on desktop

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -867,7 +867,9 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 # It fired once per barge-in, not once per directive -- there
                 # is a single call site and the browser only sends `interrupt`
                 # from its own speech-over-playback path.
-                await websocket.send_text(_safe_json_dumps({"serverContent": {"interrupted": True}}))
+                await websocket.send_text(
+                    _safe_json_dumps({"serverContent": {"interrupted": True}})
+                )
                 continue
             if message.get("type") == "app_context" or "appContext" in message:
                 context_payload = message.get("appContext")
@@ -1548,7 +1550,9 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             close_reason = "unknown_tool_call"
             logger.warning("one_adk_live_unknown_tool_call error=%s", str(tool_error)[:160])
             await websocket.send_text(
-                _safe_json_dumps({"sessionEnded": {"reason": "unknown_tool_call", "resumable": True}})
+                _safe_json_dumps(
+                    {"sessionEnded": {"reason": "unknown_tool_call", "resumable": True}}
+                )
             )
             return
         except Exception as runtime_error:  # noqa: BLE001 - the browser must be told
@@ -1611,10 +1615,14 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 time_left = getattr(go_away, "time_left", None)
                 logger.info("one_adk_live_go_away time_left=%s", str(time_left)[:32])
                 await websocket.send_text(
-                    _safe_json_dumps({"goAway": {"timeLeft": str(time_left) if time_left else None}})
+                    _safe_json_dumps(
+                        {"goAway": {"timeLeft": str(time_left) if time_left else None}}
+                    )
                 )
             if getattr(event, "interrupted", False):
-                await websocket.send_text(_safe_json_dumps({"serverContent": {"interrupted": True}}))
+                await websocket.send_text(
+                    _safe_json_dumps({"serverContent": {"interrupted": True}})
+                )
             input_tx = getattr(event, "input_transcription", None)
             if input_tx is not None and getattr(input_tx, "text", None):
                 if not getattr(event, "partial", False):
@@ -1861,7 +1869,9 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
 
             if getattr(event, "turn_complete", False):
                 turn_count += 1
-                await websocket.send_text(_safe_json_dumps({"serverContent": {"turnComplete": True}}))
+                await websocket.send_text(
+                    _safe_json_dumps({"serverContent": {"turnComplete": True}})
+                )
 
     up = asyncio.create_task(pump_browser_to_queue())
     down = asyncio.create_task(pump_events_to_browser())

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -677,9 +677,7 @@ def get_location_nearby_check_in_preferences(
     """
     try:
         return {
-            "preferences": _service().get_nearby_check_in_defaults(
-                user_id=_user_id(token_data)
-            )
+            "preferences": _service().get_nearby_check_in_defaults(user_id=_user_id(token_data))
         }
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -799,9 +799,7 @@ async def _execute_backend_direct_mutation(
                         owner_user_id=user_id, grant_id=str(grant.get("id") or "")
                     )
                 except Exception:  # noqa: BLE001 - one failure must not lose or hide the rest
-                    logger.exception(
-                        "one_adk_backend_direct_partial_failure action=%s", action_id
-                    )
+                    logger.exception("one_adk_backend_direct_partial_failure action=%s", action_id)
                     failed_names.append(grant_name)
                     continue
                 stopped_names.append(grant_name)
@@ -1187,9 +1185,7 @@ async def _execute_backend_direct_mutation(
                         user_id=user_id, connection_id=str(connection.get("connectionId") or "")
                     )
                 except Exception:  # noqa: BLE001 - one failure must not lose or hide the rest
-                    logger.exception(
-                        "one_adk_backend_direct_partial_failure action=%s", action_id
-                    )
+                    logger.exception("one_adk_backend_direct_partial_failure action=%s", action_id)
                     failed_names.append(connection_name)
                     continue
                 removed_names.append(connection_name)
@@ -1374,7 +1370,9 @@ async def list_my_connections(tool_context: ToolContext) -> dict[str, Any]:
     if user_id is None:
         raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
     return await _read_tool_result(
-        "your connections", "connections", lambda: ConnectionsService().list_connections(user_id=user_id)
+        "your connections",
+        "connections",
+        lambda: ConnectionsService().list_connections(user_id=user_id),
     )
 
 
@@ -1408,7 +1406,9 @@ async def list_my_outgoing_location_requests(tool_context: ToolContext) -> dict[
     return await _read_tool_result(
         "your outgoing location requests",
         "requests",
-        lambda: OneLocationAgentService().list_pending_requester_requests(requester_user_id=user_id),
+        lambda: OneLocationAgentService().list_pending_requester_requests(
+            requester_user_id=user_id
+        ),
     )
 
 

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -53,6 +53,7 @@ def _iso(value: Any) -> str | None:
         return str(value.astimezone(timezone.utc).isoformat())
     return str(value)
 
+
 # The SQL predicate for "this RIA profile is real enough to carry a capability".
 #
 # One string, interpolated into every statement that asks the question, because

--- a/consent-protocol/tests/routes/test_connections_route.py
+++ b/consent-protocol/tests/routes/test_connections_route.py
@@ -102,9 +102,7 @@ def test_get_voice_preferences_returns_the_stored_default():
         }
         resp = client.get("/api/one/connect/voice-preferences")
     assert resp.status_code == 200
-    assert resp.json() == {
-        "preferences": {"shareScopesFromLastRequest": False, "updatedAt": None}
-    }
+    assert resp.json() == {"preferences": {"shareScopesFromLastRequest": False, "updatedAt": None}}
     svc_cls.return_value.get_voice_preferences.assert_called_once_with(user_id="user-a")
 
 

--- a/consent-protocol/tests/test_onboarding_goal_agent.py
+++ b/consent-protocol/tests/test_onboarding_goal_agent.py
@@ -23,7 +23,11 @@ def test_available_action_ids_bound_matches_the_frontend_publisher():
     """
     field = OnboardingJourneyContext.model_fields["available_action_ids"]
     max_length = next(
-        (constraint.max_length for constraint in field.metadata if hasattr(constraint, "max_length")),
+        (
+            constraint.max_length
+            for constraint in field.metadata
+            if hasattr(constraint, "max_length")
+        ),
         PydanticUndefined,
     )
     assert max_length == 18

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -1390,9 +1390,7 @@ class TestBackendDirectCheckoutNearby:
                 OneLocationNearbyPresenceService, "checkout", autospec=True
             ) as checkout_mock,
         ):
-            result = await run_app_action(
-                "location.checkout_nearby", {}, _tool_context(state)
-            )
+            result = await run_app_action("location.checkout_nearby", {}, _tool_context(state))
         assert result["status"] == "completed"
         assert "checked you out" in result["message"].lower()
         checkout_mock.assert_called_once()
@@ -2721,7 +2719,9 @@ class TestBackendDirectActionResultSubject:
             ),
             patch.object(OneLocationCircleService, "leave_circle", autospec=True),
         ):
-            await run_app_action("location.leave_circle", {"circle": "family"}, _tool_context(state))
+            await run_app_action(
+                "location.leave_circle", {"circle": "family"}, _tool_context(state)
+            )
         assert self._parked_subject(state, "location.leave_circle") is None
 
     @pytest.mark.asyncio
@@ -2813,9 +2813,7 @@ class TestBackendDirectActionResultSubject:
             ),
             patch.object(ConnectionsService, "create_request", autospec=True),
         ):
-            await run_app_action(
-                "connect.send_request", {"person": "Sarah"}, _tool_context(state)
-            )
+            await run_app_action("connect.send_request", {"person": "Sarah"}, _tool_context(state))
         assert self._parked_subject(state, "connect.send_request") == {"name": "Sarah Chen"}
 
     @pytest.mark.asyncio
@@ -3277,7 +3275,9 @@ class TestBackendDirectLocationReadTools:
                 OneLocationAgentService,
                 "list_active_owner_grants",
                 autospec=True,
-                side_effect=OneLocationAgentError("LOCATION_STATE_UNAVAILABLE", "Try again shortly."),
+                side_effect=OneLocationAgentError(
+                    "LOCATION_STATE_UNAVAILABLE", "Try again shortly."
+                ),
             ),
         ):
             result = await list_my_location_shares(_tool_context(state))

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -14,13 +14,12 @@ import { cn } from "@/lib/utils";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { Badge } from "@/components/ui/badge";
 import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Sheet,
   SheetContent,
@@ -88,10 +87,6 @@ export interface AnalysisHistoryDashboardProps {
   ephemeralEntry?: AnalysisHistoryEntry | null;
 }
 
-type PopoverAnchorPosition = {
-  left: number;
-  top: number;
-};
 
 interface DebateCoverageRow {
   key: string;
@@ -816,7 +811,6 @@ export function AnalysisHistoryDashboard({
   const historyMapRef = useRef<AnalysisHistoryMap>({});
   const [versionsOpen, setVersionsOpen] = useState(false);
   const [versionsTicker, setVersionsTicker] = useState<string | null>(null);
-  const [versionsAnchor, setVersionsAnchor] = useState<PopoverAnchorPosition | null>(null);
   const [pendingDelete, setPendingDelete] = useState<PendingDeleteAction>(null);
   const [deleteInFlight, setDeleteInFlight] = useState(false);
 
@@ -1037,23 +1031,13 @@ export function AnalysisHistoryDashboard({
   const closeVersions = useCallback(() => {
     setVersionsOpen(false);
     setVersionsTicker(null);
-    setVersionsAnchor(null);
   }, []);
 
   const openVersions = useCallback((
     ticker: string,
-    event?: React.MouseEvent<HTMLTableRowElement> | React.KeyboardEvent<HTMLTableRowElement>,
+    _event?: React.MouseEvent<HTMLTableRowElement> | React.KeyboardEvent<HTMLTableRowElement>,
   ) => {
-    const rect = event?.currentTarget.getBoundingClientRect();
     setVersionsTicker(ticker);
-    setVersionsAnchor(
-      rect
-        ? { left: rect.left + rect.width / 2, top: rect.bottom }
-        : {
-            left: typeof window === "undefined" ? 0 : window.innerWidth / 2,
-            top: typeof window === "undefined" ? 0 : window.innerHeight / 2,
-          },
-    );
     setVersionsOpen(true);
   }, []);
 
@@ -1191,27 +1175,12 @@ export function AnalysisHistoryDashboard({
           </SheetContent>
         </Sheet>
       ) : (
-        <Popover open={versionsOpen} onOpenChange={(open) => !open && closeVersions()} modal>
-          {versionsAnchor ? (
-            <PopoverAnchor asChild>
-              <span
-                aria-hidden="true"
-                className="pointer-events-none fixed h-px w-px"
-                style={{ left: versionsAnchor.left, top: versionsAnchor.top }}
-              />
-            </PopoverAnchor>
-          ) : null}
-          <PopoverContent
-            align="center"
-            side="bottom"
-            sideOffset={8}
-            className="w-[min(28rem,calc(100vw-1.5rem))] p-0"
-            withBackdrop
-          >
-            <PopoverHeader className="border-b border-border/60 px-4 py-3">
-              <PopoverTitle>{versionsTicker ? `${versionsTicker} history` : "Analysis history"}</PopoverTitle>
-              <PopoverDescription>Choose a saved version to review.</PopoverDescription>
-            </PopoverHeader>
+        <Dialog open={versionsOpen} onOpenChange={(open) => !open && closeVersions()}>
+          <DialogContent className="w-[min(28rem,calc(100vw-1.5rem))] p-0 sm:max-w-md">
+            <DialogHeader className="border-b border-border/60 px-4 py-3">
+              <DialogTitle>{versionsTicker ? `${versionsTicker} history` : "Analysis history"}</DialogTitle>
+              <DialogDescription>Choose a saved version to review.</DialogDescription>
+            </DialogHeader>
             <div className="max-h-[min(28rem,calc(100vh-10rem))] overflow-y-auto p-3">
               <VersionOptions
                 entries={versionsForTicker}
@@ -1222,8 +1191,8 @@ export function AnalysisHistoryDashboard({
                 onDelete={(entry) => setPendingDelete({ kind: "entry", entry })}
               />
             </div>
-          </PopoverContent>
-        </Popover>
+          </DialogContent>
+        </Dialog>
       )}
 
       <AlertDialog


### PR DESCRIPTION
### Summary of Changes
* **UI Architecture Update:** Replaced the brittle `<Popover>` fallback with a standard Radix `<Dialog>` for the desktop Analysis History view.
* **Linting Cleanup:** Safely removed all unused `Popover` imports, types, and the `versionsAnchor` state to ensure the CI `Web Core (Next.js)` pipeline remains strictly green.

### Verification & Testing
* [x] **Desktop Web:** Verified that clicking history rows successfully opens a perfectly centered modal over the blurred background without freezing or rendering off-screen.
* [x] **Mobile/iOS Simulator:** Verified that the responsive `isMobile` `<Sheet>` still triggers and behaves identically from the bottom edge.
* [x] **Tests:** Ran ESLint locally (0 warnings/errors) and `npx vitest run kai` (passing).