### PR TITLE
fix(one): drop the agent roster slightly down the page

### DIFF
--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -852,7 +852,11 @@ export function OneAgentRoster({
     <section
       aria-labelledby="one-agents-heading"
       data-testid="one-agents-section"
-      className="mx-auto w-full max-w-[560px]"
+      // The roster sat flush against the header clearance while the launcher
+      // grid ended well short of the floating bottom bar, so the column read
+      // top-heavy. A small top offset drops the whole block (title, overflow
+      // menu, grid) into that slack.
+      className="mx-auto w-full max-w-[560px] pt-3 sm:pt-5"
     >
       <div className="mb-6 flex min-h-11 items-center justify-between gap-3">
         {isSearchOpen ? (


### PR DESCRIPTION
## What

Adds a small top offset to the `/one` agent roster — `pt-3 sm:pt-5` (12px, 20px from the `sm` breakpoint) on the roster `<section>`.

## Why

The section had no top offset at all, so the title row and launcher grid sat flush against the header clearance while the grid ended well short of the floating bottom bar. The column read top-heavy with dead space underneath. Shifting the block down uses the available column height more evenly.

## Scope

- `hushh-webapp/components/dashboard/one-agent-roster.tsx` — one className

Padding the roster section (rather than the page shell) keeps every other route's top-clearance layout contract untouched. Internal spacing of the block — title, overflow menu, grid gaps — is unchanged; the whole thing moves as a unit.

## Verification

`npx vitest run __tests__/components/one-dashboard-page.test.tsx` → 8/8 passing. `eslint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)