### PR TITLE
fix(ria): clarify Picks selector hierarchy

### DIFF
--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -144,12 +144,14 @@ vi.mock("@/components/profile/settings-ui", () => ({
     value,
     onValueChange,
     options,
+    className,
   }: {
     value: string;
     onValueChange: (value: string) => void;
     options: Array<{ value: string; label: string }>;
+    className?: string;
   }) => (
-    <div>
+    <div className={className}>
       {options.map((option) => (
         <button
           key={option.value}
@@ -432,6 +434,28 @@ describe("RiaPicksPage", () => {
         active_share_count: 1,
       },
     });
+  });
+
+  it("keeps the Picks collection selector visually stronger than category tabs", async () => {
+    render(<RiaPicksPage />);
+
+    await screen.findByText("NVDA");
+
+    const collectionSelector = screen.getByTestId("ria-picks-collection-selector")
+      .firstElementChild;
+    const categorySelector = screen.getByTestId("ria-picks-category-selector")
+      .firstElementChild;
+
+    expect(collectionSelector?.className).toContain("bg-[color:var(--app-card-surface)]");
+    expect(collectionSelector?.className).toContain("shadow-[var(--app-card-shadow-standard)]");
+    expect(collectionSelector?.className).toContain("[&>button]:min-h-12");
+    expect(collectionSelector?.className).toContain("[&>button[data-state=active]]:!bg-primary");
+    expect(categorySelector?.className).toContain("!border-0");
+    expect(categorySelector?.className).toContain("!shadow-none");
+    expect(categorySelector?.className).toContain("[&>button]:min-h-8");
+    expect(categorySelector?.className).toContain("[&>button]:!bg-transparent");
+    expect(categorySelector?.className).toContain("[&>button[data-state=active]]:!border-b-primary");
+    expect(categorySelector?.className).toContain("[&>button[data-state=active]]:!bg-transparent");
   });
 
   it("keeps upload and template actions out of the suggested list and exposes them in My list", async () => {

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2390,34 +2390,40 @@ export default function RiaPicksPage() {
           className="flex flex-col gap-6"
           {...(isDebateView ? { "data-no-route-swipe": "" } : {})}
         >
-          <div data-testid="ria-picks-primary">
-            <SettingsSegmentedTabs
-              value={source}
-              onValueChange={(value) => {
-                const nextSource = value as PicksSource;
-                setSource(nextSource);
-                setUploadOpen(false);
-                updatePicksRouteState({ source: nextSource });
-              }}
-              options={sourceOptions}
-              mobileColumns={2}
-            />
-          </div>
+          <div className="space-y-3">
+            <div data-testid="ria-picks-collection-selector">
+              <SettingsSegmentedTabs
+                value={source}
+                onValueChange={(value) => {
+                  const nextSource = value as PicksSource;
+                  setSource(nextSource);
+                  setUploadOpen(false);
+                  updatePicksRouteState({ source: nextSource });
+                }}
+                options={sourceOptions}
+                mobileColumns={2}
+                className="rounded-[var(--app-card-radius-compact)] border-[color:var(--app-separator-strong)] bg-[color:var(--app-card-surface)] p-1.5 shadow-[var(--app-card-shadow-standard)] [&>button]:min-h-12 [&>button]:rounded-[calc(var(--app-card-radius-compact)-4px)] [&>button]:text-[15px] [&>button]:font-semibold [&>button[data-state=active]]:!border-primary [&>button[data-state=active]]:!bg-primary [&>button[data-state=active]]:!text-primary-foreground [&>button[data-state=active]]:shadow-[var(--shadow-sm)]"
+              />
+            </div>
 
-          <SettingsSegmentedTabs
-            value={isDebateView ? "debate" : category}
-            onValueChange={(value) => {
-              if (value === "debate") {
-                updatePicksRouteState({ view: "debate" });
-                return;
-              }
-              const nextCategory = value as PicksCategory;
-              setCategory(nextCategory);
-              updatePicksRouteState({ category: nextCategory, view: null });
-            }}
-            options={categoryOptions}
-            mobileColumns={2}
-          />
+            <div data-testid="ria-picks-category-selector">
+              <SettingsSegmentedTabs
+                value={isDebateView ? "debate" : category}
+                onValueChange={(value) => {
+                  if (value === "debate") {
+                    updatePicksRouteState({ view: "debate" });
+                    return;
+                  }
+                  const nextCategory = value as PicksCategory;
+                  setCategory(nextCategory);
+                  updatePicksRouteState({ category: nextCategory, view: null });
+                }}
+                options={categoryOptions}
+                mobileColumns={2}
+                className="rounded-none !border-0 !bg-transparent !p-0 !shadow-none backdrop-blur-0 [&>button]:min-h-8 [&>button]:rounded-none [&>button]:!border-0 [&>button]:!border-b-2 [&>button]:!border-transparent [&>button]:!bg-transparent [&>button]:px-2 [&>button]:py-1.5 [&>button]:text-xs [&>button]:!font-normal [&>button]:!shadow-none [&>button[data-state=active]]:!border-b-primary [&>button[data-state=active]]:!bg-transparent [&>button[data-state=active]]:!text-foreground [&>button[data-state=active]]:!shadow-none"
+              />
+            </div>
+          </div>
 
           {isDebateView ? (
             iamUnavailable ? (


### PR DESCRIPTION
## Summary

- Clarifies the RIA Picks selector hierarchy by making Suggested list/My list read as the primary collection selector.
- Makes Top picks/Avoid/Screening/Debate read as quieter category tabs below the collection selector.
- Adds a focused Picks page regression test so the two levels do not collapse back to identical styling.

Closes #6029

## Scope

- Frontend-only: `hushh-webapp/app/ria/picks/page.tsx` and its page test.
- No backend, API, filtering, ranking, routing, auth, Talk to One, bottom nav, dependency, lockfile, or generated contract changes.

## Validation

- `npx.cmd vitest run __tests__/app/ria/picks-page.test.tsx`
- `npx.cmd eslint app/ria/picks/page.tsx __tests__/app/ria/picks-page.test.tsx --max-warnings=0`
- `npm.cmd run typecheck`
- `npm.cmd run verify:design-system`
- `npm.cmd run verify:docs`
- `npm.cmd run verify:cache`
- `git diff --check`

## Browser Notes

- Re-evaluated selector hierarchy with a temporary compiled-CSS Playwright harness at `1440x900`, `440x956`, `393x852`, and `375x812` in light and dark themes.
- Direct fresh-browser access to `/ria/picks` redirects to login, so protected-route visual proof requires an authenticated session; the harness used the same shared segmented-tab classes and generated CSS without changing app behavior.
- Result: primary selector is larger/filled/elevated, secondary selector is flat/no-shadow/no outer border with an underline active state, and no horizontal overflow was detected at the tested mobile widths.
