### PR TITLE
style(email): restyle Email Draft review card to match Gmail native compose design

### DIFF
--- a/hushh-webapp/components/agent/email-draft-card.tsx
+++ b/hushh-webapp/components/agent/email-draft-card.tsx
@@ -277,22 +277,9 @@ export function EmailDraftCard({
           </div>
         </div>
       ) : (
-        <div className="space-y-4 px-4 py-5 sm:px-5">
-          <label className="block">
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                To
-              </span>
-              {!showCcBcc ? (
-                <button
-                  type="button"
-                  onClick={() => setShowCcBcc(true)}
-                  className="text-xs font-medium text-primary transition-colors hover:underline focus-visible:outline-none"
-                >
-                  + CC / BCC
-                </button>
-              ) : null}
-            </div>
+        <div className="space-y-3 px-4 py-4 sm:px-5">
+          <div className="flex items-center gap-2 border-b border-border/60 py-1.5">
+            <span className="w-16 shrink-0 text-sm font-medium text-muted-foreground">To</span>
             <Input
               id={`${idPrefix}-to`}
               data-testid="one-email-draft-to"
@@ -300,17 +287,26 @@ export function EmailDraftCard({
               value={draft.to}
               onChange={(event) => updateDraft("to", event.target.value)}
               disabled={disabled}
-              placeholder="name@example.com"
+              placeholder="Recipients"
               aria-label="To"
-              className="h-11 rounded-xl bg-background/70 text-[15px]"
+              className="h-9 rounded-none border-0 bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0"
             />
-          </label>
+            {!showCcBcc ? (
+              <button
+                type="button"
+                onClick={() => setShowCcBcc(true)}
+                className="ml-auto shrink-0 text-xs font-medium text-primary transition-colors hover:underline focus-visible:outline-none"
+              >
+                + CC / BCC
+              </button>
+            ) : null}
+          </div>
 
           {showCcBcc ? (
-            <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid gap-2 sm:grid-cols-2">
               {(["cc", "bcc"] as const).map((field) => (
-                <label key={field}>
-                  <span className="mb-2 block text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                <div className="flex items-center gap-2 border-b border-border/60 py-1.5" key={field}>
+                  <span className="w-16 shrink-0 text-sm font-medium text-muted-foreground">
                     {field === "cc" ? "Cc" : "Bcc"}
                   </span>
                   <Input
@@ -322,17 +318,15 @@ export function EmailDraftCard({
                     disabled={disabled}
                     placeholder="Optional"
                     aria-label={field === "cc" ? "Cc" : "Bcc"}
-                    className="h-10 rounded-xl bg-background/70 text-[15px]"
+                    className="h-9 rounded-none border-0 bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0"
                   />
-                </label>
+                </div>
               ))}
             </div>
           ) : null}
 
-          <label className="block">
-            <span className="mb-2 block text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Subject
-            </span>
+          <div className="flex items-center gap-2 border-b border-border/60 py-1.5">
+            <span className="w-16 shrink-0 text-sm font-medium text-muted-foreground">Subject</span>
             <Input
               id={`${idPrefix}-subject`}
               data-testid="one-email-draft-subject"
@@ -340,15 +334,13 @@ export function EmailDraftCard({
               value={draft.subject}
               onChange={(event) => updateDraft("subject", event.target.value)}
               disabled={disabled}
+              placeholder="Subject"
               aria-label="Subject"
-              className="h-11 rounded-xl bg-background/70 text-[15px] font-medium"
+              className="h-9 rounded-none border-0 bg-transparent px-0 text-[15px] font-medium shadow-none focus-visible:ring-0"
             />
-          </label>
-          <label className="block">
-            <span className="mb-2 flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              <span>Message</span>
-              <span className="normal-case font-normal tracking-normal">Rich email</span>
-            </span>
+          </div>
+
+          <div className="pt-2">
             <EmailRichTextComposer
               disabled={disabled}
               id={`${idPrefix}-message`}
@@ -356,7 +348,7 @@ export function EmailDraftCard({
               showPreviewOnFirstContent={autoDraft}
               value={draft.body}
             />
-          </label>
+          </div>
 
           {missingDetails.length > 0 ? (
             <div

--- a/hushh-webapp/components/agent/email-rich-text.tsx
+++ b/hushh-webapp/components/agent/email-rich-text.tsx
@@ -149,7 +149,7 @@ function parseBlocks(value: string): EmailBlock[] {
       index += 1;
       continue;
     }
-    const bullet = line.match(/^[-*]\s+(.+)$/);
+    const bullet = line.match(/^[-*•]\s+(.+)$/);
     const numbered = line.match(/^\d+[.)]\s+(.+)$/);
     if (bullet || numbered) {
       const ordered = Boolean(numbered);
@@ -157,9 +157,10 @@ function parseBlocks(value: string): EmailBlock[] {
       while (index < lines.length) {
         const candidate = ordered
           ? (lines[index] ?? "").match(/^\d+[.)]\s+(.+)$/)
-          : (lines[index] ?? "").match(/^[-*]\s+(.+)$/);
+          : (lines[index] ?? "").match(/^[-*•]\s+(.+)$/);
         if (!candidate) break;
-        items.push(candidate[1] ?? "");
+        const cleanText = (candidate[1] ?? "").replace(/^[-*•]\s*/, "").trim();
+        items.push(cleanText);
         index += 1;
       }
       blocks.push({ kind: "list", ordered, items });
@@ -256,7 +257,7 @@ export function richEmailHtmlFromMarkdown(value: string): string {
       if (block.kind === "list") {
         const tag = block.ordered ? "ol" : "ul";
         return `<${tag} style="${EMAIL_BLOCK_STYLES.list}">${block.items
-          .map((item) => `<li style="${EMAIL_BLOCK_STYLES.listItem}">${inlineHtml(item)}</li>`)
+          .map((item) => `<li style="${EMAIL_BLOCK_STYLES.listItem}">${inlineHtml(item.replace(/^[-*•]\s*/, ""))}</li>`)
           .join("")}</${tag}>`;
       }
       if (block.kind === "quote") {
@@ -280,7 +281,7 @@ export function EmailRichTextPreview({
   className?: string;
 }) {
   return (
-    <div className={cn("space-y-3 text-sm leading-6 text-foreground", className)}>
+    <div className={cn("space-y-3 text-[15px] leading-7 text-foreground", className)}>
       {parseBlocks(value).map((block, index) => {
         const key = `email-block-${index}`;
         if (block.kind === "heading") {
@@ -303,14 +304,20 @@ export function EmailRichTextPreview({
           const Tag = block.ordered ? "ol" : "ul";
           return (
             <Tag
-              className={cn("space-y-1 pl-5", block.ordered ? "list-decimal" : "list-disc")}
+              className={cn(
+                "my-2 space-y-1.5 pl-6 text-[15px] leading-relaxed text-foreground",
+                block.ordered ? "list-decimal" : "list-disc",
+              )}
               key={key}
             >
-              {block.items.map((item, itemIndex) => (
-                <li key={`${key}-${itemIndex}`}>
-                  {inlineNodes(item, `${key}-${itemIndex}`)}
-                </li>
-              ))}
+              {block.items.map((item, itemIndex) => {
+                const cleanItem = item.replace(/^[-*•]\s*/, "").trim();
+                return (
+                  <li className="pl-1" key={`${key}-${itemIndex}`}>
+                    {inlineNodes(cleanItem, `${key}-${itemIndex}`)}
+                  </li>
+                );
+              })}
             </Tag>
           );
         }
@@ -469,8 +476,30 @@ export function EmailRichTextComposer({
   };
 
   return (
-    <div className="overflow-hidden rounded-[var(--app-radius-lg)] border border-border/80 bg-background shadow-sm">
-      <div className="flex flex-wrap items-center gap-2 border-b border-border/60 bg-muted/30 px-2.5 py-2">
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-background shadow-xs focus-within:border-primary/50 transition-colors">
+      {previewing ? (
+        <div
+          className="min-h-52 bg-background px-4 py-4 sm:px-5"
+          data-testid="one-email-rich-preview"
+        >
+          <EmailRichTextPreview value={value} />
+        </div>
+      ) : (
+        <Textarea
+          aria-label="Message"
+          className="min-h-52 resize-y rounded-none border-0 bg-transparent px-4 py-4 text-[15px] leading-relaxed placeholder:text-muted-foreground/60 shadow-none focus-visible:ring-0 sm:px-5"
+          data-testid="one-email-draft-message"
+          disabled={disabled}
+          id={id}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Write your message…"
+          ref={textareaRef}
+          value={value}
+        />
+      )}
+
+      {/* Gmail-style minimal bottom toolbar row */}
+      <div className="flex flex-wrap items-center gap-2 border-t border-border/50 bg-background/60 px-3 py-1.5">
         <div aria-label="Text formatting" className="flex min-w-0 items-center gap-0.5" role="toolbar">
           {FORMATTING_CONTROLS.map(({ label, action }) => {
             const Icon = formattingIcon(action);
@@ -483,7 +512,7 @@ export function EmailRichTextComposer({
                 size="icon"
                 type="button"
                 variant="ghost"
-                className="h-8 w-8 rounded-lg"
+                className="h-7 w-7 rounded-md text-muted-foreground hover:bg-muted/70 hover:text-foreground"
               >
                 <Icon className="h-3.5 w-3.5" />
               </Button>
@@ -495,7 +524,7 @@ export function EmailRichTextComposer({
             <>
               <Input
                 aria-label="Link URL"
-                className="h-8 w-32 rounded-lg bg-background text-xs sm:w-44"
+                className="h-7 w-28 rounded-md bg-background/80 text-xs sm:w-40"
                 disabled={disabled}
                 onChange={(event) => setLinkUrl(event.target.value)}
                 placeholder="https://…"
@@ -508,7 +537,7 @@ export function EmailRichTextComposer({
                 size="sm"
                 type="button"
                 variant="ghost"
-                className="h-8 gap-1 rounded-lg px-2 text-xs"
+                className="h-7 gap-1 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground"
               >
                 <Link2 className="h-3.5 w-3.5" />
                 Link
@@ -521,33 +550,13 @@ export function EmailRichTextComposer({
             size="sm"
             type="button"
             variant="ghost"
-            className="h-8 gap-1 rounded-lg px-2 text-xs"
+            className="h-7 gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground hover:text-foreground"
           >
             {previewing ? <PencilLine className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             {previewing ? "Edit" : "Preview"}
           </Button>
         </div>
       </div>
-      {previewing ? (
-        <div
-          className="min-h-52 bg-background px-4 py-5 sm:px-5"
-          data-testid="one-email-rich-preview"
-        >
-          <EmailRichTextPreview value={value} />
-        </div>
-      ) : (
-        <Textarea
-          aria-label="Message"
-          className="min-h-52 resize-y rounded-none border-0 bg-transparent px-4 py-4 text-[15px] leading-7 shadow-none focus-visible:ring-0 sm:px-5"
-          data-testid="one-email-draft-message"
-          disabled={disabled}
-          id={id}
-          onChange={(event) => onChange(event.target.value)}
-          placeholder="Write your message…"
-          ref={textareaRef}
-          value={value}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Summary
Restyles the Email Draft review card component tree to match Gmail's native compose window design aesthetic (flat, minimal, borderless fields with a bottom inline formatting bar).

---

## 🛠️ Changes Included in this Commit

1. **Flat Gmail-Style Input Fields (`email-draft-card.tsx`)**:
   - Replaced rounded input containers (`rounded-xl bg-background/70`) and uppercase micro-labels (`TO`, `SUBJECT`) with flat, borderless fields featuring a subtle bottom border (`border-b border-border/60`).
   - Integrated muted left inline labels (`To`, `Cc`, `Bcc`, `Subject`) directly into the field row.
   - Retained the `+ CC / BCC` toggle button inline next to `To`.

2. **Native HTML List Rendering (`email-rich-text.tsx`)**:
   - Cleaned literal bullet characters (`-`, `*`, `•`) from parsed items.
   - Rendered bullet drafts as native `<ul><li className="list-disc pl-6 leading-relaxed">` elements with bold `<strong>` labels and hanging indents.

3. **Quiet Bottom Toolbar (`email-rich-text.tsx`)**:
   - Repositioned text formatting controls to a slim, subtle bottom bar (`border-t border-border/50 bg-background/60 px-3 py-1.5`) below the text area.
   - Removed the heavy top header panel and removed the unnecessary `"Rich email"` tag.

---

## 🧪 Verification
- [x] **Bullet Lists**: Bullet drafts render as native HTML `<ul><li>` with bullet markers (`list-disc`), hanging indents, and bold inline labels, with zero literal `-` text.
- [x] **Editability & Controls**: Raw text editing and rich text actions (Bold, Italic, Underline, Lists, Links) function cleanly.
- [x] **Unit Tests**: Passed 2/2 tests in `__tests__/app/one/email/email-agent-page-client.test.tsx`.
- [x] **Isolated Commit**: Contains strictly the UI restyling diff on a fresh branch off `origin/main`.