### PR TITLE
fix(one-location): allow multiple concurrent public location links

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -502,6 +502,14 @@ def _hash_public_value(value: str) -> str:
 # before it posts.
 PUBLIC_INVITE_MAX_DURATION_HOURS = 1.0
 
+# Multiple public links can be live for the same owner at once -- Link A to one
+# person for 15 minutes, Link B to another for an hour, independently. Nothing
+# here rejects a second, a third, or a tenth. This cap exists only so that
+# create_public_invite can't be hammered into leaving an unbounded number of
+# rows active for one owner; it is an abuse guard, not a product limit anyone
+# is expected to reach.
+PUBLIC_INVITE_MAX_ACTIVE_PER_OWNER = 10
+
 _PUBLIC_INVITE_TOKEN_DOMAIN = b"one-location-public-invite-token:v1:"
 _PUBLIC_INVITE_CODE_VERSION = "derived-v1"
 
@@ -6787,9 +6795,8 @@ class OneLocationAgentService:
                 "A public location link can stay live for at most 1 hour.",
                 status_code=422,
             )
-        # Validated before either branch below: a malformed snapshot is a 422
-        # whether this call mints a link or refreshes the live one, and doing it
-        # here means the reuse path cannot write a half-checked point.
+        # Validated before it mints anything: a malformed snapshot is a 422,
+        # not a link created with a half-checked point.
         public_location = self._public_location_snapshot_payload(location_snapshot)
         # The name the recipient will see, stamped onto the row so a reader
         # needs no identity lookup. `resolve_public_invite` resolves it again
@@ -6798,8 +6805,8 @@ class OneLocationAgentService:
 
         # Expiry is written lazily -- `_expire_public_invite` only flips a row
         # when something reads it -- so a link whose time has passed can still
-        # be sitting at status 'active'. Settle that here first, or the reuse
-        # check below hands back a dead link instead of minting a fresh one.
+        # be sitting at status 'active'. Settle that here first, so it never
+        # counts against the simultaneous-link cap below.
         self._execute_one(
             """
             UPDATE one_location_public_invites
@@ -6811,131 +6818,35 @@ class OneLocationAgentService:
             {"owner_user_id": owner_user_id},
         )
 
-        # One live public link per person, enforced where it can actually hold.
+        # Multiple public links can be live for one owner at the same time --
+        # a 15-minute link to one person and an hour-long link to another,
+        # each independently resolvable, each revoked or expired on its own.
+        # Every call here mints its own row, its own token and its own window;
+        # nothing above is looked up or touched by it.
         #
-        # Nothing stopped a second: no unique index, no lookup, just an INSERT.
-        # A reload, a second device or a double tap therefore left two links
-        # resolvable while the screen showed one, and revoking the one on
-        # screen left the other watching. The client now hides its create
-        # control while a link is live, but a client rule is not an invariant --
-        # a stale tab defeats it.
-        #
-        # Reuse rather than reject: this is the same call the person makes when
-        # they mean "give me my link", and a 409 would be a dead end on a
-        # screen whose whole job is to hand it over. Matches
-        # `one_location_circle_service.create_invite_code`, which returns the
-        # circle's existing active code rather than minting a second.
-        existing = self._execute_one(
-            """
-            SELECT *
-            FROM one_location_public_invites
-            WHERE owner_user_id = :owner_user_id
-              AND status = 'active'
-              AND expires_at > NOW()
-            ORDER BY created_at DESC
-            LIMIT 1
-            """,
-            {"owner_user_id": owner_user_id},
-        )
-        if existing:
-            existing_token = _public_invite_token_if_derivable(existing)
-            if existing_token:
-                # Reuse used to hand the row back exactly as it was found, and
-                # that made this call lie twice.
-                #
-                # Expiry: the person picked a duration and pressed a control
-                # labelled "Create link". Returning a link with four minutes
-                # left on it because one was minted 56 minutes ago breaks the
-                # only promise the screen makes -- "link stays live for 1 hour"
-                # -- and nothing on screen could contradict it, because the
-                # countdown shown afterwards is read from this row, so it
-                # agreed with the wrong answer. The window is restarted from
-                # now for exactly the duration that was asked for, in both
-                # directions: shortening is equally deliberate, and only the
-                # owner can ask for it.
-                #
-                # Snapshot: the caller has just captured a fresh point (every
-                # entry point runs the readiness gate before it posts). Keeping
-                # the old one meant a reused link opened on where the owner was
-                # up to an hour ago, presented as where they are now.
-                #
-                # Label: written on every pass, so a link minted before the
-                # name was recorded -- or one whose owner has since set a
-                # display name -- stops reading "A trusted person".
-                existing_metadata = _loads_json(existing.get("metadata")) or {}
-                if not isinstance(existing_metadata, dict):
-                    existing_metadata = {}
-                refreshed_metadata = dict(existing_metadata)
-                refreshed_metadata["codeVersion"] = _PUBLIC_INVITE_CODE_VERSION
-                if public_location:
-                    refreshed_metadata["publicLocation"] = public_location
-                if owner_safe_label:
-                    refreshed_metadata["owner_safe_label"] = owner_safe_label
-                refreshed = self._execute_one(
-                    """
-                    UPDATE one_location_public_invites
-                    SET duration_hours = :duration_hours,
-                        expires_at = NOW() + (
-                          CAST(:duration_hours AS double precision) * INTERVAL '1 hour'
-                        ),
-                        metadata = CAST(:metadata_json AS JSONB),
-                        updated_at = NOW()
-                    WHERE id = CAST(:invite_id AS UUID)
-                      AND status = 'active'
-                    RETURNING *
-                    """,
-                    {
-                        "invite_id": str(existing.get("id") or ""),
-                        "duration_hours": duration,
-                        "metadata_json": _json_param_with_public_location(refreshed_metadata),
-                    },
-                )
-                # Only the row the UPDATE actually wrote. The SELECT above and
-                # this UPDATE are separate statements, so a second device -- or
-                # the `revoke_public_link` agent tool -- can revoke the invite
-                # in between; the UPDATE is guarded on `status = 'active'` and
-                # returns nothing when that happens. Falling back to the row
-                # the SELECT read would hand the owner a link whose stored
-                # status still says 'active', so `_public_invite_payload`
-                # would attach a `publicUrl` -- a link they can copy and share
-                # that 410s the first time anyone opens it. Falling through to
-                # the mint path instead gives them a link that works, which is
-                # what they asked for.
-                existing_payload = self._public_invite_payload(refreshed) if refreshed else None
-                if existing_payload:
-                    self._insert_event(
-                        owner_user_id=owner_user_id,
-                        actor_user_id=owner_user_id,
-                        event_type="location_public_invite_created",
-                        metadata={
-                            "invite_id": existing_payload["id"],
-                            "duration_hours": duration,
-                            "location_snapshot": ("attached" if public_location else "none"),
-                            "reused": True,
-                        },
-                    )
-                    return {
-                        "invite": existing_payload,
-                        "publicToken": existing_token,
-                        "publicUrl": _public_invite_url(existing_token),
-                        # The caller asked for a link and got one; it is simply
-                        # the one that was already live. Named so a client can
-                        # tell "created" from "here is the one you have" without
-                        # comparing timestamps.
-                        "reused": True,
-                    }
-            # A row minted before tokens were derivable, or one whose digest no
-            # longer verifies. Its token is genuinely unrecoverable, so leaving
-            # it active would strand the owner behind a link nothing can show.
-            # Retire it and mint a replacement rather than refuse.
+        # The only gate is a count, to keep this from being hammered into an
+        # unbounded number of rows for one owner.
+        active_count_row = (
             self._execute_one(
                 """
-                UPDATE one_location_public_invites
-                SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
-                WHERE id = CAST(:invite_id AS UUID)
+                SELECT COUNT(*)::int AS active_count
+                FROM one_location_public_invites
+                WHERE owner_user_id = :owner_user_id
                   AND status = 'active'
+                  AND expires_at > NOW()
                 """,
-                {"invite_id": str(existing.get("id") or "")},
+                {"owner_user_id": owner_user_id},
+            )
+            or {}
+        )
+        if int(active_count_row.get("active_count") or 0) >= PUBLIC_INVITE_MAX_ACTIVE_PER_OWNER:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_LIMIT",
+                (
+                    f"You can have at most {PUBLIC_INVITE_MAX_ACTIVE_PER_OWNER} live "
+                    "location links at once. Stop one before creating another."
+                ),
+                status_code=429,
             )
 
         # The id is chosen here rather than by the default, because the token is

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2632,22 +2632,6 @@ class FourUserMemoryService(OneLocationAgentService):
                 invite["updated_at"] = datetime.now(timezone.utc)
                 return invite
             return None
-        if (
-            "UPDATE one_location_public_invites" in sql
-            and "SET duration_hours = :duration_hours" in sql
-        ):
-            # Reuse restarts the window for the duration that was just asked
-            # for, refreshes the snapshot, and rewrites the owner label.
-            invite = self.public_invites.get(params["invite_id"])
-            if not invite or invite["status"] != "active":
-                return None
-            invite["duration_hours"] = params["duration_hours"]
-            invite["expires_at"] = datetime.now(timezone.utc) + timedelta(
-                hours=float(params["duration_hours"])
-            )
-            invite["metadata"] = json.loads(params.get("metadata_json") or "{}")
-            invite["updated_at"] = datetime.now(timezone.utc)
-            return invite
         if "FROM one_location_public_invites i" in sql:
             for invite in self.public_invites.values():
                 if invite["public_code_hash"] == params["public_code_hash"]:
@@ -2663,9 +2647,9 @@ class FourUserMemoryService(OneLocationAgentService):
             and "status = 'expired'" in sql
             and "owner_user_id" in params
         ):
-            # Settling lazily-expired rows before the reuse lookup. Expiry is
-            # written only when something reads a row, so a link past its time
-            # can still be sitting at 'active'.
+            # Settling lazily-expired rows before the active-count check.
+            # Expiry is written only when something reads a row, so a link
+            # past its time can still be sitting at 'active'.
             now = datetime.now(timezone.utc)
             for invite in self.public_invites.values():
                 if (
@@ -2686,22 +2670,19 @@ class FourUserMemoryService(OneLocationAgentService):
                 invite["revoked_at"] = datetime.now(timezone.utc)
                 return invite
             return None
-        if (
-            "FROM one_location_public_invites" in sql
-            and "expires_at > NOW()" in sql
-            and "owner_user_id" in params
-        ):
-            # The reuse lookup: one live public link per person.
+        if "COUNT(*)::int AS active_count" in sql:
+            # The simultaneous-link cap: a count, not a lookup. Multiple
+            # links stay independently live for one owner; this only bounds
+            # how many.
             now = datetime.now(timezone.utc)
-            live = [
-                invite
+            active_count = sum(
+                1
                 for invite in self.public_invites.values()
                 if invite["owner_user_id"] == params["owner_user_id"]
                 and invite["status"] == "active"
                 and invite["expires_at"] > now
-            ]
-            live.sort(key=lambda invite: invite["created_at"], reverse=True)
-            return live[0] if live else None
+            )
+            return {"active_count": active_count}
         if "UPDATE one_location_public_invites" in sql and "status = 'expired'" in sql:
             # `AND expires_at <= NOW()` is part of the statement now, so the
             # double has to answer the same question the database would:
@@ -4521,98 +4502,100 @@ def test_public_invite_label_rejects_a_uid_sitting_in_the_name_column() -> None:
     assert resolved["invite"]["ownerLabel"] == "A trusted person"
 
 
-def test_public_invite_reuse_honours_the_duration_that_was_just_asked_for() -> None:
-    """A link created for an hour is live for an hour, not for what is left.
+def test_a_second_link_never_touches_the_durations_or_expiry_of_the_first() -> None:
+    """Link A's window belongs to Link A, no matter what Link B asks for.
 
-    One live public link per owner, and the second call reused the first row
-    verbatim -- so picking "1 hour" 56 minutes into an existing link handed
-    back four minutes, and the countdown afterwards agreed with it because it
-    reads the same row. The window restarts from now, for exactly what was
-    asked.
+    create_public_invite used to look an owner's existing link up and rewrite
+    it in place, so picking "1 hour" for a second link silently restarted the
+    first link's window too -- and both people watching it agreed with the
+    wrong answer, because the countdown each of them saw read the same row.
+    Two links now own two rows; creating the second must leave the first's
+    duration and expiry exactly where they were.
     """
 
     service = FourUserMemoryService()
-    first = service.create_public_invite(owner_user_id="user_a", duration_hours=0.5)
-    first_row = next(iter(service.public_invites.values()))
-    # Wind the existing link down to its last four minutes.
-    first_row["expires_at"] = datetime.now(timezone.utc) + timedelta(minutes=4)
+    link_a = service.create_public_invite(owner_user_id="user_a", duration_hours=0.25)
+    row_a = service.public_invites[link_a["invite"]["id"]]
+    expires_at_a_before = row_a["expires_at"]
 
-    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    link_b = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    row_b = service.public_invites[link_b["invite"]["id"]]
 
-    assert second.get("reused") is True
-    # Same link -- the one-at-a-time invariant still holds.
-    assert second["publicToken"] == first["publicToken"]
-    assert len(service.public_invites) == 1
-
-    remaining = datetime.fromisoformat(second["invite"]["expiresAt"]) - datetime.now(timezone.utc)
-    assert remaining > timedelta(minutes=55)
-    assert remaining <= timedelta(hours=1)
-    assert second["invite"]["durationHours"] == 1
+    assert link_a["publicToken"] != link_b["publicToken"]
+    assert link_a["invite"]["id"] != link_b["invite"]["id"]
+    assert row_a["expires_at"] == expires_at_a_before
+    assert row_a["duration_hours"] == 0.25
+    assert row_b["duration_hours"] == 1
+    assert row_a["status"] == "active"
+    assert row_b["status"] == "active"
 
 
-def test_public_invite_reuse_shows_where_the_owner_is_now() -> None:
-    # Reuse used to keep the snapshot the first call attached, so a link handed
-    # back 50 minutes later opened on where the owner had been, presented as
-    # where they are.
+def test_each_link_keeps_its_own_location_snapshot() -> None:
+    # A second link used to rewrite the first row's snapshot along with
+    # everything else, so a person already holding Link A would suddenly see
+    # wherever the owner was when they made Link B.
     service = FourUserMemoryService()
-    first_point = {
+    point_a = {
         "latitude": 28.6139,
         "longitude": 77.209,
         "accuracyM": 12,
         "capturedAt": "2026-08-23T02:06:00.000Z",
         "sourcePlatform": "web",
     }
-    second_point = {
+    point_b = {
         "latitude": 25.1441,
         "longitude": 75.8446,
         "accuracyM": 9,
         "capturedAt": "2026-08-23T02:56:00.000Z",
         "sourcePlatform": "web",
     }
-    service.create_public_invite(
-        owner_user_id="user_a", duration_hours=1, location_snapshot=first_point
+    link_a = service.create_public_invite(
+        owner_user_id="user_a", duration_hours=0.25, location_snapshot=point_a
     )
-    second = service.create_public_invite(
-        owner_user_id="user_a", duration_hours=1, location_snapshot=second_point
+    link_b = service.create_public_invite(
+        owner_user_id="user_a", duration_hours=1, location_snapshot=point_b
     )
 
-    resolved = service.resolve_public_invite(public_token=second["publicToken"])
-    assert resolved["publicLocation"]["latitude"] == 25.1441
-    assert resolved["publicLocation"]["longitude"] == 75.8446
+    resolved_a = service.resolve_public_invite(public_token=link_a["publicToken"])
+    resolved_b = service.resolve_public_invite(public_token=link_b["publicToken"])
+    assert resolved_a["publicLocation"]["latitude"] == 28.6139
+    assert resolved_a["publicLocation"]["longitude"] == 77.209
+    assert resolved_b["publicLocation"]["latitude"] == 25.1441
+    assert resolved_b["publicLocation"]["longitude"] == 75.8446
 
 
-def test_public_invite_reuse_mints_a_new_link_when_the_old_one_was_just_revoked() -> None:
-    """The reuse UPDATE is guarded on `status = 'active'`, so it can write nothing.
-
-    A second device -- or the `revoke_public_link` agent tool -- can revoke the
-    invite between the SELECT that finds it and the UPDATE that refreshes it.
-    Falling back to the row the SELECT read would hand the owner a link whose
-    stored status still says 'active', which means `_public_invite_payload`
-    attaches a `publicUrl`: a link they can copy and share that 410s the first
-    time anyone opens it. Minting instead gives them one that works.
-    """
-
+def test_revoking_one_link_leaves_a_second_link_resolvable() -> None:
+    # Revoking used to be the only way to make a second link, because create
+    # would otherwise hand the first one back. Now it is just an independent
+    # action on Link A that must have no effect on Link B.
     service = FourUserMemoryService()
-    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-    first_row = next(iter(service.public_invites.values()))
+    link_a = service.create_public_invite(owner_user_id="user_a", duration_hours=0.25)
+    link_b = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
 
-    original_execute_one = service._execute_one
+    service.revoke_public_invite(owner_user_id="user_a", invite_id=link_a["invite"]["id"])
 
-    def revoke_between_select_and_update(sql, params=None):
-        if "UPDATE one_location_public_invites" in sql and "SET duration_hours" in sql:
-            first_row["status"] = "revoked"
-        return original_execute_one(sql, params)
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        service.resolve_public_invite(public_token=link_a["publicToken"])
+    assert excinfo.value.code == "LOCATION_PUBLIC_INVITE_NOT_ACTIVE"
 
-    service._execute_one = revoke_between_select_and_update
-    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-    service._execute_one = original_execute_one
+    resolved_b = service.resolve_public_invite(public_token=link_b["publicToken"])
+    assert resolved_b["invite"]["status"] == "active"
 
-    assert second.get("reused") is not True
-    assert second["publicToken"] != first["publicToken"]
-    assert second["invite"]["status"] == "active"
-    # And the link handed back really does resolve.
-    resolved = service.resolve_public_invite(public_token=second["publicToken"])
-    assert resolved["invite"]["status"] == "active"
+
+def test_expiring_one_link_leaves_a_second_link_valid() -> None:
+    service = FourUserMemoryService()
+    link_a = service.create_public_invite(owner_user_id="user_a", duration_hours=0.25)
+    link_b = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    service.public_invites[link_a["invite"]["id"]]["expires_at"] = datetime.now(
+        timezone.utc
+    ) - timedelta(minutes=1)
+
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        service.resolve_public_invite(public_token=link_a["publicToken"])
+    assert excinfo.value.code == "LOCATION_PUBLIC_INVITE_NOT_ACTIVE"
+
+    resolved_b = service.resolve_public_invite(public_token=link_b["publicToken"])
+    assert resolved_b["invite"]["status"] == "active"
 
 
 def test_public_invite_resolve_names_the_sharer_on_a_link_minted_before_the_write() -> None:
@@ -4674,8 +4657,8 @@ def test_public_invite_expiry_is_decided_by_the_database_clock() -> None:
     assert "_utcnow()" not in expire_source
 
     create_source = inspect.getsource(module.OneLocationAgentService.create_public_invite)
-    # ...and so does the stamp, on both the mint and the reuse path.
-    assert create_source.count("INTERVAL '1 hour'") == 2
+    # ...and so does the stamp, on the one path every link is minted through.
+    assert create_source.count("INTERVAL '1 hour'") == 1
     assert "_utcnow() + timedelta" not in create_source
 
     # Behaviourally: a link inside its window survives a read.
@@ -6824,11 +6807,17 @@ def test_the_recipient_payload_never_carries_the_token(_public_invite_key) -> No
 
 
 # ---------------------------------------------------------------------------
-# One live public location link per person.
+# Multiple public location links, live at the same time, for the same owner.
 #
-# Nothing used to stop a second: no unique index, no lookup, just an INSERT. A
-# reload, a second device or a double tap left two links resolvable while the
-# screen showed one, and revoking the visible one left the other watching.
+# create_public_invite used to look an owner's live link up and hand it back
+# rewritten -- "reused": True -- rather than mint a second: one live public
+# link per person, enforced server-side. That meant Link A to one person for
+# 15 minutes and Link B to another for an hour could never both exist; making
+# B silently rewrote A's token, duration, expiry and snapshot out from under
+# whoever already had it. Every call here now mints its own row. The only
+# thing still bounded is how many rows one owner can have active at once
+# (`PUBLIC_INVITE_MAX_ACTIVE_PER_OWNER`), which is an abuse guard, not a
+# product limit.
 # ---------------------------------------------------------------------------
 
 
@@ -6836,31 +6825,30 @@ def _active_public_invites(service) -> list[dict]:
     return [invite for invite in service.public_invites.values() if invite["status"] == "active"]
 
 
-def test_creating_a_second_public_link_hands_back_the_first() -> None:
+def test_two_links_of_different_durations_stay_independently_active() -> None:
+    """Link A -> 15 min, Link B -> 1 hour. Both live, independently, at once."""
+
     service = FourUserMemoryService()
 
-    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    link_a = service.create_public_invite(owner_user_id="user_a", duration_hours=0.25)
+    link_b = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
 
-    # Same link, not a second one: this call is what the person makes when they
-    # mean "give me my link", so it answers rather than refusing.
-    assert second["publicToken"] == first["publicToken"]
-    assert second["invite"]["id"] == first["invite"]["id"]
-    assert second["reused"] is True
-    assert first.get("reused") is not True
-    assert len(_active_public_invites(service)) == 1
+    # Distinct tokens, distinct rows.
+    assert link_a["publicToken"] != link_b["publicToken"]
+    assert link_a["invite"]["id"] != link_b["invite"]["id"]
 
+    # Both rows remain active, and each keeps the duration it was given.
+    active = _active_public_invites(service)
+    assert len(active) == 2
+    assert link_a["invite"]["durationHours"] == 0.25
+    assert link_b["invite"]["durationHours"] == 1
 
-def test_the_reused_link_still_resolves() -> None:
-    # The point of reuse is that whoever already holds the link keeps seeing
-    # the owner. A token handed back that no longer resolved would be worse
-    # than a second link.
-    service = FourUserMemoryService()
-    service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-    reused = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-
-    resolved = service.resolve_public_invite(public_token=reused["publicToken"])
-    assert resolved["invite"]["status"] == "active"
+    # Revoking A must not touch B.
+    service.revoke_public_invite(owner_user_id="user_a", invite_id=link_a["invite"]["id"])
+    assert service.public_invites[link_a["invite"]["id"]]["status"] == "revoked"
+    assert service.public_invites[link_b["invite"]["id"]]["status"] == "active"
+    resolved_b = service.resolve_public_invite(public_token=link_b["publicToken"])
+    assert resolved_b["invite"]["status"] == "active"
 
 
 def test_one_persons_link_does_not_block_another_persons() -> None:
@@ -6873,7 +6861,7 @@ def test_one_persons_link_does_not_block_another_persons() -> None:
     assert len(_active_public_invites(service)) == 2
 
 
-def test_revoking_frees_the_person_to_create_another() -> None:
+def test_revoking_one_link_does_not_stop_another_from_being_created() -> None:
     service = FourUserMemoryService()
 
     first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
@@ -6881,15 +6869,14 @@ def test_revoking_frees_the_person_to_create_another() -> None:
     second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
 
     assert second["publicToken"] != first["publicToken"]
-    assert second.get("reused") is not True
     assert len(_active_public_invites(service)) == 1
 
 
-def test_an_expired_link_does_not_block_a_new_one() -> None:
+def test_a_stale_expired_link_does_not_count_against_the_active_cap() -> None:
     # Expiry is written lazily -- only when something reads the row -- so a
-    # link past its time can still be sitting at status 'active'. If create did
-    # not settle that first, the reuse lookup would hand back a dead link and
-    # the person could never make another.
+    # link past its time can still be sitting at status 'active'. create must
+    # settle that first, or a stale row would eat into the simultaneous-link
+    # cap forever.
     service = FourUserMemoryService()
 
     first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
@@ -6900,27 +6887,36 @@ def test_an_expired_link_does_not_block_a_new_one() -> None:
     second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
 
     assert second["publicToken"] != first["publicToken"]
-    assert second.get("reused") is not True
     assert stale["status"] == "expired"
     assert len(_active_public_invites(service)) == 1
 
 
-def test_a_link_whose_token_cannot_be_recovered_is_replaced() -> None:
-    # A row minted before tokens were derived from the id. Its token is gone
-    # for good, so leaving it active would strand the owner behind a link
-    # nothing can show and no create button.
+def test_a_tenth_link_succeeds_and_an_eleventh_is_rejected() -> None:
+    # The cap is an abuse guard, not a product limit: nine calls in, a tenth
+    # must still mint a fresh, independent link exactly like the first did.
     service = FourUserMemoryService()
 
-    first = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
-    legacy = service.public_invites[first["invite"]["id"]]
-    legacy["metadata"] = {}
+    created = [
+        service.create_public_invite(owner_user_id="user_a", duration_hours=1) for _ in range(10)
+    ]
+    assert len({invite["publicToken"] for invite in created}) == 10
+    assert len(_active_public_invites(service)) == 10
 
-    second = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    with pytest.raises(OneLocationAgentError) as excinfo:
+        service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    assert excinfo.value.code == "LOCATION_PUBLIC_INVITE_LIMIT"
+    assert excinfo.value.status_code == 429
+    # Rejected consistently, not as a one-time fluke: calling again while still
+    # at the cap must not somehow squeeze a row in.
+    with pytest.raises(OneLocationAgentError):
+        service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    assert len(_active_public_invites(service)) == 10
 
-    assert second["publicToken"] != first["publicToken"]
-    assert second.get("reused") is not True
-    assert legacy["status"] == "revoked"
-    assert len(_active_public_invites(service)) == 1
+    # Revoking one frees exactly one slot.
+    service.revoke_public_invite(owner_user_id="user_a", invite_id=created[0]["invite"]["id"])
+    eleventh = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    assert eleventh["publicToken"] not in {invite["publicToken"] for invite in created}
+    assert len(_active_public_invites(service)) == 10
 
 
 def test_the_owners_state_carries_the_link_back() -> None:
@@ -6981,14 +6977,18 @@ def test_a_public_link_cannot_be_asked_to_live_longer_than_an_hour() -> None:
 
 
 def test_the_durations_the_screen_offers_are_accepted() -> None:
+    # 15 min, 30 min and 1 hour, all live at once -- picking a shorter or
+    # longer duration for a new link is independent of whatever else is live.
     service = FourUserMemoryService()
 
+    quarter = service.create_public_invite(owner_user_id="user_a", duration_hours=0.25)
     half = service.create_public_invite(owner_user_id="user_a", duration_hours=0.5)
-    assert half["invite"]["durationHours"] == 0.5
-
-    service.revoke_public_invite(owner_user_id="user_a", invite_id=half["invite"]["id"])
     whole = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    assert quarter["invite"]["durationHours"] == 0.25
+    assert half["invite"]["durationHours"] == 0.5
     assert whole["invite"]["durationHours"] == 1
+    assert len(_active_public_invites(service)) == 3
 
 
 def test_sos_reaches_someone_added_through_the_emergency_circle() -> None:

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -53,6 +53,7 @@ const {
   mockApproveRequest,
   mockUpdateAutoApprovePreference,
   mockCreatePublicInvite,
+  mockRevokePublicInvite,
   mockCreateCircleInvite,
   mockListCircles,
   mockGetCircle,
@@ -110,6 +111,7 @@ const {
   mockApproveRequest: vi.fn(),
   mockUpdateAutoApprovePreference: vi.fn(),
   mockCreatePublicInvite: vi.fn(),
+  mockRevokePublicInvite: vi.fn(),
   mockCreateCircleInvite: vi.fn(),
   mockListCircles: vi.fn(),
   mockGetCircle: vi.fn(),
@@ -343,7 +345,7 @@ vi.mock("@/lib/one-location/service", () => ({
     referRecipient: vi.fn(),
     createPublicInvite: mockCreatePublicInvite,
     createCircleInvite: mockCreateCircleInvite,
-    revokePublicInvite: vi.fn(),
+    revokePublicInvite: mockRevokePublicInvite,
     revokeCircleInvite: vi.fn(),
     // Named-circle surface: the mandatory onboarding invite screen
     // find-or-creates the user's first owned Circle and issues its
@@ -1176,6 +1178,7 @@ describe("OneLocationAgentPage", () => {
     mockCreatePublicInvite.mockResolvedValue({
       publicUrl: "/one/location/view/invite_1",
     });
+    mockRevokePublicInvite.mockResolvedValue({});
     mockListCircles.mockResolvedValue([]);
     mockGetCircle.mockResolvedValue(undefined);
     mockListCircleMembersPage.mockResolvedValue({
@@ -3771,6 +3774,7 @@ describe("OneLocationAgentPage", () => {
       ),
     ).toBeTruthy();
     expect(screen.getByText("Duration")).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "15 min" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "30 min" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "1 hour" })).toBeTruthy();
     expect(screen.queryByText("Active links")).toBeNull();
@@ -4231,9 +4235,13 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("button", { name: /Revoking|Revoke link/i }),
     ).toBeTruthy();
-    // And no way to make a second while this one is live.
-    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
-    expect(screen.queryByText("Duration")).toBeNull();
+    // Multiple links can be live at once, so the create control -- and the
+    // duration picker beside it -- stays on screen rather than disappearing
+    // once one link exists.
+    expect(
+      screen.getByRole("button", { name: /^Create link$/i }),
+    ).toBeTruthy();
+    expect(screen.getByText("Duration")).toBeTruthy();
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
     );
@@ -6597,10 +6605,9 @@ describe("OneLocationAgentPage", () => {
     expect(copied).not.toContain("/one/location/request/");
   });
 
-  it("offers no way to make a second link while one is live", async () => {
-    // Two are independently resolvable, revoking the visible one leaves the
-    // other watching, and the tab can only ever show the newest. Ending this
-    // one is the way to a different one.
+  it("keeps the create control on screen while a link is live", async () => {
+    // Multiple links can be live at once -- a second one is not something the
+    // create control ever needs to get out of the way for.
     mockGetState.mockResolvedValue({
       ...locationState(),
       publicInvites: [activePublicInvite()],
@@ -6612,10 +6619,51 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
 
     expect(await screen.findByText("Temporary link")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
-    expect(screen.queryByText("Duration")).toBeNull();
-    // Ending it stays reachable -- that is the only exit.
+    expect(
+      screen.getByRole("button", { name: /^Create link$/i }),
+    ).toBeTruthy();
+    expect(screen.getByText("Duration")).toBeTruthy();
+    // Ending it stays reachable too.
     expect(screen.getByRole("button", { name: /Revoke link/i })).toBeTruthy();
+  });
+
+  it("renders one card per active link, each independently revocable", async () => {
+    // Link A -> 15 min, Link B -> 1 hour, both live. Neither card's Stop
+    // button may be confused with the other's.
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      publicInvites: [
+        activePublicInvite({
+          id: "public-invite-a",
+          durationHours: 0.25,
+          publicUrl: "/one/location/view/token-a",
+        }),
+        activePublicInvite({
+          id: "public-invite-b",
+          durationHours: 1,
+          publicUrl: "/one/location/view/token-b",
+        }),
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Links" }));
+
+    expect(await screen.findByText("15 min link")).toBeTruthy();
+    expect(screen.getByText("1 hour link")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /Revoke link/i })).toHaveLength(
+      2,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Revoke link/i })[0]);
+    await waitFor(() =>
+      expect(mockRevokePublicInvite).toHaveBeenCalledWith({
+        vaultOwnerToken: "vault-token",
+        inviteId: "public-invite-a",
+      }),
+    );
   });
 
   it("lets a link whose URL cannot be recovered be stopped", async () => {
@@ -6636,7 +6684,9 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByRole("button", { name: /Stop link/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^Copy link$/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /^Share$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /^Create link$/i }),
+    ).toBeTruthy();
   });
 
   it("brings a bookmarked temp-link URL to the Links tab", async () => {
@@ -6661,12 +6711,11 @@ describe("OneLocationAgentPage", () => {
     expect(replaced).not.toContain("action=temp-link");
   });
 
-  it("brings the create form back when the link runs out", async () => {
-    // The tab hides its create control whenever a link is live, and expiry is
-    // written server-side only when a row is READ -- nothing here refetches on
-    // a timer. Without a clock check the state this session already holds says
-    // "active" forever, so a link that ran out five minutes ago left the person
-    // looking at a dead card with no way past it until they reloaded.
+  it("drops a link's card once it runs out, without touching the create control", async () => {
+    // Expiry is written server-side only when a row is READ -- nothing here
+    // refetches on a timer. Without a clock check the state this session
+    // already holds says "active" forever, so a link that ran out five
+    // minutes ago left its card on screen with no way past it until reload.
     mockGetState.mockResolvedValue({
       ...locationState(),
       publicInvites: [
@@ -6681,7 +6730,12 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(await screen.findByText("Temporary link")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+    // The create control was never hidden by the live link in the first
+    // place.
+    expect(
+      screen.getByRole("button", { name: /^Create link$/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Revoke link/i })).toBeTruthy();
 
     // Real time, not fake. This suite's setup awaits real promises, and fake
     // timers -- even advancing ones -- leave `waitFor` running on a clock the
@@ -6699,11 +6753,14 @@ describe("OneLocationAgentPage", () => {
 
     expect(screen.getByText("Duration")).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Create link$/i })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Revoke link/i }),
+    ).toBeNull();
   });
 
   it("does not expire a link the server sent without an expiry", async () => {
     // A missing timestamp is not evidence the link has run out. Treating it as
-    // expired would hide a working link and offer to make a second.
+    // expired would drop a working link's card from the list.
     mockGetState.mockResolvedValue({
       ...locationState(),
       publicInvites: [activePublicInvite({ expiresAt: undefined })],
@@ -6715,7 +6772,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
 
     expect(await screen.findByText("Temporary link")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^Create link$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /Revoke link/i })).toBeTruthy();
   });
 
   it("treats a link that expired before the tab opened as gone", async () => {
@@ -6736,5 +6793,9 @@ describe("OneLocationAgentPage", () => {
 
     expect(await screen.findByText("Temporary link")).toBeTruthy();
     expect(screen.getByText("Duration")).toBeTruthy();
+    // No card for an invite the clock already disqualifies.
+    expect(
+      screen.queryByRole("button", { name: /Revoke link/i }),
+    ).toBeNull();
   });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2812,22 +2812,24 @@ export function OneLocationAgentPageContent({
     Record<string, string>
   >({});
   /**
-   * The link as it came back from the create call, this session only.
+   * The most recently created link, as it came back from the create call,
+   * this session only.
    *
-   * Kept because the server's copy arrives one refetch later: between "created"
-   * and the next `getState` there is a window where the only place the URL
-   * exists is this variable. `publicInviteUrl` below prefers the server's copy
-   * and falls back to this one.
+   * Kept because the server's copy arrives one refetch later: between
+   * "created" and the next `getState` there is a window where the only place
+   * the new invite's URL exists is this variable. `displayPublicInvites` below
+   * folds it in as an extra card alongside whatever `activePublicInvites`
+   * already holds, and drops it once the real row shows up in server state.
    *
-   * It carries its own expiry, and that is not decoration. A bare string
-   * outlived the link it named: once the invite ran out, the server stopped
-   * reporting it as active but this variable still held a URL, so the Links tab
-   * -- which hides its create control whenever a link is live -- kept showing a
-   * dead link with no way past it. The expiry here is the one the SERVER
-   * stamped, not the duration that was asked for, so the two agree.
+   * It carries its own expiry and duration, and that is not decoration. A bare
+   * string outlived the link it named: once the invite ran out, the server
+   * stopped reporting it as active but this variable still held a URL, so a
+   * dead link kept showing with no way past it. The expiry here is the one the
+   * SERVER stamped, not the duration that was asked for, so the two agree.
    */
   const [createdPublicInvite, setCreatedPublicInvite] = useState<{
     url: string;
+    durationHours: number;
     expiresAtMs: number | null;
   } | null>(null);
   /**
@@ -3738,18 +3740,18 @@ export function OneLocationAgentPageContent({
     ).length;
   }, [auth.userId, unwatchedTick, state?.receivedGrants]);
   /**
-   * Links that are live right now, by the clock as well as by the server.
+   * Every public link that is live right now, by the clock as well as by the
+   * server -- the Links tab renders one card per entry here, and the public
+   * heartbeat effect below publishes to every one of them.
    *
    * `status` alone is not enough. Expiry is written server-side only when a row
    * is READ, and nothing on this screen refetches on a timer -- so a link that
    * ran out five minutes ago is still `status: "active"` in the state this
-   * session already holds. That was harmless while the Links tab merely listed
-   * it. It is not harmless now: the tab hides its create control whenever a
-   * link is live, so a stale row left the person looking at a dead link with no
-   * way to make another until they reloaded the page.
+   * session already holds; without this filter a dead link would sit in the
+   * list as if it were still watchable.
    *
-   * `nowMs` ticks every 30s and on return from background, so the create form
-   * comes back on its own, which is exactly the promise the tab makes.
+   * `nowMs` ticks every 30s and on return from background, so an expired card
+   * drops out on its own.
    *
    * A row with no `expiresAt` is treated as live: the server sent it as active
    * and we have nothing to contradict that with.
@@ -3805,6 +3807,53 @@ export function OneLocationAgentPageContent({
     }
     return createdPublicInvite.url;
   }, [createdPublicInvite, latestActivePublicInvite, nowMs]);
+
+  /**
+   * `activePublicInvites`, with every URL rewritten to its current shape and
+   * the just-created link folded in for the one round trip before it shows up
+   * there for real.
+   *
+   * The Links tab renders one card per entry here. `publicUrl` is rewritten
+   * here rather than left raw: a row minted before the path moved still
+   * carries `/one/location/request/<token>`, and copying that verbatim would
+   * put the old shape back into circulation long after the app stopped
+   * producing it.
+   *
+   * The synthetic entry exists because, without it, a fresh link would be
+   * invisible for exactly the window between "created" and the next
+   * `getState` -- `handleCreatePublicInvite` fires `refresh()` without
+   * awaiting it -- which reads as "nothing happened" on the one control whose
+   * entire job is to confirm it did. Its id keeps it out of anything keyed on
+   * a real invite id; revoke stays disabled for it until the server's row
+   * (and its real id) lands.
+   */
+  const displayPublicInvites = useMemo(() => {
+    const normalized = activePublicInvites.map((invite) =>
+      invite.publicUrl
+        ? { ...invite, publicUrl: publicInviteUrlLabel(invite.publicUrl) }
+        : invite,
+    );
+    if (
+      !createdPublicInvite ||
+      (createdPublicInvite.expiresAtMs !== null &&
+        createdPublicInvite.expiresAtMs <= nowMs) ||
+      normalized.some((invite) => invite.publicUrl === createdPublicInvite.url)
+    ) {
+      return normalized;
+    }
+    const pendingInvite: OneLocationPublicInvite = {
+      id: `pending:${createdPublicInvite.url}`,
+      ownerUserId: auth.userId ?? "",
+      status: "active",
+      durationHours: createdPublicInvite.durationHours,
+      expiresAt:
+        createdPublicInvite.expiresAtMs !== null
+          ? new Date(createdPublicInvite.expiresAtMs).toISOString()
+          : null,
+      publicUrl: createdPublicInvite.url,
+    };
+    return [...normalized, pendingInvite];
+  }, [activePublicInvites, auth.userId, createdPublicInvite, nowMs]);
 
   const activeCircleInvites = useMemo(
     () =>
@@ -6025,12 +6074,19 @@ export function OneLocationAgentPageContent({
    * A failure is never surfaced. The window is the promise; the pin going a
    * tick stale is not something the owner can act on, and a toast once every
    * twenty seconds is worse than the staleness.
+   *
+   * Every active link is published to, not just one. An owner can have
+   * several public links out at once -- a 15-minute link to one person and an
+   * hour-long link to another -- and each has to keep showing where the owner
+   * is for as long as it stays live. `Promise.allSettled` fires them all off
+   * the same captured point: a link that 404s (revoked or expired between
+   * ticks) must not stop the rest from updating.
    */
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!vaultOwnerToken) return;
-    const inviteId = activePublicInvites[0]?.id;
-    if (!inviteId) return;
+    const inviteIds = activePublicInvites.map((invite) => invite.id);
+    if (inviteIds.length === 0) return;
     if (locationControl.paused) return;
     if (
       permission?.state === "denied" ||
@@ -6043,7 +6099,7 @@ export function OneLocationAgentPageContent({
     let cancelled = false;
     let inFlight = false;
 
-    const publishPublicLink = async () => {
+    const publishPublicLinks = async () => {
       if (cancelled || inFlight) return;
       if (
         typeof document !== "undefined" &&
@@ -6057,25 +6113,31 @@ export function OneLocationAgentPageContent({
         // Nothing measured this session. A page that says "Live" must never be
         // handed a remembered coordinate; the watch will deliver one shortly.
         if (!point || cancelled) return;
-        await OneLocationService.refreshPublicInviteLocation({
-          vaultOwnerToken,
-          inviteId,
-          locationSnapshot: point,
-        });
+        await Promise.allSettled(
+          inviteIds.map((inviteId) =>
+            OneLocationService.refreshPublicInviteLocation({
+              vaultOwnerToken,
+              inviteId,
+              locationSnapshot: point,
+            }),
+          ),
+        );
+        // Rejections (including the expected 404 from a link revoked or
+        // expired in another tab) are swallowed by design: the row is gone;
+        // the next state refresh drops it from `activePublicInvites`, and
+        // every other link's update already landed regardless.
       } catch {
-        // Includes the expected 404 from a link revoked in another tab. The
-        // row is gone; the next state refresh drops it from
-        // `activePublicInvites` and this effect tears itself down.
+        // liveHeartbeatPoint() itself failing. Same policy: nothing surfaced.
       } finally {
         inFlight = false;
       }
     };
 
     const interval = window.setInterval(
-      () => void publishPublicLink(),
+      () => void publishPublicLinks(),
       LIVE_LOCATION_UPDATE_INTERVAL_MS,
     );
-    void publishPublicLink();
+    void publishPublicLinks();
     return () => {
       cancelled = true;
       window.clearInterval(interval);
@@ -7371,14 +7433,18 @@ export function OneLocationAgentPageContent({
       });
       if (!readiness.ready || !readiness.point) return;
       const point = readiness.point;
+      const requestedDurationHours = publicInviteDurationHours(
+        publicLinkDurationHours,
+      );
       const response = await OneLocationService.createPublicInvite({
         vaultOwnerToken,
-        durationHours: publicInviteDurationHours(publicLinkDurationHours),
+        durationHours: requestedDurationHours,
         locationSnapshot: point,
       });
       const url = publicInviteUrlLabel(response.publicUrl);
       setCreatedPublicInvite({
         url,
+        durationHours: response.invite?.durationHours ?? requestedDurationHours,
         expiresAtMs: parseExpiryMs(response.invite?.expiresAt),
       });
       const copiedToClipboard = url ? await copyToClipboard(url) : false;
@@ -7389,20 +7455,13 @@ export function OneLocationAgentPageContent({
         copied_to_clipboard: copiedToClipboard,
         active_invite_count: activePublicInvites.length + 1,
       });
-      // One live link per person, so pressing this while one is already out
-      // there restarts that link's window rather than minting a second URL.
-      // Saying "created" would be a lie the person acts on: they would think
-      // the old link is dead and this one is new, when in fact everyone they
-      // sent it to is still watching through the same URL.
-      const reusedExistingLink = response.reused === true;
+      // Every press mints its own independent link -- it never touches
+      // whatever is already live -- so this is always "created", never a
+      // restart of something the person already handed out.
       toast.success(
-        reusedExistingLink
-          ? copiedToClipboard
-            ? "Your live link now runs for another window, and is copied."
-            : "Your live link now runs for another window."
-          : copiedToClipboard
-            ? "Public location link created and copied."
-            : "Public location link created.",
+        copiedToClipboard
+          ? "Public location link created and copied."
+          : "Public location link created.",
       );
       void refresh().catch(() => null);
     } catch (error) {
@@ -7430,40 +7489,51 @@ export function OneLocationAgentPageContent({
     vaultOwnerToken,
   ]);
 
-  const handleCopyPublicInvite = useCallback(async (): Promise<boolean> => {
-    if (!publicInviteUrl) return false;
-    try {
-      const copiedToClipboard = await copyToClipboard(publicInviteUrl);
-      if (copiedToClipboard) {
-        toast.success("Public location link copied.");
-        return true;
-      } else {
+  // Takes the URL explicitly rather than always reading `publicInviteUrl`:
+  // with several links live at once, the Links tab needs to copy whichever
+  // card's URL was pressed, not just "the" one. Callers with a single link in
+  // mind (the legacy compose flow, Share to contacts) still fall back to
+  // `publicInviteUrl`.
+  const handleCopyPublicInvite = useCallback(
+    async (url: string = publicInviteUrl): Promise<boolean> => {
+      if (!url) return false;
+      try {
+        const copiedToClipboard = await copyToClipboard(url);
+        if (copiedToClipboard) {
+          toast.success("Public location link copied.");
+          return true;
+        } else {
+          toast.error("Could not copy the public location link.");
+          return false;
+        }
+      } catch {
         toast.error("Could not copy the public location link.");
         return false;
       }
-    } catch {
-      toast.error("Could not copy the public location link.");
-      return false;
-    }
-  }, [publicInviteUrl]);
+    },
+    [publicInviteUrl],
+  );
 
-  const handleSharePublicInvite = useCallback(async () => {
-    if (!publicInviteUrl) return;
-    try {
-      const delivery = await shareOneLocationLink({
-        title: ONE_LOCATION_PUBLIC_SHARE_TITLE,
-        text: ONE_LOCATION_PUBLIC_SHARE_COPY,
-        url: publicInviteUrl,
-        dialogTitle: "Share to contacts",
-      });
-      if (delivery === "copied") {
-        toast.success("Public location link copied.");
+  const handleSharePublicInvite = useCallback(
+    async (url: string = publicInviteUrl) => {
+      if (!url) return;
+      try {
+        const delivery = await shareOneLocationLink({
+          title: ONE_LOCATION_PUBLIC_SHARE_TITLE,
+          text: ONE_LOCATION_PUBLIC_SHARE_COPY,
+          url,
+          dialogTitle: "Share to contacts",
+        });
+        if (delivery === "copied") {
+          toast.success("Public location link copied.");
+        }
+      } catch (error) {
+        if (isShareCancellationError(error)) return;
+        toast.error("Could not open the share sheet.");
       }
-    } catch (error) {
-      if (isShareCancellationError(error)) return;
-      toast.error("Could not open the share sheet.");
-    }
-  }, [publicInviteUrl]);
+    },
+    [publicInviteUrl],
+  );
 
   const handleShareContactInvite = useCallback(async () => {
     if (!vaultOwnerToken) return;
@@ -7477,14 +7547,18 @@ export function OneLocationAgentPageContent({
         });
         if (!readiness.ready || !readiness.point) return;
         const point = readiness.point;
+        const requestedDurationHours = publicInviteDurationHours(
+          publicLinkDurationHours,
+        );
         const response = await OneLocationService.createPublicInvite({
           vaultOwnerToken,
-          durationHours: publicInviteDurationHours(publicLinkDurationHours),
+          durationHours: requestedDurationHours,
           locationSnapshot: point,
         });
         url = publicInviteUrlLabel(response.publicUrl);
         setCreatedPublicInvite({
           url,
+          durationHours: response.invite?.durationHours ?? requestedDurationHours,
           expiresAtMs: parseExpiryMs(response.invite?.expiresAt),
         });
         trackEvent("one_location_public_link_created", {
@@ -8545,6 +8619,9 @@ export function OneLocationAgentPageContent({
   const handleRevokePublicInvite = useCallback(
     async (invite: OneLocationPublicInvite) => {
       if (!vaultOwnerToken) return;
+      // The synthetic bridge card from `displayPublicInvites` has no real
+      // invite id yet -- nothing to revoke until the server's row lands.
+      if (invite.id.startsWith("pending:")) return;
       setBusy("publicRevoke");
       try {
         await OneLocationService.revokePublicInvite({
@@ -13283,7 +13360,7 @@ export function OneLocationAgentPageContent({
     receivedGrants: activeReceivedGrants,
     pendingOwnerRequests,
     requestedByMe,
-    latestActivePublicInvite,
+    activePublicInvites: displayPublicInvites,
     latestActiveCircleInvite,
     activityReceipts: (locationActivity?.events ?? []).map((event) => ({
       id: event.id,
@@ -13375,7 +13452,7 @@ export function OneLocationAgentPageContent({
     onRequestMoreTime: handleRequestMoreTime,
     onCreatePublicInvite: () => void handleCreatePublicInvite(),
     onCopyPublicInvite: handleCopyPublicInvite,
-    onSharePublicInvite: () => void handleSharePublicInvite(),
+    onSharePublicInvite: (url) => void handleSharePublicInvite(url),
     onRevokePublicInvite: (invite) => void handleRevokePublicInvite(invite),
     onCreateCircleInvite: () => void handleCreateCircleInvite(),
     onCopyCircleInvite: () => void handleCopyCircleInvite(),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -330,7 +330,14 @@ export type LocationHubViewModel = {
   receivedGrants: OneLocationGrant[];
   pendingOwnerRequests: OneLocationAccessRequest[];
   requestedByMe: OneLocationAccessRequest[];
-  latestActivePublicInvite: OneLocationPublicInvite | null;
+  /**
+   * Every public link currently live for this owner, not just the newest.
+   *
+   * Multiple can be live at once -- a 15-minute link to one person and an
+   * hour-long link to another -- and the Links tab renders one card per
+   * entry here rather than collapsing them into a single "latest" link.
+   */
+  activePublicInvites: OneLocationPublicInvite[];
   latestActiveCircleInvite: OneLocationCircleInvite | null;
   activityReceipts: { id: string; title: string; detail: string }[];
 
@@ -458,8 +465,8 @@ export type LocationHubViewModel = {
   onEditLiveShareDurationCancel: () => void;
   onSaveLiveShareDuration: () => void;
   onCreatePublicInvite: () => void;
-  onCopyPublicInvite: () => boolean | Promise<boolean>;
-  onSharePublicInvite: () => void;
+  onCopyPublicInvite: (url: string) => boolean | Promise<boolean>;
+  onSharePublicInvite: (url: string) => void;
   onRevokePublicInvite: (invite: OneLocationPublicInvite) => void;
   onCreateCircleInvite: () => void;
   onCopyCircleInvite: () => void;
@@ -3687,6 +3694,7 @@ export function PeopleHub({
 /* =================================================================== */
 
 const PUBLIC_LINK_DURATION_OPTIONS = [
+  { value: "0.25", label: "15 min" },
   { value: "0.5", label: "30 min" },
   { value: "1", label: "1 hour" },
 ] as const;
@@ -3747,6 +3755,17 @@ function ActiveLinkRow({
   );
 }
 
+/** "0.25" -> "15 min link", falling back to the raw hour count for anything
+ * not on the offered list (an older link minted under a different scheme). */
+function publicLinkTitle(durationHours: number): string {
+  const match = PUBLIC_LINK_DURATION_OPTIONS.find(
+    (option) => Number(option.value) === durationHours,
+  );
+  if (match) return `${match.label} link`;
+  if (durationHours < 1) return `${Math.round(durationHours * 60)} min link`;
+  return `${durationHours} hour link`;
+}
+
 /**
  * The Links tab, which is now the whole of the live-location-link flow.
  *
@@ -3760,32 +3779,14 @@ function ActiveLinkRow({
  *
  * The question is now asked here, and the answer replaces it in place.
  *
- * One live link at a time. While one is active there is no create control at
- * all: not disabled, absent. A second link is not a thing the product wants to
- * be able to make -- both stay independently resolvable, revoking the one on
- * screen leaves the other watching, and the tab can only ever show the newest.
- * The way to a different link is to end this one, which is a button already on
- * the card. The server refuses the second as well (`create_public_invite`
- * hands back the live one), because a rule that lives only in a component is
- * defeated by a stale tab.
+ * Multiple links can be live at once -- a 15-minute link to one person and an
+ * hour-long link to another, independently. The create control is therefore
+ * always on screen, never hidden behind "one is already live": every active
+ * link gets its own card below it, each with its own Copy, Share and Stop, and
+ * stopping one never touches another.
  */
 function LinksHub({ vm }: { vm: LocationHubViewModel }) {
-  const temp = vm.latestActivePublicInvite;
   const invite = vm.latestActiveCircleInvite;
-  // Two separate questions, and both have to be asked.
-  //
-  //   is a link live?      `temp` -- the server's row
-  //   can we hand it over? `vm.publicInviteUrl` -- the URL itself
-  //
-  // Neither implies the other. An invite minted before its token could be
-  // re-derived from its row is live with no recoverable URL, so Copy would
-  // hand over nothing. And for one round trip after creating, the URL is known
-  // while the row is not: `onCreatePublicInvite` fires its refresh without
-  // awaiting it. Keying the whole tab on `temp` alone put the create form back
-  // on screen during that window, which reads as "nothing happened" and
-  // invites a second press.
-  const hasLiveLink = Boolean(temp) || Boolean(vm.publicInviteUrl);
-  const hasShareableLink = Boolean(vm.publicInviteUrl);
 
   return (
     <div className="space-y-4">
@@ -3793,31 +3794,80 @@ function LinksHub({ vm }: { vm: LocationHubViewModel }) {
         <SectionTitle as="h2">Temporary link</SectionTitle>
       </div>
 
-      {hasLiveLink ? (
-        hasShareableLink ? (
+      <div className={cn(SUBCARD_SURFACE, "space-y-5 p-5 sm:p-6")}>
+        <p className="text-[15px] leading-5 text-muted-foreground">
+          Anyone with this link can see your location until it expires.
+        </p>
+        <div className="space-y-2.5">
+          <p className="text-[15px] font-semibold leading-5 text-foreground">
+            Duration
+          </p>
+          <div
+            className="grid grid-cols-3 gap-2"
+            role="radiogroup"
+            aria-label="Temporary link duration"
+          >
+            {PUBLIC_LINK_DURATION_OPTIONS.map((option) => {
+              const selected = vm.publicLinkDurationHours === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => vm.setPublicLinkDurationHours(option.value)}
+                  className={cn(
+                    "h-11 rounded-[14px] border text-[15px] font-semibold leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2",
+                    selected
+                      ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
+                      : "border-border bg-[color:var(--app-card-surface-compact)] text-foreground hover:bg-[color:var(--app-card-surface-compact)]/80",
+                  )}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        {/* The label changes while it works. This press waits on a device fix
+            before it can post anything, so on a cold start it can sit for
+            several seconds -- and it used to sit as a bare spinner with the
+            label hidden, which is why it read as "taking longer than
+            expected" rather than as "still finding you". Naming the wait is
+            the fix available here; the wait itself is a GPS acquisition. */}
+        <Button
+          onClick={vm.onCreatePublicInvite}
+          isLoading={vm.busy === "publicInvite"}
+          data-voice-control-id="one-location-action-temp-link"
+          className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+        >
+          {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
+        </Button>
+      </div>
+
+      {/* One card per active link. Each is a complete, independent unit: its
+          own duration, its own countdown, its own URL, its own Stop -- Stop on
+          one card revokes only that invite's id and leaves every other card
+          exactly as it was. */}
+      {vm.activePublicInvites.map((publicInvite) => {
+        // The synthetic bridge card for a just-created link, before the
+        // server's row (and its real id) has landed. Revoking needs that id,
+        // so the control shows itself as busy rather than pretending to
+        // work -- honest, because a refresh really is in flight.
+        const isPending = publicInvite.id.startsWith("pending:");
+        const revokeBusy = vm.busy === "publicRevoke" || isPending;
+        return publicInvite.publicUrl ? (
           <TemporaryLinkCard
-            statusLine={
-              temp
-                ? publicLinkStatusLabel(
-                    vm.expiresCountdownLabel(temp.expiresAt),
-                  )
-                : "Active"
-            }
+            key={publicInvite.id}
+            title={publicLinkTitle(publicInvite.durationHours)}
+            statusLine={publicLinkStatusLabel(
+              vm.expiresCountdownLabel(publicInvite.expiresAt),
+            )}
             description="Anyone with this link can see your location."
-            // No countdown until the row lands: inventing one from the
-            // duration that was picked would drift from the expiry the server
-            // actually stamped.
-            onCopy={vm.onCopyPublicInvite}
-            onShare={vm.onSharePublicInvite}
-            // Revoking needs the invite's id, which arrives with the row. In
-            // the moment before it does, the control shows itself as busy
-            // rather than pretending to work -- which is honest, because a
-            // refresh really is in flight. Copy and Share are unaffected: the
-            // URL is already in hand.
-            onRevoke={() => {
-              if (temp) vm.onRevokePublicInvite(temp);
-            }}
-            revokeBusy={vm.busy === "publicRevoke" || !temp}
+            onCopy={() => vm.onCopyPublicInvite(publicInvite.publicUrl ?? "")}
+            onShare={() => vm.onSharePublicInvite(publicInvite.publicUrl ?? "")}
+            onRevoke={() => vm.onRevokePublicInvite(publicInvite)}
+            revokeBusy={revokeBusy}
           />
         ) : (
           // Live, and its URL is gone: an invite from before the token could be
@@ -3825,84 +3875,28 @@ function LinksHub({ vm }: { vm: LocationHubViewModel }) {
           // they are not offered -- but the link is still out there watching,
           // so ending it has to stay reachable. Saying why keeps this from
           // reading as a bug the person should retry.
-          <div className={cn(SUBCARD_SURFACE, "space-y-4 p-5 sm:p-6")}>
+          <div
+            key={publicInvite.id}
+            className={cn(SUBCARD_SURFACE, "space-y-4 p-5 sm:p-6")}
+          >
             <p className="text-[15px] leading-5 text-muted-foreground">
-              Active, but the link is unavailable on this device.
+              {publicLinkTitle(publicInvite.durationHours)}: active, but the
+              link is unavailable on this device.
             </p>
             <button
               type="button"
-              onClick={() => {
-                if (temp) vm.onRevokePublicInvite(temp);
-              }}
-              disabled={vm.busy === "publicRevoke" || !temp}
+              onClick={() => vm.onRevokePublicInvite(publicInvite)}
+              disabled={revokeBusy}
               className="min-h-11 w-full text-left text-[15px] font-semibold leading-5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
             >
-              {vm.busy === "publicRevoke" || !temp ? "Stopping…" : "Stop link"}
+              {revokeBusy ? "Stopping…" : "Stop link"}
             </button>
           </div>
-        )
-      ) : (
-        // No warning banner above the picker. It said two things the screen
-        // already says better: the duration control underneath states exactly
-        // how long the link lives, and the card that replaces this whole block
-        // once a link exists carries the concise visibility line on
-        // the object it is actually about. An amber panel repeating both, on
-        // the one screen whose entire purpose is to create the link, read as a
-        // reason not to press the button rather than as information.
-        <div className={cn(SUBCARD_SURFACE, "space-y-5 p-5 sm:p-6")}>
-          <p className="text-[15px] leading-5 text-muted-foreground">
-            Anyone with this link can see your location until it expires.
-          </p>
-          <div className="space-y-2.5">
-            <p className="text-[15px] font-semibold leading-5 text-foreground">
-              Duration
-            </p>
-            <div
-              className="grid grid-cols-2 gap-2"
-              role="radiogroup"
-              aria-label="Temporary link duration"
-            >
-              {PUBLIC_LINK_DURATION_OPTIONS.map((option) => {
-                const selected = vm.publicLinkDurationHours === option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    onClick={() => vm.setPublicLinkDurationHours(option.value)}
-                    className={cn(
-                      "h-11 rounded-[14px] border text-[15px] font-semibold leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2",
-                      selected
-                        ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
-                        : "border-border bg-[color:var(--app-card-surface-compact)] text-foreground hover:bg-[color:var(--app-card-surface-compact)]/80",
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-          {/* The label changes while it works. This press waits on a device fix
-              before it can post anything, so on a cold start it can sit for
-              several seconds -- and it used to sit as a bare spinner with the
-              label hidden, which is why it read as "taking longer than
-              expected" rather than as "still finding you". Naming the wait is
-              the fix available here; the wait itself is a GPS acquisition. */}
-          <Button
-            onClick={vm.onCreatePublicInvite}
-            isLoading={vm.busy === "publicInvite"}
-            data-voice-control-id="one-location-action-temp-link"
-            className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-          >
-            {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
-          </Button>
-        </div>
-      )}
+        );
+      })}
 
       {/* A Circle invite is a different object on a different table with a
-          different ceiling, and it is not subject to the one-at-a-time rule
+          different ceiling, and it is not subject to the multi-link handling
           above: it admits one named person to a Circle rather than showing the
           owner to anyone holding a URL. It keeps its row. */}
       {invite ? (

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1056,14 +1056,6 @@ export class OneLocationService {
     invite: OneLocationPublicInvite;
     publicToken: string;
     publicUrl: string;
-    /**
-     * True when the server handed back the link that was already live rather
-     * than minting a second one. Its window is restarted for the duration that
-     * was just asked for, so the link is honestly "live for an hour" either
-     * way -- but it is the SAME URL, and anyone already holding it keeps
-     * watching. Worth saying out loud rather than reporting "link created".
-     */
-    reused?: boolean;
   }> {
     return apiJsonWithRetry(
       "/api/one/location/public-invites",


### PR DESCRIPTION
## Problem

- Public location links were limited to one active link per owner.
- Creating a second link reused the existing invite and changed its duration/expiry instead of minting a new independent link.
- The Links UI also collapsed active links down to the latest one and hid the Create control while one link was active.

## Fix

- Every explicit public-link creation now mints a new invite/token/row.
- Added a maximum of 10 simultaneous active public links per owner.
- Added 15 min (`0.25h`) as a public-link duration.
- Links tab now renders all active public links independently.
- Each link has its own Copy, Share, countdown, and Revoke action.
- Creating a new link no longer hides the Create controls.
- Location heartbeat updates every active public invite using `Promise.allSettled()`.
- Revoking or expiring one link does not affect the others.

## Testing

- Backend: 174+ focused One Location tests passing after final cleanup.
- Frontend: full affected test file passes.
- Typecheck and lint pass on touched files.
- Component-level/manual browser harness verification covered:
  - 15-min link + 1-hour link created simultaneously
  - distinct URLs/tokens
  - both links active independently
  - revoking one leaves the other active
  - heartbeat fan-out reaches all active links
  - 10-link cap works

Note: the browser verification above was component-level/manual harness testing (the real `LinksHub` component driven against a client-side fake backend in a real browser), not a live Postgres-backed E2E test.

Fixes #6028