### PR TITLE
fix(one): backfill location circle event types into every validating CHECK

### DIFF
--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -104,7 +104,14 @@ ALTER TABLE one_location_events
       'location_circle_invite_created',
       'location_circle_invite_claimed',
       'location_circle_invite_revoked',
-      'location_one_network_joined'
+      'location_one_network_joined',
+      -- Added by migration 180, which reaches every environment through this
+      -- same validating ADD. Same failure mode as 'location_share_shortened'
+      -- above: any value 180 introduces has to appear here too, or replay
+      -- dies on it the first time a real row uses one.
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
     )
   );
 

--- a/consent-protocol/db/migrations/068_one_location_circle_invites.sql
+++ b/consent-protocol/db/migrations/068_one_location_circle_invites.sql
@@ -106,7 +106,12 @@ ALTER TABLE one_location_events
       'location_circle_invite_created',
       'location_circle_invite_claimed',
       'location_circle_invite_revoked',
-      'location_one_network_joined'
+      'location_one_network_joined',
+      -- Added by migration 180. Kept identical to 064's list for the same
+      -- reason as the comment above: the declarations must agree.
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
     )
   ) NOT VALID;
 

--- a/consent-protocol/db/migrations/153_one_location_duration_changed_event.sql
+++ b/consent-protocol/db/migrations/153_one_location_duration_changed_event.sql
@@ -50,7 +50,13 @@ ALTER TABLE one_location_events
       'location_circle_invite_created',
       'location_circle_invite_claimed',
       'location_circle_invite_revoked',
-      'location_one_network_joined'
+      'location_one_network_joined',
+      -- Not this branch's value either: added by migration 180, which lands
+      -- on main after this one. Same rule as the comment above -- any new
+      -- value has to appear here too, or re-adding the constraint drops it.
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
     )
   );
 

--- a/consent-protocol/db/migrations/154_one_location_access_request_duration.sql
+++ b/consent-protocol/db/migrations/154_one_location_access_request_duration.sql
@@ -131,7 +131,12 @@ ALTER TABLE one_location_events
       'location_circle_invite_created',
       'location_circle_invite_claimed',
       'location_circle_invite_revoked',
-      'location_one_network_joined'
+      'location_one_network_joined',
+      -- Added by migration 180. Kept identical to 064's list; the
+      -- declarations must agree.
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
     )
   ) NOT VALID;
 

--- a/consent-protocol/db/migrations/169_one_location_auto_approve_preferences.sql
+++ b/consent-protocol/db/migrations/169_one_location_auto_approve_preferences.sql
@@ -66,7 +66,12 @@ ALTER TABLE one_location_events
       'location_circle_invite_created',
       'location_circle_invite_claimed',
       'location_circle_invite_revoked',
-      'location_one_network_joined'
+      'location_one_network_joined',
+      -- Added by migration 180. Kept identical to 064's list; the
+      -- declarations must agree.
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
     )
   ) NOT VALID;
 

--- a/consent-protocol/tests/test_one_location_event_type_constraint.py
+++ b/consent-protocol/tests/test_one_location_event_type_constraint.py
@@ -45,6 +45,15 @@ CONSTRAINT_MIGRATIONS = (
     "180_one_location_circle_feed_durability.sql",
 )
 
+# Only these two ADD the constraint without NOT VALID, so only these two
+# actually scan existing rows -- and only these two can fail a replay. Every
+# other entry in CONSTRAINT_MIGRATIONS is a no-op against real data the
+# instant it runs, no matter what it lists.
+VALIDATING_CONSTRAINT_MIGRATIONS = (
+    "064_one_location_public_invites.sql",
+    "153_one_location_duration_changed_event.sql",
+)
+
 _CONSTRAINT_BLOCK = re.compile(
     r"ADD CONSTRAINT one_location_events_event_type_check CHECK \(\s*"
     r"event_type IN \((?P<values>.*?)\)",
@@ -94,6 +103,58 @@ def test_the_newest_constraint_migration_is_the_one_that_ships() -> None:
     assert (MIGRATIONS_DIR / newest).exists(), f"{newest} is missing"
     older = {int(name.split("_", 1)[0]) for name in CONSTRAINT_MIGRATIONS[:-1]}
     assert int(newest.split("_", 1)[0]) > max(older)
+
+
+def test_validating_migration_list_matches_which_files_actually_validate() -> None:
+    # If NOT VALID is ever added to 064/153, or dropped from one of the
+    # others, VALIDATING_CONSTRAINT_MIGRATIONS silently stops matching
+    # reality and the completeness check below stops guarding anything.
+    for name in CONSTRAINT_MIGRATIONS:
+        sql = (MIGRATIONS_DIR / name).read_text(encoding="utf-8")
+        block_start = sql.index("ADD CONSTRAINT one_location_events_event_type_check")
+        validates = "NOT VALID" not in sql[block_start : block_start + 4000]
+        expected = name in VALIDATING_CONSTRAINT_MIGRATIONS
+        assert validates == expected, (
+            f"{name}: NOT VALID presence changed -- update "
+            "VALIDATING_CONSTRAINT_MIGRATIONS to match"
+        )
+
+
+def test_every_emitted_event_type_is_allowed_by_every_validating_migration() -> None:
+    """The bug this file exists for, generalized past the newest migration.
+
+    `test_every_emitted_event_type_is_allowed_by_the_constraint` below only
+    checks the newest migration -- the one that actually ships a change to an
+    environment that already exists. But 064 and 153 add this same
+    constraint *without* NOT VALID, so replay validates their stale lists
+    against live data too, on every deploy, forever. A value can be complete
+    in 180 and still take UAT down the moment someone writes a row with it,
+    if 064 or 153 never learned about it. This is exactly the outage
+    `circle_member_added` / `location_circle_code_joined` /
+    `location_circle_member_invite_accepted` caused: added to 180 by the
+    Circle feed-durability migration, never backfilled into 064 or 153, and
+    real rows already carry the value the moment that code path runs.
+    """
+    emitted = {
+        event_type
+        for path in SERVICE_PATHS
+        for event_type in _EMITTED.findall(path.read_text(encoding="utf-8"))
+    }
+    assert "location_share_created" in emitted, (
+        "could not read event types out of one_location_agent_service; the "
+        "insert sites changed shape and this test needs updating"
+    )
+
+    for name in VALIDATING_CONSTRAINT_MIGRATIONS:
+        allowed = _allowed_types(name)
+        missing = sorted(emitted - allowed)
+        assert not missing, (
+            f"{missing} are written to one_location_events but {name} adds "
+            "the CHECK constraint without NOT VALID, so it validates against "
+            "live rows on every replay. Add them to the CHECK list in "
+            f"{name} -- otherwise the first row written with one of these "
+            "types permanently breaks that environment's migration replay."
+        )
 
 
 def test_every_emitted_event_type_is_allowed_by_the_constraint() -> None:


### PR DESCRIPTION
## Summary
- UAT deploy just failed with `CheckViolationError: check constraint "one_location_events_event_type_check" of relation "one_location_events" is violated by some row`, blocking the release of PRs #6025/#6030/#6041.
- Root cause: migration 180 added three new `one_location_events` event types for Circle transitions (`circle_member_added`, `location_circle_code_joined`, `location_circle_member_invite_accepted`), but never backfilled them into migrations 064 and 153 -- the only two migrations that `ADD CONSTRAINT` on this table without `NOT VALID`. UAT's deploy pipeline replays every migration file on every release (not just new ones), so 064/153 validate against real live data immediately, and any row already using one of the new types breaks replay from that point on.
- This is the exact same outage class documented in `tests/test_one_location_event_type_constraint.py`'s own docstring -- it has already happened three times before with other values, each fixed the same way (backfill).
- Backfilled the three values into 064, 068, 153, 154, and 169 (keeping the file's own monotonic-superset invariant intact), and added a test that checks every emitted `event_type` against every *validating* migration, not just the newest -- closing the gap that let this recur even with an existing guard test in place.

## Test plan
- [x] `pytest tests/test_one_location_event_type_constraint.py -v` -- 7/7 pass, including the two new tests
- [x] `pytest tests/test_one_location_public_invite_migration.py tests/test_one_location_request_withdraw.py tests/test_migration_authority.py -v` -- 28/28 pass
- [x] Confirmed the two `test_location_agent_manifest_v2.py` failures seen in a broader sweep are pre-existing on `main` (verified via `git stash`), unrelated to this change
- [ ] CI green
- [ ] UAT deploy retried after merge