### PR TITLE
fix(finance): fix desktop analysis history dialog

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -14,13 +14,12 @@ import { cn } from "@/lib/utils";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { Badge } from "@/components/ui/badge";
 import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Sheet,
   SheetContent,
@@ -87,11 +86,6 @@ export interface AnalysisHistoryDashboardProps {
   showDebateInputs?: boolean;
   ephemeralEntry?: AnalysisHistoryEntry | null;
 }
-
-type PopoverAnchorPosition = {
-  left: number;
-  top: number;
-};
 
 interface DebateCoverageRow {
   key: string;
@@ -816,7 +810,6 @@ export function AnalysisHistoryDashboard({
   const historyMapRef = useRef<AnalysisHistoryMap>({});
   const [versionsOpen, setVersionsOpen] = useState(false);
   const [versionsTicker, setVersionsTicker] = useState<string | null>(null);
-  const [versionsAnchor, setVersionsAnchor] = useState<PopoverAnchorPosition | null>(null);
   const [pendingDelete, setPendingDelete] = useState<PendingDeleteAction>(null);
   const [deleteInFlight, setDeleteInFlight] = useState(false);
 
@@ -1037,23 +1030,13 @@ export function AnalysisHistoryDashboard({
   const closeVersions = useCallback(() => {
     setVersionsOpen(false);
     setVersionsTicker(null);
-    setVersionsAnchor(null);
   }, []);
 
   const openVersions = useCallback((
     ticker: string,
-    event?: React.MouseEvent<HTMLTableRowElement> | React.KeyboardEvent<HTMLTableRowElement>,
+    _event?: React.MouseEvent<HTMLTableRowElement> | React.KeyboardEvent<HTMLTableRowElement>,
   ) => {
-    const rect = event?.currentTarget.getBoundingClientRect();
     setVersionsTicker(ticker);
-    setVersionsAnchor(
-      rect
-        ? { left: rect.left + rect.width / 2, top: rect.bottom }
-        : {
-            left: typeof window === "undefined" ? 0 : window.innerWidth / 2,
-            top: typeof window === "undefined" ? 0 : window.innerHeight / 2,
-          },
-    );
     setVersionsOpen(true);
   }, []);
 
@@ -1191,27 +1174,12 @@ export function AnalysisHistoryDashboard({
           </SheetContent>
         </Sheet>
       ) : (
-        <Popover open={versionsOpen} onOpenChange={(open) => !open && closeVersions()} modal>
-          {versionsAnchor ? (
-            <PopoverAnchor asChild>
-              <span
-                aria-hidden="true"
-                className="pointer-events-none fixed h-px w-px"
-                style={{ left: versionsAnchor.left, top: versionsAnchor.top }}
-              />
-            </PopoverAnchor>
-          ) : null}
-          <PopoverContent
-            align="center"
-            side="bottom"
-            sideOffset={8}
-            className="w-[min(28rem,calc(100vw-1.5rem))] p-0"
-            withBackdrop
-          >
-            <PopoverHeader className="border-b border-border/60 px-4 py-3">
-              <PopoverTitle>{versionsTicker ? `${versionsTicker} history` : "Analysis history"}</PopoverTitle>
-              <PopoverDescription>Choose a saved version to review.</PopoverDescription>
-            </PopoverHeader>
+        <Dialog open={versionsOpen} onOpenChange={(open) => !open && closeVersions()}>
+          <DialogContent className="w-[min(28rem,calc(100vw-1.5rem))] p-0 sm:max-w-md">
+            <DialogHeader className="border-b border-border/60 px-4 py-3 text-left">
+              <DialogTitle>{versionsTicker ? `${versionsTicker} history` : "Analysis history"}</DialogTitle>
+              <DialogDescription>Choose a saved version to review.</DialogDescription>
+            </DialogHeader>
             <div className="max-h-[min(28rem,calc(100vh-10rem))] overflow-y-auto p-3">
               <VersionOptions
                 entries={versionsForTicker}
@@ -1222,8 +1190,8 @@ export function AnalysisHistoryDashboard({
                 onDelete={(entry) => setPendingDelete({ kind: "entry", entry })}
               />
             </div>
-          </PopoverContent>
-        </Popover>
+          </DialogContent>
+        </Dialog>
       )}
 
       <AlertDialog


### PR DESCRIPTION
### Problem
On desktop viewports, clicking a saved analysis item (e.g., META, GOOGL) triggered the blurred backdrop overlay, but the history details container remained invisible. This occurred because the desktop view relied on a `<Popover>` anchored to dynamic mouse bounding rects (`versionsAnchor`), which failed to portal the floating content into view.

### Changes
* **Component Architecture:** Replaced the brittle `<Popover>` fallback in `analysis-history-dashboard.tsx` with a standard Radix `<Dialog>` for non-mobile screen widths.
* **Codebase Cleanup & Lint Compliance:** 
  * Removed unused `@/components/ui/popover` imports and the `PopoverAnchorPosition` type.
  * Removed the `versionsAnchor` state and bounding client rect calculations.
  * Renamed the unused event handler parameter to `_event` to satisfy strict `eslint --max-warnings=0` rules.
* **Responsive Isolation:** Preserved the existing mobile `<Sheet>` behavior without modification.

### Verification
* [x] **Desktop Web:** Verified clicking a history row opens a centered, fully interactive `<Dialog>` over the backdrop blur.
* [x] **Mobile / iOS Simulator:** Verified responsive sheet behavior continues to render from the bottom edge seamlessly.