### PR TITLE
fix(ria): align shared page content

### DIFF
--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -58,6 +58,10 @@ vi.mock("@/components/app-ui/page-sections", () => ({
   ),
 }));
 
+vi.mock("@/components/app-ui/surfaces", () => ({
+  SurfaceStack: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
 vi.mock("@/components/profile/settings-ui", () => ({
   SettingsGroup: ({
     title,

--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -54,4 +54,22 @@ describe("RIA shared header regression contract", () => {
     expect(riaPicks).toContain("density=\"compact\"");
     expect(riaPicks).toContain("stickyHeader");
   });
+
+  it("keeps RIA profile, clients, and picks on one shell measure and spacing rhythm", () => {
+    const riaProfile = read("app/ria/profile/page.tsx");
+    const riaClients = read("app/ria/clients/page.tsx");
+    const riaPicks = read("app/ria/picks/page.tsx");
+
+    expect(riaProfile).toContain("RiaPageShell");
+    expect(riaClients).toContain('width="standard"');
+    expect(riaPicks).toContain('width="standard"');
+    expect(riaClients).not.toContain('width="expanded"');
+    expect(riaPicks).not.toContain('width="expanded"');
+    expect(riaClients).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
+    expect(riaPicks).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
+    expect(riaClients).toContain("<SurfaceStack");
+    expect(riaClients).toContain('className="gap-8"');
+    expect(riaPicks).toContain("<SurfaceStack");
+    expect(riaPicks).toContain('className="gap-6"');
+  });
 });

--- a/hushh-webapp/__tests__/app/ria/picks-page-debate.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page-debate.test.tsx
@@ -144,6 +144,10 @@ vi.mock("@/components/app-ui/surfaces", () => ({
     children,
     ...props
   }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  SurfaceStack: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
 }));
 
 vi.mock("@/components/profile/settings-ui", () => ({

--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -137,6 +137,10 @@ vi.mock("@/components/app-ui/surfaces", () => ({
     children,
     ...props
   }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  SurfaceStack: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
 }));
 
 vi.mock("@/components/profile/settings-ui", () => ({

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -10,6 +10,7 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { PageHeader } from "@/components/app-ui/page-sections";
+import { SurfaceStack } from "@/components/app-ui/surfaces";
 import {
   buildKaiTestClientAccess,
   canShowKaiTestProfile,
@@ -176,7 +177,7 @@ export default function RiaClientsPage() {
   return (
     <AppPageShell
       as="main"
-      width="expanded"
+      width="standard"
       nativeTest={{
         routeId: "/ria/clients",
         marker: "native-route-ria-clients",
@@ -188,7 +189,7 @@ export default function RiaClientsPage() {
             : "empty-valid",
       }}
     >
-      <AppPageHeaderRegion>
+      <AppPageHeaderRegion className="pt-2 sm:pt-3">
         <PageHeader
           eyebrow={RIA_COPY.clients.eyebrow}
           title={
@@ -209,7 +210,7 @@ export default function RiaClientsPage() {
 
       <AppPageContentRegion>
         <RiaVerificationGate>
-        <div className="flex flex-col gap-8">
+        <SurfaceStack className="gap-8">
           {/* Connected is the roster of investors who already granted access.
               Around you is prospecting against public records — a different
               kind of person entirely, which is why they are separate views on
@@ -302,7 +303,7 @@ export default function RiaClientsPage() {
             )}
           </SettingsGroup>
           )}
-        </div>
+        </SurfaceStack>
         </RiaVerificationGate>
       </AppPageContentRegion>
     </AppPageShell>

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/components/app-ui/command-fields";
 import { DataTable } from "@/components/app-ui/data-table";
 import { PageHeader } from "@/components/app-ui/page-sections";
-import { SurfaceCard, SurfaceCardContent, SurfaceInset } from "@/components/app-ui/surfaces";
+import { SurfaceCard, SurfaceCardContent, SurfaceInset, SurfaceStack } from "@/components/app-ui/surfaces";
 import { SettingsSegmentedTabs } from "@/components/profile/settings-ui";
 import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
 import { TemplatePreviewModal } from "@/components/ria/template-preview-modal";
@@ -2357,7 +2357,7 @@ export default function RiaPicksPage() {
   return (
     <AppPageShell
       as="main"
-      width="expanded"
+      width="standard"
       nativeTest={{
         routeId: "/ria/picks",
         marker: "native-route-ria-picks",
@@ -2371,7 +2371,7 @@ export default function RiaPicksPage() {
         errorMessage: picksResource.error,
       }}
     >
-      <AppPageHeaderRegion>
+      <AppPageHeaderRegion className="pt-2 sm:pt-3">
         <PageHeader
           eyebrow={isDebateView ? RIA_COPY.debate.eyebrow : RIA_COPY.picks.eyebrow}
           title={isDebateView ? RIA_COPY.debate.title : RIA_COPY.picks.title}
@@ -2386,8 +2386,8 @@ export default function RiaPicksPage() {
       <AppPageContentRegion>
         {/* Debate is a read-only config preview — swiping should scroll it, not
             hop to the adjacent RIA tab, so the pane opts out of route-swipe. */}
-        <div
-          className="flex flex-col gap-6"
+        <SurfaceStack
+          className="gap-6"
           {...(isDebateView ? { "data-no-route-swipe": "" } : {})}
         >
           <div data-testid="ria-picks-primary">
@@ -2903,7 +2903,7 @@ export default function RiaPicksPage() {
           ) : null}
           </>
           )}
-        </div>
+        </SurfaceStack>
       </AppPageContentRegion>
     </AppPageShell>
   );


### PR DESCRIPTION
## Summary
- Align RIA Clients and Picks with the shared standard page measure used by Profile.
- Wrap tabbed content in SurfaceStack so page shadows keep overscan and tab/content spacing stays explicit.
- Add RIA contract coverage and update page test mocks.

Fixes #6062

## Validation
- npm ci
- npx vitest run __tests__/app/ria/header-regression.contract.test.ts __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/picks-page.test.tsx __tests__/app/ria/picks-page-debate.test.tsx __tests__/app/ria/profile-page.test.tsx
- npx eslint app/ria/clients/page.tsx app/ria/picks/page.tsx __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/picks-page.test.tsx __tests__/app/ria/picks-page-debate.test.tsx __tests__/app/ria/header-regression.contract.test.ts --max-warnings=0
- npm run typecheck
- npm run verify:design-system
- npm run verify:docs
- npm run verify:cache
- git diff --check

## Notes
- No backend, API, auth, data fetching, or routing changes.
- Linked to action item #6062.
- Live browser measurement of the protected /ria routes was not run because reviewer auth/BYOK credentials were not available in this session. Static source truth before this fix was Profile on the standard RIA shell while Clients/Picks used expanded/manual shell geometry; after this fix Clients/Picks use standard shell width plus SurfaceStack overscan.