### PR TITLE
copy(one-location): reword the check-in card body

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -270,7 +270,7 @@ describe("OneLocationOnboardingFlow", () => {
         name: "Stuck waiting in line?",
       }),
     ).toBeTruthy();
-    expect(screen.getByText("Check in on spot. Your Circle knows.")).toBeTruthy();
+    expect(screen.getByText("Check in on the spot and notify your circle")).toBeTruthy();
     expect(
       screen.getByRole("heading", {
         name: "Need help but can’t talk?",

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -700,7 +700,7 @@ function CheckInFeatureCard() {
           className="text-[14px] leading-[1.4] text-[#747b86] dark:text-[color:var(--app-secondary-label)]"
           data-one-feature-body
         >
-          Check in on spot. Your Circle knows.
+          Check in on the spot and notify your circle
         </p>
       </div>
       <div

--- a/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-checkin-card.layout.spec.ts
@@ -45,7 +45,7 @@ const STORY = `
         <article data-one-use-case-card data-one-feature-card="checkin">
           <div data-one-feature-copy>
             <h2 data-one-feature-title>Stuck waiting in line?</h2>
-            <p data-one-feature-body>Check in on spot. Your Circle knows.</p>
+            <p data-one-feature-body>Check in on the spot and notify your circle</p>
           </div>
           <div data-one-checkin-map-backdrop></div>
           <div data-one-use-case-art>


### PR DESCRIPTION
## What

On the "Stuck waiting in line?" card in the One Location onboarding flow:

> ~~Check in on spot. Your Circle knows.~~
> **Check in on the spot and notify your circle**

The headline is unchanged.

## Scope

Updated in all three places the string appears:

- `components/one-location/onboarding/one-location-onboarding-flow.tsx` — the rendered copy
- `__tests__/components/one-location-onboarding-flow.test.tsx` — the assertion that pins this exact string
- `e2e/one-location-checkin-card.layout.spec.ts` — the Playwright layout fixture, which mirrors the real copy so its width/height measurements stay representative

## Note for review

The new copy is taken verbatim as requested, which leaves two deliberate inconsistencies with its neighbours on the same screen:

- **"circle" lowercase** — the sibling card reads "Share your live location with your **Circle** in one tap", treating Circle as a product noun
- **no trailing period** — every other card body on this screen ends with one

Both are one-word fixes if review prefers house style.

## Verification

56 tests pass in `one-location-onboarding-flow.test.tsx`; `eslint` clean on the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)