### PR TITLE
copy(ria): reword the RIA onboarding intro lines

### DIFF
--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -146,8 +146,8 @@ const SETUP_COPY_BY_ID: Record<
     setupBlurb: "Build your advisor workspace.",
     actionLabel: "Verify RIA",
     resumeActionLabel: "Finish RIA",
-    introPremise: "A workspace built for your practice.",
-    introPromise: "You review every detail first.",
+    introPremise: "A custom workspace built for you",
+    introPromise: "You review every detail.",
     setupBullets: [
       "Verify your advisor or firm credentials.",
       "Choose the services you offer.",


### PR DESCRIPTION
## What

On https://uat.one.hushh.ai/ria/onboarding:

| | before | after |
|---|---|---|
| line 1 | ~~A workspace built for your practice.~~ | **A custom workspace built for you** |
| line 2 | ~~You review every detail first.~~ | **You review every detail.** |

## Scope

- `lib/onboarding/capability-setup-copy.ts` — the `ria` entry's `introPremise` / `introPromise`

Both strings live in the shared capability copy table and render as the premise / promise pair in `capability-cinematic-intro.tsx`. Only the `ria` entry changes; every other capability's intro is untouched. No test or layout fixture pins either string.

## Note for review

Taken verbatim as requested, which leaves line 1 without a trailing period while line 2 has one. Every other capability in the table punctuates both lines. One-character fix if review prefers house style.

## Verification

18 tests pass across `capability-setup-copy`, `setup-catalog-action-parity` and `capability-cinematic-intro`; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)