### PR TITLE
fix(one): stop suppressing global nav on active screens, un-gate list_app_actions from self-assessed uncertainty

### DIFF
--- a/consent-protocol/api/routes/one/live_context.py
+++ b/consent-protocol/api/routes/one/live_context.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 
 from hushh_mcp.onboarding_contract import SETUP_CAPABILITY_IDS
 from hushh_mcp.services.action_gateway import (
+    AVAILABLE_ACTION_IDS_CAP,
     get_action_gateway_action,
     is_navigation_action,
 )
@@ -34,9 +35,10 @@ from hushh_mcp.services.route_orchestration_index import resolve_route_orchestra
 logger = logging.getLogger(__name__)
 
 LIVE_CONTEXT_STRING_CAP = 64
-# Mirrors the frontend AVAILABLE_ACTION_IDS_CAP in
-# hushh-webapp/lib/voice/screen-context-builder.ts; keep in sync.
-LIVE_CONTEXT_ARRAY_CAP = 18
+# Mirrors the frontend's derived AVAILABLE_ACTION_IDS_CAP in
+# hushh-webapp/lib/voice/screen-context-builder.ts via the shared Python
+# constant of the same name in action_gateway.py; keep both in sync.
+LIVE_CONTEXT_ARRAY_CAP = AVAILABLE_ACTION_IDS_CAP
 LIVE_MODULE_CAP = 10
 LIVE_CAPABILITY_CAP = 10
 ONBOARDING_PHASES = frozenset(

--- a/consent-protocol/hushh_mcp/agents/onboarding/agent.py
+++ b/consent-protocol/hushh_mcp/agents/onboarding/agent.py
@@ -15,6 +15,7 @@ from hushh_mcp.onboarding_contract import (
     SETUP_CAPABILITY_IDS,
     SETUP_CAPABILITY_ORDER,
 )
+from hushh_mcp.services.action_gateway import AVAILABLE_ACTION_IDS_CAP
 
 _PHASES = (
     "anonymous_auth",
@@ -133,7 +134,9 @@ class OnboardingJourneyContext(BaseModel):
     root_resolved: bool = False
     return_route: Literal["/one/setup"] = "/one/setup"
     callback_state: Literal["none", "pending", "succeeded", "cancelled", "failed"] = "none"
-    available_action_ids: list[str] = Field(default_factory=list, max_length=18)
+    available_action_ids: list[str] = Field(
+        default_factory=list, max_length=AVAILABLE_ACTION_IDS_CAP
+    )
     setup_capability_ids: list[str] = Field(default_factory=list, max_length=10)
     screen: str = Field(default="unknown", max_length=64)
     assessment: OnboardingAssessmentV1 = Field(default_factory=OnboardingAssessmentV1)

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -1543,9 +1543,11 @@ async def run_app_action(
 ) -> dict[str, Any]:
     """Run a governed app action by its exact action id.
 
-    Use list_app_actions first when unsure of the id. Pass required inputs in
-    slots (e.g. {"symbol": "NVDA"}). The app validates guards and confirms
-    sensitive actions; never claim an outcome beyond this tool's status.
+    Call list_app_actions first unless the person's own words are already a
+    close match to a visible label -- do not decide this by how confident it
+    feels. Pass required inputs in slots (e.g. {"symbol": "NVDA"}). The app
+    validates guards and confirms sensitive actions; never claim an outcome
+    beyond this tool's status.
     """
     clean_id = str(action_id or "").strip()
     clean_slots = {k: v for k, v in (slots or {}).items() if v not in (None, "")}

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -75,6 +75,7 @@ from hushh_mcp.one_adk.specialist_availability import (
 )
 from hushh_mcp.runtime_providers import build_managed_gemini_adk_model
 from hushh_mcp.services.action_gateway import (
+    AVAILABLE_ACTION_IDS_CAP,
     get_action_gateway_action,
     is_navigation_action,
     list_action_gateway_actions,
@@ -301,10 +302,12 @@ ONE_IDENTITY_INSTRUCTION: str = (
     "for a visible action, asking about the current screen, continuing the "
     "conversation, or expressing genuine ambiguity. When they clearly ask for "
     "a currently available, low-risk visible control whose exact generated id is "
-    "in the active inventory, call run_app_action with that id immediately. Use "
-    "list_app_actions only to retrieve bounded generated candidates when the exact "
-    "id is uncertain; it is not semantic authority and never decides what the "
-    "person meant. Do this before greeting, explaining who "
+    "in the active inventory, call run_app_action with that id immediately. "
+    "Otherwise -- whenever their own words do not closely echo one of the visible "
+    "labels, including short, ambiguous, or urgent phrasing -- call list_app_actions "
+    "first with their own words, every time, rather than judging whether you feel "
+    "certain; it is not semantic authority and never decides what the person meant, "
+    "only what candidates you get to choose from. Do this before greeting, explaining who "
     "you are, or narrating onboarding. Do not infer controls from page text, and "
     "do not offer a screen-bound action from another screen. An action with an "
     "authored journey is NOT screen-bound: start_app_goal opens the screen it "
@@ -394,8 +397,9 @@ ONE_IDENTITY_INSTRUCTION: str = (
     "It opens a preview only; never start the debate until the person explicitly "
     "confirms from that preview. "
     "For other app actions (opening a workspace tab), call "
-    "run_app_action "
-    "with the exact action id, using list_app_actions first when unsure. "
+    "run_app_action with the exact action id. Call list_app_actions first unless "
+    "their words are already a close match to one of the visible labels -- do not "
+    "rely on a feeling of confidence. "
     "Actions owned by a specialist must go through that specialist's ask_ "
     "tool; run_app_action will redirect you if needed. Use google_search when "
     "the user needs fresh public information from the web. Answer general "
@@ -611,10 +615,11 @@ ONE_IDENTITY_INSTRUCTION: str = (
     "CURRENT screen. If resolve_onboarding_goal returns selected_action_id, call "
     "start_app_goal for an authored journey or run_app_action for a single-screen action. "
     "Never turn an explicit Apple or Google request back into a generic provider "
-    "question after its destination is accepted. When the exact "
-    "generated id is uncertain, call list_app_actions (it returns only actions "
-    "valid for the current screen) and pick from that, rather than naming a "
-    "step from another screen. For example, do not bring up phone "
+    "question after its destination is accepted. Whenever the person's own words "
+    "are not a close match to one of the visible labels, call list_app_actions (it "
+    "returns only actions valid for the current screen) and pick from that, rather "
+    "than naming a step from another screen or guessing an id you are not directly "
+    "looking at. For example, do not bring up phone "
     "verification unless the user is actually on the phone screen. While "
     "someone is still finishing setup, be proactive rather than waiting to be "
     "asked: after you open a screen or complete a step, briefly name ONE next "
@@ -667,7 +672,7 @@ def _one_runtime_instruction(context: Any) -> str:
     verified_action_ids = (
         [
             str(action_id).strip()
-            for action_id in available_action_ids[:18]
+            for action_id in available_action_ids[:AVAILABLE_ACTION_IDS_CAP]
             if isinstance(action_id, str) and str(action_id).strip()
         ]
         if isinstance(available_action_ids, list)
@@ -711,12 +716,12 @@ def _one_runtime_instruction(context: Any) -> str:
         ]
 
     # Render every executable id the browser published (bounded upstream at
-    # 18 by the app_context sanitizer). Rendering fewer than the allowlist
-    # previously made ids 11+ executable but invisible, which read as
-    # "actions not detected" in conversation.
+    # AVAILABLE_ACTION_IDS_CAP by the app_context sanitizer). Rendering fewer
+    # than the allowlist previously made ids 11+ executable but invisible,
+    # which read as "actions not detected" in conversation.
     action_lines: list[str] = []
     rendered_ids: set[str] = set()
-    for action_id in prompt_action_ids[:18]:
+    for action_id in prompt_action_ids[:AVAILABLE_ACTION_IDS_CAP]:
         entry = get_action_gateway_action(str(action_id))
         if entry is None:
             continue
@@ -738,12 +743,14 @@ def _one_runtime_instruction(context: Any) -> str:
                 if unrendered
                 else ""
             )
-            + "\nFirst assess meaning semantically. For a clear request matching one "
-            "of these controls, call run_app_action with that exact id. A clear "
+            + "\nFirst check whether the person's own words closely echo one of the "
+            "labels above. If so, call run_app_action with that exact id. A clear "
             "provider request selects its exact Apple or Google action; never "
-            "replace it with a generic provider explanation. Use list_app_actions "
-            "only to retrieve bounded candidates when the id is uncertain. Do not "
-            "call open_screen or google_search instead of a matching current control."
+            "replace it with a generic provider explanation. If their words do not "
+            "clearly echo one of these labels -- including short, ambiguous, or "
+            "urgent phrasing -- call list_app_actions with their own words first, "
+            "every time, rather than guessing from a label that only partly fits. "
+            "Do not call open_screen or google_search instead of a matching current control."
         )
 
     layer_instruction = ""

--- a/consent-protocol/hushh_mcp/services/action_gateway.py
+++ b/consent-protocol/hushh_mcp/services/action_gateway.py
@@ -17,6 +17,16 @@ from hushh_mcp.services.generated_contracts import generated_contract_path
 
 logger = logging.getLogger(__name__)
 
+# Mirrors the frontend's derived AVAILABLE_ACTION_IDS_CAP in
+# hushh-webapp/lib/voice/screen-context-builder.ts:
+#   ACTION_ID_SCREEN_SEGMENT_CAP (14) + len(GLOBAL_NAV_ACTION_IDS) (10).
+# There is no automated cross-language sync for this -- bump both together,
+# in the same commit, whenever either grows on the TS side. Consumed by
+# live_context.py's LIVE_CONTEXT_ARRAY_CAP, onboarding/agent.py's
+# OnboardingJourneyContext.available_action_ids max_length, and
+# one_adk/agent_tree.py's two render-time slices.
+AVAILABLE_ACTION_IDS_CAP = 24
+
 
 def _strings(value: Any) -> list[str]:
     return [str(item).strip() for item in value or [] if str(item or "").strip()]

--- a/consent-protocol/tests/test_onboarding_goal_agent.py
+++ b/consent-protocol/tests/test_onboarding_goal_agent.py
@@ -5,6 +5,7 @@ from hushh_mcp.agents.onboarding.agent import (
     OnboardingJourneyContext,
     resolve_onboarding_goal,
 )
+from hushh_mcp.services.action_gateway import AVAILABLE_ACTION_IDS_CAP
 
 
 def test_available_action_ids_bound_matches_the_frontend_publisher():
@@ -26,7 +27,7 @@ def test_available_action_ids_bound_matches_the_frontend_publisher():
         (constraint.max_length for constraint in field.metadata if hasattr(constraint, "max_length")),
         PydanticUndefined,
     )
-    assert max_length == 18
+    assert max_length == AVAILABLE_ACTION_IDS_CAP
 
 
 def test_login_only_permits_explicit_provider_actions_and_requests_choice() -> None:

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -199,6 +199,18 @@ class TestAgentTreeShape:
         assert "Never call yourself Kai" in ONE_IDENTITY_INSTRUCTION
         assert "Visible controls take priority over introductions" in ONE_IDENTITY_INSTRUCTION
         assert "list_app_actions" in ONE_IDENTITY_INSTRUCTION
+        # Replaces "call list_app_actions when the exact id is uncertain": a
+        # confidence judgment that swung on wording, not a checkable rule.
+        # Two-turn table-stakes regression: "save me" and "trigger sos"
+        # should not diverge on whether the model felt certain about either.
+        assert (
+            "call list_app_actions first with their own words, every time, "
+            "rather than judging whether you feel certain" in ONE_IDENTITY_INSTRUCTION
+        )
+        assert (
+            "Call list_app_actions first unless their words are already a "
+            "close match to one of the visible labels" in ONE_IDENTITY_INSTRUCTION
+        )
         assert "correlated app action settlement" in ONE_IDENTITY_INSTRUCTION
         assert "Conversation comes before workflow" in ONE_IDENTITY_INSTRUCTION
         assert "so what?" in ONE_IDENTITY_INSTRUCTION
@@ -209,6 +221,12 @@ class TestAgentTreeShape:
         assert "Gmail receipt sync and inbox search are paused" in ONE_IDENTITY_INSTRUCTION
         assert "named CRM" in ONE_IDENTITY_INSTRUCTION
         assert "summon that specialist" in ONE_IDENTITY_INSTRUCTION
+        # Onboarding's own instance of the same rule (replaces "When the
+        # exact generated id is uncertain, call list_app_actions").
+        assert (
+            "Whenever the person's own words are not a close match to one of "
+            "the visible labels, call list_app_actions" in ONE_IDENTITY_INSTRUCTION
+        )
 
     def test_identity_instruction_carries_persona_grounding(self):
         # Durable north-star + principle grounding is folded into the shared
@@ -261,7 +279,14 @@ class TestAgentTreeShape:
         assert "ACTIVE ROUTE PLAYBOOK" in instruction
         assert "Terms => auth.open_terms" in instruction
         assert "Do not call open_screen" in instruction
-        assert "First assess meaning semantically" in instruction
+        assert (
+            "First check whether the person's own words closely echo one of the "
+            "labels above" in instruction
+        )
+        assert (
+            "call list_app_actions with their own words first, every time, "
+            "rather than guessing from a label that only partly fits" in instruction
+        )
 
     def test_runtime_instruction_warns_when_voice_control_is_off(self):
         # Gate 1/Gate 2 refuse every actual tool call while voice is off, but
@@ -354,7 +379,7 @@ class TestAgentTreeShape:
         assert "Continue with Apple => auth.sign_in_apple" in instruction
         assert "Continue with Google => auth.sign_in_google" in instruction
         assert "clear provider request selects its exact Apple or Google action" in instruction
-        assert "list_app_actions only to retrieve bounded candidates" in instruction
+        assert "call list_app_actions with their own words first, every time" in instruction
         assert "genuinely ambiguous" in instruction
 
     def test_finance_instruction_distinguishes_an_unlocked_empty_portfolio(self):

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5185,7 +5185,7 @@
     "cache_manifest": "734cae0bc468da32e9aa6f5b680c5fb40d49696e3b90629c533791ad5288f8f4",
     "data_plane": "16a6bb7ebddcbfd360a07034ed83ba0b966d8667fe879bee928991d0f591e04d",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "351d32350df126e7dc3177b231b2962d6ec9181de526e03f31ec2b5b01de18af",
+    "one_specialist_tools": "f2c4248adbaa8615f745339fae7722a69588c49cf8bac23e2d19248c54135f7b",
     "route_index": "8b0278cc2a76ccc2b3c5b35e4e9bb4d0ca8dcf4b08f313f368ca992f634ea262",
     "route_layout": "178064ac4f170604e1014eb9eb87fad2aae55c1a9a7039dbd34c4b20ea51704b",
     "surface_map": "24c517f46dab35bc730499bb1bde7191a7b06b7f3243d681c60c0568898ee216",

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -70,22 +70,37 @@ describe("the action-id cap invariant this file's own comments document", () => 
     expect(ACTION_ID_SCREEN_SEGMENT_CAP).toBeLessThanOrEqual(AVAILABLE_ACTION_IDS_CAP);
   });
 
-  it("matches the backend's Pydantic max_length for available_action_ids", () => {
-    // consent-protocol/hushh_mcp/agents/onboarding/agent.py's
-    // OnboardingJourneyContext.available_action_ids has max_length=18 --
-    // see tests/test_onboarding_goal_agent.py's matching parity test on
-    // that side. There is no automated cross-language sync for this; both
-    // sides must be changed together, in the same commit.
-    expect(AVAILABLE_ACTION_IDS_CAP).toBe(18);
+  it("is derived, not a bare number to keep in sync by hand", () => {
+    // Used to be a bare 18 in four places (this file, the backend's
+    // LIVE_CONTEXT_ARRAY_CAP, its onboarding Pydantic max_length, and two
+    // agent_tree.py render-time slices), each requiring a manual "keep in
+    // sync" edit whenever GLOBAL_NAV_ACTION_IDS grew. It grew twice without
+    // any of those edits happening, which is what silently broke the
+    // "must ALWAYS be visible" guarantee below. Deriving it here means
+    // there is only one number to get right.
+    expect(AVAILABLE_ACTION_IDS_CAP).toBe(
+      ACTION_ID_SCREEN_SEGMENT_CAP + GLOBAL_NAV_ACTION_IDS.length,
+    );
   });
 
-  it("documents that a crowded screen already trades away some global-nav slots", () => {
-    // Not a bound that must hold -- the opposite: 14 + 8 already exceeds 18
-    // today, so the append loop in prioritizeAvailableActionIds already
-    // silently drops some GLOBAL_NAV_ACTION_IDS entries once a screen's own
-    // segment is full. Asserted here so a future reader sees this is known
-    // and accepted, not undiscovered.
-    expect(ACTION_ID_SCREEN_SEGMENT_CAP + GLOBAL_NAV_ACTION_IDS.length).toBeGreaterThan(
+  it("matches the backend's shared AVAILABLE_ACTION_IDS_CAP", () => {
+    // consent-protocol/hushh_mcp/services/action_gateway.py defines the same
+    // derivation in Python (imported by live_context.py's
+    // LIVE_CONTEXT_ARRAY_CAP, onboarding/agent.py's Pydantic max_length, and
+    // agent_tree.py's two render-time slices). There is no automated
+    // cross-language sync for this; both sides must be changed together, in
+    // the same commit, and this pins the current value so a drift is caught
+    // here instead of in a UAT deploy.
+    expect(AVAILABLE_ACTION_IDS_CAP).toBe(24);
+  });
+
+  it("never lets a crowded screen trade away a global-nav slot", () => {
+    // The bug this replaces: GLOBAL_NAV_ACTION_IDS's own comment says these
+    // "must ALWAYS be visible... regardless of the current screen", but the
+    // cap used to be a bare 18, so only the first 4 (fixed declaration
+    // order) survived once a screen's local segment filled its 14 slots.
+    // Now the cap is sized to hold both segments in full, always.
+    expect(ACTION_ID_SCREEN_SEGMENT_CAP + GLOBAL_NAV_ACTION_IDS.length).toBeLessThanOrEqual(
       AVAILABLE_ACTION_IDS_CAP,
     );
   });
@@ -1187,6 +1202,14 @@ describe("a surface that declares more controls than the context can carry", () 
     clearVoiceSurfaceMetadata();
   });
 
+  // Local (screen-owned) ids only, excluding the reserved global-nav segment
+  // -- that segment now rides along on every screen with published actions
+  // (see the includeGlobalNavigation fix above), so a plain length check
+  // against the combined array no longer isolates the screen-segment cap.
+  function localOnlyIds(actionIds: readonly string[]): string[] {
+    return actionIds.filter((id) => !GLOBAL_NAV_ACTION_IDS.includes(id));
+  }
+
   it("keeps the actions that DO something when the openers outnumber the cap", () => {
     // Location's real shape: 18 controls whose first ten all open a tab, with
     // every acting handler declared last. `publishedActionIds` was capped at
@@ -1248,7 +1271,7 @@ describe("a surface that declares more controls than the context can carry", () 
     );
     expect(snapshot.available_action_ids).toContain("location.pause_updates");
     // Still bounded -- this fixes an ordering bug, it does not lift the cap.
-    expect(snapshot.available_action_ids.length).toBeLessThanOrEqual(
+    expect(localOnlyIds(snapshot.available_action_ids).length).toBeLessThanOrEqual(
       ACTION_ID_SCREEN_SEGMENT_CAP,
     );
     // And the openers are what yields, since navigation is admitted from any
@@ -1317,7 +1340,7 @@ describe("a surface that declares more controls than the context can carry", () 
     for (const actionId of localHandlers) {
       expect(snapshot.available_action_ids).toContain(actionId);
     }
-    expect(snapshot.available_action_ids.length).toBeLessThanOrEqual(
+    expect(localOnlyIds(snapshot.available_action_ids).length).toBeLessThanOrEqual(
       ACTION_ID_SCREEN_SEGMENT_CAP,
     );
   });
@@ -1389,8 +1412,69 @@ describe("a surface that declares more controls than the context can carry", () 
     for (const actionId of peopleTabActions) {
       expect(snapshot.available_action_ids).toContain(actionId);
     }
-    expect(snapshot.available_action_ids.length).toBeLessThanOrEqual(
+    expect(localOnlyIds(snapshot.available_action_ids).length).toBeLessThanOrEqual(
       ACTION_ID_SCREEN_SEGMENT_CAP,
     );
+  });
+
+  it("still shows every global nav contract when the local segment is completely full", () => {
+    // Regression for the bug this fixes: prioritizeAvailableActionIds was
+    // called with includeGlobalNavigation = underlyingActionsAvailable &&
+    // publishedActionIds.length === 0, so ANY screen that published its own
+    // actions -- Location's permanent steady state, not just a crowded
+    // moment -- got zero GLOBAL_NAV_ACTION_IDS entries, not just a truncated
+    // few. All ten must survive now regardless of how full (or empty) the
+    // local segment is, as long as no interaction layer is actively
+    // blocking.
+    window.history.pushState({}, "", "/one/location");
+    const localHandlers = [
+      "location.accept_circle_invite",
+      "location.add_emergency_contact",
+      "location.add_to_circle",
+      "location.approve_request",
+      "location.change_share_duration",
+      "location.create_circle",
+      "location.decline_circle_invite",
+      "location.decline_request",
+      "location.delete_circle",
+      "location.delete_saved_location",
+      "location.leave_circle",
+      "location.pause_updates",
+      "location.refresh",
+      "location.remove_emergency_contact",
+      "location.remove_from_circle",
+      "location.rename_circle",
+      "location.resume_updates",
+      "location.save_current_location",
+      "location.select_ask_recipient",
+      "location.select_share_recipient",
+      "location.send_check_in",
+      "location.send_request",
+      "location.set_auto_share",
+      "location.share_selected",
+      "location.stop_share",
+      "location.stop_sos",
+      "location.trigger_sos",
+    ];
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "one_location",
+      controls: localHandlers.map((actionId) => ({
+        id: actionId,
+        actionId,
+        label: actionId,
+      })),
+    });
+
+    const context = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/one/location", "one_location"),
+      voiceContext: {},
+    });
+
+    const availableIds = (
+      context.screen_metadata as { available_action_ids: string[] }
+    ).available_action_ids;
+    for (const navId of GLOBAL_NAV_ACTION_IDS) {
+      expect(availableIds).toContain(navId);
+    }
   });
 });

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -59,13 +59,6 @@ export const ACTION_ID_SCREEN_SEGMENT_CAP = 14;
 // two caps applied after it.
 export const PUBLISHED_ACTION_IDS_CAP = 64;
 /**
- * available_action_ids carries the screen-ranked list PLUS a reserved global
- * navigation segment, so it gets a wider cap than other context arrays. The
- * backend mirrors this value (Pydantic max_length + persona sanitize limit);
- * keep all three in sync.
- */
-export const AVAILABLE_ACTION_IDS_CAP = 18;
-/**
  * Cross-screen navigation contracts that must ALWAYS be visible to the model,
  * regardless of the current screen. Without this reserved segment, strict
  * screen filtering plus the context cap made "go to profile" undiscoverable
@@ -84,6 +77,23 @@ export const GLOBAL_NAV_ACTION_IDS: readonly string[] = [
   "route.voice_settings",
   "route.one_feed",
 ];
+/**
+ * available_action_ids carries the screen-ranked local segment PLUS the
+ * reserved global navigation segment above, so it must be at least as wide
+ * as both combined -- not a separately-picked number. It used to be a bare
+ * 18. That alone was a real but narrow gap (see prioritizeAvailableActionIds'
+ * caller, which had a separate and much bigger bug suppressing nav
+ * entirely on any screen with published actions -- fixed there). Deriving
+ * the cap here means the next agent that adds its own entry to
+ * GLOBAL_NAV_ACTION_IDS grows this automatically, with no second number to
+ * remember to bump.
+ *
+ * The backend mirrors this value as AVAILABLE_ACTION_IDS_CAP in
+ * hushh_mcp/services/action_gateway.py (Pydantic max_length + the two
+ * agent_tree.py render-time slices); keep them in sync.
+ */
+export const AVAILABLE_ACTION_IDS_CAP =
+  ACTION_ID_SCREEN_SEGMENT_CAP + GLOBAL_NAV_ACTION_IDS.length;
 export const ARRAY_DIMENSION_CAP_ERROR =
   "CONSTRAINT_VIOLATION_DIMENSION_OVERFLOW";
 export const INVALID_ARRAY_TYPE_ERROR = "INVALID_ARRAY_TYPE";
@@ -917,10 +927,18 @@ export function buildStructuredScreenContext(args: {
       ...publishedActionIds,
     ],
     screen,
-    // A mounted authored inventory is the current interaction authority.
-    // Do not append global navigation behind an active setup terminal, dialog,
-    // or other visible control; that would let a voice turn escape the page.
-    underlyingActionsAvailable && publishedActionIds.length === 0,
+    // Do not append global navigation behind an active setup terminal,
+    // dialog, or other blocking control; that would let a voice turn escape
+    // the page mid-flow. underlyingActionsAvailable already answers exactly
+    // that question (false only while an interaction layer is actively
+    // blocking). The extra `publishedActionIds.length === 0` this used to
+    // carry conflated "a blocking flow is open right now" with "this screen
+    // happens to publish its own actions" -- true of every substantive
+    // screen at every steady-state moment, not just risky ones -- and
+    // silently suppressed GLOBAL_NAV_ACTION_IDS entirely (not just past its
+    // cap) on Location, Gmail, and every other screen with real local
+    // handlers, every single turn.
+    underlyingActionsAvailable,
     subview,
   );
   const screenMetadata = {


### PR DESCRIPTION
## Summary

Two related voice-routing bugs, found while diagnosing why One's voice agent picks inconsistent actions on near-identical phrasing ("save me" vs "trigger sos").

**1. Global navigation was silently suppressed on any screen with published actions, not just crowded ones.**

`GLOBAL_NAV_ACTION_IDS`'s own comment says these ids "must ALWAYS be visible to the model, regardless of the current screen" -- but `prioritizeAvailableActionIds` was called with `includeGlobalNavigation = underlyingActionsAvailable && publishedActionIds.length === 0`. Any screen that publishes its own actions (Location's permanent steady state, not a transient crowded moment) got **zero** global nav entries at all times -- `route.voice_settings`, `route.one_feed`, and every other cross-agent nav contract were undiscoverable from Location, always. The extra `&& publishedActionIds.length === 0` duplicated what `underlyingActionsAvailable` already correctly guards (an active *blocking* interaction layer); removing it restores the stated guarantee while still suppressing nav during a genuine blocking modal/dialog.

Also derived `AVAILABLE_ACTION_IDS_CAP` (previously a bare `18` hand-mirrored across four files) from `ACTION_ID_SCREEN_SEGMENT_CAP + GLOBAL_NAV_ACTION_IDS.length`, so a future agent adding its own nav entry grows the cap automatically instead of needing a second manual edit.

**2. `list_app_actions`'s real alias-based fuzzy matching was gated behind the model's own uncertainty judgment.**

`list_app_actions` already scores candidates via `_relevance_score` (aliases + search_keywords) across the full 193-action generated gateway, not just the current screen -- but it only ran when the model decided a phrase felt "uncertain" first, and that self-assessment is exactly what proved unstable turn to turn on near-identical phrasing. Replaced the four "uncertain"/"unsure" gates in `agent_tree.py`'s shared instruction (used by both the Live voice head and the text agent head) plus `run_app_action`'s own tool docstring with a mechanical rule: call `list_app_actions` first whenever the person's words are not already a close match to a visible label, rather than deciding by feel.

Both fixes live in shared infrastructure (`screen-context-builder.ts`, `agent_tree.py`, `action_tools.py`) that all 39 existing `*.voice-action-contract.json` surfaces already flow through, so they apply session-wide immediately and to any future agent with no per-surface work.

## Test plan
- [x] `pytest tests/test_one_adk_agent_tree.py tests/test_onboarding_goal_agent.py tests/test_generated_contract_packaging.py tests/test_adk_registration.py -q` -- 241/242 pass (the 1 failure, `test_setup_progress_is_partitioned_in_authored_order`, is pre-existing on `main`, confirmed via `git stash`, unrelated to this change)
- [x] `npx vitest run __tests__/voice/ __tests__/morphy-ax/morphy-ax-contract.test.ts` -- 289/289 pass, including 2 new regression tests proving the nav-suppression bug is fixed (one asserting the derived cap invariant, one asserting all 10 `GLOBAL_NAV_ACTION_IDS` survive against a real dense-Location fixture that previously surfaced zero)
- [x] `npx tsc --noEmit` clean
- [x] Governed artifacts checked: `kai-action-gateway.vnext.json` / route-orchestration-index unaffected (CRLF-only diff, discarded); `runtime-topology-index.v1.json` regenerated for real (`one_specialist_tools` hash, expected from the prompt/docstring edits); surface-map and cache-coherence both current
- [ ] CI green