### PR TITLE
Polish One agent launcher

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2115,10 +2115,11 @@ html.kb-open .ambient-chrome-mask--bottom {
 }
 
 .one-agent-launcher-grid {
-  --one-agent-icon-size: clamp(54px, 15.2vw, 62px);
-  --one-agent-cell-height: clamp(86px, 23vw, 98px);
-  --one-agent-column-gap: clamp(8px, 3vw, 16px);
-  --one-agent-row-gap: clamp(8px, 2.3vh, 18px);
+  --one-agent-icon-size: 64px;
+  --one-agent-cell-height: 128px;
+  --one-agent-column-gap: 12px;
+  --one-agent-row-gap: 14px;
+  max-width: 390px;
 }
 
 .one-agent-launcher-grid-inner {
@@ -2126,17 +2127,27 @@ html.kb-open .ambient-chrome-mask--bottom {
   row-gap: var(--one-agent-row-gap);
 }
 
-@media (max-height: 620px) {
+.one-agent-app-icon svg {
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.08));
+}
+
+@media (max-width: 360px), (max-height: 620px) {
   .one-agent-launcher-grid {
-    --one-agent-icon-size: 52px;
-    --one-agent-cell-height: 84px;
+    --one-agent-icon-size: 56px;
+    --one-agent-cell-height: 112px;
+    --one-agent-column-gap: 8px;
+    --one-agent-row-gap: 10px;
+    max-width: 336px;
   }
 }
 
 @media (min-width: 768px) {
   .one-agent-launcher-grid {
-    --one-agent-icon-size: 62px;
-    --one-agent-cell-height: 98px;
+    --one-agent-icon-size: 76px;
+    --one-agent-cell-height: 156px;
+    --one-agent-column-gap: 20px;
+    --one-agent-row-gap: 20px;
+    max-width: 640px;
   }
 }
 

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -70,28 +70,29 @@ const ONE_HOME_AGENT_DEFINITIONS: readonly AgentHomeDefinition[] = [
     id: "location",
     label: "Location",
     order: 0,
-    surface: "var(--app-accent)",
+    surface:
+      "linear-gradient(180deg, var(--app-accent) 0%, color-mix(in oklab, var(--app-accent) 88%, black) 100%)",
     glyph: "location",
   },
   {
     id: "email",
     label: "KYC",
     order: 1,
-    surface: "#32ADE6",
+    surface: "linear-gradient(180deg, #42C2F2 0%, #32ADE6 100%)",
     glyph: "kyc",
   },
   {
     id: "finance",
     label: "Finance",
     order: 2,
-    surface: "#5E5CE6",
+    surface: "linear-gradient(180deg, #6E6BFF 0%, #5856D6 100%)",
     glyph: "finance",
   },
   {
     id: "ria",
     label: "RIA",
     order: 3,
-    surface: "#AF52DE",
+    surface: "linear-gradient(180deg, #BF5AF2 0%, #AF52DE 100%)",
     glyph: "ria",
   },
   {
@@ -107,28 +108,29 @@ const ONE_HOME_AGENT_DEFINITIONS: readonly AgentHomeDefinition[] = [
     id: "calendar",
     label: "Calendar",
     order: 5,
-    surface: "var(--app-accent)",
+    surface:
+      "linear-gradient(180deg, var(--app-accent) 0%, color-mix(in oklab, var(--app-accent) 88%, black) 100%)",
     glyph: "calendar",
   },
   {
     id: "pkm",
     label: "Memory",
     order: 6,
-    surface: "#30B0C7",
+    surface: "linear-gradient(180deg, #38C7D4 0%, #30B0C7 100%)",
     glyph: "memory",
   },
   {
     id: "consent",
     label: "Consent",
     order: 7,
-    surface: "#636366",
+    surface: "linear-gradient(180deg, #6E6E73 0%, #3A3A3C 100%)",
     glyph: "consent",
   },
   {
     id: "connected-systems",
     label: "CRM",
     order: 8,
-    surface: "#3A7CA5",
+    surface: "linear-gradient(180deg, #45B8D8 0%, #2F7FA8 100%)",
     glyph: "crm",
   },
 ] as const;
@@ -533,7 +535,7 @@ function AgentHomeStatusAdornment({ status }: { status: AgentHomeStatus }) {
     return (
       <span
         data-testid="one-agent-notification-badge"
-        className="absolute -right-1.5 -top-1.5 z-20 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-destructive)] px-1 text-[11px] font-semibold leading-none text-white"
+        className="absolute -right-1.5 -top-1.5 z-20 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 border-white bg-[color:var(--app-destructive)] px-1 text-[11px] font-semibold leading-none text-white shadow-[0_1px_3px_rgba(0,0,0,0.18)] dark:border-[#1C1C1E]"
         aria-hidden
       >
         {formatBadgeValue(status.count)}
@@ -545,29 +547,14 @@ function AgentHomeStatusAdornment({ status }: { status: AgentHomeStatus }) {
     return (
       <span
         data-testid="one-agent-live-dot"
-        className="absolute -right-1 -top-1 z-20 h-[10px] w-[10px] rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-success)]"
+        className="absolute -right-1 -top-1 z-20 h-[10px] w-[10px] rounded-full border-2 border-white bg-[color:var(--app-success)] dark:border-[#1C1C1E]"
         aria-hidden
       />
     );
   }
 
   if (status.kind === "setup") {
-    return (
-      <span
-        data-testid="one-agent-setup-badge"
-        className="absolute -right-1 -top-1 z-20 inline-flex h-[17px] w-[17px] items-center justify-center rounded-full border-2 border-[color:var(--background)] bg-[color:var(--app-accent)] text-white"
-        aria-hidden
-      >
-        <svg className="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" aria-hidden>
-          <path
-            d="M6 2.1v7.8M2.1 6h7.8"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeWidth="1.8"
-          />
-        </svg>
-      </span>
-    );
+    return null;
   }
 
   return null;
@@ -585,11 +572,11 @@ function AgentHomeIcon({
       <span
         data-testid={`one-agent-icon-${definition.id}`}
         className={cn(
-          "inline-flex h-[var(--one-agent-icon-size)] w-[var(--one-agent-icon-size)] items-center justify-center rounded-[25%] text-white",
-          "shadow-[0_1px_2px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.05)] ring-1 ring-white/25",
+          "one-agent-app-icon inline-flex h-[var(--one-agent-icon-size)] w-[var(--one-agent-icon-size)] items-center justify-center rounded-[25%] text-white",
+          "shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_10px_20px_rgba(0,0,0,0.14)] ring-1 ring-white/35",
           definition.surfaceClassName,
         )}
-        style={{ backgroundColor: definition.surface }}
+        style={{ background: definition.surface }}
         aria-hidden
       >
         <AgentHomeGlyph
@@ -615,9 +602,10 @@ function AgentLauncherItem({ mode }: { mode: OneAgentMode }) {
       aria-label={accessibleName}
       data-testid={`one-agent-tile-${mode.id}`}
       className={cn(
-        "group flex min-h-[var(--one-agent-cell-height)] min-w-0 flex-col items-center justify-center gap-2 rounded-[18px] px-1.5 py-2 text-center outline-none",
-        "transition-[background-color,opacity,transform] duration-150 ease-[var(--motion-ease-standard)]",
-        "hover:bg-[rgba(120,120,128,.08)] focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] active:opacity-90 motion-reduce:transition-none",
+        "one-agent-launcher-tile group flex min-h-[var(--one-agent-cell-height)] w-full min-w-0 flex-col items-center justify-center gap-2.5 rounded-[28px] px-2 text-center outline-none",
+        "bg-white/82 shadow-[inset_0_1px_0_rgba(255,255,255,0.70),0_18px_36px_rgba(29,29,31,0.08)] ring-1 ring-black/[0.045] backdrop-blur-xl",
+        "transition-[box-shadow,opacity,transform,background-color] duration-150 ease-[var(--motion-ease-standard)]",
+        "hover:bg-white hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.82),0_20px_38px_rgba(29,29,31,0.11)] focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] active:scale-[0.985] active:opacity-95 dark:bg-white/[0.075] dark:ring-white/[0.09] dark:hover:bg-white/[0.10] motion-reduce:transition-none motion-reduce:active:scale-100",
       )}
     >
       <span className="transition-transform duration-[120ms] ease-[var(--motion-ease-standard)] group-active:scale-[0.95] motion-reduce:transition-none motion-reduce:group-active:scale-100">
@@ -625,7 +613,7 @@ function AgentLauncherItem({ mode }: { mode: OneAgentMode }) {
       </span>
       <span
         data-ui-role="body-strong"
-        className="block max-w-full whitespace-nowrap text-center text-[13px] font-semibold leading-[17px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
+        className="block max-w-full whitespace-nowrap text-center text-[14px] font-semibold leading-[18px] tracking-normal text-[#1D1D1F] dark:text-[#F5F5F7]"
       >
         {definition.label}
       </span>
@@ -637,7 +625,7 @@ function AgentLauncherGrid({ children }: { children: ReactNode }) {
   return (
     <div
       data-testid="one-agents-grid"
-      className="one-agent-launcher-grid mx-auto w-full max-w-[390px] overflow-visible px-0"
+      className="one-agent-launcher-grid mx-auto w-full overflow-visible px-0"
     >
       <div
         data-agent-roster-layout="app-icon-launcher-grid"
@@ -669,7 +657,7 @@ export function OneAgentRoster({
     <section
       aria-label="One agents"
       data-testid="one-agents-section"
-      className="mx-auto flex w-full max-w-[430px] flex-col justify-center"
+      className="mx-auto flex w-full max-w-[760px] flex-col justify-center"
     >
       <h1 className="sr-only">One</h1>
       <AgentLauncherGrid>

--- a/hushh-webapp/components/dashboard/one-dashboard-page.tsx
+++ b/hushh-webapp/components/dashboard/one-dashboard-page.tsx
@@ -17,7 +17,8 @@ export function OneDashboardPage({
     <AppPageShell
       as="main"
       width="standard"
-      className="relative isolate pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)]"
+      fitContent
+      className="relative isolate"
       nativeTest={{
         routeId: "/one",
         marker: "native-route-one-home",

--- a/hushh-webapp/e2e/one-agent-directory-ui.spec.ts
+++ b/hushh-webapp/e2e/one-agent-directory-ui.spec.ts
@@ -49,11 +49,8 @@ test.describe("first post-login Agent Directory visual contract", () => {
       await page.setViewportSize(viewport);
       await openOneDirectory(page);
 
-      await expect(
-        page.getByRole("heading", { name: "Agents (9)" }),
-      ).toBeVisible();
-      await expect(page.getByTestId("one-agents-search")).toBeVisible();
       await expect(page.getByTestId("one-agents-grid")).toBeVisible();
+      await expect(page.getByTestId("one-agents-search")).toHaveCount(0);
 
       const metrics = await page.evaluate(() => {
         const foundation = document.querySelector(".foundation-public-ambient");
@@ -64,12 +61,6 @@ test.describe("first post-login Agent Directory visual contract", () => {
           '[data-testid="one-agents-section"]',
         );
         const sectionRect = section?.getBoundingClientRect();
-        const title = document.querySelector("#one-agents-heading");
-        const titleStyle = title ? getComputedStyle(title) : null;
-        const search = document.querySelector(
-          '[data-testid="one-agents-search"]',
-        );
-        const searchStyle = search ? getComputedStyle(search) : null;
         const grid = document.querySelector('[data-testid="one-agents-grid"]');
         const layout = document.querySelector(
           '[data-agent-roster-layout="app-icon-launcher-grid"]',
@@ -117,12 +108,7 @@ test.describe("first post-login Agent Directory visual contract", () => {
         return {
           foundationBackgroundImage: foundationStyle?.backgroundImage,
           foundationBackgroundColor: foundationStyle?.backgroundColor,
-          titleFontSize: titleStyle?.fontSize,
-          titleFontWeight: titleStyle?.fontWeight,
-          titleLineHeight: titleStyle?.lineHeight,
           sectionWidth: Math.round(sectionRect?.width ?? 0),
-          searchHeight: Math.round(search?.getBoundingClientRect().height ?? 0),
-          searchRadius: searchStyle?.borderRadius,
           gridClassName: layout?.className,
           gridWidth: Math.round(gridRect?.width ?? 0),
           tileCount: tiles.length,
@@ -134,22 +120,16 @@ test.describe("first post-login Agent Directory visual contract", () => {
       });
 
       expect(metrics.foundationBackgroundImage).toBe("none");
-      expect(metrics.titleFontSize).toBe("34px");
-      expect(metrics.titleFontWeight).toBe("700");
-      expect(metrics.titleLineHeight).toBe("41px");
-      expect(metrics.sectionWidth).toBeLessThanOrEqual(560);
-      expect(metrics.searchHeight).toBeGreaterThanOrEqual(44);
-      expect(metrics.searchHeight).toBeLessThanOrEqual(46);
-      expect(metrics.searchRadius).toBe("15px");
+      expect(metrics.sectionWidth).toBeLessThanOrEqual(820);
       expect(metrics.gridClassName).toContain("grid-cols-3");
-      expect(metrics.gridWidth).toBeLessThanOrEqual(552);
+      expect(metrics.gridWidth).toBeLessThanOrEqual(640);
       expect(metrics.tileCount).toBe(9);
       expect(metrics.tiles.every((tile) => tile.height >= 100)).toBe(true);
       expect(metrics.icons.every((icon) => icon.width >= 60)).toBe(true);
       expect(metrics.icons.every((icon) => icon.height >= 60)).toBe(true);
       expect(
         metrics.icons.every((icon) =>
-          ["18px", "17px", "16px"].includes(icon.radius),
+          ["19px", "18px", "17px", "16px", "14px"].includes(icon.radius),
         ),
       ).toBe(true);
       expect(metrics.horizontalOverflow).toBe(false);


### PR DESCRIPTION
## Summary
- refine the live `/one` agent launcher into a 3x3 premium app-icon grid
- keep routes and setup routing intact while showing only truthful visual adornments: real pending counts and live Location state
- tighten responsive launcher sizing for phone and desktop without reintroducing search/list dashboard chrome

## Validation
- npm run verify:design-system
- npx vitest run __tests__/components/one-dashboard-page.test.tsx
- local Playwright screenshot/metrics on direct preview at 390x844 and 1440x900

## Notes
- No backend/API/routes changed.
- Full typecheck is not claimed here because this workspace still has unrelated untracked preview routes and generated contract noise outside this scoped diff.