### PR TITLE
fix(ria): correct marketplace request CTA label

### DIFF
--- a/hushh-webapp/__tests__/lib/marketplace/primary-card-label.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/primary-card-label.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMarketplacePrimaryCardLabel } from "@/lib/marketplace/primary-card-label";
+
+describe("resolveMarketplacePrimaryCardLabel", () => {
+  it("labels RIA primary actions as send requests when the handler sends a request", () => {
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "ria",
+        currentPersona: "ria",
+      }),
+    ).toBe("Send request");
+  });
+
+  it("preserves investor advisory copy for advisor requests", () => {
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "ria",
+        currentPersona: "investor",
+      }),
+    ).toBe("Request advisory");
+  });
+
+  it("preserves genuine profile viewing for discovery-only investor cards", () => {
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "investor",
+        currentPersona: "ria",
+        canConnect: false,
+        isInvestorShortlistable: false,
+      }),
+    ).toBe("View profile");
+  });
+
+  it("keeps connect and shortlist states distinct", () => {
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "investor",
+        currentPersona: "ria",
+        canConnect: true,
+      }),
+    ).toBe("Send request");
+
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "investor",
+        currentPersona: "ria",
+        isInvestorShortlistable: true,
+      }),
+    ).toBe("Save lead");
+  });
+});

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -41,6 +41,7 @@ import {
   marketplaceInvestorSourceLabel,
   marketplaceInvestorUserId,
 } from "@/lib/marketplace/investor-discovery";
+import { resolveMarketplacePrimaryCardLabel } from "@/lib/marketplace/primary-card-label";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { buildMarketplaceConnectionsRoute, buildRiaClientWorkspaceRoute } from "@/lib/navigation/routes";
 import {
@@ -1358,23 +1359,20 @@ export default function MarketplacePage() {
                       }
                     >
                       <span className="truncate">
-                        {swipeCard.isTestProfile
-                          ? swipeCard.kind === "investor" && currentPersona === "ria"
-                            ? "Open workspace"
-                            : "Demo"
-                          : Boolean(discoveryCardUserId(swipeCard)) &&
-                              actionLoadingUserId === discoveryCardUserId(swipeCard)
-                            ? "Connecting..."
-                            : currentPersona === "investor"
-                              ? "Request advisory"
-                              : swipeCard.canConnect
-                                ? "Send request"
-                                : swipeCard.kind === "investor" &&
-                                    isMarketplaceInvestorShortlistable(
-                                      swipeCard.profile as MarketplaceInvestor
-                                    )
-                                  ? "Save lead"
-                                  : "View profile"}
+                        {resolveMarketplacePrimaryCardLabel({
+                          kind: swipeCard.kind,
+                          isTestProfile: swipeCard.isTestProfile,
+                          isActionLoading:
+                            Boolean(discoveryCardUserId(swipeCard)) &&
+                            actionLoadingUserId === discoveryCardUserId(swipeCard),
+                          currentPersona,
+                          canConnect: swipeCard.canConnect,
+                          isInvestorShortlistable:
+                            swipeCard.kind === "investor" &&
+                            isMarketplaceInvestorShortlistable(
+                              swipeCard.profile as MarketplaceInvestor
+                            ),
+                        })}
                       </span>
                     </Button>
                   </div>
@@ -1418,6 +1416,9 @@ export default function MarketplacePage() {
             const isPublicSecInvestor =
               item.kind === "investor" &&
               isPublicSecMarketplaceInvestor(item.profile as MarketplaceInvestor);
+            const isInvestorShortlistable =
+              item.kind === "investor" &&
+              isMarketplaceInvestorShortlistable(item.profile as MarketplaceInvestor);
             return (
               <RiaSurface
                 key={`${item.kind}-${item.id}`}
@@ -1472,22 +1473,14 @@ export default function MarketplacePage() {
                       (Boolean(item.isTestProfile) && item.kind === "ria")
                     }
                   >
-                    {item.isTestProfile
-                      ? item.kind === "investor" && currentPersona === "ria"
-                        ? "Open workspace"
-                        : "Demo"
-                      : Boolean(userId) && actionLoadingUserId === userId
-                        ? "Connecting..."
-                        : currentPersona === "investor"
-                          ? "Request advisory"
-                          : item.canConnect
-                            ? "Send request"
-                            : item.kind === "investor" &&
-                                isMarketplaceInvestorShortlistable(
-                                  item.profile as MarketplaceInvestor
-                                )
-                              ? "Save lead"
-                              : "View profile"}
+                    {resolveMarketplacePrimaryCardLabel({
+                      kind: item.kind,
+                      isTestProfile: item.isTestProfile,
+                      isActionLoading: Boolean(userId) && actionLoadingUserId === userId,
+                      currentPersona,
+                      canConnect: item.canConnect,
+                      isInvestorShortlistable,
+                    })}
                   </Button>
                   <Button
                     variant="none"

--- a/hushh-webapp/lib/marketplace/primary-card-label.ts
+++ b/hushh-webapp/lib/marketplace/primary-card-label.ts
@@ -1,0 +1,33 @@
+import type { Persona } from "@/lib/services/ria-service";
+
+export type MarketplacePrimaryCardLabelInput = {
+  kind: "ria" | "investor";
+  isTestProfile?: boolean;
+  isActionLoading?: boolean;
+  currentPersona: Persona;
+  canConnect?: boolean;
+  isInvestorShortlistable?: boolean;
+};
+
+export function resolveMarketplacePrimaryCardLabel({
+  kind,
+  isTestProfile = false,
+  isActionLoading = false,
+  currentPersona,
+  canConnect = false,
+  isInvestorShortlistable = false,
+}: MarketplacePrimaryCardLabelInput): string {
+  if (isTestProfile) {
+    return kind === "investor" && currentPersona === "ria" ? "Open workspace" : "Demo";
+  }
+
+  if (isActionLoading) return "Connecting...";
+
+  if (kind === "ria") {
+    return currentPersona === "investor" ? "Request advisory" : "Send request";
+  }
+
+  if (isInvestorShortlistable) return "Save lead";
+  if (canConnect) return "Send request";
+  return "View profile";
+}


### PR DESCRIPTION
Description
In RIA → Clients → Connected → Browse the Marketplace, the primary CTA is inconsistent across marketplace client cards.

Some cards display:

"Send Request"

while other cards display:

"View Profile"

However, both CTAs currently perform the same Send Request action.

Since the intended action in this marketplace state is to send a connection request, displaying "View Profile" is misleading and does not accurately communicate what will happen when the user clicks the button.

This should be corrected as a frontend UI/UX consistency issue by displaying "Send Request" for the applicable marketplace cards while preserving the existing request functionality.

Steps To Reproduce
Open RIA → Clients.
Select Connected.
Open Browse the Marketplace.
Compare multiple marketplace client cards.
Observe that some cards display "Send Request" while others display "View Profile".
Click a card displaying "View Profile".
Observe that it performs the Send Request action rather than opening a profile.
Expected Behavior
Marketplace cards whose primary action sends a connection request should consistently display:

"Send Request"

The CTA label must accurately describe the action that occurs when it is selected.

After the fix:

"View Profile" should be replaced with "Send Request" for the affected marketplace state.
Existing Send Request functionality should remain unchanged.
No new profile-navigation behavior should be introduced.
Request state and connection logic should remain unchanged.
CTA styling and alignment should remain consistent across marketplace cards.