### PR TITLE
fix(ria): normalize marketplace heading case

### DIFF
--- a/hushh-webapp/__tests__/lib/marketplace/display-name.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/display-name.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMarketplaceDisplayName } from "@/lib/marketplace/display-name";
+
+describe("formatMarketplaceDisplayName", () => {
+  it("normalizes uppercase marketplace organization names for display", () => {
+    expect(formatMarketplaceDisplayName("BERKSHIRE HATHAWAY INC")).toBe(
+      "Berkshire Hathaway Inc"
+    );
+    expect(formatMarketplaceDisplayName("CITADEL ADVISORS LLC")).toBe("Citadel Advisors LLC");
+    expect(formatMarketplaceDisplayName("MILLENNIUM MANAGEMENT LLC")).toBe(
+      "Millennium Management LLC"
+    );
+  });
+
+  it("preserves legal suffixes, punctuation, and known acronyms", () => {
+    expect(formatMarketplaceDisplayName("BRIDGEWATER ASSOCIATES, LP")).toBe(
+      "Bridgewater Associates, LP"
+    );
+    expect(formatMarketplaceDisplayName("PERSHING SQUARE CAPITAL MANAGEMENT, L.P.")).toBe(
+      "Pershing Square Capital Management, L.P."
+    );
+    expect(formatMarketplaceDisplayName("ABC AI CAPITAL LLC")).toBe("Abc AI Capital LLC");
+    expect(formatMarketplaceDisplayName("RIA PARTNERS LLC")).toBe("RIA Partners LLC");
+    expect(formatMarketplaceDisplayName("SEC ETF USA UK")).toBe("SEC ETF USA UK");
+  });
+
+  it("keeps already-readable and intentionally mixed-case names unchanged", () => {
+    expect(formatMarketplaceDisplayName("Bridgewater Associates, LP")).toBe(
+      "Bridgewater Associates, LP"
+    );
+    expect(formatMarketplaceDisplayName("iShares")).toBe("iShares");
+  });
+
+  it("handles empty, whitespace, and punctuation-heavy values safely", () => {
+    expect(formatMarketplaceDisplayName("")).toBe("");
+    expect(formatMarketplaceDisplayName("   ")).toBe("");
+    expect(formatMarketplaceDisplayName("  CITADEL ADVISORS, LLC  ")).toBe(
+      "Citadel Advisors, LLC"
+    );
+    expect(formatMarketplaceDisplayName("A&B CAPITAL LLC")).toBe("A&B Capital LLC");
+  });
+});

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -41,6 +41,7 @@ import {
   marketplaceInvestorSourceLabel,
   marketplaceInvestorUserId,
 } from "@/lib/marketplace/investor-discovery";
+import { formatMarketplaceDisplayName } from "@/lib/marketplace/display-name";
 import { resolveMarketplacePrimaryCardLabel } from "@/lib/marketplace/primary-card-label";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { buildMarketplaceConnectionsRoute, buildRiaClientWorkspaceRoute } from "@/lib/navigation/routes";
@@ -310,7 +311,7 @@ export default function MarketplacePage() {
     return {
       id: marketplaceInvestorCardId(investor),
       kind: "investor",
-      title: investor.display_name,
+      title: formatMarketplaceDisplayName(investor.display_name),
       headline: investor.headline || "Open to advisor connections",
       summary:
         investor.strategy_summary ||
@@ -684,7 +685,7 @@ export default function MarketplacePage() {
       return {
         id: ria.id,
         kind: "ria" as const,
-        title: ria.display_name,
+        title: formatMarketplaceDisplayName(ria.display_name),
         headline: ria.headline || "Advisor profile available",
         summary: ria.strategy_summary || RIA_COPY.connect.summaryFallback,
         metaLine:
@@ -717,7 +718,7 @@ export default function MarketplacePage() {
       return {
         id: investorId,
         kind: "investor" as const,
-        title: investor.display_name,
+        title: formatMarketplaceDisplayName(investor.display_name),
         headline: investor.headline || "Open to advisor connections",
         summary:
           investor.strategy_summary ||

--- a/hushh-webapp/lib/marketplace/display-name.ts
+++ b/hushh-webapp/lib/marketplace/display-name.ts
@@ -1,0 +1,60 @@
+const PRESERVED_MARKETPLACE_TOKENS = new Map<string, string>([
+  ["AI", "AI"],
+  ["ETF", "ETF"],
+  ["L.P.", "L.P."],
+  ["LLC", "LLC"],
+  ["LP", "LP"],
+  ["RIA", "RIA"],
+  ["SEC", "SEC"],
+  ["UK", "UK"],
+  ["USA", "USA"],
+]);
+
+const MARKETPLACE_TITLE_SUFFIXES = new Map<string, string>([
+  ["CO", "Co"],
+  ["CO.", "Co."],
+  ["CORP", "Corp"],
+  ["CORP.", "Corp."],
+  ["INC", "Inc"],
+  ["INC.", "Inc."],
+  ["LTD", "Ltd"],
+  ["LTD.", "Ltd."],
+]);
+
+function isMostlyUppercase(value: string): boolean {
+  const letters = value.match(/[A-Za-z]/g) ?? [];
+  if (letters.length === 0) return false;
+  const uppercaseLetters = letters.filter((letter) => letter === letter.toUpperCase()).length;
+  return uppercaseLetters / letters.length >= 0.8;
+}
+
+function titleCaseWord(value: string): string {
+  return value.replace(/[A-Za-z][A-Za-z']*/g, (word) => {
+    const lower = word.toLowerCase();
+    return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+  });
+}
+
+function normalizeMarketplaceToken(token: string): string {
+  const commaSuffix = token.endsWith(",") ? "," : "";
+  const core = commaSuffix ? token.slice(0, -1) : token;
+  const normalizedCore = core.toUpperCase();
+
+  const preserved = PRESERVED_MARKETPLACE_TOKENS.get(normalizedCore);
+  if (preserved) return `${preserved}${commaSuffix}`;
+
+  const suffix = MARKETPLACE_TITLE_SUFFIXES.get(normalizedCore);
+  if (suffix) return `${suffix}${commaSuffix}`;
+
+  return `${core
+    .split("-")
+    .map((part) => titleCaseWord(part))
+    .join("-")}${commaSuffix}`;
+}
+
+export function formatMarketplaceDisplayName(rawName: string | null | undefined): string {
+  const name = String(rawName ?? "").trim();
+  if (!name) return "";
+  if (!isMostlyUppercase(name)) return name;
+  return name.split(/\s+/).map(normalizeMarketplaceToken).join(" ");
+}


### PR DESCRIPTION
## Summary

Normalizes the display casing of marketplace organization headings in
RIA -> Clients -> Connected -> Browse the Marketplace.

## Problem

Some organization names sourced in uppercase were displayed entirely in capitals while other marketplace headings used readable proper casing, creating inconsistent visual hierarchy.

## Root Cause

Marketplace cards built `DiscoveryCard.title` directly from `ria.display_name` and `investor.display_name`, then rendered that value unchanged in the card heading and avatar label. SEC/public organization names can arrive as uppercase source display values, and there was no marketplace display-name formatter in this render path. This was frontend presentation drift, not a CSS `text-transform` rule and not backend/source-data mutation.

## Fix

Added a frontend-only marketplace display formatter that normalizes predominantly uppercase organization names while preserving legal suffixes and common acronyms, then applied it only when marketplace cards derive their display title.

## Scope

Frontend presentation only.

No changes to:
- backend
- APIs
- marketplace source data
- SEC/EDGAR records
- client/entity records
- search/filtering
- request logic
- authentication
- business logic

## Action Item

Action Item: #6089

Fixes #6089

## QA

- [ ] Berkshire Hathaway Inc displays correctly
- [ ] Citadel Advisors LLC displays correctly
- [ ] Millennium Management LLC displays correctly
- [ ] LP / L.P. preserved
- [ ] SEC / RIA / AI preserved
- [ ] already-correct names unchanged
- [ ] desktop verified
- [ ] mobile verified
- [ ] no card layout regression

## Verification

- `npx.cmd vitest run __tests__/lib/marketplace/display-name.test.ts __tests__/lib/marketplace/primary-card-label.test.ts __tests__/app/marketplace/page-card-layout.contract.test.ts`
- `npx.cmd eslint app/marketplace/page.tsx lib/marketplace/display-name.ts __tests__/lib/marketplace/display-name.test.ts --max-warnings=0`
- `npm.cmd run typecheck`
- `npm.cmd run verify:design-system`
- `npm.cmd run verify:docs`
- `npm.cmd run verify:cache`
- `git diff --check`
