### PR TITLE
fix(connect): restore contacts refresh control

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -375,6 +375,77 @@ describe("Connect — People", () => {
     ).toEqual([1, 2, 3, 1, 2]);
   });
 
+  it("refreshes My connections from the visible refresh control", async () => {
+    const refreshedPageOne = deferred<TestConnectionPage>();
+    let firstPageCallCount = 0;
+    mocks.listConnectionsPage.mockImplementation(async (_options) => {
+      firstPageCallCount += 1;
+      if (firstPageCallCount > 1) return refreshedPageOne.promise;
+      return {
+        items: [
+          {
+            connectionId: "c-current",
+            userId: "u-current",
+            displayName: "Current Person",
+            photoUrl: null,
+          },
+        ],
+        page: 1,
+        hasMore: false,
+        totalCount: 1,
+        audience: "all",
+      };
+    });
+
+    render(<ConnectPageClient />);
+
+    expect(await screen.findByText("Current Person")).toBeTruthy();
+    expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh contacts" }));
+
+    await waitFor(() =>
+      expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(2),
+    );
+    const refreshingButton = screen.getByRole("button", {
+      name: "Refresh contacts",
+    }) as HTMLButtonElement;
+    expect(refreshingButton.disabled).toBe(true);
+    expect(refreshingButton).toHaveAttribute("aria-busy", "true");
+
+    fireEvent.click(refreshingButton);
+    expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      refreshedPageOne.resolve({
+        items: [
+          {
+            connectionId: "c-refreshed",
+            userId: "u-refreshed",
+            displayName: "Refreshed Person",
+            photoUrl: null,
+          },
+        ],
+        page: 1,
+        hasMore: false,
+        totalCount: 1,
+        audience: "all",
+      });
+      await refreshedPageOne.promise;
+    });
+
+    expect(await screen.findByText("Refreshed Person")).toBeTruthy();
+    expect(screen.queryByText("Current Person")).toBeNull();
+    const refreshButton = screen.getByRole("button", {
+      name: "Refresh contacts",
+    }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(false);
+    expect(refreshButton).toHaveAttribute("aria-busy", "false");
+    expect(mocks.listConnectionsPage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 1, limit: 50, audience: "all" }),
+    );
+  });
+
   it("restarts paging after removing a connection loaded beyond page 1", async () => {
     let removed = false;
     mocks.removeConnection.mockImplementation(async () => {

--- a/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
@@ -33,4 +33,13 @@ describe("marketplace client card layout contract", () => {
     expect(source).toContain('data-testid="marketplace-client-card-actions"');
     expect(source).toContain("mt-auto grid grid-cols-1 gap-2 pt-1 sm:grid-cols-2");
   });
+
+  it("wires the toolbar refresh beside Contacts to contact matching", () => {
+    const source = readMarketplacePage();
+
+    expect(source).toContain('aria-label="Refresh contacts"');
+    expect(source).toContain("onClick={() => void matchContacts()}");
+    expect(source).toContain("aria-busy={contactMatchLoading}");
+    expect(source).not.toContain('aria-label={directoryKind === "investors" ? "Refresh deck" : "Restart deck"}');
+  });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -7,6 +7,7 @@ import {
   BadgeCheck,
   Loader2,
   Lock,
+  RefreshCw,
   Search as SearchIcon,
   Share2,
   UserRound,
@@ -252,6 +253,8 @@ const CONNECT_PAGER_BUTTON_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
 const CONNECT_INLINE_BUTTON_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
+const CONNECT_REFRESH_BUTTON_CLASSNAME =
+  "h-8 min-h-8 w-8 min-w-8 rounded-full p-0 text-muted-foreground hover:text-foreground disabled:opacity-70";
 
 /** Maximum number of connection requests the People bulk action can send. */
 const MAX_BULK_CONNECTION_REQUESTS = 8;
@@ -715,6 +718,17 @@ export default function ConnectPageClient() {
   // the same mistake as asking for page 3 of a query they just retyped.
   const directoryAudience = CONNECT_TAB_AUDIENCE[tab];
   const isAdvisorTab = tab === "advisors";
+  const connectionsHeading = isAdvisorTab
+    ? `My RIAs (${connectionsTotalCount})`
+    : `My connections (${connectionsTotalCount})`;
+  const handleRefreshConnections = useCallback(() => {
+    if (connectionsRefreshingFirstPage) return;
+    void refreshConnectionsFirstPage({ audience: connectionAudience });
+  }, [
+    connectionAudience,
+    connectionsRefreshingFirstPage,
+    refreshConnectionsFirstPage,
+  ]);
   // Searching a name and finding nobody has one likely explanation the
   // directory cannot act on: that person has not joined yet. Offered on People
   // only -- People searches the whole of One, so "not here" really does mean
@@ -2037,38 +2051,58 @@ export default function ConnectPageClient() {
               <NearbyDirectories getIdToken={getIdToken} />
             ) : (
               <div className="space-y-4 sm:space-y-5">
-            <SettingsGroup
-              title={
-                isAdvisorTab
-                          ? `My RIAs (${connectionsTotalCount})`
-                          : `My connections (${connectionsTotalCount})`
-              }
-              separatorInset
-              contentClassName={
-                sortedConnections.length > 0
-                  ? "max-h-[232px] overflow-y-auto overscroll-contain sm:max-h-[320px]"
-                  : undefined
-              }
-              testId="connect-my-connections-group"
-            >
-              {sortedConnections.length === 0 ? (
-                <SettingsRow
-                  // No description. "Connections appear here." explained what
-                  // an empty list already showed, and the obvious replacement
-                  // -- pointing at the search box -- is the sentence the
-                  // directory section directly below already carries. Saying
-                  // it twice on one screen is what made it noise the first
-                  // time. The title is the whole message.
-                          title={
-                            isAdvisorTab ? "No RIAs yet" : "No connections yet"
-                          }
-                  density="compact"
-                  disabled
-                />
-              ) : (
-                sortedConnections.map((connection) => (
-                  <SettingsRow
-                    key={connection.connectionId}
+                <SettingsGroup
+                  title={
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="min-w-0 truncate">
+                        {connectionsHeading}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        aria-label="Refresh contacts"
+                        aria-busy={connectionsRefreshingFirstPage}
+                        title="Refresh contacts"
+                        disabled={connectionsRefreshingFirstPage}
+                        onClick={handleRefreshConnections}
+                        className={CONNECT_REFRESH_BUTTON_CLASSNAME}
+                      >
+                        <RefreshCw
+                          aria-hidden="true"
+                          className={cn(
+                            "h-3.5 w-3.5",
+                            connectionsRefreshingFirstPage && "animate-spin",
+                          )}
+                        />
+                      </Button>
+                    </span>
+                  }
+                  separatorInset
+                  contentClassName={
+                    sortedConnections.length > 0
+                      ? "max-h-[232px] overflow-y-auto overscroll-contain sm:max-h-[320px]"
+                      : undefined
+                  }
+                  testId="connect-my-connections-group"
+                >
+                  {sortedConnections.length === 0 ? (
+                    <SettingsRow
+                      // No description. "Connections appear here." explained what
+                      // an empty list already showed, and the obvious replacement
+                      // -- pointing at the search box -- is the sentence the
+                      // directory section directly below already carries. Saying
+                      // it twice on one screen is what made it noise the first
+                      // time. The title is the whole message.
+                      title={isAdvisorTab ? "No RIAs yet" : "No connections yet"}
+                      density="compact"
+                      disabled
+                    />
+                  ) : (
+                    sortedConnections.map((connection) => (
+                      <SettingsRow
+                        key={connection.connectionId}
                     // Same mark, same tone, same meaning as the results list
                     // below: verified is a state, and this screen already
                     // spends green on it. Both lists are on screen together,

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1133,11 +1133,15 @@ export default function MarketplacePage() {
               </Button>
               <button
                 type="button"
-                className="grid h-10 w-10 place-items-center rounded-full border-0 bg-card text-foreground transition-[background-color,transform] duration-200 hover:scale-105 active:scale-95"
-                aria-label={directoryKind === "investors" ? "Refresh deck" : "Restart deck"}
-                onClick={resetSwipeDeck}
+                className="grid h-10 w-10 place-items-center rounded-full border-0 bg-card text-foreground transition-[background-color,transform] duration-200 hover:scale-105 active:scale-95 disabled:opacity-70"
+                aria-label="Refresh contacts"
+                aria-busy={contactMatchLoading}
+                disabled={contactMatchLoading}
+                onClick={() => void matchContacts()}
               >
-                <RotateCcw className="h-4 w-4" />
+                <RotateCcw
+                  className={cn("h-4 w-4", contactMatchLoading && "animate-spin")}
+                />
               </button>
             </div>
 


### PR DESCRIPTION
## Summary
- Restores a visible Refresh contacts control in the Connect Contacts/My connections heading.
- Wires the marketplace toolbar refresh icon beside Contacts to contact matching instead of deck reset.
- Adds regression coverage for both the Connect refresh flow and the marketplace toolbar wiring.

Fixes #6091

## Root Cause
The Connect page already had a valid refresh path for connection graph updates, but the Contacts/My connections section had no visible user-facing refresh control wired to that path. Separately, the marketplace toolbar icon beside the Contacts pill looked like a contacts refresh control but called resetSwipeDeck, so it restarted/refreshed the deck instead of re-running contact matching.

## Scope
Frontend-only. Changed Connect and Marketplace route UI/tests. No backend, API, database, auth, request contract, dependency, package-lock, or governance changes.

## Validation
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- npm.cmd run verify:connect-search
- npm.cmd run test -- __tests__/app/marketplace/page-card-layout.contract.test.ts
- changed-file ESLint
- git diff --check