### PR TITLE
feat(one): surface Trusted devices in security settings (revoke-from-mobile)

### DIFF
--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -28,6 +28,7 @@ import {
   MessageCircleQuestion,
   Users,
   Monitor,
+  Laptop,
   Phone,
   Palette,
   RefreshCw,
@@ -3234,6 +3235,13 @@ function ProfilePageContent() {
           onClick={() =>
             updateProfileView({ panel: "security", detail: "vault" }, "push")
           }
+        />
+        <SettingsRow
+          icon={Laptop}
+          title="Trusted devices"
+          description="Computers connected to your private agent."
+          chevron
+          onClick={() => router.push(ROUTES.PROFILE_SECURITY_DEVICES)}
         />
       </SettingsGroup>
     </div>


### PR DESCRIPTION
**Phase 1 of the One×Hermes trust-console north-star — revoke-from-mobile.**

The Trusted Devices page (list + Unlink→seal, server-authoritative) was a fully-built **orphan** — nothing linked to it on web or mobile. This adds a single `SettingsRow` under "Vault methods" in the security panel that routes to `ROUTES.PROFILE_SECURITY_DEVICES`, lighting up the whole revoke-from-mobile path on the native shell.

- **Frontend-only**, 8 lines (one `Laptop` import + one row). No backend, route, or contract change.
- Green: typecheck, eslint, verify:design-system, verify:docs, governance (223/0).
- Note: the full local vitest suite has 2 pre-existing reds (`calendar-agent-page`, `connect-page-layout`) unrelated to this change (my file isn't in their import graph); they are not in the PR gating packs. Tracked separately.