### PR TITLE
chore(governance): grant imsharukhan uat + production dispatch authority

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -141,7 +141,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "parthmawai"
+      "parthmawai",
+      "imsharukhan"
     ]
   },
   "production": {
@@ -154,7 +155,8 @@
       "kushaltrivedi5",
       "ankitkumarsingh1702",
       "RGlodAkshat",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "imsharukhan"
     ],
     "owner_environment": "production"
   }


### PR DESCRIPTION
# Description

Grants `imsharukhan` UAT and production manual-dispatch authority so he can run
`ship-ios-testflight` and `release-ios-appstore` himself.

He is already a governed maintainer (`main`/`pr_train` review bypass + merge-queue
bypass, added in `fb93eb448`), but was never added to the **dispatch** allowlists
that `scripts/ci/assert-governed-actor.py` reads. His TestFlight dispatch was
refused at the *Authorize dispatching actor (uat surface)* step.

Two list entries, no logic change:

- `uat.manual_dispatch_users` += `imsharukhan`
- `production.manual_dispatch_users` += `imsharukhan`

### Blast radius (intentional, wider than iOS)

The allowlists are per-**surface**, not per-workflow, so iOS-only dispatch is not
expressible. This grant also unlocks, by design:

| Surface | Workflows now dispatchable by him |
| --- | --- |
| `uat` | `ship-ios-testflight`, `deploy-uat`, `rollback` (UAT), `ship-android-playstore-v1` |
| `production` | `release-ios-appstore`, `deploy-production`, `rollback` (production), `provision-wallet-pass-certificate` |

Production dispatch cohort goes 4 -> 5. Authorized explicitly by @ankitkumarsingh1702.

He is **not** added to `protected_pipeline_edit_users` — he can dispatch pipelines
but still cannot edit `.github/workflows/`, `scripts/ci/`, `deploy/`, or this config.

### Pre-existing drift noted (not changed here)

- `scripts/ci/verify-deployment-environment-governance.py` hardcodes
  `PRODUCTION_MANUAL_DISPATCH_USERS = ["kushaltrivedi5", "ankitkumarsingh1702"]`.
  The config has had 4 entries since `845a456bd` (Aug 7), so that assertion has
  been stale for three weeks. It is advisory-only (`orchestrate.sh advisory`), not
  a blocking gate. This PR widens the mismatch to 5-vs-2. Left for a separate PR
  rather than editing a guard inside an access-grant change.
- The same script requires `uat.manual_dispatch_users == main.review_bypass_users`.
  UAT was 7 vs a merge cohort of 13; this PR moves it to 8, reducing the gap.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — no app code changes. Affects who may *dispatch* the iOS/Android
        release workflows, not what those workflows build.

- Docs updated (exact files):
  - [x] None — `docs/reference/operations/branch-governance.md` deliberately does
        not hardcode cohort names ("see that file for the live list; they drift").

- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `config/ci-governance.json` — read at workflow runtime by
      `scripts/ci/assert-governed-actor.py`, invoked by `deploy-uat.yml`,
      `deploy-production.yml`, `ship-ios-testflight.yml`,
      `release-ios-appstore.yml`, `ship-android-playstore-v1.yml`, `rollback.yml`,
      `provision-wallet-pass-certificate.yml`.

- Trust boundary touched:
  - [x] **deploy** — this is a deploy-authority change. It widens who may dispatch
        UAT and production releases. No auth/consent/vault/PKM/finance/KYC surface.

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below: revert this commit. `assert-governed-actor.py` fails closed —
        an actor absent from the list is refused, so a revert immediately restores
        the prior cohort with no residual state anywhere (no GitHub-side mirror;
        `apply-governance.py` explicitly does not sync dispatch lists).

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `python3 scripts/ci/assert-governed-actor.py --surface uat --actor imsharukhan`
  - [x] `python3 scripts/ci/assert-governed-actor.py --surface production --actor imsharukhan`
  - [x] `python3 scripts/ci/verify-protected-pipeline-edits.py --self-test`
  - [x] `python3 scripts/ci/verify-branch-governance-doc-consistency.py`
  - [x] `python3 scripts/ci/test_verify_deployment_environment_governance.py`

Output:

```
uat manual dispatch policy passed for actor 'imsharukhan'.
production manual dispatch policy passed for actor 'imsharukhan'.
Protected pipeline edit guard self-test passed.
OK: branch-governance SOP prose is consistent across all canonical docs
```

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: `fb93eb448` added him to the merge cohort only; `845a456bd` is the precedent for a production-dispatch grant.
- [x] This PR changes a current reachable app/backend/package/docs surface: the live deploy-authority policy.
- [x] Reachable production attach point: `scripts/ci/assert-governed-actor.py`, called by seven governed workflows.
- [x] New tests import and exercise production code — n/a, no new tests; the existing guard self-tests cover this file and were run.
- [x] New helpers/components/services are wired to an existing entrypoint — n/a, data-only change to an existing policy file.
- [x] Production surface proved: both dispatch gates executed locally against the edited config (output above).
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] Not part of a stack.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: not applicable — CI policy data, no `app/api/...` change.
- [x] **iOS**: not applicable — no Swift/Capacitor plugin change.
- [x] **Android**: not applicable — no Kotlin plugin change.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) — not applicable, no runtime surface.
- [x] Tested on iOS Simulator/Device — not applicable, no app binary change.
- [x] Tested on Android Emulator/Device — not applicable.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Not applicable — no UI-visible change. Proof is the gate output above.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No.**
- [x] `checkConsentToken()` — not applicable.
- [x] Sensitive surface touched: **deploy**
- [x] Error path, rollback, or safe-failure behavior proved: the guard fails closed
      (`SystemExit` on an unlisted actor); revert restores the prior cohort exactly.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes; third-party notices unaffected
