### PR TITLE
fix(one): derive Location's published voice actions from the contract

### DIFF
--- a/hushh-webapp/__tests__/voice/location-published-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/location-published-actions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { LOCATION_VOICE_ACTIONS } from "@/app/one/location/page";
+import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+
+/**
+ * LOCATION_VOICE_ACTIONS used to be a hand-typed 23-entry list that drifted
+ * out of sync with the real contract three times (#6080, #6106-#6112). It is
+ * now derived from listKaiActionsForSurface at module scope, so this test
+ * recomputes the expected set from the same gateway data the array itself
+ * reads from -- if a future edit narrows or widens the filter without
+ * meaning to, this fails instead of silently drifting again.
+ */
+describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () => {
+  const CHECKOUT_NEARBY = "location.checkout_nearby";
+
+  const expectedIds = new Set(
+    listKaiActionsForSurface({ screen: "one_location" })
+      .filter(
+        (action) =>
+          action.execution_target.status === "wired" &&
+          (action.execution_target.path === "local_handler" ||
+            action.execution_target.path === "route") &&
+          action.execution_policy !== "manual_only" &&
+          action.action_id !== CHECKOUT_NEARBY,
+      )
+      .map((action) => action.action_id),
+  );
+
+  it("publishes exactly the wired local_handler/route actions for one_location", () => {
+    const publishedIds = new Set(LOCATION_VOICE_ACTIONS.map((action) => action.actionId));
+    expect(publishedIds).toEqual(expectedIds);
+  });
+
+  it("is not trivially small -- guards against the filter silently matching nothing", () => {
+    // Regression guard: a typo'd screen name or an over-narrow filter would
+    // make expectedIds (and therefore this equality check) pass vacuously
+    // against an empty published array. 30+ is the count found when this
+    // derivation was written; any future drop below it deserves a look even
+    // though the equality check above would already catch a mismatch.
+    expect(LOCATION_VOICE_ACTIONS.length).toBeGreaterThan(25);
+  });
+
+  it("deliberately excludes location.checkout_nearby -- it has no voice handler yet", () => {
+    // Wired in the contract, but its UI calls OneLocationService.checkoutNearby()
+    // directly with no useLocalOnboardingActionHandler registration anywhere.
+    // Publishing it would offer something guaranteed to fail. See the
+    // exclusion comment above LOCATION_VOICE_ACTIONS_EXCLUDE_IDS in page.tsx.
+    expect(LOCATION_VOICE_ACTIONS.some((action) => action.actionId === CHECKOUT_NEARBY)).toBe(
+      false,
+    );
+    // And confirm it's excluded because it's really wired-but-handlerless,
+    // not because it fell out of the surface's reachability entirely --
+    // otherwise this test would pass for the wrong reason.
+    const contractEntry = listKaiActionsForSurface({ screen: "one_location" }).find(
+      (action) => action.action_id === CHECKOUT_NEARBY,
+    );
+    expect(contractEntry?.execution_target.status).toBe("wired");
+  });
+
+  it("carries a short, non-empty purpose derived from the contract's meaning", () => {
+    for (const action of LOCATION_VOICE_ACTIONS) {
+      expect(action.purpose.length, `${action.actionId} has an empty purpose`).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes actions that were unreachable before this fix (#6106-#6112)", () => {
+    // These were entirely absent from the old hand-typed array -- not merely
+    // losing a SUBVIEW_ACTION_BOOST ranking tiebreak, as originally assumed.
+    const REGRESSION_IDS = [
+      "location.approve_request",
+      "location.decline_request",
+      "location.trigger_sos",
+      "location.stop_sos",
+      "location.create_circle",
+      "location.accept_circle_invite",
+      "location.decline_circle_invite",
+    ];
+    const publishedIds = new Set(LOCATION_VOICE_ACTIONS.map((action) => action.actionId));
+    for (const id of REGRESSION_IDS) {
+      expect(publishedIds.has(id), `${id} still missing from LOCATION_VOICE_ACTIONS`).toBe(true);
+    }
+  });
+});

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -1417,6 +1417,125 @@ describe("a surface that declares more controls than the context can carry", () 
     );
   });
 
+  it("keeps refresh reachable on Location's bare route now that it competes with 30 handlers (#6080)", () => {
+    // Regression: location.refresh was one of the 5 actions already in the
+    // old hand-typed array, but had no SUBVIEW_ACTION_BOOST entry for the
+    // bare/default subview. Once the array grew to its real, contract-derived
+    // size, refresh started losing the insertion-order tiebreak for the
+    // 14-slot cap. It is boosted on "one_location:" now, alongside the
+    // handlers that were already there.
+    window.history.pushState({}, "", "/one/location");
+    const localHandlers = [
+      "location.accept_circle_invite",
+      "location.add_emergency_contact",
+      "location.add_to_circle",
+      "location.approve_request",
+      "location.change_share_duration",
+      "location.confirm_nearby_check_in",
+      "location.create_circle",
+      "location.decline_circle_invite",
+      "location.decline_request",
+      "location.delete_circle",
+      "location.delete_saved_location",
+      "location.leave_circle",
+      "location.nearby_check_in",
+      "location.pause_updates",
+      "location.refresh",
+      "location.remove_emergency_contact",
+      "location.remove_from_circle",
+      "location.rename_circle",
+      "location.resume_updates",
+      "location.save_current_location",
+      "location.select_ask_recipient",
+      "location.select_share_recipient",
+      "location.send_check_in",
+      "location.send_request",
+      "location.set_auto_share",
+      "location.share_selected",
+      "location.sos_default",
+      "location.stop_share",
+      "location.stop_sos",
+      "location.trigger_sos",
+    ];
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "one_location",
+      controls: localHandlers.map((actionId) => ({
+        id: actionId,
+        actionId,
+        label: actionId,
+      })),
+    });
+
+    const snapshot = buildOneVoiceContextSnapshot({
+      appRuntimeState: makeRuntimeState("/one/location", "one_location", null),
+    });
+
+    expect(snapshot.available_action_ids).toContain("location.refresh");
+    expect(localOnlyIds(snapshot.available_action_ids).length).toBeLessThanOrEqual(
+      ACTION_ID_SCREEN_SEGMENT_CAP,
+    );
+  });
+
+  it("keeps sos_default reachable on the SOS subview alongside trigger_sos and stop_sos", () => {
+    // "save me" / bare emergency phrasing resolves to location.sos_default
+    // (see Voice Settings' emergency-default choice), not directly to
+    // trigger_sos. Without a boost entry it would compete on equal footing
+    // with 29 other local handlers and could lose the tiebreak on the one
+    // subview where it matters most.
+    window.history.pushState({}, "", "/one/location?view=sos");
+    const localHandlers = [
+      "location.accept_circle_invite",
+      "location.add_emergency_contact",
+      "location.add_to_circle",
+      "location.approve_request",
+      "location.change_share_duration",
+      "location.confirm_nearby_check_in",
+      "location.create_circle",
+      "location.decline_circle_invite",
+      "location.decline_request",
+      "location.delete_circle",
+      "location.delete_saved_location",
+      "location.leave_circle",
+      "location.nearby_check_in",
+      "location.pause_updates",
+      "location.refresh",
+      "location.remove_emergency_contact",
+      "location.remove_from_circle",
+      "location.rename_circle",
+      "location.resume_updates",
+      "location.save_current_location",
+      "location.select_ask_recipient",
+      "location.select_share_recipient",
+      "location.send_check_in",
+      "location.send_request",
+      "location.set_auto_share",
+      "location.share_selected",
+      "location.sos_default",
+      "location.stop_share",
+      "location.stop_sos",
+      "location.trigger_sos",
+    ];
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "one_location",
+      controls: localHandlers.map((actionId) => ({
+        id: actionId,
+        actionId,
+        label: actionId,
+      })),
+    });
+
+    const snapshot = buildOneVoiceContextSnapshot({
+      appRuntimeState: makeRuntimeState("/one/location?view=sos", "one_location", "sos"),
+    });
+
+    expect(snapshot.available_action_ids).toContain("location.sos_default");
+    expect(snapshot.available_action_ids).toContain("location.trigger_sos");
+    expect(snapshot.available_action_ids).toContain("location.stop_sos");
+    expect(localOnlyIds(snapshot.available_action_ids).length).toBeLessThanOrEqual(
+      ACTION_ID_SCREEN_SEGMENT_CAP,
+    );
+  });
+
   it("still shows every global nav contract when the local segment is completely full", () => {
     // Regression for the bug this fixes: prioritizeAvailableActionIds was
     // called with includeGlobalNavigation = underlyingActionsAvailable &&

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -85,7 +85,7 @@ import {
   VOICE_CONFIRM_DATA_KEY,
   VOICE_DISAMBIGUATION_DATA_KEY,
 } from "@/lib/voice/voice-action-card";
-import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+import { getKaiActionById, listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -630,160 +630,51 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
  * Every id here exists in `page.voice-action-contract.json`; nothing describes
  * a capability the gateway does not carry.
  */
-const LOCATION_VOICE_ACTIONS = [
-  // Local handlers FIRST, and the order is load-bearing.
-  //
-  // Every action on this surface names `one_location`, so they all tie for
-  // top rank in `prioritizeAvailableActionIds` and the 10-item cap falls back
-  // to the order they appear here. Route actions survive being cut regardless
-  // -- the relay admits navigation from any screen whether or not it was
-  // submitted -- but a dropped local handler is simply gone, and comes back
-  // from the relay as `action_unavailable`, which reads as a broken feature.
-  //
-  // With 24 actions and 10 slots, listing these last meant the only actions
-  // that DO something were the only ones guaranteed to be lost.
-  {
-    id: "location.share_selected",
-    actionId: "location.share_selected",
-    label: "Share with the people I picked",
-    purpose:
-      "Start the share with whoever is already selected, for a duration you say.",
-  },
-  {
-    id: "location.select_share_recipient",
-    actionId: "location.select_share_recipient",
-    label: "Pick someone for the share",
-    purpose:
-      "Select a named connection in the share composer without sending anything.",
-  },
-  {
-    id: "location.pause_updates",
-    actionId: "location.pause_updates",
-    label: "Pause my location",
-    purpose: "Stop sending location updates from this device.",
-  },
-  {
-    id: "location.resume_updates",
-    actionId: "location.resume_updates",
-    label: "Resume my location",
-    purpose: "Turn location updates back on for this device.",
-  },
-  {
-    id: "location.refresh",
-    actionId: "location.refresh",
-    label: "Refresh location",
-    purpose: "Reload location sharing state.",
-  },
+// location.checkout_nearby is wired in the generated gateway but has no
+// useLocalOnboardingActionHandler registration anywhere -- its own UI button
+// calls OneLocationService.checkoutNearby() directly, bypassing the voice
+// path entirely. Publishing it would offer something that always fails,
+// which is worse than not offering it. Excluded until it has a real handler
+// (tracked separately); every other exclusion below is enforced by the
+// filter, not a second hand-list to keep in sync.
+const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([
+  "location.checkout_nearby",
+]);
 
-  {
-    id: "location.open_now",
-    actionId: "location.open_now",
-    label: "Open Location now",
-    purpose: "Show current sharing status and quick actions.",
-  },
-  {
-    id: "location.open_people",
-    actionId: "location.open_people",
-    label: "Open Location people",
-    purpose: "Show the people and circles you share with.",
-  },
-  {
-    id: "location.open_links",
-    actionId: "location.open_links",
-    label: "Open Location links",
-    purpose: "Show temporary sharing links.",
-  },
-  {
-    id: "location.open_share",
-    actionId: "location.open_share",
-    label: "Share my location",
-    purpose: "Open the share composer.",
-  },
-  {
-    id: "location.open_ask",
-    actionId: "location.open_ask",
-    label: "Ask for someone's location",
-    purpose: "Open the request composer.",
-  },
-  {
-    id: "location.open_invite",
-    actionId: "location.open_invite",
-    label: "Invite someone to Location",
-    purpose: "Invite someone not on Hushh yet.",
-  },
-  {
-    id: "location.open_create_circle",
-    actionId: "location.open_create_circle",
-    label: "Create a circle",
-    purpose: "Name a new circle to share with as a group.",
-  },
-  {
-    id: "location.open_join_circle",
-    actionId: "location.open_join_circle",
-    label: "Join a circle",
-    purpose: "Enter an invite code to join a circle.",
-  },
-  {
-    id: "location.open_temporary_link",
-    actionId: "location.open_temporary_link",
-    label: "Create a temporary link",
-    purpose: "Make a link that expires.",
-  },
-  {
-    id: "location.open_check_in",
-    actionId: "location.open_check_in",
-    label: "Check in",
-    purpose: "Send a one-off note of where you are.",
-  },
-  {
-    id: "location.open_sos",
-    actionId: "location.open_sos",
-    label: "Open emergency SOS",
-    purpose: "Open the emergency alert screen.",
-  },
-  {
-    id: "location.open_sms_contacts",
-    actionId: "location.open_sms_contacts",
-    label: "Open emergency contacts",
-    purpose: "Choose who receives an SOS text.",
-  },
-  {
-    id: "location.open_settings",
-    actionId: "location.open_settings",
-    label: "Open Location privacy settings",
-    purpose: "Open privacy and precision controls.",
-  },
-  {
-    id: "location.open_active_shares",
-    actionId: "location.open_active_shares",
-    label: "Open active location shares",
-    purpose: "See and stop what is live now.",
-  },
-  {
-    id: "location.open_shared_with_me",
-    actionId: "location.open_shared_with_me",
-    label: "Open locations shared with me",
-    purpose: "See who is sharing with you.",
-  },
-  {
-    id: "location.open_needs_review",
-    actionId: "location.open_needs_review",
-    label: "Open location requests to review",
-    purpose: "Approve or decline requests.",
-  },
-  {
-    id: "location.add_connections",
-    actionId: "location.add_connections",
-    label: "Add people to share location with",
-    purpose: "Open Connect to find people.",
-  },
-  {
-    id: "location.open_map",
-    actionId: "location.open_map",
-    label: "Open the location map",
-    purpose: "Open the full-screen map.",
-  },
-];
+// Derived from the generated action gateway, not hand-typed. This used to be
+// a manually maintained list and it drifted out of sync with the real,
+// contract-authored action set three times -- once documented below, twice
+// more found in the same audit that added this comment. Location's real
+// local-handler count grew past what anyone kept remembering to mirror here;
+// deriving it means a new Location action becomes reachable the moment it is
+// added to the contract, with no second edit to forget.
+//
+// prioritizeAvailableActionIds still ranks and caps this exactly as before
+// (route actions are cap-exempt; local handlers compete for the 14-slot
+// cap and lose ties to whichever SUBVIEW_ACTION_BOOST entry matches the
+// current subview) -- this only changes what becomes a CANDIDATE, not how
+// candidates are ranked once the list is bigger.
+export const LOCATION_VOICE_ACTIONS = listKaiActionsForSurface({
+  screen: "one_location",
+})
+  .filter(
+    (action) =>
+      action.execution_target.status === "wired" &&
+      (action.execution_target.path === "local_handler" ||
+        action.execution_target.path === "route") &&
+      action.execution_policy !== "manual_only" &&
+      !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
+  )
+  .map((action) => ({
+    id: action.action_id,
+    actionId: action.action_id,
+    label: action.label,
+    // First sentence only: the contract's `meaning` is full multi-sentence
+    // prose written for the model's semantic assessment, not a short
+    // one-liner. This field is consumed as a terse purpose string elsewhere
+    // in this surface's metadata, matching the previous hand-written style.
+    purpose: action.meaning.split(/(?<=[.!?])\s/)[0] || action.meaning,
+  }));
 
 const LOCATION_VOICE_CONTROLS = [
   {

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -499,7 +499,9 @@ function readStringArray(
  * `${screen}:` (empty subview) as the default set for that screen's bare
  * route. Only screens whose local-handler count has actually outgrown
  * ACTION_ID_SCREEN_SEGMENT_CAP need an entry here -- as of writing, that is
- * Location alone (28 screen-owned local handlers competing for 14 slots).
+ * Location alone (30 screen-owned local handlers competing for 14 slots,
+ * derived from the contract in page.tsx's LOCATION_VOICE_ACTIONS -- see that
+ * file for why it is derived rather than hand-counted).
  *
  * This boosts matches to the top rank in `rankOf` below; it never demotes
  * anything. An action absent from the current subview's list still competes
@@ -515,6 +517,7 @@ const SUBVIEW_ACTION_BOOST: Readonly<Record<string, readonly string[]>> = {
     "location.stop_share",
     "location.approve_request",
     "location.decline_request",
+    "location.refresh",
   ],
   "one_location:create-circle": ["location.create_circle"],
   "one_location:share": [
@@ -540,7 +543,11 @@ const SUBVIEW_ACTION_BOOST: Readonly<Record<string, readonly string[]>> = {
     "location.add_emergency_contact",
     "location.remove_emergency_contact",
   ],
-  "one_location:sos": ["location.trigger_sos", "location.stop_sos"],
+  "one_location:sos": [
+    "location.trigger_sos",
+    "location.stop_sos",
+    "location.sos_default",
+  ],
   // The People tab is where circle membership is actually managed.
   "one_location:people": [
     "location.add_to_circle",


### PR DESCRIPTION
## Summary

`LOCATION_VOICE_ACTIONS` (`app/one/location/page.tsx`) was a hand-typed, 23-entry duplicate of what the generated action gateway already declares. It drifted out of sync three times — most recently 26 wired `local_handler`/`route` actions for Location (filed as #6080, #6106-#6112) were entirely **absent** from the published list, not merely losing a ranking tiebreak as first assumed when those issues were filed.

Fix: derive the array from `listKaiActionsForSurface({ screen: "one_location" })` instead of hand-typing it. A future Location action becomes voice-reachable the moment it's added to the contract — no second array to remember to keep in sync.

`location.checkout_nearby` is deliberately excluded via a documented `LOCATION_VOICE_ACTIONS_EXCLUDE_IDS` set — it has no `useLocalOnboardingActionHandler` registration anywhere (its UI calls `OneLocationService.checkoutNearby()` directly), so publishing it would offer something guaranteed to fail.

Also adds the two `SUBVIEW_ACTION_BOOST` entries this growth needed:
- `location.refresh` on the bare subview (fixes #6080)
- `location.sos_default` on the SOS subview

Both would otherwise start losing the 14-slot cap tiebreak now that ~30 local handlers compete for it instead of the original 5.

## Test plan

- [x] New test file `__tests__/voice/location-published-actions.test.ts`: cross-checks `LOCATION_VOICE_ACTIONS` against `listKaiActionsForSurface` directly (so this invariant can't silently drift again), confirms `checkout_nearby`'s exclusion is deliberate (wired but handlerless) not accidental, and confirms the previously-unreachable actions from #6106-#6112 are now present.
- [x] Extended `screen-context-builder.test.ts` with two new tests covering the `refresh` and `sos_default` boost entries under the 14-slot cap with the full 30-handler set.
- [x] `npx vitest run __tests__/voice/` — 303/303 passing (was 296/296 before this PR's new tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` on touched files — clean.
- [x] No contract/gateway files changed, so no governed-artifact regeneration needed (confirmed via `git status`).
- [ ] Manual: bare `/one/location` visit confirming `approve_request`/`create_circle` etc. are voice-reachable — not done in this pass (requires the local 3-terminal runtime + live voice session), noting as an open item for the reviewer or a follow-up smoke pass.

Addresses #6080, #6106, #6107, #6108, #6109, #6111, #6112 — these will be closed individually after this ships and is verified live on UAT, not auto-closed on merge.