### PR TITLE
Polish location contacts onboarding

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -1158,164 +1158,172 @@ function ContactsScreen({
         <OnboardingSkipButton onClick={onSkip} disabled={navigationDisabled} />
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
-        <span className="mt-2 flex h-14 w-14 items-center justify-center rounded-2xl bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
-          <UserPlus className="h-7 w-7" strokeWidth={2} />
-        </span>
-        <h1 className="ui-text-agent-title mt-4 text-[#151b26] dark:!text-[color:var(--app-label)]">
-          Find your people
-        </h1>
-        <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[color:var(--app-secondary-label)]">
-          {primed
-            ? "Find contacts already on One."
-            : state.kind === "matched"
-              ? "Connected matches are ready. You can request the rest."
-              : "You can always find people later from the People tab."}
-        </p>
+      <main className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
+        <div className="mx-auto flex w-full max-w-[520px] flex-col">
+          <span className="mt-2 flex h-14 w-14 items-center justify-center rounded-2xl bg-[color:var(--app-accent-soft)] text-[color:var(--app-accent)]">
+            <UserPlus className="h-7 w-7" strokeWidth={2} />
+          </span>
+          <h1 className="ui-text-agent-title mt-4 text-[#151b26] dark:!text-[color:var(--app-label)]">
+            Find your people
+          </h1>
+          <p className="mt-2 text-[15px] font-normal leading-[20px] text-[#73777f] dark:text-[color:var(--app-secondary-label)]">
+            {primed
+              ? "Find people from your contacts already on One."
+              : state.kind === "matched"
+                ? "Connected matches are ready. You can request the rest."
+                : "You can always find people later from the People tab."}
+          </p>
 
-        {primed ? (
-          <>
-            <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
-              {state.kind === "busy" ? (
-                <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-[#777d86] dark:text-[color:var(--app-secondary-label)]">
-                  <Loader2 className="h-5 w-5 animate-spin" /> Checking your
-                  contacts
-                </div>
-              ) : (
-                <div className="flex min-h-32 flex-col justify-center gap-3">
-                  {/* Say what happens to the address book before asking for it.
-                      A vague ask on a location product is what makes people
-                      decline, and the decline is permanent on iOS. */}
-                  <p className="text-[14px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
-                    One sends a protected match code and the last four digits,
-                    not names or full phone numbers. Your contact list is never
-                    stored. A match connects automatically only when that person
-                    has allowed contact connections; otherwise you can choose
-                    whether to send a request.
-                  </p>
-                  <PrimaryButton onClick={onSync} disabled={leaving}>
-                    Find contacts
-                  </PrimaryButton>
-                </div>
-              )}
-            </div>
-          </>
-        ) : null}
-
-        {state.kind === "matched" ? (
-          <ul className="mt-6 space-y-2" data-testid="onboarding-contact-matches">
-            {visibleMatches.map((match) => {
-              const added = addedUserIds.includes(match.userId);
-              const adding = addingUserIds.includes(match.userId);
-              const connected = match.connectionStatus === "connected";
-              const requestRequired = match.connectionStatus === "request_required";
-              return (
-                <li
-                  key={match.userId}
-                  className="flex items-center justify-between gap-3 rounded-2xl border border-[#e4e6e9] bg-white px-4 py-3 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]"
-                >
-                  <span className="flex min-w-0 flex-1 items-center gap-1.5 text-[15px] font-medium text-[#151b26] dark:text-[color:var(--app-label)]">
-                    <span className="min-w-0 truncate">{match.displayName}</span>
-                    {connected ? <ContactSourceBadge /> : null}
-                  </span>
-                  {requestRequired ? (
-                    <button
-                      type="button"
-                      onClick={() => onAdd(match.userId)}
-                      disabled={added || adding || leaving}
-                      className="press-scale inline-flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-full bg-[color:var(--app-accent)] px-4 text-[14px] font-bold text-[color:var(--app-accent-fg)] disabled:opacity-60"
+          {primed ? (
+            <>
+              <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-white p-6 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
+                {state.kind === "busy" ? (
+                  <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-[#777d86] dark:text-[color:var(--app-secondary-label)]">
+                    <Loader2 className="h-5 w-5 animate-spin" /> Checking your
+                    contacts
+                  </div>
+                ) : (
+                  <div className="flex min-h-28 flex-col items-center justify-center gap-4 text-center">
+                    <p className="max-w-[320px] text-[15px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
+                      Connect contacts to see who is already here.
+                    </p>
+                    <PrimaryButton
+                      className="mx-auto max-w-[360px]"
+                      onClick={onSync}
+                      disabled={leaving}
                     >
-                      {adding ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : added ? (
-                        <Check className="h-4 w-4" strokeWidth={2.5} />
-                      ) : null}
-                      {added ? "Requested" : adding ? "Sending" : "Request"}
-                    </button>
-                  ) : (
-                    <span className="inline-flex shrink-0 items-center gap-1.5 text-[13px] font-semibold text-[#5c626c] dark:text-[#aeb8c7]">
-                      {connected ? (
-                        <Check className="h-4 w-4 text-emerald-600" />
-                      ) : null}
-                      {connected ? "Connected" : "Not connected"}
+                      Find contacts
+                    </PrimaryButton>
+                  </div>
+                )}
+              </div>
+            </>
+          ) : null}
+
+          {state.kind === "matched" ? (
+            <ul
+              className="mt-6 space-y-2"
+              data-testid="onboarding-contact-matches"
+            >
+              {visibleMatches.map((match) => {
+                const added = addedUserIds.includes(match.userId);
+                const adding = addingUserIds.includes(match.userId);
+                const connected = match.connectionStatus === "connected";
+                const requestRequired =
+                  match.connectionStatus === "request_required";
+                return (
+                  <li
+                    key={match.userId}
+                    className="flex items-center justify-between gap-3 rounded-2xl border border-[#e4e6e9] bg-white px-4 py-3 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]"
+                  >
+                    <span className="flex min-w-0 flex-1 items-center gap-1.5 text-[15px] font-medium text-[#151b26] dark:text-[color:var(--app-label)]">
+                      <span className="min-w-0 truncate">
+                        {match.displayName}
+                      </span>
+                      {connected ? <ContactSourceBadge /> : null}
                     </span>
-                  )}
+                    {requestRequired ? (
+                      <button
+                        type="button"
+                        onClick={() => onAdd(match.userId)}
+                        disabled={added || adding || leaving}
+                        className="press-scale inline-flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-full bg-[color:var(--app-accent)] px-4 text-[14px] font-bold text-[color:var(--app-accent-fg)] disabled:opacity-60"
+                      >
+                        {adding ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : added ? (
+                          <Check className="h-4 w-4" strokeWidth={2.5} />
+                        ) : null}
+                        {added ? "Requested" : adding ? "Sending" : "Request"}
+                      </button>
+                    ) : (
+                      <span className="inline-flex shrink-0 items-center gap-1.5 text-[13px] font-semibold text-[#5c626c] dark:text-[#aeb8c7]">
+                        {connected ? (
+                          <Check className="h-4 w-4 text-emerald-600" />
+                        ) : null}
+                        {connected ? "Connected" : "Not connected"}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+              {visibleMatches.length < matches.length ? (
+                <li className="flex flex-col items-center gap-2 pt-2">
+                  <span className="text-xs text-[#73777f]" aria-live="polite">
+                    Showing {visibleMatches.length} of {matches.length}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setVisibleMatchCount((current) =>
+                        Math.min(current + MATCH_PAGE_SIZE, matches.length),
+                      )
+                    }
+                    className="press-scale min-h-11 rounded-full border border-[#e4e6e9] px-5 text-sm font-semibold dark:border-white/[0.08]"
+                  >
+                    Show more
+                  </button>
                 </li>
-              );
-            })}
-            {visibleMatches.length < matches.length ? (
-              <li className="flex flex-col items-center gap-2 pt-2">
-                <span className="text-xs text-[#73777f]" aria-live="polite">
-                  Showing {visibleMatches.length} of {matches.length}
-                </span>
+              ) : null}
+            </ul>
+          ) : null}
+
+          {state.kind === "none" ? (
+            <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
+              <p className="text-[15px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
+                {state.partial
+                  ? "None of the contacts you shared are on One yet."
+                  : "None of your contacts are on One yet."}
+              </p>
+              <p className="mt-2 text-[13px] leading-5 text-[#96999e] dark:text-[color:var(--app-secondary-label)]">
+                Your circle code is on the next screen — send it to whoever you
+                want here.
+              </p>
+            </div>
+          ) : null}
+
+          {state.kind === "failed" ? (
+            <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
+              <p className="text-[15px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
+                {state.message}
+              </p>
+              {state.canOpenSettings ? (
                 <button
                   type="button"
-                  onClick={() =>
-                    setVisibleMatchCount((current) =>
-                      Math.min(current + MATCH_PAGE_SIZE, matches.length),
-                    )
-                  }
-                  className="press-scale min-h-11 rounded-full border border-[#e4e6e9] px-5 text-sm font-semibold dark:border-white/[0.08]"
+                  onClick={onOpenSettings}
+                  className="press-scale mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-[#d5d9df] bg-white px-5 text-sm font-bold text-[#1f2b3d] dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-secondary-surface)] dark:text-[color:var(--app-label)]"
                 >
-                  Show more
+                  Open Settings
                 </button>
-              </li>
-            ) : null}
-          </ul>
-        ) : null}
-
-        {state.kind === "none" ? (
-          <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
-            <p className="text-[15px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
-              {state.partial
-                ? "None of the contacts you shared are on One yet."
-                : "None of your contacts are on One yet."}
-            </p>
-            <p className="mt-2 text-[13px] leading-5 text-[#96999e] dark:text-[color:var(--app-secondary-label)]">
-              Your circle code is on the next screen — send it to whoever you
-              want here.
-            </p>
-          </div>
-        ) : null}
-
-        {state.kind === "failed" ? (
-          <div className="mt-7 rounded-[20px] border border-[#e4e6e9] bg-[#f8f9fb] p-6 text-center dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-primary-surface)]">
-            <p className="text-[15px] leading-5 text-[#5c626c] dark:text-[color:var(--app-secondary-label)]">
-              {state.message}
-            </p>
-            {state.canOpenSettings ? (
-              <button
-                type="button"
-                onClick={onOpenSettings}
-                className="press-scale mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-[#d5d9df] bg-white px-5 text-sm font-bold text-[#1f2b3d] dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-secondary-surface)] dark:text-[color:var(--app-label)]"
-              >
-                Open Settings
-              </button>
-            ) : null}
-            {source === "google" ? (
-              <button
-                type="button"
-                onClick={onSync}
-                disabled={leaving}
-                className="press-scale mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-[#d5d9df] bg-white px-5 text-sm font-bold text-[#1f2b3d] disabled:opacity-50 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-secondary-surface)] dark:text-[color:var(--app-label)]"
-              >
-                Try again
-              </button>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
+              ) : null}
+              {source === "google" ? (
+                <button
+                  type="button"
+                  onClick={onSync}
+                  disabled={leaving}
+                  className="press-scale mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-[#d5d9df] bg-white px-5 text-sm font-bold text-[#1f2b3d] disabled:opacity-50 dark:border-[color:var(--app-separator)] dark:bg-[color:var(--app-secondary-surface)] dark:text-[color:var(--app-label)]"
+                >
+                  Try again
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </main>
 
       <footer className="shrink-0 px-6 pb-[calc(env(safe-area-inset-bottom,0px)+18px)] pt-3">
         {/* Always present, whatever happened above. Declining contacts, finding
             nobody, or a plugin failure must never be a dead end. */}
-        <PrimaryButton
-          onClick={onContinue}
-          disabled={navigationDisabled}
-          inverse={primed && state.kind === "idle"}
-        >
-          {state.kind === "idle" ? "Not now" : "Continue"}
-        </PrimaryButton>
+        <div className="mx-auto w-full max-w-[520px]">
+          <PrimaryButton
+            className={primed && state.kind === "idle" ? "max-w-none" : ""}
+            onClick={onContinue}
+            disabled={navigationDisabled}
+            inverse={primed && state.kind === "idle"}
+          >
+            {state.kind === "idle" ? "Not now" : "Continue"}
+          </PrimaryButton>
+        </div>
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- Tighten the One Location `Find your people` onboarding screen only.
- Replace the long contacts/privacy paragraph with short, user-facing copy.
- Keep the contacts action and navigation handlers unchanged while centering the desktop measure and constraining the CTA.

## Tests
- `npx vitest run __tests__/components/one-location-onboarding-flow.test.tsx`
- `npm run verify:design-system`
- `npm run typecheck`
- `npm run verify:one-location` (initial run had one timeout-only failure; exact failed test passed on rerun with extended timeout)
- `npx vitest run __tests__/components/one-location-agent-page.test.tsx -t "resets every abandoned share field and ignores a late review preflight" --testTimeout=15000`
- `git diff --check`

## Scope
Only the contacts onboarding screen was changed. The reverted launcher/front screens from PR #6104 were not touched.