### PR TITLE
fix(contacts): a failed probe on a phone does not mean there is nothing to read

### DIFF
--- a/hushh-webapp/lib/contacts/__tests__/use-contact-sync.test.tsx
+++ b/hushh-webapp/lib/contacts/__tests__/use-contact-sync.test.tsx
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   permissionState: "prompt" as "prompt" | "granted" | "unavailable",
+  getPermissionState: vi.fn(),
   googleAvailability: "unconfigured" as "connectable" | "unconfigured",
   requestGoogleToken: vi.fn(),
   preloadGoogle: vi.fn(),
   googleSource: vi.fn(),
   syncSignals: vi.fn(),
+  isNative: vi.fn(() => false),
   trackEvent: vi.fn(),
   onGraphMutated: vi.fn(),
   toastSuccess: vi.fn(),
@@ -18,8 +20,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/capacitor", () => ({
   HushhContacts: {
-    getPermissionState: async () => ({ state: mocks.permissionState }),
+    getPermissionState: mocks.getPermissionState,
   },
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: mocks.isNative,
 }));
 
 vi.mock("@/lib/contacts/google-people-source", () => ({
@@ -121,6 +127,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.permissionState = "prompt";
   mocks.googleAvailability = "unconfigured";
+  mocks.isNative.mockReturnValue(false);
+  mocks.getPermissionState.mockImplementation(async () => ({
+    state: mocks.permissionState,
+  }));
   mocks.syncSignals.mockResolvedValue(EMPTY_RESULT);
   // The hook calls `.catch()` on this directly. A bare vi.fn() returns
   // undefined and throws inside the mount effect, which vitest reports as an
@@ -340,5 +350,65 @@ describe("useContactSync — what it tells the surface", () => {
     });
     expect(mocks.syncSignals).not.toHaveBeenCalled();
     expect(mocks.requestGoogleToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("useContactSync — the native contract", () => {
+  // On a phone the address book is the source, and Google is not merely
+  // unused there: `googleContactsAvailability()` returns "unconfigured"
+  // whenever `isNative()`, because the shell's page origin is a custom scheme
+  // that Google will not accept as an authorised JavaScript origin. These
+  // tests hold that line from this side.
+
+  it("keeps the control available when the native probe fails", async () => {
+    // The regression this exists for. `googleConfigured` is false on native by
+    // construction, so a probe failure used to set `available` to false and
+    // the control vanished on the platform the feature is mainly for -- with
+    // an address book sitting right there. A failed probe is not evidence that
+    // there is nothing to read.
+    mocks.isNative.mockReturnValue(true);
+    mocks.getPermissionState.mockRejectedValue(new Error("bridge down"));
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.available).toBe(true));
+    expect(result.current.googleFallback).toBe(false);
+    expect(mocks.preloadGoogle).not.toHaveBeenCalled();
+  });
+
+  it("hides the control when a WEB probe fails and no Google client exists", async () => {
+    // The same failure, inverted: off a device, no plugin answer and no Google
+    // client means there genuinely is nothing to read.
+    mocks.isNative.mockReturnValue(false);
+    mocks.googleAvailability = "unconfigured";
+    mocks.getPermissionState.mockRejectedValue(new Error("no plugin"));
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.available).toBe(false));
+  });
+
+  it("still reads the device book when the OS has not been asked yet", async () => {
+    mocks.isNative.mockReturnValue(true);
+    mocks.permissionState = "prompt";
+    const { result } = setup();
+
+    await waitFor(() => expect(result.current.available).toBe(true));
+    expect(result.current.googleFallback).toBe(false);
+
+    await act(async () => {
+      await result.current.sync();
+    });
+    // No source override: the read goes to the native plugin, and the OS
+    // permission sheet is raised inside it rather than as a separate step.
+    expect(mocks.syncSignals.mock.calls[0][0].source).toBeUndefined();
+  });
+
+  it("keeps the control for a denied device, so Settings stays reachable", async () => {
+    // Denied is not unavailable. Hiding the control would remove the only
+    // route back to the OS setting that turned it off.
+    mocks.isNative.mockReturnValue(true);
+    mocks.getPermissionState.mockResolvedValue({ state: "denied" });
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.available).toBe(true));
   });
 });

--- a/hushh-webapp/lib/contacts/use-contact-sync.ts
+++ b/hushh-webapp/lib/contacts/use-contact-sync.ts
@@ -38,6 +38,7 @@ import { toast } from "sonner";
 
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { HushhContacts } from "@/lib/capacitor";
+import { isNative } from "@/lib/capacitor/platform";
 import {
   INVITE_TO_ONE_DIALOG_TITLE,
   INVITE_TO_ONE_SHARE_TEXT,
@@ -367,11 +368,23 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
       })
       .catch(() => {
         if (cancelled) return;
-        // No device plugin is still usable when the web-only Google source is
-        // configured. Native never reports Google as connectable.
-        setGoogleFallback(googleConfigured);
-        setAvailable(googleConfigured);
-        preloadGoogleFallback();
+        // A failed probe is not evidence that there is nothing to read.
+        //
+        // On native there is an address book, always; the bridge call merely
+        // did not answer. Treating that as "unavailable" would hide the
+        // control on the platform the feature is mainly for -- and hide it
+        // silently, since `googleContactsAvailability()` returns
+        // "unconfigured" whenever `isNative()`, so the Google arm below can
+        // never restore it there. The tap itself fails loudly and with a
+        // remedy, which is the better place for a real failure to surface.
+        //
+        // On web the reasoning inverts: no plugin answer and no Google client
+        // means there genuinely is no source, and a control that exists only
+        // to explain that is worse than no control.
+        const native = isNative();
+        setGoogleFallback(!native && googleConfigured);
+        setAvailable(native || googleConfigured);
+        if (!native) preloadGoogleFallback();
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
On iOS the Sync contacts control could disappear, silently, on the platform the feature is mainly for.

## What happens

The mount probe asks the plugin whether an address book is reachable. Its failure branch fell back to `googleConfigured`:

```js
.catch(() => {
  setGoogleFallback(googleConfigured);
  setAvailable(googleConfigured);   // ← false on native, always
});
```

On native that value is false **by construction**. `googleContactsAvailability()` returns `"unconfigured"` whenever `isNative()` (`lib/contacts/google-people-source.ts:98`), because the shell's page origin is a custom scheme Google will not accept as an authorised JavaScript origin. So a bridge call that merely did not answer set `available` to false, the Google arm could never restore it, and the entry point vanished — with the person's address book sitting right there.

It is reachable rather than theoretical: `HushhContactsPlugin` is registered at `ios/App/App/MyViewController.swift:72`, so a plugin or bridge error resolves to a **rejected promise**, not a missing method.

## The change

A failed probe now keeps the control on native and lets the tap surface a real error with a remedy, which is where a real failure belongs. Off a device the reasoning inverts and is unchanged: no plugin answer and no Google client means there genuinely is no source, and a control that exists only to explain that is worse than no control.

## The contract this locks

The intended split had no test on either side of it:

| | Source |
|---|---|
| **iOS / Android app** | the device address book, via the first-party plugin |
| **Browsers / web app** | the W3C picker where it exists, otherwise Google People |

Google is off on native by construction, and now four tests hold that from the JS side: a failed native probe keeps the control; the same failure on web hides it; a not-yet-asked device still reads its own book with **no source override**, so the OS permission sheet is raised inside the read rather than as a separate step; and a denied device keeps the control, so the only route back to the Settings toggle that turned it off still exists.

## Verification

```
verify:connect-search   6 files / 141 tests
verify:one-location    32 files / 660 tests
tsc, eslint             clean
```

Mutation-checked: restoring the old branch fails `keeps the control available when the native probe fails` with `expected false to be true`.

Follows #6118, which put contact sync on Connect.
