### PR TITLE
fix(connect): the roster stops showing between the top bar and the strips

### DIFF
--- a/hushh-webapp/__tests__/components/connect-sticky-header.contract.test.ts
+++ b/hushh-webapp/__tests__/components/connect-sticky-header.contract.test.ts
@@ -17,10 +17,22 @@ function read(relativePath: string) {
  * by `e2e/connect-sticky-header.layout.spec.ts`, which renders and measures
  * them. What a rendered fixture cannot hold is which offsets the COMPONENT
  * hands the browser — a fixture only ever contains what its author put there.
- * These three assertions are the other half of that pair, in the same shape the
+ * These assertions are the other half of that pair, in the same shape the
  * `phone-width geometry QA reported` block in `app/connect/page-client.test.tsx`
  * already uses.
  */
+/** The value of a `const NAME = "…";` class string, by name. */
+function classNameConstant(source: string, name: string): string {
+  const declared = source.indexOf(`const ${name} =`);
+  if (declared < 0) throw new Error(`${name} is not declared`);
+  const opens = source.indexOf('"', declared);
+  const closes = source.indexOf('";', opens + 1);
+  if (opens < 0 || closes < 0) {
+    throw new Error(`${name} is not a single string constant`);
+  }
+  return source.slice(opens + 1, closes);
+}
+
 describe("connect sticky header contract", () => {
   const source = read("app/connect/page-client.tsx");
 
@@ -42,5 +54,46 @@ describe("connect sticky header contract", () => {
     // one width and one surface.
     expect(source).toContain("--connect-sticky-header-height");
     expect(source).toContain("new ResizeObserver(publish)");
+  });
+
+  it("paints both pinned bands opaque", () => {
+    // 15% of a roster row is still a roster row. At `bg-background/85` names and
+    // avatars read through the strips and through the search field as they
+    // scroll past — reported from a phone as "the contact list is scrolling
+    // behind the header".
+    //
+    // Read off the two constants rather than the whole file: the docblocks above
+    // them quote the value this replaced, and a bare `toContain` over the source
+    // would keep failing on the explanation for its own fix.
+    for (const name of [
+      "CONNECT_STICKY_HEADER_CLASSNAME",
+      "CONNECT_STICKY_SEARCH_CLASSNAME",
+    ]) {
+      expect(classNameConstant(source, name)).not.toMatch(/bg-background\//);
+    }
+  });
+
+  it("continues the header's material up over the top mask's fade tail", () => {
+    // The header pins at `--top-shell-live-height`, which is the mask's LAST
+    // VISIBLE pixel — so the `--top-fade-active` band directly above it is
+    // chrome at the top and clear glass at the bottom, and rows crossed it in
+    // plain sight between the bar and the strips. A fixture cannot hold this:
+    // it is a band the component draws outside its own box.
+    expect(source).toContain("before:bottom-full");
+    expect(source).toContain("before:bg-background");
+    expect(source).toContain(
+      "data-[pinned=true]:before:h-[calc(var(--top-fade-active,0px)+1px)]",
+    );
+  });
+
+  it("gives the cover a height only while the header is really pinned", () => {
+    // At rest the header sits `--page-header-section-gap` below the page title —
+    // 10px at this page's compact density — so an unconditional 22px cover would
+    // sit on "Connect" rather than on the mask's tail. The sentinel is what says
+    // which of the two states the header is in; the header itself cannot, since
+    // once pinned it never leaves the scrollport.
+    expect(source).toContain("stickyPinSentinelRef");
+    expect(source).toContain("new IntersectionObserver");
+    expect(source).toContain("rootMargin: `-${pinnedAt}px 0px 0px 0px`");
   });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -182,10 +182,30 @@ const CONNECT_STRIP_COMPACT_PADDING =
  * gutters. Without it, rows scroll past visibly in the 16-24px either side of a
  * header that is supposed to be covering them.
  *
+ * `bg-background`, at full opacity, NOT `bg-background/85`. Fifteen percent of a
+ * roster row is still a roster row: names and avatars read straight through the
+ * strips at phone width, which is the "list scrolls behind the header" this
+ * fixes. The blur went with it -- it has nothing left to blur, and it cost a
+ * compositing layer on every scroll frame.
+ *
+ * `::before` continues that same material UP over `--top-fade-active`, the band
+ * where the fixed top mask dissolves to fully transparent. The header pins at
+ * the mask's last visible pixel, so that band is chrome-coloured at the top and
+ * clear glass at the bottom -- and rows slid through it in plain sight, between
+ * the bar and the strips, which is the other half of the same report. Covering
+ * it means the tail dissolves over empty page instead, exactly as it does when
+ * the page has not been scrolled.
+ *
+ * Height only under `data-pinned`: an absolutely positioned box with no height
+ * and empty content is 0px tall, so the cover exists and measures nothing until
+ * the header is really pinned. It has to be conditional. At rest this header
+ * sits `--page-header-section-gap` below the page title -- 10px at compact
+ * density -- and an unconditional 22px band would take a bite out of "Connect".
+ *
  * Held by e2e/connect-sticky-header.layout.spec.ts.
  */
 const CONNECT_STICKY_HEADER_CLASSNAME =
-  "sticky top-[var(--top-shell-live-height,0px)] z-20 mx-[calc(var(--page-inline-gutter-standard)*-1)] space-y-3 bg-background/85 px-[var(--page-inline-gutter-standard)] pb-3 pt-2 backdrop-blur-md sm:space-y-4";
+  "sticky top-[var(--top-shell-live-height,0px)] z-20 mx-[calc(var(--page-inline-gutter-standard)*-1)] space-y-3 bg-background px-[var(--page-inline-gutter-standard)] pb-3 pt-2 before:pointer-events-none before:absolute before:inset-x-0 before:bottom-full before:bg-background data-[pinned=true]:before:h-[calc(var(--top-fade-active,0px)+1px)] sm:space-y-4";
 
 /**
  * The search row pins UNDER the header, not with it.
@@ -198,9 +218,12 @@ const CONNECT_STICKY_HEADER_CLASSNAME =
  *
  * The offset is the live top shell plus whatever the header above measured, so
  * a two-strip header and a one-strip header both land it in the right place.
+ *
+ * Opaque for the same reason the header above it is: at 85% the directory rows
+ * this field filters read straight through it as they scroll past.
  */
 const CONNECT_STICKY_SEARCH_CLASSNAME =
-  "sticky top-[calc(var(--top-shell-live-height,0px)+var(--connect-sticky-header-height,0px))] z-10 mx-[calc(var(--page-inline-gutter-standard)*-1)] bg-background/85 px-[var(--page-inline-gutter-standard)] py-2 backdrop-blur-md";
+  "sticky top-[calc(var(--top-shell-live-height,0px)+var(--connect-sticky-header-height,0px))] z-10 mx-[calc(var(--page-inline-gutter-standard)*-1)] bg-background px-[var(--page-inline-gutter-standard)] py-2";
 
 const CONNECT_TAB_LABEL: Record<ConnectTab, string> = {
   people: "People",
@@ -521,6 +544,7 @@ export default function ConnectPageClient() {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const connectStackRef = useRef<HTMLDivElement | null>(null);
   const stickyHeaderRef = useRef<HTMLDivElement | null>(null);
+  const stickyPinSentinelRef = useRef<HTMLDivElement | null>(null);
   const [query, setQuery] = useState<string>(readStoredConnectSearchQuery);
   useEffect(() => {
     writeStoredConnectSearchQuery(query);
@@ -578,6 +602,59 @@ export default function ConnectPageClient() {
     const observer = new ResizeObserver(publish);
     observer.observe(header);
     return () => observer.disconnect();
+  }, [surface]);
+  /**
+   * Say whether the header is actually pinned, so its cover can be conditional.
+   *
+   * The cover is a band of page background continuing UP from the header over
+   * `--top-fade-active` -- the strip where the fixed top mask dissolves to
+   * nothing and rows were sliding through it in plain sight. Pinned, that band
+   * belongs to the chrome. At rest it is the gap under the "Connect" title,
+   * `--page-header-section-gap`, which is 10px at this page's density -- so an
+   * unconditional cover would sit on the title instead of on the mask's tail.
+   *
+   * An observer rather than a scroll handler: this fires twice per visit, at
+   * the pin boundary, instead of measuring on every frame the way the top app
+   * bar's own collapse tracking has to.
+   *
+   * `rootMargin` is the header's resolved `top`, read back rather than
+   * recomputed. `--top-shell-live-height` is a calc of six tokens declared at
+   * route-shell scope; anything here that re-derived it would be a second copy
+   * to keep in step with `signed-in-shell-content-offset.ts`.
+   */
+  useEffect(() => {
+    const header = stickyHeaderRef.current;
+    const sentinel = stickyPinSentinelRef.current;
+    if (!header || !sentinel) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const scrollRoot = document.querySelector<HTMLElement>(
+      '[data-app-scroll-root="true"]',
+    );
+    let observer: IntersectionObserver | null = null;
+    const attach = () => {
+      observer?.disconnect();
+      const pinnedAt = Math.max(
+        0,
+        Math.round(Number.parseFloat(getComputedStyle(header).top) || 0),
+      );
+      observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[entries.length - 1];
+          if (!entry) return;
+          header.dataset.pinned = entry.isIntersecting ? "false" : "true";
+        },
+        { root: scrollRoot, rootMargin: `-${pinnedAt}px 0px 0px 0px` },
+      );
+      observer.observe(sentinel);
+    };
+    attach();
+    // The offset moves with the breakpoint and with the safe-area inset, and a
+    // rotation changes both at once.
+    window.addEventListener("resize", attach);
+    return () => {
+      window.removeEventListener("resize", attach);
+      observer?.disconnect();
+    };
   }, [surface]);
   /**
    * The people picked for a bulk request, held whole rather than by id.
@@ -2154,13 +2231,33 @@ export default function ConnectPageClient() {
 
       <AppPageContentRegion>
         <SurfaceStack compact>
-          <div ref={connectStackRef} className="space-y-4 sm:space-y-5">
+          <div
+            ref={connectStackRef}
+            className="relative space-y-4 sm:space-y-5"
+          >
+            {/* Where the header sits when it is NOT pinned, held open as a 1px
+                line so an observer can watch that spot leave the scrollport.
+                Absolutely positioned, so it is out of flow: `space-y-*` gives a
+                first child `margin-block-end` only, which an absolute box with
+                `top: 0` cannot act on, and the strips below keep their rhythm.
+                Reading the header itself would prove nothing -- once pinned it
+                never leaves, which is the whole point of it. */}
+            <div
+              ref={stickyPinSentinelRef}
+              data-testid="connect-sticky-pin-sentinel"
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 top-0 h-px"
+            />
             {/* Both axes travel together. Pinning the outer strip and letting
                 the inner one scroll would leave a header naming a surface above
                 a tab bar that has already left the screen. */}
             <div
               ref={stickyHeaderRef}
               data-testid="connect-sticky-header"
+              // Written by the observer above. Declared here so the attribute
+              // exists from the first paint rather than arriving a frame later,
+              // which is a frame of the cover in the wrong state.
+              data-pinned="false"
               className={CONNECT_STICKY_HEADER_CLASSNAME}
             >
               {/* The outer axis. People, or the groups they are in. */}

--- a/hushh-webapp/e2e/connect-sticky-header.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-sticky-header.layout.spec.ts
@@ -38,6 +38,14 @@ import {
  * header's measured height on top of that — measured, because the header is one
  * strip on Circles and two everywhere else.
  *
+ * `--top-shell-live-height` is the mask's LAST VISIBLE pixel, not its solid
+ * edge, so pinning there leaves the `--top-fade-active` band above the strips
+ * showing whatever is behind it — and what is behind it is the roster. The
+ * header covers that band with its own material while it is pinned, and only
+ * while it is pinned: at rest the same band is the gap under the page title.
+ * Both halves are measured below, because a cover that is always on and a cover
+ * that is never on each pass exactly one of them.
+ *
  * jsdom proves none of this: it applies no CSS and measures every element as
  * 0x0, so `className.toContain("sticky")` passes against a strip that never
  * pins and a search row that lands behind it.
@@ -56,10 +64,13 @@ const SURFACE_STRIP_HEIGHT_PX = 38;
 const TAB_STRIP_HEIGHT_PX = 38;
 
 const STICKY_HEADER_CLASSNAME =
-  "sticky top-[var(--top-shell-live-height,0px)] z-20 mx-[calc(var(--page-inline-gutter-standard)*-1)] space-y-3 bg-background/85 px-[var(--page-inline-gutter-standard)] pb-3 pt-2 backdrop-blur-md sm:space-y-4";
+  "sticky top-[var(--top-shell-live-height,0px)] z-20 mx-[calc(var(--page-inline-gutter-standard)*-1)] space-y-3 bg-background px-[var(--page-inline-gutter-standard)] pb-3 pt-2 before:pointer-events-none before:absolute before:inset-x-0 before:bottom-full before:bg-background data-[pinned=true]:before:h-[calc(var(--top-fade-active,0px)+1px)] sm:space-y-4";
 
 const STICKY_SEARCH_CLASSNAME =
-  "sticky top-[calc(var(--top-shell-live-height,0px)+var(--connect-sticky-header-height,0px))] z-10 mx-[calc(var(--page-inline-gutter-standard)*-1)] bg-background/85 px-[var(--page-inline-gutter-standard)] py-2 backdrop-blur-md";
+  "sticky top-[calc(var(--top-shell-live-height,0px)+var(--connect-sticky-header-height,0px))] z-10 mx-[calc(var(--page-inline-gutter-standard)*-1)] bg-background px-[var(--page-inline-gutter-standard)] py-2";
+
+/** The page title Connect renders above the strips, and its gap to them. */
+const PAGE_HEADER_HEIGHT_PX = 34;
 
 async function buildStylesheet(candidates: string[]): Promise<string> {
   const webappRoot = process.cwd();
@@ -142,7 +153,17 @@ function shellMarkup(): string {
       <div
         data-app-top-bar
         style="position: fixed; inset-inline: 0; top: 0; z-index: 50; height: var(--top-shell-live-height); background: rgba(0,0,0,0.06);"
-      ></div>
+      >
+        <!-- The mask paints solid to here and then dissolves over
+             --top-fade-active to nothing. Modelled, not decorative: the band
+             between this edge and the bar's full height is the one the roster
+             was crossing in plain sight, and a bar drawn as one opaque block
+             cannot show it. -->
+        <div
+          data-app-top-bar-solid
+          style="height: var(--top-shell-mask-solid-height);"
+        ></div>
+      </div>
       <div
         data-app-scroll-root="true"
         style="position: fixed; inset: 0; overflow-y: auto;"
@@ -154,10 +175,18 @@ function shellMarkup(): string {
           data-app-shell-width="standard"
           data-top-content-anchor="true"
         >
+          <!-- Connect renders a page title above the strips, and at compact
+               density the page-header section gap leaves only 10px between the
+               two. That gap is what makes the cover conditional, so the fixture
+               has to contain the thing it must not cover. -->
+          <div class="app-page-header-region w-full min-w-0">
+            <div data-page-header style="height: ${PAGE_HEADER_HEIGHT_PX}px; background: #c8c8d0;">Connect</div>
+          </div>
           <div class="app-page-content-region w-full min-w-0">
             <div class="surface-stack surface-stack-compact">
-              <div data-connect-stack class="space-y-4 sm:space-y-5">
-                <div data-testid="connect-sticky-header" class="${STICKY_HEADER_CLASSNAME}">
+              <div data-connect-stack class="relative space-y-4 sm:space-y-5">
+                <div data-testid="connect-sticky-pin-sentinel" aria-hidden class="pointer-events-none absolute inset-x-0 top-0 h-px"></div>
+                <div data-testid="connect-sticky-header" data-pinned="false" class="${STICKY_HEADER_CLASSNAME}">
                   <div data-strip="surface" style="height: ${SURFACE_STRIP_HEIGHT_PX}px; background: #e8e8ed;">People / Circles</div>
                   <div data-strip="tab" style="height: ${TAB_STRIP_HEIGHT_PX}px; background: #e8e8ed;">People / RIAs / Around you</div>
                 </div>
@@ -186,6 +215,12 @@ async function writeFixture(): Promise<string> {
     "flex",
     "items-center",
     "gap-2",
+    "relative",
+    "pointer-events-none",
+    "absolute",
+    "inset-x-0",
+    "top-0",
+    "h-px",
     ...APP_SHELL_FRAME_CLASSNAME.split(" "),
     APP_SHELL_MAX_WIDTHS.standard,
     ...STICKY_HEADER_CLASSNAME.split(" "),
@@ -215,6 +250,29 @@ async function writeFixture(): Promise<string> {
       Math.ceil(header.getBoundingClientRect().height) + "px",
     );
   })();
+  /* The pinned-state observer, again as the component runs it. Hard-coding
+     data-pinned here would test a cover this fixture switched on by hand; the
+     question is whether the component's own rootMargin puts the switch at the
+     pin boundary. */
+  (function () {
+    var header = document.querySelector('[data-testid="connect-sticky-header"]');
+    var sentinel = document.querySelector(
+      '[data-testid="connect-sticky-pin-sentinel"]',
+    );
+    var scrollRoot = document.querySelector('[data-app-scroll-root="true"]');
+    var pinnedAt = Math.max(
+      0,
+      Math.round(parseFloat(getComputedStyle(header).top) || 0),
+    );
+    new IntersectionObserver(
+      function (entries) {
+        var entry = entries[entries.length - 1];
+        if (!entry) return;
+        header.dataset.pinned = entry.isIntersecting ? "false" : "true";
+      },
+      { root: scrollRoot, rootMargin: "-" + pinnedAt + "px 0px 0px 0px" },
+    ).observe(sentinel);
+  })();
 </script>
 </body></html>`,
   );
@@ -223,7 +281,7 @@ async function writeFixture(): Promise<string> {
 
 /** Scroll the app root by `y` and read back what is pinned where. */
 async function measureAt(page: Page, y: number) {
-  return page.evaluate((scrollTop) => {
+  return page.evaluate(async (scrollTop) => {
     const scrollRoot = document.querySelector<HTMLElement>(
       "[data-app-scroll-root]",
     )!;
@@ -232,19 +290,73 @@ async function measureAt(page: Page, y: number) {
     // `getPropertyValue` hands back the unresolved `calc(...)` string, which is
     // NaN to `parseFloat` and would quietly pass every comparison below.
     const topBar = document.querySelector<HTMLElement>("[data-app-top-bar]")!;
+    const solid = document.querySelector<HTMLElement>(
+      "[data-app-top-bar-solid]",
+    )!;
     const header = document.querySelector<HTMLElement>(
       '[data-testid="connect-sticky-header"]',
+    )!;
+    const sentinel = document.querySelector<HTMLElement>(
+      '[data-testid="connect-sticky-pin-sentinel"]',
     )!;
     const search = document.querySelector<HTMLElement>(
       '[data-testid="connect-search-row"]',
     )!;
     const directory = document.querySelector<HTMLElement>("[data-directory]")!;
+    const pageHeader = document.querySelector<HTMLElement>("[data-page-header]")!;
+    const stack = document.querySelector<HTMLElement>("[data-connect-stack]")!;
     const shell = document.querySelector<HTMLElement>(".app-page-shell")!;
+    // The observer answers a frame or two after the scroll, so waiting a fixed
+    // number of frames would be a race dressed as a constant. Wait for it to
+    // AGREE with the geometry instead: pinned is exactly "the header is no
+    // longer where the sentinel is". If the observer never fires, this times
+    // out and every assertion below fails, which is the correct outcome.
+    const settled = await new Promise<boolean>((resolve) => {
+      let framesLeft = 60;
+      const check = () => {
+        const truth =
+          header.getBoundingClientRect().top -
+            sentinel.getBoundingClientRect().top >
+          0.5;
+        if ((header.dataset.pinned === "true") === truth) return resolve(true);
+        if (framesLeft-- <= 0) return resolve(false);
+        requestAnimationFrame(check);
+      };
+      requestAnimationFrame(check);
+    });
+    /** The alpha term of a computed colour, in any of its serialisations. */
+    const alphaOf = (colour: string): number => {
+      const slashForm = /\/\s*([\d.]+%?)\s*\)/.exec(colour);
+      const legacyForm = /^rgba\([^)]*,\s*([\d.]+)\s*\)$/.exec(colour);
+      const raw = slashForm?.[1] ?? legacyForm?.[1];
+      if (raw === undefined) return 1;
+      return raw.endsWith("%")
+        ? Number.parseFloat(raw) / 100
+        : Number.parseFloat(raw);
+    };
     const shellBox = shell.getBoundingClientRect();
     const liveHeight = +topBar.getBoundingClientRect().height.toFixed(2);
     const headerBox = header.getBoundingClientRect();
     const searchBox = search.getBoundingClientRect();
     return {
+      settled,
+      pinned: header.dataset.pinned === "true",
+      solidHeight: +solid.getBoundingClientRect().height.toFixed(2),
+      // The band the header continues its own material into. Read off the
+      // rendered pseudo-element, so a cover that resolved to `auto` — which is
+      // what an unset `--top-fade-active` would give — reads as the 0 it is.
+      coverHeight: +(
+        Number.parseFloat(getComputedStyle(header, "::before").height) || 0
+      ).toFixed(2),
+      // Alpha, not the colour string. A computed background serialises as
+      // `rgb()`, `rgba()`, `oklab(… / a)` or `color(srgb … / a)` depending on
+      // the browser and on how the token was authored, and only one of those
+      // shapes was ever going to be the one this suite guessed.
+      headerAlpha: alphaOf(getComputedStyle(header).backgroundColor),
+      coverAlpha: alphaOf(getComputedStyle(header, "::before").backgroundColor),
+      searchAlpha: alphaOf(getComputedStyle(search).backgroundColor),
+      stackTop: +stack.getBoundingClientRect().top.toFixed(2),
+      pageHeaderBottom: +pageHeader.getBoundingClientRect().bottom.toFixed(2),
       liveHeight,
       headerTop: +headerBox.top.toFixed(2),
       headerBottom: +headerBox.bottom.toFixed(2),
@@ -336,6 +448,70 @@ test.describe("connect sticky header", () => {
       expect(
         Math.abs(scrolled.searchRight - scrolled.pageRight),
       ).toBeLessThanOrEqual(SLACK_PX);
+    });
+
+    test(`the strips cover the top mask's fade tail while pinned at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await writeFixture());
+      await awaitProductFont(page);
+
+      const scrolled = await measureAt(page, 700);
+
+      expect(scrolled.settled).toBe(true);
+      expect(scrolled.pinned).toBe(true);
+      // The band exists in the first place. A fixture whose bar was one opaque
+      // block would report 0 here and then pass everything below vacuously.
+      const tail = scrolled.liveHeight - scrolled.solidHeight;
+      expect(tail).toBeGreaterThan(0);
+      // And the header's own material reaches back across it, up to the mask's
+      // solid edge. Anything short of that is roster showing between the bar
+      // and the strips, which is the whole report.
+      expect(scrolled.coverHeight).toBeGreaterThanOrEqual(tail);
+      expect(scrolled.headerTop - scrolled.coverHeight).toBeLessThanOrEqual(
+        scrolled.solidHeight + SLACK_PX,
+      );
+    });
+
+    test(`both pinned bands are opaque at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await writeFixture());
+      await awaitProductFont(page);
+
+      const scrolled = await measureAt(page, 1400);
+
+      // Geometry alone does not settle this: a band in exactly the right place
+      // at 85% still shows the names scrolling under it.
+      expect(scrolled.headerAlpha).toBe(1);
+      expect(scrolled.coverAlpha).toBe(1);
+      expect(scrolled.searchAlpha).toBe(1);
+    });
+
+    test(`the cover keeps off the page title at rest at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(await writeFixture());
+      await awaitProductFont(page);
+
+      const atRest = await measureAt(page, 0);
+
+      expect(atRest.settled).toBe(true);
+      expect(atRest.pinned).toBe(false);
+      // Unpinned, the cover measures nothing at all, so the 10px that
+      // `--page-header-section-gap` leaves under "Connect" at compact density is
+      // not something it can take a bite out of.
+      expect(atRest.coverHeight).toBe(0);
+      expect(atRest.headerTop - atRest.coverHeight).toBeGreaterThanOrEqual(
+        atRest.pageHeaderBottom - SLACK_PX,
+      );
+      // And the out-of-flow sentinel left the strips where they were: it is the
+      // first child of a `space-y-*` stack, which would otherwise be a 16px
+      // shove down the page.
+      expect(Math.abs(atRest.headerTop - atRest.stackTop)).toBeLessThanOrEqual(
+        SLACK_PX,
+      );
     });
 
     test(`the search row stays out of the way before its section arrives at ${width}px`, async ({


### PR DESCRIPTION
# Description

On Connect the contact list showed **through** the header: a roster row was
readable above the Connections/Circles strip, and the rows kept reading through
the strips and the search field as they scrolled past.

#6073 pinned those strips, so this looks like pinning that did not take. It did.
The strips are exactly where they should be — two separate bands in front of the
rows are see-through, and together they are 30px, which is most of a row.

1. **22px of it is the top mask's own tail.** The strips pin at
   `--top-shell-live-height` = `--top-shell-mask-solid-height` + `--top-fade-active`
   — the mask's *last visible* pixel, not its solid edge. Across that band the
   mask falls from 94% opacity to zero, so a row crossing it is fully readable by
   the time it reaches the strips. Under a feed that dissolve is the point. Under
   a pinned header it is a window.
2. **8px of it is the strips themselves**, at `bg-background/85`. Fifteen percent
   of a name is still a name — and the search row had the same 85% over the very
   directory rows it filters.

Both bands are opaque now, and the header continues its own material up over the
mask's tail with a `::before`, so the tail dissolves over flat page background —
exactly what it does before the page is scrolled.

The cover has a height only under `data-pinned`, and that is why there is an
observer here rather than one more class: at rest the header sits
`--page-header-section-gap` below the page title — 10px at this page's compact
density — so an unconditional 22px band would take a bite out of "Connect". An
`IntersectionObserver` on a 1px sentinel held at the header's unpinned position
fires twice a visit, at the pin boundary, instead of measuring every scroll frame.
Its `rootMargin` is the header's own resolved `top`, read back rather than
re-derived from the six route-shell tokens that produce it.

Before / after, at the moment in the report — scrolled into the directory:

| | above the strips | through the strips | through the search row |
|---|---|---|---|
| before | roster row, fully readable | roster rows at 15% | roster rows at 15% |
| after | page background | nothing | nothing |

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/connect` (presentation only — no data, no navigation, no state)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: iOS and Android are this same Next surface through
    Capacitor, so this is one fix for all three. The layout spec runs on WebKit
    as well as Chromium — WebKit is the engine that ships inside the app.

- Docs updated (exact files):
  - [x] None — no doc states the pinned header's geometry; the two specs below do.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below: the cover is a pseudo-element with no height until an
    observer sets `data-pinned`. With no `IntersectionObserver` the attribute
    stays `"false"`, the cover measures 0, and the header renders exactly as it
    does today minus the translucency. Nothing here can fail into a worse state
    than the one being fixed.

- UI browser or Playwright proof:
  - [x] `cd hushh-webapp && CI=1 npx playwright test e2e/connect-sticky-header.layout.spec.ts --project=chromium` (35 passed)
  - [x] `cd hushh-webapp && CI=1 npx playwright test e2e/connect-sticky-header.layout.spec.ts --project=webkit` (35 passed)

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npx eslint app/connect/page-client.tsx e2e/connect-sticky-header.layout.spec.ts __tests__/components/connect-sticky-header.contract.test.ts --max-warnings=0`
  - [x] `cd hushh-webapp && npm run verify:connect-search` (6 files, 137 tests)
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run verify:surface-map`
  - [ ] `npm test` / `npm run build` — not run locally; left to CI and the merge
    queue, which is where this repo runs the full web suite.
  - [ ] `npm run ios:cold:audit` — not run; no native code, plugin, or bridge is
    touched by this diff.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not
      duplicate: #6073 pinned the strips, #6032 pinned the flow footer. This is the
      band #6073 left showing, and it edits #6073's own constants and specs rather
      than adding a second mechanism beside them.
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: `app/connect/page-client.tsx`, the
      `/connect` route client.
- [x] New tests import and exercise production code: the layout spec builds real
      Tailwind from `app/globals.css` and reproduces the shell through
      `resolveTopShellGeometryStyle` / `resolveSignedInShellContentOffset`; the
      contract test reads the shipped source.
- [x] New helpers/components/services are wired to an existing route.
- [x] Production surface proved: both specs above, plus a mutation check —
      restoring the old classnames fails the pinned-coverage and opacity cases,
      and an unconditional cover fails the at-rest case by 23px. Neither new test
      passes vacuously.
- [x] Required checks are current on this head, commits are signed off, and the
      branch is merged up to `main`.
- [x] Maintainer edits are enabled.
- [ ] Not part of a stack.
- [ ] Not a response to requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `app/connect/page-client.tsx`
- [x] **iOS**: not applicable — no plugin surface; the fix ships through the
      Capacitor webview and is held on WebKit by the layout spec.
- [x] **Android**: not applicable — same, through the Android webview.

## 🧪 Testing

- [x] Tested on Web (Chromium and WebKit, 320 / 375 / 390 / 430 / 768px)
- [ ] iOS Simulator/Device — not run; WebKit at phone widths is the same engine
      and the same geometry, and no native surface changed.
- [ ] Android Emulator/Device — as above.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Route: `/connect`, scrolled into the directory.

Browser proof is the layout spec rather than a screenshot, deliberately: what
went wrong here is 22px of a fade tail, and the two states that had to be told
apart — pinned and at rest — differ by whether a band has a height. Both are
measured, at five widths, on two engines:

- `the strips cover the top mask's fade tail while pinned` — the header's
  material reaches back to `--top-shell-mask-solid-height`, with the tail
  measured off separate solid / full-height boxes so the band cannot be asserted
  into existence.
- `both pinned bands are opaque` — alpha of the header, the cover and the search
  row is exactly 1.
- `the cover keeps off the page title at rest` — unpinned, the cover measures 0,
  clears the page header, and the out-of-flow sentinel has not moved the strips.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [x] `checkConsentToken()`: not applicable.
- [x] Sensitive surface touched: none.
- [x] Error path, rollback, or safe-failure behavior proved: see Rollback above.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

Part of #5608.
