### PR TITLE
fix(one): publish voice actions on Location's map and check-in routes

### DIFF
--- a/hushh-webapp/__tests__/voice/location-published-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/location-published-actions.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { LOCATION_VOICE_ACTIONS } from "@/app/one/location/page";
 import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+import {
+  LOCATION_VOICE_ACTIONS_EXCLUDE_IDS,
+  deriveLocationVoiceActions,
+} from "@/lib/voice/location-voice-actions";
 
 /**
  * LOCATION_VOICE_ACTIONS used to be a hand-typed 23-entry list that drifted
@@ -22,7 +26,7 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
           (action.execution_target.path === "local_handler" ||
             action.execution_target.path === "route") &&
           action.execution_policy !== "manual_only" &&
-          action.action_id !== CHECKOUT_NEARBY,
+          !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
       )
       .map((action) => action.action_id),
   );
@@ -45,7 +49,9 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
     // Wired in the contract, but its UI calls OneLocationService.checkoutNearby()
     // directly with no useLocalOnboardingActionHandler registration anywhere.
     // Publishing it would offer something guaranteed to fail. See the
-    // exclusion comment above LOCATION_VOICE_ACTIONS_EXCLUDE_IDS in page.tsx.
+    // exclusion comment on LOCATION_VOICE_ACTIONS_EXCLUDE_IDS in
+    // lib/voice/location-voice-actions.ts, shared by every Location screen.
+    expect(LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(CHECKOUT_NEARBY)).toBe(true);
     expect(LOCATION_VOICE_ACTIONS.some((action) => action.actionId === CHECKOUT_NEARBY)).toBe(
       false,
     );
@@ -79,6 +85,79 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
     const publishedIds = new Set(LOCATION_VOICE_ACTIONS.map((action) => action.actionId));
     for (const id of REGRESSION_IDS) {
       expect(publishedIds.has(id), `${id} still missing from LOCATION_VOICE_ACTIONS`).toBe(true);
+    }
+  });
+});
+
+/**
+ * Location's map and check-in routes (app/one/location/map/page.tsx,
+ * app/one/location/check-in/page.tsx) are separate route files from the hub
+ * (app/one/location/page.tsx) -- the only file that published voice metadata
+ * for any Location screen until now. Navigating to either route left voice
+ * with zero proactively-offered actions even though the handlers for
+ * location.nearby_check_in / location.confirm_nearby_check_in
+ * (nearby-check-in-sheet.tsx) are live there. These tests pin the exact
+ * derived set for each screen against the real gateway data, the same way
+ * the hub's own set is pinned above.
+ */
+describe("deriveLocationVoiceActions stays in sync for the map and check-in screens", () => {
+  const CHECKOUT_NEARBY = "location.checkout_nearby";
+
+  function expectedIdsFor(screen: string): Set<string> {
+    return new Set(
+      listKaiActionsForSurface({ screen })
+        .filter(
+          (action) =>
+            action.execution_target.status === "wired" &&
+            (action.execution_target.path === "local_handler" ||
+              action.execution_target.path === "route") &&
+            action.execution_policy !== "manual_only" &&
+            !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
+        )
+        .map((action) => action.action_id),
+    );
+  }
+
+  it("one_location_map publishes exactly the wired local_handler/route actions for that screen", () => {
+    const actions = deriveLocationVoiceActions("one_location_map");
+    const publishedIds = new Set(actions.map((action) => action.actionId));
+    expect(publishedIds).toEqual(expectedIdsFor("one_location_map"));
+    // Pinned exact set, not just a diff against the gateway: catches a
+    // gateway change that silently narrows this screen's reachability too.
+    expect(publishedIds).toEqual(
+      new Set([
+        "location.open_check_in",
+        "location.open_map",
+        "location.nearby_check_in",
+        "location.confirm_nearby_check_in",
+      ]),
+    );
+  });
+
+  it("one_location_check_in publishes exactly the wired local_handler/route actions for that screen", () => {
+    const actions = deriveLocationVoiceActions("one_location_check_in");
+    const publishedIds = new Set(actions.map((action) => action.actionId));
+    expect(publishedIds).toEqual(expectedIdsFor("one_location_check_in"));
+    expect(publishedIds).toEqual(
+      new Set(["location.nearby_check_in", "location.confirm_nearby_check_in"]),
+    );
+  });
+
+  it("excludes location.checkout_nearby on both screens for the same reason as the hub", () => {
+    for (const screen of ["one_location_map", "one_location_check_in"]) {
+      const actions = deriveLocationVoiceActions(screen);
+      expect(
+        actions.some((action) => action.actionId === CHECKOUT_NEARBY),
+        `${screen} should not publish ${CHECKOUT_NEARBY}`,
+      ).toBe(false);
+      // Confirm it's excluded because it's really wired-but-handlerless on
+      // this screen too, not because it fell out of reachability entirely.
+      const contractEntry = listKaiActionsForSurface({ screen }).find(
+        (action) => action.action_id === CHECKOUT_NEARBY,
+      );
+      expect(contractEntry?.execution_target.status, `${screen}: ${CHECKOUT_NEARBY}`).toBe(
+        "wired",
+      );
     }
   });
 });

--- a/hushh-webapp/app/one/location/__tests__/check-in-page-voice-publish.test.tsx
+++ b/hushh-webapp/app/one/location/__tests__/check-in-page-voice-publish.test.tsx
@@ -1,0 +1,102 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * app/one/location/check-in/page.tsx used to be one of two Location routes
+ * that never called usePublishVoiceSurfaceMetadata at all -- voice offered
+ * zero proactively-offered actions here even though
+ * NearbyCheckInSheet's handlers were live on this screen. These tests pin
+ * the wiring: the right screenId and actions publish when the screen is
+ * genuinely showing, and nothing publishes when it isn't (matches the
+ * page's own render gate, which returns null in the same cases).
+ */
+
+const authHarness = vi.hoisted(() => ({
+  loading: false,
+  isAuthenticated: true,
+  userId: "test-user" as string | null,
+}));
+
+const nearbyAvailableHarness = vi.hoisted(() => ({ value: true }));
+
+const publishSpy = vi.hoisted(() => vi.fn());
+const routerReplace = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/use-auth", () => ({
+  useRequireAuth: () => ({
+    loading: authHarness.loading,
+    isAuthenticated: authHarness.isAuthenticated,
+    userId: authHarness.userId,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: routerReplace, push: vi.fn() }),
+}));
+
+vi.mock("@/lib/one-location/nearby-check-in-availability", () => ({
+  isOneLocationNearbyCheckInAvailable: () => nearbyAvailableHarness.value,
+}));
+
+vi.mock("@/components/one-location/location-immersive-map", () => ({
+  LocationImmersiveMap: () => null,
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: (metadata: unknown) => publishSpy(metadata),
+}));
+
+import OneLocationCheckInPage from "@/app/one/location/check-in/page";
+
+describe("Location check-in page publishes voice metadata", () => {
+  afterEach(() => {
+    publishSpy.mockClear();
+    routerReplace.mockClear();
+    authHarness.loading = false;
+    authHarness.isAuthenticated = true;
+    authHarness.userId = "test-user";
+    nearbyAvailableHarness.value = true;
+  });
+
+  it("publishes the one_location_check_in screen with its derived actions when authenticated and available", () => {
+    render(<OneLocationCheckInPage />);
+
+    expect(publishSpy).toHaveBeenCalled();
+    const metadata = publishSpy.mock.calls.at(-1)?.[0] as {
+      screenId: string;
+      actions: Array<{ actionId: string }>;
+    };
+    expect(metadata).not.toBeNull();
+    expect(metadata.screenId).toBe("one_location_check_in");
+    const actionIds = metadata.actions.map((action) => action.actionId).sort();
+    expect(actionIds).toEqual([
+      "location.confirm_nearby_check_in",
+      "location.nearby_check_in",
+    ]);
+  });
+
+  it("publishes nothing while auth is still loading", () => {
+    authHarness.loading = true;
+    render(<OneLocationCheckInPage />);
+
+    expect(publishSpy).toHaveBeenCalledWith(null);
+  });
+
+  it("publishes nothing when unauthenticated", () => {
+    authHarness.isAuthenticated = false;
+    render(<OneLocationCheckInPage />);
+
+    expect(publishSpy).toHaveBeenCalledWith(null);
+  });
+
+  it("publishes nothing when nearby check-in is unavailable -- the screen redirects away instead", () => {
+    nearbyAvailableHarness.value = false;
+    render(<OneLocationCheckInPage />);
+
+    expect(publishSpy).toHaveBeenCalledWith(null);
+    expect(routerReplace).toHaveBeenCalledWith(
+      "/one/location?action=check-in",
+      { scroll: false },
+    );
+  });
+});

--- a/hushh-webapp/app/one/location/__tests__/map-page-voice-publish.test.tsx
+++ b/hushh-webapp/app/one/location/__tests__/map-page-voice-publish.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * app/one/location/map/page.tsx used to be one of two Location routes that
+ * never called usePublishVoiceSurfaceMetadata at all -- see the same note in
+ * check-in-page-voice-publish.test.tsx. These tests pin the wiring: the
+ * right screenId and actions publish once authenticated, nothing publishes
+ * before then.
+ */
+
+const authHarness = vi.hoisted(() => ({
+  loading: false,
+  isAuthenticated: true,
+  userId: "test-user" as string | null,
+}));
+
+const publishSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/use-auth", () => ({
+  useRequireAuth: () => ({
+    loading: authHarness.loading,
+    isAuthenticated: authHarness.isAuthenticated,
+    userId: authHarness.userId,
+  }),
+}));
+
+vi.mock("@/components/one-location/location-immersive-map", () => ({
+  LocationImmersiveMap: () => null,
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: (metadata: unknown) => publishSpy(metadata),
+}));
+
+import OneLocationMapPage from "@/app/one/location/map/page";
+
+describe("Location map page publishes voice metadata", () => {
+  afterEach(() => {
+    publishSpy.mockClear();
+    authHarness.loading = false;
+    authHarness.isAuthenticated = true;
+    authHarness.userId = "test-user";
+  });
+
+  it("publishes the one_location_map screen with its derived actions when authenticated", () => {
+    render(<OneLocationMapPage />);
+
+    expect(publishSpy).toHaveBeenCalled();
+    const metadata = publishSpy.mock.calls.at(-1)?.[0] as {
+      screenId: string;
+      actions: Array<{ actionId: string }>;
+    };
+    expect(metadata).not.toBeNull();
+    expect(metadata.screenId).toBe("one_location_map");
+    const actionIds = metadata.actions.map((action) => action.actionId).sort();
+    expect(actionIds).toEqual(
+      [
+        "location.confirm_nearby_check_in",
+        "location.nearby_check_in",
+        "location.open_check_in",
+        "location.open_map",
+      ].sort(),
+    );
+  });
+
+  it("publishes nothing while auth is still loading", () => {
+    authHarness.loading = true;
+    render(<OneLocationMapPage />);
+
+    expect(publishSpy).toHaveBeenCalledWith(null);
+  });
+
+  it("publishes nothing when unauthenticated", () => {
+    authHarness.isAuthenticated = false;
+    render(<OneLocationMapPage />);
+
+    expect(publishSpy).toHaveBeenCalledWith(null);
+  });
+});

--- a/hushh-webapp/app/one/location/check-in/page.tsx
+++ b/hushh-webapp/app/one/location/check-in/page.tsx
@@ -8,6 +8,8 @@ import { LocationImmersiveMap } from "@/components/one-location/location-immersi
 import { useRequireAuth } from "@/hooks/use-auth";
 import { ROUTES } from "@/lib/navigation/routes";
 import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-check-in-availability";
+import { deriveLocationVoiceActions } from "@/lib/voice/location-voice-actions";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
 /**
  * Nearby check-in, as its own destination.
@@ -24,6 +26,10 @@ import { isOneLocationNearbyCheckInAvailable } from "@/lib/one-location/nearby-c
  * `location.open_check_in` all name it directly. Nothing routes through Your
  * Map to reach it any more.
  */
+const LOCATION_CHECK_IN_VOICE_ACTIONS = deriveLocationVoiceActions(
+  "one_location_check_in",
+);
+
 export default function OneLocationCheckInPage() {
   const auth = useRequireAuth();
   const router = useRouter();
@@ -33,6 +39,26 @@ export default function OneLocationCheckInPage() {
   // and without this they opened a place list the backend would refuse. The
   // hub still renders the plain check-in, so that is where those arrivals go.
   const nearbyAvailable = isOneLocationNearbyCheckInAvailable();
+
+  // This route had no voice publisher at all -- see the same note in
+  // app/one/location/map/page.tsx. Gated on nearbyAvailable to match the
+  // render gate below: a build that redirects away from this screen has
+  // nothing here for voice to describe either.
+  usePublishVoiceSurfaceMetadata(
+    nearbyAvailable && !auth.loading && auth.isAuthenticated
+      ? {
+          screenId: "one_location_check_in",
+          title: "Check in",
+          purpose:
+            "Shows nearby places to check into and confirms a check-in once one is picked.",
+          spokenSubject: "Location, Check in",
+          actions: LOCATION_CHECK_IN_VOICE_ACTIONS,
+          availableActions: LOCATION_CHECK_IN_VOICE_ACTIONS.map(
+            (action) => action.label,
+          ),
+        }
+      : null,
+  );
 
   useEffect(() => {
     if (nearbyAvailable) return;

--- a/hushh-webapp/app/one/location/map/page.tsx
+++ b/hushh-webapp/app/one/location/map/page.tsx
@@ -2,10 +2,34 @@
 
 import { LocationImmersiveMap } from "@/components/one-location/location-immersive-map";
 import { useRequireAuth } from "@/hooks/use-auth";
+import { deriveLocationVoiceActions } from "@/lib/voice/location-voice-actions";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+
+// This route had no voice publisher at all -- app/one/location/page.tsx is
+// the only file under Location that ever called
+// usePublishVoiceSurfaceMetadata, so navigating here (the "Check in" pill on
+// Your Map, a direct link, plain navigation) left voice with zero
+// proactively-offered actions even though NearbyCheckInSheet's handlers are
+// live on this screen exactly as they are on the hub.
+const LOCATION_MAP_VOICE_ACTIONS = deriveLocationVoiceActions("one_location_map");
 
 /** Private, immersive Map. It owns no persistent app chrome or route-local map state. */
 export default function OneLocationMapPage() {
   const auth = useRequireAuth();
+
+  usePublishVoiceSurfaceMetadata(
+    !auth.loading && auth.isAuthenticated
+      ? {
+          screenId: "one_location_map",
+          title: "Your Map",
+          purpose:
+            "Shows where people who share their location with you are right now, and lets you check in nearby.",
+          spokenSubject: "Location, Your Map",
+          actions: LOCATION_MAP_VOICE_ACTIONS,
+          availableActions: LOCATION_MAP_VOICE_ACTIONS.map((action) => action.label),
+        }
+      : null,
+  );
 
   // Every map state value is owner-scoped: renderer consent, decrypted markers,
   // nearby attendees, and pending location work must never survive an account

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -85,7 +85,8 @@ import {
   VOICE_CONFIRM_DATA_KEY,
   VOICE_DISAMBIGUATION_DATA_KEY,
 } from "@/lib/voice/voice-action-card";
-import { getKaiActionById, listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+import { deriveLocationVoiceActions } from "@/lib/voice/location-voice-actions";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -630,17 +631,6 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
  * Every id here exists in `page.voice-action-contract.json`; nothing describes
  * a capability the gateway does not carry.
  */
-// location.checkout_nearby is wired in the generated gateway but has no
-// useLocalOnboardingActionHandler registration anywhere -- its own UI button
-// calls OneLocationService.checkoutNearby() directly, bypassing the voice
-// path entirely. Publishing it would offer something that always fails,
-// which is worse than not offering it. Excluded until it has a real handler
-// (tracked separately); every other exclusion below is enforced by the
-// filter, not a second hand-list to keep in sync.
-const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([
-  "location.checkout_nearby",
-]);
-
 // Derived from the generated action gateway, not hand-typed. This used to be
 // a manually maintained list and it drifted out of sync with the real,
 // contract-authored action set three times -- once documented below, twice
@@ -649,32 +639,18 @@ const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([
 // deriving it means a new Location action becomes reachable the moment it is
 // added to the contract, with no second edit to forget.
 //
+// The derivation itself (including the location.checkout_nearby exclusion --
+// it has no useLocalOnboardingActionHandler registration anywhere, so
+// publishing it would offer something guaranteed to fail) lives in
+// lib/voice/location-voice-actions.ts, shared with the map and check-in
+// routes so the exclusion has exactly one home instead of one per screen.
+//
 // prioritizeAvailableActionIds still ranks and caps this exactly as before
 // (route actions are cap-exempt; local handlers compete for the 14-slot
 // cap and lose ties to whichever SUBVIEW_ACTION_BOOST entry matches the
 // current subview) -- this only changes what becomes a CANDIDATE, not how
 // candidates are ranked once the list is bigger.
-export const LOCATION_VOICE_ACTIONS = listKaiActionsForSurface({
-  screen: "one_location",
-})
-  .filter(
-    (action) =>
-      action.execution_target.status === "wired" &&
-      (action.execution_target.path === "local_handler" ||
-        action.execution_target.path === "route") &&
-      action.execution_policy !== "manual_only" &&
-      !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
-  )
-  .map((action) => ({
-    id: action.action_id,
-    actionId: action.action_id,
-    label: action.label,
-    // First sentence only: the contract's `meaning` is full multi-sentence
-    // prose written for the model's semantic assessment, not a short
-    // one-liner. This field is consumed as a terse purpose string elsewhere
-    // in this surface's metadata, matching the previous hand-written style.
-    purpose: action.meaning.split(/(?<=[.!?])\s/)[0] || action.meaning,
-  }));
+export const LOCATION_VOICE_ACTIONS = deriveLocationVoiceActions("one_location");
 
 const LOCATION_VOICE_CONTROLS = [
   {

--- a/hushh-webapp/lib/voice/location-voice-actions.ts
+++ b/hushh-webapp/lib/voice/location-voice-actions.ts
@@ -1,0 +1,40 @@
+import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+import type { VoiceSurfaceActionDefinition } from "@/lib/voice/voice-types";
+
+// Wired in the generated gateway but with no real handler anywhere in the
+// runtime -- publishing it would offer a voice command guaranteed to fail.
+// Shared across every Location screen id (one_location, one_location_map,
+// one_location_check_in): these are the same underlying actions on each
+// screen, not per-screen exceptions, so the exclusion has to live in one
+// place or a new publishing site can silently reintroduce it.
+export const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([
+  "location.checkout_nearby",
+]);
+
+// Derives what a Location screen should publish directly from the generated
+// action gateway, so a new action becomes voice-reachable the moment it is
+// added to the contract instead of needing a second, hand-maintained list
+// per screen to remember to update.
+export function deriveLocationVoiceActions(
+  screen: string,
+): VoiceSurfaceActionDefinition[] {
+  return listKaiActionsForSurface({ screen })
+    .filter(
+      (action) =>
+        action.execution_target.status === "wired" &&
+        (action.execution_target.path === "local_handler" ||
+          action.execution_target.path === "route") &&
+        action.execution_policy !== "manual_only" &&
+        !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
+    )
+    .map((action) => ({
+      id: action.action_id,
+      actionId: action.action_id,
+      label: action.label,
+      // First sentence only: the contract's `meaning` is full multi-sentence
+      // prose written for the model's semantic assessment, not a short
+      // one-liner. This field is consumed as a terse purpose string elsewhere
+      // in this surface's metadata, matching the previous hand-written style.
+      purpose: action.meaning.split(/(?<=[.!?])\s/)[0] || action.meaning,
+    }));
+}


### PR DESCRIPTION
## Summary

`app/one/location/page.tsx` was the only file under Location that ever called `usePublishVoiceSurfaceMetadata`. Two more real, user-reachable routes exist under the same feature — `app/one/location/map/page.tsx` ("Your Map") and `app/one/location/check-in/page.tsx` — and neither ever published anything. So while someone is genuinely on either screen (the "Check in" pill on Your Map, a direct link, or plain navigation — not the hub's `?action=check-in` sheet, which keeps `page.tsx` mounted and already worked), voice offered zero proactively-offered Location actions, even though the handlers for the actions the contract already tags as reachable there (`location.nearby_check_in`, `location.confirm_nearby_check_in`, registered in `nearby-check-in-sheet.tsx`) are live via `LocationImmersiveMap`.

This is not the 14-action cap problem PR #6119 fixed on the hub screen — it's more basic: nothing published any candidates on these two screens at all.

Found and root-caused while verifying #6119; posted as an update on issue #5995 ("Integrate check-in feature for voice"), which this addresses the remaining scope of.

## Changes

- New `lib/voice/location-voice-actions.ts`: extracted the contract-derivation filter `LOCATION_VOICE_ACTIONS` already used into a reusable, screen-parameterized `deriveLocationVoiceActions(screen)`, plus the shared `LOCATION_VOICE_ACTIONS_EXCLUDE_IDS` set (currently just `location.checkout_nearby`, which has no real voice handler anywhere — tracked in issue #6110, unaffected here). Centralizing the exclusion means a new per-screen publishing site can't silently reintroduce the exact bug the exclusion was built to prevent.
- `app/one/location/page.tsx`: `LOCATION_VOICE_ACTIONS` now calls the shared function — no behavior change, confirmed by the existing test suite staying green.
- `app/one/location/map/page.tsx`: now publishes `screenId: "one_location_map"` with its derived action set, gated on auth.
- `app/one/location/check-in/page.tsx`: now publishes `screenId: "one_location_check_in"` with its derived action set, gated on auth and on the same `nearbyAvailable` check the page already uses to decide whether to render at all.

No ownership conflict with the hub's own `"one_location"` publisher — these are separate Next.js route files, and `usePublishVoiceSurfaceMetadata` auto-clears on unmount, so `page.tsx`'s publisher is fully gone whenever either of these routes is actually active.

## Test plan

- [x] New tests in `__tests__/voice/location-published-actions.test.ts`: pin the exact derived action set for both new screens against the real gateway data (`location.open_check_in`/`open_map`/`nearby_check_in`/`confirm_nearby_check_in` for the map; the latter two only for check-in), and confirm `checkout_nearby` stays excluded on both. Updated the existing hub test to import the shared exclude set instead of a hardcoded id.
- [x] New `app/one/location/__tests__/map-page-voice-publish.test.tsx` and `check-in-page-voice-publish.test.tsx`: render each page with `LocationImmersiveMap` and auth mocked, assert the publish call fires with the right `screenId`/actions when authenticated (and, for check-in, when nearby check-in is available), and that nothing publishes when unauthenticated, still loading, or (check-in only) when nearby check-in is unavailable and the page redirects away instead.
- [x] `npx vitest run __tests__/voice/ app/one/location/__tests__/` — 320/320 passing (was 303/303 before this PR's new tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` on touched files — clean.
- [x] No contract/gateway files changed, so no governed-artifact regeneration needed (confirmed via `git status`).
- [ ] Manual: on UAT after deploy, visiting `/one/location/map` and `/one/location/check-in` and confirming a direct voice request like "check in near me" is reachable there without first bouncing through the hub — not done in this pass (needs the local runtime plus a live voice session), noted as an open item for the reviewer.

Related: this addresses the remaining scope of issue #5995 and the map/check-in half of PR #6119's fix.
