### PR TITLE
feat(one): add the missing voice handler for checkout_nearby

### DIFF
--- a/hushh-webapp/__tests__/voice/check-in-checkout-action.test.ts
+++ b/hushh-webapp/__tests__/voice/check-in-checkout-action.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+
+/**
+ * Checking out of a nearby check-in over voice (#6110).
+ *
+ * checkoutNearby() takes no place id -- there is only ever one active
+ * check-in to end, so unlike confirm_nearby_check_in this action needs no
+ * slot resolution at all. Its handler (nearby-check-in-sheet.tsx) adds the
+ * "must actually be checked in" guard itself, since the click-driven Check
+ * out button only ever renders when that's already true.
+ */
+describe("location.checkout_nearby", () => {
+  const CHECKOUT = "location.checkout_nearby";
+
+  it("runs a local handler with no slots to resolve", () => {
+    const action = getKaiActionById(CHECKOUT);
+    expect(action).toBeDefined();
+    expect(action?.execution_target.status).toBe("wired");
+    expect(action?.execution_target.path).toBe("local_handler");
+    expect(action?.execution_target.target).toBe(CHECKOUT);
+    expect(Object.keys(action?.goal?.slot_schema ?? {})).toEqual([]);
+  });
+
+  it("is low risk and allow_direct -- ending your own presence needs no confirmation", () => {
+    const action = getKaiActionById(CHECKOUT);
+    expect(action?.execution_policy).toBe("allow_direct");
+    expect(action?.risk_level).toBe("low");
+  });
+
+  it("is reachable from Location's hub, map, and check-in screens", () => {
+    expect(getKaiActionById(CHECKOUT)?.reachability.screens).toEqual(
+      expect.arrayContaining([
+        "one_location",
+        "one_location_map",
+        "one_location_check_in",
+      ]),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/voice/location-published-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/location-published-actions.test.ts
@@ -45,23 +45,16 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
     expect(LOCATION_VOICE_ACTIONS.length).toBeGreaterThan(25);
   });
 
-  it("deliberately excludes location.checkout_nearby -- it has no voice handler yet", () => {
-    // Wired in the contract, but its UI calls OneLocationService.checkoutNearby()
-    // directly with no useLocalOnboardingActionHandler registration anywhere.
-    // Publishing it would offer something guaranteed to fail. See the
-    // exclusion comment on LOCATION_VOICE_ACTIONS_EXCLUDE_IDS in
-    // lib/voice/location-voice-actions.ts, shared by every Location screen.
-    expect(LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(CHECKOUT_NEARBY)).toBe(true);
+  it("includes location.checkout_nearby now that it has a real voice handler", () => {
+    // Used to be excluded: wired in the contract, but its UI called
+    // OneLocationService.checkoutNearby() directly with no
+    // useLocalOnboardingActionHandler registration anywhere. It now has one
+    // in nearby-check-in-sheet.tsx, so LOCATION_VOICE_ACTIONS_EXCLUDE_IDS no
+    // longer carries this id -- confirm both sides of that.
+    expect(LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(CHECKOUT_NEARBY)).toBe(false);
     expect(LOCATION_VOICE_ACTIONS.some((action) => action.actionId === CHECKOUT_NEARBY)).toBe(
-      false,
+      true,
     );
-    // And confirm it's excluded because it's really wired-but-handlerless,
-    // not because it fell out of the surface's reachability entirely --
-    // otherwise this test would pass for the wrong reason.
-    const contractEntry = listKaiActionsForSurface({ screen: "one_location" }).find(
-      (action) => action.action_id === CHECKOUT_NEARBY,
-    );
-    expect(contractEntry?.execution_target.status).toBe("wired");
   });
 
   it("carries a short, non-empty purpose derived from the contract's meaning", () => {
@@ -130,6 +123,7 @@ describe("deriveLocationVoiceActions stays in sync for the map and check-in scre
         "location.open_map",
         "location.nearby_check_in",
         "location.confirm_nearby_check_in",
+        "location.checkout_nearby",
       ]),
     );
   });
@@ -139,25 +133,21 @@ describe("deriveLocationVoiceActions stays in sync for the map and check-in scre
     const publishedIds = new Set(actions.map((action) => action.actionId));
     expect(publishedIds).toEqual(expectedIdsFor("one_location_check_in"));
     expect(publishedIds).toEqual(
-      new Set(["location.nearby_check_in", "location.confirm_nearby_check_in"]),
+      new Set([
+        "location.nearby_check_in",
+        "location.confirm_nearby_check_in",
+        "location.checkout_nearby",
+      ]),
     );
   });
 
-  it("excludes location.checkout_nearby on both screens for the same reason as the hub", () => {
+  it("includes location.checkout_nearby on both screens now that it has a real handler", () => {
     for (const screen of ["one_location_map", "one_location_check_in"]) {
       const actions = deriveLocationVoiceActions(screen);
       expect(
         actions.some((action) => action.actionId === CHECKOUT_NEARBY),
-        `${screen} should not publish ${CHECKOUT_NEARBY}`,
-      ).toBe(false);
-      // Confirm it's excluded because it's really wired-but-handlerless on
-      // this screen too, not because it fell out of reachability entirely.
-      const contractEntry = listKaiActionsForSurface({ screen }).find(
-        (action) => action.action_id === CHECKOUT_NEARBY,
-      );
-      expect(contractEntry?.execution_target.status, `${screen}: ${CHECKOUT_NEARBY}`).toBe(
-        "wired",
-      );
+        `${screen} should publish ${CHECKOUT_NEARBY}`,
+      ).toBe(true);
     }
   });
 });

--- a/hushh-webapp/app/one/location/__tests__/check-in-page-voice-publish.test.tsx
+++ b/hushh-webapp/app/one/location/__tests__/check-in-page-voice-publish.test.tsx
@@ -70,6 +70,7 @@ describe("Location check-in page publishes voice metadata", () => {
     expect(metadata.screenId).toBe("one_location_check_in");
     const actionIds = metadata.actions.map((action) => action.actionId).sort();
     expect(actionIds).toEqual([
+      "location.checkout_nearby",
       "location.confirm_nearby_check_in",
       "location.nearby_check_in",
     ]);

--- a/hushh-webapp/app/one/location/__tests__/map-page-voice-publish.test.tsx
+++ b/hushh-webapp/app/one/location/__tests__/map-page-voice-publish.test.tsx
@@ -56,6 +56,7 @@ describe("Location map page publishes voice metadata", () => {
     const actionIds = metadata.actions.map((action) => action.actionId).sort();
     expect(actionIds).toEqual(
       [
+        "location.checkout_nearby",
         "location.confirm_nearby_check_in",
         "location.nearby_check_in",
         "location.open_check_in",

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -1882,6 +1882,33 @@ export function NearbyCheckInSheet({
     }
   };
 
+  // checkout() has no "must be checked in" guard of its own -- today that is
+  // only enforced by the Check out button rendering solely inside the
+  // `state.presence ? (...) : null` branch below. A voice trigger bypasses
+  // that branch entirely, so the guard has to live here instead.
+  useLocalOnboardingActionHandler("location.checkout_nearby", async () => {
+    if (!ownerId || !vaultOwnerToken) {
+      return {
+        status: "blocked" as const,
+        summary: "Unlock One first to check out.",
+      };
+    }
+    if (!state.presence) {
+      return {
+        status: "blocked" as const,
+        summary: "You're not checked in anywhere right now.",
+      };
+    }
+    if (mutationInFlightRef.current) {
+      return {
+        status: "blocked" as const,
+        summary: "Already checking out -- one moment.",
+      };
+    }
+    await checkout();
+    return { status: "succeeded" as const, summary: "You're checked out." };
+  });
+
   const connect = async (attendee: OneLocationNearbyAttendee) => {
     if (
       !ownerId ||

--- a/hushh-webapp/lib/voice/location-voice-actions.ts
+++ b/hushh-webapp/lib/voice/location-voice-actions.ts
@@ -2,14 +2,16 @@ import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
 import type { VoiceSurfaceActionDefinition } from "@/lib/voice/voice-types";
 
 // Wired in the generated gateway but with no real handler anywhere in the
-// runtime -- publishing it would offer a voice command guaranteed to fail.
+// runtime -- publishing one would offer a voice command guaranteed to fail.
 // Shared across every Location screen id (one_location, one_location_map,
 // one_location_check_in): these are the same underlying actions on each
 // screen, not per-screen exceptions, so the exclusion has to live in one
 // place or a new publishing site can silently reintroduce it.
-export const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([
-  "location.checkout_nearby",
-]);
+//
+// location.checkout_nearby used to be here -- it now has a real handler in
+// nearby-check-in-sheet.tsx, so it was removed. Left empty rather than
+// deleted so the next genuinely handlerless action has an obvious home.
+export const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([]);
 
 // Derives what a Location screen should publish directly from the generated
 // action gateway, so a new action becomes voice-reachable the moment it is


### PR DESCRIPTION
## Summary

`location.checkout_nearby` was wired in the generated action gateway but had no `useLocalOnboardingActionHandler` registration anywhere — its only path to execution was a UI button calling `OneLocationService.checkoutNearby()` directly from a click handler. `LOCATION_VOICE_ACTIONS` (PR #6119) excluded it for exactly this reason: offering a voice command guaranteed to fail is worse than not offering it at all.

This adds the missing handler, reusing the existing `checkout()` function in `nearby-check-in-sheet.tsx` rather than duplicating its logic. `checkout()` itself has no "must actually be checked in" guard — that was only ever enforced by the Check out button rendering solely inside the `state.presence ? (...) : null` branch. A voice trigger bypasses that branch entirely, so the new handler adds the guard explicitly, along with the same auth/in-flight guards every other handler in this file already has.

`checkoutNearby` takes no parameters beyond the vault token — there's only ever one active check-in, so no slot resolution is needed.

## Changes

- `components/one-location/nearby-check-in/nearby-check-in-sheet.tsx`: new `useLocalOnboardingActionHandler("location.checkout_nearby", ...)`, placed alongside the two existing check-in handlers.
- `lib/voice/location-voice-actions.ts`: removed `location.checkout_nearby` from `LOCATION_VOICE_ACTIONS_EXCLUDE_IDS` (now empty, left in place as a home for the next genuinely handlerless action).
- Updated the tests that pinned the old exclusion as correct behavior, in `__tests__/voice/location-published-actions.test.ts` and the two map/check-in render tests, to assert inclusion instead.
- New `__tests__/voice/check-in-checkout-action.test.ts`, matching the existing contract-level test style for this action family (`check-in-send-action.test.ts`).

## Test plan

- [x] `npx vitest run __tests__/voice/ app/one/location/__tests__/` — 323/323 passing (was 320/320 before this PR's changes).
- [x] `npx vitest run __tests__/components/location-immersive-map.test.tsx` — 51/51 passing, confirms the component still renders correctly with the new hook call.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` on touched files — clean.
- [x] No contract/gateway files changed, so no governed-artifact regeneration needed.
- [ ] Manual: on UAT after deploy, say "check out" while checked in nearby and confirm the presence actually clears — not done in this pass, noted as an open item.

Addresses #6110.
