### PR TITLE
fix(one): stop silently dropping control-path actions from the gateway

### DIFF
--- a/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ria.clients.switch_to_nearby (#6122) was wired in the contract as
+ * execution_target.path: "control" with no handler registered anywhere --
+ * the frontend gateway parser's validator dropped the action entirely
+ * before a handler could even matter. Now that the validator accepts
+ * "control" and a handler is registered here, this pins that invoking it
+ * actually flips the Connected/Nearby toggle.
+ */
+
+const handlerHarness = vi.hoisted(() => ({
+  registered: new Map<string, () => unknown>(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/lib/agent/local-onboarding-actions", () => ({
+  useLocalOnboardingActionHandler: (actionId: string, handler: () => unknown) => {
+    handlerHarness.registered.set(actionId, handler);
+  },
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: () => undefined,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { uid: "test-user", getIdToken: vi.fn() } }),
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: () => ({ riaCapability: "active", loading: false }),
+}));
+
+vi.mock("@/lib/cache/use-stale-resource", () => ({
+  useStaleResource: () => ({ data: { items: [] }, loading: false, error: null }),
+}));
+
+vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
+  NearbyAroundYou: () => null,
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaCompatibilityState: ({ children }: { children: React.ReactNode }) => children,
+  RiaVerificationGate: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import OneRiaClientsPage from "@/app/ria/clients/page";
+
+describe("ria clients page publishes a working switch_to_nearby handler", () => {
+  afterEach(() => {
+    handlerHarness.registered.clear();
+  });
+
+  it("registers ria.clients.switch_to_nearby and flips the view when invoked", () => {
+    render(<OneRiaClientsPage />);
+
+    const handler = handlerHarness.registered.get("ria.clients.switch_to_nearby");
+    expect(handler).toBeDefined();
+
+    const result = handler!();
+    expect(result).toEqual(
+      expect.objectContaining({ status: "succeeded", summary: "Showing nearby clients." }),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/voice/control-path-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/control-path-actions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+
+/**
+ * #6122: location.find_contacts and ria.clients.switch_to_nearby are wired
+ * in the contract with execution_target.path: "control" -- a UI control the
+ * person taps directly, not a route or a local_handler-named function. That
+ * path value was missing from validateExecutionTarget's accepted union, so
+ * validateAction dropped both actions entirely: getKaiActionById returned
+ * null for either id, for every consumer, with no error anywhere.
+ */
+describe("execution_target.path: \"control\" actions are no longer silently dropped", () => {
+  it("location.find_contacts resolves and is wired", () => {
+    const action = getKaiActionById("location.find_contacts");
+    expect(action).not.toBeNull();
+    expect(action?.execution_target.status).toBe("wired");
+    expect(action?.execution_target.path).toBe("control");
+  });
+
+  it("ria.clients.switch_to_nearby resolves and is wired", () => {
+    const action = getKaiActionById("ria.clients.switch_to_nearby");
+    expect(action).not.toBeNull();
+    expect(action?.execution_target.status).toBe("wired");
+    expect(action?.execution_target.path).toBe("control");
+  });
+});

--- a/hushh-webapp/__tests__/voice/generate-kai-action-gateway-execution-target.test.ts
+++ b/hushh-webapp/__tests__/voice/generate-kai-action-gateway-execution-target.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  KNOWN_EXECUTION_TARGET_PATHS,
+  normalizeExecutionTarget,
+} from "../../scripts/voice/generate-kai-action-gateway.mjs";
+
+/**
+ * #6122: two real, contract-authored actions (location.find_contacts,
+ * ria.clients.switch_to_nearby) had execution_target.path: "control", which
+ * was not in the frontend gateway parser's accepted union
+ * (lib/voice/kai-action-gateway.ts's validateExecutionTarget) -- so the
+ * generator happily wrote them into the compiled JSON, and the frontend
+ * silently dropped both actions entirely, everywhere, with no error. The
+ * generator had no path validation of its own to have caught this at
+ * authoring time. These tests pin that it now does.
+ */
+describe("normalizeExecutionTarget rejects an unrecognized wired path", () => {
+  it("accepts every path the frontend gateway parser also accepts", () => {
+    for (const path of KNOWN_EXECUTION_TARGET_PATHS) {
+      expect(() =>
+        normalizeExecutionTarget(
+          { status: "wired", path, target: "some.target" },
+          "test.action",
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it("throws on a path that isn't in the known set, naming the offending action", () => {
+    expect(() =>
+      normalizeExecutionTarget(
+        { status: "wired", path: "typo_path", target: "some.target" },
+        "test.action",
+      ),
+    ).toThrow(/test\.action.*typo_path/s);
+  });
+
+  it("still requires target for a recognized path", () => {
+    expect(() =>
+      normalizeExecutionTarget(
+        { status: "wired", path: "local_handler" },
+        "test.action",
+      ),
+    ).toThrow(/requires path and target/);
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -9719,6 +9719,27 @@ export function OneLocationAgentPageContent({
     void refresh().catch(() => null);
     return { status: "succeeded", summary: "Location refreshed." };
   });
+  // Wired in the generated gateway as execution_target.path: "control" -- a
+  // dropdown item the person taps directly, not a route or a distinct
+  // local_handler-named function. handleSyncContactSignal already catches
+  // its own failures internally (a device permission denial, a browser
+  // blocking the Contact Picker without a direct tap) and reports them
+  // through a toast + contactSignal error state, never throwing -- a voice
+  // trigger degrades the same way a keyboard-activated tap already would,
+  // not a new failure mode.
+  useLocalOnboardingActionHandler("location.find_contacts", async () => {
+    if (!auth.user?.getIdToken) {
+      return {
+        status: "blocked" as const,
+        summary: "Sign in before syncing contacts.",
+      };
+    }
+    await handleSyncContactSignal();
+    return {
+      status: "started" as const,
+      summary: "Checking your contacts against Hushh.",
+    };
+  });
   const showInitialSkeleton =
     !loadError &&
     !state &&

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -31,6 +31,7 @@ import {
   type RiaClientAccess,
   type RiaClientListResponse,
 } from "@/lib/services/ria-service";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { RIA_TONE_BADGE } from "@/lib/ria/ria-tone";
 import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
@@ -151,6 +152,15 @@ export default function RiaClientsPage() {
     [clientItems, clientsResource.loading]
   );
   usePublishVoiceSurfaceMetadata(voiceSurfaceMetadata);
+
+  // Wired in the generated gateway as execution_target.path: "control" --
+  // the segmented Connected/Nearby toggle the person taps directly, not a
+  // route or a named function. The executor already dispatches "control"
+  // through this same handler registry; it just needed one registered.
+  useLocalOnboardingActionHandler("ria.clients.switch_to_nearby", () => {
+    setView("nearby");
+    return { status: "succeeded" as const, summary: "Showing nearby clients." };
+  });
 
   if (personaLoading) return null;
   if (riaCapability === "setup") {

--- a/hushh-webapp/lib/voice/investor-kai-action-registry.ts
+++ b/hushh-webapp/lib/voice/investor-kai-action-registry.ts
@@ -208,7 +208,16 @@ function toWiring(executionTarget: KaiActionExecutionTarget): InvestorKaiActionW
     };
   }
 
-  if (executionTarget.path === "local_handler") {
+  // "control" (a UI control the person taps directly -- a menu item, a
+  // segmented toggle -- rather than a named route or local_handler
+  // function) dispatches through the exact same resolveLocalOnboardingHandler
+  // registry as local_handler at the point of execution
+  // (agent-action-runtime.ts's executeAgentGatewayAction falls through to it
+  // for any path that isn't explicitly "route"), so it's represented the
+  // same way here. Left unbranched before #6122, "control" actions fell into
+  // the route fallback below and were reported unresolvable -- target here
+  // is a control id ("ria_clients_view_switch"), never a route href.
+  if (executionTarget.path === "local_handler" || executionTarget.path === "control") {
     return {
       status: "wired",
       handler: "executeAgentGatewayAction.localHandler",

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -23,7 +23,19 @@ export type KaiActionDelegateAgentId =
 export type KaiActionExecutionTarget =
   | {
       status: "wired";
-      path: "kai_command" | "voice_tool" | "route" | "local_handler";
+      path:
+        | "kai_command"
+        | "voice_tool"
+        | "route"
+        | "local_handler"
+        // A UI control the person taps directly (a menu item, a segmented
+        // toggle) rather than a named route or local_handler function.
+        // agent-action-runtime.ts's executor already dispatches this the
+        // same way as local_handler -- it falls through to the same
+        // resolveLocalOnboardingHandler registry for any path that isn't
+        // explicitly "route" -- so a real handler registered under the
+        // action id is all a "control" action needs to actually run.
+        | "control";
       target: string;
       params?: Record<string, unknown>;
     }
@@ -285,7 +297,8 @@ function validateExecutionTarget(
       (path !== "kai_command" &&
         path !== "voice_tool" &&
         path !== "route" &&
-        path !== "local_handler") ||
+        path !== "local_handler" &&
+        path !== "control") ||
       !target
     ) {
       return null;

--- a/hushh-webapp/scripts/voice/generate-kai-action-gateway.mjs
+++ b/hushh-webapp/scripts/voice/generate-kai-action-gateway.mjs
@@ -84,6 +84,20 @@ const KNOWN_ALIAS_COLLISIONS = new Set([
   "who can see my location::location.chat.turn::location.open_people",
 ]);
 
+// The frontend gateway parser (lib/voice/kai-action-gateway.ts) only knows
+// how to keep an action whose execution_target.path is one of these -- any
+// other value makes it drop the whole action, silently, everywhere (#6122:
+// location.find_contacts and ria.clients.switch_to_nearby vanished this way
+// for a release before anyone noticed). Failing the build here means a
+// typo'd or newly-invented path is caught at authoring time instead.
+const KNOWN_EXECUTION_TARGET_PATHS = new Set([
+  "kai_command",
+  "voice_tool",
+  "route",
+  "local_handler",
+  "control",
+]);
+
 const SPEAKER_PERSONAS = new Set(["one", "kai", "nav", "kyc"]);
 const AGENT_PERSONAS = new Set([
   "one",
@@ -471,6 +485,17 @@ function normalizeExecutionTarget(raw, actionId) {
     if (!pathValue || !target) {
       throw new Error(
         `${actionId}: wired execution_target requires path and target`,
+      );
+    }
+    if (!KNOWN_EXECUTION_TARGET_PATHS.has(pathValue)) {
+      throw new Error(
+        `${actionId}: execution_target.path "${pathValue}" is not one of ` +
+          `${[...KNOWN_EXECUTION_TARGET_PATHS].join(", ")} -- the frontend ` +
+          `gateway parser silently drops the entire action for an ` +
+          `unrecognized path (see kai-action-gateway.ts's ` +
+          `validateExecutionTarget). Add the new path to ` +
+          `KNOWN_EXECUTION_TARGET_PATHS here and to the matching union in ` +
+          `kai-action-gateway.ts if it is genuinely new.`,
       );
     }
     const normalized = {
@@ -1018,4 +1043,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
 }
 
-export { validateAliasCollisions, KNOWN_ALIAS_COLLISIONS, GLOBAL_NAV_ACTION_IDS };
+export {
+  validateAliasCollisions,
+  KNOWN_ALIAS_COLLISIONS,
+  GLOBAL_NAV_ACTION_IDS,
+  normalizeExecutionTarget,
+  KNOWN_EXECUTION_TARGET_PATHS,
+};


### PR DESCRIPTION
## Summary

`validateExecutionTarget` (`lib/voice/kai-action-gateway.ts`) only accepted `execution_target.path` values in `{kai_command, voice_tool, route, local_handler}`. Anything else made it return `null`, which made the enclosing `validateAction` return `null` for the **entire action** — not just its execution target.

Two real, contract-authored actions are `wired` with `path: "control"`:
- `location.find_contacts` (the "Find people from my contacts" dropdown item on Location)
- `ria.clients.switch_to_nearby` (the Connected/Nearby segmented toggle on RIA Clients)

Both were therefore completely absent from `KAI_ACTION_GATEWAY_ACTIONS` for every consumer — `getKaiActionById`, `listKaiActionsForSurface`, `getKaiActionsForControlId`, screen context, the command palette. Silently: no build error, no lint error, no failing test. Voice simply never knew either action existed.

## Why widening the validator is the right fix, not a workaround

`"control"` means "a UI control the person taps directly (a menu item, a segmented toggle)" rather than a route or a named handler function. At the point of execution, `agent-action-runtime.ts`'s `executeAgentGatewayAction` already dispatches it identically to `local_handler` — it falls through to the same `resolveLocalOnboardingHandler` registry for any path that isn't explicitly `"route"`. So `"control"` was already a working execution path everywhere except this one validator's accepted union.

What those two actions genuinely lacked was a registered handler, so this PR adds both.

## Changes

- `lib/voice/kai-action-gateway.ts`: added `"control"` to the `KaiActionExecutionTarget` type union and `validateExecutionTarget`'s accepted set, with a comment explaining what the path means and why it dispatches like `local_handler`.
- `app/ria/clients/page.tsx`: registered `ria.clients.switch_to_nearby` — flips the existing `view` state to `"nearby"`.
- `app/one/location/page.tsx`: registered `location.find_contacts` — calls the existing `handleSyncContactSignal` callback.
- `lib/voice/investor-kai-action-registry.ts`: **a second instance of the same bug.** Its `toWiring` branched on `kai_command`/`voice_tool`/`local_handler` and let everything else fall into the `route` fallback — so a control id like `"ria_clients_view_switch"` was treated as a route href and reported `resolvable: false, reason: "invalid route href"`. `"control"` now shares the `local_handler` branch. This was caught by that file's own existing "every wired action resolves" test once the two actions became visible, which is exactly what that test is for.
- `scripts/voice/generate-kai-action-gateway.mjs`: `normalizeExecutionTarget` had **no path validation at all** — it accepted any non-empty string and wrote it straight into the compiled JSON, to be silently dropped downstream. It now fails the build on an unrecognized path, naming the offending action and pointing at the matching union. This is what actually closes the "silent" part of this bug for good; widening the frontend validator alone only fixes the two actions found today.

## Test plan

- [x] New `__tests__/voice/control-path-actions.test.ts` — both actions now resolve via `getKaiActionById` and report `path: "control"`.
- [x] New `__tests__/app/ria/clients-page-switch-to-nearby.test.tsx` — renders the page, asserts the handler is registered and returns the expected result when invoked.
- [x] New `__tests__/voice/generate-kai-action-gateway-execution-target.test.ts` — the generator accepts every known path and throws (naming the action) on an unknown one.
- [x] `npx vitest run __tests__/voice/ __tests__/app/ria/` — 362/362 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` on touched files — clean.
- [x] `npm run verify:voice-gateway` — gateway artifacts and route orchestration index both up to date (the generator change adds validation only; it produces byte-identical output for the current contracts).
- [x] Ran the full webapp suite; the 18 failures it reports are pre-existing on `main` — verified by re-running a sample of them with these changes stashed, and they fail identically. None are in files this PR touches.
- [ ] Manual: on UAT after deploy, "find people from my contacts" on Location and "show people around me" on RIA Clients — not done in this pass, noted as an open item.

Addresses #6122.
