### PR TITLE
fix(agent): return to the page the agent was opened from on minimize

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-origin.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-origin.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentRouteWithOrigin,
+  readAgentOrigin,
+} from "@/lib/navigation/agent-origin";
+import { ROUTES } from "@/lib/navigation/routes";
+
+describe("agentRouteWithOrigin", () => {
+  it("records the originating page on the agent route", () => {
+    expect(agentRouteWithOrigin(ROUTES.EMAIL_AGENT)).toBe(
+      "/agent?from=%2Fone%2Femail",
+    );
+  });
+
+  it("keeps a query string on the origin intact through a round trip", () => {
+    const href = agentRouteWithOrigin("/one/gmail?tab=receipts");
+    expect(readAgentOrigin(new URL(href, "https://one.hushh.ai").search)).toBe(
+      "/one/gmail?tab=receipts",
+    );
+  });
+
+  it("degrades to the plain route rather than encoding an unsafe origin", () => {
+    for (const unsafe of ["//evil.com", "https://evil.com", "", null]) {
+      expect(agentRouteWithOrigin(unsafe)).toBe(ROUTES.AGENT);
+    }
+  });
+});
+
+describe("readAgentOrigin", () => {
+  it("reads the recorded origin", () => {
+    expect(readAgentOrigin("?from=%2Fone%2Femail")).toBe("/one/email");
+  });
+
+  it("accepts a search string with or without the leading question mark", () => {
+    expect(readAgentOrigin("from=/one/gmail")).toBe("/one/gmail");
+  });
+
+  it("returns null when nothing was recorded", () => {
+    expect(readAgentOrigin("")).toBeNull();
+    expect(readAgentOrigin(null)).toBeNull();
+    expect(readAgentOrigin("?other=/one/email")).toBeNull();
+  });
+
+  it("refuses origins that would navigate off-site", () => {
+    // The value arrives from the query string, so a shared link can carry
+    // anything. Each of these leaves the origin if pushed unchecked.
+    expect(readAgentOrigin("?from=//evil.com")).toBeNull();
+    expect(readAgentOrigin("?from=https%3A%2F%2Fevil.com")).toBeNull();
+    expect(readAgentOrigin("?from=%2F%5Cevil.com")).toBeNull();
+    expect(readAgentOrigin("?from=javascript%3Aalert(1)")).toBeNull();
+    expect(readAgentOrigin("?from=one%2Femail")).toBeNull();
+  });
+
+  it("refuses the agent route itself so minimize cannot loop", () => {
+    expect(readAgentOrigin(`?from=${encodeURIComponent(ROUTES.AGENT)}`)).toBeNull();
+    expect(readAgentOrigin("?from=%2Fagent%3Ffrom%3D%2Fagent")).toBeNull();
+  });
+});

--- a/hushh-webapp/app/one/email/email-agent-page-client.tsx
+++ b/hushh-webapp/app/one/email/email-agent-page-client.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/use-auth";
 import { useGmailConnectorStatus } from "@/lib/profile/gmail-connector-store";
 import { Button } from "@/lib/morphy-ux/button";
+import { agentRouteWithOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 
 /**
@@ -64,8 +65,9 @@ export function EmailAgentPageClient() {
       return;
     }
     // The handoff remains in the shared in-memory session for the legacy
-    // dedicated chat route too.
-    router.push(ROUTES.AGENT);
+    // dedicated chat route too. Record this page as the origin so minimizing
+    // the full-page agent comes back here rather than One home.
+    router.push(agentRouteWithOrigin(ROUTES.EMAIL_AGENT));
   }, [agentPopover, createHandoff, emailAgentIntroRecipient, router]);
 
   return (

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -138,6 +138,7 @@ import {
   type DelegateResult,
 } from "@/lib/agent/specialist-directive-runtime";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
+import { readAgentOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 import { GoogleCalendarService } from "@/lib/services/google-calendar-service";
 import { cn } from "@/lib/utils";
@@ -4316,6 +4317,16 @@ export function AgentChatWorkspace({
       return;
     }
     if (typeof window !== "undefined") {
+      // The page that handed off records itself as ?from=. This is checked
+      // before any history heuristic because it is the only signal that
+      // survives a reload or a shared link — and because `document.referrer`,
+      // which this used to rely on, is never set by App Router client
+      // navigation, so every minimize fell through to One home.
+      const origin = readAgentOrigin(window.location.search);
+      if (origin) {
+        router.push(origin);
+        return;
+      }
       const referrer = document.referrer ? new URL(document.referrer) : null;
       const isSameOriginReferrer =
         referrer?.origin === window.location.origin &&
@@ -4325,9 +4336,9 @@ export function AgentChatWorkspace({
         return;
       }
     }
-    // No same-origin referrer to retrace to (e.g. a direct link into this
-    // legacy full-page route): land on One home, not Profile, so minimizing
-    // always returns to the section this screen lives under.
+    // Nothing to retrace to (e.g. a direct link into this legacy full-page
+    // route with no recorded origin): land on One home, not Profile, so
+    // minimizing always returns to the section this screen lives under.
     router.push(ROUTES.ONE_HOME);
   }, [onMinimize, router]);
   const handleHistoryDrawerKeyDown = useCallback(

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Loader2, Lock, Mail, RefreshCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -37,6 +37,7 @@ import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { Button } from "@/lib/morphy-ux/button";
 import { morphyToast } from "@/lib/morphy-ux/morphy";
 import { useAuth } from "@/hooks/use-auth";
+import { agentRouteWithOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
   describeGmailReceiptScanProgress,
@@ -377,6 +378,9 @@ export default function GmailReceiptsPage({
   voicePublisherRole = "route",
 }: GmailReceiptsPageProps) {
   const router = useRouter();
+  // This component is hosted on both /one/gmail and /one/setup/gmail, so the
+  // origin handed to the agent has to be the live path, not a route constant.
+  const pathname = usePathname();
   const { user, loading } = useAuth();
   const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
   const agentPopover = useOptionalAgentPopover();
@@ -804,8 +808,8 @@ export default function GmailReceiptsPage({
       agentPopover.openAgent();
       return;
     }
-    router.push(ROUTES.AGENT);
-  }, [agentPopover, createHandoff, emailAgentIntroRecipient, router]);
+    router.push(agentRouteWithOrigin(pathname));
+  }, [agentPopover, createHandoff, emailAgentIntroRecipient, pathname, router]);
 
   useLocalOnboardingActionHandler("setup.connect_gmail", () => {
     if (journeyVariant !== "onboarding") {

--- a/hushh-webapp/lib/navigation/agent-origin.ts
+++ b/hushh-webapp/lib/navigation/agent-origin.ts
@@ -1,0 +1,65 @@
+/**
+ * Where the full-page `/agent` route should return to when it is minimized.
+ *
+ * Minimize used to infer this from `document.referrer`, which App Router client
+ * navigation never updates — every entry point into `/agent` is a client
+ * `router.push`, so the referrer stayed empty and minimize always fell through
+ * to One home. The origin is therefore carried explicitly in the URL instead:
+ * it survives a reload, a shared link and a restored tab, none of which a
+ * history- or referrer-based heuristic can.
+ */
+
+import { ROUTES } from "@/lib/navigation/routes";
+
+export const AGENT_ORIGIN_PARAM = "from";
+
+/**
+ * `/agent?from=<originPath>` — the href a feature page hands off to so minimize
+ * can retrace it. A path that is not a safe in-app target is dropped rather
+ * than encoded, so the link degrades to the plain route.
+ */
+export function agentRouteWithOrigin(originPath: string | null | undefined): string {
+  const safe = normalizeAgentOrigin(originPath);
+  if (!safe) return ROUTES.AGENT;
+  return `${ROUTES.AGENT}?${AGENT_ORIGIN_PARAM}=${encodeURIComponent(safe)}`;
+}
+
+/**
+ * The return path recorded on a `/agent` URL, or null when there is none to
+ * trust. Accepts a full search string (`?from=/one/email`) or a bare one.
+ */
+export function readAgentOrigin(search: string | null | undefined): string | null {
+  if (!search) return null;
+  let raw: string | null;
+  try {
+    raw = new URLSearchParams(
+      search.startsWith("?") ? search.slice(1) : search,
+    ).get(AGENT_ORIGIN_PARAM);
+  } catch {
+    return null;
+  }
+  return normalizeAgentOrigin(raw);
+}
+
+/**
+ * Reduce a candidate to a same-origin app path, or null.
+ *
+ * The value reaches us from the query string, so it is attacker-controllable in
+ * a shared link: anything that could leave the origin has to be rejected, not
+ * sanitised. That means a single leading slash only — `//evil.com` is
+ * protocol-relative and `https://evil.com` carries a scheme, and both would
+ * navigate off-site. `/agent` itself is rejected too, so minimize can never
+ * return to the screen it is leaving.
+ */
+function normalizeAgentOrigin(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/")) return null;
+  if (trimmed.startsWith("//")) return null;
+  // A backslash is treated as a slash by some URL parsers, so `/\evil.com`
+  // can escape the origin in exactly the way `//evil.com` does.
+  if (trimmed.startsWith("/\\")) return null;
+  const path = trimmed.split(/[?#]/, 1)[0];
+  if (path === ROUTES.AGENT) return null;
+  return trimmed;
+}


### PR DESCRIPTION
Fixes the `/agent` half of #6134.

## The bug

Open the agent from a feature page, maximize, minimize → you land on the Agents roster at `/one`, not the page you came from. Reported across many surfaces, not just the Email agent.

## Root cause

`handlePageMinimize` inferred the destination from `document.referrer`:

```ts
const referrer = document.referrer ? new URL(document.referrer) : null;
const isSameOriginReferrer = referrer?.origin === window.location.origin && ...
if (isSameOriginReferrer && window.history.length > 1) { router.back(); return; }
router.push(ROUTES.ONE_HOME);
```

**`document.referrer` is never updated by App Router client navigation.** Every entry point into `/agent` is a client `router.push` — `email-agent-page-client.tsx` and `gmail-receipts-page.tsx` both fall back to one when the popover provider isn't available. So the referrer held whatever loaded the document (usually nothing), the guard was always false, and minimize fell through to `ROUTES.ONE_HOME` every single time. Page-agnostic by construction.

## The fix

Carry the origin explicitly: `/agent?from=/one/email`. Chosen over a history heuristic because it survives a reload, a shared link and a restored tab — none of which `history.length` or a referrer can speak for.

- `lib/navigation/agent-origin.ts` — `agentRouteWithOrigin()` to build the href, `readAgentOrigin()` to read it back
- `handlePageMinimize` checks the recorded origin first, then keeps the existing referrer/`router.back()` path and the One-home fallback for direct links carrying no origin
- Both hand-off sites record where they came from. Gmail's page is hosted on **both** `/one/gmail` and `/one/setup/gmail`, so it records the live `usePathname()` rather than a route constant

### On the untrusted input

The origin arrives from the query string, so a shared link can carry anything. `readAgentOrigin` accepts a single-leading-slash app path only and returns null otherwise — rejecting protocol-relative (`//evil.com`), scheme-carrying (`https://evil.com`), backslash-escaping (`/\evil.com`) and `javascript:` values, all of which would leave the origin if pushed unchecked. `/agent` itself is rejected too, so minimize cannot loop back to the screen it is leaving. `agentRouteWithOrigin` drops an unsafe origin rather than encoding it, degrading to the plain route.

## Still open

The popover-path question in #6134 is **not** addressed here. In the reported screenshot the URL reads `/one/gmail` with the chat maximized — that is the popover at `sizeMode: "fullscreen"`, whose window controls only call `setSizeMode` / `requestClose` and never navigate. If minimizing *there* also redirects, it is a separate defect; #6134 records how to tell the two apart.

## Verification

8 new tests for the origin helper (round trip, missing/blank input, and each off-site escape vector). 36 existing tests pass across the agent chat shell, popover provider, command handoff, and all four Gmail page suites. `eslint`, `tsc --noEmit` and `npm run verify:design-system` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)