### PR TITLE
fix(one): move Connect search under its heading, unstack the pager, own the pin step

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -621,6 +622,59 @@ describe("Connect — People", () => {
     // hasMore is true in the fixture, so forward is offered and back is not.
     expect(screen.getByText("Next").closest("button")?.disabled).toBe(false);
     expect(screen.getByText("Prev").closest("button")?.disabled).toBe(true);
+  });
+
+  it("reads heading, then instruction, then the field they describe", async () => {
+    // QA, on a phone: "people ke neeche supporting line is search by name, but
+    // search bar upar hai". The field was rendered ABOVE the "People" heading,
+    // so the sentence telling you how to use it ("Search by name.") appeared
+    // UNDERNEATH the box it was instructing -- pointing backwards at a control
+    // the reader had already scrolled past -- and the field itself arrived
+    // before anything on screen had said what it searched.
+    render(<ConnectPageClient />);
+
+    const supporting = await screen.findByText("Search by name.");
+    const heading = screen.getByRole("heading", { name: "People", level: 2 });
+    const field = screen.getByLabelText("Search people");
+
+    // DOCUMENT_POSITION_FOLLOWING: the argument comes AFTER the node.
+    expect(
+      heading.compareDocumentPosition(supporting) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      supporting.compareDocumentPosition(field) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // And still above the rows it filters, rather than pushed under them.
+    expect(
+      field.compareDocumentPosition(screen.getByText("Person 0")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps the pager on one line, with the page number under the size", async () => {
+    // QA, on a phone: "sarein cheezein scattered dekh rahi -- per page, prev
+    // next ek line mein la sakte". The row was `flex-col ... sm:flex-row`, so
+    // on every shipped phone width it broke into "Page 1 - Per page [8]" and a
+    // separate right-aligned "Prev Next" underneath.
+    render(<ConnectPageClient />);
+
+    const row = await screen.findByTestId("connect-pager-row");
+    // One line: the size control and the two buttons that use it are siblings
+    // in the same row, not two stacked blocks.
+    expect(row.className).not.toContain("flex-col");
+    expect(within(row).getByText("Per page")).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Prev" })).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Next" })).toBeTruthy();
+
+    // "Page 1" is a reading of the list, not a way to change it, so it sits
+    // directly under the control rather than leading the row.
+    const status = within(row).getByText("Page 1");
+    const sizeLine = screen.getByLabelText("People per page").parentElement;
+    expect(sizeLine).not.toBeNull();
+    expect(status.previousElementSibling).toBe(sizeLine);
+    expect(status.className).toContain("text-[11px]");
   });
 
   it("asks the server for the page the reader moved to", async () => {

--- a/hushh-webapp/app/connect/connect-search-layout.ts
+++ b/hushh-webapp/app/connect/connect-search-layout.ts
@@ -45,3 +45,60 @@ export const CONNECT_SELECT_TOGGLE_CLASSNAME =
 
 /** Gap between the field and the toggle (`gap-2`). */
 export const CONNECT_SEARCH_ROW_GAP_PX = 8;
+
+/* ------------------------------------------------------------------ */
+/* The pager at the foot of the directory card.                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * THE PAGER ROW.
+ *
+ * One line at every width. It used to be `flex-col ... sm:flex-row`, so on
+ * every phone the app actually ships to it broke into "Page 1 - Per page [8]"
+ * and, underneath, a right-aligned "Prev  Next" -- four fragments with three
+ * different alignments stacked at the bottom of the card. The size control and
+ * the buttons that walk the list belong on the same line: they are the two
+ * halves of one decision.
+ *
+ * `justify-between` rather than a spacer, and both clusters keep their
+ * intrinsic width, so the row's total is measured rather than assumed. See
+ * `connect-circle-cta.layout.spec.ts`, which fails the moment it wraps at any
+ * shipped phone width.
+ */
+export const CONNECT_PAGER_ROW_CLASSNAME =
+  "flex items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3";
+
+/**
+ * The per-page select.
+ *
+ * 68px, not 74px: the widest option is two digits, and the row now has to hold
+ * Prev and Next beside it on a 320px screen. Every pixel this control does not
+ * need is a pixel the row cannot afford to give it.
+ */
+export const CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME =
+  "h-8 min-h-8 w-[68px] shrink-0 rounded-2xl text-[15px] font-medium leading-5";
+
+/**
+ * "Page 1", under the control rather than beside it.
+ *
+ * Deliberately smaller than `ui-text-helper-text` (13px) and a step quieter in
+ * colour: it is the only thing in the row that is a READING of the list rather
+ * than a way to change it, and at the same size it competed with the label of
+ * the control it sits under.
+ */
+export const CONNECT_PAGE_STATUS_CLASSNAME =
+  "font-[family-name:var(--font-app-body)] text-[11px] font-normal leading-4 tracking-[0.01em] tabular-nums text-[color:var(--app-tertiary-label)]";
+
+/**
+ * Prev, Next and "Load more connections". Lives here rather than in the screen
+ * so the browser contract can measure the button the screen really renders.
+ */
+export const CONNECT_PAGER_BUTTON_CLASSNAME =
+  "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
+
+/**
+ * Prev and Next only. `px-2.5`, not `px-3`, for the same reason the select
+ * shrank: the row is measured at 320px and the two buttons are the half of it
+ * that cannot be dropped. `min-w-[44px]` keeps the touch target legal.
+ */
+export const CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME = "min-w-[44px] px-2.5";

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -80,6 +80,11 @@ import {
 import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
 import { getDirectoryPersonDescription } from "./directory-person-label";
 import {
+  CONNECT_PAGER_BUTTON_CLASSNAME,
+  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
+  CONNECT_PAGER_ROW_CLASSNAME,
+  CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME,
+  CONNECT_PAGE_STATUS_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
   CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
@@ -309,8 +314,6 @@ const PAGE_SIZE_OPTIONS = [8, 16, 24, 50] as const;
 const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
 const CONNECT_ROW_ACTION_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px]";
-const CONNECT_PAGER_BUTTON_CLASSNAME =
-  "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
 const CONNECT_INLINE_BUTTON_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
 const CONNECT_REFRESH_BUTTON_CLASSNAME =
@@ -2490,120 +2493,6 @@ export default function ConnectPageClient() {
                     ) : null}
 
                     <div className="space-y-4">
-                      {/* No `w-full` here any more, and it is load-bearing: this row
-                  bleeds to the page gutters with a negative inline margin, and
-                  `width: 100%` resolves against the text column, so the margin
-                  only slid the row 16px left instead of widening it. A block
-                  flex container fills its containing block on its own, and with
-                  `auto` the margins can do their job. `cn` is tailwind-merge, so
-                  a later `w-full` would have beaten anything the constant said.
-                  Held by e2e/connect-sticky-header.layout.spec.ts. */}
-                      <div
-                        data-testid="connect-search-row"
-                        className={cn(
-                          CONNECT_STICKY_SEARCH_CLASSNAME,
-                          "flex items-center gap-2",
-                        )}
-                      >
-                        <div className="relative flex-1">
-                          <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
-                            <SearchIcon className="h-4.5 w-4.5" />
-                          </span>
-                          <Input
-                            ref={searchInputRef}
-                            type="text"
-                            value={query}
-                            onChange={(event) => setQuery(event.target.value)}
-                            placeholder={CONNECT_SEARCH_PLACEHOLDER}
-                            aria-label="Search people"
-                            data-voice-control-id="one-connect-search"
-                            className={cn(
-                              CONNECT_SEARCH_INPUT_CLASSNAME,
-                              query
-                                ? CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
-                                : CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
-                            )}
-                            enterKeyHint="search"
-                            onKeyDown={(event) => {
-                              // iOS soft-keyboard "return" must dismiss the keyboard;
-                              // blurring the field is what actually closes it in the
-                              // Capacitor webview (there is no form submit here).
-                              if (event.key === "Enter") {
-                                event.preventDefault();
-                                event.currentTarget.blur();
-                              }
-                            }}
-                            onFocus={(event) => {
-                              // Keyboard-dismiss "on drag": the first scroll/drag while
-                              // the field is focused blurs it, so an open keyboard never
-                              // locks the results out of view. Scoped to this field's
-                              // focus lifecycle and cleaned up on blur.
-                              const field = event.currentTarget;
-                              // Scroll the field into view above the on-screen keyboard.
-                              // Tapping it otherwise leaves it hidden behind the keyboard
-                              // until the user manually scrolls up. The delay lets the
-                              // keyboard animate in so the shrunken viewport is measured.
-                              window.setTimeout(() => {
-                                field.scrollIntoView({
-                                  block: "center",
-                                  behavior: "smooth",
-                                });
-                              }, 300);
-                              const dismiss = () => field.blur();
-                              window.addEventListener("touchmove", dismiss, {
-                                passive: true,
-                                once: true,
-                              });
-                              field.addEventListener(
-                                "blur",
-                                () =>
-                                  window.removeEventListener(
-                                    "touchmove",
-                                    dismiss,
-                                  ),
-                                { once: true },
-                              );
-                            }}
-                          />
-                          {query ? (
-                            <button
-                              type="button"
-                              aria-label="Clear search"
-                              onClick={() => {
-                                setQuery("");
-                                searchInputRef.current?.focus();
-                              }}
-                              className="press-scale absolute inset-y-0 right-0 flex w-11 items-center justify-center text-[#1d1d1f] transition-colors hover:text-black dark:text-white"
-                            >
-                              <X className="h-5 w-5" strokeWidth={2.4} />
-                            </button>
-                          ) : null}
-                        </div>
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fill"
-                          size="sm"
-                          className={CONNECT_SELECT_TOGGLE_CLASSNAME}
-                          disabled={loading || people.length === 0}
-                          aria-label={
-                            isSelectionMode
-                              ? "Cancel selecting people"
-                              : "Select many people"
-                          }
-                          onClick={() => {
-                            setIsSelectionMode((current) => !current);
-                            setSelectedPeople(new Map());
-                            setShowLimitBanner(false);
-                          }}
-                        >
-                          {/* "Select many", not "Select": this enters multi-select,
-                      and a lone "Select" reads as picking the one thing you are
-                      looking at. The visible label and the accessible name now
-                      say the same thing. */}
-                          {isSelectionMode ? "Cancel" : "Select many"}
-                        </Button>
-                      </div>
                       <SettingsGroup
                         title={CONNECT_TAB_LABEL[tab]}
                         // People only. This one JSX node also renders the RIAs
@@ -2657,6 +2546,129 @@ export default function ConnectPageClient() {
                           )
                         }
                         separatorInset
+                        // The search row belongs to THIS list, so it is read after
+                        // the heading that names the list -- not before it. It used
+                        // to sit above "People", which put the sentence that
+                        // instructs it ("Search by name.") underneath the box it
+                        // instructs, and gave the reader a field before anything on
+                        // screen had said what it searched. It still pins under the
+                        // tab strips on scroll; it just no longer arrives first.
+                        toolbar={
+                        /* No `w-full` here any more, and it is load-bearing: this row
+                    bleeds to the page gutters with a negative inline margin, and
+                    `width: 100%` resolves against the text column, so the margin
+                    only slid the row 16px left instead of widening it. A block
+                    flex container fills its containing block on its own, and with
+                    `auto` the margins can do their job. `cn` is tailwind-merge, so
+                    a later `w-full` would have beaten anything the constant said.
+                    Held by e2e/connect-sticky-header.layout.spec.ts. */
+                        <div
+                          data-testid="connect-search-row"
+                          className={cn(
+                            CONNECT_STICKY_SEARCH_CLASSNAME,
+                            "flex items-center gap-2",
+                          )}
+                        >
+                          <div className="relative flex-1">
+                            <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
+                              <SearchIcon className="h-4.5 w-4.5" />
+                            </span>
+                            <Input
+                              ref={searchInputRef}
+                              type="text"
+                              value={query}
+                              onChange={(event) => setQuery(event.target.value)}
+                              placeholder={CONNECT_SEARCH_PLACEHOLDER}
+                              aria-label="Search people"
+                              data-voice-control-id="one-connect-search"
+                              className={cn(
+                                CONNECT_SEARCH_INPUT_CLASSNAME,
+                                query
+                                  ? CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
+                                  : CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
+                              )}
+                              enterKeyHint="search"
+                              onKeyDown={(event) => {
+                                // iOS soft-keyboard "return" must dismiss the keyboard;
+                                // blurring the field is what actually closes it in the
+                                // Capacitor webview (there is no form submit here).
+                                if (event.key === "Enter") {
+                                  event.preventDefault();
+                                  event.currentTarget.blur();
+                                }
+                              }}
+                              onFocus={(event) => {
+                                // Keyboard-dismiss "on drag": the first scroll/drag while
+                                // the field is focused blurs it, so an open keyboard never
+                                // locks the results out of view. Scoped to this field's
+                                // focus lifecycle and cleaned up on blur.
+                                const field = event.currentTarget;
+                                // Scroll the field into view above the on-screen keyboard.
+                                // Tapping it otherwise leaves it hidden behind the keyboard
+                                // until the user manually scrolls up. The delay lets the
+                                // keyboard animate in so the shrunken viewport is measured.
+                                window.setTimeout(() => {
+                                  field.scrollIntoView({
+                                    block: "center",
+                                    behavior: "smooth",
+                                  });
+                                }, 300);
+                                const dismiss = () => field.blur();
+                                window.addEventListener("touchmove", dismiss, {
+                                  passive: true,
+                                  once: true,
+                                });
+                                field.addEventListener(
+                                  "blur",
+                                  () =>
+                                    window.removeEventListener(
+                                      "touchmove",
+                                      dismiss,
+                                    ),
+                                  { once: true },
+                                );
+                              }}
+                            />
+                            {query ? (
+                              <button
+                                type="button"
+                                aria-label="Clear search"
+                                onClick={() => {
+                                  setQuery("");
+                                  searchInputRef.current?.focus();
+                                }}
+                                className="press-scale absolute inset-y-0 right-0 flex w-11 items-center justify-center text-[#1d1d1f] transition-colors hover:text-black dark:text-white"
+                              >
+                                <X className="h-5 w-5" strokeWidth={2.4} />
+                              </button>
+                            ) : null}
+                          </div>
+                          <Button
+                            type="button"
+                            variant="none"
+                            effect="fill"
+                            size="sm"
+                            className={CONNECT_SELECT_TOGGLE_CLASSNAME}
+                            disabled={loading || people.length === 0}
+                            aria-label={
+                              isSelectionMode
+                                ? "Cancel selecting people"
+                                : "Select many people"
+                            }
+                            onClick={() => {
+                              setIsSelectionMode((current) => !current);
+                              setSelectedPeople(new Map());
+                              setShowLimitBanner(false);
+                            }}
+                          >
+                            {/* "Select many", not "Select": this enters multi-select,
+                        and a lone "Select" reads as picking the one thing you are
+                        looking at. The visible label and the accessible name now
+                        say the same thing. */}
+                            {isSelectionMode ? "Cancel" : "Select many"}
+                          </Button>
+                        </div>
+                        }
                       >
                         {loading ? (
                           <SettingsRow
@@ -2894,39 +2906,60 @@ export default function ConnectPageClient() {
                           })
                         )}
                         {people.length > 0 || currentPage > 1 ? (
-                          <div className="flex flex-col gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                            <div className="flex min-h-9 flex-wrap items-center gap-2.5">
-                              <span className="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]">
+                          /* One row, not two stacked fragments. "Page 1", a
+                             dot, "Per page", a select, and then Prev/Next
+                             dropped onto a second line read as four unrelated
+                             things scattered at the bottom of the card. The
+                             control and the buttons that use it now share a
+                             line -- how much you are reading at on the left,
+                             the way through the list on the right -- and the
+                             page number drops under the control as the quiet
+                             status it is, rather than leading a row it does
+                             not act on. */
+                          <div
+                            className={CONNECT_PAGER_ROW_CLASSNAME}
+                            data-testid="connect-pager-row"
+                          >
+                            <div className="flex min-w-0 flex-col items-start gap-0.5">
+                              <div className="flex items-center gap-2">
+                                <span className="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)]">
+                                  Per page
+                                </span>
+                                <Select
+                                  value={String(pageSize)}
+                                  onValueChange={(value) =>
+                                    setPageSize(Number(value))
+                                  }
+                                >
+                                  <SelectTrigger
+                                    size="sm"
+                                    aria-label="People per page"
+                                    className={CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}
+                                  >
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {PAGE_SIZE_OPTIONS.map((size) => (
+                                      <SelectItem
+                                        key={size}
+                                        value={String(size)}
+                                      >
+                                        {size}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                              {/* Status, not a control: it sits under the thing
+                                  it describes, one step down in size and
+                                  colour, so the row above stays the only line
+                                  with anything to press. */}
+                              <span className={CONNECT_PAGE_STATUS_CLASSNAME}>
                                 Page {currentPage}
                               </span>
-                              <span className="h-1 w-1 rounded-full bg-[color:var(--app-tertiary-label)]" />
-                              <span className="ui-text-helper-text text-[color:var(--app-secondary-label)]">
-                                Per page
-                              </span>
-                              <Select
-                                value={String(pageSize)}
-                                onValueChange={(value) =>
-                                  setPageSize(Number(value))
-                                }
-                              >
-                                <SelectTrigger
-                                  size="sm"
-                                  aria-label="People per page"
-                                  className="h-8 min-h-8 w-[74px] rounded-2xl text-[15px] font-medium leading-5"
-                                >
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {PAGE_SIZE_OPTIONS.map((size) => (
-                                    <SelectItem key={size} value={String(size)}>
-                                      {size}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
                             </div>
                             <div
-                              className="flex min-h-9 items-center justify-end gap-2"
+                              className="flex shrink-0 items-center justify-end gap-2"
                               aria-live="polite"
                             >
                               <Button
@@ -2936,7 +2969,7 @@ export default function ConnectPageClient() {
                                 size="sm"
                                 className={cn(
                                   CONNECT_PAGER_BUTTON_CLASSNAME,
-                                  "min-w-[44px] px-3",
+                                  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
                                 )}
                                 disabled={loading || currentPage <= 1}
                                 onClick={() => goToPage(currentPage - 1)}
@@ -2950,7 +2983,7 @@ export default function ConnectPageClient() {
                                 size="sm"
                                 className={cn(
                                   CONNECT_PAGER_BUTTON_CLASSNAME,
-                                  "min-w-[44px] px-3",
+                                  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
                                 )}
                                 disabled={loading || !hasMore}
                                 onClick={() => goToPage(currentPage + 1)}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -13081,6 +13081,12 @@ export function OneLocationAgentPageContent({
           onLocateMe={locateMeForSavedLocation}
           onPickExactLocation={handlePickExactSavedLocation}
           startWithMapPicker
+          // This is a STEP of onboarding, not a sheet over a screen. Without
+          // it the surface sat at z-600/601 under a takeover that has since
+          // moved to z-[9000], and what showed above it was the app's back
+          // arrow, avatar and Now / People / Links strip -- navigation that
+          // does nothing yet, over a step nobody has finished.
+          takeover
           collectAddressDetails
           deferredUntilVault={!vaultKey || !vaultOwnerToken}
           initialAccuracyM={saveLocationPoint?.accuracyM}

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -171,6 +171,7 @@ export function SettingsGroup({
   title,
   titleAction,
   description,
+  toolbar,
   children,
   embedded = false,
   separatorInset,
@@ -197,6 +198,17 @@ export function SettingsGroup({
    */
   titleAction?: ReactNode;
   description?: ReactNode;
+  /**
+   * A control that acts on THIS group's rows -- a search field over the list
+   * it filters, for instance. It sits between the heading and the card, so the
+   * heading that names the list and the sentence explaining how to use it are
+   * both read before the control they describe. Placed above the heading, the
+   * field arrived before anything had said what it searched, and the
+   * supporting line ("Search by name.") ended up UNDER the box it was
+   * instructing -- pointing backwards at a control the reader had already
+   * passed.
+   */
+  toolbar?: ReactNode;
   children: ReactNode;
   embedded?: boolean;
   /**
@@ -272,6 +284,19 @@ export function SettingsGroup({
             // 320px.
             <div className="shrink-0">{titleAction}</div>
           ) : null}
+        </div>
+      ) : null}
+      {toolbar ? (
+        <div
+          data-slot="settings-group-toolbar"
+          className={cn(
+            "mb-3",
+            // Without a heading above it there is no `mt-7` to sit under, so
+            // the control would hug whatever preceded the group.
+            !(eyebrow || title || description) && "mt-7",
+          )}
+        >
+          {toolbar}
         </div>
       ) : null}
       {shell}

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -128,6 +128,7 @@ vi.mock("sonner", () => ({
 import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
 import {
   forgetOneLocationControlPreference,
+  readOneLocationControlState,
   updateOneLocationControlState,
 } from "@/lib/one-location/location-control-state";
 import { DuplicateSavedLocationError } from "@/lib/one-location/saved-locations";
@@ -366,6 +367,46 @@ describe("SavedLocationsSection", () => {
           },
         },
       }),
+    );
+
+    // QA: "confirm pin karke bhi agar main apna address save kar rahi hun, aur
+    // main screen par ja rahi hun, wahan toggle off kyun dikha raha hai?"
+    //
+    // The header switch reads `selfPreviewEnabled || nearbyPresenceActive ||
+    // grants`. Saving a place went through none of those, so someone who had
+    // just granted permission, dragged a pin onto their own door and named it
+    // Home was shown "Location off" on the very next screen. Confirming a pin
+    // is the person saying where they are; the control has to agree.
+    await waitFor(() =>
+      expect(readOneLocationControlState("user-123").selfPreviewEnabled).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("cannot turn the preview on while Location is paused", async () => {
+    // The preview flag is the ONLY thing the save writes, and pause outranks
+    // it. Someone who paused Location is told to resume it first, so no place
+    // is saved and nothing flips the header switch back on behind them.
+    mocks.loadSavedLocations.mockResolvedValueOnce([]);
+    render(<SavedLocationsSection />);
+    await screen.findByText(/no places yet/i);
+
+    updateOneLocationControlState("user-123", (current) => ({
+      ...current,
+      paused: true,
+    }));
+
+    fireEvent.click(screen.getByRole("button", { name: /add place/i }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Resume Location before adding a saved place.",
+      ),
+    );
+    expect(mocks.addSavedLocation).not.toHaveBeenCalled();
+    expect(readOneLocationControlState("user-123").selfPreviewEnabled).toBe(
+      false,
     );
   });
 

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -1466,6 +1466,63 @@ describe("SaveLocationModal", () => {
       }
     });
 
+    it("stays a bottom sheet, under the app's own layers, by default", () => {
+      // Saving a place from Settings is a sheet over a screen you are coming
+      // back to, and that screen is SUPPOSED to stay visible behind it. The
+      // takeover geometry must not leak into this lane.
+      const restore = asPhone();
+      try {
+        render(<SaveLocationModal {...phoneProps} />);
+        const surface = screen.getByTestId("save-location-modal");
+
+        expect(surface.className).toContain("z-[601]");
+        expect(surface.className).not.toContain("z-[9101]");
+        expect(surface.className).not.toContain("top-0");
+        expect(surface.className).not.toContain("max-h-none");
+      } finally {
+        restore();
+      }
+    });
+
+    it("covers the app's chrome when it is an onboarding step", () => {
+      // QA, photographing the pin step: the back arrow, the avatar and the
+      // Now / People / Links strip were sitting above it -- "onboarding screen
+      // mein yeh nav bar dikhna hi nahi chahiye".
+      //
+      // Two halves to that. The surface reached only 92% of the screen from
+      // the bottom, so the top was never its to cover; and it was pinned at
+      // z-600/601 against an onboarding takeover that has since moved to
+      // z-[9000], so it was being painted UNDER the screen it belongs to.
+      const restore = asPhone();
+      try {
+        render(<SaveLocationModal {...phoneProps} takeover />);
+        const surface = screen.getByTestId("save-location-modal");
+
+        // Above the z-[9000] takeover, not below it.
+        expect(surface.className).toContain("z-[9101]");
+        expect(surface.className).not.toContain("z-[601]");
+
+        // Top of the screen to just above the keyboard: `top-0` joins the
+        // primitive's `bottom-[var(--kb-height,0px)]`, and the 92% cap is
+        // erased rather than left to win on stylesheet order.
+        expect(surface.className).toContain("top-0");
+        expect(surface.className).toContain("max-h-none");
+        expect(surface.className).not.toContain(
+          "max-h-[calc((100dvh-var(--kb-height,0px))*0.92)]",
+        );
+        expect(surface.className).toContain("bottom-[var(--kb-height,0px)]");
+
+        // A surface that reaches the top has to clear the status bar itself.
+        expect(surface.className).toContain(
+          "pt-[calc(env(safe-area-inset-top,0px)+20px)]",
+        );
+        // Nothing left to round against, and no edge to draw.
+        expect(surface.className).toContain("rounded-none");
+      } finally {
+        restore();
+      }
+    });
+
     it("makes the step rail the drag surface, without a second handle", () => {
       const restore = asPhone();
       try {

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -42,8 +42,13 @@ import {
   SHEET_PLAIN_SHELL_CLASSNAME,
   SHEET_PRESENTATION_QUERY,
   SHEET_SURFACE_CLASSNAME,
+  SHEET_TAKEOVER_DETAILS_TOP_CLASSNAME,
+  SHEET_TAKEOVER_PLAIN_TOP_CLASSNAME,
+  SHEET_TAKEOVER_SURFACE_CLASSNAME,
   STEP_DOT_REACHED_CLASSNAME,
   STEP_DOT_UPCOMING_CLASSNAME,
+  TAKEOVER_OVERLAY_Z_CLASSNAME,
+  TAKEOVER_SURFACE_Z_CLASSNAME,
 } from "@/components/one-location/onboarding/save-location-sheet-layout";
 import { isNative } from "@/lib/capacitor/platform";
 import { cn } from "@/lib/utils";
@@ -350,6 +355,16 @@ export type SaveLocationModalProps = {
   onPickExactLocation?: (picked: PickedLocation) => void;
   /** Open directly on the map instead of making the owner find an extra CTA. */
   startWithMapPicker?: boolean;
+  /**
+   * Present this as an onboarding STEP rather than as a sheet over a screen.
+   *
+   * Full height, square corners, and layered above the onboarding takeover, so
+   * none of the app's chrome -- back arrow, avatar, the Now / People / Links
+   * strip -- is visible above a step the person has not finished. Off
+   * everywhere else: saving a place from Settings is a sheet over a screen you
+   * are coming back to, and that screen SHOULD stay visible behind it.
+   */
+  takeover?: boolean;
   /** Follow pin confirmation with the complete entrance/address detail step. */
   collectAddressDetails?: boolean;
   /** Pre-select a category when editing an existing saved place. */
@@ -498,6 +513,7 @@ export function SaveLocationModal({
   onLocateMe,
   onPickExactLocation,
   startWithMapPicker = false,
+  takeover = false,
   collectAddressDetails = false,
   initialCategory = null,
   existingLocations = [],
@@ -938,7 +954,7 @@ export function SaveLocationModal({
   // presentations, so moving to the shared sheet primitive does not quietly
   // move this surface to a different layer.
   const surfaceOverlayClassName = cn(
-    "z-[600]",
+    takeover ? TAKEOVER_OVERLAY_Z_CLASSNAME : "z-[600]",
     nativeMapShowing
       ? // The native map is not part of the page: @capacitor/google-maps draws
         // it BELOW the WebView and the WebView is punched through to reveal it.
@@ -965,6 +981,27 @@ export function SaveLocationModal({
   // lift never actually rendered.
   const surfaceShadowClassName =
     "!shadow-[0_24px_60px_-12px_rgba(16,24,40,0.35),0_8px_20px_-8px_rgba(16,24,40,0.24)] dark:!shadow-[0_24px_60px_-12px_rgba(0,0,0,0.7)]";
+
+  /**
+   * One string or the other, never one layered over the other. See
+   * `SHEET_TAKEOVER_SURFACE_CLASSNAME` for why a merge cannot be trusted to
+   * erase the 92% cap.
+   */
+  const surfaceGeometryClassName = takeover
+    ? SHEET_TAKEOVER_SURFACE_CLASSNAME
+    : SHEET_SURFACE_CLASSNAME;
+  /**
+   * The status bar and notch, applied AFTER the pane's own padding: a `p-5`
+   * merged in later would take the `pt-` with it.
+   */
+  const surfaceTakeoverTopClassName = takeover
+    ? detailsPaneActive
+      ? SHEET_TAKEOVER_DETAILS_TOP_CLASSNAME
+      : SHEET_TAKEOVER_PLAIN_TOP_CLASSNAME
+    : undefined;
+  const surfaceZClassName = takeover
+    ? TAKEOVER_SURFACE_Z_CLASSNAME
+    : "z-[601]";
 
   const surfaceChildren = (
     <>
@@ -1610,11 +1647,12 @@ export function SaveLocationModal({
             if (interactionBusy || flowStep === "map") event.preventDefault();
           }}
           className={cn(
-            "z-[601]",
-            SHEET_SURFACE_CLASSNAME,
+            surfaceZClassName,
+            surfaceGeometryClassName,
             surfaceEdgeClassName,
             surfacePaddingClassName,
             surfaceShadowClassName,
+            surfaceTakeoverTopClassName,
           )}
         >
           {surfaceChildren}
@@ -1642,7 +1680,8 @@ export function SaveLocationModal({
           if (interactionBusy || flowStep === "map") event.preventDefault();
         }}
         className={cn(
-          "z-[601] rounded-[20px] border",
+          surfaceZClassName,
+          "rounded-[20px] border",
           DIALOG_SURFACE_CLASSNAME,
           surfaceEdgeClassName,
           surfacePaddingClassName,

--- a/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/onboarding/save-location-sheet-layout.ts
@@ -71,6 +71,62 @@ export const DIALOG_SURFACE_CLASSNAME = "w-full max-h-[min(92dvh,760px)]";
  */
 export const SHEET_PRESENTATION_QUERY = "(max-width: 639.98px)";
 
+/* ------------------------------------------------------------------ */
+/* Takeover: the same surface, presented as an onboarding STEP.        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * THE LAYER, during Location onboarding.
+ *
+ * A bottom sheet leaves the top of the screen showing, which is right when the
+ * thing behind it is a screen you are coming back to. During onboarding it is
+ * not: QA photographed the pin step with the app's back arrow, avatar and the
+ * Now / People / Links strip sitting above it -- "onboarding screen mein yeh
+ * nav bar dikhna hi nahi chahiye". Navigation you cannot use yet, over a step
+ * you have not finished.
+ *
+ * The z-values are the second half of the same defect. This surface was pinned
+ * at 600/601 against a comment reading "Location onboarding is a full-screen
+ * takeover at z-560". The takeover has since moved to `z-[9000]`, and nothing
+ * moved these -- so the scrim and the sheet were being painted UNDERNEATH the
+ * screen they belong to. They are stated as constants here, next to the number
+ * they have to beat, rather than inline in the component where they drifted.
+ */
+export const TAKEOVER_OVERLAY_Z_CLASSNAME = "z-[9100]";
+export const TAKEOVER_SURFACE_Z_CLASSNAME = "z-[9101]";
+
+/**
+ * Full height, square, no border: from the top of the screen to just above the
+ * keyboard.
+ *
+ * `top-0` rather than a height, so the primitive's `bottom-[var(--kb-height)]`
+ * survives and the surface still lifts above the on-screen keyboard. Setting a
+ * `h-dvh` here would subtract the keyboard a second time -- the same mistake
+ * the `max-h` comment above documents.
+ *
+ * This REPLACES `SHEET_SURFACE_CLASSNAME` rather than overriding it, which is
+ * why it restates `w-full`. tailwind-merge cannot parse
+ * `max-h-[calc((100dvh-var(--kb-height,0px))*0.92)]` -- the nested parentheses
+ * defeat its arbitrary-value matcher -- so it files the class as unknown and
+ * leaves BOTH it and `max-h-none` on the element, where the winner is decided
+ * by stylesheet order. Measured: the cap survived and the surface still
+ * stopped 8% short of the top. Choosing one string is the only reliable way
+ * to say which geometry applies.
+ */
+export const SHEET_TAKEOVER_SURFACE_CLASSNAME =
+  "w-full top-0 max-h-none rounded-none border-0";
+
+/**
+ * The status bar and notch, which a bottom sheet never had to think about
+ * because it never reached them. Two values, because the two panes start from
+ * different padding: the map/summary pane is padded 20px all round, and the
+ * details pane is a fixed frame at `p-0` whose own header supplies the rest.
+ */
+export const SHEET_TAKEOVER_PLAIN_TOP_CLASSNAME =
+  "pt-[calc(env(safe-area-inset-top,0px)+20px)]";
+export const SHEET_TAKEOVER_DETAILS_TOP_CLASSNAME =
+  "pt-[env(safe-area-inset-top,0px)]";
+
 /**
  * Sheet shell while the details pane is on screen. Turns the surface from "one
  * long scroll box with padding" into a fixed frame whose middle row scrolls.

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -37,7 +37,10 @@ import {
   type SavedLocationAddressDetails,
 } from "@/lib/one-location/saved-location-address";
 
-import { readOneLocationControlState } from "@/lib/one-location/location-control-state";
+import {
+  readOneLocationControlState,
+  updateOneLocationControlState,
+} from "@/lib/one-location/location-control-state";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
 import { useOneLocationControlState } from "@/lib/one-location/use-location-control-state";
@@ -371,6 +374,26 @@ export function SavedLocationsSection() {
               input,
             });
         if (!isCurrentVaultSession(session)) return;
+        // Confirming a pin turns the live preview on, exactly as the onboarding
+        // save path already does.
+        //
+        // Saving a place is the one action in the product where the owner has
+        // just granted permission, let the device take a fix, dragged a pin to
+        // their own doorstep and named it -- and then landed back on a hub whose
+        // header switch read "Location off". Nothing here had ever gone through
+        // `activateMyLocation`, so `selfPreviewEnabled` stayed false; a person
+        // with no grants and no nearby presence has all three disjuncts behind
+        // `locationEnabled` false, and the screen contradicted what they had
+        // just done.
+        //
+        // Only the preview flag is written. `paused` is left exactly as it is,
+        // so this can never resume a Location the owner deliberately paused --
+        // `updateOneLocationControlState` already forces the preview back off
+        // while paused, which keeps this fail-closed rather than fail-friendly.
+        updateOneLocationControlState(userId, (current) => ({
+          ...current,
+          selfPreviewEnabled: true,
+        }));
         addressResolutionIdRef.current += 1;
         setLocations(sortSavedLocationsForDisplay(next));
         setSaveLocationModalOpen(false);

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -11,6 +11,11 @@ import {
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
 import {
+  CONNECT_PAGER_BUTTON_CLASSNAME,
+  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
+  CONNECT_PAGER_ROW_CLASSNAME,
+  CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME,
+  CONNECT_PAGE_STATUS_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
   CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
@@ -683,5 +688,181 @@ test.describe("Connect list rows", () => {
     expect(Math.abs(cancel.width - 72)).toBeLessThanOrEqual(0.5);
     expect(cancel.width).toBeLessThanOrEqual(connect.width + 0.5);
     expect(cancel.height).toBeLessThanOrEqual(32.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The Connect pager, at the foot of the directory card
+// ---------------------------------------------------------------------------
+
+/**
+ * QA, on a phone: "sarein cheezein scattered dekh rahi -- page 1 . per page,
+ * prev next in next line. per page, prev next ek line mein la sakte."
+ *
+ * The row was `flex flex-col ... sm:flex-row`, and `sm:` is 640px, so on every
+ * width the App Store actually ships to it stacked: "Page 1 - Per page [8]"
+ * across the top, and a right-aligned "Prev  Next" on a second line under it.
+ * Four fragments, three alignments, one card.
+ *
+ * Putting them back on one line is only safe if they FIT on one line at 320px,
+ * which is a browser question. The JSDOM sibling proves the row still renders
+ * without `flex-col`; it measures every box as 0x0 and would pass just as
+ * happily on a row that overflowed the card by 40px.
+ */
+const PAGER_BEFORE_ROW_CLASSNAME =
+  "flex flex-col gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between";
+
+/** The pager button as the screen composes it, through the real variants. */
+const pagerButtonClass = () =>
+  cn(
+    buttonVariants({ variant: "default", size: "sm" }),
+    CONNECT_PAGER_BUTTON_CLASSNAME,
+    CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
+  );
+
+const PAGER_CANDIDATES = [
+  ...CONNECT_PAGER_ROW_CLASSNAME.split(/\s+/),
+  ...PAGER_BEFORE_ROW_CLASSNAME.split(/\s+/),
+  ...CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME.split(/\s+/),
+  ...CONNECT_PAGE_STATUS_CLASSNAME.split(/\s+/),
+  ...pagerButtonClass().split(/\s+/),
+  "flex",
+  "min-w-0",
+  "flex-col",
+  "flex-wrap",
+  "items-start",
+  "items-center",
+  "justify-end",
+  "gap-0.5",
+  "gap-2",
+  "gap-2.5",
+  "shrink-0",
+  "min-h-9",
+  "h-1",
+  "w-1",
+  "rounded-full",
+  "tabular-nums",
+  "whitespace-nowrap",
+  "ui-text-helper-text",
+  "text-[color:var(--app-secondary-label)]",
+  "bg-[color:var(--app-tertiary-label)]",
+];
+
+/**
+ * The select trigger stands in as a plain box carrying the trigger's own class
+ * string. That is faithful for geometry and only for geometry: the width and
+ * height this row has to budget for are both fixed on the trigger itself, so
+ * whatever Radix renders inside it cannot change the number measured here.
+ */
+const pagerBody = () => `<div data-testid="pager-row" class="${CONNECT_PAGER_ROW_CLASSNAME}">
+  <div data-testid="pager-size" class="flex min-w-0 flex-col items-start gap-0.5">
+    <div data-testid="pager-size-line" class="flex items-center gap-2">
+      <span class="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)]">Per page</span>
+      <div data-testid="pager-select" class="${CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}">8</div>
+    </div>
+    <span data-testid="pager-status" class="${CONNECT_PAGE_STATUS_CLASSNAME}">Page 1</span>
+  </div>
+  <div data-testid="pager-actions" class="flex shrink-0 items-center justify-end gap-2">
+    <button data-testid="pager-prev" class="${pagerButtonClass()}">Prev</button>
+    <button data-testid="pager-next" class="${pagerButtonClass()}">Next</button>
+  </div>
+</div>`;
+
+/** The same pager exactly as it shipped, for the mutation check. */
+const pagerBodyBefore = () => `<div data-testid="pager-row" class="${PAGER_BEFORE_ROW_CLASSNAME}">
+  <div data-testid="pager-size" class="flex min-h-9 flex-wrap items-center gap-2.5">
+    <span data-testid="pager-status" class="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]">Page 1</span>
+    <span class="h-1 w-1 rounded-full bg-[color:var(--app-tertiary-label)]"></span>
+    <span class="ui-text-helper-text text-[color:var(--app-secondary-label)]">Per page</span>
+    <div data-testid="pager-select" class="h-8 min-h-8 w-[74px] rounded-2xl text-[15px] font-medium leading-5"></div>
+  </div>
+  <div data-testid="pager-actions" class="flex min-h-9 items-center justify-end gap-2">
+    <button data-testid="pager-prev" class="${pagerButtonClass()}">Prev</button>
+    <button data-testid="pager-next" class="${pagerButtonClass()}">Next</button>
+  </div>
+</div>`;
+
+const fontSizeOf = (page: Page, selector: string) =>
+  page.evaluate(
+    (sel) =>
+      parseFloat(
+        getComputedStyle(document.querySelector(sel) as Element).fontSize,
+      ),
+    selector,
+  );
+
+test.describe("Connect pager", () => {
+  for (const width of PHONE_WIDTHS) {
+    test(`size control and Prev/Next share one line at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(
+        await buildFixture("connect-pager", pagerBody(), PAGER_CANDIDATES),
+      );
+      await awaitProductFont(page);
+      await fontsReady(page);
+
+      const row = await boxOf(page, '[data-testid="pager-row"]');
+      const sizeLine = await boxOf(page, '[data-testid="pager-size-line"]');
+      const actions = await boxOf(page, '[data-testid="pager-actions"]');
+      const status = await boxOf(page, '[data-testid="pager-status"]');
+
+      // Side by side, not stacked: the buttons start after the size control
+      // ends, and the two boxes overlap vertically.
+      expect(actions.left, "buttons start after the size control").toBeGreaterThan(
+        sizeLine.right,
+      );
+      expect(actions.top, "same line, not the next one").toBeLessThan(
+        sizeLine.bottom,
+      );
+      expect(sizeLine.top).toBeLessThan(actions.bottom);
+
+      // And it fits. This is the whole reason the select and the buttons gave
+      // up padding; at 320px the old geometry would not have.
+      expect(
+        actions.right,
+        `pager overflows at ${width}px`,
+      ).toBeLessThanOrEqual(row.right + 0.5);
+      expect(row.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
+      expect(row.left).toBeGreaterThanOrEqual(PAGE_PADDING_PX - 1);
+
+      // "Page 1" reads as the status under the control, not as a fifth item
+      // competing on the line.
+      expect(status.top, "page number sits under the size control").toBeGreaterThanOrEqual(
+        sizeLine.bottom - 0.5,
+      );
+      expect(status.left).toBeLessThanOrEqual(sizeLine.left + 0.5);
+
+      const statusSize = await fontSizeOf(page, '[data-testid="pager-status"]');
+      const labelSize = await fontSizeOf(page, '[data-testid="pager-size-line"] span');
+      expect(statusSize, "status is quieter than the label above it").toBeLessThan(
+        labelSize,
+      );
+    });
+  }
+
+  test("the version QA photographed really did stack", async ({ page }) => {
+    // Mutation check. `sm:` is 640px, so at 375 the shipped row was in its
+    // `flex-col` state and the buttons landed on a second line. Without this,
+    // the assertions above could be passing on a rule incapable of failing.
+    await page.setViewportSize({ width: 375, height: 844 });
+    await page.goto(
+      await buildFixture(
+        "connect-pager-before",
+        pagerBodyBefore(),
+        PAGER_CANDIDATES,
+      ),
+    );
+    await awaitProductFont(page);
+    await fontsReady(page);
+
+    const sizeLine = await boxOf(page, '[data-testid="pager-size"]');
+    const actions = await boxOf(page, '[data-testid="pager-actions"]');
+
+    expect(
+      actions.top,
+      "the shipped pager put Prev/Next on their own line",
+    ).toBeGreaterThanOrEqual(sizeLine.bottom);
   });
 });

--- a/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
+++ b/hushh-webapp/e2e/save-location-sheet.layout.spec.ts
@@ -15,6 +15,8 @@ import {
   SHEET_HEADER_CLASSNAME,
   SHEET_LAYOUT_WIDTHS,
   SHEET_SURFACE_CLASSNAME,
+  SHEET_TAKEOVER_DETAILS_TOP_CLASSNAME,
+  SHEET_TAKEOVER_SURFACE_CLASSNAME,
 } from "../components/one-location/onboarding/save-location-sheet-layout";
 
 /**
@@ -41,7 +43,9 @@ import {
  */
 
 /** Compile just the utilities this fixture uses, with the real Tailwind. */
-async function buildFixture(): Promise<string> {
+async function buildFixture({
+  takeover = false,
+}: { takeover?: boolean } = {}): Promise<string> {
   // Playwright runs from the webapp root (its config lives there).
   const webappRoot = process.cwd();
   const { compile } = (await import(
@@ -73,9 +77,18 @@ async function buildFixture(): Promise<string> {
   // components/ui/sheet.tsx, plus the surface contract this sheet adds on top.
   // Hand-writing a `max-w-[420px]` here is exactly what the fixture used to do,
   // which is why it measured a floating card and reported it as correct.
-  const sheetPositioning =
-    "fixed inset-x-0 bottom-[var(--kb-height,0px)] h-auto flex min-h-0 flex-col rounded-t-[24px] border-t";
-  const shell = `${sheetPositioning} ${SHEET_SURFACE_CLASSNAME}`;
+  //
+  // The takeover lane drops the rounded top edge and the top border because
+  // tailwind-merge removes them in the app: `rounded-none` and `border-0` from
+  // `SHEET_TAKEOVER_SURFACE_CLASSNAME` land in the same merge groups. This
+  // fixture concatenates raw strings, so leaving them in would measure a
+  // cascade the app never renders.
+  const sheetPositioning = takeover
+    ? "fixed inset-x-0 bottom-[var(--kb-height,0px)] h-auto flex min-h-0 flex-col"
+    : "fixed inset-x-0 bottom-[var(--kb-height,0px)] h-auto flex min-h-0 flex-col rounded-t-[24px] border-t";
+  const shell = takeover
+    ? `${sheetPositioning} ${SHEET_TAKEOVER_SURFACE_CLASSNAME} ${SHEET_TAKEOVER_DETAILS_TOP_CLASSNAME}`
+    : `${sheetPositioning} ${SHEET_SURFACE_CLASSNAME}`;
   const row = "flex items-center gap-2";
   const button = "relative flex h-9 w-9 shrink-0 items-center justify-center";
   const title =
@@ -416,5 +429,61 @@ test.describe("Save-location address sheet layout", () => {
     });
     // Anything under 255 and the field behind it shows through the button.
     expect(alpha).toBe(255);
+  });
+});
+
+/**
+ * The same surface as an onboarding STEP.
+ *
+ * QA photographed the pin step with the app's back arrow, avatar and the
+ * Now / People / Links strip sitting above it: "onboarding screen mein yeh nav
+ * bar dikhna hi nahi chahiye". A bottom sheet capped at 92% of the screen can
+ * never cover the top 8%, and that 8% is where the app's chrome lives.
+ *
+ * This is the half a class assertion cannot reach. The JSDOM sibling proves
+ * the surface renders `max-h-none` and `top-0`; only a browser can prove that
+ * the box those produce actually starts at y=0 -- and the first attempt did
+ * NOT, because tailwind-merge could not parse the 92% cap and left both
+ * classes standing.
+ */
+test.describe("Save-location surface as an onboarding takeover", () => {
+  for (const width of SHEET_FULL_BLEED_WIDTHS) {
+    test(`covers the whole screen at ${width}px`, async ({ page }) => {
+      const height = 844;
+      await page.setViewportSize({ width, height });
+      await page.goto(await buildFixture({ takeover: true }));
+      await awaitProductFont(page);
+
+      const surface = await boxOf(page, "save-location-modal");
+
+      // Nothing of the app is left showing above it.
+      expect(surface.y, `top edge at ${width}px`).toBeLessThanOrEqual(0.5);
+      expect(surface.height, `height at ${width}px`).toBeGreaterThanOrEqual(
+        height - 0.5,
+      );
+      // Still full-bleed, as the bottom sheet already was.
+      expect(surface.x).toBeLessThanOrEqual(0.5);
+      expect(surface.width).toBeGreaterThanOrEqual(width - 0.5);
+    });
+  }
+
+  test("the bottom sheet it replaces really did leave the top showing", async ({
+    page,
+  }) => {
+    // Mutation check. Without it the assertions above could be passing on a
+    // rule incapable of failing -- and this is the exact gap QA photographed.
+    const height = 844;
+    await page.setViewportSize({ width: 390, height });
+    await page.goto(await buildFixture());
+    await awaitProductFont(page);
+
+    const surface = await boxOf(page, "save-location-modal");
+
+    // 92% of 844 is 776, so ~68px of app chrome stayed visible above it.
+    expect(
+      surface.y,
+      "the shipped sheet started well below the top of the screen",
+    ).toBeGreaterThan(32);
+    expect(surface.height).toBeLessThan(height);
   });
 });


### PR DESCRIPTION
Four QA reports from one round of phone testing on TestFlight.

## 1. Connect — the search field arrived before the list it searches

The field rendered ABOVE the "People" heading, so the sentence instructing it
("Search by name.") sat UNDERNEATH the box it was instructing, and the field
arrived before anything on screen had said what it searched.

`SettingsGroup` gains a `toolbar` slot — a control that acts on that group's
rows, rendered between the heading and the card — and Connect passes its search
row through it. The row keeps its sticky behaviour: it still pins under the tab
strips on scroll, it just no longer arrives first.

Reading order is now heading → instruction → field → rows.

## 2. Connect pager — four fragments scattered at the foot of the card

The row was `flex flex-col … sm:flex-row`, and `sm:` is 640px, so on **every**
width the App Store ships to it stacked: "Page 1 · Per page [8]" across the top
and a separate right-aligned "Prev Next" underneath.

It is one line now — the size control on the left, the two buttons that use it
on the right — with the page number under the control as the quiet status it is
rather than leading a row it does not act on. The select (74px → 68px) and the
buttons (`px-3` → `px-2.5`) give up padding so the row fits at 320px; the
browser contract measures that rather than assuming it.

## 3. Saving a place left the header switch reading "Location off"

`locationEnabled` is `selfPreviewEnabled || nearbyPresenceActive || grants`.
Saving a place from Settings went through none of them — so someone who had
just granted permission, let the device take a fix, dragged a pin onto their own
door and tagged it Home landed on a hub that told them their location was off.

The onboarding save path already wrote the flag; this makes the Settings path
agree. **Only the preview flag is written** — `paused` is untouched, and
`updateOneLocationControlState` already forces the preview back off while
paused, so this can never resume a Location the owner deliberately paused.

## 4. The pin step showed the app's chrome above it

QA photographed "Pin your entrance" with the back arrow, the avatar and the
Now / People / Links strip sitting above it — navigation that does nothing yet,
over a step nobody has finished.

Two halves to that defect:

- a bottom sheet capped at 92% of the screen can never cover the top 8%, and
- the surface was pinned at `z-600/601` against a comment reading "Location
  onboarding is a full-screen takeover at z-560". The takeover has since moved
  to `z-[9000]` and these never followed, so the scrim and the sheet were being
  painted **underneath** the screen they belong to.

A new `takeover` prop — used only by the onboarding instance — makes the
surface full-height (`top-0`, keeping `bottom-[var(--kb-height)]` so it still
lifts above the keyboard) and layers it above the takeover. Saving a place from
Settings is unchanged and stays a sheet over the screen you are coming back to.

## Verification

Every new geometry has a browser layout contract with a mutation check against
the version QA photographed, because JSDOM measures every box as 0×0 and would
have passed all four of these the entire time they were broken.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` (changed files, `--max-warnings=0`) | clean |
| `vitest` — connect, saved-locations, save-location-modal, settings-ui | 164 passed |
| `playwright --project=chromium` — connect-circle-cta, connect-sticky-header, save-location-sheet | 116 passed |
| `playwright --project=webkit` — connect-circle-cta, save-location-sheet | 81 passed |
| `verify:design-system`, `verify:voice-gateway` | passed |

New contracts:

- `Connect pager` — the size control and Prev/Next share one line, and the row
  fits, at 320/360/375/390/430px. Mutation check proves the shipped `flex-col`
  row really did put the buttons on a second line at 375px.
- `Save-location surface as an onboarding takeover` — the surface starts at
  y=0 and is the full viewport height at eight widths from 320px to 639px.
  Mutation check proves the shipped bottom sheet really did leave ~68px of app
  chrome showing above it.
- Connect JSDOM — reading order is heading → instruction → field → rows; the
  pager is one row with the page number under the size control.
- Save-location JSDOM — the default sheet keeps `z-[601]` and its 92% cap; the
  takeover carries `z-[9101]`, `top-0`, `max-h-none` and the safe-area top.

One note worth flagging: `max-h-none` does **not** merge away
`max-h-[calc((100dvh-var(--kb-height,0px))*0.92)]`. tailwind-merge cannot parse
the nested parentheses, files the class as unknown, and leaves both standing —
the first attempt at the takeover passed JSDOM and still measured 68px short in
the browser. The takeover replaces the geometry string rather than overriding
it, and the contract is what caught it.