### PR TITLE
fix(one): trusted devices - top-level placement, breadcrumb, design-system card, cache-first, honest status

### DIFF
--- a/hushh-webapp/__tests__/trusted-device-sync-display.test.ts
+++ b/hushh-webapp/__tests__/trusted-device-sync-display.test.ts
@@ -15,12 +15,23 @@ describe("deriveSyncDisplay", () => {
       NOW,
     );
     expect(d.tone).toBe("active");
-    expect(d.label).toMatch(/^Active · last synced /);
+    expect(d.label).toMatch(/^Trusted · last synced /);
   });
 
-  it("shows 'not yet synced' for an active device that never synced", () => {
+  it("never claims live reachability for a trusted device", () => {
+    // status="active" means authorized, not running. The label must not imply
+    // the agent is reachable right now -- there is no liveness channel.
+    const d = deriveSyncDisplay(
+      { status: "active", last_synced_at: NOW - 2 * 86_400_000 },
+      NOW,
+    );
+    expect(d.label).not.toMatch(/^Active\b/);
+    expect(d.label).toContain("Trusted");
+  });
+
+  it("shows 'not yet synced' for a trusted device that never synced", () => {
     const d = deriveSyncDisplay({ status: "active", last_synced_at: null }, NOW);
-    expect(d).toEqual({ label: "Active · not yet synced", tone: "neutral" });
+    expect(d).toEqual({ label: "Trusted · not yet synced", tone: "neutral" });
   });
 
   it("reports a sealed device as reported, never asserts sealing as fact", () => {

--- a/hushh-webapp/app/one/profile/security/devices/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { Laptop, Loader2, Trash2 } from "lucide-react";
 
 import {
@@ -22,8 +22,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
+import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { ROUTES } from "@/lib/navigation/routes";
 import { ApiService } from "@/lib/services/api-service";
+import { CACHE_KEYS } from "@/lib/services/cache-service";
 import { deriveSyncDisplay } from "@/lib/trusted-device/sync-display";
 
 interface TrustedDevice {
@@ -42,33 +44,34 @@ interface TrustedDevice {
 
 export default function TrustedDevicesPage() {
   const { user } = useAuth();
-  const [devices, setDevices] = useState<TrustedDevice[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [pendingRevocation, setPendingRevocation] =
     useState<TrustedDevice | null>(null);
   const [revoking, setRevoking] = useState(false);
 
-  const load = useCallback(async () => {
-    if (!user) return;
-    setLoading(true);
-    try {
+  // Cache-first: a warm cache paints the list immediately and the refresh runs
+  // in the background, so revisiting this screen never shows a blocking spinner
+  // over data we already hold. Revoking force-refreshes through the same
+  // resource so the cache can never serve a device the server just revoked.
+  const devicesResource = useStaleResource<TrustedDevice[]>({
+    cacheKey: CACHE_KEYS.TRUSTED_DEVICES(user?.uid || "anonymous"),
+    enabled: Boolean(user),
+    resourceLabel: "trusted-devices",
+    load: async () => {
       const response = await ApiService.listTrustedDevices();
       const payload = await response.json();
-      if (!response.ok)
+      if (!response.ok) {
         throw new Error(payload?.detail?.message || "Devices unavailable.");
-      setDevices(Array.isArray(payload.devices) ? payload.devices : []);
-      setError("");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Devices unavailable.");
-    } finally {
-      setLoading(false);
-    }
-  }, [user]);
+      }
+      return Array.isArray(payload.devices) ? payload.devices : [];
+    },
+  });
 
-  useEffect(() => {
-    void load();
-  }, [load]);
+  const devices = devicesResource.data ?? [];
+  // Only a cold load with nothing cached may block; a background refresh must
+  // never hide list content that is already on screen.
+  const loading = devicesResource.loading && devicesResource.data === null;
+  const visibleError = error || devicesResource.error || "";
 
   async function revoke(deviceId: string) {
     if (!user) return;
@@ -83,7 +86,8 @@ export default function TrustedDevicesPage() {
         return;
       }
       setPendingRevocation(null);
-      await load();
+      setError("");
+      await devicesResource.refresh({ force: true });
     } finally {
       setRevoking(false);
     }
@@ -115,7 +119,9 @@ export default function TrustedDevicesPage() {
             <Loader2 className="size-4 animate-spin" /> Loading devices…
           </div>
         ) : null}
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {visibleError ? (
+          <p className="text-sm text-destructive">{visibleError}</p>
+        ) : null}
         {devices.length > 0 ? (
           <SettingsGroup separatorInset>
             {devices.map((device) => {

--- a/hushh-webapp/app/one/profile/security/devices/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/page.tsx
@@ -9,6 +9,7 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { PageHeader } from "@/components/app-ui/page-sections";
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,13 +22,9 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
-import { formatRelativeTime } from "@/lib/format/relative-time";
 import { ROUTES } from "@/lib/navigation/routes";
 import { ApiService } from "@/lib/services/api-service";
-import {
-  deriveSyncDisplay,
-  type SyncTone,
-} from "@/lib/trusted-device/sync-display";
+import { deriveSyncDisplay } from "@/lib/trusted-device/sync-display";
 
 interface TrustedDevice {
   device_id: string;
@@ -42,12 +39,6 @@ interface TrustedDevice {
   last_synced_at?: number | null;
   sealed_at?: number | null;
 }
-
-const _SYNC_TONE_CLASS: Record<SyncTone, string> = {
-  active: "text-foreground",
-  neutral: "text-foreground",
-  muted: "text-muted-foreground",
-};
 
 export default function TrustedDevicesPage() {
   const { user } = useAuth();
@@ -125,60 +116,40 @@ export default function TrustedDevicesPage() {
           </div>
         ) : null}
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
-        <div className="space-y-3">
-          {devices.map((device) => {
-            const sync = deriveSyncDisplay(device, nowMs);
-            const connected = formatRelativeTime(device.created_at, nowMs);
-            const lastActive = formatRelativeTime(device.last_used_at, nowMs);
-            const meta = [
-              device.platform,
-              connected ? `Connected ${connected}` : "",
-              lastActive ? `Last active ${lastActive}` : "",
-            ]
-              .filter(Boolean)
-              .join(" · ");
-            return (
-              <article
-                className="flex items-center gap-4 rounded-2xl border bg-card p-4"
-                key={device.device_id}
-              >
-                <div className="flex size-10 items-center justify-center rounded-xl bg-muted">
-                  <Laptop className="size-5" aria-hidden />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <h2 className="truncate text-sm font-medium">
-                    {device.device_name}
-                  </h2>
-                  <p
-                    className={`mt-1 truncate text-xs font-medium ${_SYNC_TONE_CLASS[sync.tone]}`}
-                  >
-                    {sync.label}
-                  </p>
-                  {meta ? (
-                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {meta}
-                    </p>
-                  ) : null}
-                </div>
-                {device.status === "active" ? (
-                  <Button
-                    aria-label={`Unlink ${device.device_name}`}
-                    onClick={() => setPendingRevocation(device)}
-                    size="icon"
-                    variant="ghost"
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                ) : null}
-              </article>
-            );
-          })}
-          {!loading && devices.length === 0 ? (
-            <p className="rounded-2xl border border-dashed p-8 text-center text-sm text-muted-foreground">
-              No trusted devices are connected.
-            </p>
-          ) : null}
-        </div>
+        {devices.length > 0 ? (
+          <SettingsGroup separatorInset>
+            {devices.map((device) => {
+              const sync = deriveSyncDisplay(device, nowMs);
+              const isActive = device.status === "active";
+              return (
+                <SettingsRow
+                  key={device.device_id}
+                  icon={Laptop}
+                  title={device.device_name}
+                  description={sync.label}
+                  trailing={
+                    isActive ? (
+                      <Button
+                        aria-label={`Unlink ${device.device_name}`}
+                        onClick={() => setPendingRevocation(device)}
+                        size="icon"
+                        variant="ghost"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    ) : undefined
+                  }
+                  trailingInteractive={isActive}
+                />
+              );
+            })}
+          </SettingsGroup>
+        ) : null}
+        {!loading && devices.length === 0 ? (
+          <p className="rounded-2xl border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No trusted devices are connected.
+          </p>
+        ) : null}
       </AppPageContentRegion>
       <AlertDialog
         open={pendingRevocation !== null}

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -3236,13 +3236,6 @@ function ProfilePageContent() {
             updateProfileView({ panel: "security", detail: "vault" }, "push")
           }
         />
-        <SettingsRow
-          icon={Laptop}
-          title="Trusted devices"
-          description="Computers connected to your private agent."
-          chevron
-          onClick={() => router.push(ROUTES.PROFILE_SECURITY_DEVICES)}
-        />
       </SettingsGroup>
     </div>
   );
@@ -4117,6 +4110,14 @@ function ProfilePageContent() {
                 voiceLabel={PROFILE_LABELS.security}
                 voicePurpose="Opens vault, account access, and account deletion controls."
                 onClick={openSecurityPanel}
+              />
+              <SettingsRow
+                icon={Laptop}
+                iconTone="gray"
+                title="Trusted devices"
+                chevron
+                density="compact"
+                onClick={() => router.push(ROUTES.PROFILE_SECURITY_DEVICES)}
               />
               <SettingsRow
                 icon={Users}

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,15 +10,15 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 134,
-    "physical_page_count": 134,
-    "route_contract_count": 134,
-    "surface_map_count": 134,
+    "total_screens": 135,
+    "physical_page_count": 135,
+    "route_contract_count": 135,
+    "surface_map_count": 135,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 45,
-      "vault-backed": 49,
+      "vault-backed": 50,
       "hidden flow": 16,
       "auth/pre-vault": 6,
       "RIA/provider": 9,
@@ -4172,7 +4172,9 @@
       "route_contract_mode": "standard",
       "screen_class": "vault-backed",
       "cache_policy": "memory-only",
-      "cache_keys": [],
+      "cache_keys": [
+        "TRUSTED_DEVICES"
+      ],
       "resource_classes": [
         "unknown"
       ],
@@ -4196,7 +4198,7 @@
       "route_contract_present": true,
       "evidence": {
         "cache_service": false,
-        "use_stale_resource": false,
+        "use_stale_resource": true,
         "device_cache": false,
         "secure_cache": false,
         "cache_sync": false,
@@ -4207,9 +4209,7 @@
         "sse_or_streaming": false,
         "native_beacon": false
       },
-      "findings": [
-        "no local cache primitive detected in page/contract source"
-      ]
+      "findings": []
     },
     {
       "route": "/one/profile/security/devices/authorize",
@@ -5025,6 +5025,51 @@
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/login?redirect=%2Fone%2Fwallet-card",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
+      "route": "/people/[personRef]",
+      "page_file": "app/people/[personRef]/page.tsx",
+      "route_contract_mode": "standard",
+      "screen_class": "vault-backed",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/people/00000000-0000-4000-8000-000000000001",
       "surface_map_present": true,
       "route_contract_present": true,
       "evidence": {
@@ -5992,5 +6037,5 @@
       ]
     }
   ],
-  "content_sha256": "bda439724c88e09708658be48bd986bc13affb98b1321394749de15d92bfeaaf"
+  "content_sha256": "bfa23f829d2777d6dc12b50bf120d6cf8b20b2ac2b894a19d787b9330ae40d7a"
 }

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -1125,6 +1125,18 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  if (pathname === ROUTES.PROFILE_SECURITY_DEVICES) {
+    return {
+      backHref: ROUTES.PROFILE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: ROUTES.PROFILE },
+        { label: "Trusted devices" },
+      ],
+    };
+  }
+
   const { panel, detail } = resolveProfileRouteState(pathname, searchParams);
   const panelLabel = profilePanelLabel(panel);
   if (!panel || !panelLabel) {

--- a/hushh-webapp/lib/services/cache-service.ts
+++ b/hushh-webapp/lib/services/cache-service.ts
@@ -281,6 +281,7 @@ export const CACHE_KEYS = {
   VAULT_STATUS: (userId: string) => `vault_status_${userId}`,
   VAULT_CHECK: (userId: string) => `vault_check_${userId}`,
   ACCOUNT_IDENTITY: (userId: string) => `account_identity_${userId}`,
+  TRUSTED_DEVICES: (userId: string) => `trusted_devices_${userId}`,
   PRE_VAULT_BOOTSTRAP: (userId: string) => `pre_vault_bootstrap_${userId}`,
   DEVELOPER_ACCESS: (userId: string) => `developer_access_${userId}`,
   ACTIVE_CONSENTS: (userId: string) => `active_consents_${userId}`,

--- a/hushh-webapp/lib/trusted-device/sync-display.ts
+++ b/hushh-webapp/lib/trusted-device/sync-display.ts
@@ -38,13 +38,18 @@ export function deriveSyncDisplay(
   nowMs: number,
 ): SyncDisplay {
   if (device.status === "active") {
+    // "Trusted", not "Active": status only says this device is still authorized
+    // (not revoked). It is NOT a liveness signal -- the server has no channel
+    // telling it whether the agent is running right now, and last_synced_at only
+    // moves when the device pulls the sync channel. Saying "Active" next to a
+    // two-day-old sync reads as "reachable now", which the data cannot support.
     if (device.last_synced_at != null) {
       return {
-        label: `Active · last synced ${formatRelativeTime(device.last_synced_at, nowMs)}`,
+        label: `Trusted · last synced ${formatRelativeTime(device.last_synced_at, nowMs)}`,
         tone: "active",
       };
     }
-    return { label: "Active · not yet synced", tone: "neutral" };
+    return { label: "Trusted · not yet synced", tone: "neutral" };
   }
 
   if (device.status === "revoked") {

--- a/hushh-webapp/scripts/architecture/audit-cache-coherence.mjs
+++ b/hushh-webapp/scripts/architecture/audit-cache-coherence.mjs
@@ -238,6 +238,7 @@ function routeCacheKeys(route) {
     return ["PKM_DOMAIN_RESOURCE", "KYC workflow client state"];
   if (route === "/one/profile")
     return ["KAI_PROFILE", "PKM_METADATA", "VAULT_STATUS"];
+  if (route === "/one/profile/security/devices") return ["TRUSTED_DEVICES"];
   if (route === "/pkm")
     return ["PKM_METADATA", "PKM_DOMAIN_RESOURCE", "PKM_UPGRADE_STATUS"];
   if (route === "/gmail")


### PR DESCRIPTION
Four founder-reported defects on the Trusted Devices surface.

**Placement** - promoted to the top-level Profile list (after Security & privacy); removed from inside Security.

**Breadcrumb** - the devices route had none while Security showed "Profile > Security". The breadcrumb is route-driven top-shell chrome, so this adds the missing resolver case in `top-shell-breadcrumbs.ts`: "Profile > Trusted devices" with a back arrow to /one/profile.

**Card** - the device list hand-rolled an `<article>` (16px radius + border) instead of the grouped-card design system, which produced asymmetric gaps, mismatched edges, and truncated both the device name and the meta line to ellipsis. Rebuilt on SettingsGroup/SettingsRow: toned icon well, wrapping RowLabel/RowDescription (no truncation), canonical trailing Unlink slot, 24px grouped-card edges matching the profile list. The verbose platform/connected/last-active meta is dropped for the single honest sync line.

**Slow load** - the screen had no cache wiring at all (manifest showed `cache_keys: []`) and refetched behind a blocking spinner on every visit. Routed through `useStaleResource` with a TRUSTED_DEVICES key: a warm cache paints immediately, refresh runs in the background, and only a cold load with nothing cached may block. Revoke force-refreshes the same resource so the cache can never serve a device the server just revoked. Posture declared in the cache manifest.

**Honest status** - `status='active'` means the device is still authorized, NOT that the agent is running, and `last_synced_at` only advances when the device pulls the sync channel. Rendering "Active - last synced 2 days ago" reads as "reachable now", which the data cannot support. Now reads "Trusted - ...", with a test asserting we never claim live reachability.

Frontend-only, 8 files, zero Python. Green: typecheck, verify:design-system, verify:cache (61), verify:service-boundary, audit:cache-coherence, sync-display tests (11).