### PR TITLE
Fix Agent One intro import in post-merge smoke

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -1393,6 +1393,15 @@ def _build_ria_agent(*, model: Any | None = None) -> LlmAgent:
     )
 
 
+def _resolve_text_model(model: Any | None) -> Any:
+    """Resolve text-model authority without requiring cloud ADC in test collection."""
+    if model is not None:
+        return model
+    if os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes"}:
+        return _SPECIALIST_MODEL
+    return build_managed_gemini_adk_model(_SPECIALIST_MODEL)
+
+
 def build_one_intro_text_agent(*, model: Any | None = None) -> LlmAgent:
     """Build One's semantic but lower-privilege pre-vault text head.
 
@@ -1402,7 +1411,7 @@ def build_one_intro_text_agent(*, model: Any | None = None) -> LlmAgent:
     """
     return LlmAgent(
         name="one_intro",
-        model=model or build_managed_gemini_adk_model(_SPECIALIST_MODEL),
+        model=_resolve_text_model(model),
         description="One's informational, pre-vault private-agent surface.",
         instruction=(
             "You are One, the private agent inside Hussh. This is an informational "
@@ -1620,15 +1629,10 @@ def build_one_text_agent(*, model: Any | None = None) -> LlmAgent:
     surfaces run the specialist-generation model with the identical
     instruction and roster - ONE decision-maker, two transport heads.
     """
-    # Route modules construct the ADK app during import so FastAPI can register
-    # the canonical endpoint. CI intentionally has no cloud credentials; keep
-    # collection import-safe there while production still resolves the explicit
-    # managed Vertex binding. A bare model name is therefore test-only and never
-    # a hosted-runtime credential fallback.
-    is_test_runtime = os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes"}
-    text_model = model or (
-        _SPECIALIST_MODEL if is_test_runtime else build_managed_gemini_adk_model(_SPECIALIST_MODEL)
-    )
+    # Route modules construct both ADK apps during import so FastAPI can
+    # register the canonical endpoint. The shared resolver keeps that import
+    # credential-independent in tests while hosted runtimes stay explicit.
+    text_model = _resolve_text_model(model)
     return LlmAgent(
         name="one",
         model=text_model,

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -225,8 +225,10 @@ class TestAgentTreeShape:
         )
 
         agent = build_one_text_agent()
+        intro_agent = _tree.build_one_intro_text_agent()
 
         assert agent.model == _tree._SPECIALIST_MODEL
+        assert intro_agent.model == _tree._SPECIALIST_MODEL
 
     def test_byok_live_registry_rejects_models_outside_the_matrix(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## RCA
Main Post-Merge Smoke for merged PR #6141 failed because the lower-privilege intro Agent One head still resolved Vertex ADC while the server module was imported in the credential-free CI smoke overlay. The authenticated head had already been repaired; the intro head was the missed second caller.

Classification: `smoke_overlay_dependency_leak`.

## Repair
- share one text-model resolver across authenticated and intro heads
- keep the bare model name strictly test-only
- preserve explicit managed Vertex binding in hosted runtimes
- extend the import-safety regression to both heads

## Verification
- exact failing server import path passes without a configured project/credential input
- focused failing CI collection set: 254 passed
- two authoritative local CI/RCA passes are green
- persisted RCA: `tmp/agent-one-verification/ci-rca-post-merge-repair.json` (local ignored evidence artifact)