### PR TITLE
fix(one): voice cards show the whole line and stop repeating a step

### DIFF
--- a/hushh-webapp/__tests__/components/voice-walkthrough-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-walkthrough-panel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  collapseRepeatedSteps,
   currentTaskSteps,
   VoiceWalkthroughPanel,
 } from "@/components/agent/voice-walkthrough-panel";
@@ -63,6 +64,71 @@ describe("currentTaskSteps", () => {
       run({ id: "c", goalId: "goal.x", createdAtMs: 30_500, updatedAtMs: 30_500 }),
     ];
     expect(currentTaskSteps(runs).map((step) => step.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("collapseRepeatedSteps", () => {
+  it("keeps a single step untouched", () => {
+    const steps = [run({ id: "a" })];
+    expect(collapseRepeatedSteps(steps).map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("collapses two runs that would render the identical sentence", () => {
+    // The reported bug: asking twice for something that refuses drew the same
+    // refusal twice, reading as two separate failures.
+    const steps = [
+      run({
+        id: "first",
+        actionId: "location.trigger_sos",
+        phase: "blocked",
+        message: "Add at least one emergency contact before sending an SOS.",
+      }),
+      run({
+        id: "second",
+        actionId: "location.trigger_sos",
+        phase: "blocked",
+        message: "Add at least one emergency contact before sending an SOS.",
+      }),
+    ];
+    expect(collapseRepeatedSteps(steps).map((s) => s.id)).toEqual(["second"]);
+  });
+
+  it("keeps the newest of a repeat, so a retry that succeeds is what shows", () => {
+    const steps = [
+      run({ id: "failed", actionId: "location.refresh", phase: "failed", message: "Same text" }),
+      run({ id: "ok", actionId: "location.refresh", phase: "completed", message: "Same text" }),
+    ];
+    const kept = collapseRepeatedSteps(steps);
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.phase).toBe("completed");
+  });
+
+  it("keeps the same action over different subjects -- those are real separate steps", () => {
+    // Guards the obvious over-collapse: deduping on actionId alone would hide
+    // one of these, and "add Alex and Sam" would silently look like one add.
+    const steps = [
+      run({
+        id: "alex",
+        actionId: "location.add_to_circle",
+        message: "Added to Family.",
+        subject: { name: "Alex" },
+      }),
+      run({
+        id: "sam",
+        actionId: "location.add_to_circle",
+        message: "Added to Family.",
+        subject: { name: "Sam" },
+      }),
+    ];
+    expect(collapseRepeatedSteps(steps).map((s) => s.id)).toEqual(["alex", "sam"]);
+  });
+
+  it("keeps genuinely different steps of one task", () => {
+    const steps = [
+      run({ id: "nav", actionId: "location.open_now", message: "Opening Location" }),
+      run({ id: "act", actionId: "location.share_selected", message: "Sharing" }),
+    ];
+    expect(collapseRepeatedSteps(steps).map((s) => s.id)).toEqual(["nav", "act"]);
   });
 });
 
@@ -209,6 +275,60 @@ describe("VoiceWalkthroughPanel", () => {
 
     expect(onCancel).not.toHaveBeenCalled();
     expect(screen.queryByTestId("voice-walkthrough-panel")).toBeNull();
+  });
+
+  it("shows a repeated refusal once, not stacked", () => {
+    // Two attempts at the same blocked action, close enough together that
+    // currentTaskSteps groups them. The card must not read as two failures.
+    const first = appInteractionCoordinator.startActionRun({
+      actionId: "location.trigger_sos",
+      label: "Send an SOS",
+      source: "voice",
+    });
+    appInteractionCoordinator.finishActionRunFromSettlement(first.id, {
+      status: "blocked",
+      summary: "Add at least one emergency contact before sending an SOS.",
+    });
+    const second = appInteractionCoordinator.startActionRun({
+      actionId: "location.trigger_sos",
+      label: "Send an SOS",
+      source: "voice",
+    });
+    appInteractionCoordinator.finishActionRunFromSettlement(second.id, {
+      status: "blocked",
+      summary: "Add at least one emergency contact before sending an SOS.",
+    });
+
+    render(<VoiceWalkthroughPanel enabled />);
+
+    expect(
+      screen.getAllByText("Add at least one emergency contact before sending an SOS."),
+    ).toHaveLength(1);
+  });
+
+  it("does not truncate a long message -- the whole line stays readable", () => {
+    // The instruction the person has to act on lives in this sentence; an
+    // ellipsis in the middle of it hides the actionable half.
+    const long =
+      "Add at least one emergency contact before sending an SOS, then try again.";
+    const solo = appInteractionCoordinator.startActionRun({
+      actionId: "location.trigger_sos",
+      label: "Send an SOS",
+      source: "voice",
+    });
+    appInteractionCoordinator.finishActionRunFromSettlement(solo.id, {
+      status: "blocked",
+      summary: long,
+    });
+
+    render(<VoiceWalkthroughPanel enabled />);
+
+    const line = screen.getByText(long);
+    // `truncate` is what clipped it: overflow-hidden + nowrap + ellipsis.
+    // Asserting on the class is what actually pins the regression, since
+    // jsdom has no layout to measure a visual clip with.
+    expect(line.className).not.toContain("truncate");
+    expect(line.className).toContain("break-words");
   });
 
   it("shows a live step list for a multi-step task when enabled", () => {

--- a/hushh-webapp/components/agent/voice-walkthrough-panel.tsx
+++ b/hushh-webapp/components/agent/voice-walkthrough-panel.tsx
@@ -46,6 +46,41 @@ export function currentTaskSteps(runs: readonly ActionRun[]): ActionRun[] {
   return group;
 }
 
+/**
+ * Collapse steps that would render identically, keeping the most recent.
+ *
+ * Asking for the same thing twice -- or one directive arriving twice --
+ * produces two runs the card draws as the same sentence, stacked. That reads
+ * as two things having happened when only one did, and it is worst exactly
+ * where it matters most: a refusal repeated verbatim ("Add at least one
+ * emergency contact before sending an SOS") looks like two separate
+ * failures.
+ *
+ * Keyed on the rendered content, deliberately not on `actionId` alone: one
+ * task can legitimately run the same action over different subjects -- add
+ * Alex to Family, then add Sam to Family -- and those are genuinely separate
+ * steps that must both stay visible.
+ */
+export function collapseRepeatedSteps(steps: readonly ActionRun[]): ActionRun[] {
+  const keyOf = (step: ActionRun) =>
+    [
+      step.actionId,
+      step.message || step.label,
+      step.subject?.name ?? "",
+      step.subject?.detail ?? "",
+    // NUL separator, written as an escape so it is visible in source: it
+    // cannot occur inside any of these fields, so two different splits of
+    // the same characters can never collide into one key and wrongly
+    // collapse two genuinely distinct steps.
+    ].join("\u0000");
+  // Keep the LAST occurrence of each key, so the surviving row carries the
+  // newest phase -- a retry that finally succeeds must not be represented by
+  // the failed attempt that came before it.
+  const lastIndexForKey = new Map<string, number>();
+  steps.forEach((step, index) => lastIndexForKey.set(keyOf(step), index));
+  return steps.filter((step, index) => lastIndexForKey.get(keyOf(step)) === index);
+}
+
 function StepIcon({ phase }: { phase: ActionRun["phase"] }) {
   if (phase === "completed") {
     return <CheckCircle2 className="size-4 shrink-0 text-emerald-500" aria-hidden="true" />;
@@ -59,11 +94,25 @@ function StepIcon({ phase }: { phase: ActionRun["phase"] }) {
   return <Loader2 className="size-4 shrink-0 animate-spin text-primary" aria-hidden="true" />;
 }
 
+/**
+ * Wraps rather than truncates. These lines carry the only explanation of what
+ * went wrong -- "Add at least one emergency contact before sending an SOS"
+ * cut to "Add at least one emergency contact before sending..." hides the very
+ * instruction the person needs to act on. The card grows to fit instead.
+ *
+ * `break-words` covers the pathological case an ellipsis used to hide: a
+ * single unbroken token (a long place name, a URL) wider than the card would
+ * otherwise overflow it rather than wrap.
+ */
+const STEP_TEXT_BASE = "min-w-0 flex-1 break-words text-[13px]";
+
 function stepTextClass(phase: ActionRun["phase"]): string {
-  if (phase === "failed" || phase === "blocked") return "truncate text-[13px] text-destructive";
-  if (phase === "cancelled") return "truncate text-[13px] text-muted-foreground";
-  if (phase === "completed") return "truncate text-[13px] text-muted-foreground";
-  return "truncate text-[13px] font-medium text-foreground";
+  if (phase === "failed" || phase === "blocked") {
+    return `${STEP_TEXT_BASE} text-destructive`;
+  }
+  if (phase === "cancelled") return `${STEP_TEXT_BASE} text-muted-foreground`;
+  if (phase === "completed") return `${STEP_TEXT_BASE} text-muted-foreground`;
+  return `${STEP_TEXT_BASE} font-medium text-foreground`;
 }
 
 /**
@@ -92,7 +141,13 @@ export function VoiceWalkthroughPanel({
 }) {
   const runs = useActionRuns();
   const lastRun = runs[runs.length - 1] ?? null;
-  const group = enabled ? currentTaskSteps(runs) : lastRun ? [lastRun] : [];
+  // Only the grouped path needs collapsing -- the single-step path shows one
+  // run, which cannot repeat itself.
+  const group = enabled
+    ? collapseRepeatedSteps(currentTaskSteps(runs))
+    : lastRun
+      ? [lastRun]
+      : [];
   const last = group[group.length - 1] ?? null;
   const active = last ? !isTerminalActionRunPhase(last.phase) : false;
 
@@ -159,8 +214,14 @@ export function VoiceWalkthroughPanel({
       <ul className="flex flex-col gap-2">
         {group.map((step) => (
           <li key={step.id} className="flex flex-col gap-1">
-            <div className="flex items-center gap-2.5">
-              <StepIcon phase={step.phase} />
+            {/* items-start, not items-center: the text now wraps to as many
+                lines as it needs, and centring would drift the icon down
+                beside a tall block instead of marking the line it belongs to.
+                The icon's nudge optically centres it on that first line. */}
+            <div className="flex items-start gap-2.5">
+              <span className="mt-0.5 flex">
+                <StepIcon phase={step.phase} />
+              </span>
               {/* message over label: label is a static per-action-type name
                   ("Leave a circle"), message is the specific, current
                   sentence ("Preparing Leave a circle" while running,
@@ -171,11 +232,11 @@ export function VoiceWalkthroughPanel({
             </div>
             {step.subject ? (
               <div className="ml-[26px] flex min-w-0 flex-col">
-                <span className="truncate text-xs font-medium text-foreground">
+                <span className="break-words text-xs font-medium text-foreground">
                   {step.subject.name}
                 </span>
                 {step.subject.detail ? (
-                  <span className="truncate text-[11px] text-muted-foreground">
+                  <span className="break-words text-[11px] text-muted-foreground">
                     {step.subject.detail}
                   </span>
                 ) : null}


### PR DESCRIPTION
## Summary

Two problems reported on the voice walkthrough card, both visible on one screenshot at once.

**1. Long lines were cut behind an ellipsis.** Every step line carried Tailwind's `truncate` (`overflow: hidden` + `white-space: nowrap` + ellipsis), so anything wider than the card was clipped mid-sentence. That bites hardest on exactly the lines that matter most — a refusal like *"Add at least one emergency contact before sending an SOS"* rendered as *"Add at least one emergency contact before sending…"*, hiding the actionable half of the instruction. The card is `max-w-[min(calc(100vw-3rem),392px)]`, so there was nowhere for the text to go.

Now the text wraps and the card grows to fit. `break-words` handles the one case the ellipsis was quietly covering: a single unbroken token (a long place name, a URL) wider than the card, which would otherwise overflow rather than wrap. The step icon moves to `items-start` with a small optical nudge, so it marks the line it belongs to instead of drifting to the vertical middle of a three-line block. The `subject.name` / `subject.detail` lines had the identical `truncate` and get the same treatment.

**2. A repeated step piled above the new one.** Asking twice for something that refuses produced two runs that render as the same sentence, stacked — reading as two separate failures when only one thing actually happened.

Runs that would render an identical row are now collapsed to the most recent.

Two details worth calling out, because the naive version of this fix is wrong:
- **Keyed on the rendered content, not on `actionId`.** One task can legitimately run the same action over different subjects — *add Alex to Family*, then *add Sam to Family*. Deduping on `actionId` would silently hide one of those, so "add Alex and Sam" would look like a single add. There's a test pinning that.
- **Keeps the newest occurrence, not the first.** A retry that finally succeeds must be what survives, not the failed attempt before it.

## Scope note

I deliberately did **not** change the grouping heuristic itself. `currentTaskSteps` also groups *different* actions that merely arrive within 8s of each other and share no `goalId` (`WALKTHROUGH_GROUP_GAP_MS`), which is a separate way an unrelated earlier action can appear above a newer one. That's the walkthrough feature working as designed — showing a multi-step task's progress — and tightening it would change behavior the existing tests deliberately pin. If unrelated sequential actions should also stop grouping, that's a deliberate product decision and a separate change; happy to make it on request.

## Test plan

- [x] 7 new tests in `__tests__/components/voice-walkthrough-panel.test.tsx`: `collapseRepeatedSteps` unit coverage (identical rows collapse; newest phase survives; same action over different subjects stays; genuinely different steps stay), plus rendered assertions that a repeated refusal appears exactly once and that a long message keeps no `truncate` class.
- [x] `npx vitest run __tests__/components/voice-walkthrough-panel.test.tsx` — 20/20 (was 13).
- [x] `npx vitest run __tests__/components/ __tests__/voice/` — 1501/1502.
- [x] The single failure is `top-app-bar.contract.test.ts`, which this PR does not touch. Verified pre-existing by stashing these changes and re-running it on clean main — it fails identically.
- [x] `npx tsc --noEmit` — clean. `npx eslint --max-warnings=0` on touched files — clean.
- [ ] Visual confirmation on device that a wrapped multi-line error renders as intended — not done in this pass (jsdom has no layout, so the test asserts the class rather than a measured clip).

Reported by Parth from a live session; screenshot showed both issues on one card.
