### PR TITLE
fix(one): publish control-path actions, drop a handler that could never fire

### DIFF
--- a/hushh-webapp/__tests__/voice/location-published-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/location-published-actions.test.ts
@@ -7,6 +7,13 @@ import {
   deriveLocationVoiceActions,
 } from "@/lib/voice/location-voice-actions";
 
+// Mirrors PUBLISHABLE_EXECUTION_PATHS in location-voice-actions.ts.
+// `control` is in the set: agent-action-runtime dispatches it through the
+// same handler registry as `local_handler`, so a control action with a
+// handler runs like a local one. Leaving it out silently dropped
+// location.find_contacts from every Location screen.
+const PUBLISHABLE_PATHS = new Set(["local_handler", "route", "control"]);
+
 /**
  * LOCATION_VOICE_ACTIONS used to be a hand-typed 23-entry list that drifted
  * out of sync with the real contract three times (#6080, #6106-#6112). It is
@@ -23,8 +30,7 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
       .filter(
         (action) =>
           action.execution_target.status === "wired" &&
-          (action.execution_target.path === "local_handler" ||
-            action.execution_target.path === "route") &&
+          PUBLISHABLE_PATHS.has(action.execution_target.path) &&
           action.execution_policy !== "manual_only" &&
           !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
       )
@@ -45,14 +51,29 @@ describe("LOCATION_VOICE_ACTIONS stays in sync with the generated gateway", () =
     expect(LOCATION_VOICE_ACTIONS.length).toBeGreaterThan(25);
   });
 
-  it("includes location.checkout_nearby now that it has a real voice handler", () => {
-    // Used to be excluded: wired in the contract, but its UI called
-    // OneLocationService.checkoutNearby() directly with no
-    // useLocalOnboardingActionHandler registration anywhere. It now has one
-    // in nearby-check-in-sheet.tsx, so LOCATION_VOICE_ACTIONS_EXCLUDE_IDS no
-    // longer carries this id -- confirm both sides of that.
+  it("includes location.checkout_nearby, which executes backend-direct", () => {
+    // Was excluded on the mistaken reading that no local handler meant the
+    // action was broken. It is in BACKEND_DIRECT_ACTION_IDS -- it mutates
+    // server-side and never needed a frontend registration at all.
     expect(LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(CHECKOUT_NEARBY)).toBe(false);
     expect(LOCATION_VOICE_ACTIONS.some((action) => action.actionId === CHECKOUT_NEARBY)).toBe(
+      true,
+    );
+  });
+
+  it("publishes control-path actions, not just local_handler and route", () => {
+    // location.find_contacts is execution_target.path "control". It was wired,
+    // given a handler, and made visible in the gateway -- and still never
+    // offered on any Location screen, because the publish filter admitted only
+    // two of the three runnable paths. The action existed, worked, and was
+    // silently never suggested.
+    const FIND_CONTACTS = "location.find_contacts";
+    const contract = listKaiActionsForSurface({ screen: "one_location" }).find(
+      (action) => action.action_id === FIND_CONTACTS,
+    );
+    expect(contract?.execution_target.status).toBe("wired");
+    expect(contract?.execution_target.path).toBe("control");
+    expect(LOCATION_VOICE_ACTIONS.some((action) => action.actionId === FIND_CONTACTS)).toBe(
       true,
     );
   });
@@ -102,8 +123,7 @@ describe("deriveLocationVoiceActions stays in sync for the map and check-in scre
         .filter(
           (action) =>
             action.execution_target.status === "wired" &&
-            (action.execution_target.path === "local_handler" ||
-              action.execution_target.path === "route") &&
+            PUBLISHABLE_PATHS.has(action.execution_target.path) &&
             action.execution_policy !== "manual_only" &&
             !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
         )

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -1882,32 +1882,13 @@ export function NearbyCheckInSheet({
     }
   };
 
-  // checkout() has no "must be checked in" guard of its own -- today that is
-  // only enforced by the Check out button rendering solely inside the
-  // `state.presence ? (...) : null` branch below. A voice trigger bypasses
-  // that branch entirely, so the guard has to live here instead.
-  useLocalOnboardingActionHandler("location.checkout_nearby", async () => {
-    if (!ownerId || !vaultOwnerToken) {
-      return {
-        status: "blocked" as const,
-        summary: "Unlock One first to check out.",
-      };
-    }
-    if (!state.presence) {
-      return {
-        status: "blocked" as const,
-        summary: "You're not checked in anywhere right now.",
-      };
-    }
-    if (mutationInFlightRef.current) {
-      return {
-        status: "blocked" as const,
-        summary: "Already checking out -- one moment.",
-      };
-    }
-    await checkout();
-    return { status: "succeeded" as const, summary: "You're checked out." };
-  });
+  // No voice handler for location.checkout_nearby lives here, deliberately.
+  // It is in BACKEND_DIRECT_ACTION_IDS (consent-protocol's action_tools.py),
+  // so the backend mutates through the service layer directly and never parks
+  // a client directive for a local handler to pick up -- a handler registered
+  // here could not fire. One briefly existed on the mistaken reading that a
+  // missing local handler meant the action was broken; a backend-direct action
+  // needs no frontend registration at all.
 
   const connect = async (attendee: OneLocationNearbyAttendee) => {
     if (

--- a/hushh-webapp/lib/voice/location-voice-actions.ts
+++ b/hushh-webapp/lib/voice/location-voice-actions.ts
@@ -1,17 +1,29 @@
 import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
 import type { VoiceSurfaceActionDefinition } from "@/lib/voice/voice-types";
 
-// Wired in the generated gateway but with no real handler anywhere in the
-// runtime -- publishing one would offer a voice command guaranteed to fail.
-// Shared across every Location screen id (one_location, one_location_map,
-// one_location_check_in): these are the same underlying actions on each
-// screen, not per-screen exceptions, so the exclusion has to live in one
-// place or a new publishing site can silently reintroduce it.
+// Wired in the generated gateway but with no way to actually run -- publishing
+// one would offer a voice command guaranteed to fail. Shared across every
+// Location screen id (one_location, one_location_map, one_location_check_in):
+// these are the same underlying actions on each screen, not per-screen
+// exceptions, so the exclusion has to live in one place or a new publishing
+// site can silently reintroduce it.
 //
-// location.checkout_nearby used to be here -- it now has a real handler in
-// nearby-check-in-sheet.tsx, so it was removed. Left empty rather than
-// deleted so the next genuinely handlerless action has an obvious home.
+// Empty, and worth keeping that way. Before adding an id here, check whether
+// the action is in BACKEND_DIRECT_ACTION_IDS (consent-protocol's
+// action_tools.py) -- those execute server-side and need no frontend handler
+// at all, so a missing local handler is not evidence that an action is
+// broken. location.checkout_nearby was excluded on exactly that mistaken
+// reading.
 export const LOCATION_VOICE_ACTIONS_EXCLUDE_IDS = new Set<string>([]);
+
+// The execution paths a Location screen can offer. `control` belongs here
+// alongside the other two: agent-action-runtime.ts dispatches it through the
+// same resolveLocalOnboardingHandler registry as `local_handler` (it falls
+// through to it for any path that isn't `route`), so a control-path action
+// with a registered handler runs exactly like a local one. Leaving it out
+// silently dropped location.find_contacts from every Location screen even
+// after it was wired, given a handler, and made visible in the gateway.
+const PUBLISHABLE_EXECUTION_PATHS = new Set(["local_handler", "route", "control"]);
 
 // Derives what a Location screen should publish directly from the generated
 // action gateway, so a new action becomes voice-reachable the moment it is
@@ -24,8 +36,7 @@ export function deriveLocationVoiceActions(
     .filter(
       (action) =>
         action.execution_target.status === "wired" &&
-        (action.execution_target.path === "local_handler" ||
-          action.execution_target.path === "route") &&
+        PUBLISHABLE_EXECUTION_PATHS.has(action.execution_target.path) &&
         action.execution_policy !== "manual_only" &&
         !LOCATION_VOICE_ACTIONS_EXCLUDE_IDS.has(action.action_id),
     )


### PR DESCRIPTION
Two findings from a gap audit of the voice agent. Both come from the same underlying misunderstanding of how an action reaches the runtime, so they're fixed together.

## 1. Control-path actions were never published

`deriveLocationVoiceActions` admitted only `local_handler` and `route`. `location.find_contacts` has `execution_target.path: "control"`, so it was **never offered on any Location screen** — despite being wired, having a handler, and being made visible in the gateway by #6128.

That PR fixed gateway *visibility* and added the handlers, but not *publication*. The action existed, worked, and was silently never suggested — the same bug class #6119 and #6125 were opened for.

`control` belongs alongside the other two: `agent-action-runtime.ts` dispatches it through the same `resolveLocalOnboardingHandler` registry as `local_handler` (it falls through to it for any path that isn't `route`), so a control-path action with a registered handler runs exactly like a local one.

The three runnable paths now live in one named `PUBLISHABLE_EXECUTION_PATHS` set rather than an inline disjunction that's easy to under-specify again.

## 2. A handler that could never fire

The `location.checkout_nearby` handler added in #6127 is removed. The action is in `BACKEND_DIRECT_ACTION_IDS` (`consent-protocol/hushh_mcp/one_adk/action_tools.py:313`) with its own execution branch (`:1335`) and a passing test — backend-direct actions "skip the client-directive/local-handler round trip entirely", so no directive is ever parked for a local handler to pick up.

I added it on the reading that a missing local handler meant the action was broken. That's wrong for every backend-direct action, and #6110 was closed on that wrong diagnosis. The exclusion-list comment now says so explicitly, so the next person checking a "handler-less" action checks `BACKEND_DIRECT_ACTION_IDS` first.

The publishing half of #6127 was correct and is unchanged — the action stays published.

## Test plan

- [x] New test pinning that `location.find_contacts` is `control`-path, wired, **and** present in the published list.
- [x] Updated the test that duplicated the filter inline; both copies now share one `PUBLISHABLE_PATHS` constant mirroring production.
- [x] `checkout_nearby` test reworded to state the real reason it's published (backend-direct), not the wrong one.
- [x] `npx vitest run __tests__/voice/location-published-actions.test.ts __tests__/components/location-immersive-map.test.tsx app/one/location/__tests__/` — 74/74.
- [x] `npx tsc --noEmit`, `npx eslint --max-warnings=0` on touched files — clean.
- [x] No contract/gateway change, so no governed-artifact regeneration.

Addresses two findings from the voice agent gap audit.