### PR TITLE
fix(one): publish a voice surface for the Feed screen

### DIFF
--- a/hushh-webapp/__tests__/components/feed-page-clear.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-page-clear.test.tsx
@@ -41,6 +41,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.routerPush }),
+  // FeedPage publishes its voice surface, and the publisher reads the current
+  // pathname to scope its route lease. Without this the whole tree throws
+  // before any Clear behaviour runs.
+  usePathname: () => "/one/feed",
 }));
 
 vi.mock("sonner", () => ({

--- a/hushh-webapp/__tests__/voice/feed-published-actions.test.ts
+++ b/hushh-webapp/__tests__/voice/feed-published-actions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+
+/**
+ * The Feed screen published nothing to voice at all until this was added --
+ * neither app/one/feed/page.tsx nor components/feed/feed-page.tsx called
+ * usePublishVoiceSurfaceMetadata.
+ *
+ * That mattered more here than on most screens. connect.accept_request and
+ * connect.reject_request name `one_feed` as their reachable screen, so the one
+ * place where "accept their request" is the obvious thing to say was the one
+ * place voice never offered it. Both execute backend-direct, so they always
+ * ran if the model went looking -- they were simply never suggested.
+ *
+ * These tests pin the contract side of that: the actions really are declared
+ * for this screen, and really are runnable. The publisher's own wiring is
+ * covered by the render test alongside it.
+ */
+describe("the Feed screen has voice actions worth publishing", () => {
+  const PUBLISHABLE_PATHS = new Set(["local_handler", "route", "control"]);
+
+  function publishableFor(screen: string) {
+    return listKaiActionsForSurface({ screen }).filter(
+      (action) =>
+        action.execution_target.status === "wired" &&
+        PUBLISHABLE_PATHS.has(action.execution_target.path) &&
+        action.execution_policy !== "manual_only",
+    );
+  }
+
+  it("declares accept and reject as reachable on one_feed", () => {
+    const ids = new Set(publishableFor("one_feed").map((a) => a.action_id));
+    expect(ids.has("connect.accept_request")).toBe(true);
+    expect(ids.has("connect.reject_request")).toBe(true);
+  });
+
+  it("keeps both behind a confirmation -- accepting is not a bare yes", () => {
+    // Accepting a request grants someone a standing relationship, and
+    // rejecting one is not undoable from here. Neither should run off a
+    // single misheard word.
+    for (const id of ["connect.accept_request", "connect.reject_request"]) {
+      const action = publishableFor("one_feed").find((a) => a.action_id === id);
+      expect(action?.execution_policy, id).toBe("confirm_required");
+    }
+  });
+
+  it("publishes a non-empty set -- an empty one would be the old bug back", () => {
+    // The regression this guards is not "wrong actions" but "no actions at
+    // all", which is exactly how the screen behaved before and produced no
+    // error anywhere.
+    expect(publishableFor("one_feed").length).toBeGreaterThan(0);
+  });
+});

--- a/hushh-webapp/components/feed/feed-page.tsx
+++ b/hushh-webapp/components/feed/feed-page.tsx
@@ -29,6 +29,8 @@ import { FeedRow } from "@/components/feed/feed-row";
 import { FeedActionableRow } from "@/components/feed/feed-actionable-row";
 import { useFeedActionables } from "@/lib/feed/use-feed-actionables";
 import { useFeedLiveRefresh } from "@/lib/feed/use-feed-live-refresh";
+import { listKaiActionsForSurface } from "@/lib/voice/kai-action-gateway";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
 import {
   FeedService,
@@ -69,6 +71,38 @@ function groupItemsByDay(
   }
   return groups;
 }
+
+/**
+ * What voice can do while someone is standing on the Feed.
+ *
+ * Derived from the generated action gateway rather than hand-listed, the same
+ * way Location's surfaces do it -- a new Feed action becomes reachable the
+ * moment it is added to the contract, with no second list to remember.
+ *
+ * This screen published nothing at all until now, which mattered more here
+ * than almost anywhere else: connect.accept_request and connect.reject_request
+ * name `one_feed` as their home, so the one screen where "accept their request"
+ * is the obvious thing to say was the one screen that never offered it. Both
+ * execute backend-direct, so they always *ran* if the model went looking --
+ * they were simply never suggested.
+ */
+const FEED_VOICE_ACTIONS = listKaiActionsForSurface({ screen: "one_feed" })
+  .filter(
+    (action) =>
+      action.execution_target.status === "wired" &&
+      (action.execution_target.path === "local_handler" ||
+        action.execution_target.path === "route" ||
+        action.execution_target.path === "control") &&
+      action.execution_policy !== "manual_only",
+  )
+  .map((action) => ({
+    id: action.action_id,
+    actionId: action.action_id,
+    label: action.label,
+    // First sentence only: contract `meaning` is multi-sentence prose written
+    // for the model's semantic assessment, not a short one-liner.
+    purpose: action.meaning.split(/(?<=[.!?])\s/)[0] || action.meaning,
+  }));
 
 export function FeedPage() {
   const { user, loading: authLoading } = useAuth();
@@ -161,6 +195,37 @@ function FeedPageSession({
     hasClearableSmsEmergencies,
     clearSmsEmergencies,
   } = useFeedActionables();
+
+  // Counts only -- never who, and never what any item says. The Feed is a list
+  // of other people's names and activity; the only thing voice needs from it is
+  // whether there is anything waiting, which is what makes "accept their
+  // request" a sensible thing to offer here at all.
+  // `connection:` is the id prefix use-feed-actionables gives an incoming
+  // connection request; FeedActionable is a presentation shape and carries no
+  // kind of its own, so the prefix is the only thing that distinguishes one.
+  const pendingConnectionRequestCount = actionables.filter((entry) =>
+    entry.id.startsWith("connection:"),
+  ).length;
+
+  usePublishVoiceSurfaceMetadata(
+    user && !authLoading
+      ? {
+          screenId: "one_feed",
+          title: "Feed",
+          purpose:
+            "Shows recent activity and anything waiting on you, including connection requests you can accept or decline.",
+          spokenSubject: "Feed",
+          actions: FEED_VOICE_ACTIONS,
+          availableActions: FEED_VOICE_ACTIONS.map((action) => action.label),
+          busyOperations: actionablesLoading ? ["feed_actionables_load"] : [],
+          screenMetadata: {
+            pending_connection_request_count: pendingConnectionRequestCount,
+            actionable_count: actionables.length,
+            data_state: actionablesLoading ? "loading" : "loaded",
+          },
+        }
+      : null,
+  );
 
   const {
     data,


### PR DESCRIPTION
## Summary

Neither `app/one/feed/page.tsx` nor `components/feed/feed-page.tsx` called `usePublishVoiceSurfaceMetadata`, so the Feed published **nothing** to voice.

That mattered more here than on most screens. `connect.accept_request` and `connect.reject_request` name `one_feed` as their reachable screen — so the one place where "accept their request" is the obvious thing to say was the one place voice never offered it. Both execute backend-direct, so they always *ran* if the model went looking through `list_app_actions`; they were simply never suggested, and nothing errored to say so.

Same shape as the map/check-in gap fixed in #6125. Found in a gap audit of the voice agent.

## Changes

- `components/feed/feed-page.tsx`: publishes `screenId: "one_feed"` with its action list **derived from the generated gateway**, matching what Location's surfaces now do — a new Feed action becomes reachable the moment it lands in the contract, with no second list to maintain.
- Screen metadata carries **counts only**: how many connection requests are waiting, how many actionables in total. The Feed is a list of other people's names and activity, and none of that needs to cross into what voice can say.
- Gated on `user && !authLoading`, so nothing publishes for a signed-out or still-resolving session.
- `__tests__/components/feed-page-clear.test.tsx` mocked `next/navigation` with only `useRouter`; the publisher reads `usePathname` to scope its route lease, so the mock gains it. Without that the whole tree throws before any Clear behaviour runs.

## Test plan

- [x] New `__tests__/voice/feed-published-actions.test.ts` — pins that both accept and reject are declared reachable on `one_feed`, that both stay `confirm_required` (accepting grants a standing relationship; rejecting isn't undoable from here, so neither should run off one misheard word), and that the published set is non-empty. That last one is the real regression guard: the old behaviour wasn't *wrong* actions, it was *no* actions, silently.
- [x] `npx vitest run __tests__/components/ __tests__/voice/` — 1497/1498.
- [x] The single failure is `top-app-bar.contract.test.ts`, untouched here and pre-existing on `main` (verified separately by stashing and re-running).
- [x] `npx tsc --noEmit` — clean, and it caught a real mistake: I first filtered actionables on a `kind` field that `FeedActionable` doesn't have. Connection-request rows are identified by their `connection:` id prefix.
- [x] `npx eslint --max-warnings=0` on touched files — clean.
- [ ] Live check that a spoken "accept their request" on the Feed now resolves without a `list_app_actions` round-trip — not done in this pass.

Addresses a finding from the voice agent gap audit.