### PR TITLE
test(one): pin that a shared alias resolves to the action on this screen

### DIFF
--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -4056,6 +4056,54 @@ class TestListAppActions:
         if "email.chat.turn" in by_id:
             assert by_id["email.chat.turn"]["use_tool"] == "ask_email_agent"
 
+    @pytest.mark.asyncio
+    async def test_a_shared_alias_resolves_to_the_action_on_this_screen(self):
+        """Two actions can own the same alias if they live on different screens.
+
+        "people tab" is the honest name for the People tab on BOTH Connect and
+        Location, so neither should give it up -- taking it from one would just
+        break that phrase on that surface. The generator's collision guard
+        allows the pair for exactly this reason: their reachable screens do not
+        overlap.
+
+        What makes that safe is this ordering. Both score identically on an
+        exact alias match, and the tie is broken by _AVAILABILITY_ORDER, so
+        whichever one is reachable from the screen the person is actually on
+        wins. Pinned here because it is the only thing standing between a
+        deliberate shared alias and an arbitrary coin flip, and because the
+        obvious "fix" for such a pair -- deleting one of the aliases -- would
+        be a regression this test should make someone stop and reconsider.
+        """
+        location_state = {_STATE_SCREEN: "one_location"}
+        location_state["hussh:voice_context"] = {
+            "route_pattern": "/one/location",
+            "screen": "one_location",
+            "context_revision": "loc-1",
+            "available_action_ids": ["location.open_people"],
+        }
+        result = await list_app_actions("people tab", _tool_context(location_state))
+        ordered = [r["action_id"] for r in result["results"]]
+        assert "location.open_people" in ordered
+        if "connect.open_people" in ordered:
+            assert ordered.index("location.open_people") < ordered.index(
+                "connect.open_people"
+            ), "the on-screen action must outrank the identically-aliased one"
+
+        connect_state = {_STATE_SCREEN: "connect"}
+        connect_state["hussh:voice_context"] = {
+            "route_pattern": "/connect",
+            "screen": "connect",
+            "context_revision": "con-1",
+            "available_action_ids": ["connect.open_people"],
+        }
+        result = await list_app_actions("people tab", _tool_context(connect_state))
+        ordered = [r["action_id"] for r in result["results"]]
+        assert "connect.open_people" in ordered
+        if "location.open_people" in ordered:
+            assert ordered.index("connect.open_people") < ordered.index(
+                "location.open_people"
+            ), "the same phrase must resolve the other way on the other screen"
+
 
 class TestContractDrivenNavigationJourneys:
     """The navigate-then-execute journey must be authored, not hardcoded.


### PR DESCRIPTION
## Summary

A voice-agent audit flagged twelve aliases owned by two wired actions each — `"people tab"` on both `connect.open_people` and `location.open_people`, `"invite someone"` on both `connect.send_request` and `location.open_invite`, and so on. It looked like an unresolved gap: the generator's collision guard passes them, and an exact whole-query alias match scores `+90` for each.

**It isn't a gap.** Investigating it properly turned up the mechanism that already handles it, so this PR pins that mechanism instead of changing behaviour.

## Why the aliases should stay as they are

`"people tab"` is the honest name for the People tab on **both** Connect and Location. Neither should give it up — taking it from one would simply break that phrase on that surface. The collision guard allows the pair for exactly this reason: their reachable screens don't overlap.

What makes sharing safe is the ordering in `list_app_actions`:

```python
candidates.sort(key=lambda item: (item[0], item[1], item[2]))
#                                 -score,  _AVAILABILITY_ORDER,  label
```

Both tie on `-score`, and the tie breaks on `_AVAILABILITY_ORDER` (`on_screen` 0 → `journey` 1 → `navigate_first` 2). So the action reachable from the screen the person is actually standing on wins, and both are returned regardless (`_MAX_LIST_RESULTS = 10`) with their availability attached.

That was an unwritten property with no test covering it.

## What this adds

One test asserting the resolution goes both ways — `location.open_people` outranks `connect.open_people` while on Location, and the reverse while on Connect.

I verified the assertion isn't vacuous. Querying `"people tab"` from Location really does return both, in this order:

```
location.open_people    on_screen
connect.open_people     journey
```

so the comparison is between two entries that are genuinely present, not an `if` that never fires.

The test also exists to make someone stop before "fixing" such a pair by deleting one of the aliases — that would be a regression dressed as a cleanup, and the docstring says so.

## Test plan

- [x] `pytest tests/test_one_adk_agent_tree.py -k "shared_alias or ranked_results"` — 2 passed.
- [x] Probed the real ranking output directly to confirm both actions appear and are ordered as asserted.
- [x] No production code changed — test-only.

Addresses a finding from the voice agent gap audit, by documenting that it was not a defect.