### PR TITLE
fix(one): stop telling people their action opened in Finance

### DIFF
--- a/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
@@ -59,6 +59,35 @@ function runtimeState(
 }
 
 describe("executeAgentGatewayAction", () => {
+  it("never names a surface the action did not open", async () => {
+    // Regression: this runtime was Kai-only once, and every route action
+    // reported `${label} opened in Finance.` long after it became the shared
+    // path for every surface. Asking for Voice Settings answered "Open Voice
+    // Settings opened in Finance."
+    //
+    // The action's own surface_id is no better -- it names where the action is
+    // authored, not where it lands, so route.voice_settings would claim
+    // "Agents". The summary names no place at all now.
+    const router = { push: vi.fn() };
+
+    const result = await executeAgentGatewayAction({
+      actionId: "route.voice_settings",
+      allowedActionIds: [],
+      userId: "user_1",
+      router,
+      appRuntimeState: runtimeState(),
+      hasPortfolioData: true,
+      busyOperations: {},
+      setAnalysisParams: vi.fn(),
+    });
+
+    expect(result.status).toBe("started");
+    expect(result.resultSummary).not.toMatch(/Finance/i);
+    expect(result.resultSummary).not.toMatch(/Agents/i);
+    // The label alone is the honest description of what happened.
+    expect(result.resultSummary).toBe("Open Voice Settings.");
+  });
+
   it("admits generated direct route actions outside the current screen inventory", async () => {
     const router = { push: vi.fn() };
 

--- a/hushh-webapp/lib/agent/agent-action-runtime.ts
+++ b/hushh-webapp/lib/agent/agent-action-runtime.ts
@@ -507,7 +507,7 @@ export async function executeAgentGatewayAction(
       actionId: input.actionId,
       routeBefore: routeBefore.pathname,
       screenBefore: routeBefore.screen,
-      resultSummary: "Agent could not find that Finance action.",
+      resultSummary: "Agent could not find that action.",
       reason: "missing_action",
     });
   }
@@ -569,7 +569,7 @@ export async function executeAgentGatewayAction(
       resultSummary:
         availability.blocked_guidance ||
         availability.reason ||
-        "That Finance action is not available right now.",
+        "That action is not available right now.",
       reason: availability.status,
     });
   }
@@ -581,7 +581,7 @@ export async function executeAgentGatewayAction(
       label: action.label,
       routeBefore: routeBefore.pathname,
       screenBefore: routeBefore.screen,
-      resultSummary: "That Finance action is not wired for execution yet.",
+      resultSummary: "That action is not wired for execution yet.",
       reason: action.execution_target.status,
     });
   }
@@ -595,7 +595,20 @@ export async function executeAgentGatewayAction(
       routeBefore: routeBefore.pathname,
       routeAfter: action.execution_target.target,
       screenBefore: routeBefore.screen,
-      resultSummary: `${action.label} opened in Finance.`,
+      // The label alone, deliberately -- no destination named.
+      //
+      // This used to say `${label} opened in Finance.` from when this runtime
+      // was Kai-only, so asking for Voice Settings answered "Open Voice
+      // Settings opened in Finance." The action's own `surface_id` is no
+      // better: it names where the action is *authored*, not where it lands,
+      // so route.voice_settings would have claimed "Agents".
+      //
+      // Prefixing instead ("Opened X") does not survive the real labels --
+      // only 39 of 70 route actions start with "Open", and the rest would
+      // read "Opened Share my location" or "Opened Continue". The label is
+      // already an accurate name for what happened, and the card renders it
+      // against a completion tick, which is what supplies the past tense.
+      resultSummary: `${action.label}.`,
       data: {
         target: action.execution_target.target,
         goal_id: action.goal.goal_id,


### PR DESCRIPTION
## Summary

Asking to open Voice Settings answered:

> **Open Voice Settings opened in Finance.**

The action worked — it landed on Voice Settings. The sentence describing it named an app area the person was never in.

`agent-action-runtime.ts` is the shared execution path for **every** surface, but four of its user-facing strings still said "Finance" from when it was Kai-only:

```
"Agent could not find that Finance action."
"That Finance action is not available right now."
"That Finance action is not wired for execution yet."
`${action.label} opened in Finance.`
```

Every surface hits these — Location, Connect, Feed, Settings, RIA. The reported one is just the most visible.

## Why the summary names no place now

Two obvious alternatives are both wrong, so recording why:

**Use the action's `surface_id`.** It records where the action is *authored*, not where it lands. `route.voice_settings` is authored on `one_agents`, so this would have swapped one false claim for another — "opened in Agents".

**Prefix it: `Opened ${label}`.** Doesn't survive the real labels. Only 39 of 70 wired route actions start with "Open"; the rest are "Share my location", "Continue", "Check in", "Claim RIA Profile". That phrasing produces "Opened Share my location" and "Opened Continue".

The label is already an accurate name for what happened, and the walkthrough card renders it against a completion tick — which is what supplies the past tense. So the summary is the label, and nothing else.

## Test plan

- [x] New regression test asserting the summary for `route.voice_settings` contains neither "Finance" **nor** "Agents" (the tempting wrong fix), and is exactly `"Open Voice Settings."`.
- [x] `npx vitest run __tests__/voice/agent-action-runtime.test.ts` — 9/9.
- [x] `npx vitest run __tests__/voice/ __tests__/services/ __tests__/components/` — 2498/2501.
- [x] The 3 failures are `top-app-bar.contract.test.ts` and two `crm-encrypted-fields-v1.test.ts` crypto cases, none touched here. Verified pre-existing by stashing these changes and re-running on clean main — they fail identically.
- [x] `npx tsc --noEmit`, `npx eslint --max-warnings=0` on touched files — clean.
- [x] Checked no test asserted the old copy before changing it.

Reported from a live session: the card showed the wrong app area after a successful navigation.