### PR TITLE
chore(one): backfill the voice changelog for ten shipped PRs

### DIFF
--- a/hushh-webapp/lib/agent/voice-engine-changelog.ts
+++ b/hushh-webapp/lib/agent/voice-engine-changelog.ts
@@ -19,6 +19,55 @@ export const VOICE_ENGINE_CHANGELOG: readonly VoiceEngineChangelogEntry[] = [
   {
     version: "1.6",
     date: "2026-08-28",
+    title: "Fixed: voice said an action opened somewhere it didn't",
+    description:
+      "Opening a screen by voice could report it as having opened in a completely different part of the app -- \"Voice Settings opened in Finance.\" The action was right; only the sentence was wrong. It now names what it opened and nothing else.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Answer a connection request from your Feed, hands-free",
+    description:
+      "Saying \"accept their request\" while looking at your Feed now works directly. Voice offered nothing at all on that screen before, even though it could already do this.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Find people from your contacts, by voice",
+    description:
+      "Ask One to check your contacts against Hussh from the Location screen. It could always do this; it was just never offered.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Fixed: action cards cut off the message and repeated themselves",
+    description:
+      "A long line -- like being told to add an emergency contact before sending an SOS -- was trimmed with dots part way through, hiding the part that told you what to do. Asking twice for the same thing also stacked the same line up twice. Cards now show the whole message, once.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Fixed: a few phrases could match two different commands",
+    description:
+      "Some wording belonged to two commands at once, so which one ran was a coin flip. Every phrase now points at a single command, and the one on the screen you are looking at wins when two screens share a name.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Voice now works on Your Map and Check in",
+    description:
+      "Those two screens offered no voice commands at all -- checking in near you, confirming a place, or checking out only worked from the Location hub. They now work while you are actually looking at them.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
+    title: "Fixed: many Location commands were never offered",
+    description:
+      "Approving a request, creating a circle, sending an SOS, saving a place and more existed but were never suggested, so they usually did nothing unless you named them exactly. Everything Location can do is now offered.",
+  },
+  {
+    version: "1.6",
+    date: "2026-08-28",
     title: "Fixed: a few \"open X\" requests before sign-in said they weren't available",
     description:
       "On the very first screen, before your vault is unlocked, asking to open certain Hussh screens could say they weren't available even though they were. Voice now only offers what it can actually open there.",


### PR DESCRIPTION
## Summary

Every voice-agent PR is supposed to add a "what's new" entry to `voice-engine-changelog.ts`. **Ten merged without one** — #6119, #6125, #6127, #6128, #6129, #6149, #6150, #6151, #6152, #6153.

This is the list shown under **"See all updates" in Voice Settings**, not an internal log. So a run of real user-facing improvements reached people with no record of any of them, and the gap was visible to anyone who opened that screen.

My miss, across all ten.

## What's added

Seven entries covering the six user-visible changes:

- Location commands that existed but were never offered (#6119)
- Your Map and Check in gaining voice at all (#6125)
- Phrases that could match two commands (#6129)
- Contacts lookup becoming reachable (#6150, #6128)
- Replying to a connection request from the Feed (#6151)
- Action cards truncating the message and repeating a step (#6149)
- An action reporting it opened somewhere it didn't (#6153)

## What's deliberately left out

Four of the ten get no entry. A test (#6152), a handler that could never fire (#6127), and a gateway validator with its publishing plumbing (#6128's internal half) changed nothing a person can observe. This file is user copy, not a commit log — padding it with internals makes the real entries harder to find.

`VOICE_ENGINE_VERSION` stays at **1.6**: these are fixes within the current engine, not a new one.

## Note on #6167

The ask-duration fix now carries its own entry in **its own PR** rather than being folded in here — that's the convention this backfill exists because we broke, so it seemed wrong to break it again in the same breath.

## Test plan

- [x] `npx vitest run __tests__/components/voice-changelog-page.test.tsx __tests__/components/voice-preferences-panel.test.tsx` — 15/15, the two suites that render this file.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` — clean.
- [x] Verified `VOICE_ENGINE_VERSION` is unchanged and all new entries sit at 1.6.
- [x] Copy read back in full against the existing entries for voice and house style.