### PR TITLE
style: Standardize SMS Circle icon to match global SMS button

### DIFF
--- a/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
+++ b/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
@@ -237,7 +237,9 @@ describe("ConnectCirclesTab", () => {
     expect(screen.getByText("SMS Circle")).toBeTruthy();
     expect(screen.getByText("Roommates")).toBeTruthy();
     expect(screen.getByTestId("connect-circle-trusted")).toBeTruthy();
-    expect(screen.getByTestId("connect-circle-sms")).toBeTruthy();
+    const smsCircle = screen.getByTestId("connect-circle-sms");
+    expect(smsCircle).toBeTruthy();
+    expect(smsCircle.querySelector("[data-one-sms-text-icon]")).toBeTruthy();
   });
 
   it("renders the server's name for a Circle you do not own", async () => {

--- a/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
+++ b/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { KeyRound, Plus, ShieldCheck, Siren, UsersRound } from "lucide-react";
+import { KeyRound, Plus, ShieldCheck, UsersRound } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import {
@@ -18,6 +18,7 @@ import {
   CreateCircleFlow,
   JoinCircleFlow,
 } from "@/components/one-location/redesign/circles/named-circle-flows";
+import { SmsTextIcon } from "@/components/one-location/redesign/sms-text-icon";
 import { createConnectCircleActions } from "@/components/connect/circles/connect-circle-actions";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 import { CIRCLE_JOIN_CODE_PARAM } from "@/lib/one-location/circle-join-url";
@@ -596,10 +597,21 @@ export function ConnectCirclesTab({
         <SettingsGroup title="Your circles" separatorInset>
           {system.map((circle) => {
             const kind = systemKindOf(circle);
+            const isSmsCircle = kind === "sms";
             return (
               <SettingsRow
                 key={circle.id}
-                icon={kind === "trusted" ? ShieldCheck : Siren}
+                icon={kind === "trusted" ? ShieldCheck : undefined}
+                leading={
+                  isSmsCircle ? (
+                    <span
+                      aria-hidden="true"
+                      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)]"
+                    >
+                      <SmsTextIcon className="text-[8px]" />
+                    </span>
+                  ) : undefined
+                }
                 iconTone="indigo"
                 // The product name only for the Circle that is yours. An SMS
                 // Circle shows up in the list of everyone on it, and the server

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -48,6 +48,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { SmsTextIcon } from "@/components/one-location/redesign/sms-text-icon";
 import { SectionLabel, TrailingValue } from "@/components/app-ui/typography";
 import {
   EmptyState,
@@ -486,7 +487,7 @@ export function CirclesSection({
                     className={cn(
                       "flex h-9 w-9 shrink-0 items-center justify-center",
                       isSmsCircle
-                        ? "rounded-full bg-[#FF3B30] text-[11px] font-bold leading-none tracking-[-0.2px] text-white"
+                        ? "rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)]"
                         : "rounded-[10px] bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#F2F2F7]",
                     )}
                     data-testid={
@@ -496,7 +497,7 @@ export function CirclesSection({
                     }
                   >
                     {isSmsCircle ? (
-                      "SMS"
+                      <SmsTextIcon className="text-[11px] font-bold tracking-[-0.2px]" />
                     ) : showInitials ? (
                       initials
                     ) : (

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -49,6 +49,7 @@ import {
   shortAgo,
   type RequestRecipientStatus,
 } from "@/lib/one-location/request-recipient-status";
+import { SmsTextIcon } from "@/components/one-location/redesign/sms-text-icon";
 import { isSmsTriggeredGrant } from "@/lib/one-location/notifications";
 import {
   formatLocationDurationLabel,
@@ -1717,11 +1718,7 @@ function NowHub({
             title: "Save My Soul",
             subtitle: "Emergency alert",
             ariaLabel: "Save My Soul emergency alert",
-            icon: (
-              <span className="text-[10px] font-semibold leading-none">
-                SMS
-              </span>
-            ),
+            icon: <SmsTextIcon />,
             tone: "red",
             onClick: onSos,
             controlId: "one-location-action-sos",

--- a/hushh-webapp/components/one-location/redesign/sms-text-icon.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-text-icon.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+export function SmsTextIcon({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn("text-[10px] font-semibold leading-none", className)}
+      data-one-sms-text-icon=""
+    >
+      SMS
+    </span>
+  );
+}


### PR DESCRIPTION
### Context
A visual inconsistency where the "SMS Circle" in the Location tab utilized a different icon/avatar style than the standard SMS action buttons used throughout the rest of the application. 

### Changes
* Identified the global SMS icon component used for primary messaging actions.
* Updated the Circles list renderer to utilize this standard SMS icon for the "SMS Circle".
* Ensured the new icon inherits correct sizing/scaling to maintain alignment with other circle avatars (e.g., the "Trusted" circle).

### Testing
* Compiled native assets and synced via Capacitor.
* Verified on the iOS Simulator that the SMS Circle now visually aligns with the app's global design language for SMS actions.