### PR TITLE
fix(one): say "Open in Google Maps" on a shared location

### DIFF
--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -627,7 +627,7 @@ export function SharedWithMeCard({
               rel="noopener noreferrer"
               aria-label="Open shared location in Google Maps"
             >
-              Open in Maps
+              Open in Google Maps
               <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
             </a>
           </Button>


### PR DESCRIPTION
## Summary

The button on a shared location read **"Open in Maps"**. It now reads **"Open in Google Maps"**.

The label was the only thing lagging: the link has always pointed at `google.com/maps` (`lib/one-location/maps-urls.ts`), and the `aria-label` on the same element already said *"Open shared location in Google Maps"* — so a screen reader was getting the accurate name while the visible text was not.

## Test plan

- [x] Checked for other occurrences of the old string across `app`, `components`, `lib`, `__tests__` and `e2e` — none, so no test or spec asserted it.
- [x] Verified the href really is Google Maps before putting that claim in the label.
- [x] `npx tsc --noEmit` — clean.

Addresses #6180.