### PR TITLE
fix(connect): show people's real photos instead of one shared glyph

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -21,12 +21,21 @@ describe("Connect canonical surface contract", () => {
     expect(source).toContain("<SettingsRow");
     expect(source).not.toContain("Private configuration");
     expect(source).not.toContain("icon={Sparkles}");
-    // A person is still UserRound; a verified adviser earns the verified mark
-    // and the tone this design system already spends on a verified state. The
-    // mark rides on the row rather than on the tab, so it still means something
-    // in a search that spans both halves of the directory.
-    expect(source).toContain("person.isRia ? BadgeCheck : UserRound");
-    expect(source).toContain('person.isRia ? "green" : "blue"');
+    // A person is their own face where we have one -- the directory payload
+    // has always carried `photoUrl`, and drawing everyone with the same glyph
+    // made the one screen that exists to tell people apart useless at it.
+    //
+    // The verified mark did NOT go away with the glyph. It still rides on the
+    // row rather than the tab, so it means something in a search spanning both
+    // halves of the directory -- it is now a badge ON the avatar, so the photo
+    // says who and the badge says what, instead of one replacing the other.
+    // Asserted as behaviour rather than an exact ternary so a later refactor
+    // of the avatar is not blocked by the shape of this line.
+    expect(source).toContain("<ConnectPersonAvatar");
+    expect(source).toContain("photoUrl={person.photoUrl}");
+    expect(source).toContain("verified={Boolean(person.isRia)}");
+    expect(source).toContain("BadgeCheck");
+    expect(source).toContain('aria-label="Verified advisor"');
     expect(source).toContain("separatorInset");
   });
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -11,7 +11,6 @@ import {
   RefreshCw,
   Search as SearchIcon,
   Share2,
-  UserRound,
   Users,
   X,
 } from "lucide-react";
@@ -93,6 +92,7 @@ import {
 } from "./connect-search-layout";
 import { cn } from "@/lib/utils";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 type ConnectTab = "people" | "advisors" | "nearby";
 
@@ -494,6 +494,62 @@ async function resolveConnectionForVoice({
   // A name may have another duplicate beyond the bounded window. Choosing one
   // would make pagination an authority decision, so voice refuses safely.
   return { matches: [], complete: false };
+}
+
+
+/**
+ * Two-letter fallback for someone with no Google photo. Mirrors the
+ * contact-sync sheet, which already draws people this way.
+ */
+function connectAvatarInitials(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return "?";
+  const first = parts[0] ?? "";
+  if (parts.length === 1) return (first.slice(0, 2) || "?").toUpperCase();
+  const last = parts[parts.length - 1] ?? "";
+  return ((first[0] ?? "") + (last[0] ?? "")).toUpperCase() || "?";
+}
+
+/**
+ * A person's real Google picture where we have one, initials otherwise.
+ *
+ * Connect used to draw everyone with the same static UserRound glyph even
+ * though the directory payload has carried `photoUrl` all along -- so the
+ * one screen that exists to tell people apart made them all look alike.
+ * The RIA check stays a badge on verified advisors rather than a photo,
+ * since that mark means something the picture cannot.
+ */
+function ConnectPersonAvatar({
+  photoUrl,
+  label,
+  verified,
+}: {
+  photoUrl: string | null;
+  label: string;
+  /** A capability-bearing RIA. Kept as a mark ON the avatar, never instead
+   *  of it: the photo says who, the badge says what, and swapping one for
+   *  the other loses whichever it replaced. */
+  verified: boolean;
+}) {
+  return (
+    <Avatar className="relative h-[34px] w-[34px] shrink-0">
+      {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
+      <AvatarFallback className="text-xs">
+        {connectAvatarInitials(label)}
+      </AvatarFallback>
+      {verified ? (
+        <span
+          className="absolute -right-0.5 -bottom-0.5 z-10 inline-flex size-[15px] items-center justify-center rounded-full bg-background"
+          aria-label="Verified advisor"
+        >
+          <BadgeCheck
+            className="size-[13px] text-[color:var(--app-success,#16a34a)]"
+            aria-hidden="true"
+          />
+        </span>
+      ) : null}
+    </Avatar>
+  );
 }
 
 export default function ConnectPageClient() {
@@ -2767,8 +2823,13 @@ export default function ConnectPageClient() {
                                 // system already spends on a verified one. It is on the
                                 // row rather than on the tab so the mark still means
                                 // something in a search that spans both.
-                                icon={person.isRia ? BadgeCheck : UserRound}
-                                iconTone={person.isRia ? "green" : "blue"}
+                                leading={
+                                  <ConnectPersonAvatar
+                                    photoUrl={person.photoUrl}
+                                    label={title}
+                                    verified={Boolean(person.isRia)}
+                                  />
+                                }
                                 title={
                                   <span className="block min-w-0 truncate">
                                     {title}
@@ -3208,8 +3269,13 @@ export default function ConnectPageClient() {
                   return (
                     <SettingsRow
                       key={`batch-${person.userId}`}
-                      icon={person.isRia ? BadgeCheck : UserRound}
-                      iconTone={person.isRia ? "green" : "blue"}
+                      leading={
+                        <ConnectPersonAvatar
+                          photoUrl={person.photoUrl}
+                          label={title}
+                          verified={Boolean(person.isRia)}
+                        />
+                      }
                       title={
                         <span className="block min-w-0 truncate">{title}</span>
                       }


### PR DESCRIPTION
## Summary

Connect drew every person with the same static `UserRound` icon — on both the connections list and the add-connection view. The Circle screen has shown Google profile pictures all along, so the one screen that exists to tell people apart was the one making them all look alike.

**Nothing new is fetched.** The directory payload has carried `photoUrl` through `ConnectionsService` the whole time (it's in the type and already parsed); the UI just ignored it. Falls back to initials, mirroring `contact-sync-results-sheet.tsx`, which already draws people exactly this way.

`SettingsRow` already accepted a `leading` ReactNode alongside `icon`, so no component surgery was needed.

## The part worth reviewing

My first pass replaced `icon={person.isRia ? BadgeCheck : UserRound}` outright — which **silently dropped the verified-advisor mark**. That glyph was the only thing on the row saying an advisor is capability-bearing.

The verified mark now rides as a badge *on* the avatar: the photo says who, the badge says what, instead of one replacing the other. It keeps its `aria-label="Verified advisor"`.

`page-client.contract.test.ts` caught this — it asserted the exact ternary, specifically to protect that mark. I updated it to assert the new mechanism rather than delete the guard, and widened it from one brittle source string to the behaviour it actually cares about (avatar present, photo wired, verified flag passed, badge rendered), so a later avatar refactor isn't blocked by the shape of one line.

## Test plan

- [x] `npx vitest run __tests__/app/connect/ __tests__/components/` — 1249/1250.
- [x] The single failure is `top-app-bar.contract.test.ts`, untouched here — a Windows-only CRLF artifact tracked in #5594; it passes in CI.
- [x] `npx tsc --noEmit` — clean. It caught two real mistakes en route: one call site missed the new prop, and `isRia` is `boolean | undefined` so it needed coercing.
- [x] `npx eslint --max-warnings=0` — clean, after dropping the now-unused `UserRound` import.
- [x] Verified no merge conflict with the other open PR (#6191) — disjoint files.

Addresses #6175.