### PR TITLE
fix(one): make "Share location" work on the no-active-shares screen

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1445,6 +1445,10 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             vm={vm}
             collapsedGrantIds={collapsedGrantIds}
             onRequestLocation={() => openFlow("ask")}
+            onStartShare={() => {
+              vm.clearNamedCircleShareContext();
+              openShareFlow();
+            }}
             onCollapseGrant={(grantId) =>
               setCollapsedGrantIds((current) => new Set(current).add(grantId))
             }
@@ -2128,6 +2132,7 @@ function LocationDetailFlow({
   focusGrantId,
   collapsedGrantIds,
   onRequestLocation,
+  onStartShare,
   onCollapseGrant,
   onExpandGrant,
 }: {
@@ -2138,6 +2143,9 @@ function LocationDetailFlow({
   focusGrantId?: string | null;
   collapsedGrantIds: Set<string>;
   onRequestLocation?: () => void;
+  /** Opens the share composer AND its flow. Seeding the composer alone
+   *  leaves the person on the same screen with nothing visibly changed. */
+  onStartShare?: () => void;
   onCollapseGrant: (grantId: string) => void;
   onExpandGrant: (grant: OneLocationGrant) => void;
 }) {
@@ -2368,7 +2376,11 @@ function LocationDetailFlow({
                 type="button"
                 size="sm"
                 className="rounded-full"
-                onClick={() => vm.startShareComposer()}
+                // startShareComposer alone only seeds the draft -- it never
+                // opened the flow, so this button did nothing at all.
+                onClick={() =>
+                  onStartShare ? onStartShare() : vm.startShareComposer()
+                }
               >
                 Share location
               </Button>


### PR DESCRIPTION
## Summary

Stopping all location sharing lands you on the **"No active shares"** empty state, whose blue **Share location** button did nothing at all.

## Root cause

```tsx
onClick={() => vm.startShareComposer()}
```

`startShareComposer` seeds the share draft. It does **not** open the share flow — no navigation, no `?action=share`, nothing rendered. The person is left on the same screen with no feedback that anything was pressed.

The equivalent button on the hub does both halves:

```tsx
vm.clearNamedCircleShareContext();
openShareFlow();   // resetShareLocalState + startShareComposer + openFlow("share")
```

`LocationDetailFlow` had no way to reach that. It already takes an `onRequestLocation` callback for exactly this reason — it just never got the share equivalent, so the empty state was left calling the one piece it could see.

## Fix

`LocationDetailFlow` now takes `onStartShare`, and the hub passes **the same handler its own primary button uses** — so the two entry points into sharing can't drift apart again. The prop is optional and falls back to the previous call, so no other caller changes behaviour.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0` — clean.
- [x] `npx vitest run __tests__/components/ __tests__/app/` — 1480/1487.
- [x] The 7 failures are `top-app-bar.contract.test.ts` (Windows CRLF artifact, #5594) and 6 in `__tests__/app/profile/receipts/page.test.tsx`, a file this PR does not touch. Verified pre-existing by stashing these changes and re-running on clean main — identical 6 failures.
- [x] No conflict with the other open PRs — disjoint files, checked with `git merge-tree`.
- [ ] Live tap-through of stop-all → Share location — not done in this pass.

Addresses #6187.