### PR TITLE
fix(one): stop the Feed narrating an SOS as an ordinary share

### DIFF
--- a/consent-protocol/hushh_mcp/services/feed_service.py
+++ b/consent-protocol/hushh_mcp/services/feed_service.py
@@ -74,6 +74,12 @@ _SAFE_METADATA_KEYS = frozenset(
         "user_facing_status",
         "new_status",
         "actor_is_self",
+        # Which lane a location share belongs to ("sos" vs everything else).
+        # Without it the Feed cannot tell an emergency apart from an ordinary
+        # share and narrates both as "shared location, then stopped" -- the
+        # one row where that distinction matters most. A short, bounded enum
+        # written by our own service, carrying nothing about the person.
+        "share_kind",
     }
 )
 

--- a/consent-protocol/tests/test_feed_metadata_allowlist.py
+++ b/consent-protocol/tests/test_feed_metadata_allowlist.py
@@ -1,0 +1,45 @@
+"""The feed metadata allowlist is a privacy boundary, so it gets a test.
+
+`_safe_feed_metadata` decides what crosses from a domain event into the Feed
+payload a browser receives. Everything not named is dropped. That default is
+the right one -- but it means a genuinely needed field fails *silently*, with
+no error anywhere, and the surface simply renders as if the fact did not
+exist.
+
+That is exactly what happened to `share_kind`: an emergency SOS reached the
+Feed indistinguishable from an ordinary share, and narrated as "shared
+location, then stopped", because the one field separating the two lanes was
+being filtered out.
+"""
+
+from hushh_mcp.services.feed_service import _safe_feed_metadata
+
+
+class TestFeedMetadataAllowlist:
+    def test_share_kind_survives_so_an_sos_can_be_told_from_a_share(self):
+        safe = _safe_feed_metadata({"share_kind": "sos"})
+        assert safe.get("share_kind") == "sos"
+
+    def test_unknown_keys_are_still_dropped(self):
+        # The allowlist earns its keeping only if it still refuses everything
+        # it was not asked for -- widening it by one field must not widen the
+        # shape.
+        safe = _safe_feed_metadata(
+            {
+                "share_kind": "sos",
+                "precise_latitude": 19.076,
+                "recipient_email": "someone@example.com",
+                "raw_note": "a user-typed sentence",
+            }
+        )
+        assert safe == {"share_kind": "sos"}
+
+    def test_non_dict_input_is_empty_rather_than_an_error(self):
+        assert _safe_feed_metadata(None) == {}
+        assert _safe_feed_metadata("share_kind=sos") == {}
+
+    def test_values_stay_bounded(self):
+        # A domain event is not a trusted length. An over-long string is
+        # truncated rather than passed through to every Feed reader.
+        safe = _safe_feed_metadata({"counterpart_label": "x" * 5000})
+        assert len(safe["counterpart_label"]) < 5000

--- a/hushh-webapp/__tests__/lib/feed/feed-sos-share-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-sos-share-lines.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
+import type { FeedItem } from "@/lib/services/feed-service";
+
+/**
+ * An SOS must not read as an ordinary share.
+ *
+ * Receiving an emergency alert produced "Shared location with you", then
+ * "Stopped sharing location" -- the same two lines a routine share writes. On
+ * the one screen a person scans to find out what needs them, an emergency was
+ * indistinguishable from someone sharing their location for an hour.
+ *
+ * The cause was not the copy. `share_kind` -- the only field separating the SOS
+ * lane from everything else -- was missing from the feed metadata allowlist in
+ * feed_service.py, so it never reached the client and the distinction could not
+ * be drawn at all. These tests cover the rendering half; the allowlist half is
+ * what makes the metadata arrive.
+ */
+
+function item(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: "feed_1",
+    source_domain: "location",
+    event_type: "location_share_created",
+    actor_label: null,
+    metadata: { counterpart_label: "Ankit" },
+    read: false,
+    created_at: "2026-08-16T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("an SOS share reads as an emergency, not a share", () => {
+  it("names the emergency when one arrives", () => {
+    const line = presentFeedItem(
+      item({
+        metadata: {
+          counterpart_label: "Ankit",
+          share_kind: "sos",
+          feed_audience: "recipient",
+        },
+      }),
+    );
+    expect(line.description).toMatch(/SOS/i);
+    expect(line.description).not.toBe("Shared location with you");
+  });
+
+  it("names the emergency when it ends, rather than 'stopped sharing'", () => {
+    const line = presentFeedItem(
+      item({
+        event_type: "location_share_revoked",
+        metadata: {
+          counterpart_label: "Ankit",
+          share_kind: "sos",
+          feed_audience: "recipient",
+        },
+      }),
+    );
+    expect(line.description).toMatch(/SOS/i);
+    expect(line.description).not.toBe("Stopped sharing location");
+  });
+
+  it("names the emergency when it times out", () => {
+    const line = presentFeedItem(
+      item({
+        event_type: "location_share_expired",
+        metadata: { counterpart_label: "Ankit", share_kind: "sos" },
+      }),
+    );
+    expect(line.description).toMatch(/SOS/i);
+  });
+
+  it("leaves an ordinary share untouched", () => {
+    // The regression guard that matters most: SOS wording must not leak onto
+    // every share. Absent `share_kind`, and for any other lane, the existing
+    // lines stay exactly as they were.
+    for (const metadata of [
+      { counterpart_label: "Ankit", feed_audience: "recipient" },
+      {
+        counterpart_label: "Ankit",
+        feed_audience: "recipient",
+        share_kind: "check_in",
+      },
+    ]) {
+      const created = presentFeedItem(item({ metadata }));
+      expect(created.description).toBe("Shared location with you");
+      const revoked = presentFeedItem(
+        item({ event_type: "location_share_revoked", metadata }),
+      );
+      expect(revoked.description).toBe("Stopped sharing location");
+    }
+  });
+
+  it("still tells the two sides apart for an SOS", () => {
+    // The owner sent it; the recipient received it. Collapsing that would put
+    // "sent an SOS" in front of the person who was alerted.
+    const owner = presentFeedItem(
+      item({ metadata: { counterpart_label: "Ankit", share_kind: "sos" } }),
+    );
+    const recipient = presentFeedItem(
+      item({
+        metadata: {
+          counterpart_label: "Ankit",
+          share_kind: "sos",
+          feed_audience: "recipient",
+        },
+      }),
+    );
+    expect(owner.description).not.toBe(recipient.description);
+  });
+});

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -42,6 +42,20 @@ const DOMAIN_LABEL: Record<FeedSourceDomain, string> = {
   connections: "Connections",
 };
 
+/**
+ * True when this row is an emergency SOS rather than an ordinary share.
+ *
+ * The lane split is "sos" vs everything else, matching _is_sos_lane in
+ * one_location_agent_service.py -- not one lane per share kind. Until
+ * share_kind was added to the feed metadata allowlist this was unknowable
+ * client-side, so an SOS narrated as "Shared location with you", then
+ * "Stopped sharing location": an alert reading as routine activity on the
+ * one screen someone scans to find out what needs them.
+ */
+function isSosShare(metadata: Record<string, unknown>): boolean {
+  return metadataString(metadata, "share_kind").toLowerCase() === "sos";
+}
+
 function metadataString(metadata: Record<string, unknown>, key: string): string {
   const value = metadata[key];
   return typeof value === "string" && value.trim() ? value.trim() : "";
@@ -153,6 +167,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
     case "location_share_created": {
       const hasWho = who !== "Someone";
       const shareAmount = metadataDurationLabel(item.metadata, "duration");
+      const isSos = isSosShare(item.metadata);
       return {
         icon,
         domainLabel,
@@ -160,11 +175,17 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         // For an approval-born share this is the requester's ONLY row (152
         // writes it; 153 deliberately does not add a second for the approval),
         // so it names the granted amount that the event metadata carries.
-        description: sharedWithMe
-          ? shareAmount
-            ? `Shared location with you for ${shareAmount}`
-            : "Shared location with you"
-          : "You started sharing location",
+        description: isSos
+          ? sharedWithMe
+            ? shareAmount
+              ? `Emergency SOS - sharing location with you for ${shareAmount}`
+              : "Emergency SOS - sharing location with you"
+            : "You sent an emergency SOS"
+          : sharedWithMe
+            ? shareAmount
+              ? `Shared location with you for ${shareAmount}`
+              : "Shared location with you"
+            : "You started sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -179,11 +200,15 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         // "owner_revoke" is still true and "You stopped sharing location"
         // would be shown to the one person who did not stop anything.
         // Audience decides the sentence; reason only refines the owner's.
-        description: sharedWithMe
-          ? "Stopped sharing location"
-          : ownerRevoked
-            ? "You stopped sharing location"
-            : "Stopped sharing location",
+        description: isSosShare(item.metadata)
+          ? sharedWithMe
+            ? "Emergency SOS ended"
+            : "You ended your emergency SOS"
+          : sharedWithMe
+            ? "Stopped sharing location"
+            : ownerRevoked
+              ? "You stopped sharing location"
+              : "Stopped sharing location",
         href: ROUTES.ONE_LOCATION,
       };
     }
@@ -195,7 +220,9 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         label: hasWho ? who : "Location",
         // No audience split: this line names no subject, and the row's title is
         // already the other person, so it reads correctly from both sides.
-        description: "Stopped sharing - time ran out",
+        description: isSosShare(item.metadata)
+          ? "Emergency SOS ended - time ran out"
+          : "Stopped sharing - time ran out",
         href: ROUTES.ONE_LOCATION,
       };
     }


### PR DESCRIPTION
## Summary

Receiving an emergency SOS wrote **"Shared location with you"**, then **"Stopped sharing location"** — the same two lines a routine share produces. On the screen a person scans to find out what needs them, an emergency was indistinguishable from someone sharing their location for an hour.

## The cause was not the copy

`share_kind` is the only field separating the SOS lane from everything else (`_is_sos_lane` in `one_location_agent_service.py`). It was **missing from `_SAFE_METADATA_KEYS`** in `feed_service.py`, so it was filtered out before reaching the browser.

The Feed could not draw the distinction because it was never given it. That allowlist fails *silently* by design — an omitted field simply never arrives, nothing errors, and the surface renders as though the fact does not exist. Changing only the frontend copy would have produced no visible change at all.

Worth noting the activity list already handled this correctly, reading `share_kind` server-side. Only the Feed, which renders client-side from the sanitised payload, was blind to it.

## Changes

- **`feed_service.py`** — `share_kind` added to the allowlist. A short, bounded enum written by our own service, carrying nothing about the person.
- **`feed-item-renderers.tsx`** — the created, revoked and expired lines say SOS when it is one, and keep the existing two-sided wording so the sender reads "You sent an emergency SOS" while the recipient reads "Emergency SOS — sharing location with you".

## Test plan

- [x] New `feed-sos-share-lines.test.ts` — SOS wording on all three events, both sides distinguished, **and** a guard that an ordinary share (and the `check_in` lane) is untouched, since the obvious failure mode of this change is SOS wording leaking onto every share.
- [x] New `test_feed_metadata_allowlist.py` — the allowlist had **no test at all** despite being a privacy boundary. Pins that `share_kind` survives, that unknown keys (coordinates, emails, free text) are still dropped, and that values stay bounded — so widening it by one field did not widen the shape.
- [x] `npx vitest run __tests__/lib/feed/` — 83/83.
- [x] `pytest tests/test_feed_metadata_allowlist.py` — 4/4.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0`, `ruff check` — all clean.
- [ ] Live check with a real SOS on UAT — not done in this pass.

Addresses #6181 (P1).