### PR TITLE
fix(one): back from SOS contacts returns to SOS, not People

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -918,6 +918,17 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const nearbyPrivateCheckIn =
     searchParams.get(FLOW_ACTION_PARAM) === PRIVATE_CHECK_IN_ACTION &&
     searchParams.get(FLOW_SOURCE_PARAM) === NEARBY_CHECK_IN_SOURCE;
+  // Editing emergency contacts from SOS is a detour, not a destination.
+  //
+  // "Edit contacts" opens ?action=sms-contacts&source=sos, which then
+  // redirects to the SMS Circle -- and openCircleDetail pins the hub tab
+  // to "people", because that is where circles live. Closing therefore
+  // returned to the People tab and dropped the person out of the SOS flow
+  // they were part-way through. The source param already rode along; only
+  // the way back never read it. Mirrors nearbyPrivateCheckIn above.
+  const editingSosContacts =
+    searchParams.get(FLOW_ACTION_PARAM) === FLOW_TO_ACTION["circle-detail"] &&
+    searchParams.get(FLOW_SOURCE_PARAM) === SOS_FLOW_SOURCE;
   const nearbyReturnToken = searchParams.get(NEARBY_PRIVATE_RETURN_TOKEN_PARAM);
   const nearbyCheckInReturnHref =
     nearbyPrivateCheckIn && isNearbyPrivateReturnToken(nearbyReturnToken)
@@ -1405,7 +1416,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             circleId={String(searchParams.get("circleId") || "")}
             currentUserId={vm.userId}
             busy={vm.busy === "namedCircle"}
-            onBack={() => closeFlow("people")}
+            onBack={() =>
+              editingSosContacts ? openFlow("sos") : closeFlow("people")
+            }
             onLoad={vm.onLoadNamedCircle}
             onLoadOverview={vm.onLoadNamedCircleOverview}
             onLoadMembersPage={vm.onLoadNamedCircleMembersPage}


### PR DESCRIPTION
## Summary

Adding contacts for SMS/SOS and then going back dropped the person on the **People** tab, part-way through setting up an SOS.

## Root cause

"Edit contacts" opens `?action=sms-contacts&source=sos`. That redirects to the SMS Circle, and `openCircleDetail` pins the hub tab:

```ts
params.set(LOCATION_HUB_TAB_PARAM, "people");
```

which is correct in itself — circles live on People. Closing then honoured that tab, because `onBack` was hardcoded to `closeFlow("people")`.

The `source=sos` marker already rode along the entire way. Nothing read it on the way back.

## Fix

`onBack` now checks the source and returns to the SOS flow when the circle detail was reached as a detour from it. This mirrors `nearbyPrivateCheckIn` a few lines above, which solves the identical shape of problem for the check-in detour — same signal, same place, same reasoning.

Only the SOS detour changes. Opening a circle from People still closes back to People.

## Test plan

- [x] `npx vitest run __tests__/components/` — 1167/1168.
- [x] The single failure is `top-app-bar.contract.test.ts`, untouched here — the Windows CRLF artifact tracked in #5594; it passes in CI.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.
- [ ] Live tap-through of SOS → Edit contacts → back — not done in this pass.

Addresses #6177.