### PR TITLE
fix(one): Location Settings opens the app's settings, not the OS screen

### DIFF
--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1524,7 +1524,15 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                 openShareFlow();
               }}
               onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
-              onOpenSettings={vm.onOpenLocationSettings}
+              // The app's own Location settings, not the OS permission
+              // screen. This tile carries voiceActionId
+              // "location.open_settings", a route action to
+              // ?action=settings -- so asking for it by voice already
+              // opened the right screen while tapping it left the app
+              // entirely. onOpenLocationSettings stays where it belongs:
+              // the permission recovery cards, whose whole job is sending
+              // someone to the OS to grant access.
+              onOpenSettings={() => openFlow("settings")}
               onCheckIn={() =>
                 nearbyCheckInAvailable
                   ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)


### PR DESCRIPTION
## Summary

Tapping **Settings** on the Location hub called `OneLocationService.openLocationSettings()` — which leaves the app for the operating system's permission screen. So the one entry point to the app's own privacy and precision controls never reached them.

## The controls already exist

They're rendered as `LocationSettingsFlow` at `?action=settings`. And the tile already carries:

```ts
voiceActionId: "location.open_settings"
```

which is a **route** action pointing at `/one/location?action=settings`. So asking for Location settings by voice opened the right screen, while tapping the tile left the app — the two entry points disagreed, and the contract was the one telling the truth.

## Fix

The tile opens the flow. `openLocationSettings` stays exactly where it makes sense: the two `LocationPermissionRecoveryCard` call sites, whose whole purpose is sending someone to the OS to grant access. Those are deliberately unchanged — a permission-denied card should go to the OS.

## Test plan

- [x] Confirmed the contract's own `meaning` for `location.open_settings` describes the in-app screen ("the privacy and precision controls for location sharing"), so this aligns tap with what voice and the contract already do.
- [x] Verified both permission-recovery call sites still use `onOpenLocationSettings`.
- [x] `npx vitest run __tests__/components/` — 1167/1168; the one failure is `top-app-bar.contract.test.ts`, untouched here, the Windows CRLF artifact from #5594.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.
- [ ] Live tap-through — not done in this pass.

Addresses #6178.