### PR TITLE
fix(one): one ineligible person no longer fails the whole circle add

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -3316,11 +3316,53 @@ class OneLocationCircleService:
                         },
                     )
                 )
-                if any(str(row.get("status") or "") == "active" for row in target_membership_rows):
+                # One ineligible person must not take the rest of the batch
+                # down with them.
+                #
+                # These two rules used to reject the whole request: pick
+                # five people, and if a single one had left the Circle
+                # recently, nobody was added and the only explanation was
+                # that "someone" you selected had left. The rules
+                # themselves are right -- an existing member should not be
+                # re-added, and leaving costs a cooldown that binds the
+                # owner too -- but they are about one person each, so they
+                # now remove that person and let the rest through.
+                #
+                # Nothing is relaxed: a blocked person is still blocked,
+                # the same transaction still covers everyone who does get
+                # added, and an add naming only blocked people still fails
+                # loudly rather than silently succeeding with nobody.
+                blocked_reasons: dict[str, str] = {}
+                for row in target_membership_rows:
+                    blocked_user_id = str(row.get("user_id") or "")
+                    if not blocked_user_id:
+                        continue
+                    if str(row.get("status") or "") == "active":
+                        blocked_reasons[blocked_user_id] = "already_member"
+                    elif bool(row.get("left_recently")):
+                        blocked_reasons[blocked_user_id] = "left_recently"
+                if blocked_reasons:
+                    cleaned_invitee_user_ids = [
+                        user_id
+                        for user_id in cleaned_invitee_user_ids
+                        if user_id not in blocked_reasons
+                    ]
+                if not cleaned_invitee_user_ids:
+                    # Nobody addable. Report the reason that applies to
+                    # everyone named, so a single-person add still gets
+                    # the precise error it always did.
+                    if all(
+                        reason == "already_member" for reason in blocked_reasons.values()
+                    ):
+                        raise OneLocationCircleError(
+                            "LOCATION_CIRCLE_ALREADY_MEMBER",
+                            "One or more selected connections are already in the Circle.",
+                            status_code=409,
+                        )
                     raise OneLocationCircleError(
-                        "LOCATION_CIRCLE_ALREADY_MEMBER",
-                        "One or more selected connections are already in the Circle.",
-                        status_code=409,
+                        "LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY",
+                        "Someone you selected recently left this Circle. Try again later.",
+                        status_code=429,
                     )
                 # Leaving is that person saying no to this Circle specifically,
                 # and it now costs a cooldown the way declining an invitation
@@ -3333,12 +3375,7 @@ class OneLocationCircleService:
                 # It binds the OWNER too. Every other rule here protects the
                 # Circle from its members; this one protects a person from the
                 # Circle, and the owner is who they are leaving.
-                if any(bool(row.get("left_recently")) for row in target_membership_rows):
-                    raise OneLocationCircleError(
-                        "LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY",
-                        "Someone you selected recently left this Circle. Try again later.",
-                        status_code=429,
-                    )
+
                 connection_rows = _all(
                     conn.execute(
                         text(
@@ -3688,6 +3725,13 @@ class OneLocationCircleService:
                 "invites": [],
                 "createdInviteIds": [],
                 "addedUserIds": added_user_ids,
+                # Who was named but not added, and why. Additive: a caller
+                # that ignores this reads exactly what it read before. It
+                # exists so a partial add can SAY it was partial -- without
+                # it, dropping the blocked people would be indistinguishable
+                # from never having selected them.
+                "skippedUserIds": sorted(blocked_reasons),
+                "skippedReasons": dict(blocked_reasons),
             }
         except OneLocationCircleError:
             raise

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -3451,3 +3451,98 @@ def test_a_shared_system_circle_falls_back_rather_than_showing_the_uid() -> None
         }
     )
     assert named["name"] == "hushh Social's SMS Circle"
+
+
+def test_one_person_who_left_recently_does_not_block_the_rest_of_the_batch():
+    """Picking several people and having one be ineligible must not stop the rest.
+
+    Both membership rules used to reject the whole request. Leaving a Circle
+    costs a cooldown that binds the owner too -- correctly, it is how someone
+    says no to a Circle and makes it stick -- but the rule is about ONE person,
+    and applying it to the batch meant nobody was added and the only
+    explanation was that "someone" you selected had left.
+
+    Asserted at the guard rather than through a completed insert: what changed
+    is which people survive it, and the surviving list is what every later
+    step reads. Driving the full write path would need a dozen more positional
+    fixtures and would pin the harness rather than the behaviour.
+    """
+
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {
+            "id": circle_id,
+            "name": "Family",
+            "kind": "family",
+            "owner_user_id": "owner-user",
+            "member_limit": 20,
+        },
+        {"role": "owner", "inviter_display_name": "Owner"},
+        [{"user_id": "friend-one"}, {"user_id": "friend-two"}],
+        None,
+        [{"user_id": "friend-one", "status": "left", "left_recently": True}],
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+
+    with pytest.raises(OneLocationCircleError) as raised:
+        service.create_member_invites(
+            actor_user_id="owner-user",
+            circle_id=circle_id,
+            invitee_user_ids=["friend-one", "friend-two"],
+        )
+
+    # It got PAST the cooldown guard, which used to end the request here.
+    assert raised.value.code != "LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY"
+
+    # And carried only the eligible person forward. The connection lookup is
+    # the first step after the guard, so its parameters are where the filtered
+    # roster first becomes observable.
+    connection_params = [
+        params
+        for sql, params in zip(conn.sql, conn.params)
+        if "FROM one_location_connections" in sql or "connection.id AS connection_id" in sql
+    ]
+    assert connection_params, "expected the connection lookup to run"
+    assert connection_params[0]["invitee_user_ids"] == ["friend-two"]
+
+def test_an_add_naming_only_blocked_people_still_fails_loudly():
+    """Filtering must not turn a doomed request into a silent success.
+
+    With everyone named removed, there is nothing to do -- and returning an
+    empty success would tell the person their add worked when nobody was
+    added. The precise error each rule always raised is still raised.
+    """
+
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {
+            "id": circle_id,
+            "name": "Family",
+            "kind": "family",
+            "owner_user_id": "owner-user",
+            "member_limit": 20,
+        },
+        {"role": "owner", "inviter_display_name": "Owner"},
+        [{"user_id": "friend-one"}],
+        None,
+        [{"user_id": "friend-one", "status": "active", "left_recently": False}],
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+
+    with pytest.raises(OneLocationCircleError) as raised:
+        service.create_member_invites(
+            actor_user_id="owner-user",
+            circle_id=circle_id,
+            invitee_user_ids=["friend-one"],
+        )
+
+    assert raised.value.code == "LOCATION_CIRCLE_ALREADY_MEMBER"
+    assert raised.value.status_code == 409
+    # Unnamed, like every other refusal about somebody else's history.
+    assert "friend-one" not in raised.value.args[0]

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -3502,7 +3502,7 @@ def test_one_person_who_left_recently_does_not_block_the_rest_of_the_batch():
     # roster first becomes observable.
     connection_params = [
         params
-        for sql, params in zip(conn.sql, conn.params)
+        for sql, params in zip(conn.sql, conn.params, strict=True)
         if "FROM one_location_connections" in sql or "connection.id AS connection_id" in sql
     ]
     assert connection_params, "expected the connection lookup to run"


### PR DESCRIPTION
## Summary

Selecting several connections and having a single one be ineligible rejected the **entire** request. Leave someone's Circle, and when they next tried to add several people including you, nobody was added — and the only explanation was that *"someone"* they selected had recently left.

## Why it happened

Two guards in `create_member_invites`, both **right about the person and wrong about the batch**:

```python
if any(status == "active"):        raise LOCATION_CIRCLE_ALREADY_MEMBER
if any(row["left_recently"]):      raise LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY
```

An existing member should not be re-added, and leaving costs a cooldown that deliberately binds the owner too — that cooldown is how someone says no to a Circle and makes it stick. Each rule is a statement about **one** person, so each now removes that person and lets the rest through.

## Nothing is relaxed

- A blocked person is still blocked, still **unnamed** in any message, still never written.
- The same transaction still covers everyone who does get added — filtering happens before the insert, so atomicity over the surviving set is unchanged.
- An add naming **only** blocked people still fails loudly with the precise error it always raised. Filtering must not turn a doomed request into a silent success, and there's a test for exactly that.

## Reporting

The response gains `skippedUserIds` / `skippedReasons`. Without them a partial add can't say it was partial — dropping the blocked people would be indistinguishable from never having selected them. Both keys are additive; a caller ignoring them reads exactly the shape it read before, and `addedUserIds` already existed.

## Test plan

- [x] `pytest tests/services/test_one_location_circle_service.py` — 81/81, including the 79 that already existed.
- [x] New test: one recently-left person among several no longer ends the request, and the connection lookup — the first step past the guard — carries only the eligible person.
- [x] New test: an add naming only blocked people still raises the precise error, unnamed.
- [x] The pre-existing single-person cooldown test still passes unchanged, which is the check that the cooldown itself still binds.
- [x] `ruff check` — clean.
- [ ] Live multi-select add with one recently-departed member — not done in this pass.

Addresses #6182.