### PR TITLE
style: align location icon and title horizontally on map sheet

### DIFF
--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -32,6 +32,9 @@ import { toast } from "sonner";
 
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
 import {
+  MAP_CONSENT_HEADING_ICON_CLASSNAME,
+  MAP_CONSENT_HEADING_ROW_CLASSNAME,
+  MAP_CONSENT_HEADING_TITLE_CLASSNAME,
   MAP_CONSENT_PANEL_BOTTOM_PADDING,
   MAP_CONSENT_PANEL_CLASSNAME,
   MAP_CONSENT_SUPPORTING_LINE,
@@ -2912,9 +2915,11 @@ export function LocationImmersiveMap({
           data-testid="one-location-map-disclosure"
           style={{ paddingBottom: MAP_CONSENT_PANEL_BOTTOM_PADDING }}
         >
-          <div className="flex items-center gap-2">
-            <MapPin className="h-6 w-6 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
-            <h1 className="text-xl font-semibold">{MAP_CONSENT_TITLE}</h1>
+          <div className={MAP_CONSENT_HEADING_ROW_CLASSNAME}>
+            <MapPin className={MAP_CONSENT_HEADING_ICON_CLASSNAME} />
+            <h1 className={MAP_CONSENT_HEADING_TITLE_CLASSNAME}>
+              {MAP_CONSENT_TITLE}
+            </h1>
           </div>
           {/*
             This is the renderer-consent gate: accepting it writes

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2912,8 +2912,10 @@ export function LocationImmersiveMap({
           data-testid="one-location-map-disclosure"
           style={{ paddingBottom: MAP_CONSENT_PANEL_BOTTOM_PADDING }}
         >
-          <MapPin className="h-6 w-6 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
-          <h1 className="mt-3 text-xl font-semibold">{MAP_CONSENT_TITLE}</h1>
+          <div className="flex items-center gap-2">
+            <MapPin className="h-6 w-6 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+            <h1 className="text-xl font-semibold">{MAP_CONSENT_TITLE}</h1>
+          </div>
           {/*
             This is the renderer-consent gate: accepting it writes
             GOOGLE_MAPS_RENDERER_CONSENT_VERSION. That record is unchanged —

--- a/hushh-webapp/components/one-location/map-consent-panel-layout.ts
+++ b/hushh-webapp/components/one-location/map-consent-panel-layout.ts
@@ -57,6 +57,22 @@ export const MAP_CONSENT_PANEL_CLASSNAME =
 export const MAP_CONSENT_PANEL_BOTTOM_PADDING =
   "calc(1.25rem + env(safe-area-inset-bottom))";
 
+/**
+ * Heading row geometry for the icon and title.
+ *
+ * Kept in the shared layout contract so the browser fixture compiles the exact
+ * row utilities the product surface renders. Otherwise the fixture can render
+ * the right HTML but miss the flex utility in its generated CSS.
+ */
+export const MAP_CONSENT_HEADING_ROW_CLASSNAME = "flex items-center gap-2";
+
+/** The icon sizing used beside the heading. */
+export const MAP_CONSENT_HEADING_ICON_CLASSNAME =
+  "h-6 w-6 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]";
+
+/** The title styling used in the consent panel heading. */
+export const MAP_CONSENT_HEADING_TITLE_CLASSNAME = "text-xl font-semibold";
+
 /** Tailwind's `md:` breakpoint -- where the sheet becomes a centred dialog. */
 export const MAP_CONSENT_PANEL_DIALOG_MIN_WIDTH_PX = 768;
 

--- a/hushh-webapp/e2e/one-location-map-consent-panel.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-map-consent-panel.layout.spec.ts
@@ -7,6 +7,9 @@ import { awaitProductFont, productFontStyle } from "./fixtures/product-font";
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
 import {
+  MAP_CONSENT_HEADING_ICON_CLASSNAME,
+  MAP_CONSENT_HEADING_ROW_CLASSNAME,
+  MAP_CONSENT_HEADING_TITLE_CLASSNAME,
   MAP_CONSENT_PANEL_BOTTOM_PADDING,
   MAP_CONSENT_PANEL_CLASSNAME,
   MAP_CONSENT_PANEL_DIALOG_MIN_WIDTH_PX,
@@ -84,10 +87,11 @@ async function buildFixture(): Promise<string> {
     MAP_SURFACE_CLASSNAME,
     MAP_RENDERER_CLASSNAME,
     MAP_CONSENT_PANEL_CLASSNAME,
+    MAP_CONSENT_HEADING_ROW_CLASSNAME,
+    MAP_CONSENT_HEADING_ICON_CLASSNAME,
+    MAP_CONSENT_HEADING_TITLE_CLASSNAME,
     buttonClasses,
-    "mt-3 text-xl font-semibold",
     "mt-2 text-sm leading-6",
-    "h-6 w-6",
   ].join(" ");
   const css = compiler.build(classes.split(/\s+/).filter(Boolean));
 
@@ -113,9 +117,9 @@ async function buildFixture(): Promise<string> {
   <section class="${MAP_CONSENT_PANEL_CLASSNAME}"
            style="padding-bottom:${MAP_CONSENT_PANEL_BOTTOM_PADDING}"
            data-testid="one-location-map-disclosure">
-    <div class="flex items-center gap-2" data-testid="map-consent-heading-row">
-      <svg class="h-6 w-6" viewBox="0 0 24 24"></svg>
-      <h1 class="text-xl font-semibold">${MAP_CONSENT_TITLE}</h1>
+    <div class="${MAP_CONSENT_HEADING_ROW_CLASSNAME}" data-testid="map-consent-heading-row">
+      <svg class="${MAP_CONSENT_HEADING_ICON_CLASSNAME}" viewBox="0 0 24 24"></svg>
+      <h1 class="${MAP_CONSENT_HEADING_TITLE_CLASSNAME}">${MAP_CONSENT_TITLE}</h1>
     </div>
     <p class="mt-2 text-sm leading-6" data-testid="map-consent-support">${MAP_CONSENT_SUPPORTING_LINE}</p>
     <button class="${buttonClasses}" data-testid="one-location-map-consent-continue">Continue</button>

--- a/hushh-webapp/e2e/one-location-map-consent-panel.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-map-consent-panel.layout.spec.ts
@@ -113,8 +113,10 @@ async function buildFixture(): Promise<string> {
   <section class="${MAP_CONSENT_PANEL_CLASSNAME}"
            style="padding-bottom:${MAP_CONSENT_PANEL_BOTTOM_PADDING}"
            data-testid="one-location-map-disclosure">
-    <svg class="h-6 w-6" viewBox="0 0 24 24"></svg>
-    <h1 class="mt-3 text-xl font-semibold">${MAP_CONSENT_TITLE}</h1>
+    <div class="flex items-center gap-2" data-testid="map-consent-heading-row">
+      <svg class="h-6 w-6" viewBox="0 0 24 24"></svg>
+      <h1 class="text-xl font-semibold">${MAP_CONSENT_TITLE}</h1>
+    </div>
     <p class="mt-2 text-sm leading-6" data-testid="map-consent-support">${MAP_CONSENT_SUPPORTING_LINE}</p>
     <button class="${buttonClasses}" data-testid="one-location-map-consent-continue">Continue</button>
   </section>
@@ -273,6 +275,33 @@ test.describe("Your Map consent panel layout", () => {
 
     expect(lines).toBeLessThanOrEqual(2);
     expect(lines).toBe(1);
+  });
+
+  test("keeps the map icon and title on the same heading row", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(await buildFixture());
+    await awaitProductFont(page);
+
+    const row = page.getByTestId("map-consent-heading-row");
+    await expect(row).toBeVisible();
+
+    const alignment = await row.evaluate((node) => {
+      const icon = node.querySelector("svg")!.getBoundingClientRect();
+      const title = node.querySelector("h1")!.getBoundingClientRect();
+      return {
+        iconCenterY: icon.top + icon.height / 2,
+        titleCenterY: title.top + title.height / 2,
+        titleLeft: title.left,
+        iconRight: icon.right,
+      };
+    });
+
+    expect(
+      Math.abs(alignment.iconCenterY - alignment.titleCenterY),
+    ).toBeLessThanOrEqual(2);
+    expect(alignment.titleLeft).toBeGreaterThan(alignment.iconRight);
   });
 
   test("keeps Continue inside the viewport and clear of the bottom edge", async ({


### PR DESCRIPTION
### Context
A visual layout issue on the first-time Map view where the location pin icon and the "Your Map" title were stacked vertically, breaking the intended header design.

### Changes
* Located the first-time map view bottom sheet component.
* Wrapped the location icon and "Your Map" title in a flex container (`flex items-center gap-2`).
* Ensured the icon and text now render side-by-side on a single horizontal line.
* Left all text styling, map state logic, and bottom sheet behaviors completely untouched.

### Testing
* Compiled native assets and synced via Capacitor.
* Verified on the iOS Simulator. The header now correctly displays `[icon] Your Map` inline above the subtitle.