### PR TITLE
Unify One Location person avatars

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1653,9 +1653,11 @@ class OneLocationAgentService:
             allow_email_handle=allow_email_handle,
             fallback="",
         )
+        photo_url = str(row.get("custom_photo_url") or row.get("photo_url") or "").strip()
         return {
             "userId": user_id,
             "displayName": display_name or masked_phone or "Verified user",
+            "photoUrl": photo_url or None,
             "maskedEmail": mask_email(email) if email else None,
             "maskedPhone": masked_phone,
             "phoneVerified": bool(row.get("phone_verified")),
@@ -2545,8 +2547,18 @@ class OneLocationAgentService:
             "ownerUserId": str(row.get("owner_user_id") or ""),
             "recipientUserId": str(row.get("recipient_user_id") or ""),
             "ownerDisplayName": str(row.get("owner_display_name") or "") or None,
+            "ownerPhotoUrl": str(
+                row.get("owner_custom_photo_url") or row.get("owner_photo_url") or ""
+            )
+            or None,
             "ownerMaskedPhone": _mask_phone(row.get("owner_phone_number")),
             "recipientDisplayName": str(row.get("recipient_display_name") or "") or None,
+            "recipientPhotoUrl": str(
+                row.get("recipient_custom_photo_url")
+                or row.get("recipient_photo_url")
+                or ""
+            )
+            or None,
             "recipientMaskedPhone": _mask_phone(row.get("recipient_phone_number")),
             "recipientKeyId": str(row.get("recipient_key_id") or ""),
             "status": str(row.get("status") or ""),
@@ -2642,12 +2654,22 @@ class OneLocationAgentService:
             "ownerUserId": str(row.get("owner_user_id") or ""),
             "requesterUserId": str(row.get("requester_user_id") or ""),
             "requesterDisplayName": str(row.get("requester_display_name") or "") or None,
+            "requesterPhotoUrl": str(
+                row.get("requester_custom_photo_url")
+                or row.get("requester_photo_url")
+                or ""
+            )
+            or None,
             "requesterMaskedPhone": _mask_phone(row.get("requester_phone_number")),
             # Populated only by callers that joined the owner's identity (the
             # requester's own outgoing-request view) -- absent, and so None,
             # for list_pending_owner_requests, which never needs to tell the
             # owner who the owner is.
             "ownerDisplayName": str(row.get("owner_display_name") or "") or None,
+            "ownerPhotoUrl": str(
+                row.get("owner_custom_photo_url") or row.get("owner_photo_url") or ""
+            )
+            or None,
             "ownerMaskedPhone": _mask_phone(row.get("owner_phone_number")),
             "referredByUserId": str(row.get("referred_by_user_id") or "") or None,
             "status": str(row.get("status") or "pending"),
@@ -3772,6 +3794,7 @@ class OneLocationAgentService:
             """
             SELECT
               a.user_id, a.display_name, a.email, a.phone_number, a.phone_verified,
+              COALESCE(a.custom_photo_url, a.photo_url) AS photo_url,
               k.key_id, k.public_key_jwk, k.algorithm, k.created_at AS key_created_at,
               EXISTS (
                 SELECT 1
@@ -3904,6 +3927,7 @@ class OneLocationAgentService:
               SELECT
                 identity.user_id, identity.display_name, identity.email,
                 identity.phone_number, identity.phone_verified,
+                COALESCE(identity.custom_photo_url, identity.photo_url) AS photo_url,
                 LOWER(CASE
                   WHEN BTRIM(COALESCE(identity.display_name, '')) <> ''
                    AND BTRIM(identity.display_name) <> identity.user_id
@@ -3976,6 +4000,7 @@ class OneLocationAgentService:
             )
             SELECT page_rows.user_id, page_rows.display_name, page_rows.email,
                    page_rows.phone_number, page_rows.phone_verified,
+                   page_rows.photo_url,
                    recipient_key.key_id, recipient_key.public_key_jwk,
                    recipient_key.algorithm,
                    recipient_key.created_at AS key_created_at,
@@ -4155,6 +4180,7 @@ class OneLocationAgentService:
             """
             SELECT
               a.user_id, a.display_name, a.email, a.phone_number, a.phone_verified,
+              COALESCE(a.custom_photo_url, a.photo_url) AS photo_url,
               k.key_id, k.public_key_jwk, k.algorithm, k.created_at AS key_created_at
             FROM actor_identity_cache a
             LEFT JOIN LATERAL (
@@ -6630,6 +6656,8 @@ class OneLocationAgentService:
             """
             SELECT
               g.*, owner.display_name AS owner_display_name, owner.phone_number AS owner_phone_number,
+              owner.photo_url AS owner_photo_url,
+              owner.custom_photo_url AS owner_custom_photo_url,
               envelope.id AS map_envelope_id,
               envelope.grant_id AS map_envelope_grant_id,
               envelope.owner_user_id AS map_envelope_owner_user_id,
@@ -7798,6 +7826,8 @@ class OneLocationAgentService:
                     SELECT
                       g.*,
                       r.display_name AS recipient_display_name,
+                      r.photo_url AS recipient_photo_url,
+                      r.custom_photo_url AS recipient_custom_photo_url,
                       r.phone_number AS recipient_phone_number
                     FROM one_location_share_grants g
                     LEFT JOIN actor_identity_cache r ON r.user_id = g.recipient_user_id
@@ -7813,6 +7843,8 @@ class OneLocationAgentService:
                     SELECT
                       g.*,
                       o.display_name AS owner_display_name,
+                      o.photo_url AS owner_photo_url,
+                      o.custom_photo_url AS owner_custom_photo_url,
                       o.phone_number AS owner_phone_number
                     FROM one_location_share_grants g
                     LEFT JOIN actor_identity_cache o ON o.user_id = g.owner_user_id
@@ -7828,10 +7860,17 @@ class OneLocationAgentService:
                     SELECT
                       req.*,
                       requester.display_name AS requester_display_name,
+                      requester.photo_url AS requester_photo_url,
+                      requester.custom_photo_url AS requester_custom_photo_url,
                       requester.phone_number AS requester_phone_number,
+                      owner.display_name AS owner_display_name,
+                      owner.photo_url AS owner_photo_url,
+                      owner.custom_photo_url AS owner_custom_photo_url,
+                      owner.phone_number AS owner_phone_number,
                       extended.expires_at AS extends_grant_expires_at
                     FROM one_location_access_requests req
                     LEFT JOIN actor_identity_cache requester ON requester.user_id = req.requester_user_id
+                    LEFT JOIN actor_identity_cache owner ON owner.user_id = req.owner_user_id
                     -- The live share an extra-time ask is about. Joined here so both
                     -- sides can render "3 more hours on top of the 45 minutes left"
                     -- from the state they already load, with no per-row round trip.
@@ -8108,6 +8147,8 @@ class OneLocationAgentService:
             SELECT
               g.*,
               r.display_name AS recipient_display_name,
+              r.photo_url AS recipient_photo_url,
+              r.custom_photo_url AS recipient_custom_photo_url,
               r.phone_number AS recipient_phone_number
             FROM one_location_share_grants g
             LEFT JOIN actor_identity_cache r ON r.user_id = g.recipient_user_id
@@ -8132,6 +8173,8 @@ class OneLocationAgentService:
             SELECT
               g.*,
               o.display_name AS owner_display_name,
+              o.photo_url AS owner_photo_url,
+              o.custom_photo_url AS owner_custom_photo_url,
               o.phone_number AS owner_phone_number
             FROM one_location_share_grants g
             LEFT JOIN actor_identity_cache o ON o.user_id = g.owner_user_id
@@ -8151,6 +8194,8 @@ class OneLocationAgentService:
             SELECT
               req.*,
               requester.display_name AS requester_display_name,
+              requester.photo_url AS requester_photo_url,
+              requester.custom_photo_url AS requester_custom_photo_url,
               requester.phone_number AS requester_phone_number,
               extended.expires_at AS extends_grant_expires_at
             FROM one_location_access_requests req
@@ -8175,6 +8220,8 @@ class OneLocationAgentService:
             SELECT
               req.*,
               owner.display_name AS owner_display_name,
+              owner.photo_url AS owner_photo_url,
+              owner.custom_photo_url AS owner_custom_photo_url,
               owner.phone_number AS owner_phone_number,
               extended.expires_at AS extends_grant_expires_at
             FROM one_location_access_requests req

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -57,6 +57,7 @@ function initialsFrom(name: string): string {
 
 export function TrustedPersonCard({
   name,
+  photoUrl,
   subtitle,
   tone = "ready",
   statusLabel,
@@ -74,6 +75,7 @@ export function TrustedPersonCard({
   expandedContent,
 }: {
   name: string;
+  photoUrl?: string | null;
   subtitle?: string;
   tone?: "ready" | "pending" | "neutral";
   statusLabel?: string;
@@ -114,7 +116,7 @@ export function TrustedPersonCard({
       )}
     >
       <div className="flex items-center gap-3">
-        <Avatar initials={initialsFrom(name)} />
+        <Avatar initials={initialsFrom(name)} imageUrl={photoUrl} />
         <div className="min-w-0 flex-1">
           <MediumRowLabel
             as="p"
@@ -192,6 +194,7 @@ export function TrustedPersonCard({
 
 export function ActiveShareCard({
   name,
+  photoUrl,
   expiryLabel,
   metaLabel,
   onStop,
@@ -200,6 +203,7 @@ export function ActiveShareCard({
   extendBusy,
 }: {
   name: string;
+  photoUrl?: string | null;
   expiryLabel: string;
   metaLabel?: string;
   onStop: () => void;
@@ -210,7 +214,7 @@ export function ActiveShareCard({
   return (
     <div className={cn(SUBCARD_SURFACE, "space-y-3 p-3.5")}>
       <div className="flex items-center gap-3">
-        <Avatar initials={initialsFrom(name)} />
+        <Avatar initials={initialsFrom(name)} imageUrl={photoUrl} />
         <div className="min-w-0 flex-1">
           <MediumRowLabel as="p" className="truncate">
             Sharing with {name}
@@ -260,6 +264,7 @@ export function ActiveShareCard({
 
 export function RequestCard({
   name,
+  photoUrl,
   promptLine,
   reason,
   approveLabel = "Approve",
@@ -267,6 +272,7 @@ export function RequestCard({
   onDecline,
 }: {
   name: string;
+  photoUrl?: string | null;
   promptLine: string;
   reason?: string;
   approveLabel?: string;
@@ -289,7 +295,7 @@ export function RequestCard({
   return (
     <div className={cn(SUBCARD_SURFACE, "p-4 shadow-none")}>
       <div className="flex items-start gap-3">
-        <Avatar initials={initialsFrom(name)} size={40} />
+        <Avatar initials={initialsFrom(name)} imageUrl={photoUrl} size={40} />
         <div className="min-w-0 flex-1">
           <MediumRowLabel as="p">
             {name}
@@ -379,6 +385,7 @@ export type GrantViewStatus = {
 
 export function SharedWithMeCard({
   name,
+  photoUrl,
   statusLine,
   onView,
   onDismiss,
@@ -399,6 +406,7 @@ export function SharedWithMeCard({
   shareLanes,
 }: {
   name: string;
+  photoUrl?: string | null;
   statusLine: ReactNode;
   onView: () => void;
   onDismiss?: () => void;
@@ -458,7 +466,7 @@ export function SharedWithMeCard({
   return (
     <div className={cn(SUBCARD_SURFACE, "space-y-3 rounded-[18px] p-4 shadow-none")}>
       <div className="flex items-start gap-3">
-        <Avatar initials={initialsFrom(name)} size={40} />
+        <Avatar initials={initialsFrom(name)} imageUrl={photoUrl} size={40} />
         <div className="min-w-0 flex-1">
           <RowLabel as="p">
             {name}

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -55,6 +55,7 @@ import {
   mergeRecipientsByUserId,
   type CircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
+import { ContactAvatar } from "@/components/one-location/redesign/contact-picker/atoms";
 import { CircleGrowActions } from "@/components/one-location/redesign/circles/circle-grow-actions";
 
 import { TaskFlowHeader } from "./primitives";
@@ -84,28 +85,6 @@ const CARD =
 // A thin, touch-friendly scrollbar keeps it unobtrusive on mobile.
 const CONTACT_LIST_SCROLL_CLASS =
   "max-h-[280px] overflow-y-auto overscroll-contain [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/20";
-
-function initialsOf(label: string): string {
-  const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
-  }
-  return (words[0]?.slice(0, 1) || "?").toUpperCase();
-}
-
-/**
- * A person avatar reports no state, so it renders in the NEUTRAL role and lets
- * the initials do the identifying.
- *
- * It used to rotate five raw palette colours by list position, which meant the
- * same contact changed colour whenever the search filter reordered the list,
- * and put danger red on a row that carries no danger.
- */
-const CONTACT_AVATAR_TONE = cn(
-  roleClasses("neutral").tile,
-  roleClasses("neutral").glyph,
-);
-
 
 function accuracyLine(point: PlainLocationPoint | null): string | null {
   if (!point) return null;
@@ -157,6 +136,7 @@ function ContactRow({
   locked,
   completed,
   label,
+  photoUrl,
   fromContacts,
   isLast,
   onToggle,
@@ -166,6 +146,7 @@ function ContactRow({
   locked: boolean;
   completed: boolean;
   label: string;
+  photoUrl?: string | null;
   fromContacts?: boolean;
   isLast: boolean;
   onToggle: () => void;
@@ -183,15 +164,11 @@ function ContactRow({
         disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
       )}
     >
-      <span
-        className={cn(
-          "flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full",
-          CONTACT_AVATAR_TONE,
-        )}
-        aria-hidden
-      >
-        <StatusText as="span">{initialsOf(label)}</StatusText>
-      </span>
+      <ContactAvatar
+        label={label}
+        photoUrl={photoUrl}
+        className="h-[42px] w-[42px]"
+      />
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-start gap-1.5">
           <MediumRowLabel as="span" className="min-w-0 flex-1 truncate">
@@ -771,6 +748,7 @@ export function CheckInFlow({
                 locked={retryLocked}
                 completed={completedRecipientIds.includes(recipient.userId)}
                 label={vm.recipientLabel(recipient)}
+                photoUrl={recipient.photoUrl}
                 fromContacts={recipient.connectedFromContacts}
                 isLast={index === filtered.length - 1}
                 onToggle={() => toggle(recipient.userId)}

--- a/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import Image from "next/image";
 import { Loader2 } from "lucide-react";
 
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
@@ -37,21 +38,39 @@ export function initials(value: string): string {
 
 export function ContactAvatar({
   label,
+  photoUrl,
   className,
 }: {
   label: string;
+  photoUrl?: string | null;
   className?: string;
 }) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(photoUrl) && !imageFailed;
+
   return (
     <span
       className={cn(
-        "flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[15px] font-semibold",
+        "relative flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full text-[15px] font-semibold",
         CONTACT_AVATAR_TONE,
         className,
       )}
       aria-hidden
     >
-      {initials(label)}
+      {showImage && photoUrl ? (
+        <Image
+          src={photoUrl}
+          alt=""
+          fill
+          sizes="52px"
+          unoptimized
+          referrerPolicy="no-referrer"
+          className="object-cover"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        initials(label)
+      )}
     </span>
   );
 }
@@ -134,6 +153,7 @@ export function ContactRowAction({
 
 export function ContactRow({
   label,
+  photoUrl,
   subtitle,
   fromContacts,
   selected,
@@ -143,6 +163,7 @@ export function ContactRow({
   onRemove,
 }: {
   label: string;
+  photoUrl?: string | null;
   subtitle?: string | null;
   fromContacts?: boolean;
   selected: boolean;
@@ -156,7 +177,7 @@ export function ContactRow({
       className="flex min-h-[58px] items-center gap-3 px-3.5 py-2"
       data-testid="contact-picker-row"
     >
-      <ContactAvatar label={label} />
+      <ContactAvatar label={label} photoUrl={photoUrl} />
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-start gap-1.5">
           <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">

--- a/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 type MemberRow = {
   userId: string;
   label: string;
+  photoUrl?: string | null;
   fromContacts: boolean;
   /** Set when the member cannot receive SMS yet; explains why, inline. */
   blockedReason: string | null;
@@ -106,6 +107,7 @@ export function CircleMemberPicker({
     return selection.ready.map((target) => ({
       userId: target.recipient.userId,
       label: recipientLabel(target.recipient),
+      photoUrl: target.recipient.photoUrl,
       fromContacts: Boolean(target.recipient.connectedFromContacts),
       blockedReason: null,
     }));
@@ -121,6 +123,7 @@ export function CircleMemberPicker({
         .map((item) => ({
           userId: item.member.userId,
           label: recipientLabel(item.member),
+          photoUrl: item.member.photoUrl,
           fromContacts: Boolean(item.member.connectedFromContacts),
           blockedReason: item.label,
         }))
@@ -303,7 +306,7 @@ export function CircleMemberPicker({
                         (added || blocked) && "opacity-60",
                       )}
                     >
-                      <ContactAvatar label={row.label} />
+                      <ContactAvatar label={row.label} photoUrl={row.photoUrl} />
                       <span className="min-w-0 flex-1">
                         <span className="flex min-w-0 items-start gap-1.5">
                           <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">

--- a/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
@@ -145,7 +145,7 @@ export function SelectedContactsSheet({
                 const busy = busyUserId === recipient.userId;
                 return (
                   <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
-                    <ContactAvatar label={label} />
+                    <ContactAvatar label={label} photoUrl={recipient.photoUrl} />
                     <span className="min-w-0 flex-1">
                       <span className="flex min-w-0 items-start gap-1.5">
                         <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -27,6 +27,7 @@ import {
   type ReactNode,
 } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
@@ -2326,7 +2327,12 @@ function LocationDetailFlow({
               return (
                 <SettingsRow
                   key={group.counterpartUserId}
-                  leading={<ActiveShareAvatar name={name} />}
+                  leading={
+                    <ActiveShareAvatar
+                      name={name}
+                      photoUrl={group.primaryGrant.recipientPhotoUrl}
+                    />
+                  }
                   title={name}
                   description={
                     single ? (
@@ -2418,6 +2424,7 @@ function LocationDetailFlow({
                   <SharedWithMeCard
                     isSmsTriggered={Boolean(group.smsGrant)}
                     name={ownerName}
+                    photoUrl={grant.ownerPhotoUrl}
                     statusLine={
                       multiLane ? (
                         `${group.grants.length} live shares`
@@ -2556,6 +2563,7 @@ function LocationDetailFlow({
               <div key={request.id} data-request-id={request.id}>
                 <RequestCard
                   name={vm.requesterLabel(request)}
+                  photoUrl={request.requesterPhotoUrl}
                   // The amount, and whether it is extra time on a share already
                   // running. Every card used to read "Asks to see your location"
                   // whether the person wanted fifteen minutes or another day.
@@ -2956,10 +2964,16 @@ function personInitials(name: string): string {
   return ((first[0] ?? "") + (last[0] ?? "")).toUpperCase();
 }
 
-function ActiveShareAvatar({ name }: { name: string }) {
+function ActiveShareAvatar({
+  name,
+  photoUrl,
+}: {
+  name: string;
+  photoUrl?: string | null;
+}) {
   return (
     <span className="relative inline-flex h-10 w-10 shrink-0 items-center justify-center">
-      <Avatar initials={personInitials(name)} size={40} />
+      <Avatar initials={personInitials(name)} imageUrl={photoUrl} size={40} />
       <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[#34C759]" />
     </span>
   );
@@ -3022,6 +3036,7 @@ function StopGrantTextButton({
 /** One person in the People list: avatar (+ live dot) · name · status · action. */
 function PersonRow({
   name,
+  photoUrl,
   fromContacts,
   subtitle,
   active,
@@ -3030,6 +3045,7 @@ function PersonRow({
   expansion,
 }: {
   name: string;
+  photoUrl?: string | null;
   fromContacts?: boolean;
   subtitle: string;
   /** True when there's a live connection (you're sharing or they're sharing). */
@@ -3044,6 +3060,9 @@ function PersonRow({
    */
   expansion?: ReactNode;
 }) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(photoUrl) && !imageFailed;
+
   return (
     // The separator and the hover wash belong to the whole row INCLUDING its
     // breakdown: a person's two shares are one row, and a hairline cutting
@@ -3057,8 +3076,24 @@ function PersonRow({
     >
       <div className="flex min-h-[60px] items-center gap-3 px-4 py-2.5 sm:min-h-16">
         <div className="relative shrink-0">
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#D1D1D6]">
-            {personInitials(name)}
+          <span
+            className="relative flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#D1D1D6]"
+            aria-hidden
+          >
+            {showImage && photoUrl ? (
+              <Image
+                src={photoUrl}
+                alt=""
+                fill
+                sizes="36px"
+                unoptimized
+                referrerPolicy="no-referrer"
+                className="object-cover"
+                onError={() => setImageFailed(true)}
+              />
+            ) : (
+              personInitials(name)
+            )}
           </span>
           {active ? (
             <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]" />
@@ -3403,6 +3438,7 @@ export function PeopleHub({
                       <PersonRow
                         key={r.userId}
                         name={name}
+                        photoUrl={r.photoUrl}
                         fromContacts={r.connectedFromContacts}
                         expansion={
                           shareGroup && !singleGrant ? (
@@ -4147,7 +4183,7 @@ function ShareFlow({
             ? `${selected ? "Deselect" : "Select"} ${label} for private sharing`
             : undefined
         }
-        leading={<Avatar initials={initialsFrom(label)} />}
+        leading={<Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />}
         title={
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -4646,6 +4682,7 @@ function SelectionDot({ selected }: { selected: boolean }) {
 
 function RequestRecipientListRow({
   name,
+  photoUrl,
   fromContacts,
   subtitle,
   tone,
@@ -4662,6 +4699,7 @@ function RequestRecipientListRow({
   expandedContent,
 }: {
   name: string;
+  photoUrl?: string | null;
   fromContacts?: boolean;
   subtitle?: string;
   tone: "ready" | "pending" | "neutral";
@@ -4692,7 +4730,7 @@ function RequestRecipientListRow({
       )}
     >
       <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
-        <ContactAvatar label={name} />
+        <ContactAvatar label={name} photoUrl={photoUrl} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">
@@ -5165,6 +5203,7 @@ function AskFlow({
                 <RequestRecipientListRow
                   key={r.userId}
                   name={recipientLabel}
+                  photoUrl={r.photoUrl}
                   fromContacts={r.connectedFromContacts}
                   subtitle={
                     status.selectable && status.tone === "ready"
@@ -5313,12 +5352,12 @@ function SelectedRecipientsRail({
             {recipients.slice(0, 3).map((recipient) => {
               const label = recipientLabel(recipient);
               return (
-                <span
+                <ContactAvatar
                   key={recipient.userId}
-                  className="flex h-9 w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-surface)] text-[13px] font-semibold text-[color:var(--app-secondary-label)]"
-                >
-                  {initialsFrom(label)}
-                </span>
+                  label={label}
+                  photoUrl={recipient.photoUrl}
+                  className="h-9 w-9 border-2 border-[color:var(--app-card-surface-default-solid)] text-[13px]"
+                />
               );
             })}
             <span className="flex h-9 min-w-9 items-center justify-center rounded-full border-2 border-[color:var(--app-card-surface-default-solid)] bg-[color:var(--app-secondary-surface)] px-2 text-[13px] font-semibold text-[color:var(--app-secondary-label)]">
@@ -5349,7 +5388,11 @@ function SelectedRecipientsRail({
                 role="listitem"
                 className="flex min-h-14 items-center gap-3 px-4 py-2.5"
               >
-                <ContactAvatar label={label} className="h-8 w-8 text-[13px]" />
+                <ContactAvatar
+                  label={label}
+                  photoUrl={recipient.photoUrl}
+                  className="h-8 w-8 text-[13px]"
+                />
                 <span className="flex min-w-0 flex-1 items-start gap-1.5 text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">
                   <span className="min-w-0 flex-1 truncate">{label}</span>
                   {recipient.connectedFromContacts ? (

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -20,11 +20,10 @@ import type {
 import type { CircleRecipientSelection } from "@/lib/one-location/circle-recipient-selection";
 import { TaskFlowHeader } from "@/components/one-location/redesign/primitives";
 import {
-  CONTACT_AVATAR_TONE,
+  ContactAvatar,
   ContactGroup,
   ContactRow,
   EmptyStateCard,
-  initials,
 } from "@/components/one-location/redesign/contact-picker/atoms";
 import { CircleMemberPicker } from "@/components/one-location/redesign/contact-picker/circle-member-picker";
 import { ContactListControls } from "@/components/one-location/redesign/contact-picker/list-controls";
@@ -329,6 +328,7 @@ export function SmsContactsFlow({
                     return (
                       <ContactRow
                         label={label}
+                        photoUrl={recipient.photoUrl}
                         subtitle={recipientSubtitle(recipient)}
                         fromContacts={recipient.connectedFromContacts}
                         selected={selectedIds.has(recipient.userId)}
@@ -387,15 +387,11 @@ export function SmsContactsFlow({
                 orange well read as "attention" on a face, and white on
                 --app-warning measures ~2.2:1. The danger in this dialog is
                 carried by the red Remove button and the title copy. */}
-            <span
-              className={cn(
-                "flex h-[52px] w-[52px] items-center justify-center rounded-[16px] text-xl font-semibold",
-                CONTACT_AVATAR_TONE,
-              )}
-              aria-hidden
-            >
-              {pendingRemoval ? initials(recipientLabel(pendingRemoval)) : "?"}
-            </span>
+            <ContactAvatar
+              label={pendingRemoval ? recipientLabel(pendingRemoval) : "?"}
+              photoUrl={pendingRemoval?.photoUrl}
+              className="h-[52px] w-[52px] rounded-[16px] text-xl"
+            />
             <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-semibold !leading-[25px] !tracking-normal">
               <span className="text-foreground">
                 Remove{" "}

--- a/hushh-webapp/lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mergeRecipientsByUserId,
+  resolveCircleRecipientSelection,
+} from "@/lib/one-location/circle-recipient-selection";
+import type { OneLocationCircleDetail, OneLocationRecipient } from "@/lib/one-location/types";
+
+const publicKeyJwk: JsonWebKey = { kty: "EC" };
+
+describe("circle recipient avatar identity", () => {
+  it("preserves member photo URLs when resolving Circle recipients", () => {
+    const circle: OneLocationCircleDetail = {
+      id: "circle-family",
+      name: "Family",
+      kind: "family",
+      role: "owner",
+      memberCount: 2,
+      memberLimit: 100,
+      members: [
+        {
+          userId: "person-1",
+          displayName: "Roopmann V",
+          photoUrl: "https://lh3.googleusercontent.com/avatar",
+          role: "member",
+          status: "active",
+          phoneVerified: true,
+          canReceiveLocation: true,
+          keyId: "key-person-1",
+          publicKeyJwk,
+        },
+      ],
+    };
+
+    const selection = resolveCircleRecipientSelection({ circle });
+
+    expect(selection.ready[0]?.recipient.photoUrl).toBe(
+      "https://lh3.googleusercontent.com/avatar",
+    );
+  });
+
+  it("does not overwrite an existing recipient photo with a null Circle value", () => {
+    const directoryRecipient: OneLocationRecipient = {
+      userId: "person-1",
+      displayName: "Roopmann V",
+      photoUrl: "https://lh3.googleusercontent.com/directory-avatar",
+      phoneVerified: true,
+      keyAlgorithm: "test",
+      canReceiveLocation: true,
+    };
+    const circleRecipient: OneLocationRecipient = {
+      ...directoryRecipient,
+      photoUrl: null,
+      keyId: "key-person-1",
+      publicKeyJwk,
+    };
+
+    expect(
+      mergeRecipientsByUserId([directoryRecipient], [circleRecipient])[0]?.photoUrl,
+    ).toBe("https://lh3.googleusercontent.com/directory-avatar");
+  });
+});

--- a/hushh-webapp/lib/one-location/circle-recipient-selection.ts
+++ b/hushh-webapp/lib/one-location/circle-recipient-selection.ts
@@ -83,6 +83,7 @@ export function resolveCircleRecipientSelection(params: {
       recipient: {
         userId,
         displayName: member.displayName,
+        photoUrl: member.photoUrl ?? null,
         phoneVerified: member.phoneVerified,
         keyId: member.keyId!,
         publicKeyJwk: member.publicKeyJwk!,
@@ -145,6 +146,7 @@ export function mergeRecipientsByUserId(
           recipient.recommendationReasons ?? existing?.recommendationReasons,
         recommendationSummary:
           recipient.recommendationSummary ?? existing?.recommendationSummary,
+        photoUrl: recipient.photoUrl ?? existing?.photoUrl ?? null,
       });
     }
   }

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -64,6 +64,7 @@ export type OneLocationRecommendationReason = {
 export type OneLocationRecipient = {
   userId: string;
   displayName: string;
+  photoUrl?: string | null;
   maskedPhone?: string | null;
   phoneVerified: boolean;
   keyId?: string | null;
@@ -179,8 +180,10 @@ export type OneLocationGrant = {
   ownerUserId: string;
   recipientUserId: string;
   ownerDisplayName?: string | null;
+  ownerPhotoUrl?: string | null;
   ownerMaskedPhone?: string | null;
   recipientDisplayName?: string | null;
+  recipientPhotoUrl?: string | null;
   recipientMaskedPhone?: string | null;
   recipientKeyId: string;
   status: "active" | "expired" | "revoked" | string;
@@ -213,7 +216,11 @@ export type OneLocationAccessRequest = {
   ownerUserId: string;
   requesterUserId: string;
   requesterDisplayName?: string | null;
+  requesterPhotoUrl?: string | null;
   requesterMaskedPhone?: string | null;
+  ownerDisplayName?: string | null;
+  ownerPhotoUrl?: string | null;
+  ownerMaskedPhone?: string | null;
   referredByUserId?: string | null;
   status: "pending" | "approved" | "denied" | "cancelled" | string;
   message?: string | null;


### PR DESCRIPTION
## Summary
- Add `photoUrl` to One Location recipient/grant/request payloads and TS contracts.
- Preserve Circle member photos when resolving Circle recipients for share/check-in/SMS flows.
- Render real person photos across Location People, share/request pickers, selected-recipient summaries, Active Shares, Shared With Me, Needs Review, SMS contact management, and Check-In rows with initials fallback.

## Verification
- `git diff --check` ✅
- `python -m py_compile consent-protocol/hushh_mcp/services/one_location_agent_service.py` ✅
- `npx vitest run lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts` ✅ 2 tests passed
- `npm run typecheck` ⚠️ blocked by pre-existing unrelated `lib/services/agent-chat-client.ts` errors around missing `@ag-ui/client` typings/implicit anys; no remaining Location avatar errors after fix.

## Notes
- No route, handler, Circle membership, share, stop, search, add person, or navigation behavior changed.
- Client renders only backend-provided identity `photoUrl`; it does not derive avatar URLs from email.