### PR TITLE
Fix Connect tabs and nearby loading retention

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1040,7 +1040,8 @@ textarea {
   );
   --app-segmented-active-surface: #ffffff;
   --app-segmented-active-foreground: #000000;
-  --app-segmented-active-border: #000000;
+  --app-segmented-active-border: rgba(60, 60, 67, 0.08);
+  --app-segmented-active-shadow: 0 1px 2px rgba(60, 60, 67, 0.08);
   --app-shell-surface-bg: var(--app-glass-surface);
   --app-shell-surface-bg-hover: rgba(255, 255, 255, 0.9);
   --app-shell-surface-border: var(--app-glass-border);
@@ -3711,7 +3712,8 @@ body:has([data-testid="one-location-onboarding"]) [data-app-bottom-chrome-glass]
   --app-card-shadow-feature: none;
   --app-segmented-active-surface: var(--app-neutral-fill-strong);
   --app-segmented-active-foreground: #ffffff;
-  --app-segmented-active-border: #ffffff;
+  --app-segmented-active-border: rgba(235, 235, 245, 0.1);
+  --app-segmented-active-shadow: none;
   --app-shell-surface-bg: var(--app-glass-surface);
   --app-shell-surface-bg-hover: rgba(48, 48, 52, 0.96);
   --app-shell-surface-border: rgba(255, 255, 255, 0.08);

--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -87,6 +87,14 @@ function result(overrides: Record<string, unknown> = {}) {
 
 const getIdToken = async () => "id-token";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.locationState = {
@@ -208,6 +216,35 @@ describe("AdvisorsNearby", () => {
 
     await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
     expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
+  });
+
+  it("keeps the current rows visible while a radius change refreshes", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    const nextSearch = deferred<ReturnType<typeof result>>();
+    mocks.searchNearby
+      .mockResolvedValueOnce(result())
+      .mockReturnValueOnce(nextSearch.promise);
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await screen.findByText("Christine Cote");
+
+    fireEvent.click(screen.getByText("25 mi"));
+
+    expect(screen.getByText("Christine Cote")).toBeTruthy();
+    expect(screen.queryByTestId("advisors-loading")).toBeNull();
+    expect(await screen.findByTestId("advisors-refreshing")).toBeTruthy();
+
+    nextSearch.resolve(
+      result({
+        items: [{ ...ADVISOR, id: "new-advisor", name: "Taylor Morgan" }],
+      }),
+    );
+    expect(await screen.findByText("Taylor Morgan")).toBeTruthy();
   });
 
   it("pages from the offset the server returned", async () => {
@@ -518,9 +555,9 @@ describe("AdvisorsNearby", () => {
     expect(screen.queryByTestId("advisors-error")).toBeNull();
   });
 
-  it("drops a stale paging cursor when a fresh search fails", async () => {
-    // Otherwise "Show more" survives the failure and pages into a list that no
-    // longer exists.
+  it("keeps rows but drops a stale paging cursor when a fresh search fails", async () => {
+    // A radius refresh should not blank the list, but "Show more" must not
+    // survive from the previous radius and page into the wrong result set.
     mocks.locationState = {
       status: "ready",
       permission: "granted",
@@ -537,7 +574,11 @@ describe("AdvisorsNearby", () => {
     mocks.searchNearby.mockRejectedValueOnce(new Error("Not available yet."));
     fireEvent.click(screen.getByText("25 mi"));
 
-    expect(await screen.findByTestId("advisors-error")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByTestId("advisors-refreshing")).toBeNull(),
+    );
+    expect(screen.getByText("Christine Cote")).toBeTruthy();
+    expect(screen.queryByTestId("advisors-error")).toBeNull();
     expect(screen.queryByText("Show more")).toBeNull();
   });
 

--- a/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
@@ -95,6 +95,14 @@ function result(overrides: Record<string, unknown> = {}) {
 
 const getIdToken = async () => "id-token";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.locationState = {
@@ -289,6 +297,37 @@ describe("InsuranceAgentsNearby", () => {
     fireEvent.click(screen.getByText("25 mi"));
     await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
     expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
+  });
+
+  it("keeps the current rows visible while a radius change refreshes", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 47.6769, longitude: -122.206 },
+      error: null,
+    };
+    const nextSearch = deferred<ReturnType<typeof result>>();
+    mocks.searchNearby
+      .mockResolvedValueOnce(result())
+      .mockReturnValueOnce(nextSearch.promise);
+
+    render(<InsuranceAgentsNearby getIdToken={getIdToken} />);
+    await screen.findByText("B G I Agency Network Inc.");
+
+    fireEvent.click(screen.getByText("25 mi"));
+
+    expect(screen.getByText("B G I Agency Network Inc.")).toBeTruthy();
+    expect(screen.queryByTestId("insurance-agents-loading")).toBeNull();
+    expect(
+      await screen.findByTestId("insurance-agents-refreshing"),
+    ).toBeTruthy();
+
+    nextSearch.resolve(
+      result({
+        items: [{ ...AGENCY, id: "new-agency", name: "Evergreen Coverage" }],
+      }),
+    );
+    expect(await screen.findByText("Evergreen Coverage")).toBeTruthy();
   });
 
   it("filters fetched agencies locally and can clear a no-match search", async () => {
@@ -499,7 +538,7 @@ describe("InsuranceAgentsNearby", () => {
     expect(screen.getByText("B G I Agency Network Inc.")).toBeTruthy();
   });
 
-  it("drops a stale paging cursor when a fresh search fails", async () => {
+  it("keeps rows but drops a stale paging cursor when a fresh search fails", async () => {
     mocks.searchNearby.mockResolvedValueOnce(
       result({
         meta: {
@@ -528,9 +567,11 @@ describe("InsuranceAgentsNearby", () => {
     fireEvent.click(screen.getByText("25 mi"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("insurance-agents-error")).toBeTruthy(),
+      expect(screen.queryByTestId("insurance-agents-refreshing")).toBeNull(),
     );
-    // The old cursor points into a list that no longer exists.
+    expect(screen.getByText("B G I Agency Network Inc.")).toBeTruthy();
+    expect(screen.queryByTestId("insurance-agents-error")).toBeNull();
+    // The old cursor points into the previous radius result set.
     expect(screen.queryByText("Show more")).toBeNull();
   });
 

--- a/hushh-webapp/components/connect/__tests__/nearby-directories.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/nearby-directories.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/connect/advisors-nearby", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    AdvisorsNearby: () => {
+      const [count, setCount] = React.useState(0);
+      return (
+        <button
+          type="button"
+          data-testid="advisors-pane"
+          onClick={() => setCount((current) => current + 1)}
+        >
+          advisors {count}
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock("@/components/connect/insurance-agents-nearby", () => ({
+  InsuranceAgentsNearby: () => (
+    <div data-testid="insurance-pane">insurance</div>
+  ),
+}));
+
+vi.mock("@/components/connect/places-nearby", () => ({
+  PlacesNearby: () => <div data-testid="places-pane">places</div>,
+}));
+
+import { NearbyDirectories } from "@/components/connect/nearby-directories";
+
+describe("NearbyDirectories", () => {
+  it("keeps a visited Around You directory mounted when switching away and back", () => {
+    render(<NearbyDirectories getIdToken={async () => "id-token"} />);
+
+    fireEvent.click(screen.getByTestId("advisors-pane"));
+    expect(screen.getByText("advisors 1")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("nearby-directory-insurance"));
+    expect(screen.getByTestId("insurance-pane")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("nearby-directory-advisors"));
+    expect(screen.getByText("advisors 1")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/places-nearby.test.tsx
@@ -93,6 +93,14 @@ const LOCATED = {
   error: null,
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.locationState = {
@@ -289,6 +297,32 @@ describe("PlacesNearby", () => {
 
     await waitFor(() => expect(mocks.streamNearby).toHaveBeenCalledTimes(2));
     expect(mocks.streamNearby.mock.calls[1][0].radiusMi).toBe(15);
+  });
+
+  it("keeps current rows visible while a radius change refreshes", async () => {
+    mocks.locationState = LOCATED;
+    const secondSweep = deferred<void>();
+    mocks.streamNearby
+      .mockImplementationOnce(
+        streamOf([{ category: "hotels_stays", items: [place()] }]),
+      )
+      .mockImplementationOnce(async () => {
+        await secondSweep.promise;
+      });
+
+    render(<PlacesNearby getIdToken={getIdToken} />);
+    await screen.findByText("Hotel Vivanta");
+
+    fireEvent.click(screen.getByText("15 mi"));
+
+    expect(screen.getByText("Hotel Vivanta")).toBeTruthy();
+    expect(screen.queryByTestId("places-loading")).toBeNull();
+    expect(screen.getByTestId("places-streaming")).toBeTruthy();
+
+    secondSweep.resolve();
+    await waitFor(() =>
+      expect(screen.queryByTestId("places-streaming")).toBeNull(),
+    );
   });
 
   it("filters fetched places locally and can clear a no-match search", async () => {

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -72,6 +72,11 @@ export function AdvisorsNearby({
   const debouncedQuery = useDebouncedValue(query, 200);
 
   const requestRef = useRef(0);
+  const cardsRef = useRef<AdvisorCard[]>([]);
+
+  useEffect(() => {
+    cardsRef.current = cards;
+  }, [cards]);
 
   useEffect(() => {
     if (!location.snapshot) return;
@@ -92,6 +97,7 @@ export function AdvisorsNearby({
       if (offset === 0) {
         setLoading(true);
         setError(null);
+        setMeta(null);
       } else {
         setLoadingMore(true);
       }
@@ -113,9 +119,12 @@ export function AdvisorsNearby({
         if (token !== requestRef.current) return;
         setMeta(result.meta);
         setAttribution(result.attribution ?? null);
-        setCards((previous) =>
-          offset === 0 ? result.items : [...previous, ...result.items],
-        );
+        setCards((previous) => {
+          const next =
+            offset === 0 ? result.items : [...previous, ...result.items];
+          cardsRef.current = next;
+          return next;
+        });
       } catch (caught) {
         if (token !== requestRef.current) return;
         const message =
@@ -123,11 +132,15 @@ export function AdvisorsNearby({
             ? caught.message
             : "Advisors are unavailable right now.";
         if (offset === 0) {
-          // A fresh search that failed has nothing to show, and its old paging
-          // cursor now points into a list that no longer exists.
-          setError(message);
-          setCards([]);
-          setMeta(null);
+          if (cardsRef.current.length > 0) {
+            setPageError(message);
+          } else {
+            // A cold search that failed has nothing to show, and its old paging
+            // cursor now points into a list that no longer exists.
+            setError(message);
+            setCards([]);
+            setMeta(null);
+          }
         } else {
           // A failed page must not take the page already on screen with it.
           setPageError(message);
@@ -194,6 +207,8 @@ export function AdvisorsNearby({
     meta?.radiusAdjusted && meta.radiusMi
       ? `Within ${meta.radiusMi} mi.`
       : null;
+  const blockingLoading = loading && cards.length === 0;
+  const refreshing = loading && cards.length > 0;
 
   return (
     <div className="space-y-4" data-testid="advisors-nearby">
@@ -201,14 +216,14 @@ export function AdvisorsNearby({
         value={String(radiusMi)}
         onValueChange={(value) => setRadiusMi(Number(value))}
         options={RADIUS_OPTIONS}
-        disabled={loading}
+        disabled={blockingLoading}
       />
 
       {narrowed ? (
         <p className="type-footnote text-muted-foreground">{narrowed}</p>
       ) : null}
 
-      {!error && !loading && cards.length > 0 ? (
+      {!error && cards.length > 0 ? (
         <NearbyDirectorySearch
           value={query}
           onChange={setQuery}
@@ -217,7 +232,7 @@ export function AdvisorsNearby({
         />
       ) : null}
 
-      {error && !loading ? (
+      {error && !blockingLoading ? (
         // A failed search must still offer the ZIP box. "Try again" only
         // re-runs the anchor that just failed, so on its own it strands anyone
         // whose ZIP was the problem — the only way out was to leave the tab and
@@ -247,7 +262,7 @@ export function AdvisorsNearby({
         </QuietBlock>
       ) : null}
 
-      {!error && !loading && cards.length === 0 ? (
+      {!error && !blockingLoading && cards.length === 0 ? (
         // Coordinates can be perfectly good and still match nobody — FINRA is a
         // US register. Offer the one input that can actually help rather than a
         // dead end.
@@ -271,7 +286,7 @@ export function AdvisorsNearby({
         </QuietBlock>
       ) : null}
 
-      {!error && !loading && cards.length > 0 && filteredCards.length === 0 ? (
+      {!error && !blockingLoading && cards.length > 0 && filteredCards.length === 0 ? (
         <QuietBlock
           title="No matches"
           subtitle="Try a different name or firm."
@@ -296,7 +311,7 @@ export function AdvisorsNearby({
           title={meta?.grouped ? "Offices" : "Advisors"}
           separatorInset
         >
-          {loading ? (
+          {blockingLoading ? (
             <DirectoryLoadingRows testId="advisors-loading" />
           ) : (
             filteredCards.map((card) => {
@@ -332,6 +347,16 @@ export function AdvisorsNearby({
           )}
         </SettingsGroup>
       )}
+
+      {refreshing ? (
+        <p
+          className="type-footnote text-center text-muted-foreground"
+          role="status"
+          data-testid="advisors-refreshing"
+        >
+          Updating nearby…
+        </p>
+      ) : null}
 
       {meta?.hasMore && typeof meta.nextOffset === "number" && !loading ? (
         <div className="flex flex-col items-center gap-2">

--- a/hushh-webapp/components/connect/insurance-agents-nearby.tsx
+++ b/hushh-webapp/components/connect/insurance-agents-nearby.tsx
@@ -77,6 +77,11 @@ export function InsuranceAgentsNearby({
   const debouncedQuery = useDebouncedValue(query, 200);
 
   const requestRef = useRef(0);
+  const cardsRef = useRef<InsuranceAgentCard[]>([]);
+
+  useEffect(() => {
+    cardsRef.current = cards;
+  }, [cards]);
 
   useEffect(() => {
     if (!location.snapshot) return;
@@ -97,6 +102,7 @@ export function InsuranceAgentsNearby({
       if (offset === 0) {
         setLoading(true);
         setError(null);
+        setMeta(null);
       } else {
         setLoadingMore(true);
       }
@@ -118,9 +124,12 @@ export function InsuranceAgentsNearby({
         if (token !== requestRef.current) return;
         setMeta(result.meta);
         setAttribution(result.attribution ?? null);
-        setCards((previous) =>
-          offset === 0 ? result.items : [...previous, ...result.items],
-        );
+        setCards((previous) => {
+          const next =
+            offset === 0 ? result.items : [...previous, ...result.items];
+          cardsRef.current = next;
+          return next;
+        });
       } catch (caught) {
         if (token !== requestRef.current) return;
         const message =
@@ -128,11 +137,15 @@ export function InsuranceAgentsNearby({
             ? caught.message
             : "Agents are unavailable right now.";
         if (offset === 0) {
-          // A fresh search that failed has nothing to show, and its old paging
-          // cursor now points into a list that no longer exists.
-          setError(message);
-          setCards([]);
-          setMeta(null);
+          if (cardsRef.current.length > 0) {
+            setPageError(message);
+          } else {
+            // A cold search that failed has nothing to show, and its old paging
+            // cursor now points into a list that no longer exists.
+            setError(message);
+            setCards([]);
+            setMeta(null);
+          }
         } else {
           // A failed page must not take the page already on screen with it.
           setPageError(message);
@@ -173,6 +186,8 @@ export function InsuranceAgentsNearby({
   const nextRadiusMi = INSURANCE_AGENT_RADIUS_OPTIONS_MI.find(
     (mi) => mi > radiusMi,
   );
+  const blockingLoading = loading && cards.length === 0;
+  const refreshing = loading && cards.length > 0;
 
   if (!anchor) {
     return (
@@ -197,10 +212,10 @@ export function InsuranceAgentsNearby({
         value={String(radiusMi)}
         onValueChange={(value) => setRadiusMi(Number(value))}
         options={RADIUS_OPTIONS}
-        disabled={loading}
+        disabled={blockingLoading}
       />
 
-      {!error && !loading && cards.length > 0 ? (
+      {!error && cards.length > 0 ? (
         <NearbyDirectorySearch
           value={query}
           onChange={setQuery}
@@ -209,7 +224,7 @@ export function InsuranceAgentsNearby({
         />
       ) : null}
 
-      {error && !loading ? (
+      {error && !blockingLoading ? (
         // Same reasoning as the advisers directory: keep the ZIP box reachable
         // on a failure, or a bad ZIP is a dead end until the tab is remounted.
         <QuietBlock
@@ -237,7 +252,7 @@ export function InsuranceAgentsNearby({
         </QuietBlock>
       ) : null}
 
-      {!error && !loading && cards.length === 0 ? (
+      {!error && !blockingLoading && cards.length === 0 ? (
         // Coordinates can be perfectly good and still match nobody — the
         // locator covers US Nationwide agencies only. Offer the one input that
         // can actually help rather than a dead end.
@@ -261,7 +276,7 @@ export function InsuranceAgentsNearby({
         </QuietBlock>
       ) : null}
 
-      {!error && !loading && cards.length > 0 && filteredCards.length === 0 ? (
+      {!error && !blockingLoading && cards.length > 0 && filteredCards.length === 0 ? (
         <QuietBlock
           title="No matches"
           subtitle="Try a different name."
@@ -283,7 +298,7 @@ export function InsuranceAgentsNearby({
       (!loading && cards.length === 0) ||
       (!loading && filteredCards.length === 0) ? null : (
         <SettingsGroup title="Agencies" separatorInset>
-          {loading ? (
+          {blockingLoading ? (
             <DirectoryLoadingRows testId="insurance-agents-loading" />
           ) : (
             filteredCards.map((card) => {
@@ -319,6 +334,16 @@ export function InsuranceAgentsNearby({
           )}
         </SettingsGroup>
       )}
+
+      {refreshing ? (
+        <p
+          className="type-footnote text-center text-muted-foreground"
+          role="status"
+          data-testid="insurance-agents-refreshing"
+        >
+          Updating nearby…
+        </p>
+      ) : null}
 
       {meta?.hasMore && typeof meta.nextOffset === "number" && !loading ? (
         <div className="flex flex-col items-center gap-2">

--- a/hushh-webapp/components/connect/nearby-directories.tsx
+++ b/hushh-webapp/components/connect/nearby-directories.tsx
@@ -38,6 +38,17 @@ export function NearbyDirectories({
   getIdToken: () => Promise<string | null>;
 }) {
   const [directory, setDirectory] = useState<NearbyDirectory>("advisors");
+  const [visitedDirectories, setVisitedDirectories] = useState<
+    ReadonlySet<NearbyDirectory>
+  >(() => new Set(["advisors"]));
+
+  const selectDirectory = (next: NearbyDirectory) => {
+    setDirectory(next);
+    setVisitedDirectories((current) => {
+      if (current.has(next)) return current;
+      return new Set([...current, next]);
+    });
+  };
 
   return (
     <div className="space-y-4" data-testid="nearby-directories">
@@ -63,7 +74,7 @@ export function NearbyDirectories({
           <FilterChip
             key={option.value}
             active={directory === option.value}
-            onClick={() => setDirectory(option.value as NearbyDirectory)}
+            onClick={() => selectDirectory(option.value as NearbyDirectory)}
             testId={`nearby-directory-${option.value}`}
           >
             {option.label}
@@ -71,13 +82,21 @@ export function NearbyDirectories({
         ))}
       </FilterChipRow>
 
-      {directory === "places" ? (
-        <PlacesNearby getIdToken={getIdToken} />
-      ) : directory === "insurance" ? (
-        <InsuranceAgentsNearby getIdToken={getIdToken} />
-      ) : (
-        <AdvisorsNearby getIdToken={getIdToken} />
-      )}
+      {visitedDirectories.has("advisors") ? (
+        <div hidden={directory !== "advisors"} aria-hidden={directory !== "advisors"}>
+          <AdvisorsNearby getIdToken={getIdToken} />
+        </div>
+      ) : null}
+      {visitedDirectories.has("insurance") ? (
+        <div hidden={directory !== "insurance"} aria-hidden={directory !== "insurance"}>
+          <InsuranceAgentsNearby getIdToken={getIdToken} />
+        </div>
+      ) : null}
+      {visitedDirectories.has("places") ? (
+        <div hidden={directory !== "places"} aria-hidden={directory !== "places"}>
+          <PlacesNearby getIdToken={getIdToken} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/hushh-webapp/components/connect/places-nearby.tsx
+++ b/hushh-webapp/components/connect/places-nearby.tsx
@@ -48,6 +48,9 @@ const OVERVIEW_LIMIT = 8;
 
 const CATEGORY_SLUGS = PLACES_CATEGORIES.map((entry) => entry.slug);
 
+const hasPlaceRows = (groups: Record<string, PlaceCard[]>) =>
+  Object.values(groups).some((items) => items.length > 0);
+
 /**
  * "Places near you" — the ten business categories around the account's position.
  *
@@ -87,6 +90,11 @@ export function PlacesNearby({
 
   const requestRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
+  const byCategoryRef = useRef<Record<string, PlaceCard[]>>({});
+
+  useEffect(() => {
+    byCategoryRef.current = byCategory;
+  }, [byCategory]);
 
   useEffect(() => {
     if (!location.snapshot) return;
@@ -110,10 +118,13 @@ export function PlacesNearby({
       abortRef.current = controller;
 
       const token = ++requestRef.current;
+      const hasRetainedRows = hasPlaceRows(byCategoryRef.current);
       setStreaming(true);
       setError(null);
-      setByCategory({});
-      setAttribution(null);
+      if (!hasRetainedRows) {
+        setByCategory({});
+        setAttribution(null);
+      }
 
       const origin =
         target.kind === "coords"
@@ -128,7 +139,11 @@ export function PlacesNearby({
         // A slower earlier sweep must never write into a newer one.
         if (token !== requestRef.current) return;
         categoriesAnswered += 1;
-        setByCategory((current) => ({ ...current, [category]: items }));
+        setByCategory((current) => {
+          const next = { ...current, [category]: items };
+          byCategoryRef.current = next;
+          return next;
+        });
       };
 
       try {
@@ -187,18 +202,25 @@ export function PlacesNearby({
         // Nothing answered and something refused: the provider is down, not the
         // neighbourhood. Saying "Nothing nearby" here would be a claim about
         // the world that we have no evidence for.
-        if (token === requestRef.current && categoriesAnswered === 0 && failed.size > 0) {
+        if (
+          token === requestRef.current &&
+          categoriesAnswered === 0 &&
+          failed.size > 0 &&
+          !hasPlaceRows(byCategoryRef.current)
+        ) {
           setError("Places are unavailable right now.");
         }
       } catch (caught) {
         if (controller.signal.aborted) return;
         if (token !== requestRef.current) return;
         if (caught instanceof DOMException && caught.name === "AbortError") return;
-        setError(
-          caught instanceof Error
-            ? caught.message
-            : "Places are unavailable right now.",
-        );
+        if (!hasPlaceRows(byCategoryRef.current)) {
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Places are unavailable right now.",
+          );
+        }
       } finally {
         if (token === requestRef.current) setStreaming(false);
       }
@@ -337,10 +359,10 @@ export function PlacesNearby({
               onClick={() => setChip(entry.slug)}
               data-testid={`places-chip-${entry.slug}`}
               className={cn(
-                "type-footnote shrink-0 rounded-full border px-3 py-1.5 transition-colors",
+                "type-footnote press-scale shrink-0 rounded-full border px-3 py-1.5 transition-[background-color,border-color,color,transform] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]",
                 active
-                  ? "border-transparent bg-foreground text-background"
-                  : "border-border text-muted-foreground hover:text-foreground",
+                  ? "border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]"
+                  : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-[color:var(--app-secondary-label)] hover:bg-foreground/[0.035] hover:text-[color:var(--app-primary-label)]",
               )}
             >
               {entry.label}

--- a/hushh-webapp/lib/morphy-ux/ui/filter-chip.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/filter-chip.tsx
@@ -55,8 +55,8 @@ export function FilterChip({
         "type-footnote transition-[background-color,border-color,color] duration-200",
         "disabled:cursor-not-allowed disabled:opacity-60",
         active
-          ? "border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-fg)]"
-          : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-foreground",
+          ? "border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]"
+          : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-[color:var(--app-primary-label)] hover:bg-foreground/[0.035]",
         className,
       )}
     >

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -2,7 +2,6 @@
 
 import type { CSSProperties } from "react";
 
-import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { cn } from "@/lib/utils";
 
 export interface SegmentedTabOption {
@@ -33,7 +32,7 @@ export function SegmentedTabs({
     <div
       className={cn(
         "relative grid w-full rounded-full p-1 backdrop-blur-xl [grid-template-columns:repeat(var(--segmented-mobile-cols),minmax(0,1fr))] sm:[grid-template-columns:repeat(var(--segmented-desktop-cols),minmax(0,1fr))]",
-        "border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] shadow-[var(--app-card-shadow-standard)]",
+        "border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] shadow-none",
         className
       )}
       style={
@@ -57,15 +56,13 @@ export function SegmentedTabs({
               if (!disabled && !isActive) onValueChange(option.value);
             }}
             className={cn(
-              "press-scale relative isolate flex min-h-9 min-w-0 items-center justify-center overflow-hidden rounded-full border px-4 py-2 text-center transition-[background-color,border-color,box-shadow,color,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] sm:min-h-10 sm:px-4.5",
+              "press-scale relative isolate flex min-h-9 min-w-0 items-center justify-center overflow-hidden rounded-full border px-4 py-2 text-center transition-[background-color,border-color,box-shadow,color,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-10 sm:px-4.5",
               isActive
-                ? "z-10 border-[color:var(--app-segmented-active-border)] bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[0_0_0_1px_var(--app-segmented-active-border),var(--shadow-xs)]"
-                : "border-transparent bg-transparent text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
+                ? "z-10 border-[color:var(--app-segmented-active-border)] bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[var(--app-segmented-active-shadow)]"
+                : "border-transparent bg-transparent text-muted-foreground hover:bg-foreground/[0.035] hover:text-[color:var(--app-primary-label)]",
               disabled && "cursor-not-allowed opacity-60"
             )}
           >
-            {/* Ripple sits BEHIND the label (z-0) and never intercepts taps. */}
-            <MaterialRipple variant="none" effect="fade" className="z-0" />
             {/*
               A tab label is product-owned copy, not user content, so it may
               never resolve to an ellipsis: "Around yo…" is a defect, not


### PR DESCRIPTION
## Summary
- soften shared segmented tab and Around You chip selected/hover/focus states
- keep visited Around You directories mounted so switching tabs does not replay loading
- retain existing Advisors, Insurance, and Places results during radius refreshes instead of swapping to skeleton rows

## Validation
- npm run test -- components/connect/__tests__/nearby-directories.test.tsx components/connect/__tests__/advisors-nearby.test.tsx components/connect/__tests__/insurance-agents-nearby.test.tsx components/connect/__tests__/places-nearby.test.tsx
- npm run verify:design-system
- npm run verify:cache
- npx eslint app/globals.css components/connect/nearby-directories.tsx components/connect/advisors-nearby.tsx components/connect/insurance-agents-nearby.tsx components/connect/places-nearby.tsx components/connect/__tests__/nearby-directories.test.tsx components/connect/__tests__/advisors-nearby.test.tsx components/connect/__tests__/insurance-agents-nearby.test.tsx components/connect/__tests__/places-nearby.test.tsx lib/morphy-ux/ui/segmented-tabs.tsx lib/morphy-ux/ui/filter-chip.tsx

## Known unrelated local blocker
- npm run typecheck currently fails in lib/services/agent-chat-client.ts because @ag-ui/client cannot be resolved locally and its callback params become implicit any. This file was not touched by this PR.