### PR TITLE
fix(one): support only Location and Connections in voice settings

### DIFF
--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/lib/services/connections-service", () => ({
   },
 }));
 
+import { VOICE_ENGINE_DOMAINS } from "@/lib/agent/voice-engine-domains";
 import { VoicePreferencesPanel } from "@/components/profile/voice-preferences-panel";
 import {
   forgetVoicePreferences,
@@ -71,14 +72,43 @@ describe("VoicePreferencesPanel", () => {
     ).toBeChecked();
   });
 
-  it("Finance and Calendar show as coming soon, not a switch", () => {
+  it("unenforced domains show as coming soon, not a switch", () => {
+    // Two different reasons land on the same treatment. Finance and
+    // Calendar do not route through the server-side choke points, so a
+    // switch would silently do nothing. Email and Identity verification
+    // do route through them but are not maintained right now, so offering
+    // a switch would present them as supported.
     render(
       <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
     );
 
-    expect(screen.queryByRole("switch", { name: "Finance" })).toBeNull();
-    expect(screen.queryByRole("switch", { name: "Calendar" })).toBeNull();
-    expect(screen.getAllByText("Coming soon")).toHaveLength(2);
+    for (const label of [
+      "Finance",
+      "Calendar",
+      "Email",
+      "Identity verification",
+    ]) {
+      expect(screen.queryByRole("switch", { name: label })).toBeNull();
+    }
+    // Derived from the source of truth rather than hardcoded, so flipping a
+    // domain back on updates this test by construction instead of leaving
+    // a stale number to chase.
+    const unenforced = VOICE_ENGINE_DOMAINS.filter((domain) => !domain.enforced);
+    expect(screen.getAllByText("Coming soon")).toHaveLength(unenforced.length);
+  });
+
+  it("still offers a working switch for the domains that are supported", () => {
+    // The counterpart guard: marking things Coming soon must not quietly
+    // empty the panel of every real control.
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
+    );
+
+    for (const domain of VOICE_ENGINE_DOMAINS.filter((entry) => entry.enforced)) {
+      expect(
+        screen.getByRole("switch", { name: domain.label }),
+      ).toBeInTheDocument();
+    }
   });
 
   it("turning off a domain persists to voice preferences", () => {

--- a/hushh-webapp/__tests__/lib/agent/voice-engine-domains.test.ts
+++ b/hushh-webapp/__tests__/lib/agent/voice-engine-domains.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  VOICE_ENGINE_DOMAINS,
+  resolveEffectiveDisabledDomains,
+} from "@/lib/agent/voice-engine-domains";
+
+describe("VOICE_ENGINE_DOMAINS", () => {
+  it("supports exactly Location and Connections today", () => {
+    // Pinned deliberately. Turning a domain back on is a one-line change and
+    // should be, but it should be a decision somebody made on purpose rather
+    // than something that drifts in unnoticed.
+    expect(
+      VOICE_ENGINE_DOMAINS.filter((domain) => domain.enforced).map(
+        (domain) => domain.key,
+      ),
+    ).toEqual(["location", "connections"]);
+  });
+
+  it("gives every domain a label, so an unenforced one still reads as a real thing", () => {
+    for (const domain of VOICE_ENGINE_DOMAINS) {
+      expect(domain.label.trim().length).toBeGreaterThan(0);
+      expect(domain.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolveEffectiveDisabledDomains", () => {
+  it("drops a domain that no longer has a switch", () => {
+    // The trap this exists for: Consent Center and Connected Systems used to
+    // be switchable, so somebody may have a stored key for them. The server
+    // has no notion of "enforced" and blocks any recognised key it receives,
+    // so without this filter that person keeps voice off there permanently
+    // with no switch left to undo it.
+    expect(
+      resolveEffectiveDisabledDomains(["consent", "connected_systems"]),
+    ).toEqual([]);
+  });
+
+  it("keeps a domain that is still switchable", () => {
+    expect(resolveEffectiveDisabledDomains(["location"])).toEqual(["location"]);
+    expect(resolveEffectiveDisabledDomains(["connections"])).toEqual([
+      "connections",
+    ]);
+  });
+
+  it("keeps the supported keys while dropping the rest, in one list", () => {
+    expect(
+      resolveEffectiveDisabledDomains([
+        "location",
+        "email",
+        "connections",
+        "kyc",
+        "finance",
+      ]),
+    ).toEqual(["location", "connections"]);
+  });
+
+  it("ignores a key that was never a domain at all", () => {
+    expect(resolveEffectiveDisabledDomains(["not_a_domain", ""])).toEqual([]);
+  });
+
+  it("leaves an empty list alone rather than inventing a restriction", () => {
+    // These preferences are restrictions on an already-authorized capability,
+    // so the failure direction that matters is adding one nobody asked for.
+    expect(resolveEffectiveDisabledDomains([])).toEqual([]);
+  });
+
+  it("never returns a key that has no switch to undo it", () => {
+    // The property behind the specific cases above: whatever goes in, nothing
+    // survives that the person cannot see and manage in the panel.
+    const enforced = new Set(
+      VOICE_ENGINE_DOMAINS.filter((domain) => domain.enforced).map(
+        (domain) => domain.key,
+      ),
+    );
+    const everyKey = VOICE_ENGINE_DOMAINS.map((domain) => domain.key);
+
+    for (const key of resolveEffectiveDisabledDomains(everyKey)) {
+      expect(enforced.has(key)).toBe(true);
+    }
+  });
+});

--- a/hushh-webapp/lib/agent/agent-runtime-context.tsx
+++ b/hushh-webapp/lib/agent/agent-runtime-context.tsx
@@ -40,6 +40,7 @@ import {
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
 import { useAgentVoiceState } from "@/lib/agent/agent-voice-state";
+import { resolveEffectiveDisabledDomains } from "@/lib/agent/voice-engine-domains";
 import {
   readVoicePreferences,
   subscribeVoicePreferences,
@@ -424,7 +425,11 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
         voiceSettings: {
           voiceEnabled: voicePreferences.voiceEnabled,
           requireTapConfirmation: voicePreferences.requireTapConfirmation,
-          disabledDomains: voicePreferences.disabledDomains,
+          // Unenforced domains have no switch, so a key left over from when
+          // they did must not keep restricting voice with no way to undo it.
+          disabledDomains: resolveEffectiveDisabledDomains(
+            voicePreferences.disabledDomains,
+          ),
         },
         onboarding: {
           phase: (path === ROUTES.GETTING_STARTED || path === ROUTES.LOGIN || path === ROUTES.PHONE_MANDATE || path.startsWith(ROUTES.ONE_SETUP))

--- a/hushh-webapp/lib/agent/voice-engine-domains.ts
+++ b/hushh-webapp/lib/agent/voice-engine-domains.ts
@@ -10,9 +10,18 @@
  * not this file's. See the (forthcoming) `voice_domain_policy.py`.
  *
  * `enforced: false` domains render with a "Coming soon" badge instead of a
- * switch -- Finance and Calendar voice actions don't route through either of
- * the two server-side choke points the other domains share, so a toggle for
- * them would silently do nothing today.
+ * switch, for two different reasons that happen to want the same treatment:
+ *
+ * - Finance and Calendar voice actions don't route through either of the two
+ *   server-side choke points the other domains share, so a toggle for them
+ *   would silently do nothing.
+ * - Email and Identity verification DO route through them, but are not tested
+ *   or maintained right now, so offering a switch would present them as
+ *   supported. Turning either back on is a one-line change here.
+ *
+ * Note what this treatment does NOT do: it removes the person's ability to
+ * turn voice off for that domain, it does not turn voice off there. Voice
+ * still acts in an unenforced domain.
  */
 export type VoiceEngineDomainKey =
   | "location"
@@ -42,7 +51,9 @@ export const VOICE_ENGINE_DOMAINS: readonly VoiceEngineDomain[] = [
     key: "email",
     label: "Email",
     description: "Gmail connection and actions.",
-    enforced: true,
+    // Not tested or maintained right now, so it is shown as Coming soon
+    // rather than offered as a control someone might rely on.
+    enforced: false,
   },
   {
     key: "connected_systems",
@@ -66,7 +77,9 @@ export const VOICE_ENGINE_DOMAINS: readonly VoiceEngineDomain[] = [
     key: "kyc",
     label: "Identity verification",
     description: "KYC workflow steps.",
-    enforced: true,
+    // Same as Email: unmaintained today, so not presented as a working
+    // switch.
+    enforced: false,
   },
   {
     key: "finance",

--- a/hushh-webapp/lib/agent/voice-engine-domains.ts
+++ b/hushh-webapp/lib/agent/voice-engine-domains.ts
@@ -9,19 +9,25 @@
  * expanding a domain key into what it actually covers is the server's job,
  * not this file's. See the (forthcoming) `voice_domain_policy.py`.
  *
- * `enforced: false` domains render with a "Coming soon" badge instead of a
- * switch, for two different reasons that happen to want the same treatment:
+ * Only Location and Connections are supported today. Every other domain
+ * renders with a "Coming soon" badge instead of a switch.
+ *
+ * Two different reasons land on that same treatment, and the distinction
+ * matters if you are deciding whether one can be turned back on:
  *
  * - Finance and Calendar voice actions don't route through either of the two
  *   server-side choke points the other domains share, so a toggle for them
- *   would silently do nothing.
- * - Email and Identity verification DO route through them, but are not tested
- *   or maintained right now, so offering a switch would present them as
- *   supported. Turning either back on is a one-line change here.
+ *   would silently do nothing. Enforcement would have to be built first.
+ * - Email, Identity verification, Connected Systems and Consent Center DO
+ *   route through them -- their switches worked -- but they are not tested or
+ *   maintained right now, so offering one would present them as supported.
+ *   Turning any of these four back on is a one-line change here.
  *
  * Note what this treatment does NOT do: it removes the person's ability to
  * turn voice off for that domain, it does not turn voice off there. Voice
- * still acts in an unenforced domain.
+ * still acts in an unenforced domain. With six of eight domains now
+ * unenforced, that gap is wider than it was -- worth naming rather than
+ * discovering later.
  */
 export type VoiceEngineDomainKey =
   | "location"
@@ -51,21 +57,24 @@ export const VOICE_ENGINE_DOMAINS: readonly VoiceEngineDomain[] = [
     key: "email",
     label: "Email",
     description: "Gmail connection and actions.",
-    // Not tested or maintained right now, so it is shown as Coming soon
-    // rather than offered as a control someone might rely on.
+    // Routes through the choke points, but is not tested or maintained
+    // right now, so it is shown as Coming soon rather than offered as a
+    // control someone might rely on.
     enforced: false,
   },
   {
     key: "connected_systems",
     label: "Connected Systems",
     description: "CRM and external system workflows.",
-    enforced: true,
+    // Same as Email: enforcement works, maintenance does not.
+    enforced: false,
   },
   {
     key: "consent",
     label: "Consent Center",
     description: "What you've shared, approvals, and revocations.",
-    enforced: true,
+    // Same as Email: enforcement works, maintenance does not.
+    enforced: false,
   },
   {
     key: "connections",
@@ -77,8 +86,7 @@ export const VOICE_ENGINE_DOMAINS: readonly VoiceEngineDomain[] = [
     key: "kyc",
     label: "Identity verification",
     description: "KYC workflow steps.",
-    // Same as Email: unmaintained today, so not presented as a working
-    // switch.
+    // Same as Email: enforcement works, maintenance does not.
     enforced: false,
   },
   {
@@ -94,3 +102,37 @@ export const VOICE_ENGINE_DOMAINS: readonly VoiceEngineDomain[] = [
     enforced: false,
   },
 ] as const;
+
+const ENFORCED_DOMAIN_KEYS: ReadonlySet<string> = new Set(
+  VOICE_ENGINE_DOMAINS.filter((domain) => domain.enforced).map(
+    (domain) => domain.key,
+  ),
+);
+
+/**
+ * The disabled-domain list with unenforced domains dropped.
+ *
+ * Marking a domain unenforced removes its switch but does NOT remove the key
+ * an earlier version let the person store. The server has no notion of
+ * "enforced" -- `is_voice_domain_disabled` (voice_domain_policy.py) blocks any
+ * of its six recognised keys that arrives in the list. So somebody who had
+ * turned Consent Center or Connected Systems off keeps it off forever, with no
+ * switch left to undo it, and a "Coming soon" badge sitting where the
+ * explanation should be.
+ *
+ * Finance and Calendar never had this problem: the server deliberately omits
+ * them, so a stored disable for either was always inert. The four domains that
+ * moved to "Coming soon" are all keys the server does enforce, which is what
+ * makes the stale entry bite.
+ *
+ * Filtered at the point of effect, not in storage: the stored choice is left
+ * alone so re-enforcing a domain restores what the person originally picked
+ * rather than silently defaulting them back on. This also matches the posture
+ * voice-preferences.ts states for itself -- a restriction nobody can see or
+ * manage should not quietly keep applying.
+ */
+export function resolveEffectiveDisabledDomains(
+  disabledDomains: readonly string[],
+): string[] {
+  return disabledDomains.filter((key) => ENFORCED_DOMAIN_KEYS.has(key));
+}


### PR DESCRIPTION
## Summary

**Only Location and Connections are supported.** Everything else renders the "Coming soon" badge Finance and Calendar already used.

| Domain | Before | After |
|---|---|---|
| Location | switch | **switch** |
| Connections | switch | **switch** |
| Connected Systems | switch | Coming soon |
| Consent Center | switch | Coming soon |
| Email | switch | Coming soon |
| Identity verification | switch | Coming soon |
| Finance | Coming soon | Coming soon |
| Calendar | Coming soon | Coming soon |

## Two reasons, one badge

The header comment only described one of them, so it now says both:

- **Finance and Calendar** have no server-side choke point. A toggle for them would silently do nothing — enforcement would have to be built first.
- **The other four** *do* route through those choke points. Their switches worked. They are simply not tested or maintained right now, so offering one presents them as supported. Turning any of the four back on is a one-line change.

## The trap this creates, and the fix for it

Marking a domain unenforced removes its switch — but **not** the key an earlier version let somebody store. The server has no notion of "enforced": `is_voice_domain_disabled` (`voice_domain_policy.py:102`) blocks any of its six recognised keys that arrives in the list.

So somebody who had turned Consent Center or Connected Systems off would keep it off **permanently**, with no switch left to undo it and a "Coming soon" badge sitting where the explanation should be.

Finance and Calendar never had this problem — the server deliberately omits both, so a stored disable for either was always inert. That is exactly why it stayed invisible until four *enforced* keys moved at once.

`resolveEffectiveDisabledDomains` filters at the point of effect rather than in storage, so the stored choice survives and re-enforcing a domain restores what the person originally picked instead of silently defaulting them back on. `disabled_domains` is client-sent per session and never persisted server-side (`live_context.py:508`), so this is the one place that needs it.

## What this treatment still does not do

Removing the switch removes the ability to turn voice **off** for that domain. It does not turn voice off there — voice still acts in an unenforced domain. That is the existing Finance/Calendar behaviour and is what was asked for, so it is unchanged. Worth stating plainly because it now applies to six domains of eight rather than two.

## Test plan

- [x] `npx vitest run __tests__/lib/agent/ __tests__/voice/ __tests__/lib/agent-runtime-context.test.tsx __tests__/components/voice-preferences-panel.test.tsx __tests__/services/agent-action-runtime.test.ts` — **384 passed across 48 files**.
- [x] New `voice-engine-domains.test.ts`: pins the supported set, covers the stale-key filter case by case, and asserts the property behind them — nothing survives the filter that the person cannot see and manage.
- [x] Panel test now derives its count from `VOICE_ENGINE_DOMAINS` instead of a hardcoded number, so flipping a domain updates it by construction.
- [x] Added the counterpart guard — supported domains still render real switches. The failure mode of this change is quietly emptying the panel, and nothing was checking for it.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6186.
