### PR TITLE
fix(one): correct the Require-a-tap-to-confirm copy

### DIFF
--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -283,4 +283,24 @@ describe("VoicePreferencesPanel", () => {
       }),
     );
   });
+
+  it("does not claim these actions already ask to confirm", () => {
+    // The copy this replaces said "For actions that already ask to
+    // confirm." Nothing already asks -- voice does not confirm by default,
+    // so that named a set which is empty in practice, and the switch read as
+    // broken to anyone who tried it. Pinned because the failure was silent:
+    // the control worked the whole time, only the words were wrong.
+    render(
+      <VoicePreferencesPanel userId={userId} onOpenChangelog={() => {}} onOpenExamples={() => {}} />,
+    );
+
+    expect(screen.queryByText(/already ask to confirm/i)).toBeNull();
+    expect(
+      screen.getByText("For actions that share or change something."),
+    ).toBeInTheDocument();
+    // The switch itself must survive the rewording.
+    expect(
+      screen.getByRole("switch", { name: "Require a tap to confirm" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -380,10 +380,31 @@ export function VoicePreferencesPanel({
           stackTrailingOnMobile
         />
       </SettingsGroup>
-      <SettingsGroup title="Safety" description="For actions that already ask to confirm.">
+      {/*
+        The old copy here read "For actions that already ask to confirm" /
+        "Stops a spoken yes or no from confirming." Both were wrong, and
+        together they made a working control look broken.
+
+        Nothing "already asks". Voice deliberately does not confirm by
+        default -- `_directive_flags` in action_tools.py raises a card only
+        for `trusted_activation_required` (4 actions of 198) unless this
+        setting is on. So the group described a set that is empty in
+        practice, and the row promised to stop a spoken yes that was never
+        being asked for in the first place.
+
+        Turn this on and 35 `confirm_required` actions start asking, and
+        only a tap settles them. Both halves matter: the asking is new, not
+        just the tap. Somebody who reads the old copy tries it on an
+        ordinary action, sees no card, and concludes the switch does
+        nothing.
+      */}
+      <SettingsGroup
+        title="Safety"
+        description="For actions that share or change something."
+      >
         <SettingsRow
           title="Require a tap to confirm"
-          description="Stops a spoken yes or no from confirming."
+          description="They ask first, and a spoken yes won't do."
           disabled={!state.voiceEnabled}
           trailing={
             <Switch


### PR DESCRIPTION
## The switch works. The words around it did not.

Reported as: *"there is written tap, but that voice card doesn't come up, just the voice asks for the confirmation."* I traced the enforcement path end to end before touching anything, and it is intact — client and server. The control was never broken. Two copy claims made it read as broken.

## What was wrong

**"For actions that already ask to confirm"** names a set that is empty in practice. Voice deliberately does not confirm by default — `_directive_flags` (`consent-protocol/hushh_mcp/one_adk/action_tools.py:284`) raises a card only for `trusted_activation_required`, **4 actions of 198**, unless this setting is on. Nothing "already asks".

So the row's promise to **"stop a spoken yes or no from confirming"** described stopping something that was never happening.

Turn the setting on and **35 `confirm_required` actions start asking**, settled only by a tap. The asking is the new part, not just the tap — and the old copy never said so.

That explains the report exactly: read the copy, try it on an ordinary action, see no card, conclude the switch does nothing. The **138 `allow_direct`** actions are untouched by this setting by design, and One asking a conversational question of its own is unrelated to it.

## Why not change "tap" to "say"/"speak"

That was the other option suggested, and it would make things worse. "Say to confirm" describes what happens with the setting **off**. Wording a safety control as the behaviour it exists to prevent turns it into a documented no-op — and the tap really is enforced once it is on, in both places:

- `agent-bar.tsx:1460` keeps the confirmation pending for a real tap instead of settling on the spoken yes
- `agent-bar.tsx:2061` renders the card with Cancel/Authorize rather than "say yes to continue"

## The change

| | before | after |
|---|---|---|
| Group | For actions that already ask to confirm. | For actions that share or change something. |
| Row | Stops a spoken yes or no from confirming. | They ask first, and a spoken yes won't do. |

Names the real set, and both halves of the behaviour.

## Test plan

- [x] No behaviour change — copy only. The enforcement path is correct as-is and is untouched.
- [x] Added a test pinning this, because the failure mode was silent: the control was right the whole time and only the words were wrong, so nothing broke to signal the drift. It asserts the false claim is gone, the honest one is present, and the switch survived the rewording.
- [x] `npx vitest run __tests__/components/voice-preferences-panel.test.tsx` — 14/14.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6184.
