### PR TITLE
feat(memory): minimal iOS Memory redesign for /one/pkm (#6190)

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PkmNaturalPanel } from "@/components/profile/pkm-natural-panel";
@@ -29,10 +29,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
-  useAuth: () => ({
-    user,
-    loading: false,
-  }),
+  useAuth: () => ({ user, loading: false }),
 }));
 
 vi.mock("@/lib/vault/vault-context", () => ({
@@ -43,89 +40,106 @@ vi.mock("@/lib/vault/vault-context", () => ({
   }),
 }));
 
-vi.mock("@/components/profile/pkm-data-manager", () => ({
-  PkmDataManagerPanel: ({
-    domains,
-    onOpenDomain,
-    sharingReady,
-    sharingError,
-  }: {
-    domains: Array<{ key: string; title: string; accessSummary: string }>;
-    onOpenDomain: (domain: { key: string; title: string; accessSummary: string }) => void;
-    sharingReady: boolean;
-    sharingError: string | null;
-  }) => (
-    <div>
-      <div data-testid="sharing-ready">{String(sharingReady)}</div>
-      {sharingError ? <div>{sharingError}</div> : null}
-      {domains.map((domain) => (
-        <div key={domain.key}>
-          <button type="button" onClick={() => onOpenDomain(domain)}>
-            Open {domain.title}
-          </button>
-          <span>{domain.accessSummary}</span>
-        </div>
-      ))}
-    </div>
-  ),
-}));
+const NOW = new Date().toISOString();
+const WEEK_AGO = new Date(Date.now() - 8 * 86_400_000).toISOString();
 
-vi.mock("@/components/profile/pkm-section-preview", () => ({
-  PkmSectionPreview: () => <div>Exact category preview</div>,
-}));
-
-async function openIndividualFieldReview() {
-  const label = await screen.findByText("Review individual fields");
-  const summary = label.closest("summary");
-  if (!summary) throw new Error("Expected individual field review disclosure");
-  fireEvent.click(summary);
+function baseMetadata() {
+  return {
+    modelVersion: 6,
+    contractVersion: 6,
+    readableProjectionVersion: 2,
+    domains: [
+      {
+        key: "financial",
+        displayName: "Financial",
+        icon: "wallet",
+        color: "neutral",
+        attributeCount: 0,
+        summary: {},
+        availableScopes: [],
+        lastUpdated: NOW,
+        readableUpdatedAt: NOW,
+        readableSourceLabel: "finance setup",
+      },
+      {
+        key: "preferences",
+        displayName: "Preferences",
+        icon: "star",
+        color: "neutral",
+        attributeCount: 0,
+        summary: {},
+        availableScopes: [],
+        lastUpdated: WEEK_AGO,
+        readableUpdatedAt: WEEK_AGO,
+        readableSourceLabel: "a conversation",
+      },
+      {
+        key: "work",
+        displayName: "Work",
+        icon: "briefcase",
+        color: "neutral",
+        attributeCount: 0,
+        summary: {},
+        availableScopes: [],
+        lastUpdated: null,
+        readableSourceLabel: null,
+      },
+      {
+        key: "runtime_secrets",
+        displayName: "Runtime Secrets",
+        icon: "lock",
+        color: "neutral",
+        attributeCount: 0,
+        summary: {},
+        availableScopes: [],
+        lastUpdated: NOW,
+        readableSourceLabel: null,
+      },
+    ],
+    totalAttributes: 3,
+    lastUpdated: NOW,
+    upgradableDomains: [],
+    needsUpgrade: false,
+  };
 }
 
-describe("PkmNaturalPanel", () => {
+const FULL_BLOB = {
+  financial: {
+    profile: { risk_profile: "balanced" },
+    accounts: { primary_bank: "Chase" },
+  },
+  preferences: { travel: { seat_choice: "aisle seat" } },
+  runtime_secrets: { provider_key: "sk-must-not-render" },
+};
+
+describe("PkmNaturalPanel — Memory redesign", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(PersonalKnowledgeModelService, "getMetadata").mockResolvedValue({
-      modelVersion: 6,
-      contractVersion: 6,
-      readableProjectionVersion: 2,
-      domains: [
-        {
-          key: "financial",
-          displayName: "Financial",
-          icon: "wallet",
-          color: "neutral",
-          attributeCount: 3,
-          summary: { consumer_item_count: 3 },
-          availableScopes: [],
-          lastUpdated: "2026-07-14T12:00:00Z",
-          readableSourceLabel: "finance setup",
-        },
-      ],
-      totalAttributes: 3,
-      lastUpdated: "2026-07-14T12:00:00Z",
-      upgradableDomains: [],
-      needsUpgrade: false,
-    });
+    vi.spyOn(PersonalKnowledgeModelService, "getMetadata").mockResolvedValue(
+      baseMetadata() as never,
+    );
     vi.spyOn(ConsentCenterService, "getCenter").mockResolvedValue({
       pending_requests: [],
       active_grants: [],
       recent_activity: [],
-    });
+    } as never);
     vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(null);
-    vi.spyOn(PersonalKnowledgeModelService, "loadDomainData").mockResolvedValue({
-      profile: { risk_profile: "balanced" },
-    });
-    vi.spyOn(PersonalKnowledgeModelService, "loadFullBlob").mockResolvedValue({
-      financial: { profile: { risk_profile: "balanced" } },
-    });
-    vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockResolvedValue({
-      activeRecipientCount: 0,
-      recipientLabels: [],
-      entersNextExportRevision: false,
-      summary: "No active recipients are affected.",
-      affectedGrantIds: [],
-      affectedExportIds: [],
-    });
+    vi.spyOn(PersonalKnowledgeModelService, "loadDomainData").mockResolvedValue(
+      FULL_BLOB.financial as never,
+    );
+    vi.spyOn(PersonalKnowledgeModelService, "loadFullBlob").mockResolvedValue(
+      FULL_BLOB as never,
+    );
+    vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockImplementation(
+      async ({ domain, scopePath }) => ({
+        activeRecipientCount: domain === "financial" && scopePath === "profile" ? 1 : 0,
+        recipientLabels: domain === "financial" && scopePath === "profile" ? ["Planner Pro"] : [],
+        entersNextExportRevision: false,
+        summary: "ok",
+        affectedGrantIds: [],
+        affectedExportIds: [],
+      }),
+    );
     vi.spyOn(AgentPkmAutoSavePolicy, "loadAgentPkmAutoSavePolicy").mockResolvedValue({
       enabled: false,
       version: 1,
@@ -135,138 +149,238 @@ describe("PkmNaturalPanel", () => {
       async ({ enabled }) => ({
         enabled,
         version: 1,
-        enabledAt: enabled ? "2026-07-30T00:00:00.000Z" : null,
+        enabledAt: enabled ? NOW : null,
       }),
     );
     previewAgentPkmMemory.mockResolvedValue({
       cards: [
-        {
-          card_id: "memory-card-1",
-          write_mode: "confirm_first",
-          sharing_impact: { active_recipient_count: 0 },
-        },
+        { card_id: "memory-card-1", write_mode: "confirm_first", sharing_impact: { active_recipient_count: 0 } },
       ],
     });
-    addToPKM.mockResolvedValue({
-      attempted: 1,
-      saved: 1,
-      failed: 0,
-      domains: ["financial"],
-      results: [],
-    });
+    addToPKM.mockResolvedValue({ attempted: 1, saved: 1, failed: 0, domains: ["financial"], results: [] });
   });
 
-  it("uses the shared switch with an explicit automatic-saving state", async () => {
+  async function openMainScreen() {
     render(<PkmNaturalPanel />);
+    return screen.findByRole("button", { name: "Open memory: Risk Profile" });
+  }
 
+  it("shows search, Recently learned, and Categories with newest memory first", async () => {
+    await openMainScreen();
+
+    expect(screen.getByRole("searchbox", { name: "Search Memory" })).toBeTruthy();
+
+    const recent = screen.getByTestId("memory-recently-learned");
+    const recentNames = within(recent)
+      .getAllByRole("button")
+      .map((node) => node.getAttribute("aria-label"));
+    // Financial (updated today) sorts ahead of Preferences (updated a week ago).
+    expect(recentNames[0]).toBe("Open memory: Risk Profile");
+    expect(recentNames).toContain("Open memory: Seat Choice");
+    expect(recentNames.indexOf("Open memory: Risk Profile")).toBeLessThan(
+      recentNames.indexOf("Open memory: Seat Choice"),
+    );
+
+    expect(screen.getByText("Recently learned")).toBeTruthy();
+    expect(screen.getByText("Categories")).toBeTruthy();
+
+    // Tab viewport tracks the active pane's height (no frozen tallest-pane
+    // height leaving dead space under shorter tabs like Sharing).
+    expect(
+      document.querySelector("[data-swipe-views-height-mode]")?.getAttribute("data-swipe-views-height-mode"),
+    ).toBe("active");
+  });
+
+  it("lists only consumer-visible, non-empty categories with correct counts", async () => {
+    await openMainScreen();
+
+    const categories = screen.getByTestId("memory-categories");
+    expect(within(categories).getByTestId("memory-category-financial")).toHaveTextContent(
+      "2 memories",
+    );
+    expect(within(categories).getByTestId("memory-category-preferences")).toHaveTextContent(
+      "1 memory",
+    );
+    // Empty domain and reserved internal domain never appear.
+    expect(screen.queryByTestId("memory-category-work")).toBeNull();
+    expect(screen.queryByTestId("memory-category-runtime_secrets")).toBeNull();
+    expect(screen.queryByText(/sk-must-not-render/)).toBeNull();
+  });
+
+  it("opens a category into a simple memory list", async () => {
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Open category: Financial" }));
+
+    expect(await screen.findByRole("heading", { name: "Financial" })).toBeTruthy();
+    expect(screen.getByTestId("memory-category-list-financial")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open memory: Primary Bank" })).toBeTruthy();
+  });
+
+  it("searches title/value and shows a clean empty state", async () => {
+    await openMainScreen();
+    const box = screen.getByRole("searchbox", { name: "Search Memory" });
+
+    fireEvent.change(box, { target: { value: "balanced" } });
+    expect(await screen.findByTestId("memory-search-results")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open memory: Risk Profile" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open memory: Primary Bank" })).toBeNull();
+
+    fireEvent.change(box, { target: { value: "zzz-nothing" } });
+    expect(await screen.findByText('No memories match “zzz-nothing”.')).toBeTruthy();
+  });
+
+  it("shows value and per-scope sharing only — never a guessed source or timestamp", async () => {
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+
+    expect(await screen.findByRole("heading", { name: "Risk Profile" })).toBeTruthy();
+    expect(screen.getByText("balanced")).toBeTruthy();
+    // Domain-level provenance must not be dressed up as this memory's own.
+    expect(screen.queryByText("Learned from")).toBeNull();
+    expect(screen.queryByText("Last updated")).toBeNull();
+
+    const meta = screen.getByTestId("memory-detail-meta");
+    expect(meta).toHaveTextContent("Sharing");
+    // profile scope is shared for financial in this fixture.
+    await waitFor(() => expect(meta).toHaveTextContent("Shared"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Memory" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open memory: Primary Bank" }));
+    const meta2 = await screen.findByTestId("memory-detail-meta");
+    // accounts scope is NOT shared even though another scope in the same domain is.
+    await waitFor(() => expect(meta2).toHaveTextContent("Private"));
+    expect(meta2).not.toHaveTextContent("Shared");
+  });
+
+  it("edits a memory through the existing write coordinator on the exact path", async () => {
+    let writtenDomain: Record<string, unknown> | null = null;
+    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockImplementationOnce(async (params) => {
+      const plan = await params.build({
+        currentDomainData: { profile: { risk_profile: "balanced" }, accounts: { primary_bank: "Chase" } },
+        currentManifest: null,
+        currentEncryptedDomain: null,
+        baseFullBlob: {},
+        attempt: 1,
+        upgradedInSession: false,
+      });
+      writtenDomain = plan.domainData;
+      expect(plan.operation).toBe("update");
+      expect(plan.scopePath).toBe("profile");
+      return { saveState: "saved", success: true, fullBlob: { financial: plan.domainData } };
+    });
+
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+    await screen.findByRole("heading", { name: "Risk Profile" });
+    await waitFor(() =>
+      expect(PersonalKnowledgeModelService.getMutationSharingImpact).toHaveBeenCalled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const input = await screen.findByRole("textbox", { name: "New value for Risk Profile" });
+    fireEvent.change(input, { target: { value: "growth" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalledTimes(1));
+    expect(writtenDomain).toEqual({
+      profile: { risk_profile: "growth" },
+      accounts: { primary_bank: "Chase" },
+    });
+    expect(clearAgentPkmContext).toHaveBeenCalledWith("reviewer");
+    // Returns to the list after a successful edit.
+    await waitFor(() =>
+      expect(screen.queryByRole("heading", { name: "Risk Profile" })).toBeNull(),
+    );
+  });
+
+  it("requires confirmation before forgetting and deletes the exact path", async () => {
+    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockImplementationOnce(async (params) => {
+      const plan = await params.build({
+        currentDomainData: { profile: { risk_profile: "balanced" }, accounts: { primary_bank: "Chase" } },
+        currentManifest: null,
+        currentEncryptedDomain: null,
+        baseFullBlob: {},
+        attempt: 0,
+        upgradedInSession: false,
+      });
+      expect(plan.operation).toBe("delete");
+      expect(plan.domainData).toEqual({ profile: {}, accounts: { primary_bank: "Chase" } });
+      return { saveState: "saved", success: true, fullBlob: { financial: plan.domainData } };
+    });
+
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+    await screen.findByRole("heading", { name: "Risk Profile" });
+    await waitFor(() =>
+      expect(PersonalKnowledgeModelService.getMutationSharingImpact).toHaveBeenCalled(),
+    );
+
+    // The action row does not delete on its own — a confirm dialog is required.
+    fireEvent.click(screen.getByRole("button", { name: "Forget Memory" }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(PkmWriteCoordinator.saveMergedDomain).not.toHaveBeenCalled();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Forget Memory" }));
+
+    await waitFor(() => expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.queryByRole("heading", { name: "Risk Profile" })).toBeNull(),
+    );
+  });
+
+  it("fails closed: no verified sharing impact disables edit and delete", async () => {
+    vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockRejectedValue(
+      new Error("impact unavailable"),
+    );
+
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+    await screen.findByRole("heading", { name: "Risk Profile" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: "Forget Memory" })).toBeDisabled();
+    expect(screen.getByTestId("memory-detail-meta")).toHaveTextContent("Not available");
+  });
+
+  it("keeps the automatic-memory preference (on the Add screen, off the Saved list)", async () => {
+    await openMainScreen();
+    // Not cluttering the primary Saved screen.
+    const savedPanel = document.querySelector('[data-pkm-saved-panel="true"]') as HTMLElement;
+    expect(within(savedPanel).queryByRole("switch")).toBeNull();
+    expect(within(savedPanel).queryByTestId("memory-auto-save-row")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
     const toggle = await screen.findByRole("switch", {
       name: "Turn automatic memory saving on",
     });
     expect(toggle).toHaveAttribute("aria-checked", "false");
-
     fireEvent.click(toggle);
 
     await waitFor(() =>
       expect(AgentPkmAutoSavePolicy.saveAgentPkmAutoSavePolicy).toHaveBeenCalledWith(
         expect.objectContaining({
           enabled: true,
-          confirmation: expect.objectContaining({
-            confirmedByUser: true,
-            source: "pkm_memory_auto_save_toggle",
-          }),
+          confirmation: expect.objectContaining({ confirmedByUser: true }),
         }),
       ),
     );
-    expect(
-      await screen.findByRole("switch", {
-        name: "Turn automatic memory saving off",
-      }),
-    ).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByTestId("memory-auto-save-row")).toContainElement(
-      screen.getByRole("switch", { name: "Turn automatic memory saving off" }),
-    );
   });
 
-  it("loads metadata and the private memory preference before decrypting a category", async () => {
-    render(<PkmNaturalPanel />);
+  it("keeps the review-first Add flow intact", async () => {
+    await openMainScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
 
-    const openFinancial = await screen.findByRole("button", { name: "Open Financial" });
-    expect(PersonalKnowledgeModelService.getMetadata).toHaveBeenCalledTimes(1);
-    expect(PersonalKnowledgeModelService.getDomainManifest).not.toHaveBeenCalled();
-    expect(PersonalKnowledgeModelService.loadDomainData).not.toHaveBeenCalledWith(
-      expect.objectContaining({ domain: "financial" })
-    );
-
-    fireEvent.click(openFinancial);
-
-    await waitFor(() => {
-      expect(PersonalKnowledgeModelService.loadDomainData).toHaveBeenCalledWith(
-        expect.objectContaining({ domain: "financial", userId: "reviewer" })
-      );
-    });
-    expect(PersonalKnowledgeModelService.getDomainManifest).toHaveBeenCalledWith(
-      "reviewer",
-      "financial",
-      "memory-only-owner-token"
-    );
-    expect(await screen.findByText("Exact category preview")).toBeTruthy();
-  });
-
-  it("refreshes the Memory viewport after this owner saves PKM elsewhere", async () => {
-    const getMetadata = vi.spyOn(PersonalKnowledgeModelService, "getMetadata");
-    render(<PkmNaturalPanel />);
-
-    await screen.findByRole("button", { name: "Open Financial" });
-    window.dispatchEvent(
-      new CustomEvent("pkm-domain-changed", {
-        detail: { userId: "reviewer", domain: "financial" },
-      }),
-    );
-
-    await waitFor(() => expect(getMetadata).toHaveBeenCalledTimes(2));
-    expect(getMetadata).toHaveBeenLastCalledWith(
-      "reviewer",
-      true,
-      "memory-only-owner-token",
-    );
-  });
-
-  it("uses the canonical settings-row geometry for the automatic-memory control", async () => {
-    render(<PkmNaturalPanel />);
-
-    await screen.findByRole("button", { name: "Open Financial" });
-
-    expect(screen.getByTestId("memory-auto-save-group")).toBeTruthy();
-    const row = screen.getByTestId("memory-auto-save-row");
-    expect(row).toBeTruthy();
-    expect(row.firstElementChild).toHaveClass("grid-cols-1");
-    expect(
-      screen.getByRole("switch", { name: "Turn automatic memory saving on" }),
-    ).toBeTruthy();
-  });
-
-  it("exposes the free-text review-first Memory flow without a rollout flag", async () => {
-    render(<PkmNaturalPanel />);
-
-    fireEvent.click(await screen.findByRole("button", { name: "Add" }));
     const note = await screen.findByRole("textbox", { name: "Memory note" });
-    fireEvent.change(note, {
-      target: { value: "I prefer morning flights whenever possible." },
-    });
+    fireEvent.change(note, { target: { value: "I prefer morning flights whenever possible." } });
     fireEvent.click(screen.getByRole("button", { name: "Review memory" }));
 
     await waitFor(() =>
       expect(previewAgentPkmMemory).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId: "reviewer",
-          message: "I prefer morning flights whenever possible.",
-          vaultOwnerToken: "memory-only-owner-token",
-        }),
+        expect.objectContaining({ userId: "reviewer" }),
       ),
     );
-    expect(await screen.findByText("Proposed saved detail")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Save to Memory" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Memory" }));
     await waitFor(() =>
       expect(addToPKM).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -277,243 +391,13 @@ describe("PkmNaturalPanel", () => {
     );
   });
 
-  it("keeps a failed automatic-memory update retryable without falsely telling the user to unlock", async () => {
-    vi.spyOn(AgentPkmAutoSavePolicy, "saveAgentPkmAutoSavePolicy").mockRejectedValueOnce(
-      new Error("Failed to store domain data: 422 - invalid request"),
-    );
+  it("still renders the Saved screen when domain-level sharing verification fails", async () => {
+    vi.spyOn(ConsentCenterService, "getCenter").mockRejectedValueOnce(new Error("consent unavailable"));
 
-    render(<PkmNaturalPanel />);
-
-    const toggle = await screen.findByRole("switch", {
-      name: "Turn automatic memory saving on",
-    });
-    fireEvent.click(toggle);
-
-    expect(
-      await screen.findByText("Automatic memory saving couldn’t be updated. Try again."),
-    ).toBeTruthy();
-    expect(screen.queryByText(/unlock your vault again/i)).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-    await waitFor(() =>
-      expect(AgentPkmAutoSavePolicy.saveAgentPkmAutoSavePolicy).toHaveBeenCalledTimes(2),
-    );
-    expect(
-      await screen.findByRole("switch", {
-        name: "Turn automatic memory saving off",
-      }),
-    ).toHaveAttribute("aria-checked", "true");
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
-  });
-
-  it("renders saved categories without waiting for the slower sharing request", async () => {
-    let resolveSharing: ((value: {
-      pending_requests: never[];
-      active_grants: never[];
-      recent_activity: never[];
-    }) => void) | null = null;
-    vi.spyOn(ConsentCenterService, "getCenter").mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveSharing = resolve;
-      }),
-    );
-
-    render(<PkmNaturalPanel />);
-
-    expect(await screen.findByRole("button", { name: "Open Financial" })).toBeTruthy();
-    expect(screen.getByTestId("sharing-ready").textContent).toBe("false");
-
-    resolveSharing?.({
-      pending_requests: [],
-      active_grants: [],
-      recent_activity: [],
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId("sharing-ready").textContent).toBe("true");
-    });
-  });
-
-  it("does not claim there is no active access when sharing status cannot be verified", async () => {
-    vi.spyOn(ConsentCenterService, "getCenter").mockRejectedValueOnce(
-      new Error("consent unavailable")
-    );
-
-    render(<PkmNaturalPanel />);
-
-    await screen.findByRole("button", { name: "Open Financial" });
-    expect(screen.getByTestId("sharing-ready").textContent).toBe("false");
-    expect(
-      screen.getByText("Sharing access couldn’t be verified. Refresh to try again.")
-    ).toBeTruthy();
-    expect(screen.getByText("Access status unavailable")).toBeTruthy();
-    expect(screen.queryByText("No active access")).toBeNull();
-  });
-
-  it("corrects only the confirmed path against the coordinator's latest domain state", async () => {
-    let writtenDomain: Record<string, unknown> | null = null;
-    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockImplementationOnce(
-      async (params) => {
-        const plan = await params.build({
-          currentDomainData: {
-            profile: { risk_profile: "balanced", sibling: "preserve-me" },
-          },
-          currentManifest: null,
-          currentEncryptedDomain: null,
-          baseFullBlob: {},
-          attempt: 1,
-          upgradedInSession: false,
-        });
-        writtenDomain = plan.domainData;
-        expect(plan.operation).toBe("update");
-        expect(plan.scopePath).toBe("profile");
-        expect(JSON.stringify(plan.summary)).not.toContain("balanced");
-        expect(JSON.stringify(plan.summary)).not.toContain("growth");
-        return {
-          saveState: "saved",
-          success: true,
-          fullBlob: { financial: plan.domainData },
-        };
-      }
-    );
-
-    render(<PkmNaturalPanel />);
-    fireEvent.click(await screen.findByRole("button", { name: "Open Financial" }));
-    await waitFor(() =>
-      expect(PersonalKnowledgeModelService.getMutationSharingImpact).toHaveBeenCalled()
-    );
-    await openIndividualFieldReview();
-    fireEvent.click(await screen.findByRole("button", { name: "Correct saved detail" }));
-    fireEvent.change(screen.getByRole("textbox", { name: "Corrected detail value" }), {
-      target: { value: "growth" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Save corrected detail" }));
-
-    await waitFor(() => expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalledTimes(1));
-    expect(writtenDomain).toEqual({
-      profile: { risk_profile: "growth", sibling: "preserve-me" },
-    });
-    expect(clearAgentPkmContext).toHaveBeenCalledWith("reviewer");
-    expect(PersonalKnowledgeModelService.getMetadata).toHaveBeenLastCalledWith(
-      "reviewer",
-      true,
-      "memory-only-owner-token"
-    );
-    expect(await screen.findByText("Saved detail corrected.")).toBeTruthy();
-  });
-
-  it("requires delete confirmation and records the confirmed delete operation", async () => {
-    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockImplementationOnce(
-      async (params) => {
-        const plan = await params.build({
-          currentDomainData: { profile: { risk_profile: "balanced", sibling: "keep" } },
-          currentManifest: null,
-          currentEncryptedDomain: null,
-          baseFullBlob: {},
-          attempt: 0,
-          upgradedInSession: false,
-        });
-        expect(plan.operation).toBe("delete");
-        expect(plan.scopePath).toBe("profile");
-        expect(plan.domainData).toEqual({ profile: { sibling: "keep" } });
-        return {
-          saveState: "saved",
-          success: true,
-          fullBlob: { financial: plan.domainData },
-        };
-      }
-    );
-
-    render(<PkmNaturalPanel />);
-    fireEvent.click(await screen.findByRole("button", { name: "Open Financial" }));
-    await waitFor(() =>
-      expect(PersonalKnowledgeModelService.getMutationSharingImpact).toHaveBeenCalled()
-    );
-    await openIndividualFieldReview();
-    fireEvent.click(await screen.findByRole("button", { name: "Remove saved detail" }));
-    await screen.findByText("Remove this saved detail?");
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(PkmWriteCoordinator.saveMergedDomain).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Remove saved detail" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Remove" }));
-
-    await waitFor(() => expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalledTimes(1));
-    expect(await screen.findByText("Saved detail removed.")).toBeTruthy();
-  });
-
-  it("surfaces a failed correction without claiming success", async () => {
-    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockResolvedValueOnce({
-      saveState: "failed",
-      success: false,
-      message: "The latest saved detail must be refreshed.",
-      fullBlob: {},
-    });
-
-    render(<PkmNaturalPanel />);
-    fireEvent.click(await screen.findByRole("button", { name: "Open Financial" }));
-    await waitFor(() =>
-      expect(PersonalKnowledgeModelService.getMutationSharingImpact).toHaveBeenCalled()
-    );
-    await openIndividualFieldReview();
-    fireEvent.click(await screen.findByRole("button", { name: "Correct saved detail" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save corrected detail" }));
-
-    expect(await screen.findByText("The latest saved detail must be refreshed.")).toBeTruthy();
-    expect(screen.queryByText("Saved detail corrected.")).toBeNull();
-    expect(clearAgentPkmContext).not.toHaveBeenCalled();
-  });
-
-  it("shows and forwards the authenticated sharing impact for a shared correction", async () => {
-    vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockResolvedValueOnce({
-      activeRecipientCount: 1,
-      recipientLabels: ["Planner Pro"],
-      entersNextExportRevision: true,
-      summary: "This change will enter the next encrypted export revision for Planner Pro.",
-      affectedGrantIds: ["grant-current"],
-      affectedExportIds: ["export-current"],
-    });
-    vi.spyOn(PkmWriteCoordinator, "saveMergedDomain").mockImplementationOnce(async (params) => {
-      expect(params.confirmation).toMatchObject({
-        sharingImpactAcknowledged: true,
-        sharingImpact: {
-          activeRecipientCount: 1,
-          recipientLabels: ["Planner Pro"],
-          affectedGrantIds: ["grant-current"],
-          affectedExportIds: ["export-current"],
-        },
-      });
-      return { saveState: "saved", success: true, fullBlob: {} };
-    });
-
-    render(<PkmNaturalPanel />);
-    fireEvent.click(await screen.findByRole("button", { name: "Open Financial" }));
-    expect(
-      await screen.findByText("This update is shared with Planner Pro.")
-    ).toBeTruthy();
-    await openIndividualFieldReview();
-    fireEvent.click(screen.getByRole("button", { name: "Correct saved detail" }));
-    expect(screen.queryByText(/encrypted export revision/i)).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Save corrected detail" }));
-
-    await waitFor(() => expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalled());
-  });
-
-  it("fails closed when sharing impact cannot be verified", async () => {
-    vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockRejectedValueOnce(
-      new Error("impact unavailable")
-    );
-
-    render(<PkmNaturalPanel />);
-    fireEvent.click(await screen.findByRole("button", { name: "Open Financial" }));
-
-    expect(
-      await screen.findByText(
-        "Current sharing couldn’t be verified. Refresh before changing details."
-      )
-    ).toBeTruthy();
-    await openIndividualFieldReview();
-    expect(screen.getByRole("button", { name: "Correct saved detail" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Remove saved detail" })).toBeDisabled();
+    await openMainScreen();
+    // No crash, no false access claim, categories still browsable.
+    expect(screen.getByTestId("memory-category-financial")).toBeTruthy();
+    expect(screen.queryByText(/no active access/i)).toBeNull();
+    expect(screen.queryByText(/shared/i)).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildPkmMemorySnapshot,
   deletePkmDomainValue,
+  pkmMemoryRowLabels,
   selectRelevantPkmMemoryCards,
   updatePkmDomainValue,
 } from "@/lib/pkm/pkm-memory-cards";
@@ -169,5 +170,44 @@ describe("PKM memory cards", () => {
     expect(card.pathSegments).toContain("sf_residence_001");
     expect(card.detail).not.toMatch(/sf residence|sf_residence_001/i);
     expect(card.detail).toContain("Changes");
+  });
+
+  describe("pkmMemoryRowLabels", () => {
+    it("uses the leaf path segment as the row name and the value sentence as the subtitle", () => {
+      const snapshot = buildPkmMemorySnapshot({
+        metadata,
+        fullBlob: {
+          professional: { preferences: { morning_flights: "morning flights" } },
+        },
+      });
+      const card = snapshot.cards.find((entry) => entry.path.endsWith("morning_flights"));
+      expect(card).toBeDefined();
+
+      const labels = pkmMemoryRowLabels(card!);
+      expect(labels.primary).toBe("Morning Flights");
+      expect(labels.secondary).toBe("morning flights");
+    });
+
+    it("falls back to the raw value when the name would echo the sentence", () => {
+      const labels = pkmMemoryRowLabels({
+        id: "financial:x",
+        domain: "financial",
+        domainTitle: "Financial",
+        title: "Risk Profile",
+        detail: "Stored in Financial.",
+        value: "balanced",
+        valueFingerprint: "fp",
+        path: "profile.risk_profile",
+        pathSegments: ["profile", "risk_profile"],
+        sourceLabel: "Saved memory",
+        updatedAt: null,
+        confidence: 0.9,
+        kind: "financial",
+        editable: true,
+        searchText: "financial risk profile balanced",
+      });
+      expect(labels.primary).toBe("Risk Profile");
+      expect(labels.secondary).toBe("balanced");
+    });
   });
 });

--- a/hushh-webapp/app/one/pkm/page.tsx
+++ b/hushh-webapp/app/one/pkm/page.tsx
@@ -3,7 +3,7 @@ import { PkmSettingsShell } from "@/components/profile/pkm-settings-shell";
 
 export default function PkmPage() {
   return (
-    <PkmSettingsShell title="Memory" description="What One knows about you">
+    <PkmSettingsShell title="Memory" description="What One remembers about you">
       <PkmNaturalPanel />
     </PkmSettingsShell>
   );

--- a/hushh-webapp/components/profile/pkm-memory-detail.tsx
+++ b/hushh-webapp/components/profile/pkm-memory-detail.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { Button } from "@/lib/morphy-ux/morphy";
+import { pkmMemoryRowLabels, type PkmMemoryCard } from "@/lib/pkm/pkm-memory-cards";
+
+export type MemorySharingState = "loading" | "private" | "shared" | "unavailable";
+
+function sharingRowValue(state: MemorySharingState): string {
+  switch (state) {
+    case "loading":
+      return "Checking…";
+    case "shared":
+      return "Shared";
+    case "unavailable":
+      return "Not available";
+    default:
+      return "Private";
+  }
+}
+
+/**
+ * One memory. Source and timestamp are deliberately not shown: the underlying
+ * card carries only domain-level provenance, so labelling it as this memory's
+ * own would be a guess. Sharing stays — it is verified per scope with
+ * getMutationSharingImpact. Editing and deletion are quiet, secondary rows.
+ */
+export function PkmMemoryDetail({
+  card,
+  sharingState,
+  canMutate,
+  saving,
+  deleting,
+  actionError,
+  onBack,
+  onOpenSharing,
+  onSave,
+  onForget,
+}: {
+  card: PkmMemoryCard;
+  sharingState: MemorySharingState;
+  canMutate: boolean;
+  saving: boolean;
+  deleting: boolean;
+  actionError: string | null;
+  onBack: () => void;
+  onOpenSharing: () => void;
+  onSave: (nextValue: string) => void;
+  onForget: () => void;
+}) {
+  const { primary, secondary } = pkmMemoryRowLabels(card);
+  const [editOpen, setEditOpen] = useState(false);
+  const [forgetOpen, setForgetOpen] = useState(false);
+  const [editValue, setEditValue] = useState(card.value);
+  const busy = saving || deleting;
+
+  useEffect(() => {
+    if (!saving && !actionError) setEditOpen(false);
+  }, [saving, actionError]);
+
+  useEffect(() => {
+    setEditValue(card.value);
+  }, [card.id, card.value]);
+
+  return (
+    <div className="space-y-7" data-pkm-detail-panel="true" data-pkm-memory-detail="true">
+      <button
+        type="button"
+        onClick={onBack}
+        className="-ml-1 inline-flex min-h-11 items-center gap-1 text-[15px] font-normal text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" aria-hidden />
+        Memory
+      </button>
+
+      <div className="space-y-2">
+        <h2 className="text-[26px] font-semibold leading-tight tracking-tight text-foreground">
+          {primary}
+        </h2>
+        {secondary ? (
+          <p className="text-[15px] leading-7 text-muted-foreground">{secondary}</p>
+        ) : null}
+      </div>
+
+      <SettingsGroup separatorInset testId="memory-detail-meta">
+        <SettingsRow
+          title="Sharing"
+          onClick={onOpenSharing}
+          ariaLabel="Open sharing settings"
+          trailing={
+            <span className="flex items-center gap-1 text-[15px] text-muted-foreground">
+              {sharingRowValue(sharingState)}
+              <ChevronRight className="h-4 w-4 text-muted-foreground/60" aria-hidden />
+            </span>
+          }
+        />
+      </SettingsGroup>
+
+      {actionError ? <p className="px-1 text-sm text-destructive">{actionError}</p> : null}
+
+      <SettingsGroup separatorInset testId="memory-detail-actions">
+        <SettingsRow
+          title="Edit"
+          disabled={!canMutate || busy}
+          onClick={() => {
+            setEditValue(card.value);
+            setEditOpen(true);
+          }}
+        />
+        <SettingsRow
+          title="Forget Memory"
+          tone="destructive"
+          disabled={!canMutate || busy}
+          onClick={() => setForgetOpen(true)}
+          trailing={
+            deleting ? <Loader2 className="h-4 w-4 animate-spin text-destructive" aria-hidden /> : undefined
+          }
+        />
+      </SettingsGroup>
+
+      <AlertDialog open={forgetOpen} onOpenChange={(open) => (busy ? undefined : setForgetOpen(open))}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Forget this memory?</AlertDialogTitle>
+            <AlertDialogDescription>
+              One will no longer remember “{primary}”. This can’t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={onForget}>
+              Forget Memory
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog open={editOpen} onOpenChange={(open) => (saving ? undefined : setEditOpen(open))}>
+        <DialogContent showCloseButton={false} className="gap-4 sm:max-w-[380px]">
+          <DialogHeader>
+            <DialogTitle>Edit Memory</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-medium text-foreground">{primary}</p>
+          <Input
+            value={editValue}
+            onChange={(event) => setEditValue(event.target.value)}
+            aria-label={`New value for ${primary}`}
+            autoFocus
+          />
+          {actionError ? <p className="text-sm text-destructive">{actionError}</p> : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="none"
+              effect="fade"
+              disabled={saving}
+              onClick={() => setEditOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              effect="fade"
+              disabled={saving || !editValue.trim() || editValue === card.value}
+              onClick={() => onSave(editValue)}
+            >
+              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : null}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/hushh-webapp/components/profile/pkm-memory-row.tsx
+++ b/hushh-webapp/components/profile/pkm-memory-row.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { SettingsRow } from "@/components/app-ui/settings-ui";
+import { pkmMemoryRowLabels, type PkmMemoryCard } from "@/lib/pkm/pkm-memory-cards";
+
+/**
+ * One memory as an iOS-style navigation row: a short name, the readable value
+ * beneath it, and a chevron. Used by Recently learned, category browsing, and
+ * search results so those three surfaces never drift apart.
+ *
+ * Deliberately carries no metadata (source, timestamp, sharing state) and no
+ * inline edit/forget controls — those live in the memory detail view.
+ */
+export function PkmMemoryRow({
+  card,
+  onOpen,
+  testId,
+}: {
+  card: PkmMemoryCard;
+  onOpen: (card: PkmMemoryCard) => void;
+  testId?: string;
+}) {
+  const { primary, secondary } = pkmMemoryRowLabels(card);
+  return (
+    <SettingsRow
+      title={primary}
+      description={secondary || undefined}
+      onClick={() => onOpen(card)}
+      chevron
+      ariaLabel={`Open memory: ${primary}`}
+      testId={testId ?? `memory-row-${card.id}`}
+    />
+  );
+}

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -1,24 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Check, ChevronDown, ChevronLeft, Edit3, Loader2, Lock, Minus, ShieldAlert, Trash2, X } from "lucide-react";
+import { ChevronLeft, Loader2, Lock, ShieldAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 
-import { PkmDataManagerPanel } from "@/components/profile/pkm-data-manager";
-import { PkmSectionPreview } from "@/components/profile/pkm-section-preview";
-import { SettingsGroup, SettingsRow, SettingsSegmentedTabs } from "@/components/app-ui/settings-ui";
-import { Badge } from "@/components/ui/badge";
+import { PkmMemoryRow } from "@/components/profile/pkm-memory-row";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+  PkmMemoryDetail,
+  type MemorySharingState,
+} from "@/components/profile/pkm-memory-detail";
+import { SettingsGroup, SettingsRow, SettingsSegmentedTabs } from "@/components/app-ui/settings-ui";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
@@ -30,13 +21,8 @@ import { Button } from "@/lib/morphy-ux/morphy";
 import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
 import {
   buildPkmDomainPresentation,
-  buildPkmProfileSummaryPresentation,
   isConsumerBrowsablePkmDomain,
 } from "@/lib/profile/pkm-profile-presentation";
-import {
-  buildPkmSectionPreviewPresentation,
-  type PkmSectionPreviewPresentation,
-} from "@/lib/profile/pkm-section-preview";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
   addToPKM,
@@ -80,7 +66,6 @@ import { useVault } from "@/lib/vault/vault-context";
 type DomainDetailState = {
   manifest: DomainManifest | null;
   data: Record<string, unknown> | null;
-  preview: PkmSectionPreviewPresentation | null;
   loading: boolean;
   error: boolean;
 };
@@ -95,7 +80,6 @@ const MEMORY_WORKSPACE_TABS = [
 const EMPTY_DOMAIN_DETAIL: DomainDetailState = {
   manifest: null,
   data: null,
-  preview: null,
   loading: false,
   error: false,
 };
@@ -106,30 +90,6 @@ function cardScopePath(card: PkmMemoryCard): string {
 
 function cardImpactKey(card: PkmMemoryCard): string {
   return `${card.domain}::${cardScopePath(card)}`;
-}
-
-function relativeMemoryDate(value: string | null): string {
-  if (!value) return "an unknown time";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "an unknown time";
-  const startOfDay = (input: Date) =>
-    new Date(input.getFullYear(), input.getMonth(), input.getDate()).getTime();
-  const diffDays = Math.round((startOfDay(new Date()) - startOfDay(date)) / 86_400_000);
-  if (diffDays <= 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays} days ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
-function formatSharingImpactDisclosure(impact: PkmMutationSharingImpact): string {
-  const labels = impact.recipientLabels.map((label) => label.trim()).filter(Boolean);
-  const recipient =
-    labels.length === 1
-      ? labels[0]
-      : `${impact.activeRecipientCount} recipient${
-          impact.activeRecipientCount === 1 ? "" : "s"
-        }`;
-  return `This update is shared with ${recipient}.`;
 }
 
 export function PkmNaturalPanel({
@@ -146,19 +106,16 @@ export function PkmNaturalPanel({
   const [metadata, setMetadata] = useState<PersonalKnowledgeModelMetadata | null>(null);
   const [activeGrants, setActiveGrants] = useState<ConsentCenterEntry[]>([]);
   const [sharingResolved, setSharingResolved] = useState(false);
-  const [sharingError, setSharingError] = useState<string | null>(null);
   const [bootstrapLoading, setBootstrapLoading] = useState(true);
   const [bootstrapError, setBootstrapError] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [selectedDomainKey, setSelectedDomainKey] = useState<string | null>(null);
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [domainDetail, setDomainDetail] = useState<DomainDetailState>(EMPTY_DOMAIN_DETAIL);
-  const [editingCardId, setEditingCardId] = useState<string | null>(null);
-  const [editValue, setEditValue] = useState("");
+  const [memoryCardsNonce, setMemoryCardsNonce] = useState(0);
   const [memoryActionId, setMemoryActionId] = useState<string | null>(null);
-  const [memoryActionMessage, setMemoryActionMessage] = useState<string | null>(null);
   const [memoryActionError, setMemoryActionError] = useState<string | null>(null);
   const [sharingImpacts, setSharingImpacts] = useState<Record<string, PkmMutationSharingImpact>>({});
-  const [sharingImpactLoading, setSharingImpactLoading] = useState(false);
   const [sharingImpactError, setSharingImpactError] = useState<string | null>(null);
   const [sharingImpactRefreshNonce, setSharingImpactRefreshNonce] = useState(0);
   const [autoSavePolicy, setAutoSavePolicy] = useState<AgentPkmAutoSavePolicy>(
@@ -180,8 +137,8 @@ export function PkmNaturalPanel({
   const [sharingManifestsLoading, setSharingManifestsLoading] = useState(false);
   const [sharingActionKey, setSharingActionKey] = useState<string | null>(null);
   const [homeSearchQuery, setHomeSearchQuery] = useState("");
-  const [recentCards, setRecentCards] = useState<PkmMemoryCard[]>([]);
-  const [recentCardsLoading, setRecentCardsLoading] = useState(false);
+  const [memoryCards, setMemoryCards] = useState<PkmMemoryCard[]>([]);
+  const [memoryCardsLoading, setMemoryCardsLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -193,7 +150,6 @@ export function PkmNaturalPanel({
           setMetadata(null);
           setActiveGrants([]);
           setSharingResolved(false);
-          setSharingError(null);
           setBootstrapLoading(false);
           setBootstrapError(false);
         }
@@ -203,7 +159,6 @@ export function PkmNaturalPanel({
       setBootstrapLoading(true);
       setBootstrapError(false);
       setSharingResolved(false);
-      setSharingError(null);
       const force =
         refreshNonce > 0 || refreshToken > 0 || pkmChangeRevision > 0;
       const metadataTask = PersonalKnowledgeModelService.getMetadata(
@@ -237,8 +192,9 @@ export function PkmNaturalPanel({
           setSharingResolved(true);
         })
         .catch(() => {
-          if (cancelled) return;
-          setSharingError("Sharing access couldn’t be verified. Refresh to try again.");
+          // Domain-level sharing is not shown on the Saved screen anymore; a
+          // memory's own sharing state is verified per scope in its detail view.
+          if (!cancelled) setSharingResolved(false);
         });
       await Promise.allSettled([metadataTask, sharingTask]);
     }
@@ -314,37 +270,48 @@ export function PkmNaturalPanel({
     [selectedDomainKey, visibleMetadataDomains]
   );
 
-  const selectedDomain = useMemo(() => {
-    if (!selectedMetadataDomain) return null;
-    return buildPkmDomainPresentation({
-      domain: selectedMetadataDomain,
-      activeGrants,
-      sharingResolved,
-      manifest: domainDetail.manifest,
-    });
-  }, [activeGrants, domainDetail.manifest, selectedMetadataDomain, sharingResolved]);
+  // Only ever browse cards whose domain a consumer is allowed to see. This is a
+  // second guard behind buildPkmMemorySnapshot: reserved domains (runtime
+  // secrets, KYC) and domains a backend marks not consumer-visible must never
+  // reach Recently learned, categories, search, or a detail view.
+  const browsableCards = useMemo(() => {
+    const allowed = new Set(visibleMetadataDomains.map((domain) => domain.key));
+    return memoryCards.filter((card) => allowed.has(card.domain));
+  }, [memoryCards, visibleMetadataDomains]);
 
-  const summary = useMemo(
+  const domainMemoryCards = useMemo(
     () =>
-      buildPkmProfileSummaryPresentation({
-        metadata,
-        domains: domainPresentations,
-        activeGrants,
-        metadataResolved: metadata !== null,
-        sharingResolved,
-      }),
-    [activeGrants, domainPresentations, metadata, sharingResolved]
+      selectedDomainKey
+        ? browsableCards.filter((card) => card.domain === selectedDomainKey)
+        : [],
+    [browsableCards, selectedDomainKey]
   );
 
-  const domainMemoryCards = useMemo(() => {
-    if (!selectedMetadataDomain || !domainDetail.data) return [];
-    return buildPkmMemorySnapshot({
-      metadata,
-      fullBlob: { [selectedMetadataDomain.key]: domainDetail.data },
-      maxCards: 64,
-      maxCardsPerDomain: 64,
-    }).cards;
-  }, [domainDetail.data, metadata, selectedMetadataDomain]);
+  const selectedCard = useMemo(
+    () => browsableCards.find((card) => card.id === selectedCardId) || null,
+    [browsableCards, selectedCardId]
+  );
+
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const card of browsableCards) {
+      counts.set(card.domain, (counts.get(card.domain) || 0) + 1);
+    }
+    return counts;
+  }, [browsableCards]);
+
+  const categories = useMemo(
+    () =>
+      domainPresentations
+        .map((domain) => ({
+          key: domain.key,
+          title: domain.title,
+          summary: domain.summary,
+          count: Math.max(domain.detailCount, categoryCounts.get(domain.key) || 0),
+        }))
+        .filter((domain) => domain.count > 0),
+    [categoryCounts, domainPresentations]
+  );
 
   const nativeDataState: NativeTestDataState =
     authLoading || bootstrapLoading || domainDetail.loading
@@ -373,14 +340,9 @@ export function PkmNaturalPanel({
 
     async function loadMutationImpacts() {
       if (!user || !vaultOwnerToken || !selectedMetadataDomain || domainMemoryCards.length === 0) {
-        if (!cancelled) {
-          setSharingImpacts({});
-          setSharingImpactLoading(false);
-          setSharingImpactError(null);
-        }
+        if (!cancelled) setSharingImpactError(null);
         return;
       }
-      setSharingImpactLoading(true);
       setSharingImpactError(null);
       try {
         const scopeEntries = Array.from(
@@ -397,14 +359,13 @@ export function PkmNaturalPanel({
             }),
           ] as const)
         );
-        if (!cancelled) setSharingImpacts(Object.fromEntries(impacts));
+        if (!cancelled) {
+          setSharingImpacts((current) => ({ ...current, ...Object.fromEntries(impacts) }));
+        }
       } catch {
         if (!cancelled) {
-          setSharingImpacts({});
           setSharingImpactError("Current sharing couldn’t be verified. Refresh before changing details.");
         }
-      } finally {
-        if (!cancelled) setSharingImpactLoading(false);
       }
     }
 
@@ -455,14 +416,6 @@ export function PkmNaturalPanel({
         setDomainDetail({
           manifest,
           data: domainData,
-          preview: buildPkmSectionPreviewPresentation({
-            domain: selectedMetadataDomain.key,
-            domainTitle: selectedMetadataDomain.displayName,
-            permissionLabel: selectedMetadataDomain.displayName,
-            permissionDescription: `Saved details in ${selectedMetadataDomain.displayName}.`,
-            topLevelScopePath: "",
-            value: domainData,
-          }),
           loading: false,
           error: false,
         });
@@ -523,7 +476,6 @@ export function PkmNaturalPanel({
     let cancelled = false;
     if (
       workspaceTab !== "browse" ||
-      selectedDomainKey ||
       !user ||
       !isVaultUnlocked ||
       !vaultKey ||
@@ -531,7 +483,7 @@ export function PkmNaturalPanel({
     ) {
       return undefined;
     }
-    setRecentCardsLoading(true);
+    setMemoryCardsLoading(true);
     void PersonalKnowledgeModelService.loadFullBlob({
       userId: user.uid,
       vaultKey,
@@ -542,30 +494,31 @@ export function PkmNaturalPanel({
         const snapshot = buildPkmMemorySnapshot({
           metadata,
           fullBlob,
-          maxCards: 200,
-          maxCardsPerDomain: 40,
+          maxCards: 400,
+          maxCardsPerDomain: 80,
         });
         const sorted = [...snapshot.cards].sort((left, right) => {
           const leftTime = left.updatedAt ? Date.parse(left.updatedAt) : 0;
           const rightTime = right.updatedAt ? Date.parse(right.updatedAt) : 0;
           return rightTime - leftTime;
         });
-        setRecentCards(sorted);
+        setMemoryCards(sorted);
       })
       .catch(() => {
-        if (!cancelled) setRecentCards([]);
+        if (!cancelled) setMemoryCards([]);
       })
       .finally(() => {
-        if (!cancelled) setRecentCardsLoading(false);
+        if (!cancelled) setMemoryCardsLoading(false);
       });
     return () => {
       cancelled = true;
     };
   }, [
     isVaultUnlocked,
+    memoryCardsNonce,
     metadata,
     pkmChangeRevision,
-    selectedDomainKey,
+    refreshNonce,
     user,
     vaultKey,
     vaultOwnerToken,
@@ -593,31 +546,13 @@ export function PkmNaturalPanel({
   }
 
   function resetMemoryActionState() {
-    setEditingCardId(null);
-    setEditValue("");
     setMemoryActionId(null);
   }
 
-  function rebuildDomainDetail(
-    domainData: Record<string, unknown>,
-    manifest = domainDetail.manifest
-  ): DomainDetailState {
-    if (!selectedMetadataDomain) return EMPTY_DOMAIN_DETAIL;
-    return {
-      manifest,
-      data: domainData,
-      preview: buildPkmSectionPreviewPresentation({
-        domain: selectedMetadataDomain.key,
-        domainTitle: selectedMetadataDomain.displayName,
-        permissionLabel: selectedMetadataDomain.displayName,
-        permissionDescription: `Saved details in ${selectedMetadataDomain.displayName}.`,
-        topLevelScopePath: "",
-        value: domainData,
-      }),
-      loading: false,
-      error: false,
-    };
-  }
+  useEffect(() => {
+    if (selectedCard) void ensureSharingImpact(selectedCard);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCardId]);
 
   async function persistMemoryCardChange(params: {
     card: PkmMemoryCard;
@@ -632,7 +567,6 @@ export function PkmNaturalPanel({
     }
     setMemoryActionId(`${params.card.id}:${params.action}`);
     setMemoryActionError(null);
-    setMemoryActionMessage(null);
     let persistedDomainData: Record<string, unknown> | null = null;
     try {
       const result = await PkmWriteCoordinator.saveMergedDomain({
@@ -683,18 +617,14 @@ export function PkmNaturalPanel({
       if (!result.success || !persistedDomainData) {
         throw new Error(result.message || "This saved detail couldn’t be updated.");
       }
-      const nextDomainData =
-        (result.fullBlob[params.card.domain] as Record<string, unknown> | undefined) ||
-        persistedDomainData;
-      setDomainDetail(rebuildDomainDetail(nextDomainData));
       clearAgentPkmContext(user.uid);
       setMetadata(
         await PersonalKnowledgeModelService.getMetadata(user.uid, true, vaultOwnerToken)
       );
-      setMemoryActionMessage(
-        params.action === "edited" ? "Saved detail corrected." : "Saved detail removed."
-      );
+      morphyToast.success(params.action === "edited" ? "Memory updated." : "Memory forgotten.");
       resetMemoryActionState();
+      setSelectedCardId(null);
+      setMemoryCardsNonce((value) => value + 1);
     } catch (error) {
       setMemoryActionError(
         error instanceof Error ? error.message : "This saved detail couldn’t be updated."
@@ -854,175 +784,52 @@ export function PkmNaturalPanel({
     }
   }
 
-  function renderMemoryCard(card: PkmMemoryCard) {
-    const editing = editingCardId === card.id;
-    const saving = memoryActionId === `${card.id}:edited`;
-    const deleting = memoryActionId === `${card.id}:deleted`;
-    const sharingImpact = sharingImpacts[cardImpactKey(card)];
+  function memorySharingState(card: PkmMemoryCard): MemorySharingState {
+    const impact = sharingImpacts[cardImpactKey(card)];
+    if (impact) return impact.activeRecipientCount > 0 ? "shared" : "private";
+    if (sharingImpactError) return "unavailable";
+    return "loading";
+  }
+
+  const trimmedQuery = homeSearchQuery.trim();
+  const searchResults = trimmedQuery
+    ? selectRelevantPkmMemoryCards(browsableCards, homeSearchQuery, 24)
+    : [];
+  const matchedCategories = trimmedQuery
+    ? categories.filter((domain) =>
+        `${domain.title} ${domain.summary}`.toLowerCase().includes(trimmedQuery.toLowerCase())
+      )
+    : categories;
+  const recentMemories = browsableCards.slice(0, 6);
+
+  function openMemory(card: PkmMemoryCard) {
+    setSelectedCardId(card.id);
+    setMemoryActionError(null);
+  }
+
+  function renderCategoryRow(domain: { key: string; title: string; count: number }) {
     return (
-      <div className="space-y-2 py-3 pl-6 first:pt-1 last:pb-1">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
-            <p className="break-words text-sm font-medium text-foreground">{card.title}</p>
-            <p className="text-xs text-muted-foreground">{card.detail}</p>
-            {sharingImpact?.activeRecipientCount ? (
-              <p className="text-xs text-muted-foreground">{formatSharingImpactDisclosure(sharingImpact)}</p>
-            ) : null}
-          </div>
-          <div className="flex shrink-0 gap-1">
-            {editing ? (
-              <>
-                <Button type="button" variant="none" effect="fade" disabled={saving || !sharingImpact} aria-label="Save corrected detail" onClick={() => void persistMemoryCardChange({ card, action: "edited", nextValue: editValue })}>
-                  {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Check className="h-4 w-4" aria-hidden />}
-                </Button>
-                <Button type="button" variant="none" effect="fade" disabled={saving} aria-label="Cancel correction" onClick={resetMemoryActionState}>
-                  <X className="h-4 w-4" aria-hidden />
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button type="button" variant="none" effect="fade" disabled={sharingImpactLoading || !sharingImpact} aria-label="Correct saved detail" onClick={() => { setEditingCardId(card.id); setEditValue(card.value); setMemoryActionError(null); setMemoryActionMessage(null); }}>
-                  <Edit3 className="h-4 w-4" aria-hidden />
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button type="button" variant="none" effect="fade" disabled={deleting || sharingImpactLoading || !sharingImpact} aria-label="Remove saved detail">
-                      {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Trash2 className="h-4 w-4" aria-hidden />}
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent size="sm">
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Remove this saved detail?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Other details in {card.domainTitle} will stay unchanged.
-                        {sharingImpact?.activeRecipientCount ? ` ${formatSharingImpactDisclosure(sharingImpact)}` : ""}
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction variant="destructive" onClick={() => void persistMemoryCardChange({ card, action: "deleted" })}>Remove</AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </>
-            )}
-          </div>
-        </div>
-        {editing ? <Input value={editValue} onChange={(event) => setEditValue(event.target.value)} aria-label="Corrected detail value" /> : null}
-      </div>
+      <SettingsRow
+        key={domain.key}
+        title={domain.title}
+        description={`${domain.count} ${domain.count === 1 ? "memory" : "memories"}`}
+        onClick={() => setSelectedDomainKey(domain.key)}
+        chevron
+        ariaLabel={`Open category: ${domain.title}`}
+        testId={`memory-category-${domain.key}`}
+      />
     );
   }
 
-  function domainPrivacyLabel(domainKey: string): "Shared" | "Private" {
-    const domain = domainPresentations.find((entry) => entry.key === domainKey);
-    return domain && domain.accessCount > 0 ? "Shared" : "Private";
-  }
-
-  const homeFilteredDomains = (() => {
-    const query = homeSearchQuery.trim().toLowerCase();
-    if (!query) return domainPresentations;
-    return domainPresentations.filter((domain) => {
-      const haystack = [domain.title, domain.summary, domain.sourceLabels.join(" "), domain.sections.join(" ")]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(query);
-    });
-  })();
-
-  const visibleRecentCards = selectRelevantPkmMemoryCards(
-    recentCards,
-    homeSearchQuery,
-    homeSearchQuery.trim() ? 12 : 6
+  const addMemoryRow = (
+    <SettingsRow
+      title="Add Memory"
+      onClick={() => setWorkspaceTab("add")}
+      chevron
+      ariaLabel="Add Memory"
+      testId="memory-add-row"
+    />
   );
-
-  function renderRecentMemoryRow(card: PkmMemoryCard) {
-    const editing = editingCardId === card.id;
-    const saving = memoryActionId === `${card.id}:edited`;
-    const deleting = memoryActionId === `${card.id}:deleted`;
-    const sharingImpact = sharingImpacts[cardImpactKey(card)];
-    return (
-      <div className="space-y-2 py-3 first:pt-1 last:pb-1">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1.5">
-            <p className="break-words text-sm font-medium text-foreground">{card.title}</p>
-            <p className="text-xs text-muted-foreground">
-              From {card.sourceLabel} · {relativeMemoryDate(card.updatedAt)}
-            </p>
-            <Badge variant="secondary" className="text-[11px]">
-              {domainPrivacyLabel(card.domain)}
-            </Badge>
-          </div>
-          <div className="flex shrink-0 gap-1">
-            {editing ? (
-              <>
-                <Button
-                  type="button"
-                  variant="none"
-                  effect="fade"
-                  disabled={saving || !sharingImpact}
-                  aria-label={`Save corrected detail for ${card.title}`}
-                  onClick={() => void persistMemoryCardChange({ card, action: "edited", nextValue: editValue })}
-                >
-                  {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Check className="h-4 w-4" aria-hidden />}
-                </Button>
-                <Button type="button" variant="none" effect="fade" disabled={saving} aria-label="Cancel correction" onClick={resetMemoryActionState}>
-                  <X className="h-4 w-4" aria-hidden />
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  type="button"
-                  variant="none"
-                  effect="fade"
-                  aria-label={`Edit ${card.title}`}
-                  onClick={() => {
-                    setEditingCardId(card.id);
-                    setEditValue(card.value);
-                    setMemoryActionError(null);
-                    setMemoryActionMessage(null);
-                    void ensureSharingImpact(card);
-                  }}
-                >
-                  <Edit3 className="h-4 w-4" aria-hidden />
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="none"
-                      effect="fade"
-                      disabled={deleting}
-                      aria-label={`Forget ${card.title}`}
-                      onClick={() => void ensureSharingImpact(card)}
-                    >
-                      {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Trash2 className="h-4 w-4" aria-hidden />}
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent size="sm">
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Forget this detail?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        One will no longer remember this.
-                        {sharingImpact?.activeRecipientCount ? ` ${formatSharingImpactDisclosure(sharingImpact)}` : ""}
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction variant="destructive" onClick={() => void persistMemoryCardChange({ card, action: "deleted" })}>Forget</AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </>
-            )}
-          </div>
-        </div>
-        {editing ? (
-          <Input value={editValue} onChange={(event) => setEditValue(event.target.value)} aria-label={`Corrected value for ${card.title}`} />
-        ) : null}
-      </div>
-    );
-  }
 
   if (authLoading) {
     return (
@@ -1060,97 +867,74 @@ export function PkmNaturalPanel({
     );
   }
 
-  if (selectedDomain && selectedMetadataDomain) {
+  if (selectedCard) {
     return (
-      <>{nativeBeacon}<div className="space-y-4" data-pkm-detail-panel="true">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <Button
-            type="button"
-            variant="none"
-            effect="fade"
-            onClick={() => setSelectedDomainKey(null)}
-          >
-            <ChevronLeft className="mr-2 h-4 w-4" aria-hidden />
-            All categories
-          </Button>
-          <Button
-            type="button"
-            variant="none"
-            effect="fade"
-            onClick={() => router.push(ROUTES.CONSENTS)}
-          >
-            Manage sharing
-          </Button>
-        </div>
+      <>
+        {nativeBeacon}
+        <PkmMemoryDetail
+          card={selectedCard}
+          sharingState={memorySharingState(selectedCard)}
+          canMutate={Boolean(sharingImpacts[cardImpactKey(selectedCard)])}
+          saving={memoryActionId === `${selectedCard.id}:edited`}
+          deleting={memoryActionId === `${selectedCard.id}:deleted`}
+          actionError={memoryActionError}
+          onBack={() => {
+            setSelectedCardId(null);
+            setMemoryActionError(null);
+          }}
+          onOpenSharing={() => router.push(ROUTES.CONSENTS)}
+          onSave={(nextValue) =>
+            void persistMemoryCardChange({ card: selectedCard, action: "edited", nextValue })
+          }
+          onForget={() => void persistMemoryCardChange({ card: selectedCard, action: "deleted" })}
+        />
+      </>
+    );
+  }
 
-        <SurfaceInset className="space-y-3 p-4">
-          <div className="space-y-1">
-            <p className="text-sm font-semibold tracking-tight text-foreground">
-              {selectedDomain.title}
-            </p>
-            <p className="text-sm leading-6 text-muted-foreground">{selectedDomain.summary}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {selectedDomain.detailCount > 0 ? (
-              <Badge variant="secondary">
-                {selectedDomain.detailCount} saved item
-                {selectedDomain.detailCount === 1 ? "" : "s"}
-              </Badge>
-            ) : null}
-            {selectedDomain.sourceLabels.map((sourceLabel) => (
-              <Badge key={sourceLabel} variant="secondary">
-                {sourceLabel}
-              </Badge>
+  if (selectedMetadataDomain) {
+    const categoryTitle = selectedMetadataDomain.displayName;
+    const categoryCards = domainMemoryCards;
+    return (
+      <>{nativeBeacon}<div className="space-y-7" data-pkm-detail-panel="true">
+        <button
+          type="button"
+          onClick={() => setSelectedDomainKey(null)}
+          className="-ml-1 inline-flex min-h-11 items-center gap-1 text-[15px] font-normal text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          Memory
+        </button>
+
+        <h2 className="text-[26px] font-semibold leading-tight tracking-tight text-foreground">
+          {categoryTitle}
+        </h2>
+
+        {sharingImpactError ? (
+          <p className="px-1 text-sm text-destructive">{sharingImpactError}</p>
+        ) : null}
+
+        {categoryCards.length > 0 ? (
+          <SettingsGroup separatorInset testId={`memory-category-list-${selectedMetadataDomain.key}`}>
+            {categoryCards.map((card) => (
+              <PkmMemoryRow key={card.id} card={card} onOpen={openMemory} />
             ))}
-            <Badge variant="secondary">{selectedDomain.accessSummary}</Badge>
-          </div>
-        </SurfaceInset>
-
-        {domainDetail.loading ? (
+          </SettingsGroup>
+        ) : domainDetail.loading || memoryCardsLoading ? (
           <SurfaceInset className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            Decrypting this category…
+            Opening {categoryTitle}…
           </SurfaceInset>
         ) : domainDetail.error ? (
           <SurfaceInset className="space-y-1 p-4 text-sm text-muted-foreground">
             <p className="font-semibold text-foreground">This category couldn’t be opened</p>
-            <p>Return to all categories and try again.</p>
+            <p>Go back and try again.</p>
           </SurfaceInset>
-        ) : domainDetail.preview ? (
-          <div className="space-y-4">
-            <PkmSectionPreview presentation={domainDetail.preview} />
-
-            {memoryActionMessage ? <p className="text-sm text-emerald-700 dark:text-emerald-300">{memoryActionMessage}</p> : null}
-            {memoryActionError ? <p className="text-sm text-destructive">{memoryActionError}</p> : null}
-            {sharingImpactError ? <p className="text-sm text-destructive">{sharingImpactError}</p> : null}
-            {domainMemoryCards.length > 0 ? (
-              <SurfaceInset className="p-4">
-                <details className="group">
-                  <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
-                    <span className="min-w-0 space-y-0.5">
-                      <span className="block text-sm font-semibold text-foreground">Review individual fields</span>
-                      <span className="block text-sm text-muted-foreground">
-                        {domainMemoryCards.length} saved detail{domainMemoryCards.length === 1 ? "" : "s"}
-                      </span>
-                    </span>
-                    <ChevronDown
-                      className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
-                      aria-hidden
-                    />
-                  </summary>
-                  <div className="mt-3 border-t border-[color:var(--app-card-border-standard)] pt-2">
-                    <p className="px-6 py-2 text-xs leading-5 text-muted-foreground">
-                      Open a detail only when you need to correct or remove it.
-                    </p>
-                    <div className="divide-y divide-[color:var(--app-card-border-standard)]">
-                      {domainMemoryCards.map((card) => <div key={card.id}>{renderMemoryCard(card)}</div>)}
-                    </div>
-                  </div>
-                </details>
-              </SurfaceInset>
-            ) : null}
-          </div>
-        ) : null}
+        ) : (
+          <SurfaceInset className="p-4 text-sm text-muted-foreground">
+            Nothing is saved in {categoryTitle} yet.
+          </SurfaceInset>
+        )}
       </div></>
     );
   }
@@ -1171,99 +955,82 @@ export function PkmNaturalPanel({
           activeValue={workspaceTab}
           onSelectionChange={(value) => setWorkspaceTab(value as MemoryWorkspaceTab)}
           viewportMinHeight="0px"
+          heightMode="active"
         >
-          <div className="space-y-4 pb-1 pr-px">
-        <SettingsGroup separatorInset testId="memory-auto-save-group">
-          <SettingsRow
-            testId="memory-auto-save-row"
-            title="Let One remember useful preferences"
-            description={
-              autoSavePolicyError ||
-              "One can save simple preferences automatically. Sensitive details will still ask first."
-            }
-            tone={autoSavePolicyError ? "destructive" : "default"}
-            stackTrailingOnMobile
-            trailing={
-              <div className="flex min-h-11 w-full items-center justify-end gap-2 sm:w-auto">
-                {autoSavePolicyError && autoSavePolicyRetryValue !== null ? (
-                  <Button
-                    type="button"
-                    variant="none"
-                    effect="fade"
-                    size="sm"
-                    onClick={() => void updateAutoSavePolicy(autoSavePolicyRetryValue)}
-                    disabled={autoSavePolicySaving || autoSavePolicyLoading}
-                  >
-                    Retry
-                  </Button>
-                ) : null}
-                <span aria-live="polite" className="text-xs font-medium text-muted-foreground">
-                  {autoSavePolicy.enabled ? "On" : "Off"}
-                </span>
-                <Switch
-                  checked={autoSavePolicy.enabled}
-                  onCheckedChange={(enabled) => void updateAutoSavePolicy(enabled)}
-                  disabled={autoSavePolicyLoading || autoSavePolicySaving}
-                  aria-label={
-                    autoSavePolicy.enabled
-                      ? "Turn automatic memory saving off"
-                      : "Turn automatic memory saving on"
-                  }
-                  className="shrink-0"
-                />
-              </div>
-            }
-          />
-        </SettingsGroup>
-
+          <div className="space-y-5 pb-1 pr-px" data-pkm-saved-panel="true">
           <Input
             type="search"
             value={homeSearchQuery}
             onChange={(event) => setHomeSearchQuery(event.target.value)}
-            placeholder="Search what One knows"
-            aria-label="Search what One knows"
+            placeholder="Search Memory"
+            aria-label="Search Memory"
             autoComplete="off"
             autoCorrect="off"
             spellCheck={false}
-            className="h-10"
+            className="h-11"
           />
 
-          {recentCardsLoading && visibleRecentCards.length === 0 ? (
+          {memoryCardsLoading && memoryCards.length === 0 ? (
             <SurfaceInset className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-              Checking what One has learned…
+              Opening Memory…
             </SurfaceInset>
-          ) : visibleRecentCards.length > 0 ? (
-            <SurfaceInset className="p-4" data-pkm-recently-learned="true">
-              <p className="mb-1 text-sm font-semibold text-foreground">Recently learned</p>
-              <div className="divide-y divide-[color:var(--app-card-border-standard)]">
-                {visibleRecentCards.map((card) => (
-                  <div key={card.id}>{renderRecentMemoryRow(card)}</div>
-                ))}
-              </div>
-            </SurfaceInset>
-          ) : null}
+          ) : trimmedQuery ? (
+            searchResults.length === 0 && matchedCategories.length === 0 ? (
+              <SurfaceInset className="p-4 text-sm text-muted-foreground" data-pkm-search-empty="true">
+                No memories match “{trimmedQuery}”.
+              </SurfaceInset>
+            ) : (
+              <>
+                {searchResults.length > 0 ? (
+                  <SettingsGroup title="Memories" separatorInset testId="memory-search-results">
+                    {searchResults.map((card) => (
+                      <PkmMemoryRow key={card.id} card={card} onOpen={openMemory} />
+                    ))}
+                  </SettingsGroup>
+                ) : null}
+                {matchedCategories.length > 0 ? (
+                  <SettingsGroup title="Categories" separatorInset>
+                    {matchedCategories.map(renderCategoryRow)}
+                  </SettingsGroup>
+                ) : null}
+              </>
+            )
+          ) : (
+            <>
+              {recentMemories.length > 0 ? (
+                <SettingsGroup title="Recently learned" separatorInset testId="memory-recently-learned">
+                  {recentMemories.map((card) => (
+                    <PkmMemoryRow key={card.id} card={card} onOpen={openMemory} />
+                  ))}
+                </SettingsGroup>
+              ) : null}
 
-          <PkmDataManagerPanel
-            signedIn
-            loading={bootstrapLoading}
-            metadataReady={metadata !== null}
-            metadataError={bootstrapError ? "Saved details couldn’t be loaded. Try again." : null}
-            sharingReady={sharingResolved}
-            sharingError={sharingError}
-            needsVaultCreation={false}
-            needsUnlock={false}
-            summary={summary}
-            domains={homeFilteredDomains}
-            loadingManifestsByDomain={{}}
-            manifestErrorsByDomain={{}}
-            onOpenSharing={() => setWorkspaceTab("sharing")}
-            onOpenImport={() => router.push(ROUTES.PROFILE_SECURITY_VAULT)}
-            onRefresh={() => setRefreshNonce((value) => value + 1)}
-            onOpenDomain={(domain) => setSelectedDomainKey(domain.key)}
-          />
+              {categories.length > 0 ? (
+                <SettingsGroup title="Categories" separatorInset testId="memory-categories">
+                  {categories.map(renderCategoryRow)}
+                  {addMemoryRow}
+                </SettingsGroup>
+              ) : (
+                <>
+                  {!memoryCardsLoading ? (
+                    <p className="px-1 text-sm text-muted-foreground">
+                      One hasn’t saved anything yet.
+                    </p>
+                  ) : null}
+                  <SettingsGroup separatorInset>{addMemoryRow}</SettingsGroup>
+                </>
+              )}
+
+              {bootstrapError ? (
+                <p className="px-1 text-sm text-muted-foreground">
+                  Some memories couldn’t be loaded. Pull to refresh.
+                </p>
+              ) : null}
+            </>
+          )}
           </div>
-          <div className="pb-1 pr-px">
+          <div className="space-y-5 pb-1 pr-px">
           <SurfaceInset className="space-y-4 p-4" data-pkm-memory-capture="true">
             <div className="space-y-1">
               <p className="text-sm font-semibold text-foreground">Teach One something</p>
@@ -1288,40 +1055,145 @@ export function PkmNaturalPanel({
             ) : null}
             {captureCards.length > 0 ? <Button className="w-full justify-center" type="button" effect="fade" disabled={captureSaving} onClick={() => void saveMemoryCapture()}>{captureSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : null}Save to Memory</Button> : null}
           </SurfaceInset>
+
+          <SettingsGroup separatorInset testId="memory-auto-save-group">
+            <SettingsRow
+              testId="memory-auto-save-row"
+              title="Let One remember useful preferences"
+              description={
+                autoSavePolicyError ||
+                "One can save simple preferences automatically. Sensitive details will still ask first."
+              }
+              tone={autoSavePolicyError ? "destructive" : "default"}
+              stackTrailingOnMobile
+              trailing={
+                <div className="flex min-h-11 w-full items-center justify-end gap-2 sm:w-auto">
+                  {autoSavePolicyError && autoSavePolicyRetryValue !== null ? (
+                    <Button
+                      type="button"
+                      variant="none"
+                      effect="fade"
+                      size="sm"
+                      onClick={() => void updateAutoSavePolicy(autoSavePolicyRetryValue)}
+                      disabled={autoSavePolicySaving || autoSavePolicyLoading}
+                    >
+                      Retry
+                    </Button>
+                  ) : null}
+                  <span aria-live="polite" className="text-xs font-medium text-muted-foreground">
+                    {autoSavePolicy.enabled ? "On" : "Off"}
+                  </span>
+                  <Switch
+                    checked={autoSavePolicy.enabled}
+                    onCheckedChange={(enabled) => void updateAutoSavePolicy(enabled)}
+                    disabled={autoSavePolicyLoading || autoSavePolicySaving}
+                    aria-label={
+                      autoSavePolicy.enabled
+                        ? "Turn automatic memory saving off"
+                        : "Turn automatic memory saving on"
+                    }
+                    className="shrink-0"
+                  />
+                </div>
+              }
+            />
+          </SettingsGroup>
           </div>
-          <div className="pb-1 pr-px">
-          <SurfaceInset className="space-y-4 p-4" data-pkm-memory-sharing="true">
-            <div className="space-y-1">
+          <div className="space-y-4 pb-1 pr-px" data-pkm-memory-sharing="true">
+            <div className="space-y-1 px-1">
               <p className="text-sm font-semibold text-foreground">Memory sharing</p>
-              <p className="text-sm text-muted-foreground">Choose what One can share when someone asks for access.</p>
+              <p className="text-sm text-muted-foreground">
+                Choose what One can share when someone asks for access.
+              </p>
             </div>
-            {sharingManifestsLoading ? <p className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" aria-hidden />Checking sharing settings…</p> : null}
-            {!sharingManifestsLoading && visibleMetadataDomains.map((domain) => {
-              const manifest = sharingManifests[domain.key] || null;
-              const bundles = buildPkmShareBundles(manifest);
-              if (!manifest || bundles.length === 0) return null;
-              const state = pkmShareBundleState(bundles);
-              const allHandles = bundles.map((bundle) => bundle.scopeHandle).filter((value): value is string => Boolean(value));
-              const busy = sharingActionKey === `${domain.key}:${allHandles.join(",")}`;
-              return (
-                <div key={domain.key} className="space-y-2 rounded-xl border border-[color:var(--app-card-border-standard)] p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div><p className="text-sm font-medium text-foreground">{domain.displayName}</p><p className="text-xs text-muted-foreground">{state === "indeterminate" ? "Some items ask before sharing" : state === "checked" ? "Ask before sharing" : "Private"}</p></div>
-                    <button type="button" role="checkbox" aria-checked={state === "indeterminate" ? "mixed" : state === "checked"} aria-label={`Set all ${domain.displayName} items ${state === "checked" ? "private" : "to ask before sharing"}`} disabled={busy || allHandles.length === 0} onClick={() => void updateSharingBundles({ domain: domain.key, manifest, scopeHandles: allHandles, enabled: state !== "checked" })} className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--app-card-border-standard)] bg-muted text-foreground disabled:opacity-50">
-                      {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : state === "checked" ? <Check className="h-4 w-4" aria-hidden /> : state === "indeterminate" ? <Minus className="h-4 w-4" aria-hidden /> : null}
-                    </button>
-                  </div>
-                  <div className="divide-y divide-[color:var(--app-card-border-standard)]">
+
+            {sharingManifestsLoading ? (
+              <p className="flex items-center gap-2 px-1 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Checking sharing settings…
+              </p>
+            ) : null}
+
+            {!sharingManifestsLoading &&
+              visibleMetadataDomains.map((domain) => {
+                const manifest = sharingManifests[domain.key] || null;
+                const bundles = buildPkmShareBundles(manifest);
+                if (!manifest || bundles.length === 0) return null;
+                const state = pkmShareBundleState(bundles);
+                const allHandles = bundles
+                  .map((bundle) => bundle.scopeHandle)
+                  .filter((value): value is string => Boolean(value));
+                const allBusy = sharingActionKey === `${domain.key}:${allHandles.join(",")}`;
+                return (
+                  <SettingsGroup
+                    key={domain.key}
+                    title={domain.displayName}
+                    separatorInset
+                    testId={`memory-sharing-${domain.key}`}
+                    titleAction={
+                      bundles.length > 1 && allHandles.length > 0 ? (
+                        <button
+                          type="button"
+                          disabled={allBusy}
+                          aria-pressed={state === "checked"}
+                          aria-label={`Set every ${domain.displayName} item ${
+                            state === "checked" ? "private" : "to ask before sharing"
+                          }`}
+                          onClick={() =>
+                            void updateSharingBundles({
+                              domain: domain.key,
+                              manifest,
+                              scopeHandles: allHandles,
+                              enabled: state !== "checked",
+                            })
+                          }
+                          className="inline-flex min-h-11 items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+                        >
+                          {allBusy ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                          ) : null}
+                          {state === "checked" ? "Make all private" : "Ask for all"}
+                        </button>
+                      ) : undefined
+                    }
+                  >
                     {bundles.map((bundle) => {
                       const bundleKey = `${domain.key}:${bundle.scopeHandle || bundle.topLevelScopePath}`;
-                      return <SettingsRow key={bundleKey} title={bundle.label} description={bundle.enabled ? "Ask before sharing" : "Private"} trailing={<Switch checked={bundle.enabled} disabled={sharingActionKey === bundleKey || !bundle.scopeHandle} onCheckedChange={(enabled) => bundle.scopeHandle && void updateSharingBundles({ domain: domain.key, manifest, scopeHandles: [bundle.scopeHandle], enabled })} aria-label={`${bundle.enabled ? "Make private" : "Ask before sharing"} ${bundle.label}`} />} />;
+                      return (
+                        <SettingsRow
+                          key={bundleKey}
+                          title={bundle.label}
+                          description={bundle.enabled ? "Ask before sharing" : "Private"}
+                          trailing={
+                            <Switch
+                              checked={bundle.enabled}
+                              disabled={sharingActionKey === bundleKey || !bundle.scopeHandle}
+                              onCheckedChange={(enabled) =>
+                                bundle.scopeHandle &&
+                                void updateSharingBundles({
+                                  domain: domain.key,
+                                  manifest,
+                                  scopeHandles: [bundle.scopeHandle],
+                                  enabled,
+                                })
+                              }
+                              aria-label={`${bundle.enabled ? "Make private" : "Ask before sharing"} ${bundle.label}`}
+                            />
+                          }
+                        />
+                      );
                     })}
-                  </div>
-                </div>
-              );
-            })}
-            {!sharingManifestsLoading && visibleMetadataDomains.length > 0 && Object.values(sharingManifests).every((manifest) => buildPkmShareBundles(manifest).length === 0) ? <p className="text-sm text-muted-foreground">Nothing to share yet.</p> : null}
-          </SurfaceInset>
+                  </SettingsGroup>
+                );
+              })}
+
+            {!sharingManifestsLoading &&
+            visibleMetadataDomains.length > 0 &&
+            Object.values(sharingManifests).every(
+              (manifest) => buildPkmShareBundles(manifest).length === 0,
+            ) ? (
+              <p className="px-1 text-sm text-muted-foreground">Nothing to share yet.</p>
+            ) : null}
           </div>
         </SwipeViews>
       </div>

--- a/hushh-webapp/lib/pkm/pkm-memory-cards.ts
+++ b/hushh-webapp/lib/pkm/pkm-memory-cards.ts
@@ -334,6 +334,51 @@ export function selectRelevantPkmMemoryCards(
     .slice(0, limit);
 }
 
+const GENERIC_LEAF_LABELS = new Set([
+  "value",
+  "values",
+  "detail",
+  "details",
+  "profile",
+  "data",
+  "entry",
+  "item",
+  "note",
+  "notes",
+]);
+
+/**
+ * Human-readable labels for one memory row.
+ *
+ * `primary` is a short noun ("Morning flights", "Risk profile") derived from the
+ * last meaningful path segment; `secondary` is the readable value sentence
+ * ("You prefer morning flights"). When the derived name would just echo the
+ * sentence, the raw value is used as the subtitle instead so the row never
+ * repeats itself.
+ */
+export function pkmMemoryRowLabels(card: PkmMemoryCard): {
+  primary: string;
+  secondary: string;
+} {
+  const leaf = [...card.pathSegments]
+    .reverse()
+    .find((segment): segment is string => typeof segment === "string" && segment.trim().length > 0);
+  const derived = leaf ? titleize(leaf) : "";
+  const primary =
+    derived && !GENERIC_LEAF_LABELS.has(derived.toLowerCase())
+      ? derived
+      : card.domainTitle;
+  const value = compact(card.value);
+  let sentence = compact(card.title);
+  const prefix = `${primary}: `.toLowerCase();
+  if (sentence.toLowerCase().startsWith(prefix)) {
+    sentence = sentence.slice(prefix.length).trim();
+  }
+  const secondary =
+    sentence && sentence.toLowerCase() !== primary.toLowerCase() ? sentence : value;
+  return { primary, secondary };
+}
+
 function domainInsightSummary(params: {
   domain: DomainSummary | undefined;
   cards: readonly PkmMemoryCard[];
@@ -419,7 +464,7 @@ export function buildPkmMemorySnapshot(params: {
       ...(params.metadata?.domains.map((domain) => domain.key).filter(Boolean) || []),
       ...Object.keys(params.fullBlob || {}),
     ])
-  );
+  ).filter((domainKey) => !shouldSkipPkmMemoryKey(domainKey));
 
   const cardsByDomain = new Map<string, PkmMemoryCard[]>();
   for (const domainKey of domainKeys) {


### PR DESCRIPTION
## Summary

Redesigns the Saved view of `/one/pkm` into a calm, Apple-Settings-style Memory experience — "don't show the database, show the person what One remembers." Frontend UX + data-organisation only.

**No change** to PKM storage schema, encryption, backend APIs, Vault, auth, consent architecture, sharing authorization, `PkmWriteCoordinator` / `updatePkmDomainValue` / `deletePkmDomainValue`, `updateScopeExposure`, or the Add flow introduced by #5939 / #6141.

### Main Memory screen
- `Memory` / `What One remembers about you`, a `Search Memory` field, `Recently learned` (newest first, from the existing `PkmMemoryCard` snapshot), `Categories` (consumer-browsable domains only, `N memories`, empty categories hidden), and `Add Memory` as the last row of the Categories group.
- Removes the dashboard panel, per-row badges/metadata, refresh + sharing buttons, and the domain-level sharing banner. The automatic-memory preference moves to the Add screen.

### Memory detail (new `pkm-memory-detail.tsx`)
- Name, value, and a single `Sharing` row. Source and timestamp are **not** shown: the card only carries domain-level provenance, so presenting it as this memory's own would be a guess (no backend change made to fix this).
- `Edit` (bottom sheet) and `Forget Memory` (confirmation required) are quiet secondary rows; deletion still runs through `PkmWriteCoordinator` and the existing consent/sharing-impact checks.

### Sharing
- Per-memory sharing label is verified **per scope** via `PersonalKnowledgeModelService.getMutationSharingImpact(domain, scopePath)` instead of inferred from domain-level access. Unverifiable state never shows as `Shared` and never bypasses the existing mutation guard.
- Sharing tab restyled to flat `SettingsGroup`-per-domain lists (no nested cards); the select-all control is now a subtle text action.

### Other
- New reusable `pkm-memory-row.tsx` shared by Recently learned, category browsing, and search so those surfaces stay consistent.
- `pkm-memory-cards.ts`: adds `pkmMemoryRowLabels`; filters reserved domains (`runtime_secrets`, `kyc_*`) out of `buildPkmMemorySnapshot` via the existing `shouldSkipPkmMemoryKey` classifier (already used as a domain filter in `agent-pkm-context-store.ts`) so they cannot leak into the memory projection or LLM context.
- `SwipeViews heightMode="active"` on the Memory tabs so the viewport tracks the active pane and shorter tabs (Sharing) do not leave dead scroll space — matches `consent-center-page.tsx` / `kai-market-hub-page.tsx` / `location-redesign-hub.tsx`.

## Test plan

- [x] `npx vitest run __tests__/components/pkm-natural-panel.test.tsx __tests__/lib/pkm-memory-cards.test.ts __tests__/services/pkm-memory-tree.test.ts __tests__/services/pkm-cache.test.ts __tests__/components/pkm-data-manager.test.tsx __tests__/components/pkm-section-preview.test.tsx` — all green (37 tests). Covers: Memory title/search/Recently-learned ordering, consumer-visible categories + counts + empty hidden, category browse, search + empty state, detail value + per-scope sharing (one shared scope ≠ siblings Shared), edit via write coordinator on the exact path, forget requires confirm, fail-closed edit/forget when impact unverifiable, auto-save preference on the Add screen, reserved-domain filtering, `heightMode="active"`.
- [x] `npx tsc --noEmit` — no new errors (pre-existing `@ag-ui/client` module-resolution errors in `agent-chat-client.ts` are unrelated: the dep is pinned in `package-lock.json` but not installed in this environment).
- [x] `npx eslint` on all touched files — clean.
- [ ] Manual walkthrough at 320 / 375 / 430px, light + dark, against a running backend — needs an authenticated session + unlocked vault (local offline backend can't start; verified route compiles against the UAT backend).

Closes #6190