### PR TITLE
fix(one-location): Change time opens on presets, not a bare wheel

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -6373,6 +6373,69 @@ describe("OneLocationAgentPage", () => {
     }
   }, 15000);
 
+  it("offers the common lengths as one tap, with the wheel behind Custom", async () => {
+    // The report: Change time opened straight onto a two-column scroll wheel.
+    // Almost every change to a running share is one of five lengths, so those
+    // are now always visible and cost one tap each. The wheel is still
+    // reachable for anything in between -- removed from the default view, not
+    // removed.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
+    try {
+      render(<OneLocationAgentPage />);
+      await skipLocationEntryFlow();
+      await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+      const card = await screen.findByTestId("one-location-live-share");
+      await act(async () => {
+        fireEvent.click(
+          within(card).getByTestId("one-location-live-share-change-time"),
+        );
+      });
+      const editor = await screen.findByTestId(
+        "one-location-live-share-duration-editor",
+      );
+
+      for (const label of [
+        "15 min",
+        "1 hour",
+        "2 hours",
+        "4 hours",
+        "8 hours",
+        "Until I stop",
+      ]) {
+        expect(
+          within(editor).getByRole("button", { name: label }),
+        ).toBeInTheDocument();
+      }
+
+      // One tap on a rung is the whole interaction -- no drag, no confirm
+      // step of its own before Save.
+      await act(async () => {
+        fireEvent.click(within(editor).getByRole("button", { name: "2 hours" }));
+      });
+      await act(async () => {
+        fireEvent.click(
+          within(editor).getByTestId("one-location-live-share-duration-save"),
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockSetGrantDuration).toHaveBeenCalledWith(
+          expect.objectContaining({
+            grantId: "grant_1",
+            durationHours: 2,
+          }),
+        ),
+      );
+      // Same grant, still. Changing a length must not read as end-and-restart.
+      expect(mockRevokeGrant).not.toHaveBeenCalled();
+      expect(mockCreateGrant).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 15000);
+
   it("remembers the running share on the device, and only ids and times", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -33,7 +33,13 @@ export const SHARE_DURATION_LADDER: DurationRung[] = [
   { value: "1", label: "1 hour" },
 ];
 
-export const REQUEST_DURATION_LADDER: DurationRung[] = [
+/**
+ * The fuller ladder, used by the Request screen and by the live-share "New
+ * time" editor. Named for its shape rather than one lane, because it now
+ * serves both: a person changing an active share reaches for the same five
+ * lengths as a person asking for one.
+ */
+export const FULL_DURATION_LADDER: DurationRung[] = [
   { value: "0.25", label: "15 min" },
   { value: "1", label: "1 hour" },
   { value: "2", label: "2 hours" },

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -151,7 +151,7 @@ import {
   ReasonChips,
   type ReasonValue,
 } from "./selectors";
-import { REQUEST_DURATION_LADDER } from "./duration-presets";
+import { FULL_DURATION_LADDER } from "./duration-presets";
 import {
   LiveShareStatusCard,
   ShareCountdownText,
@@ -4597,16 +4597,31 @@ function LiveShareDurationEditor({
       data-ui-contract="control-group"
       data-ui-id="location-live-share-duration-editor"
     >
+      {/*
+        Presets, not the bare wheel this used to open on. Almost every change
+        to a running share is one of the same five lengths, and the wheel
+        charged ~200px plus two coordinated drags to reach any of them --
+        inside a card that already sits under the live-share status block. The
+        wheel is still here for anything in between, behind `Custom`, where it
+        costs nothing until somebody asks for it. Same control the Request
+        screen already uses, so the two duration screens stop disagreeing.
+
+        `until_stopped` stays available: this is a decision about your own
+        location, so open-ended is a real answer here (unlike the Request lane,
+        which turns the rung off).
+      */}
       <DurationSelector
         value={value}
         onChange={onChange}
-        presentation="wheel"
+        presentation="ladder"
+        rungs={FULL_DURATION_LADDER}
         untilStopValue="until_stopped"
         label="New time"
+        // Beside the label rather than on its own line under the control --
+        // "New time … Ends 6:50 PM" is one statement, and it is how every
+        // other ladder on these screens already reads.
+        hint={shareEndsAtLabel(value, nowMs)}
       />
-      <p className={MUTED_TEXT} aria-live="polite">
-        {shareEndsAtLabel(value, nowMs)}
-      </p>
       <div className="grid grid-cols-2 gap-2">
         <Button
           variant="ghost"
@@ -5068,7 +5083,7 @@ function AskFlow({
               label="How long"
               presentation="ladder"
               allowUntilStop={false}
-              rungs={REQUEST_DURATION_LADDER}
+              rungs={FULL_DURATION_LADDER}
             />
             <ReasonChips
               value={reason}


### PR DESCRIPTION
## Summary

**Change time** on a running share opened straight onto a two-column scroll wheel — ~200px of screen and two coordinated drags to reach any value, inside a card that already sits under the live-share status block.

It now opens on the same preset ladder the Request screen uses:

**15 min · 1 hour · 2 hours · 4 hours · 8 hours · Until I stop · Custom**

The wheel is **not gone** — it sits behind `Custom`, where it costs nothing until somebody asks for a length between the rungs, and it still opens seeded on the current value rather than resetting to a preset the person never chose.

## Notes

- **`until_stopped` stays available here.** It is a decision about your own location, so open-ended is a real answer — unlike the Request lane, which turns that rung off because there is no asking to see someone else's location until *they* stop.
- **The read-back moved beside the label** — "New time … Ends 6:50 PM" is one statement, and it is how every other ladder on these screens already reads. Saves a line in the card that was the problem.
- **`REQUEST_DURATION_LADDER` → `FULL_DURATION_LADDER`.** It now serves both lanes, and a name saying "request" would send the next reader looking for a difference that isn't there.

No new component was needed — `DurationSelector` already supported `presentation="ladder"`, and this call site was the one still asking for `"wheel"`.

## Test plan

- [x] `npx vitest run __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts components/one-location/redesign/__tests__/` — **300 passed across 18 files**.
- [x] New test: the editor offers all six rungs, one tap on `2 hours` then Save sends `durationHours: 2` **on the same grant** — no revoke, no re-create, so changing a length still never reads to the recipient as end-and-restart.
- [x] The two existing editor tests pass unchanged. The "untouched picker spends no call" one still holds: a share with 30 minutes left is not a rung, so it opens on `Custom` showing 0h 30m — the seeding path, exercised for free.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6188.
