### PR TITLE
fix(one): say what the reuse-access setting actually does

### DIFF
--- a/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/voice-preferences-panel.test.tsx
@@ -300,7 +300,7 @@ describe("VoicePreferencesPanel", () => {
     );
 
     const toggle = await screen.findByRole("switch", {
-      name: "Reuse scopes from last request",
+      name: "Reuse access from last time",
     });
     expect(toggle).not.toBeChecked();
 
@@ -332,5 +332,32 @@ describe("VoicePreferencesPanel", () => {
     expect(
       screen.getByRole("switch", { name: "Require a tap to confirm" }),
     ).toBeInTheDocument();
+  });
+
+  it("says the reuse setting asks as well as offers", async () => {
+    // The copy this replaces said only "offer the same access as last time".
+    // connect.send_request reuses offeredScopeHandles AND
+    // requestedScopeHandles, so the setting also asks for the same access
+    // again. On a consent control that half matters most -- "offer" reads as
+    // "only affects what I give away".
+    mockGetVoicePreferences.mockResolvedValue({
+      shareScopesFromLastRequest: false,
+    });
+    render(
+      <VoicePreferencesPanel
+        userId={userId}
+        getIdToken={async () => "id-token"}
+        onOpenChangelog={() => {}}
+        onOpenExamples={() => {}}
+      />,
+    );
+
+    const description = await screen.findByText(/repeat voice request/i);
+    expect(description.textContent).toMatch(/asks for and offers/i);
+    // Scoped to the one person, never extrapolated from somebody else.
+    expect(description.textContent).toMatch(/with that person/i);
+    // The recipient approving is the load-bearing reassurance; it must not be
+    // dropped in a future trim.
+    expect(description.textContent).toMatch(/still approve/i);
   });
 });

--- a/hushh-webapp/components/profile/voice-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/voice-preferences-panel.tsx
@@ -266,9 +266,25 @@ function ConnectAgentDefaultsGroup({
       title="Connect"
       description="Defaults One uses for voice-initiated connection requests."
     >
+      {/*
+        The old copy said the setting lets a repeat request "offer the same
+        access as last time". It does more than offer: connect.send_request
+        reuses BOTH offeredScopeHandles and requestedScopeHandles, so it also
+        ASKS for the same access again. On a consent control that asymmetry is
+        the whole point -- somebody reading "offer" reasonably concludes this
+        only affects what they give away, not what they request.
+
+        "last time" was also vaguer than the behaviour. Scopes come from this
+        requester's most recent request to THIS exact person; there is
+        deliberately no wider "usual scopes" fallback, so a repeat can never
+        extrapolate from someone else and a first request is always empty.
+        That narrowness is reassuring, and the copy was hiding it.
+
+        "Scopes" is our word, not a person's. The row says access instead.
+      */}
       <SettingsRow
-        title="Reuse scopes from last request"
-        description="Let a repeat voice request offer the same access as last time. The other person still approves every request."
+        title="Reuse access from last time"
+        description="A repeat voice request asks for and offers the same access you did with that person before. They still approve every request."
         trailing={
           <Switch
             checked={shareScopes}
@@ -283,7 +299,7 @@ function ConnectAgentDefaultsGroup({
                 )
                 .catch(() => setShareScopes(!checked));
             }}
-            aria-label="Reuse scopes from last request"
+            aria-label="Reuse access from last time"
           />
         }
       />


### PR DESCRIPTION
## The setting works. The copy understated it.

Traced end to end before changing anything: the panel writes it, the API persists it to `connection_voice_preferences`, and `connect.send_request` (`action_tools.py:1047`) reads it lazily — only once a request actually reaches the point of being created — and applies it. **No behaviour change in this PR.**

## What was wrong

| | |
|---|---|
| **Before** | Let a repeat voice request **offer** the same access as last time. The other person still approves every request. |
| **After** | A repeat voice request **asks for and offers** the same access you did with that person before. They still approve every request. |

**It does more than offer.** `connect.send_request` reuses both `offeredScopeHandles` *and* `requestedScopeHandles` (`action_tools.py:1101-1105`) — it asks for the same access again too. On a consent control that asymmetry is the whole point: someone reading "offer" reasonably concludes it only affects what they give away, not what they request of the other person.

**"last time" was vaguer than the behaviour, in the unhelpful direction.** Scopes come from this requester's most recent request to *this exact person*. `get_last_request_scope_handles` has deliberately no wider "usual scopes" fallback, so a repeat can never extrapolate from someone else, and a first request is always empty — the setting is simply inert until you have asked that person once. That narrowness is the reassuring part, and the copy was hiding it.

**Retitled off "scopes"** — our word, not a person's. The row now says access, matching the description under it. `aria-label` moved with it.

## Test plan

- [x] `npx vitest run __tests__/components/voice-preferences-panel.test.tsx` — 16/16.
- [x] New test pins all three claims in the description: that it asks as well as offers, that it is scoped to that one person, and that the recipient still approves. The third is the load-bearing reassurance and must not be lost to a future trim.
- [x] The existing toggle test (loads from the endpoint, persists on change) passes with the new label.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6185.
