### PR TITLE
fix(vault): restore the lock-state policy lost in the 2026-08-20 revert

### DIFF
--- a/hushh-webapp/__tests__/components/capability-vault-prerequisite.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-vault-prerequisite.test.tsx
@@ -121,10 +121,10 @@ describe("CapabilityVaultPrerequisite", () => {
     );
 
     await waitFor(() => expect(vaultMocks.checkVault).toHaveBeenCalledWith("user_1"));
-    expect(await screen.findByRole("dialog", { name: /^set up your private vault$/i })).toBeTruthy();
+    expect(await screen.findByRole("dialog", { name: /^set a lock$/i })).toBeTruthy();
     expect(
       screen.getByRole("dialog", {
-        name: /^set up your private vault$/i,
+        name: /^set a lock$/i,
       }).getAttribute("data-generated-default"),
     ).toBe("true");
     expect(screen.queryByText("Location workspace")).toBeNull();
@@ -143,7 +143,7 @@ describe("CapabilityVaultPrerequisite", () => {
     );
 
     await screen.findByRole("dialog", {
-      name: /^set up your private vault$/i,
+      name: /^set a lock$/i,
     });
     fireEvent.click(screen.getByRole("button", { name: "Complete vault setup" }));
 
@@ -170,8 +170,8 @@ describe("CapabilityVaultPrerequisite", () => {
       </CapabilityVaultPrerequisite>,
     );
 
-    await screen.findByRole("dialog", { name: /^open your private vault$/i });
-    expect(screen.queryByRole("heading", { name: /open your private vault first/i })).toBeNull();
+    await screen.findByRole("dialog", { name: /^unlock one$/i });
+    expect(screen.queryByRole("heading", { name: /unlock one first/i })).toBeNull();
   });
 
   it("retains the capability boundary when the presence check fails and supports retry", async () => {
@@ -184,12 +184,12 @@ describe("CapabilityVaultPrerequisite", () => {
       </CapabilityVaultPrerequisite>,
     );
 
-    expect(await screen.findByText(/could not confirm your vault/i)).toBeTruthy();
+    expect(await screen.findByText(/couldn't confirm your lock/i)).toBeTruthy();
     await act(async () => {
       screen.getByRole("button", { name: "Try again" }).click();
     });
     await waitFor(() => expect(vaultMocks.checkVault).toHaveBeenCalledTimes(2));
-    expect(await screen.findByRole("dialog", { name: /^set up your private vault$/i })).toBeTruthy();
+    expect(await screen.findByRole("dialog", { name: /^set a lock$/i })).toBeTruthy();
     expect(screen.queryByText("Location workspace")).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/lib/vault/lock-state.test.ts
+++ b/hushh-webapp/__tests__/lib/vault/lock-state.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLockReady,
+  isLockRequiredError,
+  lockActionLabel,
+  lockBlockedSummary,
+  LockRequiredError,
+  needsLockPrompt,
+  resolveLockState,
+  resolveVaultAvailabilityState,
+  type LockState,
+  type LockStateInputs,
+} from "@/lib/vault/vault-access-policy";
+
+/**
+ * The five states must stay distinct.
+ *
+ * Every reported symptom of the lock regression is two of these collapsed into
+ * one: a person with no lock told to "Unlock One", a person who is merely
+ * locked offered first-run setup, a screen painting a verdict before anything
+ * was read, and a failed request read as an account with no lock. Each `it`
+ * below pins one of those apart.
+ */
+
+const settled: LockStateInputs = {
+  hasVault: null,
+  isVaultUnlocked: false,
+  authLoading: false,
+};
+
+function state(overrides: Partial<LockStateInputs>): LockState {
+  return resolveLockState({ ...settled, ...overrides });
+}
+
+describe("resolveLockState — unknown is never a verdict", () => {
+  it("waits while auth is still restoring, even with a known lock", () => {
+    expect(state({ authLoading: true, hasVault: true })).toBe("loading");
+  });
+
+  it("waits while auth is still restoring, even with no lock on record", () => {
+    // The dangerous direction: `false` here would render "Set a lock" at
+    // somebody who is signed in and holds one.
+    expect(state({ authLoading: true, hasVault: false })).toBe("loading");
+  });
+
+  it("waits while lock ownership has not been read", () => {
+    expect(state({ hasVault: null })).toBe("loading");
+  });
+
+  it("treats an absent value the same as an explicit unknown", () => {
+    expect(state({ hasVault: undefined })).toBe("loading");
+  });
+
+  it("never reports unconfigured before the answer is in", () => {
+    const unresolved: LockState[] = [
+      state({ hasVault: null }),
+      state({ hasVault: null, authLoading: true }),
+      state({ hasVault: undefined }),
+    ];
+    expect(unresolved.every((value) => value === "loading")).toBe(true);
+  });
+});
+
+describe("resolveLockState — a failed read is not an absent lock", () => {
+  it("reports error, not unconfigured, when the presence check failed", () => {
+    expect(state({ presenceFailed: true, hasVault: null })).toBe("error");
+  });
+
+  it("still reports error when a stale negative is sitting in hasVault", () => {
+    expect(state({ presenceFailed: true, hasVault: false })).toBe("error");
+  });
+
+  it("lets a live key override a failed presence read", () => {
+    // The key in memory is proof. A background check that fell over cannot
+    // relock somebody who is demonstrably unlocked.
+    expect(
+      state({
+        presenceFailed: true,
+        isVaultUnlocked: true,
+        vaultOwnerToken: "token",
+      }),
+    ).toBe("unlocked");
+  });
+});
+
+describe("resolveLockState — configured, locked and unlocked stay apart", () => {
+  it("reports unconfigured only for a settled, successful, negative read", () => {
+    expect(state({ hasVault: false })).toBe("unconfigured");
+  });
+
+  it("reports locked for an account that owns a lock with no key in memory", () => {
+    expect(state({ hasVault: true })).toBe("locked");
+  });
+
+  it("does not call a locked account unconfigured", () => {
+    // The headline regression, stated as an assertion.
+    expect(state({ hasVault: true })).not.toBe("unconfigured");
+  });
+
+  it("reports unlocked from the owner token alone", () => {
+    expect(state({ hasVault: true, vaultOwnerToken: "token" })).toBe("unlocked");
+  });
+
+  it("reports unlocked from the context's own boolean alone", () => {
+    // A caller holding only `useVault().isVaultUnlocked` is as entitled to the
+    // answer as one holding the token.
+    expect(state({ hasVault: true, isVaultUnlocked: true })).toBe("unlocked");
+  });
+
+  it("ignores a whitespace-only token", () => {
+    expect(state({ hasVault: true, vaultOwnerToken: "   " })).toBe("locked");
+  });
+
+  it("returns exactly one state for every input combination", () => {
+    const valid: LockState[] = [
+      "loading",
+      "unconfigured",
+      "locked",
+      "unlocked",
+      "error",
+    ];
+    for (const hasVault of [true, false, null] as const) {
+      for (const isVaultUnlocked of [true, false]) {
+        for (const authLoading of [true, false]) {
+          for (const presenceFailed of [true, false]) {
+            const resolved = resolveLockState({
+              hasVault,
+              isVaultUnlocked,
+              authLoading,
+              presenceFailed,
+            });
+            expect(valid).toContain(resolved);
+          }
+        }
+      }
+    }
+  });
+});
+
+describe("the words each state is owed", () => {
+  it("offers setup only to somebody with no lock", () => {
+    expect(lockActionLabel("unconfigured")).toBe("Set a lock");
+  });
+
+  it("offers unlock to somebody whose lock is merely shut", () => {
+    expect(lockActionLabel("locked")).toBe("Unlock One");
+  });
+
+  it("never offers setup to a locked account", () => {
+    expect(lockActionLabel("locked")).not.toBe(lockActionLabel("unconfigured"));
+  });
+
+  it("keeps every visible label inside the four-word budget", () => {
+    for (const value of ["unconfigured", "locked"] as const) {
+      expect(lockActionLabel(value).split(/\s+/).length).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("asks somebody to wait rather than blaming them, while loading", () => {
+    expect(lockBlockedSummary("loading")).toBe("Still checking");
+  });
+
+  it("names the fault on error instead of claiming there is no lock", () => {
+    expect(lockBlockedSummary("error")).toBe("Couldn't check your lock");
+    expect(lockBlockedSummary("error")).not.toBe(
+      lockBlockedSummary("unconfigured"),
+    );
+  });
+
+  it("says nothing when the action may simply run", () => {
+    expect(lockBlockedSummary("unlocked")).toBe("");
+  });
+});
+
+describe("who may be prompted", () => {
+  it("prompts a locked and an unconfigured person", () => {
+    expect(needsLockPrompt("locked")).toBe(true);
+    expect(needsLockPrompt("unconfigured")).toBe(true);
+  });
+
+  it("never prompts while the answer is still unknown", () => {
+    // Prompting here accuses somebody of being locked during a frame of our
+    // own bookkeeping.
+    expect(needsLockPrompt("loading")).toBe(false);
+  });
+
+  it("never hides a failed read behind a credential sheet", () => {
+    expect(needsLockPrompt("error")).toBe(false);
+  });
+
+  it("lets only an unlocked state proceed", () => {
+    expect(isLockReady("unlocked")).toBe(true);
+    for (const value of [
+      "loading",
+      "unconfigured",
+      "locked",
+      "error",
+    ] as const) {
+      expect(isLockReady(value)).toBe(false);
+    }
+  });
+});
+
+describe("resolveVaultAvailabilityState — the booleans agree with the state", () => {
+  it("does not claim creation is needed while the read is unresolved", () => {
+    const availability = resolveVaultAvailabilityState({
+      hasVault: null,
+      isVaultUnlocked: false,
+    });
+    expect(availability.state).toBe("loading");
+    expect(availability.needsVaultCreation).toBe(false);
+    expect(availability.vaultUnknown).toBe(true);
+  });
+
+  it("does not claim creation is needed when the read failed", () => {
+    const availability = resolveVaultAvailabilityState({
+      hasVault: false,
+      isVaultUnlocked: false,
+      presenceFailed: true,
+    });
+    expect(availability.state).toBe("error");
+    expect(availability.needsVaultCreation).toBe(false);
+    expect(availability.vaultCheckFailed).toBe(true);
+  });
+
+  it("claims creation only for a settled negative", () => {
+    const availability = resolveVaultAvailabilityState({
+      hasVault: false,
+      isVaultUnlocked: false,
+    });
+    expect(availability.state).toBe("unconfigured");
+    expect(availability.needsVaultCreation).toBe(true);
+    expect(availability.needsUnlock).toBe(false);
+  });
+
+  it("claims unlock for a lock that exists and is shut", () => {
+    const availability = resolveVaultAvailabilityState({
+      hasVault: true,
+      isVaultUnlocked: false,
+    });
+    expect(availability.state).toBe("locked");
+    expect(availability.needsUnlock).toBe(true);
+    expect(availability.needsVaultCreation).toBe(false);
+  });
+
+  it("keeps the capability booleans intact for the decrypt question", () => {
+    const availability = resolveVaultAvailabilityState({
+      hasVault: true,
+      isVaultUnlocked: true,
+      vaultKey: "key",
+      vaultOwnerToken: "token",
+    });
+    expect(availability.state).toBe("unlocked");
+    expect(availability.canMutateSecureData).toBe(true);
+    expect(availability.canReadSecureData).toBe(true);
+  });
+
+  it("exposes exactly one true state flag at a time", () => {
+    const combos: LockStateInputs[] = [
+      { hasVault: null, isVaultUnlocked: false },
+      { hasVault: false, isVaultUnlocked: false },
+      { hasVault: true, isVaultUnlocked: false },
+      { hasVault: true, isVaultUnlocked: true, vaultOwnerToken: "t" },
+      { hasVault: false, isVaultUnlocked: false, presenceFailed: true },
+    ];
+    for (const combo of combos) {
+      const availability = resolveVaultAvailabilityState(combo);
+      const flags = [
+        availability.vaultUnknown,
+        availability.needsVaultCreation,
+        availability.needsUnlock,
+        availability.vaultCheckFailed,
+        availability.state === "unlocked",
+      ].filter(Boolean);
+      expect(flags).toHaveLength(1);
+    }
+  });
+});
+
+describe("LockRequiredError", () => {
+  it("carries the state so a caller opens the right sheet", () => {
+    expect(new LockRequiredError("unconfigured").lockState).toBe("unconfigured");
+    expect(new LockRequiredError("locked").lockState).toBe("locked");
+  });
+
+  it("speaks the state's own words by default", () => {
+    // One Voice reads this verbatim, so it must not say "unlock" to somebody
+    // who has nothing to unlock.
+    expect(new LockRequiredError("unconfigured").message).toBe(
+      "Set a lock first",
+    );
+    expect(new LockRequiredError("locked").message).toBe("Unlock One first");
+  });
+
+  it("is recognisable across a module boundary", () => {
+    const plain = { lockRequired: true };
+    expect(isLockRequiredError(new LockRequiredError())).toBe(true);
+    expect(isLockRequiredError(plain)).toBe(true);
+    expect(isLockRequiredError(new Error("server said no"))).toBe(false);
+    expect(isLockRequiredError(null)).toBe(false);
+  });
+});

--- a/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
@@ -271,3 +271,104 @@ describe("PreVaultUserStateService.bootstrapState", () => {
     });
   });
 });
+
+/**
+ * `hasVault` on this record answers "does this account own a lock". It has to
+ * be able to say "I don't know", because the record is not always read from the
+ * backend — `primeSetupResolved` builds one locally when the cache is cold, and
+ * that payload says nothing about locks.
+ *
+ * While the field was a plain boolean, "said nothing" normalised to a confident
+ * `false`. `VaultService.readBootstrapVaultCheck` served that as the answer and
+ * `checkVault` pinned it into a 30-minute session hint — so finishing setup
+ * could persist "this person has no lock" moments after they made one, and
+ * every screen that trusts a cached negative then offered "Set a lock".
+ */
+describe("PreVaultUserStateService — lock presence is allowed to be unknown", () => {
+  it("keeps an explicit backend answer, in both directions", async () => {
+    const userId = "user-lock-explicit";
+    getIdTokenMock.mockResolvedValue("token");
+    apiJsonMock.mockResolvedValueOnce({
+      userId,
+      hasVault: true,
+      vaultStatus: "active",
+    });
+
+    const state = await PreVaultUserStateService.bootstrapState(userId, {
+      force: true,
+    });
+
+    expect(state.hasVault).toBe(true);
+  });
+
+  it("believes an explicit false even when the status string says active", async () => {
+    // `/db/vault/check` and `/db/vault/pre-vault-state` answer this by looking
+    // at the unlock-method rows; the status string alone does not. ORing the
+    // two, as this used to, threw the better-informed answer away.
+    const userId = "user-lock-no-wrapper";
+    getIdTokenMock.mockResolvedValue("token");
+    apiJsonMock.mockResolvedValueOnce({
+      userId,
+      hasVault: false,
+      vaultStatus: "active",
+    });
+
+    const state = await PreVaultUserStateService.bootstrapState(userId, {
+      force: true,
+    });
+
+    expect(state.hasVault).toBe(false);
+  });
+
+  it("derives from the status when only the status was reported", async () => {
+    const userId = "user-lock-status-only";
+    getIdTokenMock.mockResolvedValue("token");
+    apiJsonMock.mockResolvedValueOnce({ userId, vaultStatus: "active" });
+
+    const state = await PreVaultUserStateService.bootstrapState(userId, {
+      force: true,
+    });
+
+    expect(state.hasVault).toBe(true);
+  });
+
+  it("reports a placeholder row as no lock, not as unknown", async () => {
+    const userId = "user-lock-placeholder";
+    getIdTokenMock.mockResolvedValue("token");
+    apiJsonMock.mockResolvedValueOnce({ userId, vaultStatus: "placeholder" });
+
+    const state = await PreVaultUserStateService.bootstrapState(userId, {
+      force: true,
+    });
+
+    expect(state.hasVault).toBe(false);
+  });
+
+  it("says unknown when the payload reported neither field", async () => {
+    const userId = "user-lock-silent";
+    getIdTokenMock.mockResolvedValue("token");
+    apiJsonMock.mockResolvedValueOnce({ userId, setupCompleted: true });
+
+    const state = await PreVaultUserStateService.bootstrapState(userId, {
+      force: true,
+    });
+
+    expect(state.hasVault).toBeNull();
+  });
+
+  it("does not invent a negative when finishing setup with a cold cache", () => {
+    // The exact sequence that shipped the bug: the hub commits completion, the
+    // bootstrap cache is cold, so a record is built locally — and it used to
+    // assert `hasVault: false` about somebody who had just made a lock.
+    const userId = "user-prime-cold";
+
+    const primed = PreVaultUserStateService.primeSetupResolved({
+      userId,
+      skipped: false,
+    });
+
+    expect(primed.setupCompleted).toBe(true);
+    expect(primed.hasVault).toBeNull();
+    expect(primed.hasVault).not.toBe(false);
+  });
+});

--- a/hushh-webapp/__tests__/services/vault-bootstrap-service-passkey-label.test.ts
+++ b/hushh-webapp/__tests__/services/vault-bootstrap-service-passkey-label.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveWebPasskeyDeviceLabel } from "@/lib/services/vault-bootstrap-service";
+
+// Chrome's Client Hints spec requires browsers to ship a randomized "GREASE"
+// brand entry in navigator.userAgentData.brands so sites can't hardcode a
+// match against it — the punctuation between "Not"/"A"/"Brand" varies by
+// session. A label built from an unfiltered brand read "Not-A?Brand passkey
+// on Windows" in production because the old filter only recognized one
+// punctuation combination.
+const GREASE_BRAND_VARIANTS = [
+  "Not;A Brand",
+  "Not.A/Brand",
+  "Not-A?Brand",
+  "Not A;Brand",
+  "Not_A_Brand",
+  "Not/A)Brand",
+];
+
+function stubUserAgentData(
+  brands: Array<{ brand: string; version: string }>,
+  platform = "Windows",
+) {
+  Object.defineProperty(window.navigator, "userAgentData", {
+    value: { brands, platform },
+    configurable: true,
+  });
+}
+
+describe("resolveWebPasskeyDeviceLabel", () => {
+  afterEach(() => {
+    // @ts-expect-error test-only cleanup of a stubbed property
+    delete window.navigator.userAgentData;
+  });
+
+  it.each(GREASE_BRAND_VARIANTS)(
+    "filters out the GREASE placeholder brand %j and falls back to a real brand",
+    (greaseBrand) => {
+      stubUserAgentData([
+        { brand: greaseBrand, version: "24" },
+        { brand: "Chromium", version: "128" },
+        { brand: "Google Chrome", version: "128" },
+      ]);
+
+      const label = resolveWebPasskeyDeviceLabel();
+
+      expect(label).toBe("Google Chrome passkey on Windows");
+      expect(label.toLowerCase()).not.toContain("not");
+    },
+  );
+
+  it("falls back to the user-agent string when every brand is filtered out", () => {
+    stubUserAgentData([{ brand: "Not-A?Brand", version: "24" }]);
+
+    const label = resolveWebPasskeyDeviceLabel();
+
+    // No usable brand survives the filter, so this must never surface the
+    // placeholder text — it should read from navigator.userAgent instead.
+    expect(label.toLowerCase()).not.toContain("not-a");
+    expect(label.toLowerCase()).not.toContain("not;a");
+  });
+});

--- a/hushh-webapp/components/app-ui/vault-status-inline.tsx
+++ b/hushh-webapp/components/app-ui/vault-status-inline.tsx
@@ -30,19 +30,34 @@ export function VaultStatusInline({
    */
   mode?: "informational" | "blocking";
 }) {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
+  const [checkFailed, setCheckFailed] = useState(false);
 
   useEffect(() => {
+    // No user is not "no lock". Firebase restores a session from disk on every
+    // load, so `user` is null for the whole of that window — and answering
+    // `false` there rendered "Lock required" at somebody who is signed in and
+    // holds a lock. Unknown stays unknown until an identity exists.
     if (!user) {
-      setHasVault(false);
+      setHasVault(null);
+      setCheckFailed(false);
       return;
     }
     let isMounted = true;
-    VaultService.checkVault(user.uid).then((exists) => {
-      if (isMounted) setHasVault(exists);
-    });
+    setCheckFailed(false);
+    VaultService.checkVault(user.uid)
+      .then((exists) => {
+        if (isMounted) setHasVault(exists);
+      })
+      .catch((error) => {
+        // A read that threw is not an answer of "no". Without this the promise
+        // rejected unhandled and `hasVault` stayed null for good, so the
+        // component sat on its unknown branch with nothing to say why.
+        console.warn("[VaultStatusInline] Could not check lock state:", error);
+        if (isMounted) setCheckFailed(true);
+      });
     return () => {
       isMounted = false;
     };
@@ -53,6 +68,8 @@ export function VaultStatusInline({
     isVaultUnlocked,
     vaultKey,
     vaultOwnerToken,
+    authLoading: authLoading || !user,
+    presenceFailed: checkFailed,
   });
 
   if (availability.canMutateSecureData) {
@@ -64,7 +81,7 @@ export function VaultStatusInline({
         )}
       >
         <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
-        Vault ready
+        Unlocked
       </p>
     );
   }
@@ -79,7 +96,7 @@ export function VaultStatusInline({
         )}
       >
         <Lock className="h-3.5 w-3.5 shrink-0" />
-        Vault locked, unlock to continue
+        Locked, unlock to continue
       </p>
     );
   }
@@ -94,7 +111,25 @@ export function VaultStatusInline({
         )}
       >
         <Database className="h-3.5 w-3.5 shrink-0" />
-        Vault setup required
+        Lock required
+      </p>
+    );
+  }
+
+  // A read that failed used to fall through to the spinner below and stay
+  // there. Name the fault instead: an endless "Checking…" is indistinguishable
+  // from a slow network, and the person has no way to know to try again.
+  if (availability.vaultCheckFailed) {
+    return (
+      <p
+        className={cn(
+          "type-footnote flex items-center gap-1.5 text-muted-foreground",
+          mode === "blocking" && "text-amber-700 dark:text-amber-400",
+          className,
+        )}
+      >
+        <Lock className="h-3.5 w-3.5 shrink-0" />
+        Couldn&apos;t check your lock
       </p>
     );
   }
@@ -107,7 +142,7 @@ export function VaultStatusInline({
       )}
     >
       <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
-      Checking vault status…
+      Checking…
     </p>
   );
 }

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -162,7 +162,12 @@ export function PhoneMandateGuard({
     }
 
     let cancelled = false;
-    const setVaultPresence = (next: boolean) => {
+    // `boolean | null`, because the bootstrap state now reports "not read
+    // yet" as null instead of flattening it to false. This component already
+    // handles that: null holds the redirect (`hasVault !== null` below) and
+    // renders the loader rather than deciding. Only this setter was narrower
+    // than the value it receives.
+    const setVaultPresence = (next: boolean | null) => {
       if (!cancelled) {
         setHasVault((current) => (current === next ? current : next));
       }

--- a/hushh-webapp/components/vault/capability-vault-prerequisite.tsx
+++ b/hushh-webapp/components/vault/capability-vault-prerequisite.tsx
@@ -161,15 +161,13 @@ export function CapabilityVaultPrerequisite({
 
   const failed = state === "failed";
   const actionLabel =
-    state === "unlock_required"
-      ? "Open your private vault"
-      : "Set up your private vault";
+    state === "unlock_required" ? "Unlock One" : "Set a lock";
 
   if (failed) {
     return (
       <section className="mx-auto flex min-h-[18rem] w-full max-w-[32rem] flex-col items-center justify-center gap-3 px-4 text-center sm:px-6">
         <p className="text-sm leading-6 text-muted-foreground">
-          We could not confirm your vault yet.
+          We couldn't confirm your lock yet.
         </p>
         <Button
           type="button"
@@ -195,7 +193,7 @@ export function CapabilityVaultPrerequisite({
           open={dialogOpen}
           onOpenChange={setDialogOpen}
           title={actionLabel}
-          description={`Continue ${capabilityLabel} setup after your private vault is ready.`}
+          description={`Continue ${capabilityLabel} setup once you're unlocked.`}
           enableGeneratedDefault={
             !preferPassphraseUnlockForAutomation(nativeTestConfig)
           }

--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -46,7 +46,7 @@ export function RecoveryKeyDialog({
   };
 
   const handleDownload = async () => {
-    const content = `Hussh Vault Recovery Key\n\n${recoveryKey}\n\nKeep this safe! You'll need it if you forget your passphrase.`;
+    const content = `Hussh Recovery Key\n\n${recoveryKey}\n\nKeep this safe! You'll need it if you forget your passphrase.`;
     const success = await downloadTextFile(content, 'hushh-recovery-key.txt');
     if (success) {
       setDownloaded(true);
@@ -62,7 +62,7 @@ export function RecoveryKeyDialog({
             Save Your Recovery Key
           </DialogTitle>
           <DialogDescription>
-            This is the ONLY way to recover your vault if you forget your passphrase.
+            This is the ONLY way to recover access if you forget your passphrase.
             Save it somewhere safe!
           </DialogDescription>
         </DialogHeader>

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1215,7 +1215,7 @@ export function VaultFlow({
             <div className="space-y-2.5">
               <VaultFlowHeader
                 icon={isGeneratedVaultMode ? Fingerprint : Lock}
-                title="Open your private place"
+                title="Unlock One"
                 description={
                   isGeneratedVaultMode
                     ? "Confirm with your device."

--- a/hushh-webapp/components/vault/vault-lock-guard.tsx
+++ b/hushh-webapp/components/vault/vault-lock-guard.tsx
@@ -314,8 +314,8 @@ export function VaultLockGuard({ children }: VaultLockGuardProps) {
       dismissible={false}
       surfaceVariant="hard_gate"
       enableGeneratedDefault={!skipGeneratedDefaultUnlock}
-      title="Unlock Vault"
-      description="Unlock your Vault to continue."
+      title="Unlock One"
+      description="Unlock to continue."
       onSuccess={() => undefined}
       // Escape hatch for the HARD gate only: a user who forgot their vault
       // password has no other way out (the focused credential surface

--- a/hushh-webapp/lib/services/pre-vault-user-state-service.ts
+++ b/hushh-webapp/lib/services/pre-vault-user-state-service.ts
@@ -27,7 +27,21 @@ export type OneRuntimeSetupChoice =
 
 export type PreVaultUserState = {
   userId: string;
-  hasVault: boolean;
+  /**
+   * Whether this account owns a lock. `null` means the record carried no
+   * answer — not that the answer is no.
+   *
+   * It has to be nullable because this record is not always read from the
+   * backend. `primeSetupResolved` builds one locally when the cache is cold,
+   * and that payload says nothing about locks. While this was a plain
+   * `boolean`, `normalizeResponse` turned "said nothing" into a confident
+   * `false`, `readBootstrapVaultCheck` served that as the answer, and
+   * `VaultService.checkVault` pinned it into a 30-minute session hint —
+   * so finishing setup could persist "this person has no lock" moments after
+   * they made one. Every downstream reader already handles `null` by asking
+   * again; the type was the only thing stopping it.
+   */
+  hasVault: boolean | null;
   vaultStatus: VaultStatus;
   firstLoginAt: number | null;
   lastLoginAt: number | null;
@@ -130,6 +144,32 @@ function toNullableBool(value: unknown): boolean | null {
   return null;
 }
 
+/**
+ * Whether the payload actually reported lock ownership, and what it said.
+ *
+ * Three cases, and only the third is new:
+ *
+ *  - the payload states `hasVault` — believe it. The backend consulted the
+ *    wrapper rows to answer (`check_vault_exists`), so it is better informed
+ *    than the status string, and an explicit `false` beside an "active" status
+ *    means a header row with no usable unlock method. ORing the two, as this
+ *    used to, threw that answer away.
+ *  - the payload states only a status — derive from it, as before.
+ *  - the payload states neither — the record is a locally built one that knows
+ *    nothing about locks. Return `null` so the readers ask, instead of
+ *    inventing a "no".
+ */
+function resolveReportedHasVault(
+  payload: BootstrapStateResponse,
+): boolean | null {
+  const reported = toNullableBool(payload.hasVault);
+  if (reported !== null) return reported;
+  const status =
+    typeof payload.vaultStatus === "string" ? payload.vaultStatus.trim() : "";
+  if (!status) return null;
+  return status === "active";
+}
+
 function normalizeResponse(
   userId: string,
   payload: BootstrapStateResponse,
@@ -137,7 +177,7 @@ function normalizeResponse(
   const status = (payload.vaultStatus || "placeholder") as VaultStatus;
   return {
     userId: String(payload.userId || userId),
-    hasVault: Boolean(payload.hasVault) || status === "active",
+    hasVault: resolveReportedHasVault(payload),
     vaultStatus: status,
     firstLoginAt: toMillis(payload.firstLoginAt),
     lastLoginAt: toMillis(payload.lastLoginAt),

--- a/hushh-webapp/lib/services/vault-bootstrap-service.ts
+++ b/hushh-webapp/lib/services/vault-bootstrap-service.ts
@@ -70,8 +70,8 @@ export type GeneratedVaultUnlockInput = {
 };
 
 const DEFAULT_VAULT_SECRET_PREFIX = "vault_default_secret";
-const BIOMETRIC_PROMPT_SET = "Authenticate to enable secure default vault";
-const BIOMETRIC_PROMPT_GET = "Authenticate to unlock your secure vault";
+const BIOMETRIC_PROMPT_SET = "Set up quick unlock for One";
+const BIOMETRIC_PROMPT_GET = "Unlock One";
 
 function keychainSecretKey(userId: string): string {
   return `${DEFAULT_VAULT_SECRET_PREFIX}:${userId}`;
@@ -122,7 +122,7 @@ function resolveRpId(): string {
   });
 }
 
-function resolveWebPasskeyDeviceLabel(): string {
+export function resolveWebPasskeyDeviceLabel(): string {
   if (typeof navigator === "undefined") return "Browser passkey";
 
   const nav = navigator as Navigator & {
@@ -134,8 +134,14 @@ function resolveWebPasskeyDeviceLabel(): string {
   const brands = nav.userAgentData?.brands || [];
   const brand =
     brands.find(
-      (item) =>
-        item.brand && !/chromium|not.a\/brand|not a brand/i.test(item.brand),
+      // Chrome's GREASE placeholder brand ("Not;A Brand", "Not.A/Brand",
+      // "Not-A?Brand", ...) randomizes its punctuation every session so sites
+      // can't key off one literal string — matching only "not.a/brand" let
+      // every other variant through as if it were a real browser name, which
+      // is how a passkey label ended up reading "Not-A?Brand passkey on
+      // Windows". `.?` treats each separator slot as optional-any-char so it
+      // catches all of them.
+      (item) => item.brand && !/chromium|not.?a.?brand/i.test(item.brand),
     )?.brand || "";
   const platform = nav.userAgentData?.platform || "";
   const ua = navigator.userAgent || "";

--- a/hushh-webapp/lib/services/vault-method-service.ts
+++ b/hushh-webapp/lib/services/vault-method-service.ts
@@ -22,7 +22,7 @@ function ensureVaultKeyHex(value: string): string {
   const normalized = value.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(normalized)) {
     throw new Error(
-      "Vault key in memory is invalid. Unlock vault again and retry.",
+      "Your unlock key is invalid. Unlock again and retry.",
     );
   }
   return normalized;
@@ -49,7 +49,7 @@ function normalizeVaultMethodError(error: unknown): Error {
 
   if (lowered.includes("passphrase wrapper missing")) {
     return new Error(
-      "Passphrase wrapper is missing for this vault. Use passphrase/recovery flow once to repair wrapper enrollment.",
+      "Passphrase is missing. Use passphrase or recovery once to repair it.",
     );
   }
 
@@ -128,7 +128,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       if (params.targetMethod === "passphrase") {
@@ -241,7 +241,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       const nextPassphrase = params.newPassphrase.trim();
@@ -306,7 +306,7 @@ export class VaultMethodService {
       const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
-        throw new Error("Vault key mismatch detected. Unlock vault again.");
+        throw new Error("Key mismatch detected. Unlock again.");
       }
 
       const wrapperId = params.wrapperId ?? "default";

--- a/hushh-webapp/lib/vault/trusted-device-passkey-handoff.ts
+++ b/hushh-webapp/lib/vault/trusted-device-passkey-handoff.ts
@@ -112,7 +112,7 @@ export async function buildTrustedDevicePasskeyHandoff(params: {
     wrapper.iv,
   );
   if (!vaultKey) {
-    throw new Error("The selected One passkey could not unlock this vault.");
+    throw new Error("The selected One passkey could not unlock this.");
   }
   await VaultService.assertVaultKeyMatchesState(vaultState, vaultKey);
 

--- a/hushh-webapp/lib/vault/vault-access-policy.ts
+++ b/hushh-webapp/lib/vault/vault-access-policy.ts
@@ -1,5 +1,64 @@
 "use client";
 
+/**
+ * The one answer to "can this person use a locked feature right now?"
+ * ====================================================================
+ *
+ * Five states, and they are not interchangeable:
+ *
+ *   loading       nothing is known yet — wait, do not paint a destination
+ *   unconfigured  no lock exists       — offer "Set a lock"
+ *   locked        a lock exists, shut  — offer "Unlock One"
+ *   unlocked      a key is in memory   — proceed, show no credential surface
+ *   error         presence could not be read — say so and offer a retry
+ *
+ * Why the five-state version had to be added here
+ * -----------------------------------------------
+ * This module already modelled four of them, as a bag of booleans
+ * (`vaultUnknown` / `needsVaultCreation` / `needsUnlock` / `canReadSecureData`).
+ * A bag is not a decision: a caller picks the one boolean it happens to know
+ * about and silently inherits whatever the others meant. Three screens use this
+ * file today and all three get the answer wrong the same way — they hand it a
+ * `hasVault: false` that was manufactured in a `catch` block or during auth
+ * restore, and the bag faithfully reports `needsVaultCreation`, so somebody who
+ * owns a lock is offered first-run lock CREATION.
+ *
+ * The rest of the app never got here at all. `VaultContextType` exposes exactly
+ * one boolean about state — `isVaultUnlocked` — so a consumer holding only
+ * `useVault()` is structurally incapable of telling the three "no token" cases
+ * apart:
+ *
+ *   - no token because there is no lock          (unconfigured)
+ *   - no token because the lock is shut          (locked)
+ *   - no token because auth has not settled yet  (loading)
+ *
+ * That collapse produces both reported symptoms. A person with no lock is told
+ * to "Unlock One" — a door with no key behind it. A person who is merely locked
+ * is offered first-run lock setup, as if the lock they already own did not
+ * exist. `isVaultUnlocked` is also `false` on every single mount, which is the
+ * flash: whatever a screen renders for "false" appears for a frame before
+ * anything has been read.
+ *
+ * The rules
+ * ---------
+ * 1. **A key in memory is authority and nothing outranks it.** It is proof the
+ *    lock is open right now. Every other input describes the past.
+ * 2. **Unknown is not false.** `hasVault === null` means "not read yet" and
+ *    resolves to `loading`, never `unconfigured`. Offering setup to somebody
+ *    who owns a lock is the exact regression this module exists to prevent.
+ * 3. **A failed read is not an absent lock.** Pass `presenceFailed` and the
+ *    answer is `error`, so the caller says so and offers a retry instead of
+ *    quietly downgrading the person to a new user.
+ * 4. **No settled identity, no verdict.** The vault context withholds a
+ *    perfectly good token while `vaultUserId !== currentUserId`
+ *    (lib/vault/vault-context.tsx), so a null token during an identity
+ *    transition proves nothing. Pass `authLoading` and it resolves to
+ *    `loading`.
+ *
+ * Pure by design: no React, no network, no storage, no clock. Everything
+ * arrives as an argument, so every transition is directly testable.
+ */
+
 export type VaultCapabilityState = {
   hasVaultKey: boolean;
   hasVaultOwnerToken: boolean;
@@ -8,11 +67,37 @@ export type VaultCapabilityState = {
   canMutateSecureData: boolean;
 };
 
+/**
+ * The mutually exclusive states of the lock. Exactly one is ever true.
+ *
+ * Prefer switching on this over reading the individual booleans below. Those
+ * remain for the narrow questions that are genuinely about capability ("may I
+ * decrypt right now?") rather than about which screen to show.
+ */
+export type LockState =
+  /** Not enough is known. Wait — never guess a destination or a label. */
+  | "loading"
+  /** No lock has ever been made. The next step is to create one. */
+  | "unconfigured"
+  /** A lock exists and is shut. The next step is to open it. */
+  | "locked"
+  /** A key is in memory. The action may proceed with no credential surface. */
+  | "unlocked"
+  /** Presence could not be resolved. Report it; never read it as "no lock". */
+  | "error";
+
 export type VaultAvailabilityState = VaultCapabilityState & {
+  /** The one decision. Switch on this. */
+  state: LockState;
   hasVault: boolean;
+  /** `state === "loading"`. */
   vaultUnknown: boolean;
+  /** `state === "unconfigured"`. Never true for a failed or unsettled read. */
   needsVaultCreation: boolean;
+  /** `state === "locked"`. */
   needsUnlock: boolean;
+  /** `state === "error"`. */
+  vaultCheckFailed: boolean;
 };
 
 export function resolveVaultCapabilityState(params: {
@@ -36,20 +121,153 @@ export function resolveVaultCapabilityState(params: {
   };
 }
 
-export function resolveVaultAvailabilityState(params: {
-  hasVault: boolean | null;
+export type LockStateInputs = {
+  /**
+   * Whether this account owns a lock. `null` means "not read yet" and must not
+   * be flattened to `false` by the caller.
+   *
+   * Read it from the wrapper-aware presence answer
+   * (`VaultService.checkVault` / `peekVaultPresence`) — the same source the
+   * unlock sheet itself uses to choose between creating and opening. Any other
+   * source can disagree with the screen the person is about to see.
+   */
+  hasVault: boolean | null | undefined;
+  /** `useVault().isVaultUnlocked`. */
   isVaultUnlocked: boolean;
   vaultKey?: string | null;
+  /** `useVault().vaultOwnerToken` — memory-only, and the only real authority. */
   vaultOwnerToken?: string | null;
-}): VaultAvailabilityState {
+  /**
+   * `useAuth().loading`, or false when the caller genuinely has a settled
+   * identity. True holds the answer at `loading` rather than blaming somebody
+   * for a frame of our own bookkeeping.
+   */
+  authLoading?: boolean;
+  /**
+   * True when the presence read threw and no cached answer survived. Distinct
+   * from `hasVault === null`, which only means "still reading".
+   */
+  presenceFailed?: boolean;
+};
+
+export function resolveLockState({
+  hasVault,
+  isVaultUnlocked,
+  vaultKey,
+  vaultOwnerToken,
+  authLoading = false,
+  presenceFailed = false,
+}: LockStateInputs): LockState {
+  // Rule 1. A usable key present is proof, whatever else is still settling.
+  //
+  // Either signal is sufficient. `isVaultUnlocked` is the vault context's own
+  // claim (`!!vaultKey && !!vaultOwnerToken`), so a caller that holds only that
+  // boolean is as entitled to the answer as one holding the token itself.
+  const capability = resolveVaultCapabilityState({
+    isVaultUnlocked,
+    vaultKey,
+    vaultOwnerToken,
+  });
+  if (capability.canReadSecureData || capability.isUnlocked) return "unlocked";
+  // Rule 4. No settled identity, no verdict.
+  if (authLoading) return "loading";
+  // Rule 3. A read that failed is not an answer of "no".
+  if (presenceFailed) return "error";
+  // Rule 2. Unknown stays unknown.
+  if (hasVault === null || hasVault === undefined) return "loading";
+  return hasVault ? "locked" : "unconfigured";
+}
+
+export function resolveVaultAvailabilityState(
+  params: LockStateInputs,
+): VaultAvailabilityState {
   const capability = resolveVaultCapabilityState(params);
-  const hasVault = params.hasVault === true;
+  const state = resolveLockState(params);
 
   return {
     ...capability,
-    hasVault,
-    vaultUnknown: params.hasVault === null,
-    needsVaultCreation: params.hasVault === false,
-    needsUnlock: hasVault && !capability.canReadSecureData,
+    state,
+    hasVault: params.hasVault === true,
+    vaultUnknown: state === "loading",
+    needsVaultCreation: state === "unconfigured",
+    needsUnlock: state === "locked",
+    vaultCheckFailed: state === "error",
   };
+}
+
+/** True only when the action may run now with no credential surface. */
+export function isLockReady(state: LockState): boolean {
+  return state === "unlocked";
+}
+
+/**
+ * True when the person can be asked for the lock.
+ *
+ * Deliberately excludes `loading` and `error`. Prompting on `loading` accuses
+ * somebody of being locked during a frame of our own bookkeeping; prompting on
+ * `error` hides a fault behind a credential sheet.
+ */
+export function needsLockPrompt(state: LockState): boolean {
+  return state === "locked" || state === "unconfigured";
+}
+
+/**
+ * The action label for the state, in the approved product vocabulary.
+ *
+ * "Set a lock" and "Unlock One" are different promises and must never be
+ * swapped. Both sit inside the four-word budget.
+ */
+export function lockActionLabel(state: LockState): string {
+  return state === "unconfigured" ? "Set a lock" : "Unlock One";
+}
+
+/**
+ * What One says when an action cannot run yet.
+ *
+ * Non-visual callers (One Voice) read these verbatim, so each is a short plain
+ * sentence naming the actual next step rather than a generic refusal.
+ * `loading` asks for a moment instead of assigning blame; `error` names the
+ * fault instead of pretending the person has no lock.
+ */
+export function lockBlockedSummary(state: LockState): string {
+  switch (state) {
+    case "unconfigured":
+      return "Set a lock first";
+    case "locked":
+      return "Unlock One first";
+    case "error":
+      return "Couldn't check your lock";
+    case "loading":
+      return "Still checking";
+    case "unlocked":
+      return "";
+  }
+}
+
+/**
+ * Thrown by a handler that genuinely cannot proceed without the owner token.
+ *
+ * Typed so a caller can tell "you need the lock" apart from "the server said
+ * no" and open the right sheet, instead of pattern-matching on a sentence. It
+ * carries the state, so the surface picks between creating and opening without
+ * asking the question a second time.
+ */
+export class LockRequiredError extends Error {
+  readonly lockRequired = true as const;
+  readonly lockState: LockState;
+
+  constructor(lockState: LockState = "locked", message?: string) {
+    super(message || lockBlockedSummary(lockState) || "Unlock One first");
+    this.name = "LockRequiredError";
+    this.lockState = lockState;
+  }
+}
+
+export function isLockRequiredError(error: unknown): error is LockRequiredError {
+  return (
+    error instanceof LockRequiredError ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { lockRequired?: unknown }).lockRequired === true)
+  );
 }


### PR DESCRIPTION
## Summary

Restores the vault frontend the 2026-08-20 revert (`a60c51dfc`, merged `db0796eda`) took out. **Vault frontend only — everything else that revert removed stays gone.** Full investigation in #6183.

`vault-access-policy.ts` comes back from 55 lines to 273: a five-state machine (`loading / unconfigured / locked / unlocked / error`) in place of a bag of four independent booleans, on three rules — **a key in memory is authority**, **unknown is not false**, **a failed read is not an absent lock**. Plus `lockActionLabel` / `lockBlockedSummary` and a typed `LockRequiredError` carrying the state, and the two deleted test files.

## This is not a cosmetic restore

`vault-status-inline.tsx` was answering `hasVault: false` while Firebase restored the session from disk, so somebody **signed in and holding a lock** was shown **"Vault setup required"** — on the connected-systems onboarding screen among others. Its `checkVault` call also had no `.catch()`, so a rejection left an unhandled promise and a spinner that never resolved.

The restored version answers `null` for both and passes `authLoading` / `presenceFailed` instead. That fixes one of the three consumers outright; the other two are a follow-up (see below).

## Two things deliberately NOT restored

- **`vault-lock-guard.tsx`'s entry-step gate**, and the three tests covering it. It imports `@/lib/onboarding/onboarding-entry-context` and `@/lib/onboarding/user-entry-state`, which that revert also deleted and which are not coming back. I kept the *copy* half of that file's change — "Unlock One" / "Unlock to continue." — which matches `lockActionLabel` in the restored policy, whose own comment is explicit that "Set a lock" and "Unlock One" are different promises and must never be swapped.
- **The rest of the revert.** Vault frontend only.

## How it was applied

Not a blanket `git checkout` of the old tree — that would have deleted nine days of newer work. Each file was classified first:

- **11 files restored wholesale**, because `main` had not touched them since the revert.
- **4 files 3-way merged** by applying the inverse of the revert's own diff, so newer work survives. `vault-flow.tsx` alone had gained 58 lines; it comes out of this with a one-line change.

`phone-mandate-guard.tsx` needed its local `setVaultPresence` widened to `boolean | null`. That is the restore working as intended: the bootstrap state now reports "not read yet" as `null` rather than flattening it to `false`, and this component already handled `null` correctly everywhere downstream (`hasVault !== null` guards the redirect, `hasVault === null` renders the loader). Only the setter was narrower than the value it receives.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] Vault suite: **146 passed**, 3 failed.
- [x] Broad sweep (`__tests__/services/`, `__tests__/lib/`, `__tests__/app/profile/`, connected-systems onboarding): **1764 passed**, 8 failed.
- [x] **All 11 failures verified pre-existing** — stashed the restore and reproduced the identical set on clean `main`. They are the Windows-local WebCrypto ones (`hermes-vault-vector`, `trusted-device-passkey-handoff`, `crm-encrypted-fields-v1`) plus `profile/receipts/page.test.tsx`. CI is green on all of them.
- [x] Restored `lock-state.test.ts` — 30 assertions covering every transition, all pass.
- [x] `__tests__/utils/vault-access-policy.test.ts`, the test `main` has today, passes **unchanged** — the restore contradicts nothing currently asserted, it constrains cases nothing was asserting.
- [x] `eslint --max-warnings=0` on all 15 changed files — clean.

## Follow-up

Two consumers still manufacture `false` in a `catch` and were not part of this revert, so they are not this PR's to fix: `profile-workspace-page.tsx:959` and `pkm-agent-lab/page-client.tsx:410`. They still offer first-run vault creation to someone who owns a vault when the presence read throws. Separate PR next, where the behaviour change is reviewable on its own.

Relates to #6183.
