### PR TITLE
fix(location): remove possessive pronoun from request withdrawal push

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -9417,7 +9417,7 @@ class OneLocationAgentService:
             user_id=owner_user_id,
             notification_type="location_access_request_withdrawn",
             title="Location request taken back",
-            body=f"{requester_label} took back their location request.",
+            body=f"{requester_label} took back location request.",
             notification_tag=f"one-location-request:{request_id}",
             request_url=_one_location_url(requestId=request_id, section="approvals"),
             data={

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2554,9 +2554,7 @@ class OneLocationAgentService:
             "ownerMaskedPhone": _mask_phone(row.get("owner_phone_number")),
             "recipientDisplayName": str(row.get("recipient_display_name") or "") or None,
             "recipientPhotoUrl": str(
-                row.get("recipient_custom_photo_url")
-                or row.get("recipient_photo_url")
-                or ""
+                row.get("recipient_custom_photo_url") or row.get("recipient_photo_url") or ""
             )
             or None,
             "recipientMaskedPhone": _mask_phone(row.get("recipient_phone_number")),
@@ -2655,9 +2653,7 @@ class OneLocationAgentService:
             "requesterUserId": str(row.get("requester_user_id") or ""),
             "requesterDisplayName": str(row.get("requester_display_name") or "") or None,
             "requesterPhotoUrl": str(
-                row.get("requester_custom_photo_url")
-                or row.get("requester_photo_url")
-                or ""
+                row.get("requester_custom_photo_url") or row.get("requester_photo_url") or ""
             )
             or None,
             "requesterMaskedPhone": _mask_phone(row.get("requester_phone_number")),

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -3351,9 +3351,7 @@ class OneLocationCircleService:
                     # Nobody addable. Report the reason that applies to
                     # everyone named, so a single-person add still gets
                     # the precise error it always did.
-                    if all(
-                        reason == "already_member" for reason in blocked_reasons.values()
-                    ):
+                    if all(reason == "already_member" for reason in blocked_reasons.values()):
                         raise OneLocationCircleError(
                             "LOCATION_CIRCLE_ALREADY_MEMBER",
                             "One or more selected connections are already in the Circle.",

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -3508,6 +3508,7 @@ def test_one_person_who_left_recently_does_not_block_the_rest_of_the_batch():
     assert connection_params, "expected the connection lookup to run"
     assert connection_params[0]["invitee_user_ids"] == ["friend-two"]
 
+
 def test_an_add_naming_only_blocked_people_still_fails_loudly():
     """Filtering must not turn a doomed request into a silent success.
 

--- a/consent-protocol/tests/test_one_location_request_withdraw.py
+++ b/consent-protocol/tests/test_one_location_request_withdraw.py
@@ -224,6 +224,7 @@ def test_the_owner_notification_replaces_the_original_ask() -> None:
     ]
     assert sent, "the owner was never told the ask was taken back"
     assert sent[0]["user_id"] == "user_b"
+    assert sent[0]["body"] == "User A took back location request."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- Removes possessive pronoun from the backend One Location request-withdrawal push body.
- Adds a focused regression assertion for that notification payload.

Verification:
- uv run ruff check hushh_mcp/services/one_location_agent_service.py tests/test_one_location_request_withdraw.py
- uv run pytest tests/test_one_location_request_withdraw.py -q
- XcodeBuildMCP build_run_sim succeeded for com.hushh.app on iPhone 17 Pro

Notes:
- No behavior, state, API, routing, or unrelated notification changes.