### PR TITLE
Refine Connect hub tab order

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -15,7 +15,8 @@ describe("Connect canonical surface contract", () => {
     expect(source).toContain("<AppPageShell");
     expect(source).toContain('width="standard"');
     expect(source).toContain("<PageHeader");
-    expect(source).toContain("icon={BookUser}");
+    expect(source).toContain('<PageHeader title="Connect" />');
+    expect(source).not.toContain("icon={BookUser}");
     expect(source).not.toContain('eyebrow="One"');
     expect(source).not.toContain("icon={Users}\n          accent");
     expect(source).toContain("<SettingsGroup");
@@ -97,7 +98,7 @@ describe("Connect canonical surface contract", () => {
       '"[&>button]:px-1 min-[360px]:[&>button]:px-3 sm:[&>button]:px-4.5"',
     );
     expect(source).toContain(
-      '["people", "advisors", "nearby", "circles"] as const',
+      '["people", "advisors", "circles", "nearby"] as const',
     );
   });
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -227,7 +227,7 @@ const CONNECT_HUB_TAB_LABEL: Record<ConnectHubTab, string> = {
 };
 
 const CONNECT_HUB_TABS = (
-  ["people", "advisors", "nearby", "circles"] as const
+  ["people", "advisors", "circles", "nearby"] as const
 ).map((value) => ({ value, label: CONNECT_HUB_TAB_LABEL[value] }));
 
 /**
@@ -2293,7 +2293,7 @@ export default function ConnectPageClient() {
       }}
     >
       <AppPageHeaderRegion className="mx-auto w-full max-w-[720px]">
-        <PageHeader title="Connect" icon={BookUser} accent="neutral" />
+        <PageHeader title="Connect" />
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="mx-auto w-full max-w-[720px]">


### PR DESCRIPTION
## Summary
- move Around you to the last Connect hub tab position
- remove the header icon beside the Connect page title
- pin the requested tab order/header contract in the Connect source contract test

## Verification
- npm test -- __tests__/app/connect/page-client.contract.test.ts __tests__/app/connect/page-client.test.tsx
- npx eslint app/connect/page-client.tsx __tests__/app/connect/page-client.contract.test.ts --max-warnings=0
- npm run typecheck -- --pretty false
- npm run verify:connect-search
- ./bin/hushh codex pre-pr