### PR TITLE
Refine Connect pagination footer

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -178,8 +178,8 @@ type TestConnectionPage = {
   audience: "all";
 };
 
-/** Ten people, so a limit of 8 is visibly a cap rather than the whole set. */
-const EVERYONE = Array.from({ length: 10 }, (_, index) =>
+/** One hundred people, so the pager range and final-page copy are visible. */
+const EVERYONE = Array.from({ length: 100 }, (_, index) =>
   person(`u${index}`, `Person ${index}`),
 );
 
@@ -213,10 +213,24 @@ beforeEach(() => {
     items: [],
     offerableItems: [],
   });
-  mocks.searchDirectory.mockResolvedValue({
-    items: EVERYONE.slice(0, 8),
-    hasMore: true,
-    page: 1,
+  mocks.searchDirectory.mockImplementation(async (options) => {
+    const page = Math.max(1, Number(options.page) || 1);
+    const limit = Math.max(1, Number(options.limit) || 20);
+    const query = String(options.query || "")
+      .trim()
+      .toLowerCase();
+    const matches = query
+      ? EVERYONE.filter((entry) =>
+          entry.displayName?.toLowerCase().includes(query),
+        )
+      : EVERYONE;
+    const start = (page - 1) * limit;
+    return {
+      items: matches.slice(start, start + limit),
+      hasMore: start + limit < matches.length,
+      page,
+      totalCount: matches.length,
+    };
   });
 });
 
@@ -596,7 +610,7 @@ describe("Connect — People", () => {
     // unsearched surface must ask for a capped set, and no query.
     expect(mocks.searchDirectory.mock.calls[0][0]).toMatchObject({
       page: 1,
-      limit: 8,
+      limit: 20,
     });
     expect(mocks.searchDirectory.mock.calls[0][0].query).toBe("");
 
@@ -604,7 +618,7 @@ describe("Connect — People", () => {
     expect(screen.getByText("Person 0")).toBeTruthy();
   });
 
-  it("offers paging and a page size, rather than a sample with no way past it", async () => {
+  it("offers range-based paging rather than a sample with no way past it", async () => {
     // A bounded first screenful was the right instinct, but refusing to page
     // left the rest of the directory unreachable. Both now hold: a screenful
     // by default, and a way through it.
@@ -616,11 +630,13 @@ describe("Connect — People", () => {
     // parallel CI load while passing 4-for-4 on an idle laptop. This file is
     // now a required check on every Connect PR, so an assertion that depends
     // on scheduler luck would train people to re-run CI instead of reading it.
-    expect(await screen.findByText("Page 1")).toBeTruthy();
+    expect(await screen.findByText("1–20 of 100")).toBeTruthy();
     expect(screen.getByLabelText("People per page")).toBeTruthy();
     // hasMore is true in the fixture, so forward is offered and back is not.
-    expect(screen.getByText("Next").closest("button")?.disabled).toBe(false);
-    expect(screen.getByText("Prev").closest("button")?.disabled).toBe(true);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Next page")).not.toBeDisabled(),
+    );
+    expect(screen.getByLabelText("Previous page")).toBeDisabled();
   });
 
   it("reads heading, then instruction, then the field they describe", async () => {
@@ -652,28 +668,20 @@ describe("Connect — People", () => {
     ).toBeTruthy();
   });
 
-  it("keeps the pager on one line, with the page number under the size", async () => {
-    // QA, on a phone: "sarein cheezein scattered dekh rahi -- per page, prev
-    // next ek line mein la sakte". The row was `flex-col ... sm:flex-row`, so
-    // on every shipped phone width it broke into "Page 1 - Per page [8]" and a
-    // separate right-aligned "Prev Next" underneath.
+  it("keeps the pager inside the grouped list as a compact range row", async () => {
     render(<ConnectPageClient />);
 
     const row = await screen.findByTestId("connect-pager-row");
-    // One line: the size control and the two buttons that use it are siblings
-    // in the same row, not two stacked blocks.
     expect(row.className).not.toContain("flex-col");
-    expect(within(row).getByText("Per page")).toBeTruthy();
-    expect(within(row).getByRole("button", { name: "Prev" })).toBeTruthy();
-    expect(within(row).getByRole("button", { name: "Next" })).toBeTruthy();
-
-    // "Page 1" is a reading of the list, not a way to change it, so it sits
-    // directly under the control rather than leading the row.
-    const status = within(row).getByText("Page 1");
-    const sizeLine = screen.getByLabelText("People per page").parentElement;
-    expect(sizeLine).not.toBeNull();
-    expect(status.previousElementSibling).toBe(sizeLine);
-    expect(status.className).toContain("text-[11px]");
+    expect(row.className).toContain("min-h-14");
+    expect(within(row).getByText("1–20 of 100")).toBeTruthy();
+    expect(
+      within(row).getByRole("button", { name: "Previous page" }),
+    ).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Next page" })).toBeTruthy();
+    expect(screen.getByLabelText("People per page").textContent).toContain(
+      "20 per page",
+    );
   });
 
   it("asks the server for the page the reader moved to", async () => {
@@ -683,18 +691,20 @@ describe("Connect — People", () => {
     // is on is the page the server is asked for.
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
-    expect(screen.getByLabelText("People per page").textContent).toContain("8");
+    expect(screen.getByLabelText("People per page").textContent).toContain(
+      "20 per page",
+    );
 
-    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByLabelText("Next page"));
 
     await waitFor(() => {
       const latest =
         mocks.searchDirectory.mock.calls[
           mocks.searchDirectory.mock.calls.length - 1
         ][0];
-      expect(latest).toMatchObject({ page: 2, limit: 8 });
+      expect(latest).toMatchObject({ page: 2, limit: 20 });
     });
-    expect(await screen.findByText("Page 2")).toBeTruthy();
+    expect(await screen.findByText("21–40 of 100")).toBeTruthy();
   });
 
   it("opens the full directory once a name is typed", async () => {
@@ -711,7 +721,7 @@ describe("Connect — People", () => {
     expect(searched.query).toBe("Person 9");
     // A search is paged like everything else now. Returning the whole matching
     // set unpaged is the same unbounded list, just filtered.
-    expect(searched.limit).toBe(8);
+    expect(searched.limit).toBe(20);
     expect(searched.page).toBe(1);
 
     // The empty-query description disappearing is the unambiguous signal that
@@ -719,7 +729,7 @@ describe("Connect — People", () => {
     await waitFor(() =>
       expect(screen.queryByText("Search by name.")).toBeNull(),
     );
-    expect(await screen.findByText("Page 1")).toBeTruthy();
+    expect(await screen.findByText(/1–\d+ of \d+/)).toBeTruthy();
   });
 
   it("restores a typed search query after the page remounts", async () => {
@@ -822,7 +832,7 @@ describe("Connect — People", () => {
     expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({
       query: "N",
       page: 1,
-      limit: 8,
+      limit: 20,
     });
     for (const name of ["Nilesh", "Nirmal", "Nolan"]) {
       expect(await screen.findByText(name)).toBeTruthy();
@@ -951,7 +961,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
     expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({ page: 2 });
 

--- a/hushh-webapp/app/connect/connect-search-layout.ts
+++ b/hushh-webapp/app/connect/connect-search-layout.ts
@@ -53,12 +53,9 @@ export const CONNECT_SEARCH_ROW_GAP_PX = 8;
 /**
  * THE PAGER ROW.
  *
- * One line at every width. It used to be `flex-col ... sm:flex-row`, so on
- * every phone the app actually ships to it broke into "Page 1 - Per page [8]"
- * and, underneath, a right-aligned "Prev  Next" -- four fragments with three
- * different alignments stacked at the bottom of the card. The size control and
- * the buttons that walk the list belong on the same line: they are the two
- * halves of one decision.
+ * One quiet footer row inside the grouped list. Phone widths show only the
+ * visible range and icon buttons; larger widths add the compact page-size
+ * control only when it can help.
  *
  * `justify-between` rather than a spacer, and both clusters keep their
  * intrinsic width, so the row's total is measured rather than assumed. See
@@ -66,28 +63,23 @@ export const CONNECT_SEARCH_ROW_GAP_PX = 8;
  * shipped phone width.
  */
 export const CONNECT_PAGER_ROW_CLASSNAME =
-  "flex items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3";
+  "flex min-h-14 items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] px-4 py-1 shadow-none";
 
 /**
  * The per-page select.
  *
- * 68px, not 74px: the widest option is two digits, and the row now has to hold
- * Prev and Next beside it on a 320px screen. Every pixel this control does not
- * need is a pixel the row cannot afford to give it.
+ * The label is the value: "20 per page". It stays compact and disappears on
+ * phone widths where page size is fixed.
  */
 export const CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME =
-  "h-8 min-h-8 w-[68px] shrink-0 rounded-2xl text-[15px] font-medium leading-5";
+  "h-9 min-h-9 w-auto min-w-[108px] shrink-0 rounded-full border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-secondary-fill)] px-3 text-[14px] font-medium leading-5 shadow-none hover:bg-[color:var(--app-tertiary-fill)]";
 
 /**
- * "Page 1", under the control rather than beside it.
- *
- * Deliberately smaller than `ui-text-helper-text` (13px) and a step quieter in
- * colour: it is the only thing in the row that is a READING of the list rather
- * than a way to change it, and at the same size it competed with the label of
- * the control it sits under.
+ * Visible range, not page chrome. Tabular numbers keep the footer steady while
+ * moving through the directory.
  */
 export const CONNECT_PAGE_STATUS_CLASSNAME =
-  "font-[family-name:var(--font-app-body)] text-[11px] font-normal leading-4 tracking-[0.01em] tabular-nums text-[color:var(--app-tertiary-label)]";
+  "font-[family-name:var(--font-app-body)] text-[14px] font-medium leading-5 tracking-normal tabular-nums text-[color:var(--app-secondary-label)]";
 
 /**
  * Prev, Next and "Load more connections". Lives here rather than in the screen
@@ -97,8 +89,8 @@ export const CONNECT_PAGER_BUTTON_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
 
 /**
- * Prev and Next only. `px-2.5`, not `px-3`, for the same reason the select
- * shrank: the row is measured at 320px and the two buttons are the half of it
- * that cannot be dropped. `min-w-[44px]` keeps the touch target legal.
+ * Previous/next only. Icon buttons, never filled pills; the full 44px hit area
+ * remains visible even when disabled.
  */
-export const CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME = "min-w-[44px] px-2.5";
+export const CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME =
+  "!h-11 !min-h-11 !w-11 !min-w-11 rounded-full bg-transparent !p-0 text-[color:var(--app-secondary-label)] shadow-none hover:bg-[color:var(--app-secondary-fill)] hover:text-[color:var(--app-label)] disabled:opacity-35";

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -6,6 +6,8 @@ import { toast } from "sonner";
 import {
   BadgeCheck,
   BookUser,
+  ChevronLeft,
+  ChevronRight,
   Loader2,
   Lock,
   RefreshCw,
@@ -54,6 +56,7 @@ import { useRequireAuth } from "@/hooks/use-auth";
 import { ContactSyncResultsSheet } from "@/components/one-location/contact-sync-results-sheet";
 import { useContactSync } from "@/lib/contacts/use-contact-sync";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { buildPersonProfileRoute, ROUTES } from "@/lib/navigation/routes";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
@@ -290,7 +293,7 @@ async function mapWithConcurrency<T, R>(
  * and knows nobody's exact name is not staring at an empty surface — not so
  * they can browse the register, which is the thing that stops scaling.
  */
-const SUGGESTED_PEOPLE_LIMIT = 8;
+const SUGGESTED_PEOPLE_LIMIT = 20;
 
 /**
  * How many people a page shows, and the sizes the reader can pick.
@@ -300,7 +303,7 @@ const SUGGESTED_PEOPLE_LIMIT = 8;
  * through the rest, so this replaces it with real paging: the default is still
  * a screenful, and someone who wants to scan more can say so.
  */
-const PAGE_SIZE_OPTIONS = [8, 16, 24, 50] as const;
+const PAGE_SIZE_OPTIONS = [20, 50] as const;
 const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
 const CONNECT_ROW_ACTION_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px]";
@@ -486,7 +489,6 @@ async function resolveConnectionForVoice({
   return { matches: [], complete: false };
 }
 
-
 /**
  * Two-letter fallback for someone with no Google photo. Mirrors the
  * contact-sync sheet, which already draws people this way.
@@ -621,6 +623,11 @@ export default function ConnectPageClient() {
   const [hasMore, setHasMore] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
+  const [directoryPage, setDirectoryPage] = useState(1);
+  const [directoryTotalCount, setDirectoryTotalCount] = useState(0);
+  const directoryListTopRef = useRef<HTMLDivElement | null>(null);
+  const previousDirectoryPageRef = useRef(1);
+  const isMobile = useIsMobile();
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
@@ -975,6 +982,38 @@ export default function ConnectPageClient() {
   const inviteToOneShare = useMemo(() => buildInviteToOneShare(), []);
   const canInviteToOne = tab === "people" && inviteToOneShare !== null;
 
+  useEffect(() => {
+    if (!isMobile || pageSize === DEFAULT_PAGE_SIZE) return;
+    setPageSize(DEFAULT_PAGE_SIZE);
+  }, [isMobile, pageSize]);
+
+  const handlePageSizeChange = useCallback((value: string) => {
+    const nextPageSize = Number(value);
+    if (
+      !PAGE_SIZE_OPTIONS.includes(
+        nextPageSize as (typeof PAGE_SIZE_OPTIONS)[number],
+      )
+    ) {
+      return;
+    }
+    setPageSize(nextPageSize);
+    setCurrentPage(1);
+  }, []);
+
+  const directoryRangeLabel = useMemo(() => {
+    if (directoryTotalCount <= 0) return "0 of 0";
+    const rangeStart = Math.min(
+      (directoryPage - 1) * pageSize + 1,
+      directoryTotalCount,
+    );
+    const visibleCount = Math.max(people.length, 1);
+    const rangeEnd = Math.min(
+      rangeStart + visibleCount - 1,
+      directoryTotalCount,
+    );
+    return `${rangeStart}\u2013${rangeEnd} of ${directoryTotalCount}`;
+  }, [directoryPage, directoryTotalCount, pageSize, people.length]);
+
   // A share sheet is modal but not instant: on iOS it animates in, and the
   // promise does not settle until it is dismissed. Two taps in that window
   // asked the platform to present a second sheet over the first, which iOS
@@ -1041,6 +1080,14 @@ export default function ConnectPageClient() {
           // an endless scroll with no sense of position in it.
           setPeople(page.items);
           setHasMore(page.hasMore);
+          setDirectoryPage(page.page);
+          setDirectoryTotalCount(
+            Math.max(
+              0,
+              Number(page.totalCount) || 0,
+              (page.page - 1) * pageSize + page.items.length,
+            ),
+          );
           // Selections deliberately survive this. They used to be pruned to
           // whoever the new page happened to show, on the reasoning that a
           // count the reader cannot see is a promise the surface can't account
@@ -1078,6 +1125,15 @@ export default function ConnectPageClient() {
     // refused. Bumping the nonce re-asks the server for the same page.
     directoryRefreshNonce,
   ]);
+
+  useEffect(() => {
+    if (previousDirectoryPageRef.current === directoryPage) return;
+    previousDirectoryPageRef.current = directoryPage;
+    directoryListTopRef.current?.scrollIntoView({
+      block: "start",
+      behavior: "smooth",
+    });
+  }, [directoryPage]);
 
   const selectSurface = useCallback(
     (next: ConnectSurface) => {
@@ -2540,7 +2596,7 @@ export default function ConnectPageClient() {
                       </div>
                     ) : null}
 
-                    <div className="space-y-4">
+                    <div ref={directoryListTopRef} className="space-y-4">
                       <SettingsGroup
                         title={CONNECT_TAB_LABEL[tab]}
                         // People only. This one JSX node also renders the RIAs
@@ -2602,7 +2658,7 @@ export default function ConnectPageClient() {
                         // screen had said what it searched. It still pins under the
                         // tab strips on scroll; it just no longer arrives first.
                         toolbar={
-                        /* No `w-full` here any more, and it is load-bearing: this row
+                          /* No `w-full` here any more, and it is load-bearing: this row
                     bleeds to the page gutters with a negative inline margin, and
                     `width: 100%` resolves against the text column, so the margin
                     only slid the row 16px left instead of widening it. A block
@@ -2610,115 +2666,115 @@ export default function ConnectPageClient() {
                     `auto` the margins can do their job. `cn` is tailwind-merge, so
                     a later `w-full` would have beaten anything the constant said.
                     Held by e2e/connect-sticky-header.layout.spec.ts. */
-                        <div
-                          data-testid="connect-search-row"
-                          className={cn(
-                            CONNECT_STICKY_SEARCH_CLASSNAME,
-                            "flex items-center gap-2",
-                          )}
-                        >
-                          <div className="relative flex-1">
-                            <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
-                              <SearchIcon className="h-4.5 w-4.5" />
-                            </span>
-                            <Input
-                              ref={searchInputRef}
-                              type="text"
-                              value={query}
-                              onChange={(event) => setQuery(event.target.value)}
-                              placeholder={CONNECT_SEARCH_PLACEHOLDER}
-                              aria-label="Search people"
-                              data-voice-control-id="one-connect-search"
-                              className={cn(
-                                CONNECT_SEARCH_INPUT_CLASSNAME,
-                                query
-                                  ? CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
-                                  : CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
-                              )}
-                              enterKeyHint="search"
-                              onKeyDown={(event) => {
-                                // iOS soft-keyboard "return" must dismiss the keyboard;
-                                // blurring the field is what actually closes it in the
-                                // Capacitor webview (there is no form submit here).
-                                if (event.key === "Enter") {
-                                  event.preventDefault();
-                                  event.currentTarget.blur();
-                                }
-                              }}
-                              onFocus={(event) => {
-                                // Keyboard-dismiss "on drag": the first scroll/drag while
-                                // the field is focused blurs it, so an open keyboard never
-                                // locks the results out of view. Scoped to this field's
-                                // focus lifecycle and cleaned up on blur.
-                                const field = event.currentTarget;
-                                // Scroll the field into view above the on-screen keyboard.
-                                // Tapping it otherwise leaves it hidden behind the keyboard
-                                // until the user manually scrolls up. The delay lets the
-                                // keyboard animate in so the shrunken viewport is measured.
-                                window.setTimeout(() => {
-                                  field.scrollIntoView({
-                                    block: "center",
-                                    behavior: "smooth",
-                                  });
-                                }, 300);
-                                const dismiss = () => field.blur();
-                                window.addEventListener("touchmove", dismiss, {
-                                  passive: true,
-                                  once: true,
-                                });
-                                field.addEventListener(
-                                  "blur",
-                                  () =>
-                                    window.removeEventListener(
-                                      "touchmove",
-                                      dismiss,
-                                    ),
-                                  { once: true },
-                                );
-                              }}
-                            />
-                            {query ? (
-                              <button
-                                type="button"
-                                aria-label="Clear search"
-                                onClick={() => {
-                                  setQuery("");
-                                  searchInputRef.current?.focus();
-                                }}
-                                className="press-scale absolute inset-y-0 right-0 flex w-11 items-center justify-center text-[#1d1d1f] transition-colors hover:text-black dark:text-white"
-                              >
-                                <X className="h-5 w-5" strokeWidth={2.4} />
-                              </button>
-                            ) : null}
-                          </div>
-                          <Button
-                            type="button"
-                            variant="none"
-                            effect="fill"
-                            size="sm"
-                            className={CONNECT_SELECT_TOGGLE_CLASSNAME}
-                            disabled={loading || people.length === 0}
-                            aria-label={
-                              isSelectionMode
-                                ? "Cancel selecting people"
-                                : "Select many people"
-                            }
-                            onClick={() => {
-                              setIsSelectionMode((current) => !current);
-                              setSelectedPeople(new Map());
-                              setShowLimitBanner(false);
-                            }}
+                          <div
+                            data-testid="connect-search-row"
+                            className={cn(
+                              CONNECT_STICKY_SEARCH_CLASSNAME,
+                              "flex items-center gap-2",
+                            )}
                           >
-                            {/* "Select many", not "Select": this enters multi-select,
+                            <div className="relative flex-1">
+                              <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
+                                <SearchIcon className="h-4.5 w-4.5" />
+                              </span>
+                              <Input
+                                ref={searchInputRef}
+                                type="text"
+                                value={query}
+                              onChange={(event) => setQuery(event.target.value)}
+                                placeholder={CONNECT_SEARCH_PLACEHOLDER}
+                                aria-label="Search people"
+                                data-voice-control-id="one-connect-search"
+                                className={cn(
+                                  CONNECT_SEARCH_INPUT_CLASSNAME,
+                                  query
+                                    ? CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
+                                    : CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
+                                )}
+                                enterKeyHint="search"
+                                onKeyDown={(event) => {
+                                  // iOS soft-keyboard "return" must dismiss the keyboard;
+                                  // blurring the field is what actually closes it in the
+                                  // Capacitor webview (there is no form submit here).
+                                  if (event.key === "Enter") {
+                                    event.preventDefault();
+                                    event.currentTarget.blur();
+                                  }
+                                }}
+                                onFocus={(event) => {
+                                  // Keyboard-dismiss "on drag": the first scroll/drag while
+                                  // the field is focused blurs it, so an open keyboard never
+                                  // locks the results out of view. Scoped to this field's
+                                  // focus lifecycle and cleaned up on blur.
+                                  const field = event.currentTarget;
+                                  // Scroll the field into view above the on-screen keyboard.
+                                  // Tapping it otherwise leaves it hidden behind the keyboard
+                                  // until the user manually scrolls up. The delay lets the
+                                  // keyboard animate in so the shrunken viewport is measured.
+                                  window.setTimeout(() => {
+                                    field.scrollIntoView({
+                                      block: "center",
+                                      behavior: "smooth",
+                                    });
+                                  }, 300);
+                                  const dismiss = () => field.blur();
+                                window.addEventListener("touchmove", dismiss, {
+                                      passive: true,
+                                      once: true,
+                                });
+                                  field.addEventListener(
+                                    "blur",
+                                    () =>
+                                      window.removeEventListener(
+                                        "touchmove",
+                                        dismiss,
+                                      ),
+                                    { once: true },
+                                  );
+                                }}
+                              />
+                              {query ? (
+                                <button
+                                  type="button"
+                                  aria-label="Clear search"
+                                  onClick={() => {
+                                    setQuery("");
+                                    searchInputRef.current?.focus();
+                                  }}
+                                  className="press-scale absolute inset-y-0 right-0 flex w-11 items-center justify-center text-[#1d1d1f] transition-colors hover:text-black dark:text-white"
+                                >
+                                  <X className="h-5 w-5" strokeWidth={2.4} />
+                                </button>
+                              ) : null}
+                            </div>
+                            <Button
+                              type="button"
+                              variant="none"
+                              effect="fill"
+                              size="sm"
+                              className={CONNECT_SELECT_TOGGLE_CLASSNAME}
+                              disabled={loading || people.length === 0}
+                              aria-label={
+                                isSelectionMode
+                                  ? "Cancel selecting people"
+                                  : "Select many people"
+                              }
+                              onClick={() => {
+                                setIsSelectionMode((current) => !current);
+                                setSelectedPeople(new Map());
+                                setShowLimitBanner(false);
+                              }}
+                            >
+                              {/* "Select many", not "Select": this enters multi-select,
                         and a lone "Select" reads as picking the one thing you are
                         looking at. The visible label and the accessible name now
                         say the same thing. */}
-                            {isSelectionMode ? "Cancel" : "Select many"}
-                          </Button>
-                        </div>
+                              {isSelectionMode ? "Cancel" : "Select many"}
+                            </Button>
+                          </div>
                         }
                       >
-                        {loading ? (
+                        {loading && people.length === 0 ? (
                           <SettingsRow
                             title="Finding people…"
                             density="compact"
@@ -2968,67 +3024,54 @@ export default function ConnectPageClient() {
                           })
                         )}
                         {people.length > 0 || currentPage > 1 ? (
-                          /* One row, not two stacked fragments. "Page 1", a
-                             dot, "Per page", a select, and then Prev/Next
-                             dropped onto a second line read as four unrelated
-                             things scattered at the bottom of the card. The
-                             control and the buttons that use it now share a
-                             line -- how much you are reading at on the left,
-                             the way through the list on the right -- and the
-                             page number drops under the control as the quiet
-                             status it is, rather than leading a row it does
-                             not act on. */
                           <div
                             className={CONNECT_PAGER_ROW_CLASSNAME}
                             data-testid="connect-pager-row"
                           >
-                            <div className="flex min-w-0 flex-col items-start gap-0.5">
-                              <div className="flex items-center gap-2">
-                                <span className="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)]">
-                                  Per page
-                                </span>
-                                <Select
-                                  value={String(pageSize)}
-                                  onValueChange={(value) =>
-                                    setPageSize(Number(value))
-                                  }
-                                >
-                                  <SelectTrigger
-                                    size="sm"
-                                    aria-label="People per page"
-                                    className={CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}
-                                  >
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {PAGE_SIZE_OPTIONS.map((size) => (
-                                      <SelectItem
-                                        key={size}
-                                        value={String(size)}
-                                      >
-                                        {size}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              </div>
-                              {/* Status, not a control: it sits under the thing
-                                  it describes, one step down in size and
-                                  colour, so the row above stays the only line
-                                  with anything to press. */}
-                              <span className={CONNECT_PAGE_STATUS_CLASSNAME}>
-                                Page {currentPage}
-                              </span>
-                            </div>
-                            <div
-                              className="flex shrink-0 items-center justify-end gap-2"
+                            <span
+                              className={CONNECT_PAGE_STATUS_CLASSNAME}
                               aria-live="polite"
                             >
+                              {directoryRangeLabel}
+                            </span>
+                            <div className="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
+                              {directoryTotalCount > DEFAULT_PAGE_SIZE ||
+                              pageSize !== DEFAULT_PAGE_SIZE ? (
+                                <div className="hidden items-center sm:flex">
+                                  <Select
+                                    value={String(pageSize)}
+                                    onValueChange={handlePageSizeChange}
+                                  >
+                                    <SelectTrigger
+                                      size="sm"
+                                      aria-label="People per page"
+                                      className={
+                                        CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME
+                                      }
+                                    >
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {PAGE_SIZE_OPTIONS.map((size) => (
+                                        <SelectItem
+                                          key={size}
+                                          value={String(size)}
+                                        >
+                                          {size} per page
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                              ) : null}
                               <Button
                                 type="button"
                                 variant="none"
-                                effect="fill"
+                                effect="fade"
                                 size="sm"
+                                showRipple={false}
+                                aria-label="Previous page"
+                                title="Previous page"
                                 className={cn(
                                   CONNECT_PAGER_BUTTON_CLASSNAME,
                                   CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
@@ -3036,13 +3079,19 @@ export default function ConnectPageClient() {
                                 disabled={loading || currentPage <= 1}
                                 onClick={() => goToPage(currentPage - 1)}
                               >
-                                Prev
+                                <ChevronLeft
+                                  className="h-5 w-5"
+                                  aria-hidden="true"
+                                />
                               </Button>
                               <Button
                                 type="button"
                                 variant="none"
-                                effect="fill"
+                                effect="fade"
                                 size="sm"
+                                showRipple={false}
+                                aria-label="Next page"
+                                title="Next page"
                                 className={cn(
                                   CONNECT_PAGER_BUTTON_CLASSNAME,
                                   CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
@@ -3050,7 +3099,10 @@ export default function ConnectPageClient() {
                                 disabled={loading || !hasMore}
                                 onClick={() => goToPage(currentPage + 1)}
                               >
-                                Next
+                                <ChevronRight
+                                  className="h-5 w-5"
+                                  aria-hidden="true"
+                                />
                               </Button>
                             </div>
                           </div>

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -107,7 +107,10 @@ async function buildStylesheet(candidates: string[]): Promise<string> {
         id === "tailwindcss"
           ? path.join(webappRoot, "node_modules/tailwindcss/index.css")
           : id === "tw-animate-css"
-            ? path.join(webappRoot, "node_modules/tw-animate-css/dist/tw-animate.css")
+            ? path.join(
+                webappRoot,
+                "node_modules/tw-animate-css/dist/tw-animate.css",
+              )
             : path.resolve(base, id);
       return {
         path: file,
@@ -271,7 +274,10 @@ test.describe("Circle name row", () => {
         ).toBeLessThanOrEqual(0.5);
 
         // Same box, same line, flush on both edges.
-        expect(Math.abs(action.top - input.top), `${state}: top`).toBeLessThanOrEqual(0.5);
+        expect(
+          Math.abs(action.top - input.top),
+          `${state}: top`,
+        ).toBeLessThanOrEqual(0.5);
         expect(
           Math.abs(action.bottom - input.bottom),
           `${state}: bottom`,
@@ -300,7 +306,9 @@ test.describe("Circle name row", () => {
     });
   }
 
-  test("the version QA photographed really was 6px too tall", async ({ page }) => {
+  test("the version QA photographed really was 6px too tall", async ({
+    page,
+  }) => {
     // Mutation check. Without this, the assertions above could be passing on a
     // rule that was never capable of failing.
     //
@@ -320,10 +328,13 @@ test.describe("Circle name row", () => {
     const input = await boxOf(page, '[data-testid="circle-name-input"]');
     const action = await boxOf(page, '[data-testid="circle-name-action"]');
 
-    expect(Math.abs(input.height - CIRCLE_NAME_ROW_HEIGHT_PX)).toBeLessThanOrEqual(0.5);
-    expect(action.height, "the shipped Save button measured 50px").toBeGreaterThan(
-      input.height + 4,
-    );
+    expect(
+      Math.abs(input.height - CIRCLE_NAME_ROW_HEIGHT_PX),
+    ).toBeLessThanOrEqual(0.5);
+    expect(
+      action.height,
+      "the shipped Save button measured 50px",
+    ).toBeGreaterThan(input.height + 4);
   });
 });
 
@@ -380,7 +391,9 @@ const BEFORE = {
 const BUTTON_BASE = "inline-flex items-center justify-center whitespace-nowrap";
 
 /** The row exactly as Connect builds it: field, `gap-2`, fixed-width toggle. */
-const searchRowBody = (empty: boolean) => `<div class="flex w-full items-center gap-2">
+const searchRowBody = (
+  empty: boolean,
+) => `<div class="flex w-full items-center gap-2">
   <div class="relative flex-1">
     <input data-testid="connect-search" placeholder="${CONNECT_SEARCH_PLACEHOLDER}"
       class="${INPUT_CLASSNAME} ${CONNECT_SEARCH_INPUT_CLASSNAME} ${
@@ -437,15 +450,24 @@ test.describe("Connect search row", () => {
     test(`placeholder is fully readable at ${width}px`, async ({ page }) => {
       await page.setViewportSize({ width, height: 844 });
       await page.goto(
-        await buildFixture("connect-search", searchRowBody(true), SEARCH_CANDIDATES),
+        await buildFixture(
+          "connect-search",
+          searchRowBody(true),
+          SEARCH_CANDIDATES,
+        ),
       );
       await fontsReady(page);
 
       // The fixture must be measuring the real 17px field type. If globals.css
       // ever stops reaching this page, every assertion below would pass against
       // a smaller fallback font and prove nothing.
-      const current = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
-      expect(current.fontSize, "field is at the app's real input type").toBe("17px");
+      const current = await page.evaluate(
+        probePlaceholder,
+        CONNECT_SEARCH_PLACEHOLDER,
+      );
+      expect(current.fontSize, "field is at the app's real input type").toBe(
+        "17px",
+      );
 
       // Sub-pixel tolerance, matching the 0.5px this file already allows on every
       // other measured box. Text advance widths differ by a fraction between the
@@ -484,14 +506,28 @@ test.describe("Connect search row", () => {
     await page.setViewportSize({ width: 375, height: 844 });
 
     await page.goto(
-      await buildFixture("connect-search-empty", searchRowBody(true), SEARCH_CANDIDATES),
+      await buildFixture(
+        "connect-search-empty",
+        searchRowBody(true),
+        SEARCH_CANDIDATES,
+      ),
     );
-    const empty = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
+    const empty = await page.evaluate(
+      probePlaceholder,
+      CONNECT_SEARCH_PLACEHOLDER,
+    );
 
     await page.goto(
-      await buildFixture("connect-search-typed", searchRowBody(false), SEARCH_CANDIDATES),
+      await buildFixture(
+        "connect-search-typed",
+        searchRowBody(false),
+        SEARCH_CANDIDATES,
+      ),
     );
-    const typed = await page.evaluate(probePlaceholder, CONNECT_SEARCH_PLACEHOLDER);
+    const typed = await page.evaluate(
+      probePlaceholder,
+      CONNECT_SEARCH_PLACEHOLDER,
+    );
 
     // An empty field has no clear button in it, so it should not be holding
     // 44px back from the only thing it is showing.
@@ -508,7 +544,11 @@ test.describe("Connect search row", () => {
     }) => {
       await page.setViewportSize({ width, height: 844 });
       await page.goto(
-        await buildFixture("connect-toggle", searchRowBody(true), SEARCH_CANDIDATES),
+        await buildFixture(
+          "connect-toggle",
+          searchRowBody(true),
+          SEARCH_CANDIDATES,
+        ),
       );
 
       const toggle = await boxOf(page, '[data-testid="connect-select-toggle"]');
@@ -642,13 +682,16 @@ test.describe("Connect list rows", () => {
       page,
     }) => {
       await page.setViewportSize({ width, height: 844 });
-      await page.goto(await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES));
+      await page.goto(
+        await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES),
+      );
       await awaitProductFont(page);
       await fontsReady(page);
 
-      expect(width, "this width is below sm: and therefore a phone").toBeLessThan(
-        SM_BREAKPOINT_PX,
-      );
+      expect(
+        width,
+        "this width is below sm: and therefore a phone",
+      ).toBeLessThan(SM_BREAKPOINT_PX);
 
       const stackedTitle = await boxOf(page, '[data-testid="stacked-title"]');
       const stackedAction = await boxOf(page, '[data-testid="stacked-action"]');
@@ -668,7 +711,9 @@ test.describe("Connect list rows", () => {
         "the shipped row keeps the action beside the name",
       ).toBeLessThan(inlineTitle.bottom);
       expect(inlineAction.right).toBeGreaterThan(inlineTitle.right);
-      expect(inlineAction.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
+      expect(inlineAction.right).toBeLessThanOrEqual(
+        width - PAGE_PADDING_PX + 1,
+      );
     });
   }
 
@@ -676,7 +721,9 @@ test.describe("Connect list rows", () => {
     page,
   }) => {
     await page.setViewportSize({ width: 375, height: 844 });
-    await page.goto(await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES));
+    await page.goto(
+      await buildFixture("connect-rows", rowsBody, ROW_CANDIDATES),
+    );
     await awaitProductFont(page);
     await fontsReady(page);
 
@@ -696,18 +743,9 @@ test.describe("Connect list rows", () => {
 // ---------------------------------------------------------------------------
 
 /**
- * QA, on a phone: "sarein cheezein scattered dekh rahi -- page 1 . per page,
- * prev next in next line. per page, prev next ek line mein la sakte."
- *
- * The row was `flex flex-col ... sm:flex-row`, and `sm:` is 640px, so on every
- * width the App Store actually ships to it stacked: "Page 1 - Per page [8]"
- * across the top, and a right-aligned "Prev  Next" on a second line under it.
- * Four fragments, three alignments, one card.
- *
- * Putting them back on one line is only safe if they FIT on one line at 320px,
- * which is a browser question. The JSDOM sibling proves the row still renders
- * without `flex-col`; it measures every box as 0x0 and would pass just as
- * happily on a row that overflowed the card by 40px.
+ * The Connect footer is a range reader plus previous/next controls on phones,
+ * and gains a compact page-size menu from the tablet breakpoint up. It stays
+ * inside the grouped list with one separator; it is not a second control card.
  */
 const PAGER_BEFORE_ROW_CLASSNAME =
   "flex flex-col gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between";
@@ -734,10 +772,19 @@ const PAGER_CANDIDATES = [
   "items-center",
   "justify-end",
   "gap-0.5",
+  "gap-1.5",
   "gap-2",
   "gap-2.5",
   "shrink-0",
+  "hidden",
+  "sm:flex",
   "min-h-9",
+  "min-h-14",
+  "!h-11",
+  "!min-h-11",
+  "!w-11",
+  "!min-w-11",
+  "!p-0",
   "h-1",
   "w-1",
   "rounded-full",
@@ -754,22 +801,21 @@ const PAGER_CANDIDATES = [
  * height this row has to budget for are both fixed on the trigger itself, so
  * whatever Radix renders inside it cannot change the number measured here.
  */
-const pagerBody = () => `<div data-testid="pager-row" class="${CONNECT_PAGER_ROW_CLASSNAME}">
-  <div data-testid="pager-size" class="flex min-w-0 flex-col items-start gap-0.5">
-    <div data-testid="pager-size-line" class="flex items-center gap-2">
-      <span class="ui-text-helper-text whitespace-nowrap text-[color:var(--app-secondary-label)]">Per page</span>
-      <div data-testid="pager-select" class="${CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}">8</div>
+const pagerBody =
+  () => `<div data-testid="pager-row" class="${CONNECT_PAGER_ROW_CLASSNAME}">
+  <span data-testid="pager-status" class="${CONNECT_PAGE_STATUS_CLASSNAME}">1-20 of 100</span>
+  <div data-testid="pager-actions" class="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
+    <div data-testid="pager-size" class="hidden items-center sm:flex">
+      <div data-testid="pager-select" class="${CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}">20 per page</div>
     </div>
-    <span data-testid="pager-status" class="${CONNECT_PAGE_STATUS_CLASSNAME}">Page 1</span>
-  </div>
-  <div data-testid="pager-actions" class="flex shrink-0 items-center justify-end gap-2">
-    <button data-testid="pager-prev" class="${pagerButtonClass()}">Prev</button>
-    <button data-testid="pager-next" class="${pagerButtonClass()}">Next</button>
+    <button data-testid="pager-prev" class="${pagerButtonClass()}">‹</button>
+    <button data-testid="pager-next" class="${pagerButtonClass()}">›</button>
   </div>
 </div>`;
 
 /** The same pager exactly as it shipped, for the mutation check. */
-const pagerBodyBefore = () => `<div data-testid="pager-row" class="${PAGER_BEFORE_ROW_CLASSNAME}">
+const pagerBodyBefore =
+  () => `<div data-testid="pager-row" class="${PAGER_BEFORE_ROW_CLASSNAME}">
   <div data-testid="pager-size" class="flex min-h-9 flex-wrap items-center gap-2.5">
     <span data-testid="pager-status" class="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]">Page 1</span>
     <span class="h-1 w-1 rounded-full bg-[color:var(--app-tertiary-label)]"></span>
@@ -793,7 +839,7 @@ const fontSizeOf = (page: Page, selector: string) =>
 
 test.describe("Connect pager", () => {
   for (const width of PHONE_WIDTHS) {
-    test(`size control and Prev/Next share one line at ${width}px`, async ({
+    test(`phone footer shows range plus icon arrows at ${width}px`, async ({
       page,
     }) => {
       await page.setViewportSize({ width, height: 844 });
@@ -804,22 +850,21 @@ test.describe("Connect pager", () => {
       await fontsReady(page);
 
       const row = await boxOf(page, '[data-testid="pager-row"]');
-      const sizeLine = await boxOf(page, '[data-testid="pager-size-line"]');
       const actions = await boxOf(page, '[data-testid="pager-actions"]');
       const status = await boxOf(page, '[data-testid="pager-status"]');
+      const sizeDisplay = await page
+        .locator('[data-testid="pager-size"]')
+        .evaluate((node) => getComputedStyle(node).display);
 
-      // Side by side, not stacked: the buttons start after the size control
-      // ends, and the two boxes overlap vertically.
-      expect(actions.left, "buttons start after the size control").toBeGreaterThan(
-        sizeLine.right,
+      expect(sizeDisplay, "phone hides the page-size menu").toBe("none");
+      expect(actions.left, "buttons start after the range").toBeGreaterThan(
+        status.right,
       );
       expect(actions.top, "same line, not the next one").toBeLessThan(
-        sizeLine.bottom,
+        status.bottom,
       );
-      expect(sizeLine.top).toBeLessThan(actions.bottom);
+      expect(status.top).toBeLessThan(actions.bottom);
 
-      // And it fits. This is the whole reason the select and the buttons gave
-      // up padding; at 320px the old geometry would not have.
       expect(
         actions.right,
         `pager overflows at ${width}px`,
@@ -827,20 +872,46 @@ test.describe("Connect pager", () => {
       expect(row.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
       expect(row.left).toBeGreaterThanOrEqual(PAGE_PADDING_PX - 1);
 
-      // "Page 1" reads as the status under the control, not as a fifth item
-      // competing on the line.
-      expect(status.top, "page number sits under the size control").toBeGreaterThanOrEqual(
-        sizeLine.bottom - 0.5,
-      );
-      expect(status.left).toBeLessThanOrEqual(sizeLine.left + 0.5);
-
-      const statusSize = await fontSizeOf(page, '[data-testid="pager-status"]');
-      const labelSize = await fontSizeOf(page, '[data-testid="pager-size-line"] span');
-      expect(statusSize, "status is quieter than the label above it").toBeLessThan(
-        labelSize,
-      );
+      for (const id of ["pager-prev", "pager-next"]) {
+        const button = await boxOf(page, `[data-testid="${id}"]`);
+        expect(button.width, `${id} width`).toBeGreaterThanOrEqual(43.5);
+        expect(button.height, `${id} height`).toBeGreaterThanOrEqual(43.5);
+      }
     });
   }
+
+  test("tablet footer keeps the compact page-size menu", async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 844 });
+    await page.goto(
+      await buildFixture("connect-pager-tablet", pagerBody(), PAGER_CANDIDATES),
+    );
+    await awaitProductFont(page);
+    await fontsReady(page);
+
+    const select = await boxOf(page, '[data-testid="pager-select"]');
+    const status = await boxOf(page, '[data-testid="pager-status"]');
+    expect(
+      select.left,
+      "select sits after the range on tablet",
+    ).toBeGreaterThan(status.right);
+    expect(select.width, "compact select").toBeLessThanOrEqual(132);
+  });
+
+  test("the range status stays quieter than row controls", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(
+      await buildFixture("connect-pager-status", pagerBody(), PAGER_CANDIDATES),
+    );
+    await awaitProductFont(page);
+    await fontsReady(page);
+
+    const statusSize = await fontSizeOf(page, '[data-testid="pager-status"]');
+    const buttonSize = await fontSizeOf(page, '[data-testid="pager-next"]');
+    expect(
+      statusSize,
+      "range is quieter than button chrome",
+    ).toBeLessThanOrEqual(buttonSize);
+  });
 
   test("the version QA photographed really did stack", async ({ page }) => {
     // Mutation check. `sm:` is 640px, so at 375 the shipped row was in its

--- a/hushh-webapp/lib/services/connections-service.ts
+++ b/hushh-webapp/lib/services/connections-service.ts
@@ -34,6 +34,7 @@ export interface DirectoryPage {
   items: DirectoryPerson[];
   page: number;
   hasMore: boolean;
+  totalCount: number;
   audience?: DirectoryAudience;
 }
 
@@ -352,7 +353,25 @@ export class ConnectionsService {
         headers: authHeaders(opts.idToken),
       },
     );
-    return jsonOrThrow<DirectoryPage>(response);
+    const payload = await jsonOrThrow<Partial<DirectoryPage>>(response);
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const page = Math.max(1, Number(payload.page) || opts.page || 1);
+    const limit = Math.max(1, Number(opts.limit) || items.length || 1);
+    const visibleUpperBound = (page - 1) * limit + items.length;
+    return {
+      items,
+      page,
+      hasMore: Boolean(payload.hasMore),
+      totalCount: Math.max(
+        0,
+        visibleUpperBound,
+        Number(payload.totalCount) || 0,
+      ),
+      audience:
+        payload.audience === "people" || payload.audience === "ria"
+          ? payload.audience
+          : opts.audience,
+    };
   }
 
   static async listConnections(opts: {


### PR DESCRIPTION
## Summary
- refine Connect directory pagination footer to show range-based paging
- set directory page size to 20 by default with 20/50 compact desktop options
- keep existing rows visible during page transitions and hide per-page control on phone widths

## Validation
- npm test -- __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts __tests__/services/connections-service.test.ts
- npx playwright test e2e/connect-circle-cta.layout.spec.ts --project=chromium --grep "Connect pager"
- npm exec eslint -- app/connect/page-client.tsx app/connect/connect-search-layout.ts lib/services/connections-service.ts __tests__/app/connect/page-client.test.tsx e2e/connect-circle-cta.layout.spec.ts
- npm run typecheck
- git diff --check origin/main...HEAD

## Notes
- Preserves server-side pagination API, search, relationship actions, and multi-select state across pages.
- UAT deploy will use the landed green main SHA with scope=auto.