### PR TITLE
Refine Connect directory loading state

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -707,6 +707,53 @@ describe("Connect — People", () => {
     expect(await screen.findByText("21–40 of 100")).toBeTruthy();
   });
 
+  it("keeps the visible directory stable while the next page loads", async () => {
+    const pageTwo = deferred<{
+      items: ReturnType<typeof person>[];
+      hasMore: boolean;
+      page: number;
+      totalCount: number;
+    }>();
+    mocks.searchDirectory.mockImplementation(async (options) => {
+      const page = Math.max(1, Number(options.page) || 1);
+      const limit = Math.max(1, Number(options.limit) || 20);
+      if (page === 2) return pageTwo.promise;
+      const start = (page - 1) * limit;
+      return {
+        items: EVERYONE.slice(start, start + limit),
+        hasMore: start + limit < EVERYONE.length,
+        page,
+        totalCount: EVERYONE.length,
+      };
+    });
+
+    render(<ConnectPageClient />);
+    expect(await screen.findByText("Person 0")).toBeTruthy();
+    expect(await screen.findByText("1–20 of 100")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Next page"));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Loading people")).toBeTruthy(),
+    );
+    expect(screen.getByText("Person 0")).toBeTruthy();
+    expect(screen.queryByText("Finding people…")).toBeNull();
+    expect(screen.getByLabelText("Next page")).toBeDisabled();
+
+    await act(async () => {
+      pageTwo.resolve({
+        items: EVERYONE.slice(20, 40),
+        hasMore: true,
+        page: 2,
+        totalCount: EVERYONE.length,
+      });
+    });
+
+    expect(await screen.findByText("Person 20")).toBeTruthy();
+    expect(screen.queryByText("Person 0")).toBeNull();
+    expect(screen.queryByLabelText("Loading people")).toBeNull();
+  });
+
   it("opens the full directory once a name is typed", async () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1013,6 +1013,7 @@ export default function ConnectPageClient() {
     );
     return `${rangeStart}\u2013${rangeEnd} of ${directoryTotalCount}`;
   }, [directoryPage, directoryTotalCount, pageSize, people.length]);
+  const isDirectoryRefreshing = loading && people.length > 0;
 
   // A share sheet is modal but not instant: on iOS it animates in, and the
   // promise does not settle until it is dismissed. Two taps in that window
@@ -3029,10 +3030,19 @@ export default function ConnectPageClient() {
                             data-testid="connect-pager-row"
                           >
                             <span
-                              className={CONNECT_PAGE_STATUS_CLASSNAME}
+                              className={cn(
+                                CONNECT_PAGE_STATUS_CLASSNAME,
+                                "inline-flex items-center gap-2",
+                              )}
                               aria-live="polite"
                             >
                               {directoryRangeLabel}
+                              {isDirectoryRefreshing ? (
+                                <Loader2
+                                  className="h-3.5 w-3.5 animate-spin"
+                                  aria-label="Loading people"
+                                />
+                              ) : null}
                             </span>
                             <div className="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
                               {directoryTotalCount > DEFAULT_PAGE_SIZE ||


### PR DESCRIPTION
## Summary
- keep Connect directory rows visible while a later page/search refresh is loading
- show a quiet pager spinner instead of replacing populated rows with the initial loading row
- add regression coverage for large-directory paging stability

## Verification
- `npx eslint app/connect/page-client.tsx __tests__/app/connect/page-client.test.tsx --max-warnings=0`
- `npm test -- --run __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts`
- `npm run verify:connect-search`
- `npm run typecheck`