### PR TITLE
fix(one-location): stop the shared map drawing a card inside a clip

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -233,4 +233,27 @@ describe("One Location — the Share confirm step is a measured column", () => {
     // And the hint is no longer right-aligned into the far corner.
     expect(classNames.some((c) => c.includes("text-right"))).toBe(false);
   });
+
+  it("does not draw a second card inside the clipped map preview", () => {
+    // The report: the map's outline "does not follow the map's actual shape
+    // and gets cut off at the corners". LocalMapPreview drew its own card --
+    // border plus a 24px radius -- inside SharedWithMeCard's 14px clip, so
+    // the child bulged past the parent on all four corners and the border was
+    // sliced there. Standalone (Check-In) it still IS the card and keeps both.
+    const page = repoFile("app/one/location/page.tsx");
+
+    // The nested branch inherits the container's rounding rather than
+    // asserting one of its own.
+    expect(page).toContain('nested');
+    expect(page).toContain('"rounded-[inherit]"');
+    // ...and the standalone branch keeps the card it is.
+    expect(page).toContain(
+      '"rounded-[var(--app-card-radius-standard)] border border-border/70"',
+    );
+
+    // The one call site that sits inside a clipping container asks for it.
+    expect(HUB_SOURCE).toContain(
+      "// SharedWithMeCard already draws and clips the card",
+    );
+  });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1643,12 +1643,25 @@ function LocalMapPreview({
   showNavigation = true,
   viewportResetKey,
   staleAction,
+  nested = false,
 }: {
   point: PlainLocationPoint;
   // Self-location previews do not need Directions/Start - you are already there.
   showNavigation?: boolean;
   viewportResetKey?: string | number;
   staleAction?: ReactNode;
+  /**
+   * True when a container already draws the card around this preview.
+   *
+   * Standalone (Check-In), this component IS the card and needs its own
+   * border and 24px radius. Inside SharedWithMeCard it sits in a subcard that
+   * already clips to 14px, and drawing a second 24px card inside a 14px clip
+   * is what sliced the outline off at the corners: the child bulged past the
+   * parent on all four, so the border read as the wrong shape rather than as
+   * a border at all. Nested, it inherits the container's rounding and draws
+   * no border of its own.
+   */
+  nested?: boolean;
 }) {
   const captured = formatDateTime(point.capturedAt);
   const accuracy = locationAccuracyLabel(point);
@@ -1668,7 +1681,14 @@ function LocalMapPreview({
         : `Paused · last seen ${freshness.agoLabel}`;
 
   return (
-    <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
+    <div
+      className={cn(
+        "w-full min-w-0 max-w-full overflow-hidden bg-[color:var(--app-card-surface-default-solid)]",
+        nested
+          ? "rounded-[inherit]"
+          : "rounded-[var(--app-card-radius-standard)] border border-border/70",
+      )}
+    >
       <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
         <LiveMap point={point} viewportResetKey={viewportResetKey} />
         <div className="pointer-events-none absolute left-3 top-3">
@@ -13366,12 +13386,14 @@ export function OneLocationAgentPageContent({
       showNavigation,
       viewportResetKey,
       staleAction,
+      nested,
     ) => (
       <LocalMapPreview
         point={point}
         showNavigation={showNavigation}
         viewportResetKey={`${mapViewportResetKey}:${viewportResetKey ?? "default"}`}
         staleAction={staleAction}
+        nested={nested}
       />
     ),
     mapLocationHref: googleMapsLocationUrl,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -607,6 +607,8 @@ export type LocationHubViewModel = {
     showNavigation?: boolean,
     viewportResetKey?: string | number,
     staleAction?: ReactNode,
+    /** True when the caller already draws the card around the preview. */
+    nested?: boolean,
   ) => ReactNode;
   mapLocationHref: (point: PlainLocationPoint) => string;
   decryptedPoints: Record<string, PlainLocationPoint>;
@@ -2551,6 +2553,9 @@ function LocationDetailFlow({
                             )}
                             Ask to refresh
                           </Button>,
+                          // SharedWithMeCard already draws and clips the card
+                          // around this preview.
+                          true,
                         )
                       : null}
                   </SharedWithMeCard>


### PR DESCRIPTION
## The cause

`LocalMapPreview` draws **its own card** — a border plus a **24px** radius. Inside `SharedWithMeCard` it sits in a wrapper that clips at **14px**.

A 24px rounded rect inside a 14px clip bulges past it on all four corners, so exactly the corners of the border were sliced away. What survived was four straight edges that stop short — which reads as *"an outline that doesn't follow the map's shape"* rather than as a border at all.

## Why neither radius is the thing to change

Both are deliberate, and the component has two genuinely different contexts:

| | Container | What it needs |
|---|---|---|
| **Check-In** | plain `div`, no clip | The preview **is** the card — keeps its 24px and its border |
| **Shared with me** | subcard clipping at 14px | 14px is the design's inner radius; a second card is redundant *and* clipped |

Changing `LocalMapPreview` to 14px would have broken Check-In. Widening the wrapper to 24px would have put an inner radius **larger** than the 18px subcard around it — the classic wrong-nesting look.

## The fix

The preview takes a `nested` flag: inherit the container's rounding, draw no border of its own. Defaults to `false`, so Check-In is untouched — only the `SharedWithMeCard` call site passes it.

## Test plan

- [x] `npx vitest run __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts components/one-location/redesign/__tests__/` — **301 passed across 18 files**.
- [x] Pinned in the copy-pass contract test, where this file's other layout invariants already live: the nested branch inherits rounding, the standalone branch keeps its card, and the one call site inside a clipping container asks for it.
- [x] A geometry bug like this **fails silently** — nothing throws, the border just goes the wrong shape — so a source-level assertion is the only thing that catches it coming back.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6179.
