### PR TITLE
Refine Connect shell and loading experience

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -78,26 +78,26 @@ describe("Connect canonical surface contract", () => {
     expect(source).not.toContain("offeredHandles: catalog.offerableItems");
   });
 
-  it("keeps the four-option hub strip narrow enough that no tab title truncates", () => {
-    // Measured, not assumed. With the strip's stock 16px option padding, the
-    // hub's widest label is the first thing to lose useful space at phone
-    // widths. Tab titles are ours, not user content, so an ellipsis in one is a
-    // defect rather than graceful degradation.
-    //
-    // Chromium against the built stylesheet, after this override: 320/360/375/
-    // 390/430/768/1280px all clean, no horizontal overflow, strip height
-    // unchanged. jsdom cannot catch a regression here -- it does no layout --
-    // and Playwright is not in the blocking lane, so the override itself is
-    // what gets pinned. Removing it puts the ellipsis straight back.
+  it("keeps Connect navigation split into one primary strip and one compact directory menu", () => {
+    // The old four-option strip was readable only through width overrides and
+    // still competed with the page title. Connect now follows the Location hub
+    // rhythm: one primary route strip, then a compact directory selector inside
+    // the Connections surface.
     const source = readFileSync(
       join(process.cwd(), "app/connect/page-client.tsx"),
       "utf8",
     );
 
+    expect(source).toContain("const CONNECT_PRIMARY_TABS = [");
+    expect(source).toContain('{ value: "connections", label: "Connections" }');
+    expect(source).toContain('{ value: "circles", label: "Circles" }');
     expect(source).toContain(
-      '"[&>button]:px-1 min-[360px]:[&>button]:px-3 sm:[&>button]:px-4.5"',
+      'const CONNECT_DIRECTORY_TABS = (["people", "advisors", "nearby"] as const).map(',
     );
     expect(source).toContain(
+      "aria-label={`Current directory: ${CONNECT_TAB_LABEL[tab]}`}",
+    );
+    expect(source).not.toContain(
       '["people", "advisors", "circles", "nearby"] as const',
     );
   });

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -119,6 +119,11 @@ vi.mock("@/components/connect/nearby-directories", () => ({
   NearbyDirectories: () => <div data-testid="nearby-directories-stub" />,
 }));
 
+function chooseDirectory(name: "People" | "RIAs" | "Around you") {
+  fireEvent.click(screen.getByRole("button", { name: /Current directory:/ }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name }));
+}
+
 vi.mock("sonner", () => ({
   toast: {
     success: mocks.toastSuccess,
@@ -430,7 +435,7 @@ describe("Connect — People", () => {
     expect(
       mocks.listConnectionsPage.mock.calls.map(([options]) => options.page),
     ).toEqual([1, 2, 3, 1, 2]);
-  });
+  }, 10_000);
 
   it("refreshes My connections from the visible refresh control", async () => {
     const refreshedPageOne = deferred<TestConnectionPage>();
@@ -618,25 +623,19 @@ describe("Connect — People", () => {
     expect(screen.getByText("Person 0")).toBeTruthy();
   });
 
-  it("offers range-based paging rather than a sample with no way past it", async () => {
+  it("offers in-list progressive loading rather than visible pagination", async () => {
     // A bounded first screenful was the right instinct, but refusing to page
     // left the rest of the directory unreachable. Both now hold: a screenful
     // by default, and a way through it.
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("Search by name.")).toBeTruthy();
-    // The pager paints a tick after the empty-state copy, so a synchronous
-    // read here fails whenever the machine is loaded -- it went 3-for-5 under
-    // parallel CI load while passing 4-for-4 on an idle laptop. This file is
-    // now a required check on every Connect PR, so an assertion that depends
-    // on scheduler luck would train people to re-run CI instead of reading it.
-    expect(await screen.findByText("1–20 of 100")).toBeTruthy();
-    expect(screen.getByLabelText("People per page")).toBeTruthy();
-    // hasMore is true in the fixture, so forward is offered and back is not.
-    await waitFor(() =>
-      expect(screen.getByLabelText("Next page")).not.toBeDisabled(),
-    );
-    expect(screen.getByLabelText("Previous page")).toBeDisabled();
+    expect(
+      await screen.findByRole("button", { name: "Load 20 more people" }),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("People per page")).toBeNull();
+    expect(screen.queryByLabelText("Next page")).toBeNull();
+    expect(screen.queryByLabelText("Previous page")).toBeNull();
   });
 
   it("reads heading, then instruction, then the field they describe", async () => {
@@ -668,34 +667,25 @@ describe("Connect — People", () => {
     ).toBeTruthy();
   });
 
-  it("keeps the pager inside the grouped list as a compact range row", async () => {
+  it("keeps load-more inside the grouped list as a compact row", async () => {
     render(<ConnectPageClient />);
 
-    const row = await screen.findByTestId("connect-pager-row");
+    const row = await screen.findByTestId("connect-load-more-row");
     expect(row.className).not.toContain("flex-col");
     expect(row.className).toContain("min-h-14");
-    expect(within(row).getByText("1–20 of 100")).toBeTruthy();
     expect(
-      within(row).getByRole("button", { name: "Previous page" }),
+      within(row).getByRole("button", { name: "Load 20 more people" }),
     ).toBeTruthy();
-    expect(within(row).getByRole("button", { name: "Next page" })).toBeTruthy();
-    expect(screen.getByLabelText("People per page").textContent).toContain(
-      "20 per page",
-    );
+    expect(screen.queryByTestId("connect-pager-row")).toBeNull();
   });
 
-  it("asks the server for the page the reader moved to", async () => {
-    // The size control is a Radix popover, which jsdom cannot drive without
-    // pointer plumbing that would test the library rather than this surface.
-    // Next is a plain button and proves the same contract: the page the reader
-    // is on is the page the server is asked for.
+  it("asks the server for the next batch the reader loads", async () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
-    expect(screen.getByLabelText("People per page").textContent).toContain(
-      "20 per page",
-    );
 
-    fireEvent.click(screen.getByLabelText("Next page"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Load 20 more people" }),
+    );
 
     await waitFor(() => {
       const latest =
@@ -704,7 +694,8 @@ describe("Connect — People", () => {
         ][0];
       expect(latest).toMatchObject({ page: 2, limit: 20 });
     });
-    expect(await screen.findByText("21–40 of 100")).toBeTruthy();
+    expect(await screen.findByText("Person 20")).toBeTruthy();
+    expect(screen.getByText("Person 0")).toBeTruthy();
   });
 
   it("keeps the visible directory stable while the next page loads", async () => {
@@ -729,16 +720,16 @@ describe("Connect — People", () => {
 
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
-    expect(await screen.findByText("1–20 of 100")).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText("Next page"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Load 20 more people" }),
+    );
 
     await waitFor(() =>
-      expect(screen.getByLabelText("Loading people")).toBeTruthy(),
+      expect(screen.getByText("Loading more…")).toBeTruthy(),
     );
     expect(screen.getByText("Person 0")).toBeTruthy();
     expect(screen.queryByText("Finding people…")).toBeNull();
-    expect(screen.getByLabelText("Next page")).toBeDisabled();
 
     await act(async () => {
       pageTwo.resolve({
@@ -750,8 +741,8 @@ describe("Connect — People", () => {
     });
 
     expect(await screen.findByText("Person 20")).toBeTruthy();
-    expect(screen.queryByText("Person 0")).toBeNull();
-    expect(screen.queryByLabelText("Loading people")).toBeNull();
+    expect(screen.getByText("Person 0")).toBeTruthy();
+    expect(screen.queryByText("Loading more…")).toBeNull();
   });
 
   it("opens the full directory once a name is typed", async () => {
@@ -776,7 +767,7 @@ describe("Connect — People", () => {
     await waitFor(() =>
       expect(screen.queryByText("Search by name.")).toBeNull(),
     );
-    expect(await screen.findByText(/1–\d+ of \d+/)).toBeTruthy();
+    expect(screen.queryByLabelText("People per page")).toBeNull();
   });
 
   it("restores a typed search query after the page remounts", async () => {
@@ -1008,7 +999,9 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Load 20 more people" }),
+    );
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
     expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({ page: 2 });
 
@@ -1300,8 +1293,8 @@ describe("Connect — People", () => {
     expect(await screen.findByText('No one matches "Nobody"')).toBeTruthy();
   });
 
-  it("caps bulk connection requests at 8 people", async () => {
-    const bulkPeople = Array.from({ length: 9 }, (_, index) =>
+  it("caps bulk connection requests at 10 people", async () => {
+    const bulkPeople = Array.from({ length: 11 }, (_, index) =>
       person(`bulk-${index}`, `Bulk person ${index}`),
     );
     mocks.searchDirectory.mockResolvedValue({
@@ -1313,28 +1306,28 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Bulk person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
 
-    expect(screen.getByText("Pick up to 8, across pages.")).toBeTruthy();
+    expect(screen.getByText("Pick up to 10, across pages.")).toBeTruthy();
 
-    for (let index = 0; index < 8; index += 1) {
+    for (let index = 0; index < 10; index += 1) {
       fireEvent.click(screen.getByLabelText(`Select Bulk person ${index}`));
     }
 
-    expect(screen.getByText("Review 8 of 8")).toBeTruthy();
+    expect(screen.getByText("Review 10")).toBeTruthy();
     expect(
-      (screen.getByLabelText("Select Bulk person 8") as HTMLButtonElement)
+      (screen.getByLabelText("Select Bulk person 10") as HTMLButtonElement)
         .disabled,
     ).toBe(true);
 
     fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
     expect(
-      (screen.getByLabelText("Select Bulk person 8") as HTMLButtonElement)
+      (screen.getByLabelText("Select Bulk person 10") as HTMLButtonElement)
         .disabled,
     ).toBe(false);
     fireEvent.click(screen.getByLabelText("Select Bulk person 0"));
 
-    fireEvent.click(screen.getByRole("button", { name: "Review 8 of 8" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review 10" }));
     expect(
       await screen.findByRole("heading", { name: "Send connection requests" }),
     ).toBeTruthy();
@@ -1350,19 +1343,19 @@ describe("Connect — People", () => {
     expect(await screen.findByText("No access yet")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Send requests" }));
 
-    await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(8));
+    await waitFor(() => expect(mocks.sendRequest).toHaveBeenCalledTimes(10));
 
     expect(mocks.sendRequest).toHaveBeenCalledWith(
       expect.objectContaining({ addresseeUserId: "bulk-0" }),
     );
     expect(mocks.sendRequest).not.toHaveBeenCalledWith(
-      expect.objectContaining({ addresseeUserId: "bulk-8" }),
+      expect.objectContaining({ addresseeUserId: "bulk-10" }),
     );
   }, 10_000);
 
   it("keeps a selection after the reader pages away from it", async () => {
     // The reported bug, exactly: pick four on page one, go to page two, pick
-    // two more, and the counter reads "2 of 8" -- the first four were dropped
+    // two more, and the counter reads "2" -- the first four were dropped
     // the moment their page stopped being rendered, and the send that followed
     // asked two people instead of six.
     //
@@ -1372,9 +1365,9 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
     fireEvent.click(screen.getByLabelText("Select Person 0"));
-    expect(screen.getByText("Review 1 of 8")).toBeTruthy();
+    expect(screen.getByText("Review 1")).toBeTruthy();
 
     mocks.searchDirectory.mockResolvedValue({
       items: [person("u9", "Person 9")],
@@ -1387,14 +1380,14 @@ describe("Connect — People", () => {
 
     expect(await screen.findByText("Person 9")).toBeTruthy();
     // Still one, and still counted, though its row is nowhere on screen.
-    expect(screen.getByText("Review 1 of 8")).toBeTruthy();
+    expect(screen.getByText("Review 1")).toBeTruthy();
 
     // Picking someone from the new result set adds to the first, and the sheet
     // names both -- nothing is promised that the reader cannot see listed.
     fireEvent.click(screen.getByLabelText("Select Person 9"));
-    expect(screen.getByText("Review 2 of 8")).toBeTruthy();
+    expect(screen.getByText("Review 2")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Review 2 of 8" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review 2" }));
     await waitFor(() =>
       expect(screen.getByText("Selected people")).toBeTruthy(),
     );
@@ -1428,7 +1421,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Connected Carl")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
 
     // Eligible: a real, enabled checkbox.
     expect(
@@ -1508,10 +1501,10 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("Ada Advisor")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Select many people" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select people" }));
     fireEvent.click(screen.getByLabelText("Select Ada Advisor"));
     fireEvent.click(screen.getByLabelText("Select Ben Advisor"));
-    fireEvent.click(screen.getByRole("button", { name: "Review 2 of 8" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review 2" }));
 
     // One row per advisor, because each is a separate ask.
     expect(
@@ -1548,7 +1541,7 @@ describe("Connect — People", () => {
       expect.objectContaining({ audience: "people" }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     await waitFor(() =>
       expect(mocks.searchDirectory).toHaveBeenLastCalledWith(
@@ -1590,7 +1583,7 @@ describe("Connect — People", () => {
     expect(screen.getByText("Verified Adviser")).toBeTruthy();
     expect(screen.getByText("Ordinary Person")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     // The heading counts the list it is actually showing. Counting one list
     // and rendering another is the exact shape of the original Connect search
@@ -1649,7 +1642,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("People Only Row")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
     expect(screen.queryByText("People Only Row")).toBeNull();
@@ -1672,7 +1665,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
     expect(await screen.findByText("My connections (1)")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
     expect(screen.queryByText("Unannotated Person")).toBeNull();
@@ -1889,25 +1882,15 @@ describe("Connect — the phone-width geometry QA reported", () => {
     ).toBe(true);
   });
 
-  it("says on its face that the toggle selects more than one person", async () => {
-    // This used to assert the label was exactly "Select", on width grounds.
-    // It fit, and it read as "select this one" — the opposite of what the
-    // control does — so a tester asked whether anyone would know it starts
-    // multi-select. The durable invariant underneath that test is WCAG 2.5.3,
-    // not the word count: the accessible name must start with the visible
-    // label, or "tap Select many" is an instruction voice control cannot
-    // follow. Both are asserted here; the width is proved in a real browser by
-    // e2e/connect-circle-cta.layout.spec.ts, which jsdom cannot do.
+  it("keeps the selection toggle compact and accessible", async () => {
     render(<ConnectPageClient />);
     const toggle = await screen.findByRole("button", {
-      name: "Select many people",
+      name: "Select people",
     });
-    expect(toggle.textContent).toBe("Select many");
+    expect(toggle.textContent).toBe("Select");
     expect(
       toggle.getAttribute("aria-label")!.startsWith(toggle.textContent!),
     ).toBe(true);
-    // Not a single bare verb: the label has to carry the plural.
-    expect(toggle.textContent!.split(/\s+/).length).toBeGreaterThan(1);
   });
 });
 
@@ -2108,7 +2091,7 @@ describe("Connect — inviting someone who is not on One yet", () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Bob Kanjilal" },
     });
@@ -2149,7 +2132,9 @@ describe("Connect — Circles", () => {
     // The whole directory half is gone, not merely scrolled past: the search
     // box drives a paged server query that has nothing to do with this tab.
     expect(screen.queryByLabelText("Search people")).toBeNull();
-    expect(screen.getByRole("button", { name: "RIAs" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Current directory:/ }),
+    ).toBeNull();
   });
 
   it("names the default surface explicitly, so back to People navigates", async () => {
@@ -2160,7 +2145,7 @@ describe("Connect — Circles", () => {
     mocks.searchParams = new URLSearchParams("tab=circles");
     render(<ConnectPageClient />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "People" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Connections" }));
 
     await waitFor(() => expect(mocks.routerPush).toHaveBeenCalled());
     expect(String(mocks.routerPush.mock.calls[0][0])).toContain("tab=all");
@@ -2175,7 +2160,7 @@ describe("Connect — Circles", () => {
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Select many people" }),
+      await screen.findByRole("button", { name: "Select people" }),
     );
     expect(
       screen.getByRole("button", { name: "Cancel selecting people" }),
@@ -2187,7 +2172,7 @@ describe("Connect — Circles", () => {
     expect(String(mocks.routerPush.mock.calls[0][0])).toContain("tab=circles");
     // Back to a plain list, with nothing armed against it.
     expect(
-      screen.getByRole("button", { name: "Select many people" }),
+      screen.getByRole("button", { name: "Select people" }),
     ).toBeTruthy();
   });
 
@@ -2198,7 +2183,7 @@ describe("Connect — Circles", () => {
     render(<ConnectPageClient />);
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     expect(
       await screen.findByText("Advisors with a verified profile."),
@@ -2267,7 +2252,7 @@ describe("Connect — contact sync", () => {
     render(<ConnectPageClient />);
 
     await screen.findByRole("button", { name: "Sync contacts" });
-    fireEvent.click(screen.getByRole("button", { name: "RIAs" }));
+    chooseDirectory("RIAs");
 
     await waitFor(() =>
       expect(

--- a/hushh-webapp/app/connect/connect-search-layout.ts
+++ b/hushh-webapp/app/connect/connect-search-layout.ts
@@ -2,10 +2,10 @@
  * Geometry for Connect's search row, in one place both the screen and the
  * browser layout contract read from.
  *
- * The row is a search field and a selection toggle sharing one line. QA found
- * it clipped on a phone: the placeholder rendered as "Search people by nam".
- * Three separate things were spending the row's width, and only one of them
- * was the label:
+ * The row is now only the search field. QA found the older side-by-side
+ * search/select row clipped on a phone: the placeholder rendered as
+ * "Search people by nam". Three separate things were spending the row's width,
+ * and only one of them was the label:
  *
  *  1. The placeholder was five words where two carry the meaning.
  *  2. The toggle said "Select multiple" -- ~55px explaining a mode whose own
@@ -23,7 +23,7 @@
 export const CONNECT_SEARCH_PLACEHOLDER = "Search people";
 
 /** Left inset clears the search glyph; the right one is conditional. */
-export const CONNECT_SEARCH_INPUT_CLASSNAME = "h-10 pl-11";
+export const CONNECT_SEARCH_INPUT_CLASSNAME = "h-11 pl-11";
 
 /** Added only while the clear button is actually in the gutter. */
 export const CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME = "pr-11";
@@ -32,16 +32,14 @@ export const CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME = "pr-11";
 export const CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME = "pr-3.5";
 
 /**
- * The selection toggle, at a fixed width so switching between "Select many"
- * and "Cancel" cannot resize the search field beside it.
+ * The selection toggle, at a fixed width so switching between "Select"
+ * and "Cancel" cannot resize the directory header beside it.
  *
- * 104px, not 84px: the label has to say that it selects MORE THAN ONE person
- * before it is pressed. "Select" alone read as "select this one", which is the
- * opposite of what the control does. The width is measured against the widest
- * of the two labels at 320px in `connect-circle-cta.layout.spec.ts`.
+ * 72px clears the wider "Cancel" label while keeping the directory name as
+ * the dominant control in the header.
  */
 export const CONNECT_SELECT_TOGGLE_CLASSNAME =
-  "h-10 min-h-10 w-[104px] shrink-0 rounded-full px-0 text-[15px] font-semibold leading-5";
+  "h-10 min-h-10 w-[72px] shrink-0 rounded-full px-0 text-[15px] font-semibold leading-5";
 
 /** Gap between the field and the toggle (`gap-2`). */
 export const CONNECT_SEARCH_ROW_GAP_PX = 8;

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -6,8 +6,8 @@ import { toast } from "sonner";
 import {
   BadgeCheck,
   BookUser,
-  ChevronLeft,
-  ChevronRight,
+  Check,
+  ChevronDown,
   Loader2,
   Lock,
   RefreshCw,
@@ -45,18 +45,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useRequireAuth } from "@/hooks/use-auth";
 import { ContactSyncResultsSheet } from "@/components/one-location/contact-sync-results-sheet";
 import { useContactSync } from "@/lib/contacts/use-contact-sync";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { buildPersonProfileRoute, ROUTES } from "@/lib/navigation/routes";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
@@ -82,10 +74,6 @@ import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
 import { getDirectoryPersonDescription } from "./directory-person-label";
 import {
   CONNECT_PAGER_BUTTON_CLASSNAME,
-  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
-  CONNECT_PAGER_ROW_CLASSNAME,
-  CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME,
-  CONNECT_PAGE_STATUS_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
   CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
@@ -155,14 +143,6 @@ export function writeStoredConnectSearchQuery(query: string): void {
 }
 
 /**
- * A four-segment hub has tighter phone-width pressure than Location's three
- * segments. Padding is the only thing that gives: labels, height, and selected
- * affordance stay shared with the app segmented control.
- */
-const CONNECT_STRIP_COMPACT_PADDING =
-  "[&>button]:px-1 min-[360px]:[&>button]:px-3 sm:[&>button]:px-4.5";
-
-/**
  * The pinned header: the Connect hub strip, and nothing else.
  *
  * `--top-shell-live-height` rather than `top-0` -- the scroll root clears the
@@ -222,16 +202,16 @@ const CONNECT_TAB_LABEL: Record<ConnectTab, string> = {
   nearby: "Around you",
 };
 
-type ConnectHubTab = ConnectTab | "circles";
+type ConnectPrimaryTab = "connections" | "circles";
 
-const CONNECT_HUB_TAB_LABEL: Record<ConnectHubTab, string> = {
-  ...CONNECT_TAB_LABEL,
-  circles: "Circles",
-};
+const CONNECT_PRIMARY_TABS = [
+  { value: "connections", label: "Connections" },
+  { value: "circles", label: "Circles" },
+] as const;
 
-const CONNECT_HUB_TABS = (
-  ["people", "advisors", "circles", "nearby"] as const
-).map((value) => ({ value, label: CONNECT_HUB_TAB_LABEL[value] }));
+const CONNECT_DIRECTORY_TABS = (["people", "advisors", "nearby"] as const).map(
+  (value) => ({ value, label: CONNECT_TAB_LABEL[value] }),
+);
 
 /**
  * Which half of the directory each tab pages through.
@@ -255,7 +235,7 @@ const CONNECT_TAB_AUDIENCE: Record<ConnectTab, DirectoryAudience> = {
 /**
  * How many directory reads or connection writes may be in flight at once.
  *
- * A bulk action of 8 people is 8 catalog reads and then up to 8 writes, and
+ * A bulk action of 10 people is 10 catalog reads and then up to 10 writes, and
  * each write holds a database connection for its whole transaction. The pool is
  * 5 connections with 10 overflow, and production runs a smaller instance than
  * UAT does, so an unbounded Promise.all is the shape that exhausts it. Three at
@@ -303,7 +283,6 @@ const SUGGESTED_PEOPLE_LIMIT = 20;
  * through the rest, so this replaces it with real paging: the default is still
  * a screenful, and someone who wants to scan more can say so.
  */
-const PAGE_SIZE_OPTIONS = [20, 50] as const;
 const DEFAULT_PAGE_SIZE = SUGGESTED_PEOPLE_LIMIT;
 const CONNECT_ROW_ACTION_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px]";
@@ -313,7 +292,7 @@ const CONNECT_REFRESH_BUTTON_CLASSNAME =
   "h-8 min-h-8 w-8 min-w-8 rounded-full p-0 text-muted-foreground hover:text-foreground disabled:opacity-70";
 
 /** Maximum number of connection requests the People bulk action can send. */
-const MAX_BULK_CONNECTION_REQUESTS = 8;
+const MAX_BULK_CONNECTION_REQUESTS = 10;
 
 /**
  * Bounds on resolving ONE spoken name against the directory.
@@ -578,7 +557,8 @@ export default function ConnectPageClient() {
   });
 
   const [tab, setTab] = useState<ConnectTab>("people");
-  const hubTab: ConnectHubTab = surface === "circles" ? "circles" : tab;
+  const primaryTab: ConnectPrimaryTab =
+    surface === "circles" ? "circles" : "connections";
   /**
    * What the Circles tab is doing, reported up.
    *
@@ -600,6 +580,10 @@ export default function ConnectPageClient() {
   const connectStackRef = useRef<HTMLDivElement | null>(null);
   const stickyHeaderRef = useRef<HTMLDivElement | null>(null);
   const stickyPinSentinelRef = useRef<HTMLDivElement | null>(null);
+  const directoryMenuRef = useRef<HTMLDivElement | null>(null);
+  const directoryMenuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const loadMoreDirectoryRef = useRef<HTMLDivElement | null>(null);
+  const [directoryMenuOpen, setDirectoryMenuOpen] = useState(false);
   const [query, setQuery] = useState<string>(readStoredConnectSearchQuery);
   useEffect(() => {
     writeStoredConnectSearchQuery(query);
@@ -622,12 +606,7 @@ export default function ConnectPageClient() {
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
-  const [directoryPage, setDirectoryPage] = useState(1);
-  const [directoryTotalCount, setDirectoryTotalCount] = useState(0);
-  const directoryListTopRef = useRef<HTMLDivElement | null>(null);
-  const previousDirectoryPageRef = useRef(1);
-  const isMobile = useIsMobile();
+  const pageSize = DEFAULT_PAGE_SIZE;
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
@@ -716,6 +695,26 @@ export default function ConnectPageClient() {
       observer?.disconnect();
     };
   }, [surface]);
+
+  useEffect(() => {
+    if (!directoryMenuOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const menu = directoryMenuRef.current;
+      if (!menu || !(event.target instanceof Node)) return;
+      if (!menu.contains(event.target)) setDirectoryMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setDirectoryMenuOpen(false);
+      directoryMenuButtonRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [directoryMenuOpen]);
   /**
    * The people picked for a bulk request, held whole rather than by id.
    *
@@ -982,37 +981,6 @@ export default function ConnectPageClient() {
   const inviteToOneShare = useMemo(() => buildInviteToOneShare(), []);
   const canInviteToOne = tab === "people" && inviteToOneShare !== null;
 
-  useEffect(() => {
-    if (!isMobile || pageSize === DEFAULT_PAGE_SIZE) return;
-    setPageSize(DEFAULT_PAGE_SIZE);
-  }, [isMobile, pageSize]);
-
-  const handlePageSizeChange = useCallback((value: string) => {
-    const nextPageSize = Number(value);
-    if (
-      !PAGE_SIZE_OPTIONS.includes(
-        nextPageSize as (typeof PAGE_SIZE_OPTIONS)[number],
-      )
-    ) {
-      return;
-    }
-    setPageSize(nextPageSize);
-    setCurrentPage(1);
-  }, []);
-
-  const directoryRangeLabel = useMemo(() => {
-    if (directoryTotalCount <= 0) return "0 of 0";
-    const rangeStart = Math.min(
-      (directoryPage - 1) * pageSize + 1,
-      directoryTotalCount,
-    );
-    const visibleCount = Math.max(people.length, 1);
-    const rangeEnd = Math.min(
-      rangeStart + visibleCount - 1,
-      directoryTotalCount,
-    );
-    return `${rangeStart}\u2013${rangeEnd} of ${directoryTotalCount}`;
-  }, [directoryPage, directoryTotalCount, pageSize, people.length]);
   const isDirectoryRefreshing = loading && people.length > 0;
 
   // A share sheet is modal but not instant: on iOS it animates in, and the
@@ -1065,7 +1033,7 @@ export default function ConnectPageClient() {
     async function run() {
       if (!user) return;
       try {
-        setHasMore(false);
+        if (currentPage <= 1) setHasMore(false);
         setLoading(true);
         setError(null);
         const idToken = await user.getIdToken();
@@ -1077,24 +1045,23 @@ export default function ConnectPageClient() {
           audience: directoryAudience,
         });
         if (!cancelled) {
-          // One page replaces the last. Appending was what made the directory
-          // an endless scroll with no sense of position in it.
-          setPeople(page.items);
+          setPeople((current) => {
+            if (page.page <= 1) return page.items;
+            const merged = new Map(
+              current.map((person) => [person.userId, person]),
+            );
+            for (const person of page.items) {
+              merged.set(person.userId, person);
+            }
+            return Array.from(merged.values());
+          });
           setHasMore(page.hasMore);
-          setDirectoryPage(page.page);
-          setDirectoryTotalCount(
-            Math.max(
-              0,
-              Number(page.totalCount) || 0,
-              (page.page - 1) * pageSize + page.items.length,
-            ),
-          );
           // Selections deliberately survive this. They used to be pruned to
           // whoever the new page happened to show, on the reasoning that a
           // count the reader cannot see is a promise the surface can't account
           // for -- but the promise was real and the pruning silently broke it:
           // four picked on page one became zero on arriving at page two, and
-          // two more picked there read as "2 of 8". The count is now backed by
+          // two more picked there read as "2 selected". The count is now backed by
           // the rows themselves, and the sheet lists every one of them by name
           // before anything is sent, so nothing is promised unseen.
         }
@@ -1127,15 +1094,6 @@ export default function ConnectPageClient() {
     directoryRefreshNonce,
   ]);
 
-  useEffect(() => {
-    if (previousDirectoryPageRef.current === directoryPage) return;
-    previousDirectoryPageRef.current = directoryPage;
-    directoryListTopRef.current?.scrollIntoView({
-      block: "start",
-      behavior: "smooth",
-    });
-  }, [directoryPage]);
-
   const selectSurface = useCallback(
     (next: ConnectSurface) => {
       if (next === surface) return;
@@ -1167,13 +1125,12 @@ export default function ConnectPageClient() {
     [router, searchParams, surface],
   );
 
-  const selectHubTab = useCallback(
-    (next: ConnectHubTab) => {
+  const selectPrimaryTab = useCallback(
+    (next: ConnectPrimaryTab) => {
       if (next === "circles") {
         selectSurface("circles");
         return;
       }
-      setTab(next);
       if (surface !== "all") {
         selectSurface("all");
       }
@@ -1181,16 +1138,38 @@ export default function ConnectPageClient() {
     [selectSurface, surface],
   );
 
-  const goToPage = useCallback(
-    (next: number) => {
-      if (loading || next < 1) return;
-      // `hasMore` is the only forward signal the directory gives, so a next
-      // page is offered exactly when the server says one exists.
-      if (next > currentPage && !hasMore) return;
-      setCurrentPage(next);
-    },
-    [currentPage, hasMore, loading],
-  );
+  const loadNextDirectoryBatch = useCallback(() => {
+    if (surface === "circles" || tab === "nearby" || loading || !hasMore)
+      return;
+    setCurrentPage((page) => page + 1);
+  }, [hasMore, loading, surface, tab]);
+
+  useEffect(() => {
+    const sentinel = loadMoreDirectoryRef.current;
+    if (
+      !sentinel ||
+      surface === "circles" ||
+      tab === "nearby" ||
+      !hasMore ||
+      loading ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+    const scrollRoot = document.querySelector<HTMLElement>(
+      '[data-app-scroll-root="true"]',
+    );
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          loadNextDirectoryBatch();
+        }
+      },
+      { root: scrollRoot, rootMargin: "240px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadNextDirectoryBatch, loading, surface, tab]);
 
   const sendConnectionRequest = useCallback(
     async (
@@ -2353,7 +2332,7 @@ export default function ConnectPageClient() {
         <PageHeader title="Connect" />
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[720px]">
+      <AppPageContentRegion className="mx-auto w-full max-w-[720px] pb-[var(--app-bottom-content-clearance)]">
         <SurfaceStack compact>
           <div
             ref={connectStackRef}
@@ -2382,11 +2361,107 @@ export default function ConnectPageClient() {
               className={CONNECT_STICKY_HEADER_CLASSNAME}
             >
               <SegmentedTabs
-                value={hubTab}
-                onValueChange={(value) => selectHubTab(value as ConnectHubTab)}
-                options={CONNECT_HUB_TABS}
-                className={CONNECT_STRIP_COMPACT_PADDING}
+                value={primaryTab}
+                onValueChange={(value) =>
+                  selectPrimaryTab(value as ConnectPrimaryTab)
+                }
+                options={[...CONNECT_PRIMARY_TABS]}
               />
+              {surface !== "circles" ? (
+                <div className="flex min-h-11 items-center justify-between gap-3">
+                  {isSelectionMode ? (
+                    <span
+                      className="type-callout font-semibold text-[color:var(--app-primary-label)]"
+                      aria-live="polite"
+                    >
+                      {selectedPeople.size} of {MAX_BULK_CONNECTION_REQUESTS}{" "}
+                      selected
+                    </span>
+                  ) : (
+                    <div ref={directoryMenuRef} className="relative">
+                      <button
+                        ref={directoryMenuButtonRef}
+                        type="button"
+                        aria-haspopup="menu"
+                        aria-expanded={directoryMenuOpen}
+                        aria-label={`Current directory: ${CONNECT_TAB_LABEL[tab]}`}
+                        className="inline-flex min-h-11 items-center gap-1.5 rounded-full px-1 text-[17px] font-semibold leading-[22px] text-[color:var(--app-primary-label)] transition-colors hover:text-[color:var(--app-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
+                        onClick={() =>
+                          setDirectoryMenuOpen((current) => !current)
+                        }
+                      >
+                        {CONNECT_TAB_LABEL[tab]}
+                        <ChevronDown
+                          className="h-4 w-4 text-[color:var(--app-secondary-label)]"
+                          aria-hidden
+                        />
+                      </button>
+                      {directoryMenuOpen ? (
+                        <div
+                          role="menu"
+                          className="absolute left-0 top-full z-30 mt-1 w-[184px] overflow-hidden rounded-[14px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-standard)] p-1 shadow-[0_10px_30px_rgba(0,0,0,0.10)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+                        >
+                          {CONNECT_DIRECTORY_TABS.map((option) => {
+                            const active = tab === option.value;
+                            return (
+                              <button
+                                key={option.value}
+                                type="button"
+                                role="menuitemradio"
+                                aria-checked={active}
+                                className={cn(
+                                  "flex min-h-11 w-full items-center justify-between rounded-[10px] px-3 text-left text-[15px] font-medium leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]",
+                                  active
+                                    ? "text-[color:var(--app-accent)]"
+                                    : "text-[color:var(--app-primary-label)] hover:bg-[color:var(--app-secondary-fill)]",
+                                )}
+                                onClick={() => {
+                                  setTab(option.value);
+                                  setDirectoryMenuOpen(false);
+                                  window.requestAnimationFrame(() =>
+                                    directoryMenuButtonRef.current?.focus(),
+                                  );
+                                }}
+                              >
+                                <span>{option.label}</span>
+                                {active ? (
+                                  <Check
+                                    className="h-4 w-4"
+                                    aria-hidden="true"
+                                  />
+                                ) : null}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+                  {tab !== "nearby" ? (
+                    <Button
+                      type="button"
+                      variant="none"
+                      effect="fill"
+                      size="sm"
+                      showRipple={false}
+                      className={CONNECT_SELECT_TOGGLE_CLASSNAME}
+                      disabled={loading || people.length === 0}
+                      aria-label={
+                        isSelectionMode
+                          ? "Cancel selecting people"
+                          : "Select people"
+                      }
+                      onClick={() => {
+                        setIsSelectionMode((current) => !current);
+                        setSelectedPeople(new Map());
+                        setShowLimitBanner(false);
+                      }}
+                    >
+                      {isSelectionMode ? "Cancel" : "Select"}
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
 
             {surface === "circles" ? (
@@ -2597,7 +2672,7 @@ export default function ConnectPageClient() {
                       </div>
                     ) : null}
 
-                    <div ref={directoryListTopRef} className="space-y-4">
+                    <div className="space-y-4">
                       <SettingsGroup
                         title={CONNECT_TAB_LABEL[tab]}
                         // People only. This one JSX node also renders the RIAs
@@ -2671,10 +2746,10 @@ export default function ConnectPageClient() {
                             data-testid="connect-search-row"
                             className={cn(
                               CONNECT_STICKY_SEARCH_CLASSNAME,
-                              "flex items-center gap-2",
+                              "block",
                             )}
                           >
-                            <div className="relative flex-1">
+                            <div className="relative">
                               <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
                                 <SearchIcon className="h-4.5 w-4.5" />
                               </span>
@@ -2748,30 +2823,6 @@ export default function ConnectPageClient() {
                                 </button>
                               ) : null}
                             </div>
-                            <Button
-                              type="button"
-                              variant="none"
-                              effect="fill"
-                              size="sm"
-                              className={CONNECT_SELECT_TOGGLE_CLASSNAME}
-                              disabled={loading || people.length === 0}
-                              aria-label={
-                                isSelectionMode
-                                  ? "Cancel selecting people"
-                                  : "Select many people"
-                              }
-                              onClick={() => {
-                                setIsSelectionMode((current) => !current);
-                                setSelectedPeople(new Map());
-                                setShowLimitBanner(false);
-                              }}
-                            >
-                              {/* "Select many", not "Select": this enters multi-select,
-                        and a lone "Select" reads as picking the one thing you are
-                        looking at. The visible label and the accessible name now
-                        say the same thing. */}
-                              {isSelectionMode ? "Cancel" : "Select many"}
-                            </Button>
                           </div>
                         }
                       >
@@ -2933,7 +2984,7 @@ export default function ConnectPageClient() {
                                               MAX_BULK_CONNECTION_REQUESTS
                                           ) {
                                             toast.error(
-                                              `You can only select up to ${MAX_BULK_CONNECTION_REQUESTS} people at a time.`,
+                                              `You can select up to ${MAX_BULK_CONNECTION_REQUESTS} people.`,
                                             );
                                             setShowLimitBanner(true);
                                             return;
@@ -3024,98 +3075,38 @@ export default function ConnectPageClient() {
                             );
                           })
                         )}
-                        {people.length > 0 || currentPage > 1 ? (
+                        {people.length > 0 && hasMore ? (
                           <div
-                            className={CONNECT_PAGER_ROW_CLASSNAME}
-                            data-testid="connect-pager-row"
+                            ref={loadMoreDirectoryRef}
+                            className="flex min-h-14 items-center justify-center border-t border-[color:var(--app-card-border-standard)] px-4 py-2"
+                            data-testid="connect-load-more-row"
+                            aria-live="polite"
                           >
-                            <span
-                              className={cn(
-                                CONNECT_PAGE_STATUS_CLASSNAME,
-                                "inline-flex items-center gap-2",
-                              )}
-                              aria-live="polite"
-                            >
-                              {directoryRangeLabel}
-                              {isDirectoryRefreshing ? (
+                            {isDirectoryRefreshing ? (
+                              <span className="inline-flex items-center gap-2 text-[14px] font-medium leading-5 text-[color:var(--app-secondary-label)]">
                                 <Loader2
                                   className="h-3.5 w-3.5 animate-spin"
-                                  aria-label="Loading people"
+                                  aria-hidden="true"
                                 />
-                              ) : null}
-                            </span>
-                            <div className="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
-                              {directoryTotalCount > DEFAULT_PAGE_SIZE ||
-                              pageSize !== DEFAULT_PAGE_SIZE ? (
-                                <div className="hidden items-center sm:flex">
-                                  <Select
-                                    value={String(pageSize)}
-                                    onValueChange={handlePageSizeChange}
-                                  >
-                                    <SelectTrigger
-                                      size="sm"
-                                      aria-label="People per page"
-                                      className={
-                                        CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME
-                                      }
-                                    >
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                      {PAGE_SIZE_OPTIONS.map((size) => (
-                                        <SelectItem
-                                          key={size}
-                                          value={String(size)}
-                                        >
-                                          {size} per page
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
-                                </div>
-                              ) : null}
+                                Loading more…
+                              </span>
+                            ) : (
                               <Button
                                 type="button"
                                 variant="none"
                                 effect="fade"
                                 size="sm"
                                 showRipple={false}
-                                aria-label="Previous page"
-                                title="Previous page"
-                                className={cn(
-                                  CONNECT_PAGER_BUTTON_CLASSNAME,
-                                  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
-                                )}
-                                disabled={loading || currentPage <= 1}
-                                onClick={() => goToPage(currentPage - 1)}
+                                aria-label={`Load ${DEFAULT_PAGE_SIZE} more people`}
+                                className={CONNECT_PAGER_BUTTON_CLASSNAME}
+                                onClick={loadNextDirectoryBatch}
                               >
-                                <ChevronLeft
-                                  className="h-5 w-5"
-                                  aria-hidden="true"
-                                />
+                                Load {DEFAULT_PAGE_SIZE} more
                               </Button>
-                              <Button
-                                type="button"
-                                variant="none"
-                                effect="fade"
-                                size="sm"
-                                showRipple={false}
-                                aria-label="Next page"
-                                title="Next page"
-                                className={cn(
-                                  CONNECT_PAGER_BUTTON_CLASSNAME,
-                                  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
-                                )}
-                                disabled={loading || !hasMore}
-                                onClick={() => goToPage(currentPage + 1)}
-                              >
-                                <ChevronRight
-                                  className="h-5 w-5"
-                                  aria-hidden="true"
-                                />
-                              </Button>
-                            </div>
+                            )}
                           </div>
+                        ) : people.length > 0 ? (
+                          <span className="sr-only">All people loaded</span>
                         ) : null}
                         {isSelectionMode &&
                           selectedPeople.size > 0 &&
@@ -3136,7 +3127,7 @@ export default function ConnectPageClient() {
                                   ]);
                                 }}
                               >
-                                {`Review ${selectedPeople.size} of ${MAX_BULK_CONNECTION_REQUESTS}`}
+                                {`Review ${selectedPeople.size}`}
                               </Button>
                             </div>
                           )}

--- a/hushh-webapp/components/connect/nearby-directory-ui.tsx
+++ b/hushh-webapp/components/connect/nearby-directory-ui.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { Search as SearchIcon, X } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   CaptionText,
   PageSubtitle,
@@ -40,9 +39,19 @@ export type DirectoryAttribution = {
 
 export function DirectoryLoadingRows({ testId }: { testId: string }) {
   return (
-    <div className="space-y-3 px-1 py-2" data-testid={testId}>
-      {[0, 1, 2, 3].map((row) => (
-        <Skeleton key={row} className="h-11 w-full rounded-xl" />
+    <div className="space-y-1 px-0 py-1" data-testid={testId}>
+      {[0, 1, 2].map((row) => (
+        <div
+          key={row}
+          className="grid min-h-[60px] grid-cols-[40px_minmax(0,1fr)] items-center gap-3 px-4"
+          aria-hidden
+        >
+          <div className="h-9 w-9 rounded-full bg-[color:var(--app-secondary-fill)] motion-safe:animate-pulse" />
+          <div className="min-w-0 space-y-2">
+            <div className="h-3.5 w-2/5 rounded-full bg-[color:var(--app-secondary-fill)] motion-safe:animate-pulse" />
+            <div className="h-3 w-3/5 rounded-full bg-[color:var(--app-tertiary-fill)] motion-safe:animate-pulse" />
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,17 +11,10 @@ import {
 
 // Relative, not "@/": the e2e tsconfig deliberately carries no path aliases.
 import {
-  CONNECT_PAGER_BUTTON_CLASSNAME,
-  CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
-  CONNECT_PAGER_ROW_CLASSNAME,
-  CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME,
-  CONNECT_PAGE_STATUS_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME,
   CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME,
   CONNECT_SEARCH_PLACEHOLDER,
-  CONNECT_SEARCH_ROW_GAP_PX,
-  CONNECT_SELECT_TOGGLE_CLASSNAME,
 } from "../app/connect/connect-search-layout";
 import {
   CIRCLE_NAME_ACTION_CLASSNAME,
@@ -29,8 +22,8 @@ import {
   CIRCLE_NAME_ROW_CLASSNAME,
   CIRCLE_NAME_ROW_HEIGHT_PX,
 } from "../components/one-location/redesign/circles/circle-name-row-layout";
-import { INPUT_CLASSNAME } from "../components/ui/input";
 import { buttonVariants } from "../components/ui/button";
+import { INPUT_CLASSNAME } from "../components/ui/input";
 import { cn } from "../lib/utils";
 
 /**
@@ -40,8 +33,8 @@ import { cn } from "../lib/utils";
  *   2. "remove neeche aa rha" -- the trailing control on a connection row
  *      dropping onto its own line.
  *   3. "text is long currently inside search bar" -- the Connect placeholder
- *      clipping to "Search people by nam", and the request button beside it
- *      reading oversized.
+ *      clipping to "Search people by nam" when the select action shared the
+ *      same row.
  *
  * Every one of them is invisible to the JSDOM suite, which applies no CSS and
  * measures every element as 0x0. A `className.toContain(...)` assertion would
@@ -337,7 +330,6 @@ test.describe("Circle name row", () => {
     ).toBeGreaterThan(input.height + 4);
   });
 });
-
 // ---------------------------------------------------------------------------
 // 2. The Connect search row
 // ---------------------------------------------------------------------------
@@ -347,13 +339,9 @@ const SEARCH_CANDIDATES = [
   ...CONNECT_SEARCH_INPUT_CLASSNAME.split(/\s+/),
   ...CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME.split(/\s+/),
   ...CONNECT_SEARCH_INPUT_PLAIN_CLASSNAME.split(/\s+/),
-  ...CONNECT_SELECT_TOGGLE_CLASSNAME.split(/\s+/),
-  "flex",
+  "block",
   "w-full",
-  "items-center",
-  "gap-2",
   "relative",
-  "flex-1",
   "inline-flex",
   "justify-center",
   "whitespace-nowrap",
@@ -370,31 +358,11 @@ const SEARCH_CANDIDATES = [
   "shrink-0",
 ];
 
-/**
- * The row as it shipped, and as QA photographed it.
- *
- * Kept here rather than in the app module because these are dead values: a
- * five-word placeholder, a content-sized toggle spelling out "Select multiple",
- * and a right gutter reserved for a clear button that is not in an empty field.
- * A fit assertion that never rejects anything is not a fit assertion, so the
- * contract measures the real before-geometry rather than trusting that the
- * after-geometry is roomy.
- */
-const BEFORE = {
-  placeholder: "Search people by name",
-  inputClassName: "h-10 pl-11 pr-11",
-  toggleClassName:
-    "h-10 min-h-10 shrink-0 rounded-full px-4 text-[15px] font-semibold leading-5",
-  toggleLabel: "Select multiple",
-} as const;
-
-const BUTTON_BASE = "inline-flex items-center justify-center whitespace-nowrap";
-
-/** The row exactly as Connect builds it: field, `gap-2`, fixed-width toggle. */
+/** The row exactly as Connect builds it: one full-width search field. */
 const searchRowBody = (
   empty: boolean,
-) => `<div class="flex w-full items-center gap-2">
-  <div class="relative flex-1">
+) => `<div class="block w-full">
+  <div class="relative">
     <input data-testid="connect-search" placeholder="${CONNECT_SEARCH_PLACEHOLDER}"
       class="${INPUT_CLASSNAME} ${CONNECT_SEARCH_INPUT_CLASSNAME} ${
         empty
@@ -402,18 +370,6 @@ const searchRowBody = (
           : CONNECT_SEARCH_INPUT_CLEARABLE_CLASSNAME
       }" />
   </div>
-  <button data-testid="connect-select-toggle"
-    class="${BUTTON_BASE} min-h-9 h-9 ${CONNECT_SELECT_TOGGLE_CLASSNAME}">Select many</button>
-</div>`;
-
-/** The same row before this change, for the mutation check. */
-const searchRowBodyBefore = () => `<div class="flex w-full items-center gap-2">
-  <div class="relative flex-1">
-    <input data-testid="connect-search" placeholder="${BEFORE.placeholder}"
-      class="${INPUT_CLASSNAME} ${BEFORE.inputClassName}" />
-  </div>
-  <button data-testid="connect-select-toggle"
-    class="${BUTTON_BASE} min-h-9 h-9 ${BEFORE.toggleClassName}">${BEFORE.toggleLabel}</button>
 </div>`;
 
 /**
@@ -479,24 +435,6 @@ test.describe("Connect search row", () => {
         `"${CONNECT_SEARCH_PLACEHOLDER}" needs ${current.needed.toFixed(1)}px of ${current.available.toFixed(1)}px`,
       ).toBeLessThanOrEqual(current.available + 0.5);
 
-      // Mutation check, against the row as it actually shipped -- the long
-      // placeholder in a field that also reserved its clear gutter, beside a
-      // toggle that spelled out "Select multiple". If this passed, the
-      // assertion above would have passed while QA was photographing the bug,
-      // and it would be guarding nothing.
-      await page.goto(
-        await buildFixture(
-          "connect-search-before",
-          searchRowBodyBefore(),
-          SEARCH_CANDIDATES,
-        ),
-      );
-      await fontsReady(page);
-      const before = await page.evaluate(probePlaceholder, BEFORE.placeholder);
-      expect(
-        before.needed,
-        `"${BEFORE.placeholder}" needed ${before.needed.toFixed(1)}px of ${before.available.toFixed(1)}px and clipped`,
-      ).toBeGreaterThan(before.available);
     });
   }
 
@@ -534,60 +472,23 @@ test.describe("Connect search row", () => {
     expect(empty.available).toBeGreaterThan(typed.available);
   });
 
-  // Every compact width the product supports, not just 375. The label grew from
-  // "Select" to "Select many" so the control says on its face that it selects
-  // more than one person, and the whole risk of that change is the narrowest
-  // phone — which is the one width the old single-viewport test never ran.
   for (const width of [320, 360, 375, 390, 430] as const) {
-    test(`the selection toggle holds its label and its width at ${width}px`, async ({
-      page,
-    }) => {
+    test(`search owns the full content row at ${width}px`, async ({ page }) => {
       await page.setViewportSize({ width, height: 844 });
       await page.goto(
         await buildFixture(
-          "connect-toggle",
+          "connect-search-full-width",
           searchRowBody(true),
           SEARCH_CANDIDATES,
         ),
       );
 
-      const toggle = await boxOf(page, '[data-testid="connect-select-toggle"]');
       const field = await boxOf(page, '[data-testid="connect-search"]');
-
-      // Fixed width: "Select many" and "Cancel" are different lengths, and a
-      // content-sized toggle would hand the difference to the search field and
-      // move it on every tap. The number is read off the shipped token rather
-      // than written down twice.
-      const tokenWidth = Number(
-        /w-\[(\d+)px\]/.exec(CONNECT_SELECT_TOGGLE_CLASSNAME)?.[1],
+      expect(field.left).toBeGreaterThanOrEqual(0);
+      expect(field.right).toBeLessThanOrEqual(width + 0.5);
+      expect(field.width).toBeGreaterThanOrEqual(
+        width - PAGE_PADDING_PX * 2,
       );
-      expect(Number.isFinite(tokenWidth)).toBe(true);
-      expect(Math.abs(toggle.width - tokenWidth)).toBeLessThanOrEqual(0.5);
-
-      // The label FITS. This is the assertion the width number cannot make on
-      // its own: a wider label inside an unchanged box would still measure the
-      // box correctly and ship clipped text.
-      const label = await page.evaluate(() => {
-        const el = document.querySelector(
-          '[data-testid="connect-select-toggle"]',
-        ) as HTMLElement;
-        return {
-          text: el.textContent ?? "",
-          scrollWidth: el.scrollWidth,
-          clientWidth: el.clientWidth,
-          lines: el.getClientRects().length,
-        };
-      });
-      expect(label.text).toBe("Select many");
-      expect(label.scrollWidth).toBeLessThanOrEqual(label.clientWidth + 1);
-      expect(label.lines).toBe(1);
-
-      // The field still owns the rest of the row, and nothing leaves the page.
-      expect(
-        Math.abs(toggle.left - field.right - CONNECT_SEARCH_ROW_GAP_PX),
-      ).toBeLessThanOrEqual(0.5);
-      expect(toggle.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
-      expect(field.width).toBeGreaterThan(120);
     });
   }
 });
@@ -735,205 +636,5 @@ test.describe("Connect list rows", () => {
     expect(Math.abs(cancel.width - 72)).toBeLessThanOrEqual(0.5);
     expect(cancel.width).toBeLessThanOrEqual(connect.width + 0.5);
     expect(cancel.height).toBeLessThanOrEqual(32.5);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 4. The Connect pager, at the foot of the directory card
-// ---------------------------------------------------------------------------
-
-/**
- * The Connect footer is a range reader plus previous/next controls on phones,
- * and gains a compact page-size menu from the tablet breakpoint up. It stays
- * inside the grouped list with one separator; it is not a second control card.
- */
-const PAGER_BEFORE_ROW_CLASSNAME =
-  "flex flex-col gap-3 border-t border-[color:var(--app-card-border-standard)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between";
-
-/** The pager button as the screen composes it, through the real variants. */
-const pagerButtonClass = () =>
-  cn(
-    buttonVariants({ variant: "default", size: "sm" }),
-    CONNECT_PAGER_BUTTON_CLASSNAME,
-    CONNECT_PAGER_BUTTON_EXTRA_CLASSNAME,
-  );
-
-const PAGER_CANDIDATES = [
-  ...CONNECT_PAGER_ROW_CLASSNAME.split(/\s+/),
-  ...PAGER_BEFORE_ROW_CLASSNAME.split(/\s+/),
-  ...CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME.split(/\s+/),
-  ...CONNECT_PAGE_STATUS_CLASSNAME.split(/\s+/),
-  ...pagerButtonClass().split(/\s+/),
-  "flex",
-  "min-w-0",
-  "flex-col",
-  "flex-wrap",
-  "items-start",
-  "items-center",
-  "justify-end",
-  "gap-0.5",
-  "gap-1.5",
-  "gap-2",
-  "gap-2.5",
-  "shrink-0",
-  "hidden",
-  "sm:flex",
-  "min-h-9",
-  "min-h-14",
-  "!h-11",
-  "!min-h-11",
-  "!w-11",
-  "!min-w-11",
-  "!p-0",
-  "h-1",
-  "w-1",
-  "rounded-full",
-  "tabular-nums",
-  "whitespace-nowrap",
-  "ui-text-helper-text",
-  "text-[color:var(--app-secondary-label)]",
-  "bg-[color:var(--app-tertiary-label)]",
-];
-
-/**
- * The select trigger stands in as a plain box carrying the trigger's own class
- * string. That is faithful for geometry and only for geometry: the width and
- * height this row has to budget for are both fixed on the trigger itself, so
- * whatever Radix renders inside it cannot change the number measured here.
- */
-const pagerBody =
-  () => `<div data-testid="pager-row" class="${CONNECT_PAGER_ROW_CLASSNAME}">
-  <span data-testid="pager-status" class="${CONNECT_PAGE_STATUS_CLASSNAME}">1-20 of 100</span>
-  <div data-testid="pager-actions" class="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
-    <div data-testid="pager-size" class="hidden items-center sm:flex">
-      <div data-testid="pager-select" class="${CONNECT_PAGE_SIZE_TRIGGER_CLASSNAME}">20 per page</div>
-    </div>
-    <button data-testid="pager-prev" class="${pagerButtonClass()}">‹</button>
-    <button data-testid="pager-next" class="${pagerButtonClass()}">›</button>
-  </div>
-</div>`;
-
-/** The same pager exactly as it shipped, for the mutation check. */
-const pagerBodyBefore =
-  () => `<div data-testid="pager-row" class="${PAGER_BEFORE_ROW_CLASSNAME}">
-  <div data-testid="pager-size" class="flex min-h-9 flex-wrap items-center gap-2.5">
-    <span data-testid="pager-status" class="ui-text-helper-text tabular-nums text-[color:var(--app-secondary-label)]">Page 1</span>
-    <span class="h-1 w-1 rounded-full bg-[color:var(--app-tertiary-label)]"></span>
-    <span class="ui-text-helper-text text-[color:var(--app-secondary-label)]">Per page</span>
-    <div data-testid="pager-select" class="h-8 min-h-8 w-[74px] rounded-2xl text-[15px] font-medium leading-5"></div>
-  </div>
-  <div data-testid="pager-actions" class="flex min-h-9 items-center justify-end gap-2">
-    <button data-testid="pager-prev" class="${pagerButtonClass()}">Prev</button>
-    <button data-testid="pager-next" class="${pagerButtonClass()}">Next</button>
-  </div>
-</div>`;
-
-const fontSizeOf = (page: Page, selector: string) =>
-  page.evaluate(
-    (sel) =>
-      parseFloat(
-        getComputedStyle(document.querySelector(sel) as Element).fontSize,
-      ),
-    selector,
-  );
-
-test.describe("Connect pager", () => {
-  for (const width of PHONE_WIDTHS) {
-    test(`phone footer shows range plus icon arrows at ${width}px`, async ({
-      page,
-    }) => {
-      await page.setViewportSize({ width, height: 844 });
-      await page.goto(
-        await buildFixture("connect-pager", pagerBody(), PAGER_CANDIDATES),
-      );
-      await awaitProductFont(page);
-      await fontsReady(page);
-
-      const row = await boxOf(page, '[data-testid="pager-row"]');
-      const actions = await boxOf(page, '[data-testid="pager-actions"]');
-      const status = await boxOf(page, '[data-testid="pager-status"]');
-      const sizeDisplay = await page
-        .locator('[data-testid="pager-size"]')
-        .evaluate((node) => getComputedStyle(node).display);
-
-      expect(sizeDisplay, "phone hides the page-size menu").toBe("none");
-      expect(actions.left, "buttons start after the range").toBeGreaterThan(
-        status.right,
-      );
-      expect(actions.top, "same line, not the next one").toBeLessThan(
-        status.bottom,
-      );
-      expect(status.top).toBeLessThan(actions.bottom);
-
-      expect(
-        actions.right,
-        `pager overflows at ${width}px`,
-      ).toBeLessThanOrEqual(row.right + 0.5);
-      expect(row.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
-      expect(row.left).toBeGreaterThanOrEqual(PAGE_PADDING_PX - 1);
-
-      for (const id of ["pager-prev", "pager-next"]) {
-        const button = await boxOf(page, `[data-testid="${id}"]`);
-        expect(button.width, `${id} width`).toBeGreaterThanOrEqual(43.5);
-        expect(button.height, `${id} height`).toBeGreaterThanOrEqual(43.5);
-      }
-    });
-  }
-
-  test("tablet footer keeps the compact page-size menu", async ({ page }) => {
-    await page.setViewportSize({ width: 768, height: 844 });
-    await page.goto(
-      await buildFixture("connect-pager-tablet", pagerBody(), PAGER_CANDIDATES),
-    );
-    await awaitProductFont(page);
-    await fontsReady(page);
-
-    const select = await boxOf(page, '[data-testid="pager-select"]');
-    const status = await boxOf(page, '[data-testid="pager-status"]');
-    expect(
-      select.left,
-      "select sits after the range on tablet",
-    ).toBeGreaterThan(status.right);
-    expect(select.width, "compact select").toBeLessThanOrEqual(132);
-  });
-
-  test("the range status stays quieter than row controls", async ({ page }) => {
-    await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto(
-      await buildFixture("connect-pager-status", pagerBody(), PAGER_CANDIDATES),
-    );
-    await awaitProductFont(page);
-    await fontsReady(page);
-
-    const statusSize = await fontSizeOf(page, '[data-testid="pager-status"]');
-    const buttonSize = await fontSizeOf(page, '[data-testid="pager-next"]');
-    expect(
-      statusSize,
-      "range is quieter than button chrome",
-    ).toBeLessThanOrEqual(buttonSize);
-  });
-
-  test("the version QA photographed really did stack", async ({ page }) => {
-    // Mutation check. `sm:` is 640px, so at 375 the shipped row was in its
-    // `flex-col` state and the buttons landed on a second line. Without this,
-    // the assertions above could be passing on a rule incapable of failing.
-    await page.setViewportSize({ width: 375, height: 844 });
-    await page.goto(
-      await buildFixture(
-        "connect-pager-before",
-        pagerBodyBefore(),
-        PAGER_CANDIDATES,
-      ),
-    );
-    await awaitProductFont(page);
-    await fontsReady(page);
-
-    const sizeLine = await boxOf(page, '[data-testid="pager-size"]');
-    const actions = await boxOf(page, '[data-testid="pager-actions"]');
-
-    expect(
-      actions.top,
-      "the shipped pager put Prev/Next on their own line",
-    ).toBeGreaterThanOrEqual(sizeLine.bottom);
   });
 });

--- a/hushh-webapp/e2e/tab-title-integrity.spec.ts
+++ b/hushh-webapp/e2e/tab-title-integrity.spec.ts
@@ -36,8 +36,7 @@ const WIDTHS = [320, 360, 375, 390, 430, 768, 1280] as const;
  * simply unchecked -- so add to this when adding tabs.
  */
 const TAB_STRIPS: ReadonlyArray<{ surface: string; labels: string[] }> = [
-  { surface: "connect", labels: ["People", "RIAs", "Around you"] },
-  { surface: "connect/around-you", labels: ["Advisors", "Insurance", "Places"] },
+  { surface: "connect", labels: ["Connections", "Circles"] },
 ];
 
 /** The class strings SegmentedTabs emits, read from the component itself. */
@@ -46,7 +45,7 @@ function readSegmentedTabsClasses(): { option: string; label: string } {
     join(process.cwd(), "lib/morphy-ux/ui/segmented-tabs.tsx"),
     "utf8",
   );
-  const option = source.match(/"(press-scale relative isolate flex[^"]+)"/)?.[1];
+  const option = source.match(/"(relative isolate flex[^"]+)"/)?.[1];
   const label = source.match(/"(ui-text-form-label relative[^"]+)"/)?.[1];
   if (!option || !label) {
     throw new Error(

--- a/hushh-webapp/lib/morphy-ux/ui/filter-chip.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/filter-chip.tsx
@@ -51,12 +51,12 @@ export function FilterChip({
       data-state={active ? "active" : "inactive"}
       onClick={onClick}
       className={cn(
-        "press-scale inline-flex min-w-0 shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5",
+        "inline-flex min-w-0 shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5",
         "type-footnote transition-[background-color,border-color,color] duration-200",
         "disabled:cursor-not-allowed disabled:opacity-60",
         active
           ? "border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]"
-          : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-[color:var(--app-primary-label)] hover:bg-foreground/[0.035]",
+          : "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-[color:var(--app-primary-label)] hover:bg-[color:var(--app-secondary-fill)]",
         className,
       )}
     >

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -56,10 +56,10 @@ export function SegmentedTabs({
               if (!disabled && !isActive) onValueChange(option.value);
             }}
             className={cn(
-              "press-scale relative isolate flex min-h-9 min-w-0 items-center justify-center overflow-hidden rounded-full border px-4 py-2 text-center transition-[background-color,border-color,box-shadow,color,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-10 sm:px-4.5",
+              "relative isolate flex min-h-9 min-w-0 items-center justify-center overflow-hidden rounded-full border px-4 py-2 text-center transition-[background-color,border-color,box-shadow,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:min-h-10 sm:px-4.5",
               isActive
                 ? "z-10 border-[color:var(--app-segmented-active-border)] bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[var(--app-segmented-active-shadow)]"
-                : "border-transparent bg-transparent text-muted-foreground hover:bg-foreground/[0.035] hover:text-[color:var(--app-primary-label)]",
+                : "border-transparent bg-transparent text-[color:var(--app-secondary-label)] hover:bg-[color:var(--app-secondary-fill)] hover:text-[color:var(--app-primary-label)]",
               disabled && "cursor-not-allowed opacity-60"
             )}
           >

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -982,13 +982,25 @@ function resolveTopShellBreadcrumbInner(
     }
   }
 
-  if (pathname === ROUTES.CONNECT || pathname === ROUTES.MARKETPLACE) {
+  if (pathname === ROUTES.CONNECT) {
     return {
       backHref: ROUTES.ONE_HOME,
       width: "profile",
       align: "center",
-      // Connect is a level-two workspace. Keep the shared shell back affordance
-      // available so this entry behaves like the other One capability routes.
+      // Connect is a level-two workspace. Like Location, the top shell names
+      // the parent ("One") while the route owns the single visible page title.
+      hideBack: false,
+      items: [{ label: "One" }],
+    };
+  }
+
+  if (pathname === ROUTES.MARKETPLACE) {
+    return {
+      backHref: ROUTES.ONE_HOME,
+      width: "profile",
+      align: "center",
+      // Keep Marketplace on its existing shared-shell breadcrumb; the Connect
+      // route above is the only place where the duplicate page title exists.
       hideBack: false,
       items: [{ label: "One", href: ROUTES.ONE_HOME }, { label: "Connect" }],
     };


### PR DESCRIPTION
## Summary
- Replace the duplicate Connect shell with a Location-style top breadcrumb and a single in-page Connect title.
- Replace the legacy four-tab strip with primary Connections/Circles navigation plus a compact directory menu for People, RIAs, and Around you.
- Convert directory pagination into progressive in-list loading, keep existing rows visible while loading more, and raise bulk request review cap to 10.
- Soften shared segmented/filter hover states and replace bright nearby skeleton bars with neutral row skeletons.

## Validation
- `npx eslint app/connect/page-client.tsx app/connect/connect-search-layout.ts components/connect/nearby-directory-ui.tsx lib/navigation/top-shell-breadcrumbs.ts lib/morphy-ux/ui/segmented-tabs.tsx lib/morphy-ux/ui/filter-chip.tsx __tests__/app/connect/page-client.test.tsx e2e/connect-circle-cta.layout.spec.ts e2e/tab-title-integrity.spec.ts --max-warnings=0`
- `npm run typecheck`
- `npm test -- --run __tests__/app/connect/page-client.test.tsx components/connect/__tests__/nearby-directories.test.tsx`
- `npm run build`
- `npx playwright test e2e/connect-circle-cta.layout.spec.ts e2e/tab-title-integrity.spec.ts --project=chromium`