### PR TITLE
Refine Location sharing controls and hub hierarchy

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
@@ -10,6 +10,10 @@ const HUB = path.join(
 
 const source = readFileSync(HUB, "utf8");
 
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 function functionBody(name: string): string {
   const start = source.indexOf(`function ${name}(`);
   expect(start, `${name} not found in the hub`).toBeGreaterThan(-1);
@@ -18,17 +22,54 @@ function functionBody(name: string): string {
 }
 
 describe("Location hub hierarchy", () => {
-  it("keeps the module header before the local tab strip and Links content", () => {
+  it("keeps exactly one Location title before the local tab strip and content", () => {
     const body = functionBody("LocationRedesignHub");
     const headerIndex = body.indexOf("<PageHeader");
+    const titleMatches =
+      body.match(/<PageTitle\s+as="span">\s*Location\s*<\/PageTitle>/g) ?? [];
     const tabsIndex = body.indexOf("<TopShellTabs");
     const swipeIndex = body.indexOf("<SwipeViews");
     const linksIndex = body.indexOf("<LinksHub");
 
+    expect(countOccurrences(body, "<PageHeader")).toBe(1);
+    expect(titleMatches).toHaveLength(1);
+    expect(countOccurrences(body, "<TopShellTabs")).toBe(1);
+    expect(countOccurrences(body, "<SwipeViews")).toBe(1);
     expect(headerIndex).toBeGreaterThan(-1);
     expect(tabsIndex).toBeGreaterThan(headerIndex);
     expect(swipeIndex).toBeGreaterThan(tabsIndex);
     expect(linksIndex).toBeGreaterThan(swipeIndex);
+  });
+
+  it("keeps focused Location action routes outside the tabbed hub chrome", () => {
+    const body = functionBody("LocationRedesignHub");
+    const flowGuardIndex = body.indexOf('if (flow !== "none")');
+    const actionFlowIndex = body.indexOf(
+      'data-testid="one-location-action-flow"',
+    );
+    const hubStartIndex = body.indexOf("/* Hub (Now | People | Links)");
+    const actionFlowWindow = body.slice(flowGuardIndex, hubStartIndex);
+
+    expect(flowGuardIndex).toBeGreaterThan(-1);
+    expect(actionFlowIndex).toBeGreaterThan(flowGuardIndex);
+    expect(hubStartIndex).toBeGreaterThan(actionFlowIndex);
+    expect(actionFlowWindow).not.toContain("<PageHeader");
+    expect(actionFlowWindow).not.toContain("<TopShellTabs");
+    expect(actionFlowWindow).not.toContain("<SwipeViews");
+    expect(actionFlowWindow).not.toContain("<LocationPermissionRecoveryCard");
+
+    for (const flow of [
+      '"share"',
+      '"ask"',
+      '"check-in"',
+      '"sos"',
+      '"active-shares"',
+      '"shared-with-me"',
+      '"needs-review"',
+      '"settings"',
+    ]) {
+      expect(actionFlowWindow).toContain(`flow === ${flow}`);
+    }
   });
 
   it("uses the central Location tab registry for the in-hub tabs and pager", () => {

--- a/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
@@ -47,4 +47,22 @@ describe("Location hub hierarchy", () => {
     expect(swipeWindow).toContain("tabSetId={LOCATION_TAB_DEFINITION.id}");
     expect(swipeWindow).toContain("options={LOCATION_SWIPE_OPTIONS}");
   });
+
+  it("keeps Now, People, and Links on shared Location primitives", () => {
+    const peopleBody = functionBody("PeopleHub");
+    const linksBody = functionBody("LinksHub");
+
+    expect(source).toContain("const LOCATION_GROUP_SURFACE");
+    expect(source).not.toContain("PEOPLE_GROUP_SURFACE");
+    expect(peopleBody).toContain("className={LOCATION_GROUP_SURFACE}");
+
+    expect(linksBody).toContain("<SettingsGroup");
+    expect(linksBody).toContain(
+      "shellClassName={LOCATION_GROUP_SHELL_CLASSNAME}",
+    );
+    expect(linksBody).toContain("<SettingsRow");
+    expect(linksBody).toContain("<DurationSelector");
+    expect(linksBody).not.toContain("<TemporaryLinkCard");
+    expect(linksBody).not.toContain("SUBCARD_SURFACE");
+  });
 });

--- a/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const HUB = path.join(
+  process.cwd(),
+  "components/one-location/redesign/location-redesign-hub.tsx",
+);
+
+const source = readFileSync(HUB, "utf8");
+
+function functionBody(name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  expect(start, `${name} not found in the hub`).toBeGreaterThan(-1);
+  const next = source.indexOf("\nfunction ", start + 1);
+  return source.slice(start, next === -1 ? source.length : next);
+}
+
+describe("Location hub hierarchy", () => {
+  it("keeps the module header before the local tab strip and Links content", () => {
+    const body = functionBody("LocationRedesignHub");
+    const headerIndex = body.indexOf("<PageHeader");
+    const tabsIndex = body.indexOf("<TopShellTabs");
+    const swipeIndex = body.indexOf("<SwipeViews");
+    const linksIndex = body.indexOf("<LinksHub");
+
+    expect(headerIndex).toBeGreaterThan(-1);
+    expect(tabsIndex).toBeGreaterThan(headerIndex);
+    expect(swipeIndex).toBeGreaterThan(tabsIndex);
+    expect(linksIndex).toBeGreaterThan(swipeIndex);
+  });
+
+  it("uses the central Location tab registry for the in-hub tabs and pager", () => {
+    const body = functionBody("LocationRedesignHub");
+    const tabsWindow = body.slice(
+      body.indexOf("<TopShellTabs"),
+      body.indexOf("<SwipeViews"),
+    );
+    const swipeWindow = body.slice(
+      body.indexOf("<SwipeViews"),
+      body.indexOf("</SwipeViews>"),
+    );
+
+    expect(tabsWindow).toContain("LOCATION_TAB_DEFINITION");
+    expect(tabsWindow).toContain("activeValue: tab");
+    expect(swipeWindow).toContain("tabSetId={LOCATION_TAB_DEFINITION.id}");
+    expect(swipeWindow).toContain("options={LOCATION_SWIPE_OPTIONS}");
+  });
+});

--- a/hushh-webapp/__tests__/navigation/top-shell-tabs.test.ts
+++ b/hushh-webapp/__tests__/navigation/top-shell-tabs.test.ts
@@ -7,16 +7,12 @@ import {
 import { resolveTopShellRouteProfile } from "@/components/app-ui/top-shell-metrics";
 
 describe("top shell contextual tabs", () => {
-  it("uses route state as the selection authority for Location", () => {
-    expect(resolveTopShellTabSet("/one/location")).toMatchObject({
-      label: "Location",
-      activeValue: "now",
-    });
-    expect(resolveTopShellTabSet("/one/location?view=inbox")).toMatchObject({
-      // Legacy Inbox links land on the canonical Now tab; focused action
-      // parameters are resolved by the Location hub after route settlement.
-      activeValue: "now",
-    });
+  it("keeps Location tabs inside the Location hub instead of the global top shell", () => {
+    // The Location page renders Now / People / Links under the module header.
+    // Keeping them in the fixed top shell puts the tabs before "Location" and
+    // reverses the hierarchy, especially visible on the Links tab.
+    expect(resolveTopShellTabSet("/one/location")).toBeNull();
+    expect(resolveTopShellTabSet("/one/location?view=inbox")).toBeNull();
     expect(resolveTopShellTabSet("/one/location?action=share")).toBeNull();
     expect(resolveTopShellTabSet("/one/location/map")).toBeNull();
   });
@@ -153,16 +149,12 @@ describe("top shell contextual tabs", () => {
     });
   });
 
-  it("keeps static-export Location tabs in the shared top shell", () => {
-    expect(resolveTopShellTabSet("/one/location/?view=links")).toMatchObject({
-      id: "location",
-      activeValue: "links",
-    });
+  it("keeps static-export Location hub routes out of the shared top shell", () => {
+    expect(resolveTopShellTabSet("/one/location/?view=links")).toBeNull();
     expect(
       resolveTopShellRouteProfile("/one/location/?view=inbox").model,
     ).toMatchObject({
-      mode: "bar-with-tabs",
-      tabs: { id: "location", activeValue: "now" },
+      mode: "bar",
     });
   });
 
@@ -170,7 +162,7 @@ describe("top shell contextual tabs", () => {
     ["/login", "hidden"],
     ["/one/profile", "bar"],
     ["/one/location?action=share", "bar"],
-    ["/one/location?view=people", "bar-with-tabs"],
+    ["/one/location?view=people", "bar"],
     ["/one/kai?tab=analysis", "bar-with-tabs"],
     ["/one/consent?tab=history", "bar-with-tabs"],
     ["/ria/picks", "bar-with-tabs"],

--- a/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -107,5 +107,44 @@ describe("the circle row's second line", () => {
       circle({ id: "c_neutral", name: "Trusted", systemKind: "trusted" }),
     ]);
     expect(screen.getByTestId("one-location-circle-neutral-mark")).toBeTruthy();
+  });
+
+  it("separates circles created by you, joined circles, and built-in circles", () => {
+    renderCircles([
+      circle({ id: "joined_1", name: "Road Trip", role: "member" }),
+      circle({ id: "owned_1", name: "Family", role: "owner" }),
+      circle({
+        id: "built_in_trusted",
+        name: "Trusted",
+        role: "owner",
+        systemKind: "trusted",
+      }),
+      circle({ id: "owned_2", name: "Close Friends", role: "owner" }),
+      circle({
+        id: "built_in_sms",
+        name: "Emergency Circle",
+        role: "owner",
+        isSystem: true,
+        systemKind: "sms",
+      }),
+    ]);
+
+    const created = screen.getByTestId("one-location-circle-group-created");
+    const joined = screen.getByTestId("one-location-circle-group-joined");
+    const builtIn = screen.getByTestId("one-location-circle-group-built-in");
+
+    expect(within(created).getByText("Created by you")).toBeTruthy();
+    expect(within(created).getByText("Family")).toBeTruthy();
+    expect(within(created).getByText("Close Friends")).toBeTruthy();
+    expect(within(created).queryByText("Road Trip")).toBeNull();
+
+    expect(within(joined).getByText("Joined circles")).toBeTruthy();
+    expect(within(joined).getByText("Road Trip")).toBeTruthy();
+    expect(within(joined).queryByText("Family")).toBeNull();
+
+    expect(within(builtIn).getByText("Built-in")).toBeTruthy();
+    expect(within(builtIn).getByText("Trusted")).toBeTruthy();
+    expect(within(builtIn).getByText("Emergency Circle")).toBeTruthy();
+    expect(within(builtIn).getByText("Save My Soul · Only you")).toBeTruthy();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -104,14 +104,6 @@ describe("LiveShareStatusCard", () => {
     visibility.mockRestore();
   });
 
-  it("fills the progress bar with the time already spent", () => {
-    // Started 09:30, ends 11:00, now 10:00 — a third of the way through.
-    render(<LiveShareStatusCard status={status()} onManage={vi.fn()} />);
-
-    const bar = screen.getByTestId("one-location-live-share-progress");
-    expect(bar.getAttribute("style")).toContain("width: 33%");
-  });
-
   it("tells assistive tech the time in words, not once a second", () => {
     render(
       <LiveShareStatusCard
@@ -141,7 +133,6 @@ describe("LiveShareStatusCard", () => {
     expect(countdown()).toBe("30:00");
     expect(screen.getByText("so far")).toBeTruthy();
     expect(screen.getByText("Until you stop")).toBeTruthy();
-    expect(screen.queryByTestId("one-location-live-share-progress")).toBeNull();
   });
 
   it("names the person when the server state is loaded", () => {
@@ -216,11 +207,11 @@ describe("LiveShareStatusCard", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 
-  it("offers Change time on a single share, beside the end time", () => {
+  it("offers Change time on a single share after the primary share action", () => {
     // The reported bug: a 30-minute share could be stopped and nothing else.
-    // The control has to be there, and it has to be the footer's sibling --
-    // beside the end time it edits, and not clustered with Stop, which is the
-    // one destructive control on this card.
+    // The control has to be there, but the compact Now card keeps it below the
+    // primary "Share with more" CTA instead of exposing the duration editor on
+    // the page.
     const onChangeDuration = vi.fn();
     render(
       <LiveShareStatusCard
@@ -228,6 +219,7 @@ describe("LiveShareStatusCard", () => {
         onManage={vi.fn()}
         onStop={vi.fn()}
         onChangeDuration={onChangeDuration}
+        onShareMore={vi.fn()}
       />,
     );
 
@@ -235,8 +227,12 @@ describe("LiveShareStatusCard", () => {
     change.click();
     expect(onChangeDuration).toHaveBeenCalledTimes(1);
 
-    const ends = screen.getByText(/^Ends /);
-    expect(change.closest("div")).toBe(ends.parentElement);
+    expect(screen.getByText(/^Ends /)).toBeTruthy();
+    const shareMore = screen.getByRole("button", { name: "Share with more" });
+    expect(
+      (shareMore.compareDocumentPosition(change) & Node.DOCUMENT_POSITION_FOLLOWING) !==
+        0,
+    ).toBe(true);
   });
 
   it("opens the share composer from the live timer card for another share", () => {

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -175,9 +175,97 @@ function circleListPeopleLabel(memberCount: number | null | undefined): string {
   return `${others} ${others === 1 ? "person" : "people"}`;
 }
 
+type CircleListGroupKey = "created" | "joined" | "built-in";
+
+type CircleListGroup = {
+  key: CircleListGroupKey;
+  title: string;
+  circles: OneLocationCircleSummary[];
+};
+
+function circleListGroupKey(
+  circle: OneLocationCircleSummary,
+): CircleListGroupKey {
+  if (circle.systemKind || circle.isSystem) return "built-in";
+  return circle.role === "owner" ? "created" : "joined";
+}
+
+function groupCirclesForPeopleTab(
+  circles: readonly OneLocationCircleSummary[],
+): CircleListGroup[] {
+  const groups: CircleListGroup[] = [
+    { key: "created", title: "Created by you", circles: [] },
+    { key: "joined", title: "Joined circles", circles: [] },
+    { key: "built-in", title: "Built-in", circles: [] },
+  ];
+  const groupByKey = new Map(groups.map((group) => [group.key, group]));
+
+  for (const circle of circles) {
+    groupByKey.get(circleListGroupKey(circle))?.circles.push(circle);
+  }
+
+  return groups.filter((group) => group.circles.length > 0);
+}
+
 function circleDetailMemberCountLabel(count: number): string {
   if (count <= 1) return "Only you";
   return `${count} people`;
+}
+
+function CircleSummaryRow({
+  circle,
+  onOpen,
+}: {
+  circle: OneLocationCircleSummary;
+  onOpen: (circleId: string) => void;
+}) {
+  const isSmsCircle = circle.systemKind === "sms";
+  const initials = circleInitials(circle.name);
+  const showInitials =
+    !isSmsCircle && circle.systemKind !== "trusted" && initials;
+
+  return (
+    <SettingsRow
+      leading={
+        <span
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center",
+            isSmsCircle
+              ? "rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)]"
+              : "rounded-[10px] bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#F2F2F7]",
+          )}
+          data-testid={
+            isSmsCircle
+              ? "one-location-circle-sms-mark"
+              : "one-location-circle-neutral-mark"
+          }
+        >
+          {isSmsCircle ? (
+            <SmsTextIcon className="text-[11px] font-bold tracking-[-0.2px]" />
+          ) : showInitials ? (
+            initials
+          ) : (
+            <UsersRound className="h-[17px] w-[17px]" />
+          )}
+        </span>
+      }
+      title={circle.name}
+      description={
+        isSmsCircle
+          ? `Save My Soul · ${circleListPeopleLabel(circle.memberCount)}`
+          : circleListPeopleLabel(circle.memberCount)
+      }
+      chevron
+      onClick={() => onOpen(circle.id)}
+      className={cn(
+        "[--settings-row-gap:12px] [--settings-row-px:16px] [--settings-row-py:10px]",
+        "[&>button]:min-h-[60px] sm:[&>button]:min-h-16",
+        "[&_[data-slot=settings-row-title]]:!text-[17px] [&_[data-slot=settings-row-title]]:!font-medium [&_[data-slot=settings-row-title]]:!leading-[22px] [&_[data-slot=settings-row-title]]:!tracking-[-0.3px]",
+        "[&_[data-slot=settings-row-description]]:!mt-0.5 [&_[data-slot=settings-row-description]]:!text-[13px] [&_[data-slot=settings-row-description]]:!font-normal [&_[data-slot=settings-row-description]]:!leading-[18px] [&_[data-slot=settings-row-description]]:!tracking-[-0.2px]",
+      )}
+      testId={`one-location-circle-${circle.id}`}
+    />
+  );
 }
 
 function circleFlowErrorMessage(error: unknown, fallback: string): string {
@@ -226,16 +314,10 @@ export function CirclesSection({
     ? (incomingInvites.find((invite) => invite.id === focusedInviteId) ?? null)
     : null;
 
-  const orderedCircles = useMemo(() => {
-    return [...circles].sort((left, right) => {
-      const isSystemLeft = Boolean(left.systemKind || left.isSystem);
-      const isSystemRight = Boolean(right.systemKind || right.isSystem);
-      if (isSystemLeft !== isSystemRight) {
-        return isSystemLeft ? 1 : -1;
-      }
-      return 0;
-    });
-  }, [circles]);
+  const circleGroups = useMemo(
+    () => groupCirclesForPeopleTab(circles),
+    [circles],
+  );
 
   useEffect(() => {
     if (
@@ -468,62 +550,36 @@ export function CirclesSection({
         </div>
       ) : null}
 
-      {orderedCircles.length ? (
-        <SettingsGroup
-          separatorInset
-          shellClassName={CIRCLES_GROUP_SURFACE}
-          testId="one-location-circle-list"
-        >
-          {orderedCircles.map((circle) => {
-            const isSmsCircle = circle.systemKind === "sms";
-            const initials = circleInitials(circle.name);
-            const showInitials =
-              !isSmsCircle && circle.systemKind !== "trusted" && initials;
-            return (
-              <SettingsRow
-                key={circle.id}
-                leading={
-                  <span
-                    className={cn(
-                      "flex h-9 w-9 shrink-0 items-center justify-center",
-                      isSmsCircle
-                        ? "rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)]"
-                        : "rounded-[10px] bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#F2F2F7]",
-                    )}
-                    data-testid={
-                      isSmsCircle
-                        ? "one-location-circle-sms-mark"
-                        : "one-location-circle-neutral-mark"
-                    }
-                  >
-                    {isSmsCircle ? (
-                      <SmsTextIcon className="text-[11px] font-bold tracking-[-0.2px]" />
-                    ) : showInitials ? (
-                      initials
-                    ) : (
-                      <UsersRound className="h-[17px] w-[17px]" />
-                    )}
-                  </span>
-                }
-                title={circle.name}
-                description={
-                  isSmsCircle
-                    ? `Save My Soul · ${circleListPeopleLabel(circle.memberCount)}`
-                    : circleListPeopleLabel(circle.memberCount)
-                }
-                chevron
-                onClick={() => onOpen(circle.id)}
-                className={cn(
-                  "[--settings-row-gap:12px] [--settings-row-px:16px] [--settings-row-py:10px]",
-                  "[&>button]:min-h-[60px] sm:[&>button]:min-h-16",
-                  "[&_[data-slot=settings-row-title]]:!text-[17px] [&_[data-slot=settings-row-title]]:!font-medium [&_[data-slot=settings-row-title]]:!leading-[22px] [&_[data-slot=settings-row-title]]:!tracking-[-0.3px]",
-                  "[&_[data-slot=settings-row-description]]:!mt-0.5 [&_[data-slot=settings-row-description]]:!text-[13px] [&_[data-slot=settings-row-description]]:!font-normal [&_[data-slot=settings-row-description]]:!leading-[18px] [&_[data-slot=settings-row-description]]:!tracking-[-0.2px]",
-                )}
-                testId={`one-location-circle-${circle.id}`}
-              />
-            );
-          })}
-        </SettingsGroup>
+      {circleGroups.length ? (
+        <div className="space-y-4" data-testid="one-location-circle-list">
+          {circleGroups.map((group) => (
+            <section
+              key={group.key}
+              className="space-y-2"
+              data-testid={`one-location-circle-group-${group.key}`}
+            >
+              <SectionLabel
+                as="h3"
+                className="px-[6px] text-[13px] font-normal leading-[18px] text-[color:var(--app-secondary-label)]"
+              >
+                {group.title}
+              </SectionLabel>
+              <SettingsGroup
+                separatorInset
+                shellClassName={CIRCLES_GROUP_SURFACE}
+                testId={`one-location-circle-group-list-${group.key}`}
+              >
+                {group.circles.map((circle) => (
+                  <CircleSummaryRow
+                    key={circle.id}
+                    circle={circle}
+                    onOpen={onOpen}
+                  />
+                ))}
+              </SettingsGroup>
+            </section>
+          ))}
+        </div>
       ) : (
         <div className={CIRCLES_EMPTY_STATE_WRAPPER}>
           <EmptyState

--- a/hushh-webapp/components/one-location/redesign/live-share-card-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/live-share-card-layout.ts
@@ -11,7 +11,7 @@
  * control inside a 320px phone without clipping any of them.
  */
 
-/** Card body. `overflow-hidden` clips the progress fill to the rounded corner. */
+/** Card body. The running-share card stays compact on the Now hub. */
 export const LIVE_SHARE_CARD_CLASSNAME = "overflow-hidden p-4";
 
 /**
@@ -35,36 +35,19 @@ export const LIVE_SHARE_ACTION_CLASSNAME =
 export const LIVE_SHARE_TITLE_CLASSNAME =
   "mt-3 text-[17px] font-semibold leading-[22px] text-foreground [overflow-wrap:anywhere]";
 
-/** Wraps so the unit word drops below the clock instead of pushing it out. */
+/** The remaining time and wall-clock end read as one sentence. */
 export const LIVE_SHARE_CLOCK_ROW_CLASSNAME =
-  "mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5";
+  "mt-1 flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[15px] leading-[20px] text-[color:var(--app-secondary-label)]";
 
 /** `tabular-nums` keeps the width fixed as the digits change, so it cannot jitter. */
 export const LIVE_SHARE_CLOCK_CLASSNAME =
-  "text-[34px] font-semibold leading-[40px] tracking-[-0.5px] text-foreground tabular-nums";
-
-export const LIVE_SHARE_PROGRESS_TRACK_CLASSNAME =
-  "mt-3 h-1.5 w-full overflow-hidden rounded-full bg-black/[0.07] dark:bg-white/[0.12]";
-
-export const LIVE_SHARE_PROGRESS_FILL_CLASSNAME =
-  "h-full rounded-full bg-emerald-500 transition-[width] duration-500 ease-linear";
+  "font-semibold text-foreground tabular-nums";
 
 export const LIVE_SHARE_FOOTER_CLASSNAME = "min-w-0 [overflow-wrap:anywhere]";
 
 /**
- * End time on the left, "Change time" on the right — the action sits with the
- * fact it edits.
- *
- * Both pills do fit in the header at 320px; measured, not assumed. They are
- * split up for what they mean, not for room. Stop ends someone's access and is
- * the only destructive control on this card: pairing it with a benign action
- * in one right-aligned cluster makes them look like a matched set, and the tap
- * you do not want to make by accident should not sit inside a toolbar.
- * "Change time" beside "Ends 6:03 PM" is the fact and its edit, together.
- *
- * `flex-wrap` is the safety margin down here: "Ends 11:30 PM" beside a 44px
- * pill is close to the edge on the narrowest phone, and dropping the action to
- * its own line is the right way to run out of room.
+ * The secondary action sits under the primary share CTA so the Now card keeps
+ * one obvious next action and one quieter editing affordance.
  */
 export const LIVE_SHARE_FOOTER_ROW_CLASSNAME =
-  "mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1";
+  "mt-3 flex flex-col gap-2";

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -26,7 +26,6 @@ import {
   formatShareDuration,
   formatShareEndsAt,
   parseTimestamp,
-  shareProgressRatio,
 } from "@/lib/one-location/share-countdown";
 import { useShareClock } from "@/lib/one-location/use-share-clock";
 import {
@@ -37,11 +36,9 @@ import {
   LIVE_SHARE_FOOTER_CLASSNAME,
   LIVE_SHARE_FOOTER_ROW_CLASSNAME,
   LIVE_SHARE_HEADER_CLASSNAME,
-  LIVE_SHARE_PROGRESS_FILL_CLASSNAME,
-  LIVE_SHARE_PROGRESS_TRACK_CLASSNAME,
   LIVE_SHARE_TITLE_CLASSNAME,
 } from "./live-share-card-layout";
-import { CARD_SURFACE, MUTED_TEXT } from "./tokens";
+import { CARD_SURFACE } from "./tokens";
 
 export type LiveShareStatus = {
   /** How many of your shares are live right now. */
@@ -154,7 +151,6 @@ export function LiveShareStatusCard({
     onEnded?.();
   }, [ended, onEnded]);
 
-  const progress = shareProgressRatio(startedAtMs, endsAtMs, nowMs);
   const clock = openEnded
     ? formatShareDuration(elapsedMs)
     : formatShareDuration(Math.max(0, remainingMs ?? 0));
@@ -266,7 +262,12 @@ export function LiveShareStatusCard({
         {title}
       </p>
 
-      <p className={LIVE_SHARE_CLOCK_ROW_CLASSNAME}>
+      <p
+        className={LIVE_SHARE_CLOCK_ROW_CLASSNAME}
+        data-ui-contract="required-copy"
+        data-ui-id="location-live-share-time-summary"
+        data-ui-truncation="forbid"
+      >
         <span
           // The visible clock changes every second; a live region here would
           // announce it every second too. The sentence below carries the value
@@ -280,58 +281,25 @@ export function LiveShareStatusCard({
         >
           {clock}
         </span>
-        <span aria-hidden="true" className={cn(MUTED_TEXT, "shrink-0")}>
+        <span aria-hidden="true" className="shrink-0">
           {openEnded ? "so far" : "left"}
         </span>
-        <span className="sr-only">{spoken}</span>
-      </p>
-
-      {progress !== null ? (
-        <div
-          aria-hidden="true"
-          className={LIVE_SHARE_PROGRESS_TRACK_CLASSNAME}
-        >
-          <div
-            data-testid="one-location-live-share-progress"
-            className={LIVE_SHARE_PROGRESS_FILL_CLASSNAME}
-            style={{ width: `${Math.round(progress * 100)}%` }}
-          />
-        </div>
-      ) : null}
-
-      {footer || onChangeDuration ? (
-        <div className={LIVE_SHARE_FOOTER_ROW_CLASSNAME}>
-          {footer ? (
-            <p
-              data-ui-contract="required-copy"
+        {footer ? (
+          <>
+            <span aria-hidden="true" className="shrink-0">
+              ·
+            </span>
+            <span
+              aria-hidden="true"
               data-ui-id="location-live-share-ends"
-              data-ui-truncation="forbid"
-              data-ui-role="description"
-              className={cn(MUTED_TEXT, LIVE_SHARE_FOOTER_CLASSNAME)}
+              className={cn(LIVE_SHARE_FOOTER_CLASSNAME, "min-w-0")}
             >
               {footer}
-            </p>
-          ) : null}
-
-          {onChangeDuration ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={runChildAction(onChangeDuration)}
-              className={cn(
-                LIVE_SHARE_ACTION_CLASSNAME,
-                "ml-auto text-[color:var(--app-accent)]",
-              )}
-              data-ui-contract="occlusion-sensitive"
-              data-ui-role="control"
-              data-ui-id="location-live-share-duration"
-              data-testid="one-location-live-share-change-time"
-            >
-              Change time
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+            </span>
+          </>
+        ) : null}
+        <span className="sr-only">{spoken}</span>
+      </p>
 
       {onShareMore ? (
         <Button
@@ -345,6 +313,26 @@ export function LiveShareStatusCard({
         >
           Share with more
         </Button>
+      ) : null}
+
+      {onChangeDuration ? (
+        <div className={LIVE_SHARE_FOOTER_ROW_CLASSNAME}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={runChildAction(onChangeDuration)}
+            className={cn(
+              LIVE_SHARE_ACTION_CLASSNAME,
+              "mx-auto text-[color:var(--app-accent)]",
+            )}
+            data-ui-contract="occlusion-sensitive"
+            data-ui-role="control"
+            data-ui-id="location-live-share-duration"
+            data-testid="one-location-live-share-change-time"
+          >
+            Change time
+          </Button>
+        </div>
       ) : null}
     </section>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -420,7 +420,7 @@ export type LocationHubViewModel = {
   onWithdrawRequest: (requestId: string) => void;
   onViewGrant: (grant: OneLocationGrant) => void;
   onStopGrant: (grantId: string) => void;
-  /** Grant currently showing the inline duration editor, or null. */
+  /** Grant currently showing the duration editor, or null. */
   editingGrantId: string | null;
   /**
    * Grant whose duration is being saved, or null. Deliberately not
@@ -1705,15 +1705,34 @@ function NowHub({
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
-      {vm.liveShare && vm.liveShareDurationEditing ? (
-        <LiveShareDurationEditor
-          value={vm.liveShareDurationHours}
-          onChange={vm.setLiveShareDurationHours}
-          onCancel={vm.onEditLiveShareDurationCancel}
-          onSave={vm.onSaveLiveShareDuration}
-          saving={vm.liveShareDurationSaving}
-        />
-      ) : null}
+      <Dialog
+        open={Boolean(vm.liveShare && vm.liveShareDurationEditing)}
+        onOpenChange={(open) => {
+          if (!open) vm.onEditLiveShareDurationCancel();
+        }}
+      >
+        <DialogContent
+          className="max-w-[min(420px,calc(100%-2rem))] gap-4 rounded-[24px] p-4 sm:max-w-[420px]"
+          showCloseButton={!vm.liveShareDurationSaving}
+        >
+          <DialogHeader className="gap-1 text-left">
+            <DialogTitle className="text-[20px] font-semibold leading-[25px] text-[color:var(--app-primary-label)]">
+              Change time
+            </DialogTitle>
+            <DialogDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+              Set a new end time for this share.
+            </DialogDescription>
+          </DialogHeader>
+          <LiveShareDurationEditor
+            value={vm.liveShareDurationHours}
+            onChange={vm.setLiveShareDurationHours}
+            onCancel={vm.onEditLiveShareDurationCancel}
+            onSave={vm.onSaveLiveShareDuration}
+            saving={vm.liveShareDurationSaving}
+            surface={false}
+          />
+        </DialogContent>
+      </Dialog>
       {/* Every row and cell below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
@@ -4564,11 +4583,7 @@ function ShareFlow({
 }
 
 /**
- * The new-end-time editor that opens under the live share card.
- *
- * Inline rather than a sheet: the card it edits stays on screen above it, so
- * "27:03 left" and the time being picked are readable together, and there is
- * no overlay to trap focus in or size against a fresh set of widths.
+ * The new-end-time editor opened from the live share card.
  *
  * The wheel, not the four-option select the received-shares editor uses. This
  * one opens on what the share actually has left, and 32 minutes snapped to
@@ -4580,12 +4595,14 @@ function LiveShareDurationEditor({
   onCancel,
   onSave,
   saving,
+  surface = true,
 }: {
   value: string;
   onChange: (next: string) => void;
   onCancel: () => void;
   onSave: () => void;
   saving: boolean;
+  surface?: boolean;
 }) {
   // Same 30-second tick as the share confirm step: an editor left open must
   // not keep quoting an end time that has already gone past.
@@ -4597,7 +4614,11 @@ function LiveShareDurationEditor({
 
   return (
     <div
-      className={cn(SUBCARD_SURFACE, "space-y-4 p-4")}
+      className={cn(
+        surface ? SUBCARD_SURFACE : null,
+        "space-y-4",
+        surface ? "p-4" : null,
+      )}
       data-testid="one-location-live-share-duration-editor"
       data-ui-contract="control-group"
       data-ui-id="location-live-share-duration-editor"

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -13,9 +13,9 @@
  *   NOT call services, encrypt, or mutate consent state. It only renders and
  *   delegates to the existing handlers, so the feature's functionality, consent
  *   gating, analytics, and crypto are unchanged.
- * - The global shell owns the visible tab strip. This route consumes the same
- *   central registry only to render the active swipe panel; focused task flows
- *   hide the shell tabs through their `?action=` route state.
+ * - The Location hub owns the visible tab strip directly under its module
+ *   header. It still consumes the central registry so labels, destinations,
+ *   selection, swipes, and deep links cannot drift from the shared top shell.
  */
 
 import {
@@ -64,6 +64,7 @@ import {
 } from "@/lib/one-location/grant-lanes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { TopShellTabs } from "@/components/app-ui/top-shell-tabs";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1525,6 +1526,13 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         busy={vm.locationAcquiring}
         onRetry={vm.onShowMyLocation}
         onOpenSettings={vm.onOpenLocationSettings}
+      />
+
+      <TopShellTabs
+        tabSet={{
+          ...LOCATION_TAB_DEFINITION,
+          activeValue: tab,
+        }}
       />
 
       <div className="-mx-[var(--page-inline-gutter-standard)]">

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -33,10 +33,13 @@ import { toast } from "sonner";
 
 import {
   Loader2,
+  Copy,
+  Link2,
   MapPin,
   Pencil,
   Plus,
   Send,
+  Share2,
   Check,
   ShieldCheck,
   UserRoundPlus,
@@ -92,7 +95,6 @@ import {
   RowDescription,
   RowLabel,
   SectionLabel,
-  SectionTitle,
   TrailingValue,
 } from "@/components/app-ui/typography";
 import type {
@@ -134,7 +136,6 @@ import {
   initialsFrom,
   RequestCard,
   SharedWithMeCard,
-  TemporaryLinkCard,
   type GrantViewStatus,
 } from "./cards";
 
@@ -1601,12 +1602,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
 const PEOPLE_HEADER_ACTION =
   "relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]";
 
-/** People-only grouped surface: compact geometry, shared semantic theme. */
-const PEOPLE_GROUP_SURFACE =
-  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] dark:shadow-none";
-
 const LOCATION_GROUP_SURFACE =
-  "overflow-hidden rounded-[16px] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
+  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
+
+const LOCATION_GROUP_SHELL_CLASSNAME =
+  "[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:!shadow-none";
 
 const LOCATION_INTERACTIVE_SURFACE =
   "bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
@@ -3466,7 +3466,7 @@ export function PeopleHub({
             <div className="col-span-3 row-start-3 mt-3 sm:col-span-4 sm:mt-3.5">
               {filtered.length ? (
                 <div
-                  className={PEOPLE_GROUP_SURFACE}
+                  className={LOCATION_GROUP_SURFACE}
                   data-testid="one-location-people-list"
                 >
                   {filtered.map((r, i) => {
@@ -3821,54 +3821,135 @@ function publicLinkStatusLabel(label?: string | null): string {
   return label.replace(/^Stops in\b/i, "Expires in");
 }
 
-/** One active-link row: tinted icon tile · title · subtitle · Copy (design). */
+function LinkIdentityMark({
+  tone = "accent",
+}: {
+  tone?: "accent" | "success";
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]",
+        tone === "success"
+          ? "bg-[color:var(--app-success)]/12 text-[color:var(--app-success)] dark:bg-[color:var(--app-success)]/15"
+          : "bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]",
+      )}
+    >
+      {tone === "success" ? (
+        <ShieldCheck className="h-[17px] w-[17px]" strokeWidth={2.1} />
+      ) : (
+        <Link2 className="h-[17px] w-[17px]" strokeWidth={2.1} />
+      )}
+    </span>
+  );
+}
+
+function PublicLinkActionRows({
+  onCopy,
+  onShare,
+  onRevoke,
+  revokeBusy,
+}: {
+  onCopy: () => boolean | Promise<boolean>;
+  onShare: () => void;
+  onRevoke: () => void;
+  revokeBusy?: boolean;
+}) {
+  const [copyLabel, setCopyLabel] = useState("Copy link");
+  const [copyBusy, setCopyBusy] = useState(false);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetRef.current) {
+        clearTimeout(copyResetRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (copyBusy) return;
+    setCopyBusy(true);
+    try {
+      const copied = await onCopy();
+      if (!copied) return;
+      setCopyLabel("Copied");
+      if (copyResetRef.current) {
+        clearTimeout(copyResetRef.current);
+      }
+      copyResetRef.current = setTimeout(() => {
+        setCopyLabel("Copy link");
+      }, 1600);
+    } finally {
+      setCopyBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 px-4 pb-4 pt-2">
+      <div className="grid grid-cols-1 gap-2 min-[340px]:grid-cols-2">
+        <Button
+          onClick={onShare}
+          className="ui-text-button-label h-12 rounded-[15px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+        >
+          <Share2 className="mr-1.5 h-4 w-4" />
+          Share
+        </Button>
+        <Button
+          variant="outline"
+          onClick={handleCopy}
+          disabled={copyBusy}
+          aria-busy={copyBusy || undefined}
+          className="ui-text-button-label h-12 rounded-[15px]"
+        >
+          <Copy className="mr-1.5 h-4 w-4" />
+          {copyBusy ? "Copying…" : copyLabel}
+        </Button>
+      </div>
+      <div className="border-t border-[color:var(--app-separator)] pt-1">
+        <button
+          type="button"
+          onClick={onRevoke}
+          disabled={revokeBusy}
+          className="ui-text-button-label min-h-11 w-full text-left text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+        >
+          {revokeBusy ? "Revoking…" : "Revoke link"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** One active-link row: shared grouped row · title · subtitle · Copy. */
 function ActiveLinkRow({
-  icon,
-  tileClass,
+  tone,
   title,
   subtitle,
   onCopy,
-  first,
 }: {
-  icon: ReactNode;
-  tileClass: string;
+  tone: "accent" | "success";
   title: string;
   subtitle: string;
   onCopy: () => void;
-  first: boolean;
 }) {
   return (
-    <div
-      className={cn(
-        "flex min-h-[60px] items-center gap-3.5 py-3.5",
-        !first && "border-t border-[color:var(--app-separator)]",
-      )}
-    >
-      <span
-        className={cn(
-          "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[10px]",
-          tileClass,
-        )}
-      >
-        {icon}
-      </span>
-      <div className="min-w-0 flex-1">
-        <RowLabel as="p" className="truncate">
-          {title}
-        </RowLabel>
-        <RowDescription as="p" className="mt-0.5 truncate">
-          {subtitle}
-        </RowDescription>
-      </div>
-      <Button
-        variant="outline"
-        onClick={onCopy}
-        size="sm"
-        className="shrink-0 border-[color:var(--app-accent)] px-4 text-[color:var(--app-accent)]"
-      >
-        Copy
-      </Button>
-    </div>
+    <SettingsRow
+      density="compact"
+      leading={<LinkIdentityMark tone={tone} />}
+      title={title}
+      description={subtitle}
+      trailing={
+        <Button
+          variant="outline"
+          onClick={onCopy}
+          size="sm"
+          className="shrink-0 border-[color:var(--app-accent)] px-4 text-[color:var(--app-accent)]"
+        >
+          Copy
+        </Button>
+      }
+    />
   );
 }
 
@@ -3914,135 +3995,123 @@ function LinksHub({ vm }: { vm: LocationHubViewModel }) {
 
   return (
     <div className="space-y-4">
-      <div className="px-[6px]">
-        <SectionTitle as="h2">Temporary link</SectionTitle>
-      </div>
-
-      {hasLiveLink ? (
-        hasShareableLink ? (
-          <TemporaryLinkCard
-            statusLine={
-              temp
-                ? publicLinkStatusLabel(
-                    vm.expiresCountdownLabel(temp.expiresAt),
-                  )
-                : "Active"
-            }
-            description="Anyone with this link can see your location."
-            // No countdown until the row lands: inventing one from the
-            // duration that was picked would drift from the expiry the server
-            // actually stamped.
-            onCopy={vm.onCopyPublicInvite}
-            onShare={vm.onSharePublicInvite}
-            // Revoking needs the invite's id, which arrives with the row. In
-            // the moment before it does, the control shows itself as busy
-            // rather than pretending to work -- which is honest, because a
-            // refresh really is in flight. Copy and Share are unaffected: the
-            // URL is already in hand.
-            onRevoke={() => {
-              if (temp) vm.onRevokePublicInvite(temp);
-            }}
-            revokeBusy={vm.busy === "publicRevoke" || !temp}
-          />
+      <SettingsGroup
+        title="Temporary link"
+        separatorInset
+        shellClassName={LOCATION_GROUP_SHELL_CLASSNAME}
+        className="[&>div:first-child]:mt-0"
+        testId="one-location-links-temporary-link"
+      >
+        {hasLiveLink ? (
+          hasShareableLink ? (
+            <>
+              <SettingsRow
+                density="compact"
+                leading={<LinkIdentityMark />}
+                title="Link is live"
+                description={
+                  <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--app-success)]" />
+                    <span>
+                      {temp
+                        ? publicLinkStatusLabel(
+                            vm.expiresCountdownLabel(temp.expiresAt),
+                          )
+                        : "Active"}
+                    </span>
+                    <span aria-hidden="true">·</span>
+                    <span>Anyone with this link can see your location.</span>
+                  </span>
+                }
+              />
+              <PublicLinkActionRows
+                onCopy={vm.onCopyPublicInvite}
+                onShare={vm.onSharePublicInvite}
+                onRevoke={() => {
+                  if (temp) vm.onRevokePublicInvite(temp);
+                }}
+                revokeBusy={vm.busy === "publicRevoke" || !temp}
+              />
+            </>
+          ) : (
+            <>
+              <SettingsRow
+                density="compact"
+                leading={<LinkIdentityMark />}
+                title="Link is live"
+                description="Active, but unavailable on this device."
+              />
+              <div className="px-4 pb-4 pt-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (temp) vm.onRevokePublicInvite(temp);
+                  }}
+                  disabled={vm.busy === "publicRevoke" || !temp}
+                  className="ui-text-button-label min-h-11 w-full text-left text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+                >
+                  {vm.busy === "publicRevoke" || !temp
+                    ? "Stopping…"
+                    : "Stop link"}
+                </button>
+              </div>
+            </>
+          )
         ) : (
-          // Live, and its URL is gone: an invite from before the token could be
-          // re-derived from its row. Copy and Share would be dead controls, so
-          // they are not offered -- but the link is still out there watching,
-          // so ending it has to stay reachable. Saying why keeps this from
-          // reading as a bug the person should retry.
-          <div className={cn(SUBCARD_SURFACE, "space-y-4 p-5 sm:p-6")}>
-            <p className="text-[15px] leading-5 text-muted-foreground">
-              Active, but the link is unavailable on this device.
-            </p>
-            <button
-              type="button"
-              onClick={() => {
-                if (temp) vm.onRevokePublicInvite(temp);
-              }}
-              disabled={vm.busy === "publicRevoke" || !temp}
-              className="min-h-11 w-full text-left text-[15px] font-semibold leading-5 text-[color:var(--app-destructive)] transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
-            >
-              {vm.busy === "publicRevoke" || !temp ? "Stopping…" : "Stop link"}
-            </button>
-          </div>
-        )
-      ) : (
-        // No warning banner above the picker. It said two things the screen
-        // already says better: the duration control underneath states exactly
-        // how long the link lives, and the card that replaces this whole block
-        // once a link exists carries the concise visibility line on
-        // the object it is actually about. An amber panel repeating both, on
-        // the one screen whose entire purpose is to create the link, read as a
-        // reason not to press the button rather than as information.
-        <div className={cn(SUBCARD_SURFACE, "space-y-5 p-5 sm:p-6")}>
-          <p className="text-[15px] leading-5 text-muted-foreground">
-            Anyone with this link can see your location until it expires.
-          </p>
-          <div className="space-y-2.5">
-            <p className="text-[15px] font-semibold leading-5 text-foreground">
-              Duration
-            </p>
-            <div
-              className="grid grid-cols-2 gap-2"
-              role="radiogroup"
-              aria-label="Temporary link duration"
-            >
-              {PUBLIC_LINK_DURATION_OPTIONS.map((option) => {
-                const selected = vm.publicLinkDurationHours === option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    onClick={() => vm.setPublicLinkDurationHours(option.value)}
-                    className={cn(
-                      "h-11 rounded-[14px] border text-[15px] font-semibold leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2",
-                      selected
-                        ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
-                        : "border-border bg-[color:var(--app-card-surface-compact)] text-foreground hover:bg-[color:var(--app-card-surface-compact)]/80",
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
+          <>
+            <SettingsRow
+              density="compact"
+              leading={<LinkIdentityMark />}
+              title="Create a temporary link"
+              description="Anyone with this link can see your location until it expires."
+            />
+            <div className="space-y-4 px-4 pb-4 pt-2">
+              <DurationSelector
+                value={vm.publicLinkDurationHours}
+                onChange={vm.setPublicLinkDurationHours}
+                options={PUBLIC_LINK_DURATION_OPTIONS.map((option) => option)}
+                label="Duration"
+                presentation="buttons"
+                maxWidthClassName={null}
+              />
+              {/* The label changes while it works. This press waits on a device fix
+                  before it can post anything, so on a cold start it can sit for
+                  several seconds -- and it used to sit as a bare spinner with the
+                  label hidden, which is why it read as "taking longer than
+                  expected" rather than as "still finding you". Naming the wait is
+                  the fix available here; the wait itself is a GPS acquisition. */}
+              <Button
+                onClick={vm.onCreatePublicInvite}
+                isLoading={vm.busy === "publicInvite"}
+                data-voice-control-id="one-location-action-temp-link"
+                className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+              >
+                {vm.busy === "publicInvite"
+                  ? "Creating link…"
+                  : "Create link"}
+              </Button>
             </div>
-          </div>
-          {/* The label changes while it works. This press waits on a device fix
-              before it can post anything, so on a cold start it can sit for
-              several seconds -- and it used to sit as a bare spinner with the
-              label hidden, which is why it read as "taking longer than
-              expected" rather than as "still finding you". Naming the wait is
-              the fix available here; the wait itself is a GPS acquisition. */}
-          <Button
-            onClick={vm.onCreatePublicInvite}
-            isLoading={vm.busy === "publicInvite"}
-            data-voice-control-id="one-location-action-temp-link"
-            className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-          >
-            {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
-          </Button>
-        </div>
-      )}
+          </>
+        )}
+      </SettingsGroup>
 
       {/* A Circle invite is a different object on a different table with a
           different ceiling, and it is not subject to the one-at-a-time rule
           above: it admits one named person to a Circle rather than showing the
           owner to anyone holding a URL. It keeps its row. */}
       {invite ? (
-        <div className={cn("overflow-hidden px-3.5", SUBCARD_SURFACE)}>
+        <SettingsGroup
+          separatorInset
+          shellClassName={LOCATION_GROUP_SHELL_CLASSNAME}
+          testId="one-location-links-invite-link"
+        >
           <ActiveLinkRow
-            first
-            tileClass="bg-[color:var(--app-success)]/12 dark:bg-[color:var(--app-success)]/15"
-            icon={
-              <ShieldCheck className="h-[17px] w-[17px] text-[color:var(--app-success)]" />
-            }
+            tone="success"
             title="Invite link"
             subtitle={`${vm.expiresCountdownLabel(invite.expiresAt)} · one person`}
             onCopy={vm.onCopyCircleInvite}
           />
-        </div>
+        </SettingsGroup>
       ) : null}
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -165,14 +165,20 @@ export function DurationSelector({
           </SelectContent>
         </Select>
       ) : (
-        <div className="flex flex-wrap gap-2">
+        <div
+          className="flex flex-wrap gap-2"
+          role="radiogroup"
+          aria-labelledby={label ? labelId : undefined}
+          aria-label={label ? undefined : "Duration"}
+        >
           {options.map((option) => {
             const active = option.value === value;
             return (
               <button
                 key={option.value}
                 type="button"
-                aria-pressed={active}
+                role="radio"
+                aria-checked={active}
                 onClick={() => onChange(option.value)}
                 className={cn(
                   "h-9 rounded-full border px-4 transition-colors touch-manipulation",

--- a/hushh-webapp/e2e/one-location-live-share.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-live-share.layout.spec.ts
@@ -14,8 +14,6 @@ import {
   LIVE_SHARE_FOOTER_CLASSNAME,
   LIVE_SHARE_FOOTER_ROW_CLASSNAME,
   LIVE_SHARE_HEADER_CLASSNAME,
-  LIVE_SHARE_PROGRESS_FILL_CLASSNAME,
-  LIVE_SHARE_PROGRESS_TRACK_CLASSNAME,
   LIVE_SHARE_TITLE_CLASSNAME,
 } from "../components/one-location/redesign/live-share-card-layout";
 
@@ -109,8 +107,6 @@ async function buildFixture(): Promise<string> {
     LIVE_SHARE_TITLE_CLASSNAME,
     LIVE_SHARE_CLOCK_ROW_CLASSNAME,
     LIVE_SHARE_CLOCK_CLASSNAME,
-    LIVE_SHARE_PROGRESS_TRACK_CLASSNAME,
-    LIVE_SHARE_PROGRESS_FILL_CLASSNAME,
     LIVE_SHARE_FOOTER_CLASSNAME,
     LIVE_SHARE_FOOTER_ROW_CLASSNAME,
     "h-2 w-2 shrink-0 rounded-full inline-flex items-center justify-center",
@@ -128,12 +124,11 @@ async function buildFixture(): Promise<string> {
     <p class="${LIVE_SHARE_CLOCK_ROW_CLASSNAME}">
       <span class="${LIVE_SHARE_CLOCK_CLASSNAME}" data-testid="clock-${item.id}">${item.clock}</span>
       <span data-testid="unit-${item.id}">left</span>
+      <span>·</span>
+      <span class="${LIVE_SHARE_FOOTER_CLASSNAME}" data-testid="footer-${item.id}">${item.footer}</span>
     </p>
-    <div class="${LIVE_SHARE_PROGRESS_TRACK_CLASSNAME}" data-testid="track-${item.id}">
-      <div class="${LIVE_SHARE_PROGRESS_FILL_CLASSNAME}" style="width:33%" data-testid="fill-${item.id}"></div>
-    </div>
-    <div class="${LIVE_SHARE_FOOTER_ROW_CLASSNAME}" data-testid="footer-row-${item.id}">
-      <p class="${LIVE_SHARE_FOOTER_CLASSNAME}" data-testid="footer-${item.id}">${item.footer}</p>
+    <button class="${LIVE_SHARE_ACTION_CLASSNAME} mt-4 inline-flex min-h-[48px] w-full items-center justify-center rounded-[16px] px-5" data-testid="share-more-${item.id}">Share with more</button>
+    <div class="${LIVE_SHARE_FOOTER_ROW_CLASSNAME}">
       <button class="${LIVE_SHARE_ACTION_CLASSNAME} inline-flex items-center justify-center" data-testid="change-${item.id}">Change time</button>
     </div>
   </section>`,
@@ -235,11 +230,8 @@ test.describe("One Location live share card layout", () => {
         expect(stop.height).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET);
         expect(stop.right).toBeLessThanOrEqual(width + 1);
 
-        // "Change time" shares the footer line with the end time. At 320px
-        // that is the tight case: it either fits beside "Ends 11:30 PM" or
-        // wraps under it, and either way it has to stay fully on screen, fully
-        // tappable, and with its whole label — "Change" alone is a different
-        // promise.
+        // "Change time" is deliberately lighter than "Share with more", but it
+        // remains a real tap target after the primary CTA.
         const change = await page.getByTestId(`change-${item.id}`).evaluate(PROBE);
         expect(
           change.height,
@@ -253,18 +245,11 @@ test.describe("One Location live share card layout", () => {
           `change-${item.id} clipped its label at ${width}px`,
         ).toBeLessThanOrEqual(change.clientWidth + 1);
 
-        // And the end time it sits beside is not squeezed out by it.
-        const footerRow = await page
-          .getByTestId(`footer-row-${item.id}`)
+        const shareMore = await page
+          .getByTestId(`share-more-${item.id}`)
           .evaluate(PROBE);
-        expect(footerRow.scrollHeight).toBeLessThanOrEqual(
-          footerRow.clientHeight + 1,
-        );
-
-        // The progress fill must stay inside its rounded track.
-        const track = await page.getByTestId(`track-${item.id}`).evaluate(PROBE);
-        const fill = await page.getByTestId(`fill-${item.id}`).evaluate(PROBE);
-        expect(fill.right).toBeLessThanOrEqual(track.right + 1);
+        expect(shareMore.height).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET);
+        expect(shareMore.right).toBeLessThanOrEqual(width + 1);
       }
     });
   }

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -214,21 +214,12 @@ function resolveSelection(
 
 /**
  * Resolves the one route-owned contextual tab group for the shared top shell.
- * Direct links, shell clicks, and page swipes converge on this same selection.
+ * Location is intentionally excluded here: its hub renders the same registered
+ * tabs directly under the Location module header so Now, People, and Links keep
+ * the correct local hierarchy while retaining shared tab/swipe state.
  */
 export function resolveTopShellTabSet(routeKey: string): TopShellTabSet | null {
   const { pathname, searchParams } = splitRouteKey(routeKey);
-
-  if (pathname === "/one/location" && !searchParams.get("action")) {
-    const definition = TOP_SHELL_TAB_REGISTRY.location;
-    return {
-      ...definition,
-      activeValue: resolveRegisteredTopShellTabValue(
-        definition,
-        searchParams.get(definition.queryParam),
-      ),
-    };
-  }
 
   if (pathname === KAI_MARKET_PATH) {
     const definition = TOP_SHELL_TAB_REGISTRY.finance;


### PR DESCRIPTION
## Summary\n- compact active sharing controls on the Location Now tab\n- move Now / People / Links into the Location hub beneath the module header\n- keep Links state/API behavior intact while fixing the tab/header hierarchy\n- add focused contracts for top-shell resolution and Location hub order\n\n## Validation\n- npm run test -- __tests__/navigation/top-shell-tabs.test.ts __tests__/components/one-location-hub-hierarchy.contract.test.ts __tests__/components/one-location-tab-transition.contract.test.tsx\n- npx eslint components/one-location/redesign/location-redesign-hub.tsx lib/navigation/top-shell-tabs.ts __tests__/navigation/top-shell-tabs.test.ts __tests__/components/one-location-hub-hierarchy.contract.test.ts --max-warnings=0\n- npm run typecheck -- --pretty false\n- npm run build