### PR TITLE
db(migrations): reserve the parked 900 band on main, and unpin the DB contract check's interpreter

### DIFF
--- a/consent-protocol/db/migrations/parked/900_personal_agent_registry.sql
+++ b/consent-protocol/db/migrations/parked/900_personal_agent_registry.sql
@@ -1,0 +1,79 @@
+-- Per-user personal-information agent registry (Phase 0 — schema only).
+--
+-- PARKED (unapplied, flag-off): numbered in the 900 band, deliberately OUT of the
+-- active migration sequence. It is NOT in db/release_migration_manifest.json, so it
+-- is never applied until the personal-agent feature is greenlit; at that point it is
+-- renumbered into sequence and added to the manifest. The high band keeps it from
+-- colliding with main's fast-moving migration head on every branch sync.
+--
+-- One row per Hushh One user maps their phone-number primary key (stored ONLY
+-- as an HMAC hash, never raw) and their opaque HusshID to the always-on
+-- personal agent: its A2A route, the pod's X25519 PUBLIC key (Hushh never holds
+-- the pod private key — zero-knowledge, same guarantee as the local MCP
+-- connector), and the runtime/prompt versions the pod is pinned to.
+--
+-- backend / external_agent_id / a2a_route / pod_pubkey stay NULL until the agent
+-- is actually provisioned (Phase 1) by the selected compute backend. The design
+-- is backend-neutral: `backend` names the host (gcp | anypoint | null), and
+-- `external_agent_id` is its host id (was `anypoint_agent_id`). Phase 0 only lands
+-- the schema; nothing reads or writes this table until the PERSONAL_AGENT_ENABLED
+-- kill-switch is turned on. Non-breaking + idempotent.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS personal_agent_registry (
+    user_id                 TEXT PRIMARY KEY,
+    hushh_id                TEXT NOT NULL,
+    phone_e164_hash         TEXT,
+    space_id                TEXT,
+    backend                 TEXT,
+    external_agent_id       TEXT,
+    a2a_route               TEXT,
+    backend_metadata        JSONB,
+    attestation_ref         TEXT,
+    pod_pubkey              TEXT,
+    pod_key_id              TEXT,
+    pod_key_wrapping_alg    TEXT,
+    runtime_version         TEXT,
+    prompt_version          TEXT,
+    status                  TEXT NOT NULL DEFAULT 'unprovisioned',
+    region                  TEXT,
+    provisioned_at          TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_agent_registry_hushh_id
+    ON personal_agent_registry(hushh_id);
+
+CREATE INDEX IF NOT EXISTS idx_personal_agent_registry_status
+    ON personal_agent_registry(status);
+
+-- Retained AFTER account deletion (outside the per-user delete cascade) so that
+-- deprovisioning the external agent endpoint stays auditable once the user's
+-- rows are gone. Holds no raw PII: only the opaque HusshID + external agent id.
+CREATE TABLE IF NOT EXISTS personal_agent_deletion_tombstones (
+    id                  BIGSERIAL PRIMARY KEY,
+    hushh_id            TEXT NOT NULL,
+    external_agent_id   TEXT,
+    status              TEXT NOT NULL DEFAULT 'deprovision_requested',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_personal_agent_tombstones_status
+    ON personal_agent_deletion_tombstones(status);
+
+COMMENT ON TABLE personal_agent_registry IS
+    'Per-user personal-information agent: phone(hashed) -> HusshID -> pod route + pod PUBLIC key + version pins. Feature-flagged (PERSONAL_AGENT_ENABLED). Phase 0.';
+COMMENT ON COLUMN personal_agent_registry.phone_e164_hash IS
+    'HMAC hash of the verified E.164 phone (the user primary key). Never the raw phone number.';
+COMMENT ON COLUMN personal_agent_registry.pod_pubkey IS
+    'Base64 X25519 PUBLIC key of the user pod. Hushh wraps scoped exports to it; the pod holds the private key. Zero-knowledge.';
+COMMENT ON COLUMN personal_agent_registry.backend IS
+    'Which compute backend hosts this agent (gcp | anypoint | null). Backend-neutral provider abstraction. NULL until provisioned.';
+COMMENT ON COLUMN personal_agent_registry.external_agent_id IS
+    'Backend-neutral host id for the provisioned agent (formerly anypoint_agent_id). NULL until provisioned.';
+COMMENT ON COLUMN personal_agent_registry.space_id IS
+    'The spaceID of this agent instance (one node/instance per HusshID). NULL until provisioned.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/901_agent_prompt_versions.sql
+++ b/consent-protocol/db/migrations/parked/901_agent_prompt_versions.sql
@@ -1,0 +1,44 @@
+-- Versioned prompt store for hot prompt-sync WITHOUT redeploy (Phase 0 — schema).
+--
+-- PARKED (unapplied, flag-off): 900-band, out of the active sequence, not in
+-- db/release_migration_manifest.json. Renumbered into sequence + manifested at
+-- greenlight. High band avoids per-sync collision with main's migration head.
+--
+-- Agents resolve their system prompt from this table at runtime (see the
+-- GET /api/one/agent-prompt endpoint). Editing a prompt = insert a new version
+-- row and flip its status to 'active' (optionally staged via canary_percent) —
+-- no redeploy — and rollback is flipping the prior version back to 'active'.
+-- At most one 'active' row per (agent_id, channel) is enforced below.
+--
+-- Non-breaking + idempotent. Inert until PERSONAL_AGENT_ENABLED is on.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_prompt_versions (
+    id              BIGSERIAL PRIMARY KEY,
+    agent_id        TEXT NOT NULL,
+    channel         TEXT NOT NULL DEFAULT 'default',
+    version         TEXT NOT NULL,
+    prompt_text     TEXT NOT NULL,
+    prompt_sha256   TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'canary',
+    canary_percent  INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT agent_prompt_versions_status_check
+        CHECK (status IN ('active', 'canary', 'retired')),
+    CONSTRAINT agent_prompt_versions_canary_pct_check
+        CHECK (canary_percent BETWEEN 0 AND 100)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_prompt_versions_unique
+    ON agent_prompt_versions(agent_id, channel, version);
+
+-- At most one active prompt per (agent_id, channel): the "flip active" contract.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_prompt_versions_one_active
+    ON agent_prompt_versions(agent_id, channel)
+    WHERE status = 'active';
+
+COMMENT ON TABLE agent_prompt_versions IS
+    'Versioned agent prompts for runtime sync without redeploy. Flip status=active (or stage via canary_percent) to roll forward/back. Phase 0.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/902_personal_agent_tombstone_hushh_id_index.sql
+++ b/consent-protocol/db/migrations/parked/902_personal_agent_tombstone_hushh_id_index.sql
@@ -1,0 +1,20 @@
+-- Index the deletion tombstones by HusshID for recycled-phone generation
+-- rotation (Phase 0 — SECURITY-REVIEW.md L1).
+--
+-- PARKED (unapplied, flag-off): 900-band, out of the active sequence, not in
+-- db/release_migration_manifest.json. Renumbered into sequence + manifested at
+-- greenlight. High band avoids per-sync collision with main's migration head.
+--
+-- provision() derives a candidate HusshID per generation and asks whether that
+-- HusshID was already tombstoned (a prior owner of a since-recycled phone). That
+-- lookup keys on hushh_id, so index it. Rare (once per provision) but the
+-- tombstone table grows unbounded over time, so avoid a seq scan.
+--
+-- Non-breaking + idempotent. Inert until PERSONAL_AGENT_ENABLED is on.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_personal_agent_tombstones_hushh_id
+    ON personal_agent_deletion_tombstones(hushh_id);
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/903_webauthn_credentials.sql
+++ b/consent-protocol/db/migrations/parked/903_webauthn_credentials.sql
@@ -1,0 +1,54 @@
+-- Server-verified WebAuthn / FIDO2 credential store + one-time challenge store (M14).
+--
+-- PARKED (unapplied, flag-off): 900-band, out of the active migration sequence, not
+-- in db/release_migration_manifest.json, so it is never applied until the WebAuthn
+-- feature is greenlit; at that point it is renumbered into sequence and manifested.
+-- The high band keeps it from colliding with main's fast-moving migration head.
+--
+-- Gated by WEBAUTHN_ENABLED. This is the credential public-key store the existing
+-- client-side PRF vault-unlock flow never had -- the foundation for passkey/hardware-
+-- key LOGIN + step-up (docs/future/identity-assurance/README.md). Non-breaking +
+-- idempotent; touches no existing table.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         TEXT NOT NULL,
+    credential_id   TEXT NOT NULL UNIQUE,   -- base64url credential id
+    public_key      TEXT NOT NULL,          -- base64url COSE public key
+    sign_count      BIGINT NOT NULL DEFAULT 0,
+    aaguid          TEXT,                   -- authenticator model (AAL/attestation policy)
+    device_type     TEXT,                   -- single_device | multi_device
+    backed_up       BOOLEAN,
+    rp_id           TEXT NOT NULL,
+    device_label    TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_user
+    ON webauthn_credentials(user_id);
+
+-- One-time, short-TTL challenges, consumed by value (works for usernameless auth).
+CREATE TABLE IF NOT EXISTS webauthn_challenges (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         TEXT,                   -- NULL for usernameless authentication
+    challenge       TEXT NOT NULL,          -- base64url
+    ceremony        TEXT NOT NULL,          -- registration | authentication
+    rp_id           TEXT NOT NULL,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webauthn_challenges_challenge
+    ON webauthn_challenges(challenge);
+CREATE INDEX IF NOT EXISTS idx_webauthn_challenges_expires
+    ON webauthn_challenges(expires_at);
+
+COMMENT ON TABLE webauthn_credentials IS
+    'Server-verified WebAuthn/FIDO2 credential public keys (passkeys + hardware keys). sign_count catches cloned authenticators; aaguid drives AAL/attestation policy. Gated by WEBAUTHN_ENABLED. M14.';
+COMMENT ON COLUMN webauthn_credentials.aaguid IS
+    'Authenticator model id (e.g. a Google Titan / YubiKey AAGUID) for attestation + enterprise allow-list / AAL3 policy.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/904_consent_audit_receipts.sql
+++ b/consent-protocol/db/migrations/parked/904_consent_audit_receipts.sql
@@ -1,0 +1,82 @@
+-- Tamper-evident consent-audit receipt chain (PCHP / NIST 800-53 AU-9 + AU-10).
+--
+-- PARKED (unapplied, flag-off): numbered in the 900 band, deliberately OUT of the
+-- active migration sequence. It is NOT in db/release_migration_manifest.json, so it
+-- is never applied until CONSENT_AUDIT_CHAIN_ENABLED is greenlit; at that point it
+-- is renumbered into sequence and added to the manifest. The high band keeps it
+-- from colliding with main's fast-moving migration head on every branch sync.
+--
+-- Why: the primary consent ledger (`consent_audit`) is event-sourced and HMAC-signed
+-- at the token layer, but the TABLE itself is mutable (rows carry an updatable
+-- `revoked_at`) and unchained -- so a silent edit or delete of an audit row is not
+-- detectable. This table adds the missing tamper-evidence WITHOUT changing the
+-- operational `consent_audit` write path: on every consent event a receipt is ALSO
+-- appended here, fail-safe, to a per-subject append-only hash chain --
+--
+--     hash      = sha256( prev_hash || '\n' || canonical_payload )
+--     signature = Ed25519( CONSENT_AUDIT_ED25519_PRIVATE_KEY, hash )
+--
+-- The signature is NOT keyed with APP_SIGNING_KEY, and the difference is the whole
+-- point. That key MINTS consent tokens, so signing the ledger with it meant the
+-- party with the most reason to rewrite the record of a permission held the key
+-- that could -- and because verification recomputed the MAC, no verifier existed
+-- anywhere that could check the chain without also being able to forge it. That is
+-- not AU-10 non-repudiation, it is self-attestation. The chain now signs under its
+-- own Ed25519 namespace and verifies with the PUBLIC key.
+--
+-- TWO LEDGERS, one table. `ledger` discriminates, and each ledger is its own
+-- per-subject sequence:
+--   'consent'  -- the person-visible permission record.
+--   'internal' -- the agent's OWN operations (consent_db.insert_internal_event),
+--                 which reached no chain at all before this: the largest class of
+--                 actions the system takes, with no receipt. Kept as a separate
+--                 sequence because merging would advance the head an owner pins on
+--                 every Kai turn, and a pin that moves constantly cannot detect the
+--                 truncation it exists to detect.
+--
+-- APPLYING THIS OVER AN EARLIER DEV COPY: rows written before the key separation
+-- carry an HMAC signature that verification now REFUSES (accepting it would restore
+-- the downgrade), and their hashes predate `ledger` entering the canonical payload.
+-- Truncate the table on dev as part of applying this. That is free only while the
+-- chain is dev-only; it stops being free the moment the flag reaches UAT.
+--
+-- verify_chain(subject_id) replays the chain and reports the first dropped,
+-- reordered, or tampered receipt (AU-9 protection of audit info, AU-10
+-- non-repudiation). Mirrors the proven fabric_receipts primitive (migration 119)
+-- but keyed on the consent subject rather than the PWM owner. Stores only consent-
+-- event metadata + receipt hashes; never token secrets or PKM values.
+-- Non-breaking + idempotent.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS consent_audit_receipts (
+  id              BIGSERIAL PRIMARY KEY,
+  subject_id      TEXT   NOT NULL,
+  ledger          TEXT   NOT NULL DEFAULT 'consent',
+  seq             BIGINT NOT NULL,
+  event_type      TEXT   NOT NULL,
+  agent_id        TEXT,
+  scope           TEXT,
+  request_id      TEXT,
+  token_id        TEXT,
+  audit_event_id  BIGINT,
+  issued_at_ms    BIGINT NOT NULL,
+  metadata        JSONB  NOT NULL DEFAULT '{}'::jsonb,
+  prev_hash       TEXT   NOT NULL,
+  hash            TEXT   NOT NULL,
+  signature       TEXT   NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (subject_id, ledger, seq),
+  UNIQUE (subject_id, ledger, hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consent_audit_receipts_subject
+  ON consent_audit_receipts (subject_id, ledger, id);
+
+CREATE INDEX IF NOT EXISTS idx_consent_audit_receipts_audit_event
+  ON consent_audit_receipts (audit_event_id);
+
+COMMENT ON TABLE consent_audit_receipts IS
+  'Tamper-evident consent-audit receipt chain (NIST 800-53 AU-9/AU-10). Append-only, per (subject_id, ledger): hash = sha256(prev_hash || canonical payload), signature = Ed25519 under CONSENT_AUDIT_ED25519_PRIVATE_KEY -- deliberately NOT the token-minting APP_SIGNING_KEY, so an auditor can verify with the public key while holding nothing that could write. ledger is consent (person-visible permissions) or internal (the agent own operations). Stores metadata + hashes only, never secrets.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/905_personal_agent_liveness.sql
+++ b/consent-protocol/db/migrations/parked/905_personal_agent_liveness.sql
@@ -1,0 +1,109 @@
+-- Pod liveness: a truthful source of "is this person's agent actually alive?".
+--
+-- PARKED (dev-only band, same contract as 900-904): out of
+-- db/release_migration_manifest.json, applied only by the dev migration lane, so
+-- the release migration head is untouched.
+--
+-- Why this exists
+-- ---------------
+-- personal_agent_reconcile_worker.py states the gap in its own docstring: the
+-- registry has no last-activity column, so "there is no truthful source of pod
+-- idleness in the schema today", and it refuses to reap on row AGE because that
+-- would tear down warm pods belonging to active people. The worker was written to
+-- take its idle set from an injected callable precisely so it would not have to
+-- lie about what `updated_at` means. These columns are what that callable can
+-- finally read.
+--
+-- Three columns, three distinct facts. Collapsing them would lose information:
+--
+--   last_heartbeat_at  -- OBSERVED. When the pod itself last spoke to the hub.
+--                         Written only by the pod's own authenticated heartbeat,
+--                         never inferred, so NULL genuinely means "never heard
+--                         from" and not "we forgot to look".
+--
+--   health_state       -- JUDGED. The hub's conclusion about the pod, which is a
+--                         different thing from the observation above and must not
+--                         be recomputed from it at read time by every caller.
+--                         Persisted so the presence surface, the reconcile sweep
+--                         and an operator all read one verdict rather than three
+--                         independently-derived ones that can disagree.
+--
+--   liveness_mode      -- The RULE by which silence is to be interpreted for THIS
+--                         pod. See below; this is the column that keeps the whole
+--                         feature from being wrong for half the fleet.
+--
+-- Why liveness_mode is stored per row and not read from the environment
+-- --------------------------------------------------------------------
+-- Silence means opposite things depending on how the pod was created:
+--
+--   warm     (minScale >= 1) -- a warm instance is paid for, so the pod is
+--                               *supposed* to be running. Silence is a fault.
+--   economy  (minScale  = 0) -- the pod is scale-to-zero. It is SUPPOSED to be
+--                               asleep when idle. Silence is the healthy steady
+--                               state, and "heal" here would mean waking (and
+--                               billing) a pod nobody asked for.
+--
+-- HUSSH_POD_MIN_INSTANCES is a deploy-wide environment variable that can change at
+-- any time. If liveness were judged against its CURRENT value, then flipping the
+-- fleet to economy would instantly re-classify every already-running warm pod, and
+-- flipping back would mark every sleeping economy pod as failed -- a mass false
+-- alarm, or worse, a mass auto-heal. The rule is therefore captured per row at
+-- creation from the value the pod was ACTUALLY created with, and each pod is
+-- judged by its own contract for as long as it lives.
+--
+-- Default 'warm': migration 900 predates any economy tier and every pod created
+-- before this migration was created with the minScale=1 default, so 'warm' is the
+-- historically accurate backfill rather than a convenient guess. It is also the
+-- safe direction -- a warm pod misjudged as economy would go unhealed and silently
+-- stay dead, while an economy pod misjudged as warm merely produces a probe.
+
+BEGIN;
+
+ALTER TABLE personal_agent_registry
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS health_state      TEXT NOT NULL DEFAULT 'unknown',
+    ADD COLUMN IF NOT EXISTS liveness_mode     TEXT NOT NULL DEFAULT 'warm',
+    -- When the hub last actually asked (probed) rather than merely waited. Keeps a
+    -- confirm-then-heal sweep from re-probing the same silent pod every pass: the
+    -- probe costs a request against a pod that may be asleep, and on the economy
+    -- tier a probe is what WAKES it, so an unthrottled sweep would keep the whole
+    -- economy fleet permanently awake -- exactly the bill the tier exists to avoid.
+    ADD COLUMN IF NOT EXISTS last_probe_at     TIMESTAMPTZ,
+    -- Consecutive confirmed failures. An auto-heal is a service replacement, so it
+    -- must not fire on a single blip; the evaluator requires this to cross a
+    -- threshold. Reset to 0 by any successful heartbeat or probe.
+    ADD COLUMN IF NOT EXISTS liveness_failures INTEGER NOT NULL DEFAULT 0,
+    -- When this pod was last auto-healed, so a pod that is broken in a way a
+    -- restart cannot fix (bad image, poisoned config) cannot be restarted forever
+    -- in a loop. The evaluator backs off against this.
+    ADD COLUMN IF NOT EXISTS last_healed_at    TIMESTAMPTZ;
+
+-- Legal values, enforced in the schema rather than only in Python. The registry is
+-- read by the presence surface, the reconcile worker and operators; a typo'd state
+-- that reached the table would be a silent wrong answer in all three.
+ALTER TABLE personal_agent_registry
+    DROP CONSTRAINT IF EXISTS personal_agent_registry_health_state_check;
+ALTER TABLE personal_agent_registry
+    ADD CONSTRAINT personal_agent_registry_health_state_check
+    CHECK (health_state IN ('unknown', 'healthy', 'degraded', 'unreachable', 'sleeping'));
+
+ALTER TABLE personal_agent_registry
+    DROP CONSTRAINT IF EXISTS personal_agent_registry_liveness_mode_check;
+ALTER TABLE personal_agent_registry
+    ADD CONSTRAINT personal_agent_registry_liveness_mode_check
+    CHECK (liveness_mode IN ('warm', 'economy'));
+
+-- The sweep's access pattern: find pods whose heartbeat is older than a cutoff.
+-- Partial on the statuses that can actually own a running host, because a row in
+-- 'unprovisioned' or 'deprovisioned' has no pod to be alive or dead -- indexing
+-- those would grow the index with rows the sweep must never act on.
+CREATE INDEX IF NOT EXISTS idx_personal_agent_registry_heartbeat
+    ON personal_agent_registry(last_heartbeat_at)
+    WHERE status IN ('provisioning', 'connecting', 'provisioned');
+
+-- Operator/dashboard access pattern: "show me everything not healthy right now".
+CREATE INDEX IF NOT EXISTS idx_personal_agent_registry_health_state
+    ON personal_agent_registry(health_state)
+    WHERE health_state <> 'healthy';
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/906_personal_agent_user_cloud.sql
+++ b/consent-protocol/db/migrations/parked/906_personal_agent_user_cloud.sql
@@ -1,0 +1,126 @@
+-- The person's own cloud: WHERE their pod runs, and WHOSE model credential serves it.
+--
+-- PARKED (dev-only band, same contract as 900-905): out of
+-- db/release_migration_manifest.json, applied only by the dev migration lane, so
+-- the release migration head is untouched.
+--
+-- Why this exists
+-- ---------------
+-- `PodSpec` has carried `deployment_target` and `model_credential_mode` since the
+-- per-person deployment axes landed, and the registry has had nowhere to put either.
+-- The consequence is not that BYOC is untested -- it is that BYOC is SINGLE-TENANT.
+-- `byoc_substrate.resolve_substrate_ensurer` and `UserGcpBackend.__init__` both read
+-- HUSSH_USER_GCP_PROJECT from the process environment, so the second person to choose
+-- their own cloud has their pod, their CMEK bucket, their KMS key and their service
+-- account created inside the FIRST person's project. That is an isolation failure, not
+-- a configuration gap, and these columns are the coordinates that end it.
+--
+-- Why columns and not backend_metadata JSONB
+-- ------------------------------------------
+-- backend_metadata is written at personal_agent_provisioning_service.py:522, AFTER
+-- backend.provision returns. The substrate ensurer is resolved at :501, BEFORE it. So
+-- tenant coordinates stored in backend_metadata are unreadable at the exact moment they
+-- are needed. backend_metadata is an OUTPUT of provisioning; these are INPUTS to it, and
+-- putting an input in the output blob means every provision overwrites the input with
+-- whatever the backend reported. Teardown and the orphan sweep also need to find a
+-- tenant BY QUERY, which a sometimes-absent JSONB key cannot support.
+--
+-- Six columns, six distinct facts. Collapsing any two would lose information:
+--
+--   deployment_target        -- WHICH backend builds this person's pod. Nullable, and
+--                               NULL means "the deployment default", which is what
+--                               every pre-existing row honestly is.
+--
+--   model_credential_mode    -- WHOSE credential the agent spends. Orthogonal to the
+--                               target on purpose: a person on their own cloud may
+--                               still hand over an API key, and the pair is what makes
+--                               that expressible rather than a special case.
+--
+--   user_cloud_project       -- The person's OWN GCP project id. The single fact whose
+--                               absence made the whole tier single-tenant.
+--
+--   user_cloud_region        -- Their region. Separate from the existing `region`
+--                               column, which records where the pod was actually
+--                               placed; this records where they ASKED for it. They
+--                               differ when a region is unavailable, and a request and
+--                               an outcome must not share a column.
+--
+--   user_cloud_bootstrap_sa  -- The account they authorized. STORED, never derived from
+--                               the project name, for the reason user_gcp_backend.py
+--                               already gives about identities: a guessed account that
+--                               happens to exist would be used silently, and the entire
+--                               point of the grant is that it was deliberately made.
+--
+--   user_cloud_authorized_at -- WHEN hushh last proved it can actually act there, by
+--                               minting a token and reading the bindings back. Separate
+--                               from user_cloud_project because "they typed a name" and
+--                               "hushh can act in it" are different facts, and
+--                               collapsing them into one boolean is how a gate becomes
+--                               decorative. NULL is the honest state for a project that
+--                               was named but never authorized, and provisioning must
+--                               refuse it rather than fall back to hushh's own cloud.
+
+BEGIN;
+
+ALTER TABLE personal_agent_registry
+    ADD COLUMN IF NOT EXISTS deployment_target        TEXT,
+    ADD COLUMN IF NOT EXISTS model_credential_mode    TEXT,
+    ADD COLUMN IF NOT EXISTS user_cloud_project       TEXT,
+    ADD COLUMN IF NOT EXISTS user_cloud_region        TEXT,
+    ADD COLUMN IF NOT EXISTS user_cloud_bootstrap_sa  TEXT,
+    ADD COLUMN IF NOT EXISTS user_cloud_authorized_at TIMESTAMPTZ;
+
+-- Legal values, enforced in the schema rather than only in Python, for the same reason
+-- 905 gives: the registry is read by the provisioning brain, the substrate resolver, the
+-- presence surface and operators, and a typo'd target that reached the table would be a
+-- silent wrong answer in all four. NULL stays legal -- it means "deployment default".
+--
+-- Each constraint is dropped exactly once before being added. A bare ADD CONSTRAINT
+-- succeeds on the first deploy and raises DuplicateObjectError forever after, because
+-- the release guard replays the set on every deploy. Migration 141 taught this twice.
+ALTER TABLE personal_agent_registry
+    DROP CONSTRAINT IF EXISTS personal_agent_registry_deployment_target_check;
+ALTER TABLE personal_agent_registry
+    ADD CONSTRAINT personal_agent_registry_deployment_target_check
+    CHECK (deployment_target IS NULL
+           OR deployment_target IN ('gcp', 'user_gcp', 'anypoint', 'null'));
+
+ALTER TABLE personal_agent_registry
+    DROP CONSTRAINT IF EXISTS personal_agent_registry_model_credential_mode_check;
+ALTER TABLE personal_agent_registry
+    ADD CONSTRAINT personal_agent_registry_model_credential_mode_check
+    CHECK (model_credential_mode IS NULL
+           OR model_credential_mode IN ('user_adc', 'byok_per_turn', 'fleet_adc'));
+
+-- A user_gcp row without a project is the exact shape of the single-tenant bug: it is
+-- the row that would silently fall back to the process-wide environment variable and put
+-- this person's pod in somebody else's project. Refuse it in the schema, so no code path
+-- anywhere can create one.
+ALTER TABLE personal_agent_registry
+    DROP CONSTRAINT IF EXISTS personal_agent_registry_user_gcp_needs_project_check;
+ALTER TABLE personal_agent_registry
+    ADD CONSTRAINT personal_agent_registry_user_gcp_needs_project_check
+    CHECK (deployment_target IS DISTINCT FROM 'user_gcp'
+           OR user_cloud_project IS NOT NULL);
+
+-- Two people must not resolve to one project. This is the isolation invariant stated
+-- where it cannot be bypassed: with it, "user #2 provisioned into user #1's cloud" stops
+-- being a bug that needs a test and becomes a state the database will not hold.
+--
+-- Partial, because it applies only to the tier that owns a project. Rows on hushh's own
+-- backends share hushh's project by design and must not collide.
+--
+-- Reversible: an enterprise that genuinely wants several people in one project is a real
+-- future case, and it is a DROP INDEX plus a decision about what isolation then means --
+-- not a schema rewrite.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_agent_registry_one_owner_per_cloud
+    ON personal_agent_registry(user_cloud_project)
+    WHERE deployment_target = 'user_gcp' AND user_cloud_project IS NOT NULL;
+
+-- Teardown and the orphan sweep both ask "what did we create in project X?". Without
+-- this they ask it with a sequential scan over the whole fleet.
+CREATE INDEX IF NOT EXISTS idx_personal_agent_registry_user_cloud_project
+    ON personal_agent_registry(user_cloud_project)
+    WHERE user_cloud_project IS NOT NULL;
+
+COMMIT;

--- a/consent-protocol/db/migrations/parked/907_pod_lifecycle_events.sql
+++ b/consent-protocol/db/migrations/parked/907_pod_lifecycle_events.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- Migration 907: pod_lifecycle_events — the provisioning narrative log
+-- ============================================================================
+-- Append-only narrative of one person's agent being built: lifecycle
+-- transitions, the 16 substrate steps, and terminal verdicts. The registry row
+-- (migration 900) REMAINS the single authority for state; this table is
+-- replayable narrative and a cursor source, never authority. On any
+-- disagreement the row wins — enforced by the stream's snapshot frame, which
+-- is read from the row on every connect.
+--
+-- WHY per-user seq AND NOT BIGSERIAL
+-- A BIGSERIAL value is handed out before commit, so writer A can hold 100
+-- while B holds 101 and commits first; a tailing reader that has seen 101
+-- never sees 100. That two-writer race is real here: the reconcile retry can
+-- overlap a live provision. Per-user seq computed inside one
+-- INSERT ... SELECT COALESCE(MAX(seq),0)+1 with PRIMARY KEY (user_id, seq)
+-- makes the race fail loudly (the writer retries once) instead of silently
+-- skipping a frame. It also keeps the cursor legible — "step 9 of your
+-- setup" — rather than a global row id that leaks fleet volume.
+--
+-- NO idempotency key, deliberately. A UNIQUE over (attempt, stage, step)
+-- silently destroys any legitimately repeating event under a fail-safe writer
+-- that swallows rejections. Presence (sleeping/waking) never enters this
+-- table at all, so the repeating-event case this would guard against does not
+-- exist; provisioning-retry duplicates are distinguished by `attempt`,
+-- incremented by the reconcile worker.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS pod_lifecycle_events (
+  user_id         TEXT        NOT NULL,
+  seq             BIGINT      NOT NULL,          -- per-user, gap-free. THE cursor.
+  hushh_id        TEXT,
+  attempt         INT         NOT NULL DEFAULT 1,
+  event           TEXT        NOT NULL,          -- stage | substrate_step | terminal
+  stage           TEXT        NOT NULL,          -- vocabulary shared with trace_pod_journey.py
+  registry_status TEXT        NOT NULL,          -- what AUTHORITY said when this row was written
+  progress_pct    SMALLINT    NOT NULL DEFAULT 0,
+  substrate_step  TEXT,                          -- one of the 16 bootstrap step ids
+  step_ok         BOOLEAN,
+  terminal        BOOLEAN     NOT NULL DEFAULT FALSE,
+  reason          TEXT,                          -- closed enum; never exception text
+  occurred_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ NOT NULL DEFAULT now() + interval '30 days',
+  PRIMARY KEY (user_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pod_lifecycle_expiry
+  ON pod_lifecycle_events (expires_at);
+
+-- ----------------------------------------------------------------------------
+-- Doorbell, never data. A NOTIFY payload is readable by any session that can
+-- LISTEN and is capped at 8000 bytes; the listener re-reads the actual rows by
+-- cursor. Same shape as migration 011's consent_audit trigger.
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pod_lifecycle_notify()
+RETURNS TRIGGER AS $$
+DECLARE
+  payload TEXT;
+BEGIN
+  payload := json_build_object('user_id', NEW.user_id, 'seq', NEW.seq)::TEXT;
+  PERFORM pg_notify('pod_lifecycle_new', payload);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS pod_lifecycle_after_insert ON pod_lifecycle_events;
+CREATE TRIGGER pod_lifecycle_after_insert
+  AFTER INSERT ON pod_lifecycle_events
+  FOR EACH ROW
+  EXECUTE FUNCTION pod_lifecycle_notify();
+
+COMMENT ON TABLE pod_lifecycle_events IS
+  'Append-only provisioning narrative. The registry row is authority; this is replayable narrative and the stream cursor source. 30-day retention via expires_at.';
+
+-- ----------------------------------------------------------------------------
+-- The registry status column becomes a closed set, and `reaped` joins it.
+--
+-- `status` has been free text since migration 900, so a typo in any of the
+-- four writers is undetectable until a reader misroutes on it. `reaped` is a
+-- correctness fix, not a nicety: today a reaped pod's row stays `provisioned`
+-- and /status reports a healthy agent for a host that does not exist.
+--
+-- NOT VALID first, then VALIDATE: existing rows are checked in a second step
+-- so a single historical oddity cannot brick the migration half-applied.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE personal_agent_registry
+  DROP CONSTRAINT IF EXISTS personal_agent_registry_status_check;
+
+ALTER TABLE personal_agent_registry
+  ADD CONSTRAINT personal_agent_registry_status_check
+  -- The REGISTRY vocabulary, exactly. `reserved` is deliberately absent: it is a
+  -- CLIENT state (_STATE_BY_REGISTRY_STATUS maps unprovisioned/pending onto it)
+  -- and has never been written to this column. Admitting it here would let a
+  -- future writer confuse the two vocabularies the mapping exists to separate.
+  CHECK (status IN (
+    'unprovisioned',
+    'pending',
+    'provisioning',
+    'connecting',
+    'provisioned',
+    'provisioning_failed',
+    'reaped'
+  )) NOT VALID;
+
+ALTER TABLE personal_agent_registry
+  VALIDATE CONSTRAINT personal_agent_registry_status_check;

--- a/consent-protocol/db/migrations/parked/908_personal_agent_tombstone_metadata.sql
+++ b/consent-protocol/db/migrations/parked/908_personal_agent_tombstone_metadata.sql
@@ -1,0 +1,12 @@
+-- 908: orphan address on deletion tombstones.
+--
+-- WHERE an unreclaimed pod lives (project/region/target) so a billing host stays
+-- reclaimable after the registry row is gone.
+--
+-- This column was briefly added by editing 900 in place, which tripped the
+-- migration authority on the next dev deploy: 900 was already APPLIED, and an
+-- applied migration's checksum is immutable (MigrationAuthorityError,
+-- db/migrate.py). The lesson is the release lane's rule holding in the parked
+-- lane too -- schema changes ride NEW migrations, never edits to applied ones.
+ALTER TABLE personal_agent_deletion_tombstones
+    ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/consent-protocol/db/migrations/parked/909_byoc_setup_jobs.sql
+++ b/consent-protocol/db/migrations/parked/909_byoc_setup_jobs.sql
@@ -1,0 +1,30 @@
+-- 909: the one-click cloud setup becomes an observable background job.
+--
+-- The six-stage chain (create project, link billing, enable APIs, apply IAM,
+-- settle the grant, prove and record) ran inside ONE synchronous HTTP request
+-- bounded by three stacked timeouts (backend settle 45s, proxy 55s, browser
+-- 60s). A fresh project legitimately needs longer -- measured live 2026-08-21:
+-- the founder's hussh-one-6pf68p spent 24s creating and enabling, leaving the
+-- settle window 15s against Google's minutes-scale IAM propagation -- so the
+-- person was told to "press Continue again", which is a machine's job.
+--
+-- One row per person, superseded in place by each new attempt: history is not
+-- the point, the CURRENT truth is. The row is written by the background task
+-- after each stage and read by the status route, which is what lets a person
+-- leave the screen, keep onboarding, and come back to a finished cloud.
+--
+-- The person's OAuth token NEVER touches this table: it lives in the task's
+-- memory for the job's lifetime, exactly as it lived in the request coroutine
+-- before. Stage names, timestamps, a typed refusal, and coordinates only.
+CREATE TABLE IF NOT EXISTS byoc_setup_jobs (
+    user_id TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'running',
+    stage TEXT NOT NULL DEFAULT 'starting',
+    stages JSONB NOT NULL DEFAULT '[]'::jsonb,
+    error_code TEXT,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/consent-protocol/db/migrations/parked/910_personal_agent_status_needs_reinit.sql
+++ b/consent-protocol/db/migrations/parked/910_personal_agent_status_needs_reinit.sql
@@ -1,0 +1,36 @@
+-- 910: admit `needs_reinit` into the registry status vocabulary.
+--
+-- The recovery lifecycle (2026-08-21) added the writer -- `mark_needs_reinit`
+-- flips a CONFIRMED-gone host's row to `needs_reinit` and clears the sticky
+-- cloud authorization -- but migration 907's CHECK enumerated the vocabulary
+-- without it. Observed live on dev (2026-08-25): the reachability gate detected
+-- a deleted host, the wake path tried to record the verdict, and Postgres
+-- refused with `personal_agent_registry_status_check` -- so the row stayed
+-- `active` with a dead host and the app's recovery affordance never rendered.
+-- A vocabulary reader and writer living in two files with nothing comparing
+-- them, again -- this time the second file was SQL. The paired guard now lives
+-- in tests/test_pod_status_vocabulary_is_one_vocabulary.py.
+--
+-- Same shape as 907: DROP IF EXISTS + ADD ... NOT VALID + VALIDATE, so replay
+-- is safe and a single historical oddity cannot brick the migration half-way.
+
+ALTER TABLE personal_agent_registry
+  DROP CONSTRAINT IF EXISTS personal_agent_registry_status_check;
+
+ALTER TABLE personal_agent_registry
+  ADD CONSTRAINT personal_agent_registry_status_check
+  -- The REGISTRY vocabulary, exactly: every status a writer produces and the
+  -- status route maps. `reserved` stays deliberately absent (a CLIENT state).
+  CHECK (status IN (
+    'unprovisioned',
+    'pending',
+    'provisioning',
+    'connecting',
+    'provisioned',
+    'provisioning_failed',
+    'needs_reinit',
+    'reaped'
+  )) NOT VALID;
+
+ALTER TABLE personal_agent_registry
+  VALIDATE CONSTRAINT personal_agent_registry_status_check;

--- a/consent-protocol/db/migrations/parked/911_pod_migration_jobs.sql
+++ b/consent-protocol/db/migrations/parked/911_pod_migration_jobs.sql
@@ -1,0 +1,64 @@
+-- 911: moving a private agent from one cloud to another becomes an observable job.
+--
+-- A person who started on the hosted tier must be able to move their agent into
+-- their own project without losing anything it has learned. That move is a chain
+-- of eleven steps across two clouds -- freeze, provision the destination, export,
+-- ferry, import and re-seal, verify, switch the row, reap the old host -- and any
+-- of them can take minutes. Running it inside one HTTP request would repeat the
+-- mistake 909 exists to correct, with a much worse failure mode: a timeout there
+-- costs a retry, a timeout here could leave a person's memory in flight between
+-- two pods with nothing recording where it got to.
+--
+-- One row per person, superseded in place by each new attempt, exactly as
+-- `byoc_setup_jobs` does. History is not the point; the CURRENT truth is, and it
+-- is what lets a person leave the screen and come back to a finished move.
+--
+-- WHAT THIS TABLE MAY NEVER HOLD, stated because the temptation is real:
+-- no key material, no bundle contents, no decrypted anything. The re-seal happens
+-- INSIDE the destination pod, because hushh structurally cannot perform it -- the
+-- bootstrap identity deliberately holds no KMS encrypt or decrypt. What is
+-- recorded here is coordinates and progress: which stage, when, and the two chain
+-- heads whose equality is the proof that nothing was lost.
+--
+-- `source_head_sha` / `target_head_sha` are the whole verification story. The
+-- commit log's chain hash is computed over PLAINTEXT fields ({seq, kind, payload,
+-- prev_sha}), so a re-seal that preserves them verifies identically under the
+-- destination's own key. Byte-equal heads is therefore a cryptographic statement
+-- that every record arrived intact and in order, not a sample of them. The switch
+-- happens only when they match; a mismatch fails the job with the source still
+-- frozen and whole, so the worst outcome is a move that did not happen.
+CREATE TABLE IF NOT EXISTS pod_migration_jobs (
+    user_id TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    hushh_id TEXT NOT NULL,
+    -- Where it is going.
+    target_project TEXT NOT NULL,
+    target_region TEXT,
+    -- Where it is coming FROM, captured at freeze time.
+    --
+    -- Duplicating a registry fact is normally the wrong instinct, and it is the
+    -- right one here: standing up the destination rewrites the row's host
+    -- coordinates, so by the time the export runs the row no longer knows where
+    -- the source pod is. Reading the source address from the row would then
+    -- export from the pod that has no history yet -- an empty bundle, reported
+    -- as a successful move. The ticket is the only place this can be held.
+    source_pod_url TEXT,
+    source_service TEXT,
+    status TEXT NOT NULL DEFAULT 'running',
+    stage TEXT NOT NULL DEFAULT 'starting',
+    stages JSONB NOT NULL DEFAULT '[]'::jsonb,
+    -- The zero-loss oracle. Both are NULL until their side reports; the switch
+    -- refuses unless they are equal and non-empty.
+    source_head_sha TEXT,
+    source_record_count INTEGER,
+    target_head_sha TEXT,
+    target_record_count INTEGER,
+    error_code TEXT,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The status route reads by user; the sweep reads by staleness.
+CREATE INDEX IF NOT EXISTS idx_pod_migration_jobs_status_updated
+    ON pod_migration_jobs (status, updated_at DESC);

--- a/consent-protocol/db/migrations/parked/912_personal_agent_status_migrating.sql
+++ b/consent-protocol/db/migrations/parked/912_personal_agent_status_migrating.sql
@@ -1,0 +1,46 @@
+-- 912: admit `migrating` into the registry status vocabulary.
+--
+-- Moving a person's agent between clouds needs a state that means "this row's
+-- pod is frozen while its memory is in flight". Without one, the only options
+-- were to leave the row `provisioned` (so the relay keeps serving turns into a
+-- pod whose log is being exported, and the export races a live writer) or to
+-- borrow `provisioning` (which the retry sweep would pick up and re-provision,
+-- replacing the very pod being migrated from).
+--
+-- `migrating` is read as a REFUSAL by every writer path -- the relay declines
+-- turns and ticks with a person-language message, the reconcile sweep skips the
+-- row entirely, and liveness suspends judgement -- which is what makes the
+-- export's single-writer assumption true rather than hoped for. The commit log's
+-- generation check is the second half of that guarantee: the export pins the
+-- head generation at start and re-reads it at finish, so a write that slipped
+-- through anyway aborts the export instead of silently losing a record.
+--
+-- Written before 911's job service so the status vocabulary and its writer land
+-- together. Migration 910 exists because they did not, once: the writer shipped,
+-- the CHECK did not learn the word, and a live recovery failed at the database
+-- with the row left claiming a host that was gone.
+--
+-- Same shape as 907 and 910: DROP IF EXISTS + ADD ... NOT VALID + VALIDATE, so
+-- replay is safe and one historical oddity cannot brick the migration half-way.
+
+ALTER TABLE personal_agent_registry
+  DROP CONSTRAINT IF EXISTS personal_agent_registry_status_check;
+
+ALTER TABLE personal_agent_registry
+  ADD CONSTRAINT personal_agent_registry_status_check
+  -- The REGISTRY vocabulary, exactly: every status a writer produces and the
+  -- status route maps. `reserved` stays deliberately absent (a CLIENT state).
+  CHECK (status IN (
+    'unprovisioned',
+    'pending',
+    'provisioning',
+    'connecting',
+    'provisioned',
+    'provisioning_failed',
+    'needs_reinit',
+    'migrating',
+    'reaped'
+  )) NOT VALID;
+
+ALTER TABLE personal_agent_registry
+  VALIDATE CONSTRAINT personal_agent_registry_status_check;

--- a/scripts/ops/verify_runtime_db_contract.sh
+++ b/scripts/ops/verify_runtime_db_contract.sh
@@ -83,7 +83,15 @@ esac
 
 command -v gcloud >/dev/null 2>&1 || { echo "gcloud is required" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
-command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+# The interpreter that runs the release guard. Overridable because the guard
+# imports `asyncpg`, which lives in the consent-protocol environment and not in
+# whatever `python3` resolves to on a PATH. Hardcoding it here is how a caller
+# that HAD resolved the right interpreter still ended up running the guard under
+# one that could not import it (measured 2026-08-29: the RCA runner chose the
+# project venv for every check except this one, because this one goes through
+# bash). Defaults to `python3`, so every existing caller is unchanged.
+PYTHON="${PYTHON:-python3}"
+command -v "$PYTHON" >/dev/null 2>&1 || { echo "$PYTHON is required" >&2; exit 1; }
 
 if [ -z "$REPORT_PATH" ]; then
   REPORT_PATH="$(mktemp "${TMPDIR:-/tmp}/runtime-db-contract.XXXXXX")"
@@ -195,7 +203,7 @@ export DB_NAME
 export DB_USER
 export DB_PASSWORD
 
-python3 "$REPO_ROOT/scripts/ops/db_migration_release_guard.py" \
+"$PYTHON" "$REPO_ROOT/scripts/ops/db_migration_release_guard.py" \
   --release-environment "$RELEASE_ENVIRONMENT" \
   --contract-file "$CONTRACT_FILE" \
   --report-path "$REPORT_PATH"


### PR DESCRIPTION
Two additive changes, deliberately scoped so neither can affect UAT, production, or main's release lane.

## What this is

The per-person pod schema lives on a development branch that is 336 commits ahead of `main` and 308 behind it (644 files, +104k). That branch is not merging any time soon, and it should not. This lands only the part that benefits from existing on `main` early, plus one unrelated operator-path fix.

## 1. Reserve the parked 900 band (13 files, additive)

`consent-protocol/db/migrations/parked/900_*.sql` through `912_*.sql`, unapplied and unreferenced.

**Nothing on `main` can see them.** Every enumerator that decides what runs, deploys, or is checked reads `db/migrations/` non-recursively, so a subdirectory matches none of them:

| Enumerator | How |
|---|---|
| `scripts/ops/db_migration_release_guard.py:64` | `iterdir()` + `is_file()` |
| `scripts/ops/verify_release_migration_contract.py:116` | `iterdir()` + `is_file()` |
| `consent-protocol/tests/test_migrations_are_replay_safe.py:96` | `glob("*.sql")` |

They are also absent from `db/release_migration_manifest.json`, which `migrate.py` resolves by flat filename join, never by directory scan. The release guard runs post-apply in all three deploy workflows and sees nothing new.

Verified on this branch: `verify_release_migration_contract.py` reports repo head **185**, UAT contract **185**, prod contract **185**, dev **185** — identical to `main`.

**Why now.** `main`'s migration head moved 176 to 185 while this schema was in flight. Holding the band on `main` turns the eventual renumber-into-sequence into a rename inside one PR, rather than a renumber race against every branch cut in the interval.

**Deliberately not ported:** `db/dev_migration_manifest.json`, `migrate.py`'s dev lane, and `tests/test_dev_migration_lane.py`. Without a manifest, a reader, or a writer these files are inert, which is the point of landing them early. The promotion procedure stays with the feature work.

## 2. Unpin the interpreter in `verify_runtime_db_contract.sh`

It hardcoded `python3` when invoking `db_migration_release_guard.py`. That guard imports `asyncpg`, which lives in the consent-protocol environment and not in whatever `python3` resolves to on an operator's PATH, so a caller that had already resolved a working interpreter still ran this one check under one that could not import it.

`PYTHON="${PYTHON:-python3}"` preserves prior behaviour byte-for-byte for every existing caller. **No workflow or CI script invokes this file**; it is an operator path only.

## Verification

- `consent-protocol/scripts/run-test-ci.sh` — **1564 passed**, exit 0
- `scripts/ops/verify_release_migration_contract.py` — head 185, contracts aligned, exit 0
- `tests/test_migrations_are_replay_safe.py`, `tests/test_server_startup_guards.py` — 16 passed
- `./bin/hushh docs verify` — passed
- `scripts/ci/check-dco-signoff.sh` — passed for 2 commits
- Diff shape: 13 added, 1 modified. No renames, no deletions. No protected pipeline path touched.

## Notes for review

- Please merge as a **merge commit**, not a squash. The two commits have disjoint paths and disjoint rollback triggers, and per-item revertability is worth keeping.
- Rollback for (1) is `git rm` on 13 files that nothing references; for (2) it is a one-line revert that no caller can observe.