### PR TITLE
feat(one-location): 2px accent frame on the Shared with me map preview

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1689,7 +1689,18 @@ function LocalMapPreview({
           : "rounded-[var(--app-card-radius-standard)] border border-border/70",
       )}
     >
-      <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
+      <div
+        className={cn(
+          "relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]",
+          // Nested in SharedWithMeCard the preview draws no card of its own, so
+          // THIS element frames the map: a 2px iOS-accent outline rounded to the
+          // container's 14px inner radius on top (so the stroke follows the same
+          // curve the container clips to instead of being sliced by it) and
+          // square on the bottom, where the metadata column continues below.
+          nested &&
+            "rounded-t-[14px] rounded-b-none border-2 border-[color:var(--app-accent)]",
+        )}
+      >
         <LiveMap point={point} viewportResetKey={viewportResetKey} />
         <div className="pointer-events-none absolute left-3 top-3">
           <span


### PR DESCRIPTION
## What

Adds the intentional visual for the **Shared with me** map preview: a continuous **2px `--app-accent`** outline around the map viewport — rounded on the top corners, square on the bottom.

| | |
|---|---|
| Top-left / top-right | rounded to the 14px nested inner radius |
| Bottom-left / bottom-right | square |
| Border | 2px, all four sides, continuous across the bottom |
| Metadata + "Location may be stale" | outside the frame, unchanged |

## Why this is not the clipping bug

The clipped corners and the browser-zoom seam were already fixed in `46f879e1f` (#6217) by making the nested preview inherit `SharedWithMeCard`'s 14px rounding and drop its own card. This PR builds **on top of** that architecture — it does not revert it.

## How

One change, in `LocalMapPreview`, gated on `nested`:

- `nested` path (SharedWithMeCard): the map viewport carries `border-2 border-[color:var(--app-accent)] rounded-t-[14px] rounded-b-none`.
- standalone Check-In (`nested = false`): untouched — still its own 24px card.
- `LiveMap` gets **no** radius; the viewport's `overflow-hidden` is the map's direct-parent clip. All three nesting levels round to the same 14px → no radius mismatch, no seam.

The `nested` / `rounded-[inherit]` / standalone-card structure and the hub's `// SharedWithMeCard already draws and clips` comment are intact; the pinning contract test still passes.

## Verification

- Isolated repro mirroring the 3-level nested tree at **100 / 125 / 150 / 175 / 200%** browser zoom: rounded top corners clean (no sliver / white gap / double edge), square bottom, continuous 2px border, metadata + stale warning outside.
- `h-48 sm:h-56`, widths, responsive behaviour unchanged.
- Tests: `one-location-copy-pass.contract`, `shared-with-me-card`, `share-lanes`, `live-map` (41) + `one-location-agent-page` (127) pass. ESLint clean.

Closes #6222