### PR TITLE
feat(one-pkm): n-level nested Memory browsing in /one/pkm

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-memory-level.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-memory-level.test.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PkmMemoryLevel } from "@/components/profile/pkm-memory-level";
+import type { PkmMemoryCard, PkmPathSegment } from "@/lib/pkm/pkm-memory-cards";
+
+function financialData() {
+  return {
+    goals: {
+      retirement: {
+        target_corpus: "5 crore",
+        milestones: [
+          { name: "First 1 crore", status: "done" },
+          { name: "Second target", status: "pending" },
+        ],
+      },
+      house: { down_payment: "40 lakh" },
+    },
+  } as Record<string, unknown>;
+}
+
+/** Harness that owns the navigation stack exactly like PkmNaturalPanel does. */
+function Harness({
+  onExit,
+  onOpenLeaf,
+}: {
+  onExit: () => void;
+  onOpenLeaf: (card: PkmMemoryCard) => void;
+}) {
+  const [pathStack, setPathStack] = useState<PkmPathSegment[]>([]);
+  return (
+    <PkmMemoryLevel
+      domainKey="financial"
+      domainTitle="Financial"
+      data={financialData()}
+      pathStack={pathStack}
+      loading={false}
+      error={false}
+      sharingImpactError={null}
+      onDrill={(segment) => setPathStack((stack) => [...stack, segment])}
+      onBack={() => {
+        if (pathStack.length === 0) {
+          onExit();
+          return;
+        }
+        setPathStack((stack) => stack.slice(0, -1));
+      }}
+      onOpenLeaf={onOpenLeaf}
+    />
+  );
+}
+
+describe("PkmMemoryLevel", () => {
+  it("drills through 3+ levels showing only immediate children, then Back walks up one at a time", () => {
+    const onExit = vi.fn();
+    const onOpenLeaf = vi.fn();
+    render(<Harness onExit={onExit} onOpenLeaf={onOpenLeaf} />);
+
+    // Level 0 — domain root.
+    expect(screen.getByRole("heading", { name: "Financial" })).toBeTruthy();
+    expect(screen.getByTestId("memory-group-goals")).toHaveTextContent("Goals");
+    expect(screen.queryByText("Retirement")).toBeNull();
+
+    // Level 1.
+    fireEvent.click(screen.getByRole("button", { name: "Open Goals" }));
+    expect(screen.getByRole("heading", { name: "Goals" })).toBeTruthy();
+    const retirement = screen.getByTestId("memory-group-retirement");
+    expect(retirement).toHaveTextContent("Retirement");
+    // target_corpus + 2 milestones x {name,status} = 5 descendant memories.
+    expect(retirement).toHaveTextContent("5");
+
+    // Level 2.
+    fireEvent.click(screen.getByRole("button", { name: "Open Retirement" }));
+    expect(screen.getByRole("heading", { name: "Retirement" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open memory: Target Corpus" })).toBeTruthy();
+
+    // Level 3 — nested array, human-readable item labels (never "[0]").
+    fireEvent.click(screen.getByRole("button", { name: "Open Milestones" }));
+    expect(screen.getByRole("heading", { name: "Milestones" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open First 1 crore" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open Second target" })).toBeTruthy();
+    expect(screen.getByText("Financial › Goals › Retirement")).toBeTruthy();
+
+    // Back = exactly one level up, each press.
+    fireEvent.click(screen.getByRole("button", { name: "Retirement" }));
+    expect(screen.getByRole("heading", { name: "Retirement" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Goals" }));
+    expect(screen.getByRole("heading", { name: "Goals" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Financial" }));
+    expect(screen.getByRole("heading", { name: "Financial" })).toBeTruthy();
+
+    // Back from the root asks the parent to leave the category.
+    expect(onExit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Memory" }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a leaf with its exact path", () => {
+    const onOpenLeaf = vi.fn();
+    render(<Harness onExit={vi.fn()} onOpenLeaf={onOpenLeaf} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Goals" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Retirement" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open memory: Target Corpus" }));
+
+    expect(onOpenLeaf).toHaveBeenCalledTimes(1);
+    expect(onOpenLeaf.mock.calls[0][0].pathSegments).toEqual([
+      "goals",
+      "retirement",
+      "target_corpus",
+    ]);
+  });
+
+  it("renders a defensive not-found state when the path is gone", () => {
+    render(
+      <PkmMemoryLevel
+        domainKey="financial"
+        domainTitle="Financial"
+        data={financialData()}
+        pathStack={["goals", "missing"]}
+        loading={false}
+        error={false}
+        sharingImpactError={null}
+        onDrill={vi.fn()}
+        onBack={vi.fn()}
+        onOpenLeaf={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("This memory moved")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
@@ -207,13 +207,44 @@ describe("PkmNaturalPanel — Memory redesign", () => {
     expect(screen.queryByText(/sk-must-not-render/)).toBeNull();
   });
 
-  it("opens a category into a simple memory list", async () => {
+  it("opens a category into nested levels and Back walks up one level", async () => {
     await openMainScreen();
     fireEvent.click(screen.getByRole("button", { name: "Open category: Financial" }));
 
     expect(await screen.findByRole("heading", { name: "Financial" })).toBeTruthy();
-    expect(screen.getByTestId("memory-category-list-financial")).toBeTruthy();
+    // Immediate children only — groups with a chevron, not flattened leaves.
+    expect(await screen.findByTestId("memory-group-profile")).toHaveTextContent("Profile");
+    expect(screen.getByTestId("memory-group-accounts")).toHaveTextContent("Accounts");
+    expect(screen.queryByRole("button", { name: "Open memory: Primary Bank" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Accounts" }));
+    expect(await screen.findByRole("heading", { name: "Accounts" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open memory: Primary Bank" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Financial" }));
+    expect(await screen.findByRole("heading", { name: "Financial" })).toBeTruthy();
+    expect(screen.getByTestId("memory-group-accounts")).toBeTruthy();
+  });
+
+  it("shows a readable path on deep search hits and returns to the same results", async () => {
+    await openMainScreen();
+    const box = screen.getByRole("searchbox", { name: "Search Memory" });
+    fireEvent.change(box, { target: { value: "balanced" } });
+
+    const result = await screen.findByRole("button", { name: "Open memory: Risk Profile" });
+    expect(
+      within(screen.getByTestId("memory-search-results")).getByText("Financial › Profile"),
+    ).toBeTruthy();
+
+    fireEvent.click(result);
+    expect(await screen.findByRole("heading", { name: "Risk Profile" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Memory" }));
+    // The query and its results are still there — search is a shortcut, not a drill.
+    expect(screen.getByRole("searchbox", { name: "Search Memory" })).toHaveValue("balanced");
+    expect(
+      await screen.findByRole("button", { name: "Open memory: Risk Profile" }),
+    ).toBeTruthy();
   });
 
   it("searches title/value and shows a clean empty state", async () => {
@@ -245,6 +276,8 @@ describe("PkmNaturalPanel — Memory redesign", () => {
     await waitFor(() => expect(meta).toHaveTextContent("Shared"));
 
     fireEvent.click(screen.getByRole("button", { name: "Memory" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open category: Financial" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open Accounts" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open memory: Primary Bank" }));
     const meta2 = await screen.findByTestId("memory-detail-meta");
     // accounts scope is NOT shared even though another scope in the same domain is.

--- a/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
@@ -5,6 +5,7 @@ import {
   deletePkmDomainValue,
   pkmMemoryRowLabels,
   selectRelevantPkmMemoryCards,
+  shouldSkipPkmMemoryKey,
   updatePkmDomainValue,
 } from "@/lib/pkm/pkm-memory-cards";
 import type { PersonalKnowledgeModelMetadata } from "@/lib/services/personal-knowledge-model-service";
@@ -170,6 +171,44 @@ describe("PKM memory cards", () => {
     expect(card.pathSegments).toContain("sf_residence_001");
     expect(card.detail).not.toMatch(/sf residence|sf_residence_001/i);
     expect(card.detail).toContain("Changes");
+  });
+
+  it("browses and searches array items past index 11 (no per-array truncation)", () => {
+    const holdings = Array.from({ length: 15 }, (_, index) => `HOLD${index + 1}`);
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: { professional: { portfolio: { holdings } } },
+    });
+
+    const item15 = snapshot.cards.find((entry) => entry.path === "portfolio.holdings[14]");
+    expect(item15?.value).toBe("HOLD15");
+
+    const found = selectRelevantPkmMemoryCards(snapshot.cards, "HOLD15", 5);
+    expect(found.map((entry) => entry.value)).toContain("HOLD15");
+  });
+
+  describe("shouldSkipPkmMemoryKey", () => {
+    it("hides raw underscore-prefixed keys that normalization would otherwise unmask", () => {
+      expect(shouldSkipPkmMemoryKey("_internal")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("_private_metadata")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("  _hidden")).toBe(true);
+    });
+
+    it("still renders ordinary user keys", () => {
+      expect(shouldSkipPkmMemoryKey("risk_profile")).toBe(false);
+      expect(shouldSkipPkmMemoryKey("target_corpus")).toBe(false);
+      expect(shouldSkipPkmMemoryKey("student_id")).toBe(false);
+      expect(shouldSkipPkmMemoryKey("primary_bank")).toBe(false);
+    });
+
+    it("keeps existing reserved / secret / id filtering", () => {
+      expect(shouldSkipPkmMemoryKey("runtime_secrets")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("kyc_workflow")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("manifest_version")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("vault_passphrase")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("access_token")).toBe(true);
+      expect(shouldSkipPkmMemoryKey("artifact_id")).toBe(true);
+    });
   });
 
   describe("pkmMemoryRowLabels", () => {

--- a/hushh-webapp/__tests__/lib/pkm-memory-level.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-level.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  pkmMemoryCardBreadcrumb,
+  resolvePkmMemoryLevel,
+} from "@/lib/pkm/pkm-memory-level";
+import { buildPkmMemoryCardsFromNode } from "@/lib/pkm/pkm-memory-cards";
+
+/**
+ * Synthetic nested fixture only — the arbitrary-depth PKM shape the Memory
+ * browser must walk without reading anyone's encrypted vault.
+ */
+function financialData() {
+  return {
+    goals: {
+      retirement: {
+        target_corpus: "5 crore",
+        target_age: 55,
+        auth_token: "must-not-render",
+        milestones: [
+          { name: "First 1 crore", status: "done" },
+          { title: "Second milestone", status: "pending" },
+          { status: "future" },
+        ],
+      },
+      house: { down_payment: "40 lakh" },
+    },
+    runtime_secrets: { api_key: "sk-must-not-render" },
+    kyc_workflow: { step: "done" },
+    manifest_version: 4,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const BASE = {
+  domainKey: "financial",
+  domainTitle: "Financial",
+  sourceLabel: "Saved memory",
+  updatedAt: null,
+};
+
+describe("resolvePkmMemoryLevel", () => {
+  it("shows only the immediate children at the domain root and hides reserved/internal keys", () => {
+    const level = resolvePkmMemoryLevel({ ...BASE, data: financialData(), pathStack: [] });
+
+    expect(level.title).toBe("Financial");
+    expect(level.parentLabel).toBe("Memory");
+    expect(level.entries.map((entry) => entry.kind === "group" && entry.label)).toEqual([
+      "Goals",
+    ]);
+    expect(level.entries[0]).toMatchObject({ kind: "group", segment: "goals" });
+    // runtime_secrets / _private / kyc_workflow / updated_at never surface.
+    expect(JSON.stringify(level)).not.toContain("must-not-render");
+    expect(JSON.stringify(level)).not.toContain("Kyc");
+  });
+
+  it("descends one arbitrary level at a time and counts descendant memories", () => {
+    const data = financialData();
+
+    const goals = resolvePkmMemoryLevel({ ...BASE, data, pathStack: ["goals"] });
+    expect(goals.title).toBe("Goals");
+    expect(goals.crumbs).toEqual(["Financial", "Goals"]);
+    // Retirement: target_corpus + target_age + 5 milestone fields (auth_token is hidden).
+    expect(goals.entries.map((e) => (e.kind === "group" ? [e.label, e.childCount] : e))).toEqual([
+      ["Retirement", 7],
+      ["House", 1],
+    ]);
+
+    const retirement = resolvePkmMemoryLevel({
+      ...BASE,
+      data,
+      pathStack: ["goals", "retirement"],
+    });
+    expect(retirement.crumbs).toEqual(["Financial", "Goals", "Retirement"]);
+    // Two readable leaves, one nested array group — the secret leaf is gone.
+    expect(retirement.entries.map((e) => e.kind)).toEqual(["leaf", "leaf", "group"]);
+    const leafTitles = retirement.entries
+      .filter((e): e is Extract<typeof e, { kind: "leaf" }>=> e.kind === "leaf")
+      .map((e) => e.card.pathSegments.join("."));
+    expect(leafTitles).toEqual([
+      "goals.retirement.target_corpus",
+      "goals.retirement.target_age",
+    ]);
+    expect(JSON.stringify(retirement)).not.toContain("must-not-render");
+  });
+
+  it("labels array items from name/title/label and never from a raw index", () => {
+    const milestones = resolvePkmMemoryLevel({
+      ...BASE,
+      data: financialData(),
+      pathStack: ["goals", "retirement", "milestones"],
+    });
+
+    expect(milestones.crumbs).toEqual(["Financial", "Goals", "Retirement", "Milestones"]);
+    expect(milestones.entries.map((e) => e.kind === "group" && e.label)).toEqual([
+      "First 1 crore",
+      "Second milestone",
+      "Milestone 3",
+    ]);
+    // Drilling into an array item still exposes its exact path for mutation.
+    const nested = resolvePkmMemoryLevel({
+      ...BASE,
+      data: financialData(),
+      pathStack: ["goals", "retirement", "milestones", 0],
+    });
+    const statusLeaf = nested.entries.find(
+      (e): e is Extract<typeof e, { kind: "leaf" }>=>
+        e.kind === "leaf" && e.card.pathSegments.join(".") === "goals.retirement.milestones.0.status",
+    );
+    expect(statusLeaf).toBeDefined();
+  });
+
+  it("preserves siblings — every non-hidden child of a level is listed", () => {
+    const retirement = resolvePkmMemoryLevel({
+      ...BASE,
+      data: financialData(),
+      pathStack: ["goals", "retirement"],
+    });
+    const keys = retirement.entries.map((e) =>
+      e.kind === "leaf" ? e.card.pathSegments.at(-1) : e.segment,
+    );
+    expect(keys).toEqual(["target_corpus", "target_age", "milestones"]);
+  });
+
+  it("exposes every array item, including past index 11", () => {
+    const holdings = Array.from({ length: 15 }, (_, index) => ({
+      name: `Holding ${index + 1}`,
+      units: index + 1,
+    }));
+    const data = { portfolio: { holdings } } as Record<string, unknown>;
+
+    const level = resolvePkmMemoryLevel({
+      ...BASE,
+      data,
+      pathStack: ["portfolio", "holdings"],
+    });
+    expect(level.entries).toHaveLength(15);
+    expect(level.entries.map((e) => e.kind === "group" && e.label)).toContain("Holding 15");
+
+    // ...and its leaves carry the exact index-15 path for edit / forget.
+    const item15 = resolvePkmMemoryLevel({
+      ...BASE,
+      data,
+      pathStack: ["portfolio", "holdings", 14],
+    });
+    const unitsLeaf = item15.entries.find(
+      (e): e is Extract<typeof e, { kind: "leaf" }>=>
+        e.kind === "leaf" && e.card.pathSegments.join(".") === "portfolio.holdings.14.units",
+    );
+    expect(unitsLeaf?.card.value).toBe("15");
+  });
+
+  it("flags a path that no longer resolves", () => {
+    const level = resolvePkmMemoryLevel({
+      ...BASE,
+      data: financialData(),
+      pathStack: ["goals", "gone"],
+    });
+    expect(level.notFound).toBe(true);
+    expect(level.entries).toEqual([]);
+  });
+
+  it("keeps a drilled leaf card identical to its search-snapshot card", () => {
+    const data = financialData();
+    const level = resolvePkmMemoryLevel({
+      ...BASE,
+      data,
+      pathStack: ["goals", "retirement"],
+    });
+    const drilled = level.entries.find(
+      (e): e is Extract<typeof e, { kind: "leaf" }>=> e.kind === "leaf",
+    )!.card;
+
+    const [fromNode] = buildPkmMemoryCardsFromNode({
+      domain: "financial",
+      domainTitle: "Financial",
+      value: data.goals.retirement.target_corpus,
+      sourceLabel: "Saved memory",
+      updatedAt: null,
+      pathSegments: ["goals", "retirement", "target_corpus"],
+    });
+    expect(drilled.id).toBe(fromNode.id);
+    expect(drilled.valueFingerprint).toBe(fromNode.valueFingerprint);
+  });
+});
+
+describe("pkmMemoryCardBreadcrumb", () => {
+  it("renders a human path and drops the leaf, indices and entity ids", () => {
+    const [card] = buildPkmMemoryCardsFromNode({
+      domain: "financial",
+      domainTitle: "Financial",
+      value: "5 crore",
+      sourceLabel: "Saved memory",
+      updatedAt: null,
+      pathSegments: ["goals", "retirement", "target_corpus"],
+    });
+    expect(pkmMemoryCardBreadcrumb(card)).toBe("Financial › Goals › Retirement");
+
+    const [entityCard] = buildPkmMemoryCardsFromNode({
+      domain: "changes",
+      domainTitle: "Changes",
+      value: "I moved cities",
+      sourceLabel: "Saved memory",
+      updatedAt: null,
+      pathSegments: ["history", "entities", "mem_abc123", "summary"],
+    });
+    expect(pkmMemoryCardBreadcrumb(entityCard)).toBe("Changes › History");
+  });
+});

--- a/hushh-webapp/components/profile/pkm-memory-level.tsx
+++ b/hushh-webapp/components/profile/pkm-memory-level.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useMemo } from "react";
+import { ChevronLeft, Loader2 } from "lucide-react";
+
+import { PkmMemoryRow } from "@/components/profile/pkm-memory-row";
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { SurfaceInset } from "@/components/app-ui/surfaces";
+import type { PkmMemoryCard, PkmPathSegment } from "@/lib/pkm/pkm-memory-cards";
+import { resolvePkmMemoryLevel } from "@/lib/pkm/pkm-memory-level";
+
+/**
+ * One generic level of nested Memory browsing, iOS Settings-style. The same
+ * component renders every depth; position is driven entirely by `pathStack`, so
+ * there is no Level 1 / Level 2 / Level 3 special-casing.
+ *
+ * Only the current level's immediate children are shown: groups as navigation
+ * rows with a child count and a chevron, leaves as title + value. Back moves
+ * exactly one segment up (the parent decides what "up" means at the root).
+ */
+export function PkmMemoryLevel({
+  domainKey,
+  domainTitle,
+  data,
+  pathStack,
+  loading,
+  error,
+  sharingImpactError,
+  sourceLabel,
+  updatedAt,
+  onDrill,
+  onBack,
+  onOpenLeaf,
+}: {
+  domainKey: string;
+  domainTitle: string;
+  data: Record<string, unknown> | null;
+  pathStack: PkmPathSegment[];
+  loading: boolean;
+  error: boolean;
+  sharingImpactError: string | null;
+  sourceLabel?: string;
+  updatedAt?: string | null;
+  onDrill: (segment: PkmPathSegment) => void;
+  onBack: () => void;
+  onOpenLeaf: (card: PkmMemoryCard) => void;
+}) {
+  const level = useMemo(
+    () =>
+      resolvePkmMemoryLevel({
+        domainKey,
+        domainTitle,
+        data,
+        pathStack,
+        sourceLabel,
+        updatedAt,
+      }),
+    [domainKey, domainTitle, data, pathStack, sourceLabel, updatedAt],
+  );
+
+  const atRoot = pathStack.length === 0;
+  const isEmpty = level.entries.length === 0;
+
+  return (
+    <div className="space-y-7" data-pkm-detail-panel="true" data-pkm-memory-level="true">
+      <button
+        type="button"
+        onClick={onBack}
+        className="-ml-1 inline-flex min-h-11 items-center gap-1 text-[15px] font-normal text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" aria-hidden />
+        {level.parentLabel}
+      </button>
+
+      <div className="space-y-1">
+        {!atRoot ? (
+          <p
+            className="text-[13px] font-medium uppercase tracking-wide text-muted-foreground"
+            data-pkm-level-breadcrumb="true"
+          >
+            {level.crumbs.slice(0, -1).join(" › ")}
+          </p>
+        ) : null}
+        <h2 className="text-[26px] font-semibold leading-tight tracking-tight text-foreground">
+          {level.title}
+        </h2>
+      </div>
+
+      {sharingImpactError ? (
+        <p className="px-1 text-sm text-destructive">{sharingImpactError}</p>
+      ) : null}
+
+      {level.notFound ? (
+        <SurfaceInset className="space-y-1 p-4 text-sm text-muted-foreground">
+          <p className="font-semibold text-foreground">This memory moved</p>
+          <p>Go back and open it again.</p>
+        </SurfaceInset>
+      ) : !isEmpty ? (
+        <SettingsGroup separatorInset testId={`memory-level-list-${domainKey}`}>
+          {level.entries.map((entry) =>
+            entry.kind === "group" ? (
+              <SettingsRow
+                key={entry.key}
+                title={entry.label}
+                onClick={() => onDrill(entry.segment)}
+                chevron
+                ariaLabel={`Open ${entry.label}`}
+                testId={`memory-group-${entry.key}`}
+                trailing={
+                  <span className="text-[15px] tabular-nums text-muted-foreground">
+                    {entry.childCount}
+                  </span>
+                }
+              />
+            ) : (
+              <PkmMemoryRow key={entry.key} card={entry.card} onOpen={onOpenLeaf} />
+            ),
+          )}
+        </SettingsGroup>
+      ) : loading ? (
+        <SurfaceInset className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Opening {level.title}…
+        </SurfaceInset>
+      ) : error ? (
+        <SurfaceInset className="space-y-1 p-4 text-sm text-muted-foreground">
+          <p className="font-semibold text-foreground">This couldn’t be opened</p>
+          <p>Go back and try again.</p>
+        </SurfaceInset>
+      ) : (
+        <SurfaceInset className="p-4 text-sm text-muted-foreground">
+          Nothing is saved in {level.title} yet.
+        </SurfaceInset>
+      )}
+    </div>
+  );
+}

--- a/hushh-webapp/components/profile/pkm-memory-row.tsx
+++ b/hushh-webapp/components/profile/pkm-memory-row.tsx
@@ -9,22 +9,27 @@ import { pkmMemoryRowLabels, type PkmMemoryCard } from "@/lib/pkm/pkm-memory-car
  * search results so those three surfaces never drift apart.
  *
  * Deliberately carries no metadata (source, timestamp, sharing state) and no
- * inline edit/forget controls — those live in the memory detail view.
+ * inline edit/forget controls — those live in the memory detail view. When a
+ * `breadcrumb` is passed (deep search results), it replaces the value subtitle
+ * so the row orients the hit inside the nested structure, e.g.
+ * `Financial › Goals › Retirement`.
  */
 export function PkmMemoryRow({
   card,
   onOpen,
   testId,
+  breadcrumb,
 }: {
   card: PkmMemoryCard;
   onOpen: (card: PkmMemoryCard) => void;
   testId?: string;
+  breadcrumb?: string;
 }) {
   const { primary, secondary } = pkmMemoryRowLabels(card);
   return (
     <SettingsRow
       title={primary}
-      description={secondary || undefined}
+      description={breadcrumb || secondary || undefined}
       onClick={() => onOpen(card)}
       chevron
       ariaLabel={`Open memory: ${primary}`}

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, Loader2, Lock, ShieldAlert } from "lucide-react";
+import { Loader2, Lock, ShieldAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { PkmMemoryRow } from "@/components/profile/pkm-memory-row";
+import { PkmMemoryLevel } from "@/components/profile/pkm-memory-level";
 import {
   PkmMemoryDetail,
   type MemorySharingState,
@@ -44,7 +45,9 @@ import {
   selectRelevantPkmMemoryCards,
   updatePkmDomainValue,
   type PkmMemoryCard,
+  type PkmPathSegment,
 } from "@/lib/pkm/pkm-memory-cards";
+import { pkmMemoryCardBreadcrumb } from "@/lib/pkm/pkm-memory-level";
 import {
   buildPkmShareBundles,
   pkmShareBundleState,
@@ -110,7 +113,8 @@ export function PkmNaturalPanel({
   const [bootstrapError, setBootstrapError] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [selectedDomainKey, setSelectedDomainKey] = useState<string | null>(null);
-  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  const [pathStack, setPathStack] = useState<PkmPathSegment[]>([]);
+  const [selectedCard, setSelectedCard] = useState<PkmMemoryCard | null>(null);
   const [domainDetail, setDomainDetail] = useState<DomainDetailState>(EMPTY_DOMAIN_DETAIL);
   const [memoryCardsNonce, setMemoryCardsNonce] = useState(0);
   const [memoryActionId, setMemoryActionId] = useState<string | null>(null);
@@ -270,6 +274,12 @@ export function PkmNaturalPanel({
     [selectedDomainKey, visibleMetadataDomains]
   );
 
+  // Entering or leaving a category always starts the nested browser at the
+  // category root; Back then walks the stack down exactly one segment at a time.
+  useEffect(() => {
+    setPathStack([]);
+  }, [selectedDomainKey]);
+
   // Only ever browse cards whose domain a consumer is allowed to see. This is a
   // second guard behind buildPkmMemorySnapshot: reserved domains (runtime
   // secrets, KYC) and domains a backend marks not consumer-visible must never
@@ -285,11 +295,6 @@ export function PkmNaturalPanel({
         ? browsableCards.filter((card) => card.domain === selectedDomainKey)
         : [],
     [browsableCards, selectedDomainKey]
-  );
-
-  const selectedCard = useMemo(
-    () => browsableCards.find((card) => card.id === selectedCardId) || null,
-    [browsableCards, selectedCardId]
   );
 
   const categoryCounts = useMemo(() => {
@@ -432,6 +437,7 @@ export function PkmNaturalPanel({
     };
   }, [
     isVaultUnlocked,
+    memoryCardsNonce,
     pkmChangeRevision,
     selectedMetadataDomain,
     user,
@@ -552,7 +558,7 @@ export function PkmNaturalPanel({
   useEffect(() => {
     if (selectedCard) void ensureSharingImpact(selectedCard);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCardId]);
+  }, [selectedCard?.id]);
 
   async function persistMemoryCardChange(params: {
     card: PkmMemoryCard;
@@ -623,7 +629,7 @@ export function PkmNaturalPanel({
       );
       morphyToast.success(params.action === "edited" ? "Memory updated." : "Memory forgotten.");
       resetMemoryActionState();
-      setSelectedCardId(null);
+      setSelectedCard(null);
       setMemoryCardsNonce((value) => value + 1);
     } catch (error) {
       setMemoryActionError(
@@ -803,7 +809,7 @@ export function PkmNaturalPanel({
   const recentMemories = browsableCards.slice(0, 6);
 
   function openMemory(card: PkmMemoryCard) {
-    setSelectedCardId(card.id);
+    setSelectedCard(card);
     setMemoryActionError(null);
   }
 
@@ -879,7 +885,7 @@ export function PkmNaturalPanel({
           deleting={memoryActionId === `${selectedCard.id}:deleted`}
           actionError={memoryActionError}
           onBack={() => {
-            setSelectedCardId(null);
+            setSelectedCard(null);
             setMemoryActionError(null);
           }}
           onOpenSharing={() => router.push(ROUTES.CONSENTS)}
@@ -893,49 +899,34 @@ export function PkmNaturalPanel({
   }
 
   if (selectedMetadataDomain) {
-    const categoryTitle = selectedMetadataDomain.displayName;
-    const categoryCards = domainMemoryCards;
     return (
-      <>{nativeBeacon}<div className="space-y-7" data-pkm-detail-panel="true">
-        <button
-          type="button"
-          onClick={() => setSelectedDomainKey(null)}
-          className="-ml-1 inline-flex min-h-11 items-center gap-1 text-[15px] font-normal text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ChevronLeft className="h-4 w-4" aria-hidden />
-          Memory
-        </button>
-
-        <h2 className="text-[26px] font-semibold leading-tight tracking-tight text-foreground">
-          {categoryTitle}
-        </h2>
-
-        {sharingImpactError ? (
-          <p className="px-1 text-sm text-destructive">{sharingImpactError}</p>
-        ) : null}
-
-        {categoryCards.length > 0 ? (
-          <SettingsGroup separatorInset testId={`memory-category-list-${selectedMetadataDomain.key}`}>
-            {categoryCards.map((card) => (
-              <PkmMemoryRow key={card.id} card={card} onOpen={openMemory} />
-            ))}
-          </SettingsGroup>
-        ) : domainDetail.loading || memoryCardsLoading ? (
-          <SurfaceInset className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            Opening {categoryTitle}…
-          </SurfaceInset>
-        ) : domainDetail.error ? (
-          <SurfaceInset className="space-y-1 p-4 text-sm text-muted-foreground">
-            <p className="font-semibold text-foreground">This category couldn’t be opened</p>
-            <p>Go back and try again.</p>
-          </SurfaceInset>
-        ) : (
-          <SurfaceInset className="p-4 text-sm text-muted-foreground">
-            Nothing is saved in {categoryTitle} yet.
-          </SurfaceInset>
-        )}
-      </div></>
+      <>
+        {nativeBeacon}
+        <PkmMemoryLevel
+          domainKey={selectedMetadataDomain.key}
+          domainTitle={selectedMetadataDomain.displayName}
+          data={domainDetail.data}
+          pathStack={pathStack}
+          loading={domainDetail.loading || memoryCardsLoading}
+          error={domainDetail.error}
+          sharingImpactError={sharingImpactError}
+          sourceLabel={selectedMetadataDomain.readableSourceLabel || undefined}
+          updatedAt={
+            selectedMetadataDomain.readableUpdatedAt ||
+            selectedMetadataDomain.lastUpdated ||
+            null
+          }
+          onDrill={(segment) => setPathStack((stack) => [...stack, segment])}
+          onBack={() => {
+            if (pathStack.length === 0) {
+              setSelectedDomainKey(null);
+              return;
+            }
+            setPathStack((stack) => stack.slice(0, -1));
+          }}
+          onOpenLeaf={openMemory}
+        />
+      </>
     );
   }
 
@@ -985,7 +976,12 @@ export function PkmNaturalPanel({
                 {searchResults.length > 0 ? (
                   <SettingsGroup title="Memories" separatorInset testId="memory-search-results">
                     {searchResults.map((card) => (
-                      <PkmMemoryRow key={card.id} card={card} onOpen={openMemory} />
+                      <PkmMemoryRow
+                        key={card.id}
+                        card={card}
+                        onOpen={openMemory}
+                        breadcrumb={pkmMemoryCardBreadcrumb(card)}
+                      />
                     ))}
                   </SettingsGroup>
                 ) : null}

--- a/hushh-webapp/lib/pkm/pkm-memory-cards.ts
+++ b/hushh-webapp/lib/pkm/pkm-memory-cards.ts
@@ -43,8 +43,11 @@ export type PkmMemorySnapshot = {
 const DEFAULT_MAX_CARDS = 96;
 const DEFAULT_MAX_CARDS_PER_DOMAIN = 24;
 const MAX_VALUE_CHARS = 180;
-const MAX_DEPTH = 6;
-const MAX_ARRAY_ITEMS = 12;
+// Defensive traversal guard. Memory nesting and array length are arbitrary by
+// design, so this caps total nodes visited (against a pathologically large or
+// malformed blob) rather than imposing a fixed semantic depth or a per-array
+// item limit that would hide later entries from browsing and search.
+const MAX_TREE_NODE_VISITS = 20_000;
 
 const INTERNAL_KEYS = new Set([
   "algorithm",
@@ -144,11 +147,13 @@ function parseDomainSummary(metadata: PersonalKnowledgeModelMetadata | null): Ma
  * to resolve a turn-local provider credential; it is never agent memory.
  */
 export function shouldSkipPkmMemoryKey(key: string): boolean {
+  // A leading underscore marks a private/internal key by convention. Check it on
+  // the raw key: normalizeKey() strips underscores, so this must run before it.
+  if (String(key ?? "").trim().startsWith("_")) return true;
   const normalized = normalizeKey(key);
   if (!normalized) return true;
   if (INTERNAL_KEYS.has(normalized)) return true;
   if (INTERNAL_PKM_DOMAINS.has(normalized) || SECRET_KEY_PATTERN.test(normalized)) return true;
-  if (normalized.startsWith("_")) return true;
   if (normalized.endsWith("_id") && normalized !== "student_id") return true;
   if (normalized.includes("cipher") || normalized.includes("token")) return true;
   return false;
@@ -234,14 +239,20 @@ function flattenCards(params: {
   value: unknown;
   sourceLabel: string;
   updatedAt: string | null;
-  depth?: number;
   pathSegments?: PkmPathSegment[];
   cards?: PkmMemoryCard[];
+  visits?: { count: number };
 }): PkmMemoryCard[] {
-  const depth = params.depth || 0;
   const pathSegments = params.pathSegments || [];
   const cards = params.cards || [];
-  if (depth > MAX_DEPTH || cards.length >= DEFAULT_MAX_CARDS_PER_DOMAIN * 3) return cards;
+  const visits = params.visits || { count: 0 };
+  visits.count += 1;
+  if (
+    visits.count > MAX_TREE_NODE_VISITS ||
+    cards.length >= DEFAULT_MAX_CARDS_PER_DOMAIN * 3
+  ) {
+    return cards;
+  }
 
   const primitive = primitiveValue(params.value);
   if (primitive) {
@@ -274,13 +285,13 @@ function flattenCards(params: {
   }
 
   if (Array.isArray(params.value)) {
-    params.value.slice(0, MAX_ARRAY_ITEMS).forEach((item, index) => {
+    params.value.forEach((item, index) => {
       flattenCards({
         ...params,
         value: item,
-        depth: depth + 1,
         pathSegments: [...pathSegments, index],
         cards,
+        visits,
       });
     });
     return cards;
@@ -292,12 +303,29 @@ function flattenCards(params: {
     flattenCards({
       ...params,
       value: child,
-      depth: depth + 1,
       pathSegments: [...pathSegments, key],
       cards,
+      visits,
     });
   }
   return cards;
+}
+
+/**
+ * Public wrapper around the internal flattener: given one node of decrypted
+ * domain data and the exact path segments that reach it, return the readable
+ * leaf memory cards beneath it. Used by the nested Memory level navigator so a
+ * drilled-in leaf carries the same id / fingerprint / labels as a search hit.
+ */
+export function buildPkmMemoryCardsFromNode(params: {
+  domain: string;
+  domainTitle: string;
+  value: unknown;
+  sourceLabel: string;
+  updatedAt: string | null;
+  pathSegments: PkmPathSegment[];
+}): PkmMemoryCard[] {
+  return flattenCards(params);
 }
 
 function tokens(value: string): Set<string> {

--- a/hushh-webapp/lib/pkm/pkm-memory-level.ts
+++ b/hushh-webapp/lib/pkm/pkm-memory-level.ts
@@ -1,0 +1,297 @@
+"use client";
+
+import {
+  buildPkmMemoryCardsFromNode,
+  shouldSkipPkmMemoryKey,
+  type PkmMemoryCard,
+  type PkmPathSegment,
+} from "@/lib/pkm/pkm-memory-cards";
+
+/**
+ * One immediate child of the current Memory level.
+ *
+ * A `group` is an object/array that still has readable memories beneath it and
+ * is rendered as an iOS-style navigation row with a chevron and a count. A
+ * `leaf` is a single readable value rendered as title + value; its `card`
+ * carries the exact PKM path so edit / forget reuse the existing coordinator.
+ */
+export type PkmMemoryLevelGroup = {
+  kind: "group";
+  key: string;
+  segment: PkmPathSegment;
+  label: string;
+  childCount: number;
+};
+
+export type PkmMemoryLevelLeaf = {
+  kind: "leaf";
+  key: string;
+  card: PkmMemoryCard;
+};
+
+export type PkmMemoryLevelEntry = PkmMemoryLevelGroup | PkmMemoryLevelLeaf;
+
+export type PkmMemoryLevelView = {
+  /** Human labels from the domain down to the current level, e.g. ["Financial","Goals","Retirement"]. */
+  crumbs: string[];
+  /** Label of the current level (last crumb). */
+  title: string;
+  /** Label one level up, for the single Back control. "Memory" at the domain root. */
+  parentLabel: string;
+  entries: PkmMemoryLevelEntry[];
+  /** The current path no longer resolves in the decrypted data (it changed under us). */
+  notFound: boolean;
+};
+
+// Defensive guard for the recursive descendant count only. Traversal depth is
+// unbounded by design; this stops a pathologically large blob from stalling a
+// render.
+const MAX_COUNT_NODE_VISITS = 50_000;
+
+const NAME_KEYS = [
+  "name",
+  "title",
+  "label",
+  "display_name",
+  "displayName",
+  "nickname",
+  "headline",
+  "summary",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readablePrimitive(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+function clipText(value: string, maxChars: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}...`;
+}
+
+function humanize(segment: string): string {
+  return segment
+    .replace(/\[\d+\]/g, " ")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .trim();
+}
+
+function humanizeSingular(segment: PkmPathSegment | null): string {
+  if (segment === null || typeof segment === "number") return "Item";
+  return humanize(segment).replace(/s$/i, "") || "Item";
+}
+
+/** An object key that is an opaque identifier rather than a readable name. */
+function looksLikeOpaqueId(segment: string): boolean {
+  return (
+    /^(mem|ent|entity|item|entry|rec|record|obj|node|evt|event)[_-][a-z0-9][a-z0-9_-]{2,}$/i.test(
+      segment,
+    ) ||
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/i.test(segment) ||
+    /^[0-9a-f]{16,}$/i.test(segment)
+  );
+}
+
+function namedLabel(value: unknown): string | null {
+  if (isRecord(value)) {
+    for (const key of NAME_KEYS) {
+      const candidate = value[key];
+      if (typeof candidate === "string" && candidate.trim()) {
+        return clipText(candidate, 60);
+      }
+    }
+    return null;
+  }
+  const primitive = readablePrimitive(value);
+  return primitive ? clipText(primitive, 60) : null;
+}
+
+/**
+ * Readable label for one child, given its own segment, its value, and the
+ * segment of its parent. Array items and entity-map entries are named from a
+ * `name` / `title` / `label` field when present and never from a raw index or
+ * an internal identifier.
+ */
+function childLabel(
+  segment: PkmPathSegment,
+  value: unknown,
+  parentSegment: PkmPathSegment | null,
+): string {
+  const parentIsEntityMap =
+    typeof parentSegment === "string" &&
+    (parentSegment.toLowerCase() === "entities" || parentSegment.toLowerCase() === "_items");
+
+  if (typeof segment === "number") {
+    return (
+      namedLabel(value) ?? `${humanizeSingular(parentSegment)} ${segment + 1}`
+    );
+  }
+
+  if (parentIsEntityMap || looksLikeOpaqueId(segment)) {
+    return namedLabel(value) ?? "Saved item";
+  }
+
+  const normalized = segment.toLowerCase();
+  if (normalized === "entities" || normalized === "_items") return "Saved items";
+  return humanize(segment);
+}
+
+function countLeafMemories(node: unknown, budget: { remaining: number }): number {
+  if (budget.remaining <= 0) return 0;
+  budget.remaining -= 1;
+  if (readablePrimitive(node) !== null) return 1;
+  if (Array.isArray(node)) {
+    let total = 0;
+    for (const item of node) {
+      total += countLeafMemories(item, budget);
+      if (budget.remaining <= 0) break;
+    }
+    return total;
+  }
+  if (isRecord(node)) {
+    let total = 0;
+    for (const [key, value] of Object.entries(node)) {
+      if (shouldSkipPkmMemoryKey(key)) continue;
+      total += countLeafMemories(value, budget);
+      if (budget.remaining <= 0) break;
+    }
+    return total;
+  }
+  return 0;
+}
+
+function walkTo(
+  data: Record<string, unknown>,
+  pathStack: readonly PkmPathSegment[],
+): { node: unknown; crumbLabels: string[]; missing: boolean } {
+  let node: unknown = data;
+  let parentSegment: PkmPathSegment | null = null;
+  const crumbLabels: string[] = [];
+  for (const segment of pathStack) {
+    const container = node;
+    let child: unknown;
+    if (typeof segment === "number") {
+      child = Array.isArray(container) ? container[segment] : undefined;
+    } else {
+      child = isRecord(container) ? container[segment] : undefined;
+    }
+    if (child === undefined) {
+      return { node: undefined, crumbLabels, missing: true };
+    }
+    crumbLabels.push(childLabel(segment, child, parentSegment));
+    parentSegment = segment;
+    node = child;
+  }
+  return { node, crumbLabels, missing: false };
+}
+
+/**
+ * Resolve exactly one level of nested Memory: the crumbs down to `pathStack`
+ * and the immediate children at that position. Never descends past the current
+ * level, never emits an empty group, and never surfaces reserved / internal
+ * keys (delegated to `shouldSkipPkmMemoryKey`).
+ */
+export function resolvePkmMemoryLevel(params: {
+  domainKey: string;
+  domainTitle: string;
+  data: Record<string, unknown> | null;
+  pathStack: readonly PkmPathSegment[];
+  sourceLabel?: string;
+  updatedAt?: string | null;
+}): PkmMemoryLevelView {
+  const { domainKey, domainTitle, pathStack } = params;
+  const baseView = (over: Partial<PkmMemoryLevelView> = {}): PkmMemoryLevelView => ({
+    crumbs: [domainTitle],
+    title: domainTitle,
+    parentLabel: "Memory",
+    entries: [],
+    notFound: false,
+    ...over,
+  });
+
+  if (!isRecord(params.data)) {
+    return baseView({ notFound: pathStack.length > 0 });
+  }
+
+  const { node, crumbLabels, missing } = walkTo(params.data, pathStack);
+  const crumbs = [domainTitle, ...crumbLabels];
+  const title = crumbs[crumbs.length - 1] ?? domainTitle;
+  const parentLabel = crumbs.length >= 2 ? crumbs[crumbs.length - 2]! : "Memory";
+
+  if (missing) {
+    return { crumbs, title, parentLabel, entries: [], notFound: true };
+  }
+
+  const parentSegment = pathStack.length > 0 ? pathStack[pathStack.length - 1]! : null;
+  const rawChildren: Array<[PkmPathSegment, unknown]> = Array.isArray(node)
+    ? node.map((value, index) => [index, value] as [PkmPathSegment, unknown])
+    : isRecord(node)
+      ? Object.entries(node).filter(([key]) => !shouldSkipPkmMemoryKey(key))
+      : [];
+
+  const entries: PkmMemoryLevelEntry[] = [];
+  for (const [segment, value] of rawChildren) {
+    const childPath: PkmPathSegment[] = [...pathStack, segment];
+
+    if (readablePrimitive(value) !== null) {
+      const [card] = buildPkmMemoryCardsFromNode({
+        domain: domainKey,
+        domainTitle,
+        value,
+        sourceLabel: params.sourceLabel || "Saved memory",
+        updatedAt: params.updatedAt ?? null,
+        pathSegments: childPath,
+      });
+      if (card) entries.push({ kind: "leaf", key: String(segment), card });
+      continue;
+    }
+
+    const childCount = countLeafMemories(value, { remaining: MAX_COUNT_NODE_VISITS });
+    if (childCount === 0) continue;
+    entries.push({
+      kind: "group",
+      key: String(segment),
+      segment,
+      label: childLabel(segment, value, parentSegment),
+      childCount,
+    });
+  }
+
+  return { crumbs, title, parentLabel, entries, notFound: false };
+}
+
+/**
+ * Human-readable ancestry for a memory, e.g. `Financial › Goals › Retirement`,
+ * used to orient a deep search hit. Drops the leaf segment, array indices, and
+ * entity-map identifiers so it never leaks a raw path or internal id.
+ */
+export function pkmMemoryCardBreadcrumb(card: PkmMemoryCard): string {
+  const parts: string[] = [card.domainTitle];
+  const ancestry = card.pathSegments.slice(0, -1);
+  let skipNext = false;
+  for (const segment of ancestry) {
+    if (typeof segment === "number") continue;
+    const normalized = segment.toLowerCase();
+    if (normalized === "entities" || normalized === "_items") {
+      skipNext = true;
+      continue;
+    }
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (shouldSkipPkmMemoryKey(segment)) continue;
+    parts.push(humanize(segment));
+  }
+  return parts.join(" › ");
+}


### PR DESCRIPTION
Closes #6224

## What

Opening a category in `/one/pkm` now lets you drill through nested PKM/NoSQL data **one level at a time** in an iOS Settings-style UI, instead of a flattened list. The minimal #6190 Memory home (search, Recently learned, Categories, Add, Sharing) is unchanged.

```
Memory → Financial → Goals → Retirement → Target corpus
```

## How arbitrary depth works

One generic `PkmMemoryLevel` component renders **every** depth, driven entirely by a `pathStack: PkmPathSegment[]`. Depth = `pathStack.length`, unbounded — no Level 1/2/3 branches. Drill = push a segment; Back = pop exactly one (at the root, Back exits to Memory home).

`resolvePkmMemoryLevel()` (pure) walks the real `loadDomainData` record — structure preserved, not flattened — and returns only the **immediate** children of the current position:
- object/array with readable descendants → **group** row with a descendant-memory count + chevron
- primitive → **leaf** row (title + value); its card carries the exact PKM path
- empty / all-hidden → omitted (no empty folders)
- array items & entity-map entries labelled from `name`/`title`/`label`, never a raw index or `mem_*` id
- reserved/internal keys filtered through the existing `shouldSkipPkmMemoryKey` at every level

Deep **search** hits show a human path (`Financial › Goals › Retirement`); tapping opens the exact memory detail, and Back returns to the **same query + results** (search is a shortcut, not a drill).

## Write path unchanged

Editing / forgetting a leaf still goes through `PkmWriteCoordinator` → `updatePkmDomainValue` / `deletePkmDomainValue`, gated on `getMutationSharingImpact`, fail-closed consent behaviour intact. No whole-branch deletion (the mutation API is leaf-only). No backend / schema / encryption / Vault / auth / Add / Sharing changes.

## Fixes bundled

**Privacy regression** — `shouldSkipPkmMemoryKey` now checks the raw key for a leading `_` *before* `normalizeKey()` strips it, so `_internal` / `_private_metadata` are hidden again (the old normalized check was dead code).

**Defensive-limit regression** — removed `MAX_ARRAY_ITEMS = 12`, which silently hid array items past index 11 from search. Traversal is now bounded by a total node-visit budget (`MAX_TREE_NODE_VISITS`) + the existing per-domain card cap, so arbitrarily long arrays are fully browseable/searchable while pathological blobs stay bounded.

## Files

| File | |
|---|---|
| `lib/pkm/pkm-memory-level.ts` | new — level resolver + breadcrumb |
| `components/profile/pkm-memory-level.tsx` | new — generic level component |
| `lib/pkm/pkm-memory-cards.ts` | `_`-prefix fix, drop `MAX_ARRAY_ITEMS`, node-visit guard, export `buildPkmMemoryCardsFromNode` |
| `components/profile/pkm-natural-panel.tsx` | category branch → `PkmMemoryLevel` + nav stack; deep-search breadcrumb; `selectedCard` object |
| `components/profile/pkm-memory-row.tsx` | optional `breadcrumb` prop |
| `__tests__/lib/pkm-memory-level.test.ts` · `__tests__/components/pkm-memory-level.test.tsx` | new |
| `__tests__/lib/pkm-memory-cards.test.ts` · `__tests__/components/pkm-natural-panel.test.tsx` | updated |

## Tests

`vitest run` on the touched + adjacent PKM suites — pass. `tsc --noEmit` — clean. `eslint` (touched files) — clean.

Covered: 3+ level navigation, back navigation, nested arrays (incl. 15-item array browse + search past index 11), deep search, exact-path edit, exact-path forget, sibling preservation, hidden/internal keys (`_internal`, `_private_metadata`, `runtime_secrets`, `kyc_workflow`, …), per-scope sharing.

## Manual verification

Verified live on `localhost` against real nested vault data: category → group rows with counts, 5-level drill with breadcrumb eyebrow, Back one level at a time, entity ids hidden as "Saved items", deep-search path labels + open-exact + return-to-query, leaf detail sharing/edit/forget enabled at depth.
