### PR TITLE
Add one-hour Needs Review approval

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1486,7 +1486,80 @@ describe("OneLocationAgentPage", () => {
     expect(
       within(flow).getByRole("button", { name: "Approve 1 hour" }),
     ).toBeTruthy();
+    expect(
+      within(flow).queryByRole("button", { name: "Allow 1 hour" }),
+    ).toBeNull();
     expect(within(flow).getByRole("button", { name: "Decline" })).toBeTruthy();
+  });
+
+  it("lets Needs review approve a longer request for only one hour", async () => {
+    const request = {
+      id: "request_review_four_hours",
+      ownerUserId: "user_a",
+      requesterUserId: "user_b",
+      requesterDisplayName: "Trusted B",
+      status: "pending" as const,
+      message: "Running late",
+      requestedAt: "2026-05-20T07:30:00.000Z",
+      requestedDurationHours: 4,
+      requestedDurationMode: "timed",
+    };
+    const requester = locationState().recipients[0]!;
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [],
+      requests: [request],
+    });
+    mockApproveRequest.mockResolvedValueOnce({
+      request: {
+        ...request,
+        status: "approved",
+        approvedGrantId: "grant_one_hour",
+      },
+      grant: {
+        id: "grant_one_hour",
+        ownerUserId: "user_a",
+        recipientUserId: "user_b",
+        recipientKeyId: "key_b",
+        status: "active",
+        consentScope: "cap.location.live.view",
+        capabilityScopes: ["cap.location.live.view"],
+        durationHours: 1,
+        durationMode: "timed",
+        expiresAt: "2026-05-20T08:30:00.000Z",
+      },
+      recipient: requester,
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Needs review/i }),
+    );
+
+    const flow = await screen.findByTestId("one-location-needs-review");
+    expect(
+      within(flow).getByRole("button", { name: "Approve 4 hours" }),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      within(flow).getByRole("button", { name: "Allow 1 hour" }),
+    );
+
+    await waitFor(() => expect(mockApproveRequest).toHaveBeenCalledTimes(1));
+    expect(mockApproveRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "request_review_four_hours",
+        approvalMode: "manual",
+        durationHours: 1,
+        durationMode: "timed",
+      }),
+    );
+    await waitFor(() => expect(mockStoreEnvelope).toHaveBeenCalledTimes(1));
+    expect(within(flow).getByRole("status")).toHaveTextContent("Approved");
   });
 
   it("uses a compact sharing-first Now composition without dashboard groups", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -336,6 +336,7 @@ import type {
   OneLocationRecommendationReason,
   OneLocationRecipient,
   OneLocationRecipientPage,
+  OneLocationShareDurationMode,
   OneLocationState,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
@@ -8504,7 +8505,11 @@ export function OneLocationAgentPageContent({
   const approveAccessRequest = useCallback(
     async (
       request: OneLocationAccessRequest,
-      options?: { automatic?: boolean },
+      options?: {
+        automatic?: boolean;
+        durationHoursOverride?: number;
+        durationModeOverride?: OneLocationShareDurationMode;
+      },
     ): Promise<boolean> => {
       if (!vaultOwnerToken) return false;
       const automatic = options?.automatic === true;
@@ -8520,9 +8525,15 @@ export function OneLocationAgentPageContent({
         // the ask carried no amount (older clients, referral requests).
         const requestedHours = Number(request.requestedDurationHours);
         const approvedHours =
-          Number.isFinite(requestedHours) && requestedHours > 0
+          options?.durationHoursOverride ??
+          (Number.isFinite(requestedHours) && requestedHours > 0
             ? requestedHours
-            : Number(durationHours);
+            : Number(durationHours));
+        const approvedMode =
+          options?.durationModeOverride ??
+          (request.requestedDurationMode === "until_stopped"
+            ? "until_stopped"
+            : "timed");
         const response = await OneLocationService.approveRequest({
           vaultOwnerToken,
           requestId: request.id,
@@ -8530,11 +8541,7 @@ export function OneLocationAgentPageContent({
           // Automatic approval answers the locked request exactly; only a
           // manual owner action may override its duration.
           durationHours: automatic ? undefined : approvedHours,
-          durationMode: automatic
-            ? undefined
-            : request.requestedDurationMode === "until_stopped"
-              ? "until_stopped"
-              : "timed",
+          durationMode: automatic ? undefined : approvedMode,
           autoApproveRuleVersion: automatic
             ? autoApprovePreference.ruleVersion
             : undefined,
@@ -8603,8 +8610,14 @@ export function OneLocationAgentPageContent({
   );
 
   const handleApprove = useCallback(
-    async (request: OneLocationAccessRequest) => {
-      await approveAccessRequest(request);
+    async (
+      request: OneLocationAccessRequest,
+      options?: {
+        durationHoursOverride?: number;
+        durationModeOverride?: OneLocationShareDurationMode;
+      },
+    ) => {
+      return approveAccessRequest(request, options);
     },
     [approveAccessRequest],
   );
@@ -8669,16 +8682,18 @@ export function OneLocationAgentPageContent({
 
   const handleDeny = useCallback(
     async (requestId: string) => {
-      if (!vaultOwnerToken) return;
+      if (!vaultOwnerToken) return false;
       setBusy("deny");
       try {
         await OneLocationService.denyRequest({ vaultOwnerToken, requestId });
         toast.success("Request denied.");
         void refresh().catch(() => null);
+        return true;
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Could not deny request.",
         );
+        return false;
       } finally {
         setBusy(null);
       }
@@ -13308,8 +13323,8 @@ export function OneLocationAgentPageContent({
     onEnterShareConfirm: announceShareReviewOpened,
     onConfirmShare: () => void handleShare(),
     onSendRequest: (reason) => handleRequestAccess(reason),
-    onApprove: (request) => void handleApprove(request),
-    onDeny: (requestId) => void handleDeny(requestId),
+    onApprove: (request, options) => handleApprove(request, options),
+    onDeny: (requestId) => handleDeny(requestId),
     onWithdrawRequest: (requestId) => void handleWithdrawRequest(requestId),
     onViewGrant: (grant) => void handleView(grant),
     onStopGrant: (grantId) => void handleRevoke(grantId),

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -269,6 +269,8 @@ export function RequestCard({
   reason,
   approveLabel = "Approve",
   onApprove,
+  oneHourApproveLabel,
+  onApproveOneHour,
   onDecline,
 }: {
   name: string;
@@ -276,21 +278,45 @@ export function RequestCard({
   promptLine: string;
   reason?: string;
   approveLabel?: string;
-  onApprove: () => void;
-  onDecline: () => void;
+  onApprove: () => void | boolean | Promise<void | boolean>;
+  oneHourApproveLabel?: string;
+  onApproveOneHour?: () => void | boolean | Promise<void | boolean>;
+  onDecline: () => void | boolean | Promise<void | boolean>;
 }) {
-  // Latch the decision on THIS card, the moment it is pressed.
+  // Latch the decision on THIS card once the pressed action settles.
   //
   // Two problems this solves. First, `approveBusy` is derived from one global
   // busy value, so approving a single request put a spinner on EVERY card in
-  // the list. Second, that spinner was held across three sequential server
-  // calls — approve, publish the encrypted point, reload state — none of which
-  // the person is waiting to see. They pressed Approve; the answer is "yes".
+  // the list. Second, a failed approval used to look approved because the card
+  // answered before the callback could report failure.
   //
-  // So the card answers immediately and the work continues behind it. The same
-  // latch blocks a second press, which is what makes the optimism safe.
+  // The per-card pending state blocks double taps without turning the whole
+  // needs-review list into one global spinner.
   const [decision, setDecision] = useState<"approved" | "declined" | null>(null);
-  const decided = decision !== null;
+  const [pendingDecision, setPendingDecision] = useState<
+    "approve" | "one-hour" | "decline" | null
+  >(null);
+  const decided = decision !== null || pendingDecision !== null;
+  const hasOneHourApproval = Boolean(oneHourApproveLabel && onApproveOneHour);
+
+  const settleDecision = async (
+    nextDecision: "approved" | "declined",
+    pending: "approve" | "one-hour" | "decline",
+    action: () => void | boolean | Promise<void | boolean>,
+  ) => {
+    if (decided) return;
+    setPendingDecision(pending);
+    try {
+      const result = await action();
+      if (result === false) {
+        setPendingDecision(null);
+        return;
+      }
+      setDecision(nextDecision);
+    } catch {
+      setPendingDecision(null);
+    }
+  };
 
   return (
     <div className={cn(SUBCARD_SURFACE, "p-4 shadow-none")}>
@@ -330,28 +356,49 @@ export function RequestCard({
           {decision === "approved" ? "Approved" : "Declined"}
         </StatusText>
       ) : (
-        <div className="mt-3.5 grid grid-cols-1 gap-2.5 min-[430px]:grid-cols-[0.82fr_1.18fr]">
+        <div
+          className={cn(
+            "mt-3.5 grid grid-cols-1 gap-2.5",
+            hasOneHourApproval
+              ? "min-[430px]:grid-cols-2"
+              : "min-[430px]:grid-cols-[0.82fr_1.18fr]",
+          )}
+        >
           <Button
-            onClick={() => {
-              if (decided) return;
-              setDecision("approved");
-              onApprove();
-            }}
+            onClick={() => void settleDecision("approved", "approve", onApprove)}
             disabled={decided}
-            // Deliberately not `isLoading`: the card has already answered. A
-            // spinner here would reintroduce the wait it was pressed to remove.
-            className="ui-text-button-label order-1 h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90 min-[430px]:order-2"
+            isLoading={pendingDecision === "approve"}
+            className={cn(
+              "ui-text-button-label order-1 h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90",
+              hasOneHourApproval
+                ? "min-[430px]:col-span-2"
+                : "min-[430px]:order-2",
+            )}
           >
             {approveLabel}
           </Button>
+          {hasOneHourApproval ? (
+            <Button
+              onClick={() =>
+                void settleDecision("approved", "one-hour", () =>
+                  onApproveOneHour?.(),
+                )
+              }
+              disabled={decided}
+              isLoading={pendingDecision === "one-hour"}
+              className="ui-text-button-label order-2 h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80"
+            >
+              {oneHourApproveLabel}
+            </Button>
+          ) : null}
           <Button
-            onClick={() => {
-              if (decided) return;
-              setDecision("declined");
-              onDecline();
-            }}
+            onClick={() => void settleDecision("declined", "decline", onDecline)}
             disabled={decided}
-            className="ui-text-button-label order-2 h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80 min-[430px]:order-1"
+            isLoading={pendingDecision === "decline"}
+            className={cn(
+              "ui-text-button-label h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80",
+              hasOneHourApproval ? "order-3" : "order-2 min-[430px]:order-1",
+            )}
           >
             Decline
           </Button>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -110,6 +110,7 @@ import type {
   OneLocationGrant,
   OneLocationPublicInvite,
   OneLocationRecipient,
+  OneLocationShareDurationMode,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
 import { locationStatusLabel } from "@/lib/one-location/location-readiness";
@@ -411,8 +412,14 @@ export type LocationHubViewModel = {
   /** Resolves true when at least one request actually reached the server. */
   onSendRequest: (reason?: string | null) => Promise<boolean>;
   onAskReshare: (grant: OneLocationGrant) => void;
-  onApprove: (request: OneLocationAccessRequest) => void;
-  onDeny: (requestId: string) => void;
+  onApprove: (
+    request: OneLocationAccessRequest,
+    options?: {
+      durationHoursOverride?: number;
+      durationModeOverride?: OneLocationShareDurationMode;
+    },
+  ) => void | boolean | Promise<void | boolean>;
+  onDeny: (requestId: string) => void | boolean | Promise<void | boolean>;
   /**
    * Take back a request YOU sent. Not `onDeny`, which is the owner refusing an
    * ask made of them -- these are opposite ends of the same request.
@@ -2597,6 +2604,18 @@ function LocationDetailFlow({
                   reason={request.message ?? undefined}
                   approveLabel={locationApproveActionLabel(request, vm.nowMs)}
                   onApprove={() => vm.onApprove(request)}
+                  oneHourApproveLabel={
+                    canApproveForOneHour(request) ? "Allow 1 hour" : undefined
+                  }
+                  onApproveOneHour={
+                    canApproveForOneHour(request)
+                      ? () =>
+                          vm.onApprove(request, {
+                            durationHoursOverride: 1,
+                            durationModeOverride: "timed",
+                          })
+                      : undefined
+                  }
                   onDecline={() => vm.onDeny(request.id)}
                 />
               </div>
@@ -3205,6 +3224,14 @@ function requestDurationLabel(request: OneLocationAccessRequest): string {
     return "Until stopped";
   }
   return formatLocationDurationLabel(request.requestedDurationHours);
+}
+
+function canApproveForOneHour(request: OneLocationAccessRequest): boolean {
+  if (request.requestedDurationMode === "until_stopped") {
+    return true;
+  }
+  const requestedHours = Number(request.requestedDurationHours);
+  return Number.isFinite(requestedHours) && requestedHours > 1;
 }
 
 function sentRequestStatusLine(


### PR DESCRIPTION
## Summary
- Adds a direct `Allow 1 hour` option to One Location Needs Review cards when the requested duration is longer or open-ended.
- Keeps the existing full-duration approval and decline behavior intact.
- Reuses the existing `approveRequest` contract with `durationHours: 1` and `durationMode: "timed"`; no new route or API.
- Keeps `/one/location?action=needs-review` and `/one/location?view=now&action=needs-review` on the existing implementation.

## Validation
- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx`
- `npm test -- --run components/one-location/redesign/__tests__/resolve-location-deep-link-focus.test.ts`
- `npm run typecheck`
- `npx eslint app/one/location/page.tsx components/one-location/redesign/cards.tsx components/one-location/redesign/location-redesign-hub.tsx __tests__/components/one-location-agent-page.test.tsx --max-warnings=0`
- `npm run verify:design-system`
- `npm run build`