### PR TITLE
fix(one-location): simplify and centre the Change time duration selector

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -6446,12 +6446,12 @@ describe("OneLocationAgentPage", () => {
     }
   }, 15000);
 
-  it("offers the common lengths as one tap, with the wheel behind Custom", async () => {
-    // The report: Change time opened straight onto a two-column scroll wheel.
-    // Almost every change to a running share is one of five lengths, so those
-    // are now always visible and cost one tap each. The wheel is still
-    // reachable for anything in between -- removed from the default view, not
-    // removed.
+  it("offers four common lengths and the open-ended row, one tap each", async () => {
+    // The report (issue #6228): Change time showed too many near-identical
+    // choices -- 15 min / 1 hour / 2 hours / 4 hours / 8 hours / Custom /
+    // Until I stop -- wrapped and left-hugging under the live clock. It is
+    // trimmed to the four common lengths plus the open-ended row; `8 hours`
+    // and the `Custom` wheel are gone.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
     try {
@@ -6474,13 +6474,19 @@ describe("OneLocationAgentPage", () => {
         "1 hour",
         "2 hours",
         "4 hours",
-        "8 hours",
         "Until I stop",
       ]) {
         expect(
           within(editor).getByRole("button", { name: label }),
         ).toBeInTheDocument();
       }
+      // The two choices the issue asked to drop.
+      expect(
+        within(editor).queryByRole("button", { name: "8 hours" }),
+      ).toBeNull();
+      expect(
+        within(editor).queryByRole("button", { name: "Custom" }),
+      ).toBeNull();
 
       // One tap on a rung is the whole interaction -- no drag, no confirm
       // step of its own before Save.

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -206,11 +206,12 @@ describe("One Location — the Share confirm step is a measured column", () => {
     expect(HUB_SOURCE).toContain("maxWidthClassName={null}");
   });
 
-  it("keeps the default clamp for the two editors that have no column", () => {
-    // The live-share "New time" editor and the People tab's "New duration"
-    // render straight into the 880px shell. Without the default they stretch to
-    // ~792px and their duration cells reach 258px — the exact state an earlier
-    // round was fixing.
+  it("keeps a default clamp for a select-based editor that has no column", () => {
+    // The People tab's "New duration" renders a `select` straight into the
+    // 880px shell; without the default clamp its trigger stretches the width
+    // of the card. (The live-share "New time" ladder opts out with
+    // `maxWidthClassName={null}` on purpose — issue #6228 — because a wrapping
+    // row of content-width chips has nothing to stretch, unlike the old grid.)
     const selectors = repoFile(
       "components/one-location/redesign/selectors.tsx",
     );

--- a/hushh-webapp/components/one-location/redesign/__tests__/duration-presets.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/duration-presets.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  CHANGE_TIME_DURATION_LADDER,
   DurationPresetPicker,
   compactDurationLabel,
 } from "@/components/one-location/redesign/duration-presets";
@@ -135,6 +136,44 @@ describe("DurationPresetPicker", () => {
       expect(cell.className).toContain("min-h-11");
       expect(cell.className).not.toContain("h-9");
     }
+  });
+
+  it("drops the Custom cell and its wheel when allowCustom is false", () => {
+    // The live-share "New time" editor (issue #6228): the timed rungs plus the
+    // open-ended row are the whole choice.
+    render(
+      <DurationPresetPicker
+        value="1"
+        onChange={vi.fn()}
+        rungs={CHANGE_TIME_DURATION_LADDER}
+        untilStopValue="until_stopped"
+        allowCustom={false}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("button").map((node) => node.textContent),
+    ).toEqual(["15 min", "1 hour", "2 hours", "4 hours", "Until I stop"]);
+    expect(screen.queryByRole("button", { name: "Custom" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "8 hours" })).toBeNull();
+  });
+
+  it("never opens the wheel for an off-grid value when allowCustom is false", () => {
+    // The editor seeds on whatever the share has left — e.g. 2h45m. With no
+    // Custom cell there is nothing to close a wheel from, so it must stay shut
+    // and simply leave no rung pressed.
+    render(
+      <DurationPresetPicker
+        value="2.75"
+        onChange={vi.fn()}
+        rungs={CHANGE_TIME_DURATION_LADDER}
+        untilStopValue="until_stopped"
+        allowCustom={false}
+      />,
+    );
+
+    expect(screen.queryByRole("spinbutton", { name: "Hours" })).toBeNull();
+    expect(pressedLabels()).toEqual([]);
   });
 
   it("keeps the whole ladder focused: two presets, custom, and the open-ended row", () => {

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -34,10 +34,9 @@ export const SHARE_DURATION_LADDER: DurationRung[] = [
 ];
 
 /**
- * The fuller ladder, used by the Request screen and by the live-share "New
- * time" editor. Named for its shape rather than one lane, because it now
- * serves both: a person changing an active share reaches for the same five
- * lengths as a person asking for one.
+ * The fuller ladder, used by the Request screen. Named for its shape rather
+ * than one lane. The live-share "New time" editor used to share it; it now
+ * runs the shorter CHANGE_TIME_DURATION_LADDER below (issue #6228).
  */
 export const FULL_DURATION_LADDER: DurationRung[] = [
   { value: "0.25", label: "15 min" },
@@ -45,6 +44,24 @@ export const FULL_DURATION_LADDER: DurationRung[] = [
   { value: "2", label: "2 hours" },
   { value: "4", label: "4 hours" },
   { value: "8", label: "8 hours" },
+];
+
+/**
+ * The "Change time" ladder — the live-share end-time editor that opens from
+ * the running-share card.
+ *
+ * Four common lengths plus the open-ended rung, and nothing else: no `8 hours`
+ * and no `Custom` wheel. Changing a share that is already running is a quick
+ * decision, and the sixth near-identical choice plus a two-drag scroll wheel
+ * made the panel read like a settings screen sitting under the live clock.
+ * Anything between these lengths is still reachable by stopping the share and
+ * starting a new one.
+ */
+export const CHANGE_TIME_DURATION_LADDER: DurationRung[] = [
+  { value: "0.25", label: "15 min" },
+  { value: "1", label: "1 hour" },
+  { value: "2", label: "2 hours" },
+  { value: "4", label: "4 hours" },
 ];
 
 export const SHARE_DURATION_UNTIL_STOP_VALUE = "until_stopped";
@@ -110,6 +127,8 @@ export function DurationPresetPicker({
   rungs = SHARE_DURATION_LADDER,
   untilStopValue = SHARE_DURATION_UNTIL_STOP_VALUE,
   allowUntilStop = true,
+  allowCustom = true,
+  centered = false,
   labelledBy,
 }: {
   value: string;
@@ -125,6 +144,20 @@ export function DurationPresetPicker({
    * non-numeric sentinel into it would send NaN to a `gt=0` field.
    */
   allowUntilStop?: boolean;
+  /**
+   * False drops the `Custom` cell and the scroll wheel behind it entirely, for
+   * lanes where the timed rungs plus the open-ended row are the whole choice
+   * (the live-share "New time" editor — see issue #6228). An off-grid incoming
+   * value simply leaves no rung pressed; the read-back hint still states it.
+   */
+  allowCustom?: boolean;
+  /**
+   * From `sm` up, centre the wrapping chip row inside its container rather than
+   * letting it start at the far left, and on the phone grid let the open-ended
+   * row span both columns so it does not sit alone in the left cell. Used by
+   * the "Change time" editor, whose container is much wider than the ladder.
+   */
+  centered?: boolean;
   labelledBy?: string;
 }) {
   const isUntilStop = allowUntilStop && value === untilStopValue;
@@ -132,8 +165,9 @@ export function DurationPresetPicker({
     !isUntilStop && !rungs.some((rung) => rung.value === value);
 
   // Seeded from the incoming value, so an edit that arrives on 2h47m opens
-  // showing 2h47m instead of a preset it never chose.
-  const [wheelOpen, setWheelOpen] = useState(isCustomValue);
+  // showing 2h47m instead of a preset it never chose. Never opens when the
+  // wheel is disabled — there is no cell to close it from.
+  const [wheelOpen, setWheelOpen] = useState(allowCustom && isCustomValue);
   // The wheel has no row for the open-ended value, so remember the last real
   // number to hand it if Custom is opened from that rung. State, not a ref:
   // a ref written during render is what `react-hooks/refs` forbids, and this
@@ -162,7 +196,9 @@ export function DurationPresetPicker({
 
   return (
     <div role="group" aria-labelledby={labelledBy} className="space-y-2">
-      <div className={DURATION_GRID_CLASS}>
+      <div
+        className={cn(DURATION_GRID_CLASS, centered && "sm:justify-center")}
+      >
         {rungs.map((rung) => {
           const active = !wheelOpen && value === rung.value;
           return (
@@ -180,18 +216,20 @@ export function DurationPresetPicker({
             </button>
           );
         })}
-        <button
-          type="button"
-          aria-pressed={customPressed}
-          aria-expanded={wheelOpen}
-          onClick={() => (wheelOpen ? setWheelOpen(false) : openCustom())}
-          className={cn(
-            DURATION_CELL_CLASS,
-            customPressed ? DURATION_CELL_ON_CLASS : DURATION_CELL_OFF_CLASS,
-          )}
-        >
-          {isCustomValue ? compactDurationLabel(value) : "Custom"}
-        </button>
+        {allowCustom ? (
+          <button
+            type="button"
+            aria-pressed={customPressed}
+            aria-expanded={wheelOpen}
+            onClick={() => (wheelOpen ? setWheelOpen(false) : openCustom())}
+            className={cn(
+              DURATION_CELL_CLASS,
+              customPressed ? DURATION_CELL_ON_CLASS : DURATION_CELL_OFF_CLASS,
+            )}
+          >
+            {isCustomValue ? compactDurationLabel(value) : "Custom"}
+          </button>
+        ) : null}
 
         {/* The open-ended rung. Same height, border and radius as every cell
             beside it: it is the longest duration on the ladder, not a switch
@@ -199,7 +237,11 @@ export function DurationPresetPicker({
 
             It sits INSIDE the ladder, not under it, and shares the same
             two-by-two mobile grid as the timed choices. From `sm` up the
-            ladder is a wrapping chip row, where it is simply the last chip. */}
+            ladder is a wrapping chip row, where it is simply the last chip.
+
+            `centered` gives it both columns of the phone grid, so with an even
+            number of timed rungs beside it, it is a full-width row rather than
+            a lone chip in the left cell. */}
         {allowUntilStop ? (
           <button
             type="button"
@@ -207,6 +249,7 @@ export function DurationPresetPicker({
             onClick={() => pickRung(untilStopValue)}
             className={cn(
               DURATION_CELL_CLASS,
+              centered && "col-span-2 sm:col-span-1",
               isUntilStop ? DURATION_CELL_ON_CLASS : DURATION_CELL_OFF_CLASS,
             )}
           >

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -154,7 +154,10 @@ import {
   ReasonChips,
   type ReasonValue,
 } from "./selectors";
-import { FULL_DURATION_LADDER } from "./duration-presets";
+import {
+  CHANGE_TIME_DURATION_LADDER,
+  FULL_DURATION_LADDER,
+} from "./duration-presets";
 import {
   LiveShareStatusCard,
   ShareCountdownText,
@@ -4689,9 +4692,11 @@ function ShareFlow({
 /**
  * The new-end-time editor opened from the live share card.
  *
- * The wheel, not the four-option select the received-shares editor uses. This
- * one opens on what the share actually has left, and 32 minutes snapped to
- * "1 hour" would silently offer to double a share the person meant to trim.
+ * A short preset ladder (15 min / 1 hour / 2 hours / 4 hours / Until I stop),
+ * not the received-shares editor's select and not the scroll wheel this used
+ * to open on. It still opens on what the share actually has left, so the
+ * "Ends …" read-back stays honest even when that value matches no rung; the
+ * person then picks the length they want in one tap.
  */
 function LiveShareDurationEditor({
   value,
@@ -4728,13 +4733,19 @@ function LiveShareDurationEditor({
       data-ui-id="location-live-share-duration-editor"
     >
       {/*
-        Presets, not the bare wheel this used to open on. Almost every change
-        to a running share is one of the same five lengths, and the wheel
-        charged ~200px plus two coordinated drags to reach any of them --
-        inside a card that already sits under the live-share status block. The
-        wheel is still here for anything in between, behind `Custom`, where it
-        costs nothing until somebody asks for it. Same control the Request
-        screen already uses, so the two duration screens stop disagreeing.
+        Four common lengths plus the open-ended row, one tap each — no `Custom`
+        wheel and no `8 hours` (issue #6228). Changing a share that is already
+        running is a quick decision, and the sixth near-identical choice plus a
+        two-drag scroll wheel made this panel read like a settings screen
+        stacked under the live clock. Anything in between is still reachable by
+        stopping the share and starting a new one.
+
+        `centered` + `maxWidthClassName={null}`: the rungs sit inside a card
+        far wider than they need. Freed of the 420px clamp they centre as one
+        row from `sm` up instead of wrapping and hugging the left edge; on the
+        phone grid the open-ended row spans both columns. The clamp existed to
+        stop a stretching grid printing 258px slabs — the ladder is a
+        wrapping row of content-width chips now, so there is nothing to stretch.
 
         `until_stopped` stays available: this is a decision about your own
         location, so open-ended is a real answer here (unlike the Request lane,
@@ -4744,8 +4755,11 @@ function LiveShareDurationEditor({
         value={value}
         onChange={onChange}
         presentation="ladder"
-        rungs={FULL_DURATION_LADDER}
+        rungs={CHANGE_TIME_DURATION_LADDER}
         untilStopValue="until_stopped"
+        allowCustom={false}
+        centered
+        maxWidthClassName={null}
         label="New time"
         // Beside the label rather than on its own line under the control --
         // "New time … Ends 6:50 PM" is one statement, and it is how every

--- a/hushh-webapp/components/one-location/redesign/selectors.tsx
+++ b/hushh-webapp/components/one-location/redesign/selectors.tsx
@@ -56,6 +56,8 @@ export function DurationSelector({
   presentation = "buttons",
   untilStopValue,
   allowUntilStop = true,
+  allowCustom = true,
+  centered = false,
   maxWidthClassName = "max-w-[420px]",
   rungs,
 }: {
@@ -79,6 +81,17 @@ export function DurationSelector({
    * `Number()`, because the sentinel is a non-numeric string.
    */
   allowUntilStop?: boolean;
+  /**
+   * `ladder` only. False drops the `Custom` cell and its scroll wheel, leaving
+   * the timed rungs plus the open-ended row as the whole choice (issue #6228).
+   */
+  allowCustom?: boolean;
+  /**
+   * `ladder` only. Centre the wrapping chip row from `sm` up and let the
+   * open-ended row span the full phone grid, so the control reads as centred
+   * and intentional inside a container much wider than it.
+   */
+  centered?: boolean;
   /**
    * Width cap for the whole group.
    *
@@ -131,6 +144,8 @@ export function DurationSelector({
           onChange={onChange}
           {...(rungs ? { rungs } : {})}
           allowUntilStop={allowUntilStop}
+          allowCustom={allowCustom}
+          centered={centered}
           labelledBy={label ? labelId : undefined}
           {...(untilStopValue ? { untilStopValue } : {})}
         />


### PR DESCRIPTION
## What

Fixes #6228 — the live-share **Change time** ("New time") duration selector.

Before, it showed seven near-identical choices (15 min / 1 hour / 2 hours / 4 hours / 8 hours / Custom / Until I stop) in a left-hugging grid that wrapped to three ragged rows under the live clock.

## Changes

- **`CHANGE_TIME_DURATION_LADDER`** — a new four-rung ladder (15 min, 1 hour, 2 hours, 4 hours). `FULL_DURATION_LADDER` (Request screen) is untouched.
- **`DurationPresetPicker` / `DurationSelector`** gain two opt-in props:
  - `allowCustom={false}` — drops the `Custom` cell and the scroll wheel behind it.
  - `centered` — centres the wrapping chip row from `sm` up, and spans the open-ended row across both phone-grid columns so it is not a lone chip in the left cell.
- The editor drops its 420px width clamp (`maxWidthClassName={null}`). The ladder is a wrapping row of content-width chips now — nothing stretches into slabs — so on desktop all five options sit in one centred row, and on phones they fall into a balanced 2×2 grid with a full-width **Until I stop**.
- The editor still opens on the share's real remaining time, so the "Ends …" read-back stays honest even when that value matches no rung.

## Result

| | Before | After |
|---|---|---|
| Desktop | 6 chips left-aligned, wrapping | 5 chips, one centred row |
| Phone | 3 ragged rows + lone chip | 2×2 grid + full-width "Until I stop" |

## Tests

- `duration-presets.test.tsx` — new cases for `allowCustom={false}` (no Custom / no 8 hours) and off-grid seeding not opening the wheel.
- `one-location-agent-page.test.tsx` — Change time editor now asserts the five-item set and that `8 hours` / `Custom` are gone.
- `one-location-copy-pass.contract.test.ts` — comment updated for the editor opting out of the clamp.
- Existing `e2e/one-location-duration-ladder.layout.spec.ts` and `e2e/one-location-live-share.layout.spec.ts` still pass; `tsc --noEmit` clean.