### PR TITLE
Simplify nearby check-in flow

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -393,6 +393,12 @@ class NearbyPresenceCheckInRequest(_CamelModel):
     allow_connection_requests: bool = Field(default=False, alias="allowConnectionRequests")
 
 
+class NearbyPresenceExtendRequest(_CamelModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    increment_minutes: Literal[30, 60] = Field(alias="incrementMinutes")
+
+
 class NearbyConnectionRequest(_CamelModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -1669,6 +1675,25 @@ def checkout_nearby(
     _set_private_no_store(response)
     try:
         return _nearby_presence_service().checkout(user_id=_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.patch("/location/nearby-presence")
+@limiter.limit(RateLimits.ONE_LOCATION_NEARBY_WRITE)
+def extend_nearby_presence(
+    request: Request,
+    response: Response,
+    payload: NearbyPresenceExtendRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _require_nearby_presence_simulation(_user_id(token_data))
+    _set_private_no_store(response)
+    try:
+        return _nearby_presence_service().extend(
+            user_id=_user_id(token_data),
+            increment_minutes=payload.increment_minutes,
+        )
     except Exception as exc:
         raise _handle_error(exc) from exc
 

--- a/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
@@ -194,6 +194,13 @@ class NearbyPresenceStore(Protocol):
 
     def checkout(self, user_id: str) -> bool: ...
 
+    def extend_presence(
+        self,
+        *,
+        user_id: str,
+        increment_minutes: int,
+    ) -> dict[str, Any] | None: ...
+
     def purge_terminal(self, *, older_than_hours: float) -> dict[str, int]: ...
 
 
@@ -550,6 +557,31 @@ class PostgresNearbyPresenceStore:
             {"user_id": user_id},
         )
         return bool(row)
+
+    def extend_presence(
+        self,
+        *,
+        user_id: str,
+        increment_minutes: int,
+    ) -> dict[str, Any] | None:
+        self._expire_due()
+        return self._execute_one(
+            """
+            UPDATE one_location_nearby_presences
+            SET
+              expires_at = expires_at + (:increment_minutes * INTERVAL '1 minute'),
+              version = version + 1,
+              updated_at = NOW()
+            WHERE owner_user_id = :user_id
+              AND status = 'active'
+              AND expires_at > NOW()
+            RETURNING *
+            """,
+            {
+                "user_id": user_id,
+                "increment_minutes": int(increment_minutes),
+            },
+        )
 
     def purge_terminal(self, *, older_than_hours: float) -> dict[str, int]:
         expired_count = self._expire_due()
@@ -1218,6 +1250,33 @@ class OneLocationNearbyPresenceService:
         owner_user_id = self._require_user(user_id)
         self._store.checkout(owner_user_id)
         return {"presence": None, "attendees": [], "checkedOut": True}
+
+    def extend(
+        self,
+        *,
+        user_id: str,
+        increment_minutes: int,
+    ) -> dict[str, Any]:
+        owner_user_id = self._require_user(user_id)
+        self._require_verified_profile(owner_user_id)
+        normalized_increment = int(increment_minutes)
+        if normalized_increment not in {30, 60}:
+            raise NearbyPresenceError(
+                "NEARBY_PRESENCE_EXTENSION_INVALID",
+                "Choose 30 minutes or 1 hour.",
+                status_code=422,
+            )
+        row = self._store.extend_presence(
+            user_id=owner_user_id,
+            increment_minutes=normalized_increment,
+        )
+        if not row:
+            raise NearbyPresenceError(
+                "NEARBY_PRESENCE_NOT_ACTIVE",
+                "This check-in has already ended.",
+                status_code=409,
+            )
+        return self.get_state(user_id=owner_user_id)
 
     def request_connection(
         self,

--- a/consent-protocol/tests/test_one_location_nearby_presence_routes.py
+++ b/consent-protocol/tests/test_one_location_nearby_presence_routes.py
@@ -332,6 +332,55 @@ def test_checkout_remains_available_when_simulation_is_disabled(client, monkeypa
     assert response.headers["cache-control"] == "private, no-store"
 
 
+def test_extend_nearby_presence_uses_token_identity(client, monkeypatch):
+    class FakePresenceService:
+        def extend(self, *, user_id, increment_minutes):
+            assert user_id == "u1"
+            assert increment_minutes == 30
+            return {
+                "presence": {
+                    "status": "active",
+                    "placeLabel": "Demo Hall",
+                    "radiusMeters": 500,
+                },
+                "attendees": [],
+            }
+
+    monkeypatch.setattr(
+        location_routes,
+        "_nearby_presence_service",
+        lambda: FakePresenceService(),
+    )
+
+    response = client.patch(
+        "/api/one/location/nearby-presence",
+        json={"incrementMinutes": 30},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["presence"]["placeLabel"] == "Demo Hall"
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+def test_extend_nearby_presence_rejects_unsupported_increment(client, monkeypatch):
+    class FailIfCalledPresenceService:
+        def extend(self, **kwargs):
+            raise AssertionError("unsupported increments must not reach service")
+
+    monkeypatch.setattr(
+        location_routes,
+        "_nearby_presence_service",
+        lambda: FailIfCalledPresenceService(),
+    )
+
+    response = client.patch(
+        "/api/one/location/nearby-presence",
+        json={"incrementMinutes": 45},
+    )
+
+    assert response.status_code == 422
+
+
 def test_connection_request_accepts_alias_only_in_body(client, monkeypatch):
     class FakePresenceService:
         def request_connection(self, **kwargs):

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -46,7 +46,7 @@ describe("top shell breadcrumbs", () => {
       width: "profile",
       align: "center",
       hideBack: false,
-      items: [{ label: "One", href: "/one" }, { label: "Connect" }],
+      items: [{ label: "One" }],
     });
   });
 

--- a/hushh-webapp/app/one/location/check-in/page.tsx
+++ b/hushh-webapp/app/one/location/check-in/page.tsx
@@ -48,10 +48,10 @@ export default function OneLocationCheckInPage() {
     nearbyAvailable && !auth.loading && auth.isAuthenticated
       ? {
           screenId: "one_location_check_in",
-          title: "Check in",
+          title: "Check in nearby",
           purpose:
-            "Shows nearby places to check into and confirms a check-in once one is picked.",
-          spokenSubject: "Location, Check in",
+            "Shows nearby places and confirms an arrival once one is picked.",
+          spokenSubject: "Location, Check in nearby",
           actions: LOCATION_CHECK_IN_VOICE_ACTIONS,
           availableActions: LOCATION_CHECK_IN_VOICE_ACTIONS.map(
             (action) => action.label,

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const service = vi.hoisted(() => ({
   checkInNearby: vi.fn(),
   checkoutNearby: vi.fn(),
+  extendNearbyPresence: vi.fn(),
   getPermissionState: vi.fn(),
   getNearbyPresence: vi.fn(),
   nearbyPlaces: vi.fn(),
@@ -162,7 +163,7 @@ describe("NearbyCheckInSheet", () => {
     });
   });
 
-  it("uses the compact Check in header and a count-aware place expansion", async () => {
+  it("uses the compact nearby check-in header and a count-aware place expansion", async () => {
     service.nearbyPlaces.mockResolvedValue([
       {
         placeId: "long-name-cafe",
@@ -208,7 +209,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Check in" }),
+      screen.getByRole("heading", { name: "Check in nearby" }),
     ).toBeInTheDocument();
     // The build-stage badge is gone: it reported how finished the feature is,
     // which is a fact about the roadmap, not about the person's decision.
@@ -878,7 +879,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByTestId("nearby-presence-active");
-    const checkout = screen.getByRole("button", { name: "Check out" });
+    const checkout = screen.getByRole("button", { name: "I'm leaving" });
     // "now" adds nothing a person could act on.
     expect(
       screen.queryByRole("button", { name: "Check out now" }),
@@ -954,8 +955,8 @@ describe("NearbyCheckInSheet", () => {
     await waitFor(() => {
       expect(service.getNearbyPresence).toHaveBeenCalledTimes(2);
     });
-    fireEvent.click(screen.getByRole("button", { name: "Check out" }));
-    await screen.findByTestId("nearby-presence-setup");
+    fireEvent.click(screen.getByRole("button", { name: "I'm leaving" }));
+    await screen.findByTestId("nearby-presence-completed");
 
     resolveOldPoll?.(activeState);
     await Promise.resolve();
@@ -1005,7 +1006,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByTestId("nearby-presence-active");
-    fireEvent.click(screen.getByRole("button", { name: "Check out" }));
+    fireEvent.click(screen.getByRole("button", { name: "I'm leaving" }));
     await waitFor(() => {
       expect(service.checkoutNearby).toHaveBeenCalledTimes(1);
     });
@@ -1018,11 +1019,67 @@ describe("NearbyCheckInSheet", () => {
     await act(async () => {
       resolveCheckout?.(checkedOutState);
     });
-    expect(await screen.findByTestId("nearby-presence-setup")).toBeInTheDocument();
+    expect(await screen.findByTestId("nearby-presence-completed")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Check out" }),
+      screen.queryByRole("button", { name: "I'm leaving" }),
     ).not.toBeInTheDocument();
     expect(service.getNearbyPresence).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds time from the active check-in without reopening the setup flow", async () => {
+    const activeState = {
+      presence: {
+        status: "active" as const,
+        audience: "all_opted_in" as const,
+        radiusMeters: 500,
+        allowConnectionRequests: false,
+        consentVersion: "one-location-nearby-presence-v3",
+        checkedInAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        placeLabel: "Stanford University",
+      },
+      attendees: [
+        {
+          participantAlias: "alias-1",
+          displayName: "Neelesh Meena",
+          relationship: "connected" as const,
+          canConnect: false,
+          checkedInAt: new Date().toISOString(),
+        },
+      ],
+    };
+    service.getNearbyPresence.mockResolvedValue(activeState);
+    service.extendNearbyPresence.mockResolvedValue({
+      ...activeState,
+      presence: {
+        ...activeState.presence,
+        expiresAt: new Date(Date.now() + 90 * 60_000).toISOString(),
+      },
+    });
+
+    render(
+      <NearbyCheckInSheet
+        open
+        ownerId="user-1"
+        vaultOwnerToken="owner-token"
+        captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const active = await screen.findByTestId("nearby-presence-active");
+    expect(active.textContent).toContain("1 person nearby");
+    fireEvent.click(screen.getByRole("button", { name: "Add time" }));
+    fireEvent.click(screen.getByRole("button", { name: "30 min more" }));
+
+    await waitFor(() => {
+      expect(service.extendNearbyPresence).toHaveBeenCalledWith({
+        vaultOwnerToken: "owner-token",
+        incrementMinutes: 30,
+      });
+    });
+    expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+    expect(screen.getByTestId("nearby-presence-active")).toBeInTheDocument();
   });
 
   it("does not request location or Places for an already-active check-in", async () => {
@@ -1113,7 +1170,7 @@ describe("NearbyCheckInSheet", () => {
     );
     service.nearbyPlaces.mockClear();
 
-    fireEvent.click(screen.getByPlaceholderText("Search"));
+    fireEvent.click(screen.getByPlaceholderText("Search places"));
     await act(async () => {
       // A failed refresh must degrade the drawer, not blank it.
       fireEvent.click(screen.getByRole("button", { name: "All" }));
@@ -1317,7 +1374,7 @@ describe("NearbyCheckInSheet", () => {
     });
     expect(service.nearbyPlaces).toHaveBeenCalledTimes(1);
 
-    fireEvent.change(screen.getByPlaceholderText("Search"), {
+    fireEvent.change(screen.getByPlaceholderText("Search places"), {
       target: { value: "clinic" },
     });
     await waitFor(() => {
@@ -1341,7 +1398,7 @@ describe("NearbyCheckInSheet", () => {
     expect(screen.queryByText(/sorted by distance/)).not.toBeInTheDocument();
     expect(screen.getByText("Google Maps")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByPlaceholderText("Search"), {
+    fireEvent.change(screen.getByPlaceholderText("Search places"), {
       target: { value: "" },
     });
     expect(await screen.findByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1384,7 +1441,7 @@ describe("NearbyCheckInSheet", () => {
     });
     expect(submit).toBeEnabled();
 
-    fireEvent.change(screen.getByPlaceholderText("Search"), {
+    fireEvent.change(screen.getByPlaceholderText("Search places"), {
       target: { value: "clinic" },
     });
     expect(
@@ -2119,7 +2176,7 @@ describe("NearbyCheckInSheet", () => {
     });
   });
 
-  describe("post-checkout Saved Places offer", () => {
+  describe("post-checkout completion", () => {
     const anchoredPresence = {
       presence: {
         status: "active" as const,
@@ -2136,7 +2193,10 @@ describe("NearbyCheckInSheet", () => {
       attendees: [],
     };
 
-    const renderAndCheckOut = async (vaultKey: string | null = "vault-key") => {
+    const renderAndCheckOut = async (
+      vaultKey: string | null = "vault-key",
+      onOpenChange = vi.fn(),
+    ) => {
       service.getNearbyPresence.mockResolvedValue(anchoredPresence);
       service.checkoutNearby.mockResolvedValue({
         presence: null,
@@ -2151,25 +2211,33 @@ describe("NearbyCheckInSheet", () => {
           vaultOwnerToken="owner-token"
           vaultKey={vaultKey}
           captureCurrentPosition={vi.fn().mockResolvedValue(point)}
-          onOpenChange={vi.fn()}
+          onOpenChange={onOpenChange}
         />,
       );
 
       await screen.findByTestId("nearby-presence-active");
-      fireEvent.click(screen.getByRole("button", { name: "Check out" }));
-      await screen.findByTestId("nearby-presence-setup");
+      fireEvent.click(screen.getByRole("button", { name: "I'm leaving" }));
+      await screen.findByTestId("nearby-presence-completed");
+      return onOpenChange;
     };
 
-    it("offers the checked-out venue when it is not already saved", async () => {
+    it("ends in a simple completed state instead of reopening setup", async () => {
       savedPlaces.loadSavedLocations.mockResolvedValue([]);
 
       await renderAndCheckOut();
 
-      const prompt = await screen.findByTestId("nearby-save-place-prompt");
-      expect(prompt.textContent).toContain("Blue Bottle Coffee");
+      const completed = await screen.findByTestId("nearby-presence-completed");
+      expect(completed.textContent).toContain("Check-in ended");
+      expect(completed.textContent).toContain("Blue Bottle Coffee");
+      expect(completed.textContent).toContain("You're no longer visible nearby.");
+      expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+      expect(screen.queryByText("Checked out from")).not.toBeInTheDocument();
+      expect(
+        await screen.findByRole("button", { name: "Save for faster check-ins" }),
+      ).toBeInTheDocument();
     });
 
-    it("suppresses the offer when that venue is already saved", async () => {
+    it("suppresses the save action when that venue is already saved", async () => {
       // 37.42755/-122.16975 is a few metres from the anchor, inside the 25 m
       // duplicate radius, so this must read as the same place.
       savedPlaces.loadSavedLocations.mockResolvedValue([
@@ -2189,16 +2257,16 @@ describe("NearbyCheckInSheet", () => {
         expect(savedPlaces.loadSavedLocations).toHaveBeenCalled();
       });
       expect(
-        screen.queryByTestId("nearby-save-place-prompt"),
+        screen.queryByRole("button", { name: "Save for faster check-ins" }),
       ).not.toBeInTheDocument();
     });
 
-    it("does not offer when the vault is locked", async () => {
+    it("does not show the save action when the vault is locked", async () => {
       await renderAndCheckOut(null);
 
       expect(savedPlaces.loadSavedLocations).not.toHaveBeenCalled();
       expect(
-        screen.queryByTestId("nearby-save-place-prompt"),
+        screen.queryByRole("button", { name: "Save for faster check-ins" }),
       ).not.toBeInTheDocument();
     });
 
@@ -2207,8 +2275,11 @@ describe("NearbyCheckInSheet", () => {
       savedPlaces.addSavedLocation.mockResolvedValue([]);
 
       await renderAndCheckOut();
-      await screen.findByTestId("nearby-save-place-prompt");
-      fireEvent.click(screen.getByRole("button", { name: /Save to Places/ }));
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: "Save for faster check-ins",
+        }),
+      );
 
       await waitFor(() => {
         expect(savedPlaces.addSavedLocation).toHaveBeenCalledTimes(1);
@@ -2223,26 +2294,20 @@ describe("NearbyCheckInSheet", () => {
           longitude: -122.1697,
         },
       });
+      expect(await screen.findByText("Saved for next time.")).toBeInTheDocument();
     });
 
-    it("dismisses the offer without saving", async () => {
+    it("finishes without saving", async () => {
       savedPlaces.loadSavedLocations.mockResolvedValue([]);
+      const onOpenChange = await renderAndCheckOut("vault-key", vi.fn());
 
-      await renderAndCheckOut();
-      await screen.findByTestId("nearby-save-place-prompt");
-      fireEvent.click(
-        screen.getByRole("button", { name: "Dismiss saved place suggestion" }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: "Done" }));
 
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("nearby-save-place-prompt"),
-        ).not.toBeInTheDocument();
-      });
+      expect(onOpenChange).toHaveBeenCalledWith(false);
       expect(savedPlaces.addSavedLocation).not.toHaveBeenCalled();
     });
 
-    it("keeps Check out styled as a neutral action, not a destructive one", async () => {
+    it("keeps leaving styled as a neutral action, not a destructive one", async () => {
       service.getNearbyPresence.mockResolvedValue(anchoredPresence);
 
       render(
@@ -2256,7 +2321,7 @@ describe("NearbyCheckInSheet", () => {
       );
 
       await screen.findByTestId("nearby-presence-active");
-      const checkOut = screen.getByRole("button", { name: "Check out" });
+      const checkOut = screen.getByRole("button", { name: "I'm leaving" });
       // Red is reserved for dangerous and irreversible actions. Checking out is
       // neither — you can check back in.
       expect(checkOut.className).not.toContain("app-destructive");

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -16,10 +16,8 @@ import {
   LocateFixed,
   MapPin,
   Search,
-  ShieldCheck,
   Star,
   UsersRound,
-  X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -145,6 +143,12 @@ type PresenceLoadResult = OneLocationNearbyPresenceState | "error" | null;
  * the backend still runs the authoritative plausibility check at check-in.
  */
 type PointOrigin = "fresh" | "last-known";
+type NearbyCheckInViewState = "loading" | "setup" | "active" | "completed";
+type CompletedCheckIn = {
+  placeLabel: string | null;
+  saved: boolean;
+  saveError: string | null;
+};
 
 /**
  * A fix reused after a failed refresh is only honest for as long as the owner
@@ -378,6 +382,11 @@ function timeLeftLabel(expiresAt: string): string {
   return remainder ? `${hours}h ${remainder}m left` : `${hours}h left`;
 }
 
+function peopleNearbyLabel(count: number): string | null {
+  if (count <= 0) return null;
+  return `${count} ${count === 1 ? "person" : "people"} nearby`;
+}
+
 function initials(label: string): string {
   return (
     label
@@ -560,6 +569,8 @@ export function NearbyCheckInSheet({
   const [searching, setSearching] = useState(false);
   const [capturing, setCapturing] = useState(false);
   const [loadingPresence, setLoadingPresence] = useState(false);
+  const [viewState, setViewState] =
+    useState<NearbyCheckInViewState>("loading");
   const [state, setState] =
     useState<OneLocationNearbyPresenceState>(EMPTY_NEARBY_STATE);
   const [durationMinutes, setDurationMinutes] = useState<30 | 60 | 120>(60);
@@ -567,9 +578,13 @@ export function NearbyCheckInSheet({
   const [allowConnectionRequests, setAllowConnectionRequests] = useState(false);
   /** Whether the secondary preference row is revealed. Presentation only. */
   const [optionsOpen, setOptionsOpen] = useState(false);
+  const [addTimeOpen, setAddTimeOpen] = useState(false);
+  const [addTimeBusy, setAddTimeBusy] = useState<30 | 60 | null>(null);
   const [busy, setBusy] = useState<"check-in" | "checkout" | string | null>(
     null,
   );
+  const [completedCheckIn, setCompletedCheckIn] =
+    useState<CompletedCheckIn | null>(null);
   /**
    * The post-checkout Saved Places offer. Null whenever there is nothing to
    * offer — no anchor, vault locked, or the place is already saved — so the
@@ -1018,12 +1033,17 @@ export function NearbyCheckInSheet({
     setSearching(false);
     setCapturing(false);
     setLoadingPresence(false);
+    setViewState("loading");
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
     setOptionsOpen(false);
+    setAddTimeOpen(false);
+    setAddTimeBusy(null);
     setDurationMinutes(60);
     setVisiblePlacesCount(3);
     setBusy(null);
+    setCompletedCheckIn(null);
+    setSavePlaceCandidateState(null);
     setLocationError(null);
     setLocationRecovery(null);
     setPresenceLoadError(null);
@@ -1056,21 +1076,30 @@ export function NearbyCheckInSheet({
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
     setOptionsOpen(false);
+    setAddTimeOpen(false);
+    setAddTimeBusy(null);
     setDurationMinutes(60);
     setVisiblePlacesCount(3);
+    setCompletedCheckIn(null);
+    setSavePlaceCandidateState(null);
     setLocationError(null);
     setLocationRecovery(null);
     setPresenceLoadError(null);
     setPlacesError(null);
+    if (open) setViewState("loading");
     void loadPresence(!open, expectedOwnerEpoch).then((next) => {
       if (
-        !open ||
         next === "error" ||
-        next?.presence ||
         ownerEpochRef.current !== expectedOwnerEpoch
       ) {
         return;
       }
+      if (next?.presence) {
+        setViewState("active");
+        return;
+      }
+      if (!open) return;
+      setViewState("setup");
       void captureAndLoadPlaces("all");
     });
     return () => {
@@ -1087,8 +1116,10 @@ export function NearbyCheckInSheet({
   ]);
 
   useEffect(() => {
-    onSearchAreaChange?.(open && !state.presence ? point : null);
-  }, [onSearchAreaChange, open, point, state.presence]);
+    onSearchAreaChange?.(
+      open && viewState === "setup" && !state.presence ? point : null,
+    );
+  }, [onSearchAreaChange, open, point, state.presence, viewState]);
 
   useEffect(() => {
     return () => onSearchAreaChange?.(null);
@@ -1116,6 +1147,9 @@ export function NearbyCheckInSheet({
           !next.presence &&
           ownerEpochRef.current === expectedOwnerEpoch
         ) {
+          setViewState((current) =>
+            current === "completed" ? current : "setup",
+          );
           void captureAndLoadPlaces();
         }
       } finally {
@@ -1467,6 +1501,10 @@ export function NearbyCheckInSheet({
         return;
       }
       publishState(next);
+      setViewState("active");
+      setCompletedCheckIn(null);
+      setAddTimeOpen(false);
+      setAddTimeBusy(null);
       // The confirmation point is kept, not cleared: once checked in it is what
       // tells the owner how far they have drifted from the place they anchored
       // to. It is not republished as a search area -- presence suppresses that.
@@ -1741,6 +1779,10 @@ export function NearbyCheckInSheet({
           allowConnectionRequests: allowConnectionRequestsDefault,
         });
         publishState(next);
+        setViewState("active");
+        setCompletedCheckIn(null);
+        setAddTimeOpen(false);
+        setAddTimeBusy(null);
         setAutomaticPlaces([]);
         setSearchResults([]);
         setSelectedPlaceId("");
@@ -1820,19 +1862,82 @@ export function NearbyCheckInSheet({
           longitude: candidate.longitude,
         },
       });
-      toast.success(`Saved ${candidate.label} to your places.`);
+      toast.success("Saved.");
+      setCompletedCheckIn((current) =>
+        current ? { ...current, saved: true, saveError: null } : current,
+      );
       setSavePlaceCandidateState(null);
     } catch (error) {
       if (error instanceof DuplicateSavedLocationError) {
         // Saved from somewhere else between the offer and the tap. The intent
         // is satisfied either way, so retire the banner without an error.
+        setCompletedCheckIn((current) =>
+          current ? { ...current, saved: true, saveError: null } : current,
+        );
         setSavePlaceCandidateState(null);
         return;
       }
-      toast.error("Couldn't save that place. Try again from Saved Places.");
+      setCompletedCheckIn((current) =>
+        current
+          ? { ...current, saveError: "Couldn't save this place." }
+          : current,
+      );
+      toast.error("Couldn't save this place.");
     } finally {
       setSavingPlace(false);
     }
+  };
+
+  const addTime = async (incrementMinutes: 30 | 60) => {
+    if (!ownerId || !vaultOwnerToken || mutationInFlightRef.current) return;
+    const ownerToken = vaultOwnerToken;
+    const expectedOwnerEpoch = ownerEpochRef.current;
+    const generation = ++presenceMutationGenerationRef.current;
+    presenceReadGenerationRef.current += 1;
+    mutationInFlightRef.current = true;
+    setAddTimeBusy(incrementMinutes);
+    setBusy(`add-time:${incrementMinutes}`);
+    try {
+      const next = await OneLocationService.extendNearbyPresence({
+        vaultOwnerToken: ownerToken,
+        incrementMinutes,
+      });
+      if (
+        ownerEpochRef.current !== expectedOwnerEpoch ||
+        presenceMutationGenerationRef.current !== generation
+      ) {
+        return;
+      }
+      publishState(next);
+      setViewState(next.presence ? "active" : "setup");
+      setAddTimeOpen(false);
+      toast.success(
+        incrementMinutes === 60 ? "1 hour added." : "30 minutes added.",
+      );
+    } catch {
+      if (
+        ownerEpochRef.current === expectedOwnerEpoch &&
+        presenceMutationGenerationRef.current === generation
+      ) {
+        toast.error("Couldn't add time.");
+      }
+    } finally {
+      if (
+        ownerEpochRef.current === expectedOwnerEpoch &&
+        presenceMutationGenerationRef.current === generation
+      ) {
+        mutationInFlightRef.current = false;
+        setAddTimeBusy(null);
+        setBusy(null);
+      }
+    }
+  };
+
+  const finishCompletedCheckIn = () => {
+    setCompletedCheckIn(null);
+    setSavePlaceCandidateState(null);
+    setViewState("setup");
+    onOpenChange(false);
   };
 
   const checkout = async () => {
@@ -1856,19 +1961,26 @@ export function NearbyCheckInSheet({
         return;
       }
       publishState(next);
+      setViewState("completed");
+      setCompletedCheckIn({
+        placeLabel: savedPlaceOffer?.label ?? state.presence?.placeLabel ?? null,
+        saved: false,
+        saveError: null,
+      });
       setConsentAccepted(false);
       setAllowConnectionRequests(false);
       setOptionsOpen(false);
-      toast.success("You checked out.");
+      setAddTimeOpen(false);
+      setAddTimeBusy(null);
+      toast.success("Check-in ended.");
       void offerSavePlace(savedPlaceOffer);
-      void captureAndLoadPlaces();
     } catch {
       if (
         ownerEpochRef.current === expectedOwnerEpoch &&
         presenceMutationGenerationRef.current === generation
       ) {
         toast.error(
-          "Checkout didn't complete. You may still be visible—please try again.",
+          "Couldn't end the check-in. You may still be visible nearby.",
         );
       }
     } finally {
@@ -2037,7 +2149,9 @@ export function NearbyCheckInSheet({
             reaches this sheet who was not meant to. */}
         <SheetHeader className="gap-0 border-b border-border/60 px-5 py-4 text-left">
           <div className="flex min-h-9 items-center gap-2 pr-10">
-            <SheetTitle className="text-[17px] leading-6">Check in</SheetTitle>
+            <SheetTitle className="text-[17px] leading-6">
+              Check in nearby
+            </SheetTitle>
           </div>
         </SheetHeader>
 
@@ -2078,76 +2192,82 @@ export function NearbyCheckInSheet({
             </div>
           ) : null}
 
-          {/* Post-checkout Saved Places offer. Deliberately rendered ABOVE the
-              branch below: checkout flips this sheet from the active view to
-              the setup view, so a banner living inside either branch would be
-              unmounted by the very action that creates it. Non-blocking — the
-              setup view stays fully usable behind it, and it carries its own
-              dismiss. */}
-          {savePlaceCandidateState ? (
-            <div
-              className="mb-4 rounded-2xl border border-border/60 bg-muted/60 p-3"
-              data-testid="nearby-save-place-prompt"
-            >
-              <div className="flex items-start gap-3">
-                <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]">
-                  <Star className="h-4 w-4" />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold text-foreground">
-                    Checked out from {savePlaceCandidateState.label}
-                  </p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Save this to your Saved Places?
-                  </p>
+          {viewState === "completed" ? (
+            <div className="space-y-4" data-testid="nearby-presence-completed">
+              <section className="rounded-[18px] border border-border/60 bg-card p-4">
+                <div className="flex items-start gap-3">
+                  <span
+                    className={cn(
+                      "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
+                      SUCCESS_ROLE.tile,
+                      SUCCESS_ROLE.glyph,
+                    )}
+                    aria-hidden="true"
+                  >
+                    <Check className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-semibold">Check-in ended</p>
+                    {completedCheckIn?.placeLabel ? (
+                      <p className="mt-0.5 truncate text-sm font-medium">
+                        {completedCheckIn.placeLabel}
+                      </p>
+                    ) : null}
+                    <p className="mt-0.5 text-sm text-muted-foreground">
+                      You're no longer visible nearby.
+                    </p>
+                    {completedCheckIn?.saved ? (
+                      <p className="mt-2 text-xs font-medium text-muted-foreground">
+                        Saved for next time.
+                      </p>
+                    ) : null}
+                    {completedCheckIn?.saveError ? (
+                      <p
+                        className="mt-2 text-xs font-medium text-destructive"
+                        role="alert"
+                      >
+                        {completedCheckIn.saveError}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
-                <Button
-                  type="button"
-                  size="icon-sm"
-                  variant="ghost"
-                  className="-mr-1 -mt-1 shrink-0 text-muted-foreground"
-                  onClick={() => setSavePlaceCandidateState(null)}
-                  aria-label="Dismiss saved place suggestion"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
+              </section>
               <Button
                 type="button"
-                size="sm"
-                className="mt-3 w-full"
-                isLoading={savingPlace}
-                onClick={() => void saveCheckedOutPlace()}
+                className="h-[52px] min-h-[52px] w-full rounded-2xl"
+                onClick={finishCompletedCheckIn}
               >
-                <Star />
-                Save to Places
+                Done
               </Button>
+              {savePlaceCandidateState && !completedCheckIn?.saved ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-11 min-h-11 w-full text-muted-foreground"
+                  isLoading={savingPlace}
+                  onClick={() => void saveCheckedOutPlace()}
+                >
+                  <Star className="h-4 w-4" />
+                  Save for faster check-ins
+                </Button>
+              ) : null}
             </div>
-          ) : null}
-
-          {loadingPresence && !state.presence ? null : state.presence ? (
+          ) : viewState === "loading" ||
+            (loadingPresence && !state.presence) ? null : state.presence ? (
             <div className="space-y-4" data-testid="nearby-presence-active">
-              {/* Only rendered while a check-in is actually live, so the green
-                  is reporting state, not labelling the category. The wash and
-                  the hairline carry it; the shield keeps the foreground tone,
-                  because --app-success on --app-success-tint measures ~1.9:1
-                  and a glyph has to clear 3:1. */}
-              <section
-                className={cn(
-                  "rounded-2xl border p-4",
-                  SUCCESS_ROLE.border,
-                  SUCCESS_ROLE.tile,
-                )}
-              >
+              <section className="rounded-[18px] border border-border/60 bg-card p-4">
                 <div className="flex items-start gap-3">
-                  <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
+                  <span
+                    className={cn(
+                      "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
+                      SUCCESS_ROLE.tile,
+                      SUCCESS_ROLE.glyph,
+                    )}
+                    aria-hidden="true"
+                  >
+                    <Check className="h-4 w-4" />
+                  </span>
                   <div className="min-w-0 flex-1">
-                    {/* Three facts, one per line: that it worked, where, and
-                        how long is left. The radius and the full address were
-                        dropped — the radius is drawn on the map behind this
-                        card, and the place name is what the person picked, so
-                        repeating its postal address adds a line of reading and
-                        no decision. */}
                     <p className="font-semibold">Checked in</p>
                     <p
                       className="mt-0.5 truncate text-sm font-medium"
@@ -2156,16 +2276,13 @@ export function NearbyCheckInSheet({
                       {state.presence.placeLabel || "Your place"}
                     </p>
                     <p className="mt-0.5 text-sm text-muted-foreground">
-                      {timeLeftLabel(state.presence.expiresAt)}
+                      {[
+                        timeLeftLabel(state.presence.expiresAt),
+                        peopleNearbyLabel(state.attendees.length),
+                      ]
+                        .filter(Boolean)
+                        .join(" · ")}
                     </p>
-                    {/*
-                      Only the case that changes what someone would do.
-                      Under the nudge distance the gap is receiver noise and a
-                      building footprint, and saying "you are 37 m from it" is
-                      a fact nobody acts on. Past it, the person is somewhere
-                      else while still discoverable here, which is a privacy
-                      statement and earns its line.
-                    */}
                     {activeDriftMeters !== null &&
                     activeDriftMeters > NEARBY_DRIFT_NUDGE_METERS ? (
                       <p
@@ -2241,31 +2358,63 @@ export function NearbyCheckInSheet({
                 )}
               </section>
 
-              {/*
-                Neutral, not destructive.
-                `variant="destructive"` paints --app-destructive solid with
-                white on it, which is the treatment this product reserves for
-                SOS, delete, revoke and stop-sharing. Checking out ends a
-                presence that was always going to end on its own timer, keeps
-                the row (it only flips status and destroys the anchor key), and
-                can be redone in three taps. Red on a reversible lifecycle step
-                spends the one colour that is supposed to mean consequence, and
-                makes the calm state read as an alarm. `secondary` is the
-                neutral fill from the same button contract, so size, radius,
-                focus ring and loading behaviour are unchanged.
-              */}
-              <Button
-                type="button"
-                variant={CHECK_OUT_BUTTON_VARIANT}
-                className="w-full"
-                disabled={busy !== null}
-                onClick={() => void checkout()}
-              >
-                {busy === "checkout" ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : null}
-                Check out
-              </Button>
+              {addTimeOpen ? (
+                <section
+                  className="rounded-[18px] border border-border/60 bg-card p-3"
+                  aria-label="Add time"
+                >
+                  <div className="grid grid-cols-2 gap-2">
+                    {([30, 60] as const).map((increment) => (
+                      <Button
+                        key={increment}
+                        type="button"
+                        variant="secondary"
+                        className="h-11 min-h-11"
+                        disabled={busy !== null}
+                        onClick={() => void addTime(increment)}
+                      >
+                        {addTimeBusy === increment ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : null}
+                        {increment === 60 ? "1 hour more" : "30 min more"}
+                      </Button>
+                    ))}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="mt-2 h-10 min-h-10 w-full text-muted-foreground"
+                    disabled={busy !== null}
+                    onClick={() => setAddTimeOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                </section>
+              ) : null}
+
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="h-12 min-h-12"
+                  disabled={busy !== null}
+                  onClick={() => setAddTimeOpen((current) => !current)}
+                >
+                  Add time
+                </Button>
+                <Button
+                  type="button"
+                  variant={CHECK_OUT_BUTTON_VARIANT}
+                  className="h-12 min-h-12"
+                  disabled={busy !== null}
+                  onClick={() => void checkout()}
+                >
+                  {busy === "checkout" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : null}
+                  {busy === "checkout" ? "Leaving..." : "I'm leaving"}
+                </Button>
+              </div>
             </div>
           ) : (
             <div className="space-y-5" data-testid="nearby-presence-setup">
@@ -2396,7 +2545,7 @@ export function NearbyCheckInSheet({
                           }
                         }}
                         disabled={!point || capturing}
-                        placeholder="Search"
+                        placeholder="Search places"
                         className="h-11 rounded-full pl-9"
                       />
                       {searching ? (

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1670,6 +1670,22 @@ export class OneLocationService {
     );
   }
 
+  static async extendNearbyPresence(params: {
+    vaultOwnerToken: string;
+    incrementMinutes: 30 | 60;
+  }): Promise<OneLocationNearbyPresenceState> {
+    return apiJson<OneLocationNearbyPresenceState>(
+      "/api/one/location/nearby-presence",
+      {
+        method: "PATCH",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({
+          incrementMinutes: params.incrementMinutes,
+        }),
+      },
+    );
+  }
+
   static async requestNearbyConnection(params: {
     vaultOwnerToken: string;
     participantAlias: string;


### PR DESCRIPTION
## Summary
- Simplifies the existing Nearby Check-In sheet without adding a parallel route or component.
- Renames the visible flow to `Check in nearby`, keeps setup focused on nearby places, and changes the active exit action to `I'm leaving`.
- Replaces the post-checkout setup reload/banner with a simple `Check-in ended` state plus optional `Save for faster check-ins`.
- Adds a small PATCH endpoint/client method to extend an active nearby check-in by 30 minutes or 1 hour from progressive disclosure.

## Validation
- `npm exec vitest -- run components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx app/one/location/__tests__/check-in-page-voice-publish.test.tsx` — 56 passed
- `npm run typecheck -- --pretty false` — passed
- `npm run build` — passed, includes `/one/location/check-in`
- `git diff --check` — passed
- `consent-protocol/.venv/Scripts/python.exe -m py_compile api/routes/one/location.py hushh_mcp/services/one_location_nearby_presence_service.py tests/test_one_location_nearby_presence_routes.py` — passed

## Backend test note
- `consent-protocol/.venv/Scripts/python.exe -m pytest tests/test_one_location_nearby_presence_routes.py` is currently blocked during collection by missing local dependency `ag_ui`, before the targeted tests run.