### PR TITLE
feat(one): let an owner approve a location request for less time

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1489,13 +1489,21 @@ describe("OneLocationAgentPage", () => {
     expect(
       within(flow).getByRole("button", { name: "Approve 1 hour" }),
     ).toBeTruthy();
+    // The single hard-coded "Allow 1 hour" is gone. A one-hour ask still has
+    // shorter answers -- the two below it -- and they are offered by name
+    // rather than not at all, which was the reported gap.
     expect(
       within(flow).queryByRole("button", { name: "Allow 1 hour" }),
     ).toBeNull();
+    expect(
+      within(within(flow).getByTestId("one-location-approve-shorter"))
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim()),
+    ).toEqual(["15 min", "30 min"]);
     expect(within(flow).getByRole("button", { name: "Decline" })).toBeTruthy();
   });
 
-  it("lets Needs review approve a longer request for only one hour", async () => {
+  it("lets Needs review approve a longer request for any shorter amount", async () => {
     const request = {
       id: "request_review_four_hours",
       ownerUserId: "user_a",
@@ -1548,8 +1556,15 @@ describe("OneLocationAgentPage", () => {
       within(flow).getByRole("button", { name: "Approve 4 hours" }),
     ).toBeTruthy();
 
+    // Four shorter answers for a four-hour ask, not one fixed step.
+    expect(
+      within(within(flow).getByTestId("one-location-approve-shorter"))
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim()),
+    ).toEqual(["15 min", "30 min", "1 hour", "2 hours"]);
+
     fireEvent.click(
-      within(flow).getByRole("button", { name: "Allow 1 hour" }),
+      within(flow).getByRole("button", { name: "Approve for 1 hour instead" }),
     );
 
     await waitFor(() => expect(mockApproveRequest).toHaveBeenCalledTimes(1));

--- a/hushh-webapp/__tests__/lib/one-location/approve-duration-options.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/approve-duration-options.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  APPROVE_SHORTER_MAX_OPTIONS,
+  approveShorterDurationOptions,
+} from "@/lib/one-location/approve-duration-options";
+
+/**
+ * Reported: "i received access req for 4 hours from unknown, i can either
+ * accept with same duration or deny ... if i want to edit the time, and want
+ * to approve req for shorter duration i am not allowed to do so".
+ */
+
+function ask(
+  hours: number | null,
+  mode: "timed" | "until_stopped" = "timed",
+) {
+  return { requestedDurationHours: hours, requestedDurationMode: mode };
+}
+
+describe("approveShorterDurationOptions", () => {
+  it("offers every standard length below a four-hour ask", () => {
+    // The reported case. Four answers, not the one hard-coded "Allow 1 hour"
+    // the card used to carry.
+    expect(approveShorterDurationOptions(ask(4)).map((o) => o.label)).toEqual([
+      "15 min",
+      "30 min",
+      "1 hour",
+      "2 hours",
+    ]);
+  });
+
+  it("never offers as much as, or more than, was asked", () => {
+    // The rule the whole module exists for. Approving MORE than a request
+    // named would publish the owner's location past the window anybody asked
+    // for, from the screen whose job is answering somebody else's question.
+    for (const hours of [0.25, 0.5, 1, 2, 4, 8, 24]) {
+      const offered = approveShorterDurationOptions(ask(hours));
+      expect(
+        offered.every((option) => option.hours < hours),
+        `an option was >= the ${hours}h ask`,
+      ).toBe(true);
+    }
+  });
+
+  it("has nothing shorter to offer at the floor", () => {
+    // 15 minutes is `MIN_DURATION_HOURS`. There is no smaller answer than the
+    // smallest thing anyone can ask for, so the card shows no row at all
+    // rather than an empty one.
+    expect(approveShorterDurationOptions(ask(0.25))).toEqual([]);
+  });
+
+  it("treats an open-ended ask as having no ceiling", () => {
+    // The case where choosing matters most: the alternative to naming an
+    // amount is agreeing to be visible with no end at all.
+    const offered = approveShorterDurationOptions(ask(null, "until_stopped"));
+    expect(offered.length).toBe(APPROVE_SHORTER_MAX_OPTIONS);
+    expect(offered.map((o) => o.label)).toEqual([
+      "30 min",
+      "1 hour",
+      "2 hours",
+      "4 hours",
+    ]);
+  });
+
+  it("keeps the longest when more qualify than fit", () => {
+    // Somebody negotiating an eight-hour ask down is reaching for "an hour or
+    // two", not for the floor -- and a card that grows a row per rung stops
+    // being a decision and starts being a form.
+    const offered = approveShorterDurationOptions(ask(8));
+    expect(offered).toHaveLength(APPROVE_SHORTER_MAX_OPTIONS);
+    expect(offered.map((o) => o.label)).toEqual([
+      "30 min",
+      "1 hour",
+      "2 hours",
+      "4 hours",
+    ]);
+  });
+
+  it("offers nothing when the ask carries no readable amount", () => {
+    // An older client or a referral request. There is nothing to be shorter
+    // THAN, and guessing a ceiling would offer a "less" that might be more.
+    expect(approveShorterDurationOptions(ask(null))).toEqual([]);
+    expect(approveShorterDurationOptions(ask(0))).toEqual([]);
+    expect(
+      approveShorterDurationOptions({
+        requestedDurationHours: Number.NaN,
+        requestedDurationMode: "timed",
+      }),
+    ).toEqual([]);
+  });
+
+  it("labels minutes as minutes and hours as hours", () => {
+    expect(approveShorterDurationOptions(ask(2)).map((o) => o.label)).toEqual([
+      "15 min",
+      "30 min",
+      "1 hour",
+    ]);
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -27,6 +27,7 @@ import {
   X,
 } from "lucide-react";
 
+import type { ApproveDurationOption } from "@/lib/one-location/approve-duration-options";
 import { cn } from "@/lib/utils";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
@@ -269,8 +270,8 @@ export function RequestCard({
   reason,
   approveLabel = "Approve",
   onApprove,
-  oneHourApproveLabel,
-  onApproveOneHour,
+  shorterApprovals,
+  onApproveShorter,
   onDecline,
 }: {
   name: string;
@@ -279,8 +280,21 @@ export function RequestCard({
   reason?: string;
   approveLabel?: string;
   onApprove: () => void | boolean | Promise<void | boolean>;
-  oneHourApproveLabel?: string;
-  onApproveOneHour?: () => void | boolean | Promise<void | boolean>;
+  /**
+   * Amounts below what was asked, ascending. Empty or omitted when the ask is
+   * already at the floor, or carries no readable amount to be shorter than.
+   *
+   * This replaced a single hard-coded "Allow 1 hour". Reported: "i received
+   * access req for 4 hours ... if i want to edit the time, and want to approve
+   * req for shorter duration i am not allowed to do so". One fixed step is not
+   * a choice, and it disappeared entirely for anything asked at an hour or
+   * less -- so the card's real answer set was "all of it" or "nothing".
+   *
+   * The amounts come from `lib/one-location/approve-duration-options`, which
+   * is also what guarantees none of them is LONGER than the ask.
+   */
+  shorterApprovals?: readonly ApproveDurationOption[];
+  onApproveShorter?: (hours: number) => void | boolean | Promise<void | boolean>;
   onDecline: () => void | boolean | Promise<void | boolean>;
 }) {
   // Latch the decision on THIS card once the pressed action settles.
@@ -293,15 +307,18 @@ export function RequestCard({
   // The per-card pending state blocks double taps without turning the whole
   // needs-review list into one global spinner.
   const [decision, setDecision] = useState<"approved" | "declined" | null>(null);
-  const [pendingDecision, setPendingDecision] = useState<
-    "approve" | "one-hour" | "decline" | null
-  >(null);
+  // `shorter:<hours>` so only the tapped amount spins, not the whole row.
+  const [pendingDecision, setPendingDecision] = useState<string | null>(null);
   const decided = decision !== null || pendingDecision !== null;
-  const hasOneHourApproval = Boolean(oneHourApproveLabel && onApproveOneHour);
+  const shorterOptions =
+    onApproveShorter && shorterApprovals?.length ? shorterApprovals : [];
+  const hasShorterApprovals = shorterOptions.length > 0;
 
   const settleDecision = async (
     nextDecision: "approved" | "declined",
-    pending: "approve" | "one-hour" | "decline",
+    // "approve" | "decline" | `shorter:<hours>` -- a string, because the
+    // shorter amounts are data now rather than one hard-coded rung.
+    pending: string,
     action: () => void | boolean | Promise<void | boolean>,
   ) => {
     if (decided) return;
@@ -356,49 +373,61 @@ export function RequestCard({
           {decision === "approved" ? "Approved" : "Declined"}
         </StatusText>
       ) : (
-        <div
-          className={cn(
-            "mt-3.5 grid grid-cols-1 gap-2.5",
-            hasOneHourApproval
-              ? "min-[430px]:grid-cols-2"
-              : "min-[430px]:grid-cols-[0.82fr_1.18fr]",
-          )}
-        >
+        <div className="mt-3.5 space-y-2.5">
+          {/* The full ask stays the primary answer: it is what was actually
+              requested, and most of the time it is what gets granted. */}
           <Button
             onClick={() => void settleDecision("approved", "approve", onApprove)}
             disabled={decided}
             isLoading={pendingDecision === "approve"}
-            className={cn(
-              "ui-text-button-label order-1 h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90",
-              hasOneHourApproval
-                ? "min-[430px]:col-span-2"
-                : "min-[430px]:order-2",
-            )}
+            className="ui-text-button-label h-11 w-full rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
           >
             {approveLabel}
           </Button>
-          {hasOneHourApproval ? (
-            <Button
-              onClick={() =>
-                void settleDecision("approved", "one-hour", () =>
-                  onApproveOneHour?.(),
-                )
-              }
-              disabled={decided}
-              isLoading={pendingDecision === "one-hour"}
-              className="ui-text-button-label order-2 h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80"
-            >
-              {oneHourApproveLabel}
-            </Button>
+
+          {hasShorterApprovals ? (
+            <div className="space-y-2">
+              {/* Named, because the complaint was not that the shorter answer
+                  was hard to reach -- it was that nothing on the card said it
+                  existed. Every amount here is less than what was asked. */}
+              <p className="text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]">
+                Or approve for less
+              </p>
+              <div
+                className="grid grid-cols-2 gap-2"
+                data-testid="one-location-approve-shorter"
+              >
+                {shorterOptions.map((option) => {
+                  const key = `shorter:${option.hours}`;
+                  return (
+                    <Button
+                      key={key}
+                      onClick={() =>
+                        void settleDecision("approved", key, () =>
+                          onApproveShorter?.(option.hours),
+                        )
+                      }
+                      disabled={decided}
+                      isLoading={pendingDecision === key}
+                      // The visible label is the amount; the spoken one says
+                      // what pressing it does, because four buttons reading
+                      // only "1 hour" tell a screen reader nothing.
+                      aria-label={`Approve for ${option.label} instead`}
+                      className="ui-text-button-label h-11 min-w-0 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80"
+                    >
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
           ) : null}
+
           <Button
             onClick={() => void settleDecision("declined", "decline", onDecline)}
             disabled={decided}
             isLoading={pendingDecision === "decline"}
-            className={cn(
-              "ui-text-button-label h-11 rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80",
-              hasOneHourApproval ? "order-3" : "order-2 min-[430px]:order-1",
-            )}
+            className="ui-text-button-label h-11 w-full rounded-full bg-[color:var(--app-neutral-fill-strong)] text-[color:var(--app-label)] hover:bg-[color:var(--app-neutral-fill-strong)]/80"
           >
             Decline
           </Button>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -158,6 +158,7 @@ import {
   CHANGE_TIME_DURATION_LADDER,
   REQUEST_DURATION_LADDER,
 } from "./duration-presets";
+import { approveShorterDurationOptions } from "@/lib/one-location/approve-duration-options";
 import {
   AskForMoreTime,
   type RequestMoreTimeHours,
@@ -2655,17 +2656,23 @@ function LocationDetailFlow({
                   reason={request.message ?? undefined}
                   approveLabel={locationApproveActionLabel(request, vm.nowMs)}
                   onApprove={() => vm.onApprove(request)}
-                  oneHourApproveLabel={
-                    canApproveForOneHour(request) ? "Allow 1 hour" : undefined
-                  }
-                  onApproveOneHour={
-                    canApproveForOneHour(request)
-                      ? () =>
-                          vm.onApprove(request, {
-                            durationHoursOverride: 1,
-                            durationModeOverride: "timed",
-                          })
-                      : undefined
+                  // Every amount below what was asked, rather than the single
+                  // hard-coded "Allow 1 hour" this replaced -- which was not a
+                  // choice, and which disappeared entirely for anything asked
+                  // at an hour or less. Reported as "if i want to edit the
+                  // time, and want to approve req for shorter duration i am
+                  // not allowed to do so".
+                  //
+                  // `durationModeOverride: "timed"` on every one of them, and
+                  // that matters most on an `until_stopped` ask: naming an
+                  // amount is exactly how an owner answers "forever?" with
+                  // "two hours".
+                  shorterApprovals={approveShorterDurationOptions(request)}
+                  onApproveShorter={(hours) =>
+                    vm.onApprove(request, {
+                      durationHoursOverride: hours,
+                      durationModeOverride: "timed",
+                    })
                   }
                   onDecline={() => vm.onDeny(request.id)}
                 />
@@ -3268,14 +3275,6 @@ function requestDurationLabel(request: OneLocationAccessRequest): string {
     return "Until stopped";
   }
   return formatLocationDurationLabel(request.requestedDurationHours);
-}
-
-function canApproveForOneHour(request: OneLocationAccessRequest): boolean {
-  if (request.requestedDurationMode === "until_stopped") {
-    return true;
-  }
-  const requestedHours = Number(request.requestedDurationHours);
-  return Number.isFinite(requestedHours) && requestedHours > 1;
 }
 
 function sentRequestStatusLine(

--- a/hushh-webapp/lib/one-location/approve-duration-options.ts
+++ b/hushh-webapp/lib/one-location/approve-duration-options.ts
@@ -1,0 +1,88 @@
+import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+
+/**
+ * The shorter amounts an owner may approve an incoming request for.
+ *
+ * Reported: "i received access req for 4 hours from unknown, i can either
+ * accept with same duration or deny ... if i want to edit the time, and want
+ * to approve req for shorter duration i am not allowed to do so".
+ *
+ * Accurate, and the gap was only ever in the UI. `approveRequest` has taken
+ * `durationHours` and `durationMode` since manual approval existed, and
+ * `approveAccessRequest` already forwards a `durationHoursOverride` -- the card
+ * simply never offered one except a single hard-coded "Allow 1 hour", which is
+ * not a choice, and which vanished entirely for anything asked at an hour or
+ * less. A person handed a four-hour ask from somebody they half-know had two
+ * buttons: give them all of it, or give them nothing.
+ *
+ * SHORTER ONLY, NEVER LONGER
+ *
+ * Every option here is strictly less than what was asked. Approving MORE than
+ * a request named would publish the owner's own location past the window
+ * anybody asked for, from a screen whose whole job is answering somebody
+ * else's question -- and the requester has a way to ask for more time already
+ * (`extendsGrantId`, see `redesign/request-more-time`). Answering is not the
+ * place to volunteer extra.
+ */
+
+/**
+ * The lengths on offer, ascending. Deliberately the same five the rest of
+ * Location speaks in, so an owner who has used any other duration control
+ * recognises them -- and 0.25 is the backend floor (`MIN_DURATION_HOURS`), so
+ * nothing here can be refused for being too small.
+ */
+export const APPROVE_SHORTER_HOURS: readonly number[] = [0.25, 0.5, 1, 2, 4];
+
+/**
+ * How many fit on the card before it stops being a decision and starts being
+ * a form. Four is two rows of two on the narrowest phone.
+ */
+export const APPROVE_SHORTER_MAX_OPTIONS = 4;
+
+export type ApproveDurationOption = {
+  hours: number;
+  /** "15 min" / "1 hour" — what the button says. */
+  label: string;
+};
+
+function labelFor(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)} min`;
+  return hours === 1 ? "1 hour" : `${hours} hours`;
+}
+
+/**
+ * What this request may be approved for, below what it asked.
+ *
+ * An `until_stopped` ask has no ceiling, so every rung is shorter than it --
+ * and this is the case where choosing matters most, because the alternative
+ * is agreeing to be visible with no end at all.
+ *
+ * When more rungs qualify than fit, the LONGEST are kept. Somebody negotiating
+ * a four-hour ask down is reaching for "an hour or two", not for the floor; the
+ * floor stays reachable on the asks short enough for it to be a real answer.
+ */
+export function approveShorterDurationOptions(
+  request: Pick<
+    OneLocationAccessRequest,
+    "requestedDurationHours" | "requestedDurationMode"
+  >,
+  limit: number = APPROVE_SHORTER_MAX_OPTIONS,
+): ApproveDurationOption[] {
+  const openEnded = request.requestedDurationMode === "until_stopped";
+  const requested = Number(request.requestedDurationHours);
+  const ceiling = openEnded
+    ? Number.POSITIVE_INFINITY
+    : Number.isFinite(requested) && requested > 0
+      ? requested
+      : // No readable amount means there is nothing to be shorter THAN. An
+        // older client or a referral request lands here, and guessing a
+        // ceiling would offer the owner a "less" that might be more.
+        0;
+  if (ceiling <= 0) return [];
+
+  const shorter = APPROVE_SHORTER_HOURS.filter((hours) => hours < ceiling);
+  return shorter.slice(Math.max(0, shorter.length - limit)).map((hours) => ({
+    hours,
+    label: labelFor(hours),
+  }));
+}


### PR DESCRIPTION
> "i received access req for 4 hours from unknown, i can either accept with same duration or deny. In this case if I want to edit the time, and want to approve req for shorter duration i am not allowed to do so."

Accurate — and the gap was only ever in the card.

## The wire was already fine

`approveRequest` has taken `durationHours` and `durationMode` since manual approval existed, and `approveAccessRequest` already forwarded a `durationHoursOverride`. Nothing on the backend or in the service layer changed here.

What the screen offered was a single hard-coded **"Allow 1 hour"**, gated by `canApproveForOneHour` so it disappeared entirely for anything asked at an hour or less. One fixed step is not a choice. A person handed a four-hour ask from somebody they half-know had two buttons: give them all of it, or give them nothing.

## What it looks like now

```
Asks to see your location for 4 hours
Reason · School pickup

[        Approve 4 hours        ]   ← the full ask stays primary

Or approve for less
[  15 min  ] [  30 min  ]
[  1 hour  ] [ 2 hours  ]

[           Decline             ]
```

Named, because the complaint was not that the shorter answer was hard to reach — it was that nothing on the card said it existed.

## Shorter only, never longer

`lib/one-location/approve-duration-options.ts` filters **strictly below** the ask, and that is the property the test suite is built around rather than a comment:

```ts
for (const hours of [0.25, 0.5, 1, 2, 4, 8, 24]) {
  expect(approveShorterDurationOptions(ask(hours))
    .every((option) => option.hours < hours)).toBe(true);
}
```

Approving *more* than a request named would publish the owner's own location past the window anybody asked for, from the one screen whose whole job is answering somebody else's question. A requester who wants more already has a way to ask — `extendsGrantId`, the ask-for-more-time control. Answering is not the place to volunteer extra.

## The decisions inside it

| | |
|---|---|
| **`until_stopped` asks** | No ceiling, so every rung qualifies — and this is where choosing matters most, because the alternative is agreeing to be visible with no end at all. Every option carries `durationModeOverride: "timed"`: naming an amount is exactly how an owner answers "forever?" with "two hours". |
| **Four options, longest kept** | Somebody negotiating an eight-hour ask down reaches for "an hour or two", not for the floor. A card that grows a row per rung stops being a decision and becomes a form. |
| **At the 15-minute floor** | Nothing is shorter than the smallest thing anyone can ask for, so the row does not render at all rather than rendering empty. |
| **No readable amount** | Older clients and referral requests carry none. There is nothing to be shorter *than*, and guessing a ceiling would offer a "less" that might be more — so nothing is offered. |
| **Per-option spinner** | `pendingDecision` widens from a three-value union to `shorter:<hours>` keys, so only the tapped amount spins rather than the whole row — the same reason `requestingMoreTimeKey` is a pair and not a grant id. |

`canApproveForOneHour` is deleted; it had no caller left.

## Verification

| | |
|---|---|
| webapp typecheck + eslint | clean |
| vitest — one-location + connect | **1450 / 1450** |
| new `approve-duration-options.test.ts` | 7 / 7 |
| runtime topology index | current |

The two existing Needs-review cases were updated rather than deleted: one asserts a four-hour ask now shows all four shorter answers and that tapping "1 hour" still posts `durationHours: 1, durationMode: "timed"`; the other asserts a one-hour ask — which used to get no shorter option at all — now offers the two below it.

## Still needs a human

Approving an `until_stopped` ask for a named amount, end to end, and confirming the requester's countdown reads the granted window rather than the one they asked for.
