### PR TITLE
fix(one): make the Feed live, and stop narrating an SMS as an ordinary share

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 185,
+  "expected_migration_version": 186,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_pkm_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 185,
+  "expected_migration_version": 186,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 185,
+  "expected_migration_version": 186,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/migrations/186_feed_share_kind_projection.sql
+++ b/consent-protocol/db/migrations/186_feed_share_kind_projection.sql
@@ -1,0 +1,380 @@
+BEGIN;
+
+-- Carry the share lane into the Feed's projected metadata.
+--
+-- `share_kind` is the only field that separates the SMS (Save my Soul)
+-- emergency lane from an ordinary location share. It has been allowlisted for
+-- the Feed since #5552 and the renderer branches on it, but the two projection
+-- functions in migration 179 build their metadata key by key -- deliberately,
+-- so nothing from a domain event is copied wholesale into a plaintext row --
+-- and neither of them listed this key. So the client asked "was this an
+-- emergency?" and the answer was always no.
+--
+-- The visible result: sending an SMS alert and then stopping it read as "You
+-- started sharing location" / "You stopped sharing", the same two lines an
+-- ordinary share writes, on the one screen people scan to find out what needs
+-- them. It was wrong for BOTH audiences, because both functions omitted it.
+--
+-- Bounded to 40 characters, matching the `share_kind` column the API accepts,
+-- and extracted with the same `jsonb_typeof` guard every other string input
+-- here uses. `jsonb_strip_nulls` keeps the key absent rather than null for
+-- rows written before the emitters started stamping it, so existing Feed rows
+-- keep rendering exactly as they do today.
+
+CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  counterpart_label TEXT;
+  reason_value TEXT;
+  share_kind_value TEXT;
+  duration_hours_value TEXT;
+  duration_mode_value TEXT;
+  requested_duration_hours_value TEXT;
+  requested_duration_mode_value TEXT;
+  direction_value TEXT;
+  is_extension_value BOOLEAN;
+  public_location_view_value BOOLEAN;
+  submission_id_value TEXT;
+  source_row_id_value TEXT;
+  feed_metadata JSONB;
+BEGIN
+  IF NEW.event_type = 'location_share_created'
+     AND NEW.metadata->>'reason' = 'request_approved' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_shortened',
+    'location_share_duration_changed',
+    'location_share_expired',
+    'location_access_request',
+    'location_access_approved',
+    'location_access_denied',
+    'location_access_request_withdrawn',
+    'location_public_invite_submitted',
+    'location_one_network_joined'
+  ) THEN
+    -- Feed is plaintext. Extract only scalar renderer inputs, bound every
+    -- string, and choose the keys separately for each event family. Never
+    -- copy the domain event's metadata object wholesale.
+    counterpart_label := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'counterpart_label') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'counterpart_label'), ''), 160)
+    END;
+    reason_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'reason') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'reason'), ''), 64)
+    END;
+    share_kind_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'share_kind') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'share_kind'), ''), 40)
+    END;
+    duration_hours_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'duration_hours') IN ('number', 'string')
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_hours'), ''), 32)
+    END;
+    duration_mode_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'duration_mode') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_mode'), ''), 32)
+    END;
+    requested_duration_hours_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'requested_duration_hours') IN ('number', 'string')
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'requested_duration_hours'), ''), 32)
+    END;
+    requested_duration_mode_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'requested_duration_mode') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'requested_duration_mode'), ''), 32)
+    END;
+    direction_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'direction') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'direction'), ''), 32)
+    END;
+    is_extension_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'is_extension') = 'boolean'
+      THEN (NEW.metadata ->> 'is_extension')::BOOLEAN
+    END;
+    public_location_view_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'public_location_view') = 'boolean'
+      THEN (NEW.metadata ->> 'public_location_view')::BOOLEAN
+    END;
+    submission_id_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'submission_id') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'submission_id'), ''), 256)
+    END;
+    source_row_id_value := CASE NEW.event_type
+      WHEN 'location_share_created' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_share_revoked' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_share_shortened' THEN CASE
+        WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+          COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+          ':operation:',
+          LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+        )
+        ELSE NEW.id::TEXT
+      END
+      WHEN 'location_share_duration_changed' THEN CASE
+        WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+          COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+          ':operation:',
+          LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+        )
+        ELSE NEW.id::TEXT
+      END
+      WHEN 'location_share_expired' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_request' THEN CONCAT(
+        COALESCE(NEW.request_id::TEXT, NEW.id::TEXT),
+        ':revision:',
+        COALESCE(LEFT(NULLIF(BTRIM(NEW.metadata ->> 'request_revision'), ''), 32), '1')
+      )
+      WHEN 'location_access_approved' THEN COALESCE(NEW.request_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_denied' THEN COALESCE(NEW.request_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_request_withdrawn' THEN COALESCE(
+        NEW.request_id::TEXT,
+        NEW.id::TEXT
+      )
+      WHEN 'location_public_invite_submitted' THEN COALESCE(
+        submission_id_value,
+        NEW.id::TEXT
+      )
+      WHEN 'location_one_network_joined' THEN COALESCE(
+        LEFT(NULLIF(BTRIM(NEW.metadata ->> 'invite_id'), ''), 160),
+        LEFT(NULLIF(BTRIM(NEW.metadata ->> 'connection_id'), ''), 160),
+        NEW.id::TEXT
+      )
+      ELSE NEW.id::TEXT
+    END;
+
+    feed_metadata := CASE NEW.event_type
+      WHEN 'location_share_created' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'duration_hours', duration_hours_value,
+        'duration_mode', duration_mode_value,
+        'share_kind', share_kind_value
+      ))
+      WHEN 'location_share_revoked' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'reason', reason_value,
+        'share_kind', share_kind_value
+      ))
+      WHEN 'location_share_shortened' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'reason', reason_value,
+        'grant_id', NEW.grant_id::TEXT
+      ))
+      WHEN 'location_share_duration_changed' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'direction', direction_value,
+        'grant_id', NEW.grant_id::TEXT
+      ))
+      WHEN 'location_share_expired' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'share_kind', share_kind_value
+      ))
+      WHEN 'location_access_request' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'requested_duration_hours', requested_duration_hours_value,
+        'requested_duration_mode', requested_duration_mode_value,
+        'is_extension', is_extension_value,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_access_approved' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'duration_hours', duration_hours_value,
+        'duration_mode', duration_mode_value,
+        'is_extension', is_extension_value
+      ))
+      WHEN 'location_access_denied' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'is_extension', is_extension_value
+      ))
+      WHEN 'location_access_request_withdrawn' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_public_invite_submitted' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'public_location_view', public_location_view_value,
+        'submission_id', submission_id_value,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_one_network_joined' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label
+      ))
+      ELSE '{}'::jsonb
+    END;
+
+    INSERT INTO feed_events (
+      user_id, source_domain, event_type, metadata, source_row_id
+    )
+    VALUES (
+      NEW.owner_user_id,
+      'location',
+      NEW.event_type,
+      feed_metadata,
+      source_row_id_value
+    )
+    ON CONFLICT DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_from_one_location_events() IS
+  'Fans owner-facing One Location transitions into Feed, carrying the share lane so an SMS alert is not narrated as an ordinary share.';
+
+CREATE OR REPLACE FUNCTION feed_events_recipient_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  owner_label TEXT;
+  reason_value TEXT;
+  share_kind_value TEXT;
+  duration_hours_value TEXT;
+  duration_mode_value TEXT;
+  direction_value TEXT;
+  source_row_id_value TEXT;
+  feed_metadata JSONB;
+BEGIN
+  IF NEW.recipient_user_id IS NULL
+     OR NEW.recipient_user_id = NEW.owner_user_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type NOT IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_shortened',
+    'location_share_duration_changed',
+    'location_share_expired',
+    'location_one_network_joined'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  owner_label := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'owner_label') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'owner_label'), ''), 160)
+  END;
+  IF owner_label IS NULL THEN
+    SELECT CASE
+      WHEN NULLIF(BTRIM(display_name), '') IS NOT NULL
+       AND BTRIM(display_name) <> NEW.owner_user_id
+       AND BTRIM(display_name) !~* '^ria:'
+       AND BTRIM(display_name) !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       AND NOT (
+         BTRIM(display_name) !~ '[@[:space:]]'
+         AND LENGTH(BTRIM(display_name)) >= 20
+       )
+      THEN LEFT(BTRIM(display_name), 160)
+    END
+      INTO owner_label
+      FROM actor_identity_cache
+     WHERE user_id = NEW.owner_user_id;
+  END IF;
+
+  reason_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'reason') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'reason'), ''), 64)
+  END;
+  share_kind_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'share_kind') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'share_kind'), ''), 40)
+  END;
+  duration_hours_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'duration_hours') IN ('number', 'string')
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_hours'), ''), 32)
+  END;
+  duration_mode_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'duration_mode') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_mode'), ''), 32)
+  END;
+  direction_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'direction') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'direction'), ''), 32)
+  END;
+  source_row_id_value := CASE NEW.event_type
+    WHEN 'location_share_created' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_share_revoked' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_share_shortened' THEN CASE
+      WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+        COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+        ':operation:',
+        LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+      )
+      ELSE NEW.id::TEXT
+    END
+    WHEN 'location_share_duration_changed' THEN CASE
+      WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+        COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+        ':operation:',
+        LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+      )
+      ELSE NEW.id::TEXT
+    END
+    WHEN 'location_share_expired' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_one_network_joined' THEN COALESCE(
+      LEFT(NULLIF(BTRIM(NEW.metadata ->> 'invite_id'), ''), 160),
+      LEFT(NULLIF(BTRIM(NEW.metadata ->> 'connection_id'), ''), 160),
+      NEW.id::TEXT
+    )
+    ELSE NEW.id::TEXT
+  END;
+
+  feed_metadata := CASE NEW.event_type
+    WHEN 'location_share_created' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'duration_hours', duration_hours_value,
+      'duration_mode', duration_mode_value,
+      'share_kind', share_kind_value
+    ))
+    WHEN 'location_share_revoked' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'share_kind', share_kind_value
+    ))
+    WHEN 'location_share_shortened' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'reason', reason_value,
+      'grant_id', NEW.grant_id::TEXT
+    ))
+    WHEN 'location_share_duration_changed' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'direction', direction_value,
+      'grant_id', NEW.grant_id::TEXT
+    ))
+    WHEN 'location_share_expired' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'share_kind', share_kind_value
+    ))
+    WHEN 'location_one_network_joined' THEN jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person')
+    )
+    ELSE '{}'::jsonb
+  END;
+
+  INSERT INTO feed_events (
+    user_id, source_domain, event_type, metadata, source_row_id
+  )
+  VALUES (
+    NEW.recipient_user_id,
+    'location',
+    NEW.event_type,
+    feed_metadata,
+    source_row_id_value
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_recipient_from_one_location_events() IS
+  'Fans recipient-facing One Location transitions into Feed, carrying the share lane so an SMS alert is not narrated as an ordinary share.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/186_feed_share_kind_projection.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/186_feed_share_kind_projection.rollback.sql
@@ -1,0 +1,350 @@
+BEGIN;
+
+-- Restore migration 179's projection functions verbatim: the Feed stops
+-- carrying `share_kind`, and an SMS (Save my Soul) alert goes back to reading
+-- as an ordinary location share on both sides. Rows already written keep the
+-- key; nothing is deleted.
+
+CREATE OR REPLACE FUNCTION feed_events_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  counterpart_label TEXT;
+  reason_value TEXT;
+  duration_hours_value TEXT;
+  duration_mode_value TEXT;
+  requested_duration_hours_value TEXT;
+  requested_duration_mode_value TEXT;
+  direction_value TEXT;
+  is_extension_value BOOLEAN;
+  public_location_view_value BOOLEAN;
+  submission_id_value TEXT;
+  source_row_id_value TEXT;
+  feed_metadata JSONB;
+BEGIN
+  IF NEW.event_type = 'location_share_created'
+     AND NEW.metadata->>'reason' = 'request_approved' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_shortened',
+    'location_share_duration_changed',
+    'location_share_expired',
+    'location_access_request',
+    'location_access_approved',
+    'location_access_denied',
+    'location_access_request_withdrawn',
+    'location_public_invite_submitted',
+    'location_one_network_joined'
+  ) THEN
+    -- Feed is plaintext. Extract only scalar renderer inputs, bound every
+    -- string, and choose the keys separately for each event family. Never
+    -- copy the domain event's metadata object wholesale.
+    counterpart_label := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'counterpart_label') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'counterpart_label'), ''), 160)
+    END;
+    reason_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'reason') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'reason'), ''), 64)
+    END;
+    duration_hours_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'duration_hours') IN ('number', 'string')
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_hours'), ''), 32)
+    END;
+    duration_mode_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'duration_mode') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_mode'), ''), 32)
+    END;
+    requested_duration_hours_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'requested_duration_hours') IN ('number', 'string')
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'requested_duration_hours'), ''), 32)
+    END;
+    requested_duration_mode_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'requested_duration_mode') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'requested_duration_mode'), ''), 32)
+    END;
+    direction_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'direction') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'direction'), ''), 32)
+    END;
+    is_extension_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'is_extension') = 'boolean'
+      THEN (NEW.metadata ->> 'is_extension')::BOOLEAN
+    END;
+    public_location_view_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'public_location_view') = 'boolean'
+      THEN (NEW.metadata ->> 'public_location_view')::BOOLEAN
+    END;
+    submission_id_value := CASE
+      WHEN jsonb_typeof(NEW.metadata -> 'submission_id') = 'string'
+      THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'submission_id'), ''), 256)
+    END;
+    source_row_id_value := CASE NEW.event_type
+      WHEN 'location_share_created' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_share_revoked' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_share_shortened' THEN CASE
+        WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+          COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+          ':operation:',
+          LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+        )
+        ELSE NEW.id::TEXT
+      END
+      WHEN 'location_share_duration_changed' THEN CASE
+        WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+          COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+          ':operation:',
+          LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+        )
+        ELSE NEW.id::TEXT
+      END
+      WHEN 'location_share_expired' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_request' THEN CONCAT(
+        COALESCE(NEW.request_id::TEXT, NEW.id::TEXT),
+        ':revision:',
+        COALESCE(LEFT(NULLIF(BTRIM(NEW.metadata ->> 'request_revision'), ''), 32), '1')
+      )
+      WHEN 'location_access_approved' THEN COALESCE(NEW.request_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_denied' THEN COALESCE(NEW.request_id::TEXT, NEW.id::TEXT)
+      WHEN 'location_access_request_withdrawn' THEN COALESCE(
+        NEW.request_id::TEXT,
+        NEW.id::TEXT
+      )
+      WHEN 'location_public_invite_submitted' THEN COALESCE(
+        submission_id_value,
+        NEW.id::TEXT
+      )
+      WHEN 'location_one_network_joined' THEN COALESCE(
+        LEFT(NULLIF(BTRIM(NEW.metadata ->> 'invite_id'), ''), 160),
+        LEFT(NULLIF(BTRIM(NEW.metadata ->> 'connection_id'), ''), 160),
+        NEW.id::TEXT
+      )
+      ELSE NEW.id::TEXT
+    END;
+
+    feed_metadata := CASE NEW.event_type
+      WHEN 'location_share_created' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'duration_hours', duration_hours_value,
+        'duration_mode', duration_mode_value
+      ))
+      WHEN 'location_share_revoked' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'reason', reason_value
+      ))
+      WHEN 'location_share_shortened' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'reason', reason_value,
+        'grant_id', NEW.grant_id::TEXT
+      ))
+      WHEN 'location_share_duration_changed' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'direction', direction_value,
+        'grant_id', NEW.grant_id::TEXT
+      ))
+      WHEN 'location_share_expired' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label
+      ))
+      WHEN 'location_access_request' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'requested_duration_hours', requested_duration_hours_value,
+        'requested_duration_mode', requested_duration_mode_value,
+        'is_extension', is_extension_value,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_access_approved' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'duration_hours', duration_hours_value,
+        'duration_mode', duration_mode_value,
+        'is_extension', is_extension_value
+      ))
+      WHEN 'location_access_denied' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'is_extension', is_extension_value
+      ))
+      WHEN 'location_access_request_withdrawn' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_public_invite_submitted' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label,
+        'public_location_view', public_location_view_value,
+        'submission_id', submission_id_value,
+        'request_id', NEW.request_id::TEXT
+      ))
+      WHEN 'location_one_network_joined' THEN jsonb_strip_nulls(jsonb_build_object(
+        'counterpart_label', counterpart_label
+      ))
+      ELSE '{}'::jsonb
+    END;
+
+    INSERT INTO feed_events (
+      user_id, source_domain, event_type, metadata, source_row_id
+    )
+    VALUES (
+      NEW.owner_user_id,
+      'location',
+      NEW.event_type,
+      feed_metadata,
+      source_row_id_value
+    )
+    ON CONFLICT DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_from_one_location_events() IS
+  'Fans owner-facing One Location notification events into Feed while preserving approval-born share de-duplication.';
+
+
+CREATE OR REPLACE FUNCTION feed_events_recipient_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  owner_label TEXT;
+  reason_value TEXT;
+  duration_hours_value TEXT;
+  duration_mode_value TEXT;
+  direction_value TEXT;
+  source_row_id_value TEXT;
+  feed_metadata JSONB;
+BEGIN
+  IF NEW.recipient_user_id IS NULL
+     OR NEW.recipient_user_id = NEW.owner_user_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.event_type NOT IN (
+    'location_share_created',
+    'location_share_revoked',
+    'location_share_shortened',
+    'location_share_duration_changed',
+    'location_share_expired',
+    'location_one_network_joined'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  owner_label := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'owner_label') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'owner_label'), ''), 160)
+  END;
+  IF owner_label IS NULL THEN
+    SELECT CASE
+      WHEN NULLIF(BTRIM(display_name), '') IS NOT NULL
+       AND BTRIM(display_name) <> NEW.owner_user_id
+       AND BTRIM(display_name) !~* '^ria:'
+       AND BTRIM(display_name) !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       AND NOT (
+         BTRIM(display_name) !~ '[@[:space:]]'
+         AND LENGTH(BTRIM(display_name)) >= 20
+       )
+      THEN LEFT(BTRIM(display_name), 160)
+    END
+      INTO owner_label
+      FROM actor_identity_cache
+     WHERE user_id = NEW.owner_user_id;
+  END IF;
+
+  reason_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'reason') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'reason'), ''), 64)
+  END;
+  duration_hours_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'duration_hours') IN ('number', 'string')
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_hours'), ''), 32)
+  END;
+  duration_mode_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'duration_mode') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'duration_mode'), ''), 32)
+  END;
+  direction_value := CASE
+    WHEN jsonb_typeof(NEW.metadata -> 'direction') = 'string'
+    THEN LEFT(NULLIF(BTRIM(NEW.metadata ->> 'direction'), ''), 32)
+  END;
+  source_row_id_value := CASE NEW.event_type
+    WHEN 'location_share_created' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_share_revoked' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_share_shortened' THEN CASE
+      WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+        COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+        ':operation:',
+        LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+      )
+      ELSE NEW.id::TEXT
+    END
+    WHEN 'location_share_duration_changed' THEN CASE
+      WHEN NULLIF(BTRIM(NEW.metadata ->> 'client_operation_id'), '') IS NOT NULL THEN CONCAT(
+        COALESCE(NEW.grant_id::TEXT, 'unknown-grant'),
+        ':operation:',
+        LEFT(BTRIM(NEW.metadata ->> 'client_operation_id'), 160)
+      )
+      ELSE NEW.id::TEXT
+    END
+    WHEN 'location_share_expired' THEN COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT)
+    WHEN 'location_one_network_joined' THEN COALESCE(
+      LEFT(NULLIF(BTRIM(NEW.metadata ->> 'invite_id'), ''), 160),
+      LEFT(NULLIF(BTRIM(NEW.metadata ->> 'connection_id'), ''), 160),
+      NEW.id::TEXT
+    )
+    ELSE NEW.id::TEXT
+  END;
+
+  feed_metadata := CASE NEW.event_type
+    WHEN 'location_share_created' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'duration_hours', duration_hours_value,
+      'duration_mode', duration_mode_value
+    ))
+    WHEN 'location_share_revoked' THEN jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person')
+    )
+    WHEN 'location_share_shortened' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'reason', reason_value,
+      'grant_id', NEW.grant_id::TEXT
+    ))
+    WHEN 'location_share_duration_changed' THEN jsonb_strip_nulls(jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person'),
+      'direction', direction_value,
+      'grant_id', NEW.grant_id::TEXT
+    ))
+    WHEN 'location_share_expired' THEN jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person')
+    )
+    WHEN 'location_one_network_joined' THEN jsonb_build_object(
+      'feed_audience', 'recipient',
+      'counterpart_label', COALESCE(owner_label, 'A trusted person')
+    )
+    ELSE '{}'::jsonb
+  END;
+
+  INSERT INTO feed_events (
+    user_id, source_domain, event_type, metadata, source_row_id
+  )
+  VALUES (
+    NEW.recipient_user_id,
+    'location',
+    NEW.event_type,
+    feed_metadata,
+    source_row_id_value
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION feed_events_recipient_from_one_location_events() IS
+  'Fans recipient-facing share and One Network notification events into Feed, naming the location owner as counterpart.';
+
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -157,7 +157,8 @@
     "182_public_person_profiles.sql",
     "183_one_information_request_bundles.sql",
     "184_encrypted_one_adk_sessions.sql",
-    "185_internal_access_request_id_text.sql"
+    "185_internal_access_request_id_text.sql",
+    "186_feed_share_kind_projection.sql"
   ],
   "environment_overlays": {
     "uat": [

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -3217,7 +3217,11 @@ class OneLocationAgentService:
               target_grant.id,
               target_grant.owner_user_id,
               target_grant.recipient_user_id,
-              target_grant.expires_at
+              target_grant.expires_at,
+              -- The lane this grant belonged to. Without it the expiry event
+              -- cannot say WHICH share ran out, and an emergency reads as an
+              -- ordinary share reaching its timer.
+              COALESCE(target_grant.metadata ->> 'share_kind', '') AS share_kind
                 """,
                 {"user_id": user_id},
             )
@@ -3238,7 +3242,17 @@ class OneLocationAgentService:
                     recipient_user_id=recipient_user_id or None,
                     grant_id=grant_id,
                     event_type="location_share_expired",
-                    metadata={"reason": "expires_at", "counterpart_label": recipient_label},
+                    metadata={
+                        "reason": "expires_at",
+                        "counterpart_label": recipient_label,
+                        # Same discriminator the revoke event already carries.
+                        # Omitting it here is what made an emergency share that
+                        # simply ran out of time report itself as an ordinary
+                        # share ending -- on the Feed, and for BOTH parties,
+                        # because the recipient's row is a copy of this metadata.
+                        "share_kind": str(row.get("share_kind") or "").strip().lower()
+                        or "standard",
+                    },
                     required=True,
                 )
                 if grant_id and recipient_user_id:
@@ -5049,6 +5063,14 @@ class OneLocationAgentService:
         grant_params: dict[str, Any],
     ) -> dict[str, Any] | None:
         """Atomically authorize and replace a relationship-backed grant."""
+        share_kind = ""
+        try:
+            share_kind = str(
+                (json.loads(grant_params.get("metadata_json") or "{}") or {}).get("share_kind")
+                or ""
+            )
+        except (TypeError, ValueError):
+            share_kind = ""
         bound_connection = getattr(self, "_key_writer_connection", None)
         transaction = (
             nullcontext(bound_connection)
@@ -5157,6 +5179,12 @@ class OneLocationAgentService:
                                 # share-created row when request approval writes
                                 # its richer event immediately afterwards.
                                 "reason": str(params.get("event_reason") or ""),
+                                # The lane, for the same reason the sibling
+                                # emission above carries it: this is the enforced
+                                # write path, and a share created through a
+                                # relationship must reach the Feed describing the
+                                # same lane as one created without.
+                                "share_kind": share_kind,
                             }
                         ),
                     },
@@ -5390,6 +5418,21 @@ class OneLocationAgentService:
                     "duration_hours": _duration_metadata_value(duration),
                     "duration_mode": resolved_duration_mode,
                     "counterpart_label": recipient_label,
+                    # WHICH LANE STARTED.
+                    #
+                    # The grant row has carried `share_kind` since #5552 and the
+                    # revoke event carries it too, but this event -- the one that
+                    # announces the share -- never did. `share_kind` is the only
+                    # field separating the emergency SMS lane from an ordinary
+                    # share, so without it the Feed rendered an SOS as "You
+                    # started sharing location" and, when it ended, correctly as
+                    # an SOS: one alert narrated by two different vocabularies.
+                    #
+                    # The recipient's row is a copy of this metadata (the fan-out
+                    # trigger in migration 152 adds only `feed_audience`), so
+                    # writing it here fixes the sender's Feed and the recipient's
+                    # Feed in one place.
+                    "share_kind": resolved_kind,
                     # Why this grant exists. The audit ledger keeps the row
                     # either way; the Feed fan-out trigger reads this to drop
                     # the duplicate. Approving a request already writes
@@ -5780,7 +5823,12 @@ class OneLocationAgentService:
                 jsonb_build_object(
                   'duration_hours', g.duration_hours,
                   'duration_mode', g.duration_mode,
-                  'counterpart_label', COALESCE(NULLIF(e.display_name, ''), 'A trusted person')
+                  'counterpart_label', COALESCE(NULLIF(e.display_name, ''), 'A trusted person'),
+                  -- The lane, carried straight off the grant that was just
+                  -- written. This is the path the SMS (Save my Soul) alert
+                  -- itself takes, so without it the one share that most needs
+                  -- to be told apart was the one the Feed could not tell apart.
+                  'share_kind', COALESCE(NULLIF(g.metadata ->> 'share_kind', ''), 'standard')
                 ),
                 NOW()
               FROM completed_grant g

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -4,6 +4,7 @@ import json
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -7302,3 +7303,92 @@ def test_map_preferences_doc_states_ghost_is_general_visibility_only() -> None:
     assert "GENERAL visibility only" in doc
     assert "not a switch over private sharing" in doc
     assert "list_map_state" in doc
+
+
+# ---------------------------------------------------------------------------
+# The share lane must survive the trip to the Feed.
+# ---------------------------------------------------------------------------
+#
+# `share_kind` is the only field separating the SMS (Save my Soul) emergency
+# lane from an ordinary share. It was allowlisted into the Feed payload and
+# read by the renderer, and still never arrived: every `location_share_created`
+# emitter and the expiry sweep built their event metadata by hand and left it
+# out, so an emergency was narrated as "started sharing location".
+#
+# The webapp test that covers the rendering half constructs its metadata by
+# hand, which is exactly why the gap survived review -- it can never observe
+# what the emitters actually write. These are source contracts rather than
+# runtime tests for the same reason: they hold the EMITTERS to carrying the
+# field, which is the half nothing else checks.
+
+_SERVICE_SOURCE = Path(one_location_agent_module.__file__).read_text(encoding="utf-8")
+
+
+def _metadata_block_after(marker: str, *, source: str) -> str:
+    """The literal that follows an event-type marker, up to its closing brace."""
+
+    start = source.index(marker)
+    window = source[start : start + 2000]
+    return window
+
+
+def test_every_share_created_emitter_carries_the_share_lane() -> None:
+    # Three write paths produce this event: the non-enforced branch, the
+    # enforced transaction's raw INSERT, and the with-envelope CTE that the
+    # SMS alert itself uses. All three must stamp the lane.
+    markers = [
+        'event_type="location_share_created"',
+        "CAST(:grant_id AS UUID), 'location_share_created',",
+        "'location_share_created',\n                jsonb_build_object(",
+    ]
+    for marker in markers:
+        assert marker in _SERVICE_SOURCE, f"emitter moved: {marker!r}"
+        block = _metadata_block_after(marker, source=_SERVICE_SOURCE)
+        assert "share_kind" in block, (
+            f"{marker!r} builds Feed metadata without share_kind, so the Feed "
+            "cannot tell an SMS alert from an ordinary share"
+        )
+
+
+def test_expiring_a_share_carries_the_share_lane() -> None:
+    # An 8-hour SMS alert nobody stops is ended by the lazy expiry sweep. That
+    # writer never read the grant's metadata, so the lane was absent from the
+    # domain event itself and no projection could put it back.
+    block = _metadata_block_after('event_type="location_share_expired"', source=_SERVICE_SOURCE)
+    assert "share_kind" in block
+    assert "COALESCE(target_grant.metadata ->> 'share_kind', '')" in _SERVICE_SOURCE, (
+        "the expiry sweep must RETURN the grant's lane for the event to carry it"
+    )
+
+
+def test_revoking_a_share_still_carries_the_share_lane() -> None:
+    # This one was already correct. Pinned so a future edit cannot quietly
+    # bring it back in line with the two that were wrong.
+    block = _metadata_block_after('event_type="location_share_revoked"', source=_SERVICE_SOURCE)
+    assert "share_kind" in block
+
+
+def test_feed_projection_migration_carries_the_share_lane_to_both_audiences() -> None:
+    # Emitting it is only half the trip. Migration 179's two projection
+    # functions build Feed metadata key by key -- deliberately, so nothing is
+    # copied wholesale into a plaintext row -- and neither listed this key, so
+    # both the sender's and the recipient's rows lost it again.
+    migration = (
+        Path(one_location_agent_module.__file__).parents[2]
+        / "db"
+        / "migrations"
+        / "186_feed_share_kind_projection.sql"
+    )
+    sql = migration.read_text(encoding="utf-8")
+
+    assert sql.count("CREATE OR REPLACE FUNCTION") == 2, (
+        "both the owner and recipient projections must be replaced"
+    )
+    # Three share-lifecycle families, two audiences.
+    assert sql.count("'share_kind', share_kind_value") == 6
+    for event in (
+        "location_share_created",
+        "location_share_revoked",
+        "location_share_expired",
+    ):
+        assert event in sql

--- a/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
+++ b/hushh-webapp/__tests__/components/feed-actionable-row.test.tsx
@@ -26,7 +26,7 @@ describe("FeedActionableRow", () => {
           icon: Siren,
           iconTone: "red",
           emphasis: "emergency",
-          title: "Mom triggered an SOS",
+          title: "Mom sent an SMS",
           description: "Emergency SMS — sharing live location with you now.",
           href: "/one/location?grantId=g1&open=1&section=shared",
           chevron: true,
@@ -37,7 +37,7 @@ describe("FeedActionableRow", () => {
     const frame = screen.getByTestId("feed-sms-emergency");
     expect(frame).toHaveAttribute("role", "alert");
     expect(frame).toHaveClass("border-destructive/45");
-    expect(screen.getByText("Mom triggered an SOS")).toBeInTheDocument();
+    expect(screen.getByText("Mom sent an SMS")).toBeInTheDocument();
   });
 
   it("shows a small green live dot before the description on a live SOS card only", () => {
@@ -47,7 +47,7 @@ describe("FeedActionableRow", () => {
           icon: Siren,
           iconTone: "red",
           emphasis: "emergency",
-          title: "Mom triggered an SOS",
+          title: "Mom sent an SMS",
           description: "Emergency SMS - Sent.",
         })}
       />,
@@ -59,7 +59,7 @@ describe("FeedActionableRow", () => {
         item={actionable({
           icon: Siren,
           iconTone: "red",
-          title: "Mom triggered an SOS",
+          title: "Mom sent an SMS",
           description: "Emergency SMS - Revoked",
         })}
       />,
@@ -199,7 +199,7 @@ describe("FeedActionableRow", () => {
         item={actionable({
           icon: Siren,
           iconTone: "red",
-          title: "Mom triggered an SOS",
+          title: "Mom sent an SMS",
           description: "Emergency SMS - Revoked",
           href: "/one/location?grantId=g1&open=1&section=shared",
           chevron: true,
@@ -209,7 +209,7 @@ describe("FeedActionableRow", () => {
     );
 
     expect(screen.queryByTestId("feed-sms-emergency")).toBeNull();
-    expect(screen.getByText("Mom triggered an SOS")).toBeInTheDocument();
+    expect(screen.getByText("Mom sent an SMS")).toBeInTheDocument();
     expect(container.querySelector('[data-icon-tone="red"]')).not.toBeNull();
   });
 

--- a/hushh-webapp/__tests__/lib/feed/feed-sos-share-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-sos-share-lines.test.ts
@@ -4,18 +4,27 @@ import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
 import type { FeedItem } from "@/lib/services/feed-service";
 
 /**
- * An SOS must not read as an ordinary share.
+ * An SMS must not read as an ordinary share.
  *
- * Receiving an emergency alert produced "Shared location with you", then
- * "Stopped sharing location" -- the same two lines a routine share writes. On
- * the one screen a person scans to find out what needs them, an emergency was
- * indistinguishable from someone sharing their location for an hour.
+ * SMS is this product's own name for the emergency lane -- Save my Soul -- not
+ * the carrier's; no text message is sent anywhere in the flow. "SOS" is the
+ * server's word for the same lane (`share_kind === "sos"`, the `?action=sos`
+ * slug) and it stays on the wire, where renaming it would invalidate stored
+ * grants and deep links. What a person is SHOWN is SMS, everywhere. That rule
+ * is already enforced for notification copy by
+ * `one-location-sms-revoke-notification.test.ts`; these tests extend it to the
+ * Feed, which was the one surface still saying "emergency SOS".
  *
- * The cause was not the copy. `share_kind` -- the only field separating the SOS
- * lane from everything else -- was missing from the feed metadata allowlist in
- * feed_service.py, so it never reached the client and the distinction could not
- * be drawn at all. These tests cover the rendering half; the allowlist half is
- * what makes the metadata arrive.
+ * QA, from TestFlight: sending an SMS to a connection and stopping it produced
+ * "You started sharing location" then "You stopped sharing location" -- the two
+ * lines an ordinary share writes. `share_kind` is the only field that separates
+ * the lanes, and although it was allowlisted into the Feed payload and read
+ * here, NOTHING WROTE IT: all three `location_share_created` emitters and the
+ * expiry sweep built their metadata by hand without it, and both projection
+ * triggers in migration 179 dropped it again. Constructing metadata by hand --
+ * as the tests below must -- is exactly why that gap survived, so the emission
+ * itself is covered separately in
+ * `consent-protocol/tests/test_one_location_feed_share_kind_emission.py`.
  */
 
 function item(overrides: Partial<FeedItem> = {}): FeedItem {
@@ -31,48 +40,103 @@ function item(overrides: Partial<FeedItem> = {}): FeedItem {
   };
 }
 
-describe("an SOS share reads as an emergency, not a share", () => {
-  it("names the emergency when one arrives", () => {
-    const line = presentFeedItem(
-      item({
-        metadata: {
-          counterpart_label: "Ankit",
-          share_kind: "sos",
-          feed_audience: "recipient",
-        },
-      }),
+const owner = (extra: Record<string, unknown> = {}) => ({
+  counterpart_label: "Ankit",
+  share_kind: "sos",
+  ...extra,
+});
+const recipient = (extra: Record<string, unknown> = {}) => ({
+  ...owner(extra),
+  feed_audience: "recipient",
+});
+
+describe("an SMS share reads as an emergency, not a share", () => {
+  it("names it on the sender's own Feed when it starts", () => {
+    expect(presentFeedItem(item({ metadata: owner() })).description).toBe(
+      "You sent an SMS",
     );
-    expect(line.description).toMatch(/SOS/i);
-    expect(line.description).not.toBe("Shared location with you");
   });
 
-  it("names the emergency when it ends, rather than 'stopped sharing'", () => {
-    const line = presentFeedItem(
-      item({
-        event_type: "location_share_revoked",
-        metadata: {
-          counterpart_label: "Ankit",
-          share_kind: "sos",
-          feed_audience: "recipient",
-        },
-      }),
+  it("names it on the recipient's Feed when it arrives", () => {
+    expect(presentFeedItem(item({ metadata: recipient() })).description).toBe(
+      "Sent you an SMS",
     );
-    expect(line.description).toMatch(/SOS/i);
-    expect(line.description).not.toBe("Stopped sharing location");
   });
 
-  it("names the emergency when it times out", () => {
+  it("keeps the amount when the recipient's row carries one", () => {
     const line = presentFeedItem(
-      item({
-        event_type: "location_share_expired",
-        metadata: { counterpart_label: "Ankit", share_kind: "sos" },
-      }),
+      item({ metadata: recipient({ duration_hours: 3 }) }),
     );
-    expect(line.description).toMatch(/SOS/i);
+    expect(line.description).toBe("SMS for 3 hours");
+  });
+
+  it("names it when it ends, rather than 'stopped sharing'", () => {
+    expect(
+      presentFeedItem(
+        item({ event_type: "location_share_revoked", metadata: owner() }),
+      ).description,
+    ).toBe("You ended your SMS");
+    expect(
+      presentFeedItem(
+        item({ event_type: "location_share_revoked", metadata: recipient() }),
+      ).description,
+    ).toBe("SMS ended");
+  });
+
+  it("names it when it times out", () => {
+    expect(
+      presentFeedItem(
+        item({ event_type: "location_share_expired", metadata: owner() }),
+      ).description,
+    ).toBe("SMS ran out of time");
+  });
+
+  it("never says SOS to a person, on any side or any transition", () => {
+    // The whole point of the rename. A single leak puts the server's word in
+    // front of a reader who has only ever been shown "SMS".
+    for (const event_type of [
+      "location_share_created",
+      "location_share_revoked",
+      "location_share_expired",
+    ] as const) {
+      for (const metadata of [owner(), recipient(), owner({ duration_hours: 3 })]) {
+        const line = presentFeedItem(item({ event_type, metadata }));
+        expect(line.description, `${event_type}`).not.toMatch(/SOS/i);
+        expect(line.description).toMatch(/SMS/);
+      }
+    }
+  });
+
+  it("keeps every emergency line short enough to read on one row", () => {
+    // QA: "SMS sent in one line nahi". The description column is ~197px at
+    // 375px -- roughly 30 characters of 13px Inter -- and anything longer
+    // wraps or clips. These lines are the ones a person reads while deciding
+    // whether something needs them, so they are the ones that must not wrap.
+    const lines = [
+      presentFeedItem(item({ metadata: owner() })).description,
+      presentFeedItem(item({ metadata: recipient() })).description,
+      presentFeedItem(item({ metadata: recipient({ duration_hours: 3 }) }))
+        .description,
+      presentFeedItem(
+        item({ event_type: "location_share_revoked", metadata: owner() }),
+      ).description,
+      presentFeedItem(
+        item({ event_type: "location_share_revoked", metadata: recipient() }),
+      ).description,
+      presentFeedItem(
+        item({ event_type: "location_share_expired", metadata: owner() }),
+      ).description,
+      presentFeedItem(
+        item({ event_type: "location_share_expired", metadata: {} }),
+      ).description,
+    ];
+    for (const line of lines) {
+      expect(line.length, `"${line}" is ${line.length} characters`).toBeLessThanOrEqual(30);
+    }
   });
 
   it("leaves an ordinary share untouched", () => {
-    // The regression guard that matters most: SOS wording must not leak onto
+    // The regression guard that matters most: SMS wording must not leak onto
     // every share. Absent `share_kind`, and for any other lane, the existing
     // lines stay exactly as they were.
     for (const metadata of [
@@ -92,21 +156,11 @@ describe("an SOS share reads as an emergency, not a share", () => {
     }
   });
 
-  it("still tells the two sides apart for an SOS", () => {
+  it("still tells the two sides apart", () => {
     // The owner sent it; the recipient received it. Collapsing that would put
-    // "sent an SOS" in front of the person who was alerted.
-    const owner = presentFeedItem(
-      item({ metadata: { counterpart_label: "Ankit", share_kind: "sos" } }),
+    // "you sent" in front of the person who was alerted.
+    expect(presentFeedItem(item({ metadata: owner() })).description).not.toBe(
+      presentFeedItem(item({ metadata: recipient() })).description,
     );
-    const recipient = presentFeedItem(
-      item({
-        metadata: {
-          counterpart_label: "Ankit",
-          share_kind: "sos",
-          feed_audience: "recipient",
-        },
-      }),
-    );
-    expect(owner.description).not.toBe(recipient.description);
   });
 });

--- a/hushh-webapp/__tests__/lib/feed/use-feed-live-refresh.test.tsx
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-live-refresh.test.tsx
@@ -16,6 +16,13 @@ import {
  * while the list it badged asked the server nothing after the app opened.
  *
  * This pins the signal every Feed surface now shares.
+ *
+ * It re-checks ON MOUNT as well as on the interval. It used to start the timer
+ * and nothing else, and the resource's own mount load is unforced -- so it
+ * short-circuits against a cache entry that stays fresh for a full minute.
+ * Landing on the Feed 59s after the last fetch therefore did no network at
+ * all, and the first forced request went out 45s after that: a 105-second
+ * worst case on the screen someone opened precisely to see what just happened.
  */
 
 function setVisibility(state: DocumentVisibilityState) {
@@ -44,18 +51,42 @@ describe("useFeedLiveRefresh", () => {
     const refresh = vi.fn();
     renderHook(() => useFeedLiveRefresh(refresh));
 
-    expect(refresh).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
+    // Mount is itself the freshest moment to ask.
     expect(refresh).toHaveBeenCalledTimes(1);
 
+    vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
     vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 2);
-    expect(refresh).toHaveBeenCalledTimes(3);
+    expect(refresh).toHaveBeenCalledTimes(4);
+  });
+
+  it("asks once on mount rather than waiting out the first interval", () => {
+    // The 105s worst case, pinned. A surface that mounts visible must have
+    // asked the server before any timer has run.
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-checks when a push says new activity arrived", () => {
+    // A push IS the server telling us something happened. Before this the Feed
+    // learned about it only from its own timer, so an event that had already
+    // lit up the phone's notification tray could still be missing from the
+    // list the person opened to look at it.
+    const refresh = vi.fn();
+    renderHook(() => useFeedLiveRefresh(refresh));
+    refresh.mockClear();
+
+    dispatchFeedStateChanged("arrived");
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("stops polling while the tab is hidden and catches up on return", () => {
     const refresh = vi.fn();
     renderHook(() => useFeedLiveRefresh(refresh));
+
+    refresh.mockClear();
 
     setVisibility("hidden");
     vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 5);
@@ -75,6 +106,7 @@ describe("useFeedLiveRefresh", () => {
   it("re-checks on window focus, which iOS webviews raise without a visibility change", () => {
     const refresh = vi.fn();
     renderHook(() => useFeedLiveRefresh(refresh));
+    refresh.mockClear();
 
     window.dispatchEvent(new Event("focus"));
     expect(refresh).toHaveBeenCalledTimes(1);
@@ -83,6 +115,7 @@ describe("useFeedLiveRefresh", () => {
   it("re-checks when something was acted on, but not when rows were only marked read", () => {
     const refresh = vi.fn();
     renderHook(() => useFeedLiveRefresh(refresh));
+    refresh.mockClear();
 
     // Opening the Feed marks it read. Re-fetching in response would only return
     // the rows already on screen.
@@ -101,6 +134,7 @@ describe("useFeedLiveRefresh", () => {
   it("defers action signals from a hidden tab until it becomes visible", () => {
     const refresh = vi.fn();
     renderHook(() => useFeedLiveRefresh(refresh));
+    refresh.mockClear();
 
     setVisibility("hidden");
     dispatchFeedStateChanged("action");
@@ -121,6 +155,7 @@ describe("useFeedLiveRefresh", () => {
 
     const refresh = vi.fn();
     const { unmount } = renderHook(() => useFeedLiveRefresh(refresh));
+    refresh.mockClear();
     unmount();
     vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS * 3);
     window.dispatchEvent(new Event("focus"));
@@ -137,10 +172,13 @@ describe("useFeedLiveRefresh", () => {
       { initialProps: { fn: first } },
     );
 
+    // `first` owns the mount call; everything after the rerender is `second`.
+    expect(first).toHaveBeenCalledTimes(1);
+
     rerender({ fn: second });
     vi.advanceTimersByTime(FEED_LIVE_POLL_INTERVAL_MS);
 
-    expect(first).not.toHaveBeenCalled();
+    expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
   });
 });

--- a/hushh-webapp/__tests__/voice/location-flow-labels.test.ts
+++ b/hushh-webapp/__tests__/voice/location-flow-labels.test.ts
@@ -43,13 +43,22 @@ describe("every Location flow voice can open announces itself", () => {
     });
   });
 
-  it("names the SOS flow, which has nothing else to announce it", () => {
-    // `location.open_sos` is what a spoken SOS request navigates to, and the
-    // navigation is deliberately where it stops. If this label ever goes
+  it("names the emergency flow, which has nothing else to announce it", () => {
+    // `location.open_sos` is what a spoken emergency request navigates to, and
+    // the navigation is deliberately where it stops. If this label ever goes
     // missing, that request becomes completely silent to One rather than
     // merely incomplete.
+    //
+    // The label says SMS, the flow slug still says `sos`. That split is
+    // deliberate and load-bearing: `sos` is the wire value -- the `?action=`
+    // slug, the `share_kind`, the route id -- and renaming it would break
+    // every stored grant and deep link. SMS is what a person is shown, and
+    // this product's own name for it (Save my Soul). The same rule is already
+    // enforced for notification copy by
+    // one-location-sms-revoke-notification.test.ts.
     const sos = flowsFromContracts.find((entry) => entry.flow === "sos");
     expect(sos?.actionId).toBe("location.open_sos");
-    expect(LOCATION_FLOW_LABELS.sos).toBe("Emergency SOS");
+    expect(LOCATION_FLOW_LABELS.sos).toBe("Emergency SMS");
+    expect(LOCATION_FLOW_LABELS.sos).not.toMatch(/SOS/i);
   });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -1756,7 +1756,7 @@ export default function ConnectPageClient() {
           id: "circles",
           title: "Circles",
           purpose:
-            "See the groups you are in -- Trusted holds everyone you are connected to, the SMS Circle gets your SOS -- and open one to manage who is in it.",
+            "See the groups you are in -- Trusted holds everyone you are connected to, the SMS Circle gets your SMS -- and open one to manage who is in it.",
         },
         {
           id: "people",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -639,7 +639,7 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
   "circle-detail": "Circle detail",
   "temp-link": "Temporary link",
   "check-in": "Check in",
-  sos: "Emergency SOS",
+  sos: "Emergency SMS",
   "sms-contacts": "Emergency contacts",
   settings: "Location settings",
   "active-shares": "Active shares",
@@ -725,8 +725,8 @@ const LOCATION_VOICE_CONTROLS = [
   },
   {
     id: "one-location-action-sos",
-    label: "Send SOS",
-    purpose: "Open emergency SOS.",
+    label: "Send SMS",
+    purpose: "Open emergency SMS.",
     actionId: "location.open_sos",
     role: "button",
   },
@@ -10831,14 +10831,14 @@ export function OneLocationAgentPageContent({
     if (!vaultOwnerToken) {
       return {
         status: "blocked" as const,
-        summary: "Unlock One before stopping an SOS.",
+        summary: "Unlock One before stopping an SMS.",
       };
     }
     const incident = sosIncident;
     if (!incident?.grantIds.length) {
       return {
         status: "blocked" as const,
-        summary: "There is no SOS running to stop.",
+        summary: "There is no SMS running to stop.",
       };
     }
     const grantCount = incident.grantIds.length;
@@ -10854,8 +10854,8 @@ export function OneLocationAgentPageContent({
       // stronger than that would be one this cannot actually check.
       summary:
         grantCount === 1
-          ? "Stopped the SOS and revoked the share it created."
-          : `Stopped the SOS and revoked the ${grantCount} shares it created.`,
+          ? "Stopped the SMS and revoked the share it created."
+          : `Stopped the SMS and revoked the ${grantCount} shares it created.`,
     };
   });
 
@@ -10866,7 +10866,7 @@ export function OneLocationAgentPageContent({
       if (!vaultOwnerToken) {
         return {
           status: "blocked" as const,
-          summary: "Unlock One before sending an SOS alert.",
+          summary: "Unlock One before sending an SMS alert.",
         };
       }
       // Same re-entry guard handleTriggerSos itself enforces -- checked here
@@ -10876,14 +10876,14 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "There is already an SOS running. Say stop the S O S to end it first.",
+            "There is already an SMS running. Stop it before sending another.",
         };
       }
       if (locationPermissionBlocksSharing(permission)) {
         return {
           status: "blocked" as const,
           summary:
-            "Location access is off, so I cannot send an SOS alert with your position.",
+            "Location access is off, so I cannot send an SMS alert with your position.",
         };
       }
       const readyRecipients = smsActionRecipients.filter(
@@ -10894,7 +10894,7 @@ export function OneLocationAgentPageContent({
           status: "blocked" as const,
           summary: smsActionRecipients.length
             ? "Your emergency contacts are not ready to receive an alert yet."
-            : "Add at least one emergency contact before sending an SOS alert.",
+            : "Add at least one emergency contact before sending an SMS alert.",
         };
       }
       const note = String(slots?.note ?? "").trim() || null;
@@ -10912,16 +10912,16 @@ export function OneLocationAgentPageContent({
         );
         return {
           status: "blocked" as const,
-          summary: "Sending an SOS alert needs a confirmation.",
+          summary: "Sending an SMS alert needs a confirmation.",
           data: {
             [VOICE_CONFIRM_DATA_KEY]: {
               actionId: "location.trigger_sos",
               slots: { note: note ?? "", confirmed: true },
-              prompt: `Send an SOS alert to ${names} right now?`,
-              subject: { name: "SOS alert", detail: names },
+              prompt: `Send an SMS alert to ${names} right now?`,
+              subject: { name: "SMS alert", detail: names },
               consequence:
                 getKaiActionById("location.trigger_sos")?.meaning ?? null,
-              confirmLabel: "Send SOS",
+              confirmLabel: "Send SMS",
             },
           },
         };
@@ -10929,7 +10929,7 @@ export function OneLocationAgentPageContent({
       void handleTriggerSos(note);
       return {
         status: "succeeded" as const,
-        summary: "Sending your SOS alert now.",
+        summary: "Sending your SMS alert now.",
       };
     },
     [
@@ -10947,7 +10947,7 @@ export function OneLocationAgentPageContent({
     if (!vaultOwnerToken) {
       return {
         status: "blocked" as const,
-        summary: "Unlock One before sending an SOS alert.",
+        summary: "Unlock One before sending an SMS alert.",
       };
     }
     // Never invented: an unreadable preference falls back to "open", the
@@ -10967,7 +10967,7 @@ export function OneLocationAgentPageContent({
     router.replace(`${ROUTES.ONE_LOCATION}?action=sos`, { scroll: false });
     return {
       status: "succeeded" as const,
-      summary: "Opening the SOS screen.",
+      summary: "Opening the SMS screen.",
     };
   });
 
@@ -11001,7 +11001,7 @@ export function OneLocationAgentPageContent({
         return {
           status: "blocked" as const,
           summary:
-            "Nobody in your connections can receive an SOS under that name.",
+            "Nobody in your connections can receive an SMS under that name.",
         };
       }
       if (matches.length > 1) {
@@ -11036,7 +11036,7 @@ export function OneLocationAgentPageContent({
       }
       return {
         status: "succeeded" as const,
-        summary: `${recipientLabel(match).trim()} will now be sent your location if you trigger an SOS.`,
+        summary: `${recipientLabel(match).trim()} will now be sent your location if you send an SMS.`,
       };
     },
   );
@@ -11124,7 +11124,7 @@ export function OneLocationAgentPageContent({
       }
       return {
         status: "succeeded" as const,
-        summary: `${recipientLabel(match).trim()} will no longer be sent your location in an SOS.`,
+        summary: `${recipientLabel(match).trim()} will no longer be sent your location in an SMS.`,
       };
     },
   );

--- a/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
+++ b/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
@@ -181,7 +181,7 @@ describe("circleRowDescription", () => {
       "Everyone you're connected to · 7 people",
     );
     expect(circleRowDescription(circle("s", "SMS Circle", 4, "sms"))).toBe(
-      "Gets your SOS text · 3 people",
+      "Gets your SMS · 3 people",
     );
   });
 
@@ -190,7 +190,7 @@ describe("circleRowDescription", () => {
       "Everyone you're connected to",
     );
     expect(circleRowDescription(circle("s", "SMS Circle", 1, "sms"))).toBe(
-      "Gets your SOS text · no one yet",
+      "Gets your SMS · no one yet",
     );
   });
 
@@ -199,17 +199,21 @@ describe("circleRowDescription", () => {
     // the ones you do not own -- "Alice's SMS Circle" -- because three
     // friends' rosters would otherwise be three identical rows.
     const theirs = circle("s", "Alice's SMS Circle", 4, "sms", "member");
-    expect(circleRowDescription(theirs)).toBe("You'll get their SOS text");
+    expect(circleRowDescription(theirs)).toBe("You'll get their SMS");
   });
 
-  it("never tells a member it is their own SOS text", () => {
+  it("never tells a member it is their own SMS", () => {
     const theirs = circle("s", "Alice's SMS Circle", 4, "sms", "member");
-    expect(circleRowDescription(theirs)).not.toContain("your SOS");
+    // SMS is Save my Soul, this product's own name for the lane; "SOS" is the
+    // server's word and is never shown to a person. Both are checked so the
+    // rename cannot regress in either direction.
+    expect(circleRowDescription(theirs)).not.toContain("your SMS");
+    expect(circleRowDescription(theirs)).not.toMatch(/SOS/i);
   });
 
   it("still recognises an SMS Circle from a server that predates systemKind", () => {
     const legacy = { ...circle("s", "SMS Circle", 3, "sms"), systemKind: null };
-    expect(circleRowDescription(legacy)).toBe("Gets your SOS text · 2 people");
+    expect(circleRowDescription(legacy)).toBe("Gets your SMS · 2 people");
   });
 });
 

--- a/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
+++ b/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
@@ -101,7 +101,7 @@ const SYSTEM_CIRCLE_COPY = {
   },
   sms: {
     title: "SMS Circle",
-    description: "Gets your SOS text",
+    description: "Gets your SMS",
   },
 } as const satisfies Record<SystemCircleKind, { title: string; description: string }>;
 
@@ -148,11 +148,11 @@ export function circleRowDescription(circle: OneLocationCircleSummary): string {
   }
   if (kind === "sms") {
     // An SMS Circle appears in the list of everyone ON it, not only its
-    // owner's. "Gets your SOS text" is true for exactly one of those readers;
+    // owner's. "Gets your SMS" is true for exactly one of those readers;
     // for the rest the line has to say what it means for THEM.
     const lead = owns
       ? SYSTEM_CIRCLE_COPY.sms.description
-      : "You'll get their SOS text";
+      : "You'll get their SMS";
     if (!owns) return lead;
     return others === 0 ? `${lead} · no one yet` : `${lead} · ${people}`;
   }

--- a/hushh-webapp/e2e/location-agent-now-ui.spec.ts
+++ b/hushh-webapp/e2e/location-agent-now-ui.spec.ts
@@ -117,7 +117,7 @@ test.describe("Location Agent Now visual contract", () => {
       lineHeight: "20px",
       color: "rgb(29, 29, 31)",
     });
-    await expectTypography(actionTitles.filter({ hasText: "Send SOS" }), {
+    await expectTypography(actionTitles.filter({ hasText: "Send SMS" }), {
       fontSize: "15px",
       fontWeight: "500",
       lineHeight: "20px",

--- a/hushh-webapp/lib/agent/voice-agent-examples.ts
+++ b/hushh-webapp/lib/agent/voice-agent-examples.ts
@@ -43,7 +43,7 @@ export const VOICE_AGENT_EXAMPLE_GROUPS: readonly VoiceAgentExampleGroup[] = [
       },
       {
         phrase: "Trigger SOS",
-        result: "Opens the emergency SOS screen.",
+        result: "Opens the emergency SMS screen.",
       },
     ],
   },

--- a/hushh-webapp/lib/feed/feed-events.ts
+++ b/hushh-webapp/lib/feed/feed-events.ts
@@ -9,8 +9,14 @@ export const FEED_STATE_CHANGED_EVENT = "hushh:feed-state-changed";
  *   has these rows and re-fetching them would be a wasted request.
  * - `action` — something was approved, denied, or dismissed, so there is new
  *   activity to load. Every feed surface should re-check.
+ * - `arrived` — new activity exists that this device did not cause: a push
+ *   landed while the app was open, or the user's own write just succeeded.
+ *   Handled exactly like `action`; it is named separately because the two
+ *   answer different questions when reading a trace, and because "the Feed is
+ *   not live" was diagnosed by finding that nothing dispatched anything at all
+ *   when a push arrived — the Feed simply waited out its 45s timer.
  */
-export type FeedStateChangeReason = "read" | "action";
+export type FeedStateChangeReason = "read" | "action" | "arrived";
 
 export type FeedStateChangedDetail = { reason: FeedStateChangeReason };
 
@@ -26,8 +32,16 @@ export function dispatchFeedStateChanged(
 }
 
 /** Reads the reason off a dispatched event, defaulting to the broader `action`
- *  so an untagged legacy dispatch still refreshes everything. */
+ *  so an untagged legacy dispatch still refreshes everything.
+ *
+ *  `arrived` is preserved rather than folded into `action`. Both refresh, so
+ *  collapsing them changed no behaviour -- it only threw away the one thing
+ *  that distinguishes "the server told us" from "the reader pressed something"
+ *  at exactly the point someone would be reading a trace to find out why the
+ *  Feed did or did not update. */
 export function feedStateChangeReason(event: Event): FeedStateChangeReason {
   const detail = (event as CustomEvent<Partial<FeedStateChangedDetail>>).detail;
-  return detail?.reason === "read" ? "read" : "action";
+  if (detail?.reason === "read") return "read";
+  if (detail?.reason === "arrived") return "arrived";
+  return "action";
 }

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -202,12 +202,20 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         // For an approval-born share this is the requester's ONLY row (152
         // writes it; 153 deliberately does not add a second for the approval),
         // so it names the granted amount that the event metadata carries.
+        // "SMS", never "SOS". SMS is this product's own name -- Save my
+        // Soul -- not the phone carrier's. The service layer already says so
+        // ("the emergency (SMS / Save My Soul) lane"), the Circle that carries
+        // it is the "SMS Circle", and the notification list says "SMS sharing
+        // stopped with X". The Feed was the one surface calling it an SOS, so
+        // the same alert read as a different feature depending on where you
+        // saw it. The short form is also what keeps these lines on one row at
+        // phone width.
         description: isSos
           ? sharedWithMe
             ? shareAmount
-              ? `Emergency SOS shared with you for ${shareAmount}`
-              : "Emergency SOS shared with you"
-            : "You sent an emergency SOS"
+              ? `SMS for ${shareAmount}`
+              : "Sent you an SMS"
+            : "You sent an SMS"
           : sharedWithMe
             ? shareAmount
               ? `Shared location with you for ${shareAmount}`
@@ -230,8 +238,8 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         // Audience decides the sentence; reason only refines the owner's.
         description: isSosShare(item.metadata)
           ? sharedWithMe
-            ? "Emergency SOS ended"
-            : "You ended your emergency SOS"
+            ? "SMS ended"
+            : "You ended your SMS"
           : sharedWithMe
             ? "Sharing stopped"
             : ownerRevoked
@@ -249,9 +257,15 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         person: counterpartPerson(item.metadata, who),
         // No audience split: this line names no subject, and the row's title is
         // already the other person, so it reads correctly from both sides.
+        // Both lines shortened to fit the row on one line at 375px. The
+        // description column is ~197px there, about 30 characters of 13px
+        // Inter, and "Sharing ended when time ran out" is 31 -- which is the
+        // "Stopped sharing - time ran..." QA photographed. Nothing is lost:
+        // the row's title is already the other person, so the sentence never
+        // needed to name a subject.
         description: isSosShare(item.metadata)
-          ? "Emergency SOS ended when time ran out"
-          : "Sharing ended when time ran out",
+          ? "SMS ran out of time"
+          : "Ended when time ran out",
         href: ROUTES.ONE_LOCATION,
       };
     }

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -576,12 +576,17 @@ export function useFeedActionables(): UseFeedActionablesResult {
         id: `sms-emergency:${grant.id}`,
         icon: Siren,
         iconTone: "red",
-        // Only a still-live SOS gets the pinned "Live" emergency treatment.
+        // Only a still-live alert gets the pinned "Live" emergency treatment.
         // A revoked/expired one renders as a plain "Needs you" row (see
         // feed-page.tsx) — Siren icon + red icon-well tint are all that's
-        // left as the "this was an SOS" signal.
+        // left as the "this was an emergency" signal.
         emphasis: isRevoked ? undefined : "emergency",
-        title: `${label} triggered an SOS`,
+        // "sent an SMS", not "triggered an SOS". SMS is Save my Soul, this
+        // product's own name for the lane, and the rule that recipient-facing
+        // copy never says "SOS" is already enforced for the notification
+        // copy by one-location-sms-revoke-notification.test.ts. This row was
+        // saying both at once: an "SOS" title above an "Emergency SMS" body.
+        title: `${label} sent an SMS`,
         description: isRevoked
           ? "Emergency SMS - Revoked"
           : "Emergency SMS - Sent.",

--- a/hushh-webapp/lib/feed/use-feed-live-refresh.ts
+++ b/hushh-webapp/lib/feed/use-feed-live-refresh.ts
@@ -73,7 +73,18 @@ export function useFeedLiveRefresh(
       }
     };
 
-    if (document.visibilityState === "visible") startPolling();
+    // Refresh ON MOUNT, not only 45 seconds after it.
+    //
+    // This started the timer and nothing else, and the resource's own mount
+    // load is unforced -- so it short-circuits against a cache entry that is
+    // fresh for a full minute. Landing on the Feed 59s after the last fetch
+    // therefore did no network at all, and the first forced request went out
+    // 45s later: a 105-second worst case on the screen someone opened
+    // precisely to see what just happened.
+    if (document.visibilityState === "visible") {
+      run();
+      startPolling();
+    }
 
     document.addEventListener("visibilitychange", onVisibilityChange);
     // iOS webviews do not always pair `focus` with a `visibilitychange`, so both

--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -490,6 +490,11 @@ function setupWebServiceWorkerBridge(): void {
       accepted: false,
     };
     window.dispatchEvent(new CustomEvent(FCM_MESSAGE_EVENT, { detail }));
+    // A push IS the server telling us there is new activity. Until this line
+    // the Feed learned about it only from its own 45s timer, so an event that
+    // had already lit up the phone's notification tray could still be missing
+    // from the list the person opened to look at it.
+    dispatchFeedStateChanged("arrived");
     if (message.delivery_id && detail.accepted) {
       const source = event.source as { postMessage?: (value: unknown) => void } | null;
       source?.postMessage?.({
@@ -823,6 +828,7 @@ async function initializeWebFCM(
             detail: payload,
           })
         );
+        dispatchFeedStateChanged("arrived");
       });
       webListenerConfigured = true;
     }
@@ -911,6 +917,7 @@ function setupNativeListeners(): Promise<void> {
               detail: notification,
             })
           );
+          dispatchFeedStateChanged("arrived");
         }),
       );
 

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/one-location/location-bus";
 import type { AutoApproveScope } from "@/lib/one-location/location-control-state";
 import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
+import { dispatchFeedStateChanged } from "@/lib/feed/feed-events";
 import { ApiError, apiErrorCode, apiJson } from "@/lib/services/api-client";
 import type {
   ActionResult,
@@ -228,6 +229,22 @@ function pagedItems<T>(payload: { items?: T[] } | null, endpoint: string): T[] {
     );
   }
   return payload.items;
+}
+
+/**
+ * Tell every Feed surface that this device just wrote something worth showing.
+ *
+ * The Feed learns about OTHER people's activity from a push, and about its own
+ * from nothing at all -- so the row for an action you just took waited out the
+ * 45s poll on the very screen you opened to check it had worked. These calls
+ * are the only writes that produce a Feed row, so announcing here covers every
+ * caller (hub, agent, voice, deep link) instead of each one remembering to.
+ *
+ * Fire-and-forget and side-effect free: the Feed re-fetches, and a surface that
+ * is not mounted hears nothing.
+ */
+function announceFeedActivity(): void {
+  dispatchFeedStateChanged("arrived");
 }
 
 export class OneLocationService {
@@ -1301,6 +1318,7 @@ export class OneLocationService {
         }),
       },
     );
+    announceFeedActivity();
     return response.grant;
   }
 
@@ -1411,7 +1429,11 @@ export class OneLocationService {
     envelope: OneLocationEncryptedEnvelope;
     idempotentReplay: boolean;
   }> {
-    return apiJsonWithRetry(
+    const created = await apiJsonWithRetry<{
+      grant: OneLocationGrant;
+      envelope: OneLocationEncryptedEnvelope;
+      idempotentReplay: boolean;
+    }>(
       "/api/one/location/grants/with-envelope",
       {
         method: "POST",
@@ -1432,6 +1454,8 @@ export class OneLocationService {
       },
       1,
     );
+    announceFeedActivity();
+    return created;
   }
 
   static async storeEnvelope(params: {
@@ -1772,6 +1796,7 @@ export class OneLocationService {
         headers: jsonAuthHeaders(params.vaultOwnerToken),
       },
     );
+    announceFeedActivity();
     return response.grant;
   }
 
@@ -1802,6 +1827,7 @@ export class OneLocationService {
         }),
       },
     );
+    announceFeedActivity();
     return response.grant;
   }
 
@@ -1853,6 +1879,7 @@ export class OneLocationService {
         }),
       },
     );
+    announceFeedActivity();
     return response.grant;
   }
 
@@ -1885,6 +1912,7 @@ export class OneLocationService {
       },
       1,
     );
+    announceFeedActivity();
     return response.request;
   }
 
@@ -1908,7 +1936,11 @@ export class OneLocationService {
     recipient?: OneLocationRecipient;
   }> {
     const durationHours = Number(params.durationHours);
-    return apiJson(
+    const approved = await apiJson<{
+      request: OneLocationAccessRequest;
+      grant: OneLocationGrant;
+      recipient?: OneLocationRecipient;
+    }>(
       `/api/one/location/requests/${encodeURIComponent(params.requestId)}/approve`,
       {
         method: "POST",
@@ -1927,6 +1959,8 @@ export class OneLocationService {
         }),
       },
     );
+    announceFeedActivity();
+    return approved;
   }
 
   static async denyRequest(params: {
@@ -1940,6 +1974,7 @@ export class OneLocationService {
         headers: jsonAuthHeaders(params.vaultOwnerToken),
       },
     );
+    announceFeedActivity();
     return response.request;
   }
 
@@ -1961,6 +1996,7 @@ export class OneLocationService {
         headers: jsonAuthHeaders(params.vaultOwnerToken),
       },
     );
+    announceFeedActivity();
     return response.request;
   }
 


### PR DESCRIPTION
Closes #6234.

QA, from TestFlight: *"real time mein populate nahi ho raha … maine abhi Ankit ko
SMS send kiya and stop kiya, feed mein yeh wording sab galat hai."*

---

## 1. The Feed was not live

Nothing told it anything had happened. A push already arrives instantly for the
same events and only ever dispatched `FCM_MESSAGE_EVENT`, which **no Feed
surface listened for**; the user's own writes announced nothing at all. So the
list waited out its 45s timer on the screen someone opened precisely to check
their action had worked.

And it was worse than 45s. `useFeedLiveRefresh` started its interval on mount
and did not fetch, while the resource's mount load is unforced — so it
short-circuits against a cache entry that stays fresh for a full minute:

```
CACHE_TTL.SHORT (60s, unforced mount load)  +  FEED_LIVE_POLL_INTERVAL_MS (45s)
= 105 s worst case
```

Three fixes, all on infrastructure that already existed:

| Signal | Before | After |
|---|---|---|
| Someone else acts (push arrives) | ignored, wait ≤45s | refresh immediately |
| You act | nothing dispatched | refresh on success (9 call sites) |
| You open the Feed | timer starts, no fetch | fetch on mount |

The poll stays as the backstop it should always have been.

## 2. An SMS read as an ordinary location share

`share_kind` is the only field separating the SMS (Save my Soul) emergency lane
from a plain share. It was allowlisted into the Feed payload **and** branched on
by the renderer — and written by nobody. The gap was two layers deep:

- all three `location_share_created` emitters and the expiry sweep built their
  event metadata by hand without it (revoke already carried it);
- **both** projection triggers in migration 179 rebuild Feed metadata key by key
  — deliberately, so nothing is copied wholesale into a plaintext row — and
  neither listed the key, so it was dropped again for both audiences.

Migration **186** adds it to both projections. Because the recipient's row is a
copy of the emitted metadata, fixing the emitters corrects the sender's Feed and
the recipient's Feed together — which is the "both sides" half of the report.

The existing test passed the whole time because it constructs metadata by hand
and so can never observe what the emitters write. New source contracts in the
backend suite hold the emitters themselves.

## 3. "SMS", never "SOS"

SMS is this product's own name — **Save my Soul** — not the carrier's; no text
message is sent anywhere in the flow. The rule that a person is never shown the
word "SOS" was already written and tested for notification copy
(`one-location-sms-revoke-notification.test.ts`); the Feed and the Location voice
surfaces had simply never been brought into line. One row managed to say both at
once — an "SOS" title above an "Emergency SMS" body.

User-visible copy now says SMS everywhere. **The wire keeps `sos`**: the
`?action=sos` slug, `share_kind`, route ids and recognised speech are unchanged,
so stored grants and deep links keep working and saying "SOS" out loud still
triggers the alert.

## 4. Lines that fit on one line

| | before | after |
|---|---|---|
| sender, started | You started sharing location | **You sent an SMS** |
| recipient, started | Shared location with you | **Sent you an SMS** |
| recipient, with amount | Shared location with you for 3 hours | **SMS for 3 hours** |
| sender, stopped | You stopped sharing | **You ended your SMS** |
| recipient, stopped | Sharing stopped | **SMS ended** |
| timed out | Sharing ended when time ran out (31 ch) | **SMS ran out of time** / **Ended when time ran out** |

The description column is ~30 characters at 375px, which is why
"Sharing ended when time ran out" was the `Stopped sharing - time ran…` QA
photographed. A test pins every line at ≤30 characters.

**Clamping was deliberately not added.** An ellipsis is the thing that was
reported, so the fix is copy that fits, not copy that gets cut.

## Deploy blocker this also clears

`verify_release_migration_contract.py` refuses any repo whose migration head is
not registered, and it runs in the UAT, prod and dev deploy workflows:

```
ERROR: release_manifest_repo_head_unaccounted:canonical=185:repo=186
```

186 is registered in `release_migration_manifest.json` and all three schema
contracts are bumped, so the guard passes. Without this the whole change would
be inert in every environment and the UAT deploy would be refused.

## Verification

| Check | Result |
|---|---|
| `tsc`, `eslint`, `ruff` on every changed file | clean |
| webapp — 24 Feed/notification test files | 154 passed |
| webapp — surfaces the rename touches | 74 passed |
| backend — `test_one_location_agent_service.py` | 186 passed (4 new contracts) |
| `verify_release_migration_contract.py` | aligned at 186 |
| `verify:voice-gateway`, `verify:design-system` | current |

## Found but deliberately not fixed here

Flagged rather than folded in, because each is its own change:

- **Adding or removing an SMS contact emits no event at all**, on either side —
  a person is silently enrolled as someone's emergency contact and never told.
- `location_share_viewed` has no Feed projection, so "they opened your location"
  never reaches either Feed.
- The row title is unclamped, so a long counterparty name can still take two
  lines. Not what was reported, and clamping it has the same ellipsis trade-off
  as above.