### PR TITLE
feat(one): tell both people when SMS Circle membership changes

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 186,
+  "expected_migration_version": 187,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_pkm_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 186,
+  "expected_migration_version": 187,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 186,
+  "expected_migration_version": 187,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/migrations/187_one_location_sms_contact_events.sql
+++ b/consent-protocol/db/migrations/187_one_location_sms_contact_events.sql
@@ -1,0 +1,135 @@
+BEGIN;
+
+-- Tell someone they are (or are no longer) an SMS contact.
+--
+-- Being on a person's SMS Circle is the most consequential relationship One
+-- Location has: it is the list that receives their Save my Soul alert, and
+-- membership decides whether an emergency reaches you at all. Until now it was
+-- also the only relationship the product changed in complete silence.
+-- `add_sms_contact` was a lock plus a bare INSERT and `remove_sms_contact` a
+-- bare DELETE -- no event, no Feed row, no notification, on either side. The
+-- only feedback anywhere was a toast on the adder's own device.
+--
+-- So a person could be enrolled as somebody's emergency contact, carry that
+-- duty for months, and never be told; and could be dropped from the list
+-- without ever learning that the alert they were expecting to receive would
+-- not arrive.
+--
+-- Two new event types, and one projection that writes a row for BOTH sides:
+-- the owner sees what they changed, the contact learns what changed about
+-- them.
+
+ALTER TABLE one_location_events
+  DROP CONSTRAINT IF EXISTS one_location_events_event_type_check;
+
+ALTER TABLE one_location_events
+  ADD CONSTRAINT one_location_events_event_type_check CHECK (
+    event_type IN (
+      'location_recipient_key_registered',
+      'location_share_created',
+      'location_envelope_updated',
+      'location_share_viewed',
+      'location_share_revoked',
+      'location_share_shortened',
+      'location_share_duration_changed',
+      'location_share_expired',
+      'location_access_request',
+      'location_access_approved',
+      'location_auto_approve_rule_changed',
+      'location_access_denied',
+      'location_access_request_withdrawn',
+      'location_referral_invite',
+      'location_public_invite_created',
+      'location_public_invite_revoked',
+      'location_public_invite_submitted',
+      'location_circle_invite_created',
+      'location_circle_invite_claimed',
+      'location_circle_invite_revoked',
+      'location_one_network_joined',
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added',
+      'location_sms_contact_added',
+      'location_sms_contact_removed'
+    )
+  ) NOT VALID;
+
+-- One function, both audiences, because the two rows are the same transition
+-- read from opposite ends and keeping them together is what stops them
+-- drifting apart. Feed is plaintext: only bounded scalar renderer inputs are
+-- copied, never the domain event's metadata object.
+CREATE OR REPLACE FUNCTION feed_events_from_one_location_sms_contact_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  contact_label TEXT;
+  owner_label TEXT;
+BEGIN
+  IF NEW.event_type NOT IN (
+    'location_sms_contact_added',
+    'location_sms_contact_removed'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  contact_label := NULLIF(
+    LEFT(BTRIM(COALESCE(NEW.metadata ->> 'counterpart_label', '')), 160),
+    ''
+  );
+  owner_label := NULLIF(
+    LEFT(BTRIM(COALESCE(NEW.metadata ->> 'owner_label', '')), 160),
+    ''
+  );
+
+  -- The owner's row: what they just changed, about whom.
+  INSERT INTO feed_events (
+    user_id, source_domain, event_type, actor_label, metadata, source_row_id
+  )
+  VALUES (
+    NEW.owner_user_id,
+    'location',
+    NEW.event_type,
+    contact_label,
+    jsonb_strip_nulls(jsonb_build_object(
+      'counterpart_label', COALESCE(contact_label, 'A trusted person')
+    )),
+    NEW.id::TEXT
+  )
+  ON CONFLICT DO NOTHING;
+
+  -- The contact's row: what changed about THEM. `feed_audience` is the same
+  -- discriminator migrations 152/179 use, so the renderer reads this side with
+  -- the branch it already has.
+  IF NEW.recipient_user_id IS NOT NULL
+     AND NEW.recipient_user_id <> NEW.owner_user_id THEN
+    INSERT INTO feed_events (
+      user_id, source_domain, event_type, actor_label, metadata, source_row_id
+    )
+    VALUES (
+      NEW.recipient_user_id,
+      'location',
+      NEW.event_type,
+      owner_label,
+      jsonb_strip_nulls(jsonb_build_object(
+        'feed_audience', 'recipient',
+        'counterpart_label', COALESCE(owner_label, 'A trusted person')
+      )),
+      CONCAT(NEW.id::TEXT, ':recipient')
+    )
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS one_location_sms_contact_events_feed_fanout
+  ON one_location_events;
+CREATE TRIGGER one_location_sms_contact_events_feed_fanout
+  AFTER INSERT ON one_location_events
+  FOR EACH ROW
+  EXECUTE FUNCTION feed_events_from_one_location_sms_contact_events();
+
+COMMENT ON FUNCTION feed_events_from_one_location_sms_contact_events() IS
+  'Projects SMS Circle membership changes into Feed for the owner and the contact, so nobody is enrolled as an emergency contact in silence.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/187_one_location_sms_contact_events.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/187_one_location_sms_contact_events.rollback.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+-- Stop projecting SMS Circle membership changes, and restore migration 180's
+-- event-type constraint. Rows already written are left alone: deleting them
+-- would remove the only record a contact has that they were added.
+
+DROP TRIGGER IF EXISTS one_location_sms_contact_events_feed_fanout
+  ON one_location_events;
+DROP FUNCTION IF EXISTS feed_events_from_one_location_sms_contact_events();
+
+ALTER TABLE one_location_events
+  DROP CONSTRAINT IF EXISTS one_location_events_event_type_check;
+
+ALTER TABLE one_location_events
+  ADD CONSTRAINT one_location_events_event_type_check CHECK (
+    event_type IN (
+      'location_recipient_key_registered',
+      'location_share_created',
+      'location_envelope_updated',
+      'location_share_viewed',
+      'location_share_revoked',
+      'location_share_shortened',
+      'location_share_duration_changed',
+      'location_share_expired',
+      'location_access_request',
+      'location_access_approved',
+      'location_auto_approve_rule_changed',
+      'location_access_denied',
+      'location_access_request_withdrawn',
+      'location_referral_invite',
+      'location_public_invite_created',
+      'location_public_invite_revoked',
+      'location_public_invite_submitted',
+      'location_circle_invite_created',
+      'location_circle_invite_claimed',
+      'location_circle_invite_revoked',
+      'location_one_network_joined',
+      'location_circle_code_joined',
+      'location_circle_member_invite_accepted',
+      'circle_member_added'
+    )
+  ) NOT VALID;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -158,7 +158,8 @@
     "183_one_information_request_bundles.sql",
     "184_encrypted_one_adk_sessions.sql",
     "185_internal_access_request_id_text.sql",
-    "186_feed_share_kind_projection.sql"
+    "186_feed_share_kind_projection.sql",
+    "187_one_location_sms_contact_events.sql"
   ],
   "environment_overlays": {
     "uat": [

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4752,10 +4752,15 @@ class OneLocationAgentService:
             owner_user_id=owner_user_id,
             contact_user_id=contact_user_id,
         )
+        self._record_sms_contact_change(
+            owner_user_id=owner_user_id,
+            contact_user_id=contact_user_id,
+            added=True,
+        )
         return self.list_sms_contact_ids(owner_user_id=owner_user_id)
 
     def remove_sms_contact(self, *, owner_user_id: str, contact_user_id: str) -> list[str]:
-        self._execute_one(
+        removed = self._execute_one(
             """
             DELETE FROM one_location_sms_contacts
             WHERE owner_user_id = :owner_user_id
@@ -4767,7 +4772,75 @@ class OneLocationAgentService:
                 "contact_user_id": contact_user_id,
             },
         )
+        # Only when a row really went. Removing somebody who was never on the
+        # list is a no-op, and announcing it would tell a person they had lost
+        # a duty they never held.
+        if removed:
+            self._record_sms_contact_change(
+                owner_user_id=owner_user_id,
+                contact_user_id=contact_user_id,
+                added=False,
+            )
         return self.list_sms_contact_ids(owner_user_id=owner_user_id)
+
+    def _record_sms_contact_change(
+        self,
+        *,
+        owner_user_id: str,
+        contact_user_id: str,
+        added: bool,
+    ) -> None:
+        """Announce an SMS Circle membership change to both people.
+
+        Being on someone's SMS Circle is the list that receives their Save my
+        Soul alert, so membership decides whether an emergency reaches you at
+        all -- and it was the one relationship the product changed in total
+        silence. `add_sms_contact` was a lock plus an INSERT and
+        `remove_sms_contact` a bare DELETE: no event, no Feed row, no
+        notification, on either side. Somebody could carry that duty for months
+        without being told, or lose it without learning that the alert they
+        expected would never arrive.
+
+        The event is what the Feed projection (migration 187) fans to both
+        audiences; the push is what reaches the contact when they are not
+        looking at the app. Both are best effort: a membership change that
+        succeeded must not be reported as failed because an announcement did
+        not land.
+        """
+        owner_label = _identity_notification_label(self._identity_row(owner_user_id))
+        contact_label = _identity_notification_label(self._identity_row(contact_user_id))
+        event_type = "location_sms_contact_added" if added else "location_sms_contact_removed"
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            actor_user_id=owner_user_id,
+            recipient_user_id=contact_user_id,
+            grant_id=None,
+            event_type=event_type,
+            metadata={
+                "counterpart_label": contact_label,
+                "owner_label": owner_label,
+            },
+            required=False,
+        )
+        try:
+            self._send_metadata_notification(
+                user_id=contact_user_id,
+                notification_type=event_type,
+                title=("Added to an SMS Circle" if added else "Removed from an SMS Circle"),
+                body=(
+                    f"{owner_label} will send you their SMS alert."
+                    if added
+                    else f"{owner_label} will no longer send you their SMS alert."
+                ),
+                notification_tag=f"one-location-sms-contact:{owner_user_id}",
+                request_url=_one_location_url(section="people"),
+                data={
+                    "owner_user_id": owner_user_id,
+                    "owner_display_label": owner_label,
+                },
+            )
+        except Exception:  # noqa: BLE001 - announcement must never fail the change
+            logger.exception("one_location.sms_contact_notification_failed")
 
     def _send_location_share_created_notification(
         self,

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -6285,22 +6285,30 @@ def test_sms_grant_fails_closed_until_recipient_is_selected() -> None:
     )
     assert grant["shareKind"] == "sos"
     assert grant["shareMessage"] == "Come get me"
-    assert service.notifications == []
+
+    # Scoped to the ALERT. `add_sms_contact` above now tells the contact they
+    # were added -- a different notification, and the whole point of that
+    # change. What this test guards is that the alert itself waits for the
+    # envelope, so a recipient is never told a location is available before one
+    # is readable.
+    def share_alerts() -> list[dict]:
+        return [
+            n for n in service.notifications if n["notification_type"] == "location_share_created"
+        ]
+
+    assert share_alerts() == []
+    assert [n["notification_type"] for n in service.notifications] == ["location_sms_contact_added"]
 
     service.store_encrypted_envelope(
         owner_user_id="user_a",
         grant_id=grant["id"],
         envelope=encrypted_envelope("key-user_b", "ciphertext"),
     )
-    assert len(service.notifications) == 1
-    assert service.notifications[0]["title"] == "Save my Soul"
-    assert service.notifications[0]["body"] == "User A: Come get me"
-    assert service.notifications[0]["data"]["notification_profile"] == (
-        "one_location_sms_emergency"
-    )
-    assert service.notifications[0]["data"]["notification_category"] == (
-        "ONE_LOCATION_SMS_EMERGENCY"
-    )
+    assert len(share_alerts()) == 1
+    assert share_alerts()[0]["title"] == "Save my Soul"
+    assert share_alerts()[0]["body"] == "User A: Come get me"
+    assert share_alerts()[0]["data"]["notification_profile"] == ("one_location_sms_emergency")
+    assert share_alerts()[0]["data"]["notification_category"] == ("ONE_LOCATION_SMS_EMERGENCY")
 
 
 # ---------------------------------------------------------------------------
@@ -7392,3 +7400,78 @@ def test_feed_projection_migration_carries_the_share_lane_to_both_audiences() ->
         "location_share_expired",
     ):
         assert event in sql
+
+
+# ---------------------------------------------------------------------------
+# SMS Circle membership must reach both people.
+# ---------------------------------------------------------------------------
+#
+# Being on someone's SMS Circle is the list that receives their Save my Soul
+# alert, so membership decides whether an emergency reaches you at all. It was
+# the one relationship the product changed in total silence: `add_sms_contact`
+# was a lock plus an INSERT and `remove_sms_contact` a bare DELETE -- no event,
+# no Feed row, no push, on either side.
+
+
+def test_adding_an_sms_contact_announces_it() -> None:
+    assert "_record_sms_contact_change" in _SERVICE_SOURCE
+    add_block = _SERVICE_SOURCE[
+        _SERVICE_SOURCE.index("def add_sms_contact(") : _SERVICE_SOURCE.index(
+            "def remove_sms_contact("
+        )
+    ]
+    assert "_record_sms_contact_change(" in add_block, (
+        "adding an SMS contact must announce itself, or the person taking on "
+        "the duty is never told they have it"
+    )
+    assert "added=True" in add_block
+
+
+def test_removing_an_sms_contact_announces_it_only_when_one_went() -> None:
+    remove_block = _SERVICE_SOURCE[
+        _SERVICE_SOURCE.index("def remove_sms_contact(") : _SERVICE_SOURCE.index(
+            "def _record_sms_contact_change("
+        )
+    ]
+    # Guarded on the DELETE actually removing a row: announcing a no-op would
+    # tell somebody they had lost a duty they never held.
+    assert "if removed:" in remove_block
+    assert "added=False" in remove_block
+
+
+def test_the_sms_contact_announcement_reaches_the_contact_too() -> None:
+    block = _SERVICE_SOURCE[_SERVICE_SOURCE.index("def _record_sms_contact_change(") :][:4000]
+    # The domain event carries both labels, because the projection writes a row
+    # for each audience and each one names the OTHER person.
+    assert '"counterpart_label": contact_label' in block
+    assert '"owner_label": owner_label' in block
+    assert "recipient_user_id=contact_user_id" in block
+    # And a push, for the side that is not looking at the app.
+    assert "_send_metadata_notification(" in block
+    assert "user_id=contact_user_id" in block
+    # Never fails the membership change it is announcing.
+    assert "required=False" in block
+    assert "except Exception:" in block
+
+
+def test_sms_contact_events_are_allowed_and_projected_to_both_audiences() -> None:
+    migrations = Path(one_location_agent_module.__file__).parents[2] / "db" / "migrations"
+    sql = (migrations / "187_one_location_sms_contact_events.sql").read_text(encoding="utf-8")
+
+    # The audit table constrains its event types, so a new one that is not
+    # added to the CHECK is rejected at write time.
+    assert "one_location_events_event_type_check" in sql
+    for event in ("location_sms_contact_added", "location_sms_contact_removed"):
+        assert event in sql
+
+    # Two rows per transition: the owner's and the contact's.
+    assert sql.count("INSERT INTO feed_events") == 2
+    assert "'feed_audience', 'recipient'" in sql
+    assert "NEW.recipient_user_id <> NEW.owner_user_id" in sql
+    assert "one_location_sms_contact_events_feed_fanout" in sql
+
+    rollback = (
+        migrations / "rollback" / "187_one_location_sms_contact_events.rollback.sql"
+    ).read_text(encoding="utf-8")
+    assert "DROP TRIGGER IF EXISTS one_location_sms_contact_events_feed_fanout" in rollback
+    assert "location_sms_contact_added" not in rollback.split("ADD CONSTRAINT")[1]

--- a/hushh-webapp/__tests__/lib/feed/feed-sms-contact-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-sms-contact-lines.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
+import type { FeedItem } from "@/lib/services/feed-service";
+
+/**
+ * Nobody becomes an emergency contact in silence.
+ *
+ * Being on a person's SMS Circle is the list that receives their Save my Soul
+ * alert, so membership decides whether an emergency reaches you at all. It was
+ * also the only relationship One Location changed with no announcement of any
+ * kind: `add_sms_contact` was a lock plus an INSERT and `remove_sms_contact` a
+ * bare DELETE -- no event, no Feed row, no push, on either side. The only
+ * feedback anywhere was a toast on the adder's own device, so the person taking
+ * on the duty was never told they had it, and the person losing it never
+ * learned the alert they expected would not arrive.
+ *
+ * Both sides now get a row. The emission and the both-audience projection are
+ * covered in `test_one_location_agent_service.py`; this covers what each side
+ * reads.
+ */
+
+function item(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: "feed_1",
+    source_domain: "location",
+    event_type: "location_sms_contact_added",
+    actor_label: null,
+    metadata: { counterpart_label: "Ankit" },
+    read: false,
+    created_at: "2026-08-30T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const owner = { counterpart_label: "Ankit" };
+const contact = { counterpart_label: "Neelesh", feed_audience: "recipient" };
+
+describe("SMS Circle membership reaches both people", () => {
+  it("tells the owner who they added", () => {
+    expect(presentFeedItem(item({ metadata: owner })).description).toBe(
+      "Added to your SMS Circle",
+    );
+  });
+
+  it("tells the contact they were added", () => {
+    // The whole point: this row is the only way they find out.
+    expect(presentFeedItem(item({ metadata: contact })).description).toBe(
+      "Added you to their SMS",
+    );
+  });
+
+  it("tells the owner who they removed", () => {
+    expect(
+      presentFeedItem(
+        item({ event_type: "location_sms_contact_removed", metadata: owner }),
+      ).description,
+    ).toBe("Removed from your SMS");
+  });
+
+  it("tells the contact they were removed", () => {
+    // Losing the duty matters as much as gaining it: without this they keep
+    // expecting an alert that will never come.
+    expect(
+      presentFeedItem(
+        item({ event_type: "location_sms_contact_removed", metadata: contact }),
+      ).description,
+    ).toBe("Removed you from their SMS");
+  });
+
+  it("names the other person as the row's title, on both sides", () => {
+    expect(presentFeedItem(item({ metadata: owner })).label).toBe("Ankit");
+    expect(presentFeedItem(item({ metadata: contact })).label).toBe("Neelesh");
+  });
+
+  it("never confuses the two sides", () => {
+    for (const event_type of [
+      "location_sms_contact_added",
+      "location_sms_contact_removed",
+    ] as const) {
+      const a = presentFeedItem(item({ event_type, metadata: owner }));
+      const b = presentFeedItem(item({ event_type, metadata: contact }));
+      expect(a.description).not.toBe(b.description);
+    }
+  });
+
+  it("says SMS, never SOS, and fits on one line", () => {
+    for (const event_type of [
+      "location_sms_contact_added",
+      "location_sms_contact_removed",
+    ] as const) {
+      for (const metadata of [owner, contact]) {
+        const line = presentFeedItem(item({ event_type, metadata })).description;
+        expect(line).toMatch(/SMS/);
+        expect(line).not.toMatch(/SOS/i);
+        // ~30 characters is the description column at 375px.
+        expect(line.length, `"${line}" is ${line.length} characters`).toBeLessThanOrEqual(30);
+      }
+    }
+  });
+
+  it("still renders when the backend could not resolve a name", () => {
+    const line = presentFeedItem(item({ metadata: {} }));
+    expect(line.label).toBe("Location");
+    expect(line.description).toBe("Added to your SMS Circle");
+  });
+});

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -248,6 +248,38 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         href: ROUTES.ONE_LOCATION,
       };
     }
+    // Being on someone's SMS Circle is the list that receives their Save my
+    // Soul alert, so it decides whether an emergency reaches you at all -- and
+    // it was the one relationship the product changed in silence. Both sides
+    // get a row: the owner sees what they changed, the contact learns what
+    // changed about them. The row's title is already the other person, so
+    // neither line needs to name a subject twice.
+    case "location_sms_contact_added": {
+      const hasWho = who !== "Someone";
+      return {
+        icon,
+        domainLabel,
+        label: hasWho ? who : "Location",
+        person: counterpartPerson(item.metadata, who),
+        description: sharedWithMe
+          ? "Added you to their SMS"
+          : "Added to your SMS Circle",
+        href: ROUTES.ONE_LOCATION,
+      };
+    }
+    case "location_sms_contact_removed": {
+      const hasWho = who !== "Someone";
+      return {
+        icon,
+        domainLabel,
+        label: hasWho ? who : "Location",
+        person: counterpartPerson(item.metadata, who),
+        description: sharedWithMe
+          ? "Removed you from their SMS"
+          : "Removed from your SMS",
+        href: ROUTES.ONE_LOCATION,
+      };
+    }
     case "location_share_expired": {
       const hasWho = who !== "Someone";
       return {

--- a/hushh-webapp/lib/services/feed-service.ts
+++ b/hushh-webapp/lib/services/feed-service.ts
@@ -26,6 +26,8 @@ export type FeedEventType =
   | "location_one_network_joined"
   | "location_circle_code_joined"
   | "location_circle_member_invite_accepted"
+  | "location_sms_contact_added"
+  | "location_sms_contact_removed"
   | "circle_member_invited"
   | "circle_member_added"
   | "funding_transfer_status"


### PR DESCRIPTION
Closes #6239. Follow-up to #6238, where this was found and flagged rather than folded in.

## The gap

Being on someone's SMS Circle is the list that receives their **Save my Soul**
alert, so membership decides whether an emergency reaches you at all. It was
also the only relationship One Location changed in complete silence:

| | today |
|---|---|
| `add_sms_contact` | a lock + a bare `INSERT` |
| `remove_sms_contact` | a bare `DELETE` |
| event | none |
| Feed row | none |
| push | none |
| feedback | a toast on the **adder's own** device |

A person could be enrolled as somebody's emergency contact, carry that duty for
months and never be told — or be dropped without ever learning that the alert
they were expecting would not arrive.

## The change

Two event types, `location_sms_contact_added` / `location_sms_contact_removed`,
emitted by one `_record_sms_contact_change` helper that both call sites use.

Migration **187** extends the `one_location_events` CHECK constraint and adds a
projection that writes a row for **both audiences from one transition** — the
owner sees what they changed, the contact learns what changed about them.
Keeping both rows in one function is what stops them drifting apart.

The contact also gets a push, because the side that needs to know is the side
not looking at the app.

## Copy, both sides

| event | owner sees | contact sees |
|---|---|---|
| added | Added to your SMS Circle | **Added you to their SMS** |
| removed | Removed from your SMS | **Removed you from their SMS** |

All within the ~30-character description column at 375px, and SMS never SOS —
the rule already enforced for notification copy.

## Care taken

- **Removal announces only when a row really went.** Announcing a no-op would
  tell somebody they had lost a duty they never held.
- **Best effort in both halves** (`required=False` on the event, `try/except`
  around the push). A membership change that succeeded must never be reported as
  failed because an announcement did not land.
- An existing test asserted *"no notifications at all"* after `add_sms_contact`.
  That assertion was really about the **alert** waiting for its envelope, so it
  is now scoped to `location_share_created` rather than loosened — the contract
  it was written for is unchanged and still enforced.
- Migration 187 is registered in `release_migration_manifest.json` and all three
  schema contracts are bumped, so the deploy guard passes. (Skipping this is
  what would make the change inert in every environment and refuse the UAT
  deploy.)

## Platforms

One webapp serves **web, iOS and Android** through Capacitor, so all three pick
this up from the same renderer and the same backend — there is no per-platform
copy to keep in sync.

## Verification

| Check | Result |
|---|---|
| `tsc`, `eslint`, `ruff` on every changed file | clean |
| backend — `test_one_location_agent_service.py` | 190 passed (4 new contracts) |
| webapp — 13 Feed test files | 97 passed |
| full `web-targeted` CI lane, run locally | 183 + 147 passed |
| `verify_release_migration_contract.py` | aligned at 187 |