### PR TITLE
fix(one): make the return from OS Settings actually land somewhere

### DIFF
--- a/hushh-webapp/__tests__/lib/contacts/contact-sync-settings-return.test.tsx
+++ b/hushh-webapp/__tests__/lib/contacts/contact-sync-settings-return.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isNative: vi.fn(() => true),
+  addListener: vi.fn(),
+  remove: vi.fn(),
+  getPermissionState: vi.fn(),
+  openAppSettings: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  syncSignals: vi.fn(),
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: mocks.isNative,
+  getPlatform: () => "ios",
+}));
+
+vi.mock("@capacitor/app", () => ({
+  App: { addListener: mocks.addListener },
+}));
+
+vi.mock("@/lib/capacitor", () => ({
+  HushhContacts: {
+    getPermissionState: mocks.getPermissionState,
+    openAppSettings: mocks.openAppSettings,
+    readContacts: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: mocks.toastInfo,
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/one-location/contact-signals", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/one-location/contact-signals")
+  >("@/lib/one-location/contact-signals");
+  return {
+    ...actual,
+    syncOneLocationContactSignals: mocks.syncSignals,
+    openContactPermissionSettings: async () => {
+      const result = await mocks.openAppSettings();
+      return Boolean(result?.opened);
+    },
+  };
+});
+
+vi.mock("@/lib/observability/client", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onConnectionGraphMutated: vi.fn() },
+}));
+
+import { useContactSync } from "@/lib/contacts/use-contact-sync";
+
+/**
+ * Reported after an iOS build:
+ *
+ *   "settings ios wali jab bhi open ho rahin, either for syncing contacts or
+ *    this settings, ek back tap mein app par switch nahi karwa rha"
+ *
+ *   "baaki ke apps ... settings mein desired operation enable/disable karne ke
+ *    baad entry ka path bhi dete hain"
+ *
+ * Whether iOS draws its "‹ Back to Hushh" pill is iOS's call. What was ours is
+ * everything after the person gets back, and it did nothing: the toast that
+ * sent them was gone, no permission was re-read, and the only way forward was
+ * to find the same button and press it again. This asserts the app now
+ * finishes the job they left to enable.
+ */
+
+type Handle = { current: ReturnType<typeof useContactSync> | null };
+
+/** Publishes the hook's value through a callback rather than by writing to a
+ *  prop, which the compiler rules forbid. */
+function Harness({ onReady }: { onReady: (api: Handle["current"]) => void }) {
+  const api = useContactSync({
+    routeId: "one_location",
+    getIdToken: async () => "token",
+    accountPhoneNumber: "+919876543210",
+    userId: "user_a",
+  });
+  useEffect(() => {
+    onReady(api);
+  }, [api, onReady]);
+  return null;
+}
+
+function foreground() {
+  const call = mocks.addListener.mock.calls.find(
+    ([event]) => event === "appStateChange",
+  );
+  (call?.[1] as ((state: { isActive: boolean }) => void) | undefined)?.({
+    isActive: true,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isNative.mockReturnValue(true);
+  mocks.addListener.mockResolvedValue({ remove: mocks.remove });
+  mocks.openAppSettings.mockResolvedValue({ opened: true });
+  mocks.getPermissionState.mockResolvedValue({ state: "denied" });
+  mocks.syncSignals.mockResolvedValue({
+    matchedUserIds: [],
+    totalContacts: 0,
+    autoConnectedCount: 0,
+    alreadyConnectedCount: 0,
+    requestRequiredCount: 0,
+    suppressedCount: 0,
+    inviteCandidates: [],
+    sourcePlatform: "ios",
+    limited: false,
+    truncated: false,
+    partial: false,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+});
+
+describe("coming back from the OS settings app", () => {
+  it("watches nothing until somebody has actually been sent there", async () => {
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+
+    await waitFor(() => expect(handle.current).not.toBeNull());
+    foreground();
+
+    // An ordinary foreground is not a return from Settings, and must not kick
+    // off a scan of the address book behind the person's back.
+    await waitFor(() => expect(mocks.syncSignals).not.toHaveBeenCalled());
+  });
+
+  it("names the switch and the way back before handing them over", async () => {
+    // "settings mein desired operation enable/disable karne ke baad entry ka
+    // path bhi dete hain" -- said before they leave, because after they leave
+    // there is no surface of ours to say it on.
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+    await waitFor(() => expect(handle.current).not.toBeNull());
+
+    await handle.current!.openContactSettings();
+
+    expect(mocks.openAppSettings).toHaveBeenCalledTimes(1);
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      expect.stringContaining("come back"),
+    );
+  });
+
+  it("finishes the sync they left to enable, without a second tap", async () => {
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+    await waitFor(() => expect(handle.current).not.toBeNull());
+
+    await handle.current!.openContactSettings();
+    await waitFor(() =>
+      expect(
+        mocks.addListener.mock.calls.some(([e]) => e === "appStateChange"),
+      ).toBe(true),
+    );
+
+    // They switched Contacts on and came back.
+    mocks.getPermissionState.mockResolvedValue({ state: "granted" });
+    foreground();
+
+    await waitFor(() => expect(mocks.syncSignals).toHaveBeenCalledTimes(1));
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("Contact access is on"),
+    );
+  });
+
+  it("counts iOS limited access as a grant worth resuming on", async () => {
+    // Limited access is a real grant over a hand-picked subset, and syncing
+    // that subset is exactly what somebody who chose it asked for. Refusing to
+    // resume until they widen it answers their decision by ignoring it.
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+    await waitFor(() => expect(handle.current).not.toBeNull());
+
+    await handle.current!.openContactSettings();
+    // The native listener is attached through a dynamic import, so it is not
+    // there the instant the jump resolves.
+    await waitFor(() =>
+      expect(
+        mocks.addListener.mock.calls.some(([e]) => e === "appStateChange"),
+      ).toBe(true),
+    );
+
+    mocks.getPermissionState.mockResolvedValue({ state: "limited" });
+    foreground();
+
+    await waitFor(() => expect(mocks.syncSignals).toHaveBeenCalledTimes(1));
+  });
+
+  it("stays put when they come back having changed nothing", async () => {
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+    await waitFor(() => expect(handle.current).not.toBeNull());
+
+    await handle.current!.openContactSettings();
+    foreground();
+
+    // Still denied. Resuming here would run a sync that can only fail again,
+    // and report it as a second failure the person did not ask for.
+    await waitFor(() => expect(mocks.syncSignals).not.toHaveBeenCalled());
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does not arm the watcher when nothing actually opened", async () => {
+    // A browser, or an OS that refused. Watching for a return from a place
+    // nobody went to would leave the watcher armed for the session.
+    mocks.openAppSettings.mockResolvedValue({ opened: false });
+    const handle: Handle = { current: null };
+    render(<Harness onReady={(api) => (handle.current = api)} />);
+    await waitFor(() => expect(handle.current).not.toBeNull());
+
+    await handle.current!.openContactSettings();
+
+    expect(mocks.toastInfo).not.toHaveBeenCalled();
+    mocks.getPermissionState.mockResolvedValue({ state: "granted" });
+    foreground();
+    await waitFor(() => expect(mocks.syncSignals).not.toHaveBeenCalled());
+  });
+});

--- a/hushh-webapp/__tests__/lib/permissions/use-settings-return.test.tsx
+++ b/hushh-webapp/__tests__/lib/permissions/use-settings-return.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isNative: vi.fn(() => false),
+  addListener: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: mocks.isNative,
+  getPlatform: () => "web",
+}));
+
+vi.mock("@capacitor/app", () => ({
+  App: { addListener: mocks.addListener },
+}));
+
+import { useSettingsReturn } from "@/lib/permissions/use-settings-return";
+
+/**
+ * Reported after an iOS build: "settings ios wali jab bhi open ho rahin ... ek
+ * back tap mein app par switch nahi karwa rha."
+ *
+ * The half this covers is what the app does once the person is back. It used
+ * to do nothing on native, because the only listeners were `visibilitychange`
+ * and `focus` -- web events that a Capacitor WKWebView does not reliably fire
+ * for an app-lifecycle change. So the screen that sent somebody to Settings
+ * was the screen that could not notice them returning from it.
+ */
+
+function Harness(props: {
+  enabled: boolean;
+  readGranted: () => Promise<boolean>;
+  onRestored: () => void;
+  permissionName?: string;
+}) {
+  useSettingsReturn(props);
+  return null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isNative.mockReturnValue(false);
+  mocks.addListener.mockResolvedValue({ remove: mocks.remove });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useSettingsReturn", () => {
+  it("listens to the native lifecycle, not just web visibility", async () => {
+    // The bug, as a test. On native this MUST subscribe to `appStateChange` --
+    // it is the only signal that reliably fires when an iOS app is
+    // foregrounded from Settings.
+    mocks.isNative.mockReturnValue(true);
+    const onRestored = vi.fn();
+
+    render(
+      <Harness
+        enabled
+        readGranted={async () => false}
+        onRestored={onRestored}
+      />,
+    );
+
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    expect(mocks.addListener.mock.calls[0][0]).toBe("appStateChange");
+  });
+
+  it("re-reads permission when the app comes back to the foreground", async () => {
+    mocks.isNative.mockReturnValue(true);
+    const onRestored = vi.fn();
+    let granted = false;
+
+    render(
+      <Harness
+        enabled
+        readGranted={async () => granted}
+        onRestored={onRestored}
+      />,
+    );
+
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    const handler = mocks.addListener.mock.calls[0][1] as (state: {
+      isActive: boolean;
+    }) => void;
+
+    // Backgrounded, and still nothing granted: no false recovery.
+    handler({ isActive: false });
+    await waitFor(() => expect(onRestored).not.toHaveBeenCalled());
+
+    // They switched it on and came back.
+    granted = true;
+    handler({ isActive: true });
+    await waitFor(() => expect(onRestored).toHaveBeenCalledTimes(1));
+  });
+
+  it("arms without firing, then fires once however many signals arrive", async () => {
+    // A second call would re-enter the caller's work while the first is still
+    // running -- on iOS that spends a prompt, and for a contact sync it starts
+    // a second pass over the address book.
+    mocks.isNative.mockReturnValue(true);
+    const onRestored = vi.fn();
+
+    render(
+      <Harness enabled readGranted={async () => true} onRestored={onRestored} />,
+    );
+
+    // Nothing on mount: arming the watcher is not the same as coming back, and
+    // at this point the person has not even left yet.
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    expect(onRestored).not.toHaveBeenCalled();
+
+    const handler = mocks.addListener.mock.calls[0][1] as (state: {
+      isActive: boolean;
+    }) => void;
+
+    // Every signal at once -- native foreground, plus both web events. On iOS
+    // they really do overlap.
+    handler({ isActive: true });
+    handler({ isActive: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => expect(onRestored).toHaveBeenCalledTimes(1));
+    expect(onRestored).toHaveBeenCalledTimes(1);
+  });
+
+  it("still works on the web, where there is no native lifecycle", async () => {
+    mocks.isNative.mockReturnValue(false);
+    const onRestored = vi.fn();
+    let granted = false;
+
+    render(
+      <Harness
+        enabled
+        readGranted={async () => granted}
+        onRestored={onRestored}
+      />,
+    );
+
+    expect(mocks.addListener).not.toHaveBeenCalled();
+
+    granted = true;
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(onRestored).toHaveBeenCalledTimes(1));
+  });
+
+  it("watches nothing until somebody is actually waiting", async () => {
+    mocks.isNative.mockReturnValue(true);
+    const onRestored = vi.fn();
+    const readGranted = vi.fn(async () => true);
+
+    render(
+      <Harness
+        enabled={false}
+        readGranted={readGranted}
+        onRestored={onRestored}
+      />,
+    );
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(mocks.addListener).not.toHaveBeenCalled());
+    expect(readGranted).not.toHaveBeenCalled();
+    expect(onRestored).not.toHaveBeenCalled();
+  });
+
+  it("treats an unreadable permission as not recovered", async () => {
+    // Unreadable is not a failure to recover from, and it is certainly not a
+    // grant. The person can still press the button.
+    mocks.isNative.mockReturnValue(true);
+    const onRestored = vi.fn();
+
+    render(
+      <Harness
+        enabled
+        readGranted={async () => {
+          throw new Error("bridge unavailable");
+        }}
+        onRestored={onRestored}
+      />,
+    );
+
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    const handler = mocks.addListener.mock.calls[0][1] as (state: {
+      isActive: boolean;
+    }) => void;
+    handler({ isActive: true });
+
+    await waitFor(() => expect(onRestored).not.toHaveBeenCalled());
+  });
+
+  it("removes the native listener when it stops watching", async () => {
+    mocks.isNative.mockReturnValue(true);
+    const view = render(
+      <Harness enabled readGranted={async () => false} onRestored={vi.fn()} />,
+    );
+
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    view.unmount();
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalled());
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -215,6 +215,7 @@ import {
 } from "@/lib/one-location/grant-duration-edit";
 import { snapToWheelDurationHours } from "@/components/one-location/redesign/duration-wheel-picker";
 import { OneLocationService } from "@/lib/one-location/service";
+import { useSettingsReturn } from "@/lib/permissions/use-settings-return";
 import {
   describeContactSyncOutcome,
   openContactPermissionSettings,
@@ -6610,6 +6611,78 @@ export function OneLocationAgentPageContent({
   // Contact Picker) without the callback having to reference itself.
   const handleSyncContactSignalRef = useRef<(() => Promise<void>) | null>(null);
 
+  /**
+   * True from the moment we hand somebody to the OS settings app for contact
+   * access until they come back with it on.
+   *
+   * Reported after an iOS build: "settings ios wali jab bhi open ho rahin,
+   * either for syncing contacts or this settings, ek back tap mein app par
+   * switch nahi karwa rha -- mereko application back mein dekh kar kholna
+   * pda." Whether iOS draws its "‹ Back to Hushh" pill is iOS's call. The half
+   * that was ours was worse: the toast that sent them was gone by the time
+   * they returned, nothing re-read the permission, and the trip ended exactly
+   * where it started.
+   *
+   * Connect's `useContactSync` grew the same pair for the same report. This
+   * screen has its own contacts path and cannot borrow that hook, so it
+   * borrows the watcher instead -- one answer to "they went to the OS, tell me
+   * when they are back", rather than a second copy that drifts.
+   */
+  const [awaitingContactSettings, setAwaitingContactSettings] = useState(false);
+  const awaitingContactSettingsRef = useRef(false);
+  const markAwaitingContactSettings = useCallback((next: boolean) => {
+    awaitingContactSettingsRef.current = next;
+    setAwaitingContactSettings(next);
+  }, []);
+
+  /**
+   * Hand them over, and remember that we did. `opened === false` means nothing
+   * launched -- a browser, or an OS that refused -- and watching for a return
+   * from a place nobody went to would leave the watcher armed for the session.
+   */
+  const openContactSettingsAndWatch = useCallback(async () => {
+    const opened = await openContactPermissionSettings();
+    if (!opened) return;
+    markAwaitingContactSettings(true);
+    // Said before they leave, because after they leave there is no surface of
+    // ours to say it on -- the part the report singled out as what other apps
+    // do: "settings mein desired operation enable/disable karne ke baad entry
+    // ka path bhi dete hain".
+    toast.info(
+      "Turn on Contacts for Hushh, then come back — we'll pick up where you left off.",
+    );
+  }, [markAwaitingContactSettings]);
+
+  /**
+   * `limited` counts. iOS limited access is a real grant over a hand-picked
+   * subset, and syncing that subset is what somebody who chose it asked for.
+   */
+  const readContactsGranted = useCallback(async () => {
+    try {
+      const permission = await HushhContacts.getPermissionState();
+      return permission?.state === "granted" || permission?.state === "limited";
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const onContactsRestored = useCallback(() => {
+    if (!awaitingContactSettingsRef.current) return;
+    markAwaitingContactSettings(false);
+    // Resume the work, not just the permission. The trip was never about the
+    // switch -- it was about syncing contacts.
+    toast.success("Contact access is on. Syncing…");
+    void handleSyncContactSignalRef.current?.();
+  }, [markAwaitingContactSettings]);
+
+  useSettingsReturn({
+    enabled: awaitingContactSettings,
+    readGranted: readContactsGranted,
+    onRestored: onContactsRestored,
+    // No `permissionName`: the Permissions API has no entry for contacts, so
+    // the lifecycle signals are the whole mechanism here.
+  });
+
   // Onboarding's own contacts step. It reuses the same matcher as the hub, but
   // returns a typed result instead of driving hub state: onboarding needs to
   // render the matches inline, and the contact-permission prompt is fired by a
@@ -6986,7 +7059,7 @@ export function OneLocationAgentPageContent({
             ? {
                 action: {
                   label: "Open Settings",
-                  onClick: () => void openContactPermissionSettings(),
+                  onClick: () => void openContactSettingsAndWatch(),
                 },
               }
             : outcome.remedy === "sync_again"
@@ -7049,7 +7122,7 @@ export function OneLocationAgentPageContent({
         toast.error(message, {
           action: {
             label: "Open Settings",
-            onClick: () => void openContactPermissionSettings(),
+            onClick: () => void openContactSettingsAndWatch(),
           },
         });
       } else if (failure === "unavailable") {
@@ -7067,6 +7140,7 @@ export function OneLocationAgentPageContent({
     contactSignal,
     googleContactsFallback,
     handleInviteContactCandidates,
+    openContactSettingsAndWatch,
     loadRecipientPage,
     recipientSearch,
     refresh,
@@ -13056,7 +13130,7 @@ export function OneLocationAgentPageContent({
           onAcceptCircleCode={handleAcceptCircleCode}
           onSyncOnboardingContacts={handleSyncOnboardingContacts}
           onAddOnboardingContact={handleAddOnboardingContact}
-          onOpenContactSettings={() => void openContactPermissionSettings()}
+          onOpenContactSettings={() => void openContactSettingsAndWatch()}
           onPrepareOnboardingCircleInvite={handlePrepareOnboardingCircleInvite}
           onCopyOnboardingCircleCode={handleCopyNamedCircleCode}
           onShareOnboardingCircleCode={handleShareOnboardingCircleInvite}

--- a/hushh-webapp/lib/contacts/use-contact-sync.ts
+++ b/hushh-webapp/lib/contacts/use-contact-sync.ts
@@ -68,6 +68,7 @@ import { oneLocationErrorMessage } from "@/lib/one-location/error-message";
 import { ConnectionsService } from "@/lib/services/connections-service";
 import { ReferralService } from "@/lib/services/referral-service";
 import { isShareCancellationError, shareLink } from "@/lib/share/share-link";
+import { useSettingsReturn } from "@/lib/permissions/use-settings-return";
 
 export type ContactSyncStatus =
   | "idle"
@@ -266,6 +267,17 @@ export type UseContactSync = {
   resultsOpen: boolean;
   setResultsOpen: (open: boolean) => void;
   sync: () => Promise<void>;
+  /**
+   * Send somebody to the OS settings app for contact access, and watch for
+   * them coming back.
+   *
+   * Exposed rather than kept private because the trip is only worth taking if
+   * something is waiting on the other side: this arms the return watcher and
+   * says the way back before they go. A surface that calls
+   * `openContactPermissionSettings` directly gets the jump without either, and
+   * that is the state this was reported in.
+   */
+  openContactSettings: () => Promise<void>;
   invite: () => Promise<void>;
   requestConnection: (addresseeUserId: string) => Promise<void>;
   resultsSheetProps: ContactSyncResultsSheetProps;
@@ -319,6 +331,30 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
   const inFlightRef = useRef(false);
 
   /**
+   * True from the moment we hand somebody to the OS settings app until they
+   * come back with contact access on.
+   *
+   * Reported after an iOS build: "settings ios wali jab bhi open ho rahin,
+   * either for syncing contacts or this settings, ek back tap mein app par
+   * switch nahi karwa rha -- mereko application back mein dekh kar kholna
+   * pda." Whether iOS draws its "‹ Back to Hushh" pill is iOS's call, but the
+   * half that was ours was worse: the toast that sent them was gone by the
+   * time they returned, nothing re-read the permission, and the only way
+   * forward was to find the same button and press it again. So the trip ended
+   * where it started no matter how they got back.
+   *
+   * A ref as well as state: the state drives the watcher, and the ref lets the
+   * resume decide whether it is a resume without joining a dependency array
+   * that would restart the watcher every render.
+   */
+  const [awaitingContactSettings, setAwaitingContactSettings] = useState(false);
+  const awaitingContactSettingsRef = useRef(false);
+  const markAwaitingContactSettings = useCallback((next: boolean) => {
+    awaitingContactSettingsRef.current = next;
+    setAwaitingContactSettings(next);
+  }, []);
+
+  /**
    * The sync callback, read at click time rather than captured.
    *
    * "Sync again" and "Check more" live inside a toast that outlives the sync
@@ -331,6 +367,15 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
    * the moment the button is actually pressed.
    */
   const syncRef = useRef<(() => Promise<void>) | null>(null);
+
+  /**
+   * Read at click time, exactly like {@link syncRef} and for the same reason:
+   * the "Open Settings" action lives inside a toast that outlives the sync
+   * that raised it, and the callback it points at is declared below `sync`.
+   * Capturing it in `sync`'s closure would make `sync` depend on it and put
+   * the two in a cycle.
+   */
+  const openContactSettingsRef = useRef<(() => Promise<void>) | null>(null);
 
   /**
    * Resolve the contact source before anybody reaches the button.
@@ -606,7 +651,7 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
           case "open_settings":
             return {
               label: "Open Settings",
-              onClick: () => void openContactPermissionSettings(),
+              onClick: () => void openContactSettingsRef.current?.(),
             };
           case "invite":
             // The other half of a contact scan. Until this shipped, the count
@@ -664,7 +709,7 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
         toast.error(message, {
           action: {
             label: "Open Settings",
-            onClick: () => void openContactPermissionSettings(),
+            onClick: () => void openContactSettingsRef.current?.(),
           },
         });
       } else if (failure === "unavailable") {
@@ -682,6 +727,65 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
     syncRef.current = sync;
   }, [sync]);
 
+  /**
+   * Hand them to the OS, and remember that we did.
+   *
+   * The remembering is the whole point. Without it the app treats the return
+   * as an ordinary foreground and the person is back where they started.
+   * `opened === false` means nothing launched -- a browser, or an OS that
+   * refused -- and watching for a return from a place nobody went to would
+   * leave the watcher armed forever.
+   */
+  const openContactSettingsAndWatch = useCallback(async () => {
+    const opened = await openContactPermissionSettings();
+    if (!opened) return;
+    markAwaitingContactSettings(true);
+    // Said before they leave, because after they leave there is no surface of
+    // ours to say it on. Names the switch AND the way back, which is the part
+    // the report singled out: "settings mein desired operation enable/disable
+    // karne ke baad entry ka path bhi dete hain".
+    toast.info("Turn on Contacts for Hushh, then come back — we'll pick up where you left off.");
+  }, [markAwaitingContactSettings]);
+
+  /**
+   * Is contact access on now?
+   *
+   * `limited` counts. iOS limited access is a real grant over a hand-picked
+   * subset, and a sync across that subset is exactly what somebody who chose
+   * it asked for -- refusing to resume until they widen it would answer their
+   * decision by ignoring it.
+   */
+  const readContactsGranted = useCallback(async () => {
+    try {
+      const permission = await HushhContacts.getPermissionState();
+      return permission?.state === "granted" || permission?.state === "limited";
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const onContactsRestored = useCallback(() => {
+    if (!awaitingContactSettingsRef.current) return;
+    markAwaitingContactSettings(false);
+    // Resume the work, not just the permission. The trip was never about the
+    // switch -- it was about syncing contacts, and finishing that is what the
+    // person actually came back for.
+    toast.success("Contact access is on. Syncing…");
+    void syncRef.current?.();
+  }, [markAwaitingContactSettings]);
+
+  useEffect(() => {
+    openContactSettingsRef.current = openContactSettingsAndWatch;
+  }, [openContactSettingsAndWatch]);
+
+  useSettingsReturn({
+    enabled: awaitingContactSettings,
+    readGranted: readContactsGranted,
+    onRestored: onContactsRestored,
+    // No `permissionName`: the Permissions API has no entry for contacts, so
+    // the lifecycle signals are the whole mechanism here.
+  });
+
   return {
     available,
     googleFallback,
@@ -691,6 +795,7 @@ export function useContactSync(options: UseContactSyncOptions): UseContactSync {
     resultsOpen,
     setResultsOpen,
     sync,
+    openContactSettings: openContactSettingsAndWatch,
     invite,
     requestConnection,
     resultsSheetProps: {

--- a/hushh-webapp/lib/one-location/use-location-permission-healing.ts
+++ b/hushh-webapp/lib/one-location/use-location-permission-healing.ts
@@ -1,31 +1,32 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback } from "react";
 
 import { OneLocationService } from "@/lib/one-location/service";
+import { useSettingsReturn } from "@/lib/permissions/use-settings-return";
 
 /**
  * Notice the moment someone un-blocks location, without making them tell us.
  *
- * The recovery instructions send a person out of the page and into browser
- * settings. Every second they spend back here wondering whether it worked is a
- * second the fix looks broken, and "now reload the page" is one instruction
- * more than they should have to carry.
+ * The recovery instructions send a person out of the page and into settings.
+ * Every second they spend back here wondering whether it worked is a second
+ * the fix looks broken, and "now reload the page" is one instruction more than
+ * they should have to carry.
  *
- * Two signals, because no single one covers every browser:
+ * WHAT CHANGED, AND WHY IT MATTERED ON iOS
  *
- * 1. **`PermissionStatus.onchange`** — the exact event. Chromium fires it the
- *    instant the site's Location switch flips, even while the tab sits in the
- *    background, so the page heals before the person has finished looking back
- *    at it. Safari does not implement `permissions.query('geolocation')` at all
- *    and rejects, which is why it cannot be the only signal.
+ * This used to attach `visibilitychange` and `focus` itself, and nothing else.
+ * Those are web signals; inside a Capacitor WKWebView they are not a reliable
+ * app-lifecycle event, which is why every other surface in this app that cares
+ * about coming back pairs them with Capacitor's `appStateChange`. So the one
+ * path built to notice a return was the one path that could miss it on the
+ * native build -- reported as "settings se aane ke baad ek back tap mein app
+ * par switch nahi karwa rha", where the missing half was not the switch back
+ * but the app doing nothing once it happened.
  *
- * 2. **Returning to the tab** — `visibilitychange` and `focus`. Coarser, but it
- *    works everywhere, and it is exactly when someone comes back from settings.
- *
- * Both paths only ever *read* permission. Neither attempts a capture, so
- * nothing here can trigger a prompt, a toast, or a GPS read behind the person's
- * back — this hook observes, and hands the decision to act to its caller.
+ * The signals now live in {@link useSettingsReturn}, which contacts uses too:
+ * one answer to "they went to the OS, tell me when they are back", rather than
+ * a second copy per permission that drifts from this one.
  */
 export function useLocationPermissionHealing(params: {
   /** Only watch while the person is actually stuck. */
@@ -35,70 +36,18 @@ export function useLocationPermissionHealing(params: {
 }): void {
   const { enabled, onGranted } = params;
 
-  useEffect(() => {
-    if (!enabled) return;
-    if (typeof window === "undefined") return;
+  const readGranted = useCallback(async () => {
+    const permission = await OneLocationService.getPermissionState();
+    return permission?.state === "granted";
+  }, []);
 
-    let cancelled = false;
-    let settled = false;
-    let status: PermissionStatus | null = null;
-
-    // Fire at most once. A second call would re-enter the caller's capture
-    // while the first is still running, which on iOS spends a prompt and on
-    // web doubles the GPS work for one recovery.
-    const grant = () => {
-      if (cancelled || settled) return;
-      settled = true;
-      onGranted();
-    };
-
-    const check = async () => {
-      if (cancelled || settled) return;
-      try {
-        const permission = await OneLocationService.getPermissionState();
-        if (permission?.state === "granted") grant();
-      } catch {
-        // Unreadable permission is not a failure to recover from. The person
-        // can still press the button, and the visibility path will try again.
-      }
-    };
-
-    const onVisible = () => {
-      if (document.visibilityState === "visible") void check();
-    };
-
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", onVisible);
-
-    void (async () => {
-      try {
-        const query = navigator.permissions?.query;
-        if (!query) return;
-        const next = await navigator.permissions.query({
-          name: "geolocation" as PermissionName,
-        });
-        if (cancelled) return;
-        status = next;
-        // Already fixed before this mounted — for instance the person un-blocked
-        // it, then navigated back rather than switching tabs.
-        if (next.state === "granted") {
-          grant();
-          return;
-        }
-        next.onchange = () => {
-          if (next.state === "granted") grant();
-        };
-      } catch {
-        // WebKit rejects this query outright. The visibility listeners above
-        // are the whole recovery path there, and they are already attached.
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", onVisible);
-      if (status) status.onchange = null;
-    };
-  }, [enabled, onGranted]);
+  useSettingsReturn({
+    enabled,
+    readGranted,
+    onRestored: onGranted,
+    // Chromium fires this the instant the site's Location switch flips, even
+    // while the tab sits in the background. Safari does not implement it and
+    // rejects, which is why it is an addition rather than the mechanism.
+    permissionName: "geolocation",
+  });
 }

--- a/hushh-webapp/lib/permissions/use-settings-return.ts
+++ b/hushh-webapp/lib/permissions/use-settings-return.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { isNative } from "@/lib/capacitor/platform";
+
+/**
+ * Notice the moment somebody comes back from the OS settings app, and whether
+ * what they went there to switch on is now on.
+ *
+ * WHY THIS EXISTS
+ *
+ * Reported, after testing an iOS build:
+ *
+ *   "settings ios wali jab bhi open ho rahin, either for syncing contacts or
+ *    this settings, ek back tap mein app par switch nahi karwa rha -- mereko
+ *    application back mein dekh kar kholna pda"
+ *
+ *   "baaki ke apps ... settings mein desired operation enable/disable karne ke
+ *    baad entry ka path bhi dete hain ... ham kyun nhi kr paa rhe"
+ *
+ * The status-bar "‹ Back to Hussh" pill is iOS's to draw and nothing in this
+ * repository can force it. What IS ours is everything after the person gets
+ * back, and that half was broken in a way that made the whole trip feel like a
+ * dead end: they returned to the same screen, in the same blocked state, with
+ * the toast that sent them gone, and had to find and press the same button
+ * again. Whether or not iOS drew a pill, the app did nothing with their return.
+ *
+ * THE BUG THIS FIXES
+ *
+ * `use-location-permission-healing` already tried to do this and listens to
+ * `visibilitychange` and `focus` only. Inside a Capacitor WKWebView those are
+ * not reliable app-lifecycle signals -- which is why every other surface in
+ * this app that cares about coming back (`location-immersive-map`,
+ * `app-ui/interaction-runtime`) pairs them with Capacitor's `appStateChange`.
+ * The healing hook did not, so on the native build the one path designed to
+ * notice a return was the one path that could miss it.
+ *
+ * All three signals here, because no single one covers every surface:
+ *
+ * 1. **`appStateChange`** — the native truth. The only signal that reliably
+ *    fires when an iOS app is foregrounded from Settings.
+ * 2. **`visibilitychange` / `focus`** — the web truth, and a harmless second
+ *    opinion on native.
+ * 3. **`PermissionStatus.onchange`** — exact, where the browser implements it.
+ *    Chromium fires it the instant the switch flips, even in the background.
+ *    WebKit rejects the query outright, which is why it cannot be the only one.
+ *
+ * This hook only ever READS. It cannot prompt, capture, or write, so nothing
+ * here can act behind the person's back -- it observes, and hands the decision
+ * to its caller.
+ */
+export function useSettingsReturn(params: {
+  /** Only watch while the person is actually waiting on something. */
+  enabled: boolean;
+  /**
+   * Is the thing they went to switch on now on? Resolves false (never throws)
+   * when it cannot be read -- an unreadable permission is not a recovery.
+   */
+  readGranted: () => Promise<boolean>;
+  /** Fires at most once, when `readGranted` first answers true. */
+  onRestored: () => void;
+  /**
+   * Optional live signal for browsers that implement it. Omit for permissions
+   * the Permissions API does not name (contacts has no entry).
+   */
+  permissionName?: string;
+}): void {
+  const { enabled, readGranted, onRestored, permissionName } = params;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    let settled = false;
+    let status: PermissionStatus | null = null;
+    let removeAppListener: (() => void) | null = null;
+
+    // Once. A second call would re-enter the caller's work while the first is
+    // still running -- on iOS that spends a prompt, and for a contact sync it
+    // starts a second pass over the address book.
+    const restore = () => {
+      if (cancelled || settled) return;
+      settled = true;
+      onRestored();
+    };
+
+    const check = async () => {
+      if (cancelled || settled) return;
+      try {
+        if (await readGranted()) restore();
+      } catch {
+        // Unreadable is not a failure to recover from. The person can still
+        // press the button, and the next signal will try again.
+      }
+    };
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void check();
+    };
+
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+
+    // The native lifecycle signal. Dynamically imported for the same reason
+    // `interaction-runtime` does it: the web bundle must not carry it.
+    if (isNative()) {
+      void import("@capacitor/app")
+        .then(({ App }) =>
+          App.addListener("appStateChange", ({ isActive }) => {
+            if (isActive) void check();
+          }),
+        )
+        .then((handle) => {
+          if (cancelled) {
+            void handle.remove();
+            return;
+          }
+          removeAppListener = () => void handle.remove();
+        })
+        .catch(() => {
+          // The DOM listeners above remain the fallback.
+        });
+    }
+
+    void (async () => {
+      if (!permissionName) return;
+      try {
+        const query = navigator.permissions?.query;
+        if (!query) return;
+        const next = await navigator.permissions.query({
+          name: permissionName as PermissionName,
+        });
+        if (cancelled) return;
+        status = next;
+        // Already fixed before this mounted -- they switched it on and then
+        // navigated back rather than switching apps.
+        if (next.state === "granted") {
+          restore();
+          return;
+        }
+        next.onchange = () => {
+          if (next.state === "granted") restore();
+        };
+      } catch {
+        // WebKit rejects unknown names. The listeners above are the whole
+        // recovery path there, and they are already attached.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+      removeAppListener?.();
+      if (status) status.onchange = null;
+    };
+  }, [enabled, readGranted, onRestored, permissionName]);
+}


### PR DESCRIPTION
> "settings ios wali jab bhi open ho rahin, either for syncing contacts or this settings, ek back tap mein app par switch nahi karwa rha — mereko application back mein dekh kar kholna pda"
>
> "baaki ke apps … settings mein desired operation enable/disable karne ke baad **entry ka path bhi dete hain** … ham kyun nhi kr paa rhe"

## First, the honest split

The status-bar **"‹ Back to Hushh" pill is drawn by iOS**, and nothing in this repository can force it. Both plugins already do the only thing that earns it — `UIApplication.shared.open(openSettingsURLString)`, on the main thread, from an active scene. I did not pretend to fix that.

**The half that was ours was worse**, and it is why the round trip felt like a dead end *whichever way* you came back: **the app did nothing with the return.** The toast that sent you was gone, no permission was re-read, and the only way forward was to find the same button and press it again. So the trip ended exactly where it started — which is indistinguishable, from the outside, from "there was no way back".

## The bug

`use-location-permission-healing` existed precisely to close this, and listened to `visibilitychange` and `focus` **only**.

Those are web events. Inside a Capacitor WKWebView they are not a reliable app-lifecycle signal — which is exactly why every *other* surface in this app that cares about coming back pairs them with Capacitor's `appStateChange`:

- `components/one-location/location-immersive-map.tsx`
- `components/app-ui/interaction-runtime.tsx`

This one didn't. **The single path built to notice a return was the one path that could miss it on the native build.**

Contacts had no such path at all — you came back and re-tapped Sync.

## What changed

`lib/permissions/use-settings-return.ts` is now the one answer to *"they went to the OS, tell me when they're back and whether it worked."* Three signals, because no one of them covers every surface:

| Signal | Why |
|---|---|
| `appStateChange` | The native truth — the only one that reliably fires when an iOS app is foregrounded from Settings |
| `visibilitychange` / `focus` | The web truth, and a harmless second opinion on native |
| `PermissionStatus.onchange` | Exact, where the browser implements it. WebKit rejects the query, so it can't be the mechanism |

It only ever **reads**, so nothing here can prompt, capture or write behind anyone's back.

Location's healing hook is now a thin call into it and gains the native signal it was missing. Contacts gets the behaviour for the first time on **both** surfaces that have it — Connect's `useContactSync`, and the Location screen's own contacts path, which can't share that hook and so shares the watcher instead rather than growing a second copy that drifts.

### Three things happen now that didn't

1. **Leaving says the way back.** *"Turn on Contacts for Hushh, then come back — we'll pick up where you left off."* Said **before** they go, because afterwards there is no surface of ours to say it on. This is the "entry ka path" the report describes other apps giving.
2. **Returning is noticed** — on iOS as well as on the web.
3. **Returning finishes the job.** The sync they left to enable runs itself. The trip was never about the switch.

## Decisions worth reviewing

| | |
|---|---|
| **`limited` counts as a grant** | iOS limited contact access is a real grant over a hand-picked subset. Syncing that subset is what somebody who chose it asked for — refusing to resume until they widen it answers their decision by ignoring it. |
| **Nothing is armed unless something opened** | `opened === false` means a browser, or an OS that refused. Watching for a return from a place nobody went to would leave the watcher live for the whole session. |
| **Coming back unchanged does nothing** | Resuming there would run a sync that can only fail again, and report a second failure nobody asked for. |
| **Fires once** | The signals genuinely overlap on iOS, and a second call would re-enter a running sync — a second pass over the address book. |

## Not in scope, and worth saying

The Now tab's **Settings tile opening the device Settings app** was a real defect — and it is **already fixed on main** by `721170561` (2026-08-29), one day before this build was tested. Verified rather than assumed: that tile calls `openFlow("settings")`, and the only remaining `onOpenLocationSettings` callers are the two permission-recovery cards, whose whole job *is* sending someone to the OS.

So that half needs a **new build**, not a new fix.

## Verification

| | |
|---|---|
| webapp typecheck + eslint | clean |
| vitest — one-location, contacts, permissions, connect | **1609 / 1609** |
| runtime topology index | current |

The native lifecycle subscription is asserted **directly** (`expect(addListener.mock.calls[0][0]).toBe("appStateChange")`), because that is the regression that made this invisible on iOS and a class-level test would not have caught it.

## Still needs a human

On a real device: deny contacts, tap **Open Settings**, switch Contacts on, come back — the sync should run on its own with no second tap. Then the same for location from the recovery card. Whether iOS draws its own back pill is worth noting while you're there, but the app should now be correct either way.
