### PR TITLE
fix(one): make one-letter people search work on the paged path too

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -331,6 +331,32 @@ def _clean_kind(value: str | None) -> str:
     return kind
 
 
+def _people_query_match_params(normalized_query: str) -> dict[str, object]:
+    """Bind values for the three-tier name match the paged people searches use.
+
+    The tiers mirror `filterPeopleByQuery` in
+    `hushh-webapp/lib/one-location/people-search.ts` exactly, because a paged
+    list and an unpaged one must not disagree about what a query means. Both
+    sheets used a bare substring match ordered A-Z, so with connections named
+    "Ankit Kumar Singh" and "Neelesh Meena", typing `n` matched BOTH -- "Ankit"
+    and "Singh" each carry an "n" -- and then sorted the wrong one first. The
+    client already fixed this for its own path and is covered by the protected
+    behaviour `location-people-search-finds-a-person-from-one-letter`; the
+    server-paged path never got it.
+
+    A word boundary is anything that is not a letter or a digit, which keeps
+    "Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader splits
+    them. The query is regex-escaped, so a name containing `.` or `*` cannot
+    turn a search into a pattern.
+    """
+    escaped = re.escape(normalized_query)
+    return {
+        "query_prefix_re": f"^{escaped}" if normalized_query else "$^",
+        "query_word_re": (f"(^|[^[:alnum:]]){escaped}" if normalized_query else "$^"),
+        "query_is_single_char": len(normalized_query) == 1,
+    }
+
+
 class OneLocationCircleService:
     """Owns named Circle state and atomic membership transitions."""
 
@@ -1031,6 +1057,7 @@ class OneLocationCircleService:
         normalized_page = max(1, int(page or 1))
         normalized_limit = max(1, min(int(limit or 50), 100))
         normalized_query = str(query or "").strip().lower()
+        query_match = _people_query_match_params(normalized_query)
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(
@@ -1075,16 +1102,46 @@ class OneLocationCircleService:
                    AND membership.status = 'active'
                   LEFT JOIN actor_identity_cache identity
                     ON identity.user_id = membership.user_id
-                ), filtered AS (
-                  SELECT * FROM candidates
+                ), matched AS (
+                  -- How well the query matches, in the same three tiers the
+                  -- client picker uses (lib/one-location/people-search.ts):
+                  --   0  the name itself begins with it
+                  --   1  a word inside the name begins with it
+                  --   2  it only appears mid-word
+                  -- People read a name from the start of its words, so `n`
+                  -- means Neelesh, not the "n" inside "Ankit".
+                  SELECT *,
+                    CASE
+                      WHEN :query = '' THEN 0
+                      WHEN normalized_name ~ :query_prefix_re THEN 0
+                      WHEN normalized_name ~ :query_word_re THEN 1
+                      ELSE 2
+                    END AS match_rank
+                  FROM candidates
                   WHERE :query = '' OR POSITION(:query IN normalized_name) > 0
+                ), filtered AS (
+                  -- A single character is only meaningful as a BEGINNING:
+                  -- mid-word it matches most names in any list, which is
+                  -- exactly why one-letter search read as broken. So one
+                  -- character keeps just the word-beginning matches -- unless
+                  -- nothing begins with it, in which case the loose matches
+                  -- stand rather than emptying a list that has a match.
+                  -- Two characters and up drop nothing, so "ingh" still finds
+                  -- Singh. Same rule as the client, so a paged list and an
+                  -- unpaged one never disagree about what a query means.
+                  SELECT * FROM matched
+                  WHERE NOT :query_is_single_char
+                     OR match_rank < 2
+                     OR NOT EXISTS (
+                          SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2
+                        )
                 ), total AS (
                   SELECT COUNT(*)::BIGINT AS total_count,
                          EXISTS (SELECT 1 FROM authorized_circle) AS authorized
                   FROM filtered
                 ), page_rows AS (
                   SELECT * FROM filtered
-                  ORDER BY normalized_name, user_id
+                  ORDER BY match_rank, normalized_name, user_id
                   OFFSET :offset LIMIT :limit
                 )
                 SELECT page_rows.*,
@@ -1130,12 +1187,14 @@ class OneLocationCircleService:
                   WHERE key.user_id = page_rows.user_id AND key.status = 'active'
                   ORDER BY key.created_at DESC LIMIT 1
                 ) recipient_key ON TRUE
-                ORDER BY page_rows.normalized_name, page_rows.user_id
+                ORDER BY page_rows.match_rank, page_rows.normalized_name,
+                         page_rows.user_id
                 """,
                 {
                     "circle_id": cleaned_circle_id,
                     "viewer_user_id": user_id,
                     "query": normalized_query,
+                    **query_match,
                     "offset": offset,
                     "limit": normalized_limit,
                 },
@@ -2821,6 +2880,7 @@ class OneLocationCircleService:
         normalized_page = max(1, int(page or 1))
         normalized_limit = max(1, min(int(limit or 50), 100))
         normalized_query = str(query or "").strip().lower()
+        query_match = _people_query_match_params(normalized_query)
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(
@@ -2893,16 +2953,46 @@ class OneLocationCircleService:
                                                        ELSE connection.user_a_id END
                       AND invite.status = 'pending' AND invite.expires_at > NOW()
                   )
-                ), filtered AS (
-                  SELECT * FROM candidates
+                ), matched AS (
+                  -- How well the query matches, in the same three tiers the
+                  -- client picker uses (lib/one-location/people-search.ts):
+                  --   0  the name itself begins with it
+                  --   1  a word inside the name begins with it
+                  --   2  it only appears mid-word
+                  -- People read a name from the start of its words, so `n`
+                  -- means Neelesh, not the "n" inside "Ankit".
+                  SELECT *,
+                    CASE
+                      WHEN :query = '' THEN 0
+                      WHEN normalized_name ~ :query_prefix_re THEN 0
+                      WHEN normalized_name ~ :query_word_re THEN 1
+                      ELSE 2
+                    END AS match_rank
+                  FROM candidates
                   WHERE :query = '' OR POSITION(:query IN normalized_name) > 0
+                ), filtered AS (
+                  -- A single character is only meaningful as a BEGINNING:
+                  -- mid-word it matches most names in any list, which is
+                  -- exactly why one-letter search read as broken. So one
+                  -- character keeps just the word-beginning matches -- unless
+                  -- nothing begins with it, in which case the loose matches
+                  -- stand rather than emptying a list that has a match.
+                  -- Two characters and up drop nothing, so "ingh" still finds
+                  -- Singh. Same rule as the client, so a paged list and an
+                  -- unpaged one never disagree about what a query means.
+                  SELECT * FROM matched
+                  WHERE NOT :query_is_single_char
+                     OR match_rank < 2
+                     OR NOT EXISTS (
+                          SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2
+                        )
                 ), total AS (
                   SELECT COUNT(*)::BIGINT AS total_count,
                          EXISTS (SELECT 1 FROM authorized_circle) AS authorized
                   FROM filtered
                 ), page_rows AS (
                   SELECT * FROM filtered
-                  ORDER BY normalized_name, user_id, connection_id
+                  ORDER BY match_rank, normalized_name, user_id, connection_id
                   OFFSET :offset LIMIT :limit
                 )
                 SELECT page_rows.*, total.total_count, total.authorized,
@@ -2914,12 +3004,14 @@ class OneLocationCircleService:
                            AND contact_origin.source_ref = :actor_user_id
                        ) END AS connected_from_contacts
                 FROM total LEFT JOIN page_rows ON TRUE
-                ORDER BY page_rows.normalized_name, page_rows.user_id, page_rows.connection_id
+                ORDER BY page_rows.match_rank, page_rows.normalized_name,
+                         page_rows.user_id, page_rows.connection_id
                 """,
                 {
                     "circle_id": cleaned_circle_id,
                     "actor_user_id": actor_user_id,
                     "query": normalized_query,
+                    **query_match,
                     "offset": offset,
                     "limit": normalized_limit,
                 },

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -3547,3 +3548,78 @@ def test_an_add_naming_only_blocked_people_still_fails_loudly():
     assert raised.value.status_code == 409
     # Unnamed, like every other refusal about somebody else's history.
     assert "friend-one" not in raised.value.args[0]
+
+
+# ---------------------------------------------------------------------------
+# One-letter people search, on the PAGED path.
+# ---------------------------------------------------------------------------
+#
+# Both paged people searches filtered with a bare substring and ordered A-Z.
+# With connections named "Ankit Kumar Singh" and "Neelesh Meena", typing `n`
+# matched BOTH -- "Ankit" and "Singh" each carry an "n" -- and then sorted
+# Ankit first. One-letter search read as broken.
+#
+# `filterPeopleByQuery` in hushh-webapp/lib/one-location/people-search.ts
+# already fixed this for the client's own path and is covered by the protected
+# behaviour `location-people-search-finds-a-person-from-one-letter`. The
+# server-paged path never got it, so the same sheet behaved differently
+# depending on which loader it was given. These hold the two together.
+
+from hushh_mcp.services.one_location_circle_service import (  # noqa: E402
+    _people_query_match_params,
+)
+
+_CIRCLE_SERVICE_SOURCE = Path(circle_service_module.__file__).read_text(encoding="utf-8")
+
+
+def test_one_character_query_is_marked_as_such() -> None:
+    assert _people_query_match_params("n")["query_is_single_char"] is True
+    assert _people_query_match_params("ne")["query_is_single_char"] is False
+    assert _people_query_match_params("")["query_is_single_char"] is False
+
+
+def test_the_match_patterns_separate_a_beginning_from_a_mid_word_hit() -> None:
+    params = _people_query_match_params("n")
+    prefix = re.compile(str(params["query_prefix_re"]))
+    word = re.compile(str(params["query_word_re"]).replace("[:alnum:]", "a-z0-9"))
+
+    # "neelesh meena" begins with it; "ankit kumar singh" only carries it.
+    assert prefix.search("neelesh meena")
+    assert not prefix.search("ankit kumar singh")
+    assert word.search("neelesh meena")
+    assert not word.search("ankit kumar singh")
+
+    # A word beginning that is not the first word still ranks above mid-word.
+    assert word.search("ankit narayan")
+
+
+def test_a_query_cannot_smuggle_a_pattern_into_the_search() -> None:
+    # A name containing regex punctuation must be searched for literally.
+    params = _people_query_match_params("r.")
+    prefix = re.compile(str(params["query_prefix_re"]))
+    assert prefix.search("r. meena")
+    assert not prefix.search("rx meena")
+
+
+def test_an_empty_query_matches_nothing_through_the_rank_patterns() -> None:
+    # The SQL gates on `:query = ''` before these are consulted, but they must
+    # never match by accident if that gate is ever reordered.
+    params = _people_query_match_params("")
+    assert re.compile(str(params["query_prefix_re"])).search("anyone") is None
+
+
+def test_both_paged_people_searches_rank_and_narrow_the_same_way() -> None:
+    # Two call sites: Circle members, and the "Add people" eligible
+    # connections sheet the defect was reported on.
+    assert _CIRCLE_SERVICE_SOURCE.count("query_prefix_re") == 3  # helper + 2 SQL
+    assert _CIRCLE_SERVICE_SOURCE.count("AS match_rank") == 2
+    # Relevance first, then A-Z inside it -- the client's documented shape.
+    assert _CIRCLE_SERVICE_SOURCE.count("ORDER BY match_rank, normalized_name") == 2
+    assert _CIRCLE_SERVICE_SOURCE.count("ORDER BY page_rows.match_rank") == 2
+    # One character keeps only word-beginning matches...
+    assert _CIRCLE_SERVICE_SOURCE.count("WHERE NOT :query_is_single_char") == 2
+    # ...but never empties a list that has a match.
+    assert (
+        _CIRCLE_SERVICE_SOURCE.count("SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2")
+        == 2
+    )


### PR DESCRIPTION
Closes #6243.

## The report

Circle Detail → **Add people**, typing a single `N`:

```
N|
Your connections
  Ankit Kumar Singh      <- still here, and first
  Neelesh Meena
```

## Why

Both are correct *substring* matches — "A**n**kit" and "Si**n**gh" each carry an
`n`. The server does:

```sql
WHERE :query = '' OR POSITION(:query IN normalized_name) > 0
ORDER BY normalized_name
```

…so it keeps both and then sorts alphabetically, putting Ankit above the person
the query actually begins. At one character a substring matches most names in
any list, which is exactly why one-letter search reads as broken.

## This was already solved — on the other path

`filterPeopleByQuery` in `hushh-webapp/lib/one-location/people-search.ts` fixed
this for the client's own filtering. Its file comment describes **these exact
two names and this exact query**, and it is covered by the protected behaviour
`location-people-search-finds-a-person-from-one-letter`.

The **server-paged** loader never got the same rule — and every Location people
picker is wired to the paged loader, so the version that ships is the one
without the fix. The two paths disagreed about what a query means.

## The change

Both paged searches (Circle members, and the Add people sheet) now use the same
three tiers as the client:

| rank | meaning |
|---|---|
| 0 | the name itself begins with the query |
| 1 | a word inside the name begins with it |
| 2 | it only appears mid-word |

Ordered by **rank, then A–Z inside each rank**.

- **One character** keeps only the word-beginning matches — and falls back to
  the loose ones when nothing begins with it, so it can never empty a list that
  *has* a match.
- **Two characters and up** drop nothing, so `ingh` still finds Singh.

A word boundary is anything that is not a letter or a digit, which keeps
"Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader splits them.
The query is regex-escaped, so a name containing `.` or `*` cannot turn a search
into a pattern.

Typing `N` now puts **Neelesh first**.

## Platforms

Backend-only, so web, iOS and Android all pick it up from the same API — no
per-platform work and no client release needed.

## Verification

| Check | Result |
|---|---|
| `ruff` (check + format) | clean |
| backend — `test_one_location_circle_service.py` | 86 passed (5 new) |
| webapp — people-search + Circle picker suites | 106 passed |
| schema | no change, no migration |

The new tests cover the tiers, the regex escaping (a name with `.` cannot be
searched as a pattern), and a contract that **both** call sites rank and narrow
identically — the divergence that caused this in the first place.