### PR TITLE
fix(one): one people-search rule, and every paged list held to it

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -30,6 +30,7 @@ from hushh_mcp.services.connection_graph_service import (
 from hushh_mcp.services.contact_sync_contract import (
     CONTACT_SYNC_CONSENT_CONTRACT_VERSION,
 )
+from hushh_mcp.services.people_search_sql import people_query_match_params
 from hushh_mcp.services.requester_identity import label_from_identity_row
 
 logger = logging.getLogger(__name__)
@@ -3065,13 +3066,32 @@ class ConnectionsService:
                   )
                 )
             ),
+            matched AS (
+              -- One rule for every people search; see people_search_sql.py.
+              SELECT *,
+                CASE
+                  WHEN :query = '' THEN 0
+                  WHEN normalized_name ~ :query_prefix_re THEN 0
+                  WHEN normalized_name ~ :query_word_re THEN 1
+                  ELSE 2
+                END AS match_rank
+              FROM filtered
+            ),
+            narrowed AS (
+              SELECT * FROM matched
+              WHERE NOT :query_is_single_char
+                 OR match_rank < 2
+                 OR NOT EXISTS (
+                      SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2
+                    )
+            ),
             total AS (
-              SELECT COUNT(*)::BIGINT AS total_count FROM filtered
+              SELECT COUNT(*)::BIGINT AS total_count FROM narrowed
             ),
             page_rows AS (
               SELECT *
-              FROM filtered
-              ORDER BY normalized_name, user_id, connection_id
+              FROM narrowed
+              ORDER BY match_rank, normalized_name, user_id, connection_id
               OFFSET :offset
               LIMIT :limit
             )
@@ -3096,12 +3116,13 @@ class ConnectionsService:
               ) END AS is_ria
             FROM total
             LEFT JOIN page_rows ON TRUE
-            ORDER BY page_rows.normalized_name, page_rows.user_id,
-                     page_rows.connection_id
+            ORDER BY page_rows.match_rank, page_rows.normalized_name,
+                     page_rows.user_id, page_rows.connection_id
             """,  # nosec B608 - the RIA predicate is a static module constant.
             {
                 "user_id": viewer_id,
                 "query": normalized_query,
+                **people_query_match_params(normalized_query),
                 "audience": normalized_audience,
                 "offset": offset,
                 "limit": normalized_limit,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -33,6 +33,7 @@ from hushh_mcp.operons.location.policy import (
     normalize_source_platform,
 )
 from hushh_mcp.runtime_settings import get_core_security_settings
+from hushh_mcp.services.people_search_sql import people_query_match_params
 from hushh_mcp.types import AgentID, UserID
 from mcp_modules.log_redaction import redact_log_field, redact_log_value
 
@@ -3998,14 +3999,33 @@ class OneLocationAgentService:
                       AND mine.status = 'active'
                   )
                 )
-            ), filtered AS (
-              SELECT * FROM eligible
+            ), matched AS (
+              -- One rule for every people search; see people_search_sql.py.
+              -- This list is the People tab's Connections, and it was the
+              -- third screen reported as "one char search is not working":
+              -- `n` kept both "Neelesh Meena" and "Ankit Kumar Singh", then
+              -- sorted Ankit first.
+              SELECT *,
+                CASE
+                  WHEN :query = '' THEN 0
+                  WHEN normalized_name ~ :query_prefix_re THEN 0
+                  WHEN normalized_name ~ :query_word_re THEN 1
+                  ELSE 2
+                END AS match_rank
+              FROM eligible
               WHERE :query = '' OR POSITION(:query IN normalized_name) > 0
+            ), filtered AS (
+              SELECT * FROM matched
+              WHERE NOT :query_is_single_char
+                 OR match_rank < 2
+                 OR NOT EXISTS (
+                      SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2
+                    )
             ), total AS (
               SELECT COUNT(*)::BIGINT AS total_count FROM filtered
             ), page_rows AS (
               SELECT * FROM filtered
-              ORDER BY normalized_name, user_id
+              ORDER BY match_rank, normalized_name, user_id
               OFFSET :offset LIMIT :limit
             )
             SELECT page_rows.user_id, page_rows.display_name, page_rows.email,
@@ -4034,11 +4054,13 @@ class OneLocationAgentService:
               WHERE key.user_id = page_rows.user_id AND key.status = 'active'
               ORDER BY key.created_at DESC LIMIT 1
             ) recipient_key ON TRUE
-            ORDER BY page_rows.normalized_name, page_rows.user_id
+            ORDER BY page_rows.match_rank, page_rows.normalized_name,
+                     page_rows.user_id
             """,
             {
                 "owner_user_id": owner_user_id,
                 "query": normalized_query,
+                **people_query_match_params(normalized_query),
                 "offset": offset,
                 "limit": normalized_limit,
             },

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -29,6 +29,7 @@ from hushh_mcp.services.connection_graph_service import (
     ensure_connection_origin,
     revoke_circle_origins,
 )
+from hushh_mcp.services.people_search_sql import people_query_match_params
 from mcp_modules.log_redaction import redact_log_field
 
 logger = logging.getLogger(__name__)
@@ -329,32 +330,6 @@ def _clean_kind(value: str | None) -> str:
             status_code=422,
         )
     return kind
-
-
-def _people_query_match_params(normalized_query: str) -> dict[str, object]:
-    """Bind values for the three-tier name match the paged people searches use.
-
-    The tiers mirror `filterPeopleByQuery` in
-    `hushh-webapp/lib/one-location/people-search.ts` exactly, because a paged
-    list and an unpaged one must not disagree about what a query means. Both
-    sheets used a bare substring match ordered A-Z, so with connections named
-    "Ankit Kumar Singh" and "Neelesh Meena", typing `n` matched BOTH -- "Ankit"
-    and "Singh" each carry an "n" -- and then sorted the wrong one first. The
-    client already fixed this for its own path and is covered by the protected
-    behaviour `location-people-search-finds-a-person-from-one-letter`; the
-    server-paged path never got it.
-
-    A word boundary is anything that is not a letter or a digit, which keeps
-    "Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader splits
-    them. The query is regex-escaped, so a name containing `.` or `*` cannot
-    turn a search into a pattern.
-    """
-    escaped = re.escape(normalized_query)
-    return {
-        "query_prefix_re": f"^{escaped}" if normalized_query else "$^",
-        "query_word_re": (f"(^|[^[:alnum:]]){escaped}" if normalized_query else "$^"),
-        "query_is_single_char": len(normalized_query) == 1,
-    }
 
 
 class OneLocationCircleService:
@@ -1057,7 +1032,7 @@ class OneLocationCircleService:
         normalized_page = max(1, int(page or 1))
         normalized_limit = max(1, min(int(limit or 50), 100))
         normalized_query = str(query or "").strip().lower()
-        query_match = _people_query_match_params(normalized_query)
+        query_match = people_query_match_params(normalized_query)
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(
@@ -2880,7 +2855,7 @@ class OneLocationCircleService:
         normalized_page = max(1, int(page or 1))
         normalized_limit = max(1, min(int(limit or 50), 100))
         normalized_query = str(query or "").strip().lower()
-        query_match = _people_query_match_params(normalized_query)
+        query_match = people_query_match_params(normalized_query)
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(

--- a/consent-protocol/hushh_mcp/services/people_search_sql.py
+++ b/consent-protocol/hushh_mcp/services/people_search_sql.py
@@ -1,0 +1,88 @@
+"""One rule for how a typed query narrows a list of people, server-side.
+
+People read a name from the start of its words: `n` means Neelesh, `kum` means
+Kumar. A bare substring match does not know that. With connections named "Ankit
+Kumar Singh" and "Neelesh Meena", typing `n` matches BOTH -- "Ankit" and
+"Singh" each carry an "n" -- and an A-Z ordering then puts Ankit first, above
+the person the query actually begins. Reported three separate times, on three
+separate screens, as "one char search is not working".
+
+`filterPeopleByQuery` in ``hushh-webapp/lib/one-location/people-search.ts``
+settled this for the client and is covered by the protected behaviour
+``location-people-search-finds-a-person-from-one-letter``. Every server-paged
+list had its own copy of the old substring rule, so the same picker behaved
+differently depending on which loader it was handed -- and the paged loader is
+the one that ships.
+
+This module is the single server-side statement of that rule, so there is one
+place to read it and one place to change it.
+
+THE RULE
+--------
+
+Three tiers, ordered best first, A-Z inside each:
+
+  0  the name itself begins with the query
+  1  a word inside the name begins with it
+  2  it only appears mid-word
+
+A single character is only meaningful as a beginning -- mid-word it matches
+most names in any list -- so a one-character query keeps just tiers 0 and 1,
+and falls back to tier 2 only when nothing begins with it, so it can never
+empty a list that has a match. From two characters on nothing is dropped:
+beginnings lead, loose matches follow, so `ingh` still finds Singh.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "people_query_match_params",
+    "PEOPLE_MATCH_RANK_SQL",
+    "PEOPLE_SINGLE_CHAR_NARROW_SQL",
+]
+
+
+def people_query_match_params(normalized_query: str) -> dict[str, object]:
+    """Bind values for :data:`PEOPLE_MATCH_RANK_SQL` and its narrowing clause.
+
+    ``normalized_query`` must already be lowercased and trimmed, matching the
+    ``normalized_name`` expression the caller ranks against.
+
+    A word boundary is anything that is not a letter or a digit, which keeps
+    "Jean-Luc", "O'Brien" and "R. Meena" splitting the way a reader splits
+    them. The query is regex-escaped, so a name containing ``.`` or ``*``
+    cannot turn a search into a pattern. An empty query yields ``$^`` -- a
+    pattern that matches nothing -- so the rank expression cannot match by
+    accident if a caller ever reorders its ``:query = ''`` guard.
+    """
+    escaped = re.escape(normalized_query)
+    return {
+        "query_prefix_re": f"^{escaped}" if normalized_query else "$^",
+        "query_word_re": (f"(^|[^[:alnum:]]){escaped}" if normalized_query else "$^"),
+        "query_is_single_char": len(normalized_query) == 1,
+    }
+
+
+#: Rank expression. Select it as ``match_rank`` beside a ``normalized_name``
+#: column, then ``ORDER BY match_rank, normalized_name, ...``.
+PEOPLE_MATCH_RANK_SQL = """
+                    CASE
+                      WHEN :query = '' THEN 0
+                      WHEN normalized_name ~ :query_prefix_re THEN 0
+                      WHEN normalized_name ~ :query_word_re THEN 1
+                      ELSE 2
+                    END AS match_rank
+""".strip("\n")
+
+#: Narrowing clause for a CTE named ``matched`` that carries ``match_rank``.
+#: Keeps only word-beginning matches for a one-character query, unless nothing
+#: begins with it -- a list with a match is never emptied.
+PEOPLE_SINGLE_CHAR_NARROW_SQL = """
+                  WHERE NOT :query_is_single_char
+                     OR match_rank < 2
+                     OR NOT EXISTS (
+                          SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2
+                        )
+""".strip("\n")

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -103,6 +103,7 @@ tests/test_contact_match_correctness.py
 # production deploy back -- both green, both unrun, for as long as they have
 # existed.
 tests/services/test_one_location_circle_service.py
+tests/services/test_people_search_sql.py
 tests/test_one_location_system_circle_migration.py
 tests/test_one_location_system_circle_kinds_migration.py
 tests/test_migrations_are_replay_safe.py

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -3548,78 +3547,3 @@ def test_an_add_naming_only_blocked_people_still_fails_loudly():
     assert raised.value.status_code == 409
     # Unnamed, like every other refusal about somebody else's history.
     assert "friend-one" not in raised.value.args[0]
-
-
-# ---------------------------------------------------------------------------
-# One-letter people search, on the PAGED path.
-# ---------------------------------------------------------------------------
-#
-# Both paged people searches filtered with a bare substring and ordered A-Z.
-# With connections named "Ankit Kumar Singh" and "Neelesh Meena", typing `n`
-# matched BOTH -- "Ankit" and "Singh" each carry an "n" -- and then sorted
-# Ankit first. One-letter search read as broken.
-#
-# `filterPeopleByQuery` in hushh-webapp/lib/one-location/people-search.ts
-# already fixed this for the client's own path and is covered by the protected
-# behaviour `location-people-search-finds-a-person-from-one-letter`. The
-# server-paged path never got it, so the same sheet behaved differently
-# depending on which loader it was given. These hold the two together.
-
-from hushh_mcp.services.one_location_circle_service import (  # noqa: E402
-    _people_query_match_params,
-)
-
-_CIRCLE_SERVICE_SOURCE = Path(circle_service_module.__file__).read_text(encoding="utf-8")
-
-
-def test_one_character_query_is_marked_as_such() -> None:
-    assert _people_query_match_params("n")["query_is_single_char"] is True
-    assert _people_query_match_params("ne")["query_is_single_char"] is False
-    assert _people_query_match_params("")["query_is_single_char"] is False
-
-
-def test_the_match_patterns_separate_a_beginning_from_a_mid_word_hit() -> None:
-    params = _people_query_match_params("n")
-    prefix = re.compile(str(params["query_prefix_re"]))
-    word = re.compile(str(params["query_word_re"]).replace("[:alnum:]", "a-z0-9"))
-
-    # "neelesh meena" begins with it; "ankit kumar singh" only carries it.
-    assert prefix.search("neelesh meena")
-    assert not prefix.search("ankit kumar singh")
-    assert word.search("neelesh meena")
-    assert not word.search("ankit kumar singh")
-
-    # A word beginning that is not the first word still ranks above mid-word.
-    assert word.search("ankit narayan")
-
-
-def test_a_query_cannot_smuggle_a_pattern_into_the_search() -> None:
-    # A name containing regex punctuation must be searched for literally.
-    params = _people_query_match_params("r.")
-    prefix = re.compile(str(params["query_prefix_re"]))
-    assert prefix.search("r. meena")
-    assert not prefix.search("rx meena")
-
-
-def test_an_empty_query_matches_nothing_through_the_rank_patterns() -> None:
-    # The SQL gates on `:query = ''` before these are consulted, but they must
-    # never match by accident if that gate is ever reordered.
-    params = _people_query_match_params("")
-    assert re.compile(str(params["query_prefix_re"])).search("anyone") is None
-
-
-def test_both_paged_people_searches_rank_and_narrow_the_same_way() -> None:
-    # Two call sites: Circle members, and the "Add people" eligible
-    # connections sheet the defect was reported on.
-    assert _CIRCLE_SERVICE_SOURCE.count("query_prefix_re") == 3  # helper + 2 SQL
-    assert _CIRCLE_SERVICE_SOURCE.count("AS match_rank") == 2
-    # Relevance first, then A-Z inside it -- the client's documented shape.
-    assert _CIRCLE_SERVICE_SOURCE.count("ORDER BY match_rank, normalized_name") == 2
-    assert _CIRCLE_SERVICE_SOURCE.count("ORDER BY page_rows.match_rank") == 2
-    # One character keeps only word-beginning matches...
-    assert _CIRCLE_SERVICE_SOURCE.count("WHERE NOT :query_is_single_char") == 2
-    # ...but never empties a list that has a match.
-    assert (
-        _CIRCLE_SERVICE_SOURCE.count("SELECT 1 FROM matched narrow WHERE narrow.match_rank < 2")
-        == 2
-    )

--- a/consent-protocol/tests/services/test_people_search_sql.py
+++ b/consent-protocol/tests/services/test_people_search_sql.py
@@ -1,0 +1,132 @@
+"""One rule for people search, and every paged list held to it.
+
+People read a name from the start of its words: `n` means Neelesh, `kum` means
+Kumar. A bare substring match does not know that -- with connections named
+"Ankit Kumar Singh" and "Neelesh Meena", typing `n` matches BOTH, and an A-Z
+ordering then puts Ankit first, above the person the query actually begins.
+
+That was reported three times, on three separate screens. The client settled it
+once in `hushh-webapp/lib/one-location/people-search.ts` (protected behaviour
+`location-people-search-finds-a-person-from-one-letter`), but every server-paged
+list carried its own copy of the old substring rule -- and the paged loader is
+the one that ships.
+
+`people_search_sql` is now the single server-side statement of the rule. These
+tests hold the rule itself, and hold every paged people search to using it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import hushh_mcp.services.connections_service as connections_service_module
+import hushh_mcp.services.one_location_agent_service as agent_service_module
+import hushh_mcp.services.one_location_circle_service as circle_service_module
+from hushh_mcp.services.people_search_sql import (
+    PEOPLE_MATCH_RANK_SQL,
+    PEOPLE_SINGLE_CHAR_NARROW_SQL,
+    people_query_match_params,
+)
+
+
+def _rank_patterns(query: str) -> tuple[re.Pattern[str], re.Pattern[str]]:
+    params = people_query_match_params(query)
+    prefix = re.compile(str(params["query_prefix_re"]))
+    # Python has no POSIX class shorthand; the SQL engine does.
+    word = re.compile(str(params["query_word_re"]).replace("[:alnum:]", "a-z0-9"))
+    return prefix, word
+
+
+def test_one_character_is_flagged_so_the_query_can_be_narrowed() -> None:
+    assert people_query_match_params("n")["query_is_single_char"] is True
+    assert people_query_match_params("ne")["query_is_single_char"] is False
+    assert people_query_match_params("")["query_is_single_char"] is False
+
+
+def test_a_beginning_outranks_a_mid_word_hit() -> None:
+    prefix, word = _rank_patterns("n")
+
+    # The reported pair, exactly.
+    assert prefix.search("neelesh meena")
+    assert not prefix.search("ankit kumar singh")
+    assert word.search("neelesh meena")
+    assert not word.search("ankit kumar singh")
+
+
+def test_a_word_that_is_not_the_first_still_counts_as_a_beginning() -> None:
+    _, word = _rank_patterns("k")
+    assert word.search("ankit kumar singh")  # "kumar"
+    _, word = _rank_patterns("m")
+    assert word.search("neelesh meena")  # "meena"
+
+
+def test_punctuation_separates_words_the_way_a_reader_reads_them() -> None:
+    for name, needle in (
+        ("jean-luc picard", "l"),
+        ("o'brien", "b"),
+        ("r. meena", "m"),
+    ):
+        _, word = _rank_patterns(needle)
+        assert word.search(name), f"{needle!r} should begin a word in {name!r}"
+
+
+def test_a_query_cannot_smuggle_a_pattern_into_the_search() -> None:
+    prefix, _ = _rank_patterns("r.")
+    assert prefix.search("r. meena")
+    assert not prefix.search("rx meena")
+
+
+def test_an_empty_query_matches_nothing_through_the_rank_patterns() -> None:
+    # The SQL gates on `:query = ''` first, but the patterns must not match by
+    # accident if that guard is ever reordered.
+    prefix, word = _rank_patterns("")
+    assert prefix.search("anyone") is None
+    assert word.search("anyone") is None
+
+
+def test_two_characters_drop_nothing() -> None:
+    # "ingh" must still find Singh: from two characters on, loose matches are
+    # ranked last, never removed.
+    assert people_query_match_params("ingh")["query_is_single_char"] is False
+    prefix, word = _rank_patterns("ingh")
+    assert not prefix.search("ankit kumar singh")
+    assert not word.search("ankit kumar singh")
+    assert "singh".find("ingh") > 0  # the loose tier is what keeps it
+
+
+PAGED_PEOPLE_SEARCHES = (
+    # module, how many paged people searches it owns
+    (circle_service_module, 2),  # Circle members, and Add people
+    (agent_service_module, 1),  # the People tab's Connections list
+    (connections_service_module, 1),  # Connect's connections list
+)
+
+
+def test_every_paged_people_search_uses_the_shared_rule() -> None:
+    # The divergence is the defect. A new paged list that writes its own
+    # substring match is the same bug again on a fourth screen.
+    for module, expected in PAGED_PEOPLE_SEARCHES:
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        name = Path(module.__file__).name
+        assert "people_query_match_params" in source, f"{name} builds its own binds"
+        assert source.count("AS match_rank") == expected, name
+        assert source.count("ORDER BY match_rank, normalized_name") == expected, name
+        assert source.count("ORDER BY page_rows.match_rank") == expected, name
+        assert source.count("WHERE NOT :query_is_single_char") == expected, name
+
+
+def test_no_paged_people_search_still_orders_by_name_alone() -> None:
+    # The exact shape of the bug: a substring filter ordered A-Z.
+    for module, _ in PAGED_PEOPLE_SEARCHES:
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        name = Path(module.__file__).name
+        assert "ORDER BY normalized_name, user_id" not in source, name
+        assert "ORDER BY page_rows.normalized_name" not in source, name
+
+
+def test_the_sql_fragments_are_shaped_for_the_ctes_that_use_them() -> None:
+    assert "AS match_rank" in PEOPLE_MATCH_RANK_SQL
+    assert ":query_prefix_re" in PEOPLE_MATCH_RANK_SQL
+    assert ":query_word_re" in PEOPLE_MATCH_RANK_SQL
+    assert "FROM matched narrow" in PEOPLE_SINGLE_CHAR_NARROW_SQL


### PR DESCRIPTION
Closes #6245. Third report of the same defect (#6243 was the second), so this
fixes the *divergence* rather than the screen.

## The report

Location → **People** tab, typing `N`:

```
Connections · 2
  🔍 N
  Ankit Kumar Singh    <- still here, and first
  Neelesh Meena
```

## Why it keeps coming back

People read a name from the start of its words: `n` means Neelesh, `kum` means
Kumar. A bare substring does not know that — "A**n**kit" and "Si**n**gh" each
carry an `n`, so the filter keeps both and A–Z ordering puts the wrong one
first.

`filterPeopleByQuery` settled this **for the client**. But every server-paged
list kept its own copy of the old rule, and every picker is wired to the paged
loader — so the shipped path was the unfixed one, on screen after screen:

| paged search | state before |
|---|---|
| Circle members | old rule |
| Add people | old rule (fixed in #6244) |
| **People tab Connections** | old rule ← reported |
| **Connect connections list** | old rule ← same latent bug, never reported |

Fixing them one at a time is *how this got reported three times*.

## The change

`consent-protocol/hushh_mcp/services/people_search_sql.py` is now the single
server-side statement of the rule. All four paged searches use it.

| rank | meaning |
|---|---|
| 0 | the name itself begins with the query |
| 1 | a word inside the name begins with it |
| 2 | it only appears mid-word |

Ordered by **rank, then A–Z inside each rank**.

- **One character** keeps only ranks 0–1 — falling back to rank 2 when nothing
  begins with the query, so a list with a match is never emptied.
- **Two characters and up** drop nothing, so `ingh` still finds Singh.

A word boundary is anything that is not a letter or a digit, so "Jean-Luc",
"O'Brien" and "R. Meena" split the way a reader splits them. The query is
regex-escaped: a name containing `.` or `*` cannot turn a search into a pattern.

## What stops a fourth screen

Two contract tests, not just behaviour tests:

- every paged people search must use the shared binds **and** the shared ranking
- **none** may `ORDER BY normalized_name` alone — the exact shape of the bug

A new paged list that writes its own substring match fails CI.

## Verification

| Check | Result |
|---|---|
| `ruff` check + format | clean |
| backend — 4 affected service suites | 373 passed (10 new) |
| `test-ci.manifest.txt` | new test registered — without it, it never runs in CI |
| schema | no change, no migration |

Backend-only, so **web, iOS and Android** all pick it up from the same API with
no client release.