### PR TITLE
fix(one): make a Circle roster say who a menu belongs to, and who owns the Circle

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -176,6 +176,7 @@ export function SettingsGroup({
   embedded = false,
   separatorInset,
   className,
+  headingClassName,
   shellClassName,
   contentClassName,
   testId = "settings-group",
@@ -218,6 +219,21 @@ export function SettingsGroup({
    */
   separatorInset?: boolean;
   className?: string;
+  /**
+   * Tunes the heading block's own spacing.
+   *
+   * The block carries `mt-7` because a settings SCREEN stacks groups down a
+   * page and 28px is what separates one section from the last. Inside a
+   * bottom sheet there is no previous section -- the group is the first thing
+   * under a header that has already introduced it -- so that 28px lands as a
+   * gap between the sheet's own title and the list it is titling. Reported on
+   * the Add people sheet as "search bahut jyada neeche aa raha".
+   *
+   * A caller-supplied class rather than a `compact` boolean: the value that is
+   * wrong here is a margin, and the surfaces that need to change it are the
+   * ones that own their own vertical rhythm.
+   */
+  headingClassName?: string;
   /** Lets a bounded manager make the shared group shell a flex viewport. */
   shellClassName?: string;
   /** Lets a bounded manager make the shared row stack the scroll owner. */
@@ -258,7 +274,12 @@ export function SettingsGroup({
   return (
     <section className={cn("w-full", className)} data-testid={testId}>
       {eyebrow || title || description || titleAction ? (
-        <div className="mb-2 mt-7 flex items-start justify-between gap-3 px-[6px]">
+        <div
+          className={cn(
+            "mb-2 mt-7 flex items-start justify-between gap-3 px-[6px]",
+            headingClassName,
+          )}
+        >
           <div className="min-w-0 flex-1 space-y-[var(--settings-heading-stack-gap)]">
             {eyebrow || title ? (
               <SectionLabel

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-member-actions-menu.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-member-actions-menu.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * The Circle roster's per-member actions, on both surfaces they ship on.
+ *
+ * The defect these cover was reported with a phone screenshot: the kebab on
+ * one member opened an anchored card that painted over the NEXT member's
+ * name, so two rows' worth of identity sat under one menu and nothing said
+ * which of them the actions belonged to.
+ *
+ * So the assertions here are about identity and surface, not styling:
+ *
+ *   - under 640px there is no anchored popper at all, and the surface that
+ *     opens names the member it belongs to;
+ *   - the destructive step never stacks a second modal over the first;
+ *   - at 640px and up the anchored menu still opens, and it too names the
+ *     member -- and it closes when the confirm takes over rather than being
+ *     left open behind it.
+ *
+ * `__tests__/setup.ts` stubs `matchMedia` as permanently non-matching, which
+ * is the desktop answer; the phone lane restubs it per test.
+ */
+
+import type { ComponentProps } from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CircleMemberActionsMenu,
+  MEMBER_ACTIONS_MENU_TESTID,
+  MEMBER_ACTIONS_SHEET_QUERY,
+  MEMBER_ACTIONS_SHEET_TESTID,
+  memberRemoveConfirmDescription,
+  memberRemoveConfirmTitle,
+} from "@/components/one-location/redesign/circles/circle-member-actions-menu";
+
+const MEMBER_NAME = "Ankit Kumar Singh";
+
+/** Stubs `matchMedia` so only the sheet boundary answers, and only the way
+ *  this test wants it to. Nothing else in the tree reads a media query. */
+function setViewport(kind: "phone" | "desktop") {
+  const wantsSheet = kind === "phone";
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === MEMBER_ACTIONS_SHEET_QUERY ? wantsSheet : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function renderMenu(
+  overrides: Partial<ComponentProps<typeof CircleMemberActionsMenu>> = {},
+) {
+  const onShare = vi.fn();
+  const onRemove = vi.fn(async () => undefined);
+  render(
+    <CircleMemberActionsMenu
+      displayName={MEMBER_NAME}
+      initials="AK"
+      secondaryLine="Connected"
+      canShare
+      canRemove
+      busy={false}
+      onShare={onShare}
+      onRemove={onRemove}
+      {...overrides}
+    />,
+  );
+  return { onShare, onRemove };
+}
+
+const triggerName = `Actions for ${MEMBER_NAME}`;
+
+describe("CircleMemberActionsMenu on a phone", () => {
+  beforeEach(() => {
+    setViewport("phone");
+  });
+
+  it("opens a bottom sheet that names the member instead of an anchored menu over the next row", async () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+
+    const sheet = await screen.findByTestId(MEMBER_ACTIONS_SHEET_TESTID);
+
+    // The whole point: nothing is anchored to the row, so nothing can land on
+    // the name of the member below it.
+    expect(
+      document.querySelector("[data-radix-popper-content-wrapper]"),
+    ).toBeNull();
+    expect(screen.queryByTestId(MEMBER_ACTIONS_MENU_TESTID)).toBeNull();
+
+    // Whose actions these are, said on the surface rather than by proximity.
+    expect(within(sheet).getByText(MEMBER_NAME)).toBeInTheDocument();
+    expect(within(sheet).getByText("Connected")).toBeInTheDocument();
+
+    expect(
+      within(sheet).getByRole("menuitem", { name: /Share location/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(sheet).getByRole("menuitem", { name: /Remove from Circle/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shares with the member and closes the sheet", async () => {
+    const { onShare } = renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Share location/i }),
+    );
+
+    expect(onShare).toHaveBeenCalledTimes(1);
+    // Dismissed on the way out, so the share surface it opens is not raised
+    // behind a sheet that is still up. Asserted on the state attribute rather
+    // than on unmount: the exit is an animation, and jsdom runs none, so the
+    // node lingers in the test DOM long after it is gone on a device.
+    await waitFor(() =>
+      expect(screen.getByTestId(MEMBER_ACTIONS_SHEET_TESTID)).toHaveAttribute(
+        "data-state",
+        "closed",
+      ),
+    );
+  });
+
+  it("confirms a removal inside the same sheet rather than stacking a dialog over it", async () => {
+    const { onRemove } = renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    );
+
+    // Same surface, second pane -- so there is never a confirm painting
+    // underneath the sheet that raised it.
+    const sheet = await screen.findByTestId(MEMBER_ACTIONS_SHEET_TESTID);
+    expect(
+      within(sheet).getByText(memberRemoveConfirmTitle(MEMBER_NAME)),
+    ).toBeInTheDocument();
+    expect(
+      within(sheet).getByText(memberRemoveConfirmDescription(MEMBER_NAME)),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+
+    fireEvent.click(within(sheet).getByRole("button", { name: "Remove" }));
+    await waitFor(() => expect(onRemove).toHaveBeenCalledTimes(1));
+  });
+
+  it("backs out of the confirm without removing anyone", async () => {
+    const { onRemove } = renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    // Back to the action list, not out of the sheet entirely.
+    expect(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    ).toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("offers only the actions that apply", async () => {
+    renderMenu({ canShare: false });
+
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /Share location/i }),
+    ).toBeNull();
+  });
+});
+
+describe("CircleMemberActionsMenu on a pointer device", () => {
+  beforeEach(() => {
+    setViewport("desktop");
+  });
+
+  it("keeps the anchored menu, and names the member on it", async () => {
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: triggerName });
+    // Radix opens DropdownMenuTrigger on pointerdown (no PointerEvent in
+    // jsdom) or on Enter/Space keydown -- use the keyboard path here.
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    const menu = await screen.findByTestId(MEMBER_ACTIONS_MENU_TESTID);
+    expect(screen.queryByTestId(MEMBER_ACTIONS_SHEET_TESTID)).toBeNull();
+    expect(within(menu).getByText(MEMBER_NAME)).toBeInTheDocument();
+    expect(
+      within(menu).getByRole("menuitem", { name: /Share location/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the menu when the remove confirm takes over", async () => {
+    const { onRemove } = renderMenu();
+
+    fireEvent.keyDown(screen.getByRole("button", { name: triggerName }), {
+      key: "Enter",
+    });
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /Remove from Circle/i }),
+    );
+
+    // The menu used to stay open BEHIND the confirm: two surfaces, one
+    // decision.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menuitem", { name: /Remove from Circle/i }),
+      ).toBeNull(),
+    );
+
+    expect(
+      await screen.findByText(memberRemoveConfirmTitle(MEMBER_NAME)),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove", hidden: true }),
+    );
+    await waitFor(() => expect(onRemove).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("CircleMemberActionsMenu with nothing to offer", () => {
+  beforeEach(() => {
+    setViewport("phone");
+  });
+
+  it("still holds the kebab column open", () => {
+    renderMenu({ canShare: false, canRemove: false });
+
+    expect(screen.queryByRole("button", { name: triggerName })).toBeNull();
+    const spacer = screen.getByTestId("circle-member-menu-spacer");
+    expect(spacer).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -1387,6 +1387,59 @@ describe("named Circle flows", () => {
     ).toBeTruthy();
   });
 
+  it("stops hoisting the owner once the roster is answering a search", async () => {
+    // The owner leads a ROSTER. A searched list is answering a question, and
+    // both search paths rank a name that begins with the query above one that
+    // merely contains it -- hoisting the owner through that would put the
+    // wrong person first on the one screen where the reader has already said
+    // who they want. "Ankit Kumar Singh" and "Jhumma Kumari" both have a word
+    // beginning with "ku", so A-Z inside the rank decides, and Ankit wins.
+    const filler = Array.from({ length: 7 }, (_unused, index) => ({
+      userId: `filler-${index}`,
+      displayName: `Zz Filler ${index}`,
+      role: "member" as const,
+      phoneVerified: true,
+      secureLocationReady: true,
+    }));
+
+    render(
+      <CircleDetailFlow
+        circleId="circle-1"
+        {...detailProps(async () => ({
+          ...circle("circle-1", "Family"),
+          memberCount: 9,
+          members: [
+            {
+              userId: "owner-user",
+              displayName: "Jhumma Kumari",
+              role: "owner" as const,
+              phoneVerified: true,
+              secureLocationReady: true,
+            },
+            {
+              userId: "ankit-user",
+              displayName: "Ankit Kumar Singh",
+              role: "member" as const,
+              phoneVerified: true,
+              secureLocationReady: true,
+            },
+            ...filler,
+          ],
+        }))}
+      />,
+    );
+
+    fireEvent.change(await screen.findByPlaceholderText("Search members"), {
+      target: { value: "ku" },
+    });
+
+    const ankit = await screen.findByText("Ankit Kumar Singh");
+    expect(
+      ankit.compareDocumentPosition(screen.getByText("Jhumma Kumari")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   // Reported on the Add people sheet: "extra space between the section is
   // bad", "search bahut jyada neeche aa raha", "divs truncated bhi dikh rahe
   // hain". None of that gap was written here -- it was SheetContent's `gap-4`,

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -1322,6 +1322,120 @@ describe("named Circle flows", () => {
     expect(spacers[0]).toHaveAttribute("aria-hidden", "true");
   });
 
+  // Reported on a Trusted Circle reading "Ankit Kumar Singh / JHUMMA KUMARI
+  // (You · Owner) / Neelesh Meena" -- the roster was A-Z, and the owner is
+  // whoever the alphabet puts in the middle. "Owner hamesha sabse upar hi
+  // rahega, sabhi kind ke circles ke liye", so both kinds are asserted here
+  // rather than only the one that was photographed.
+  it.each([
+    ["a Trusted Circle", "trusted" as const],
+    ["an ordinary Circle", null],
+  ])("puts the owner at the top of %s", async (_label, systemKind) => {
+    const roster = {
+      ...circle("circle-1", systemKind === "trusted" ? "Trusted" : "Family"),
+      systemKind,
+      memberCount: 3,
+      members: [
+        {
+          userId: "ankit-user",
+          displayName: "Ankit Kumar Singh",
+          role: "member" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+        },
+        // Alphabetically between the two members, which is exactly where the
+        // report found them.
+        {
+          userId: "owner-user",
+          displayName: "Jhumma Kumari",
+          role: "owner" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+        },
+        {
+          userId: "neelesh-user",
+          displayName: "Neelesh Meena",
+          role: "member" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+        },
+      ],
+    };
+
+    render(
+      <CircleDetailFlow
+        circleId="circle-1"
+        {...detailProps(async () => roster)}
+      />,
+    );
+
+    const owner = await screen.findByText("Jhumma Kumari");
+    for (const memberName of ["Ankit Kumar Singh", "Neelesh Meena"]) {
+      expect(
+        owner.compareDocumentPosition(screen.getByText(memberName)) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+
+    // A partition, not a re-sort: the two members keep the A-Z order they
+    // had underneath the owner.
+    expect(
+      screen
+        .getByText("Ankit Kumar Singh")
+        .compareDocumentPosition(screen.getByText("Neelesh Meena")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  // Reported on the Add people sheet: "extra space between the section is
+  // bad", "search bahut jyada neeche aa raha", "divs truncated bhi dikh rahe
+  // hain". None of that gap was written here -- it was SheetContent's `gap-4`,
+  // SheetHeader's `p-4`, the body's `mt-4` and SettingsGroup's `mt-7`, four
+  // sensible defaults stacking. Asserted on the rendered classes rather than
+  // measured, because jsdom has no layout: what regressed was which owner's
+  // default is in force, and that is exactly what these read back.
+  it("does not stack four owners' default spacing above the Add people list", async () => {
+    render(
+      <CircleDetailFlow
+        circleId="circle-1"
+        {...detailProps(async () => circle("circle-1", "Family"))}
+        onLoadEligibleConnections={vi.fn(async () => ({
+          eligibleConnections: [
+            { userId: "conn-1", displayName: "Asha Meena" },
+            { userId: "conn-2", displayName: "Neel Shah" },
+          ],
+          pendingInvites: [],
+          remainingCapacity: 5,
+        }))}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add people" }));
+    const sheet = await screen.findByRole("dialog", { name: "Add people" });
+
+    // The header stops adding a second inset on top of the sheet's own, so
+    // the title lines up with the search field instead of sitting inboard of
+    // it, and stops adding 16px under a description the gap already spaced.
+    const header = sheet.querySelector('[data-slot="sheet-header"]');
+    expect(header?.className).toContain("p-0");
+    expect(header?.className).not.toContain("p-4");
+
+    const group = await screen.findByTestId(
+      "one-location-circle-eligible-connections",
+    );
+    const headingBlock = group
+      .querySelector('[data-slot="settings-group-heading"]')
+      ?.closest("section > div");
+    expect(headingBlock?.className).toContain("mt-0");
+    expect(headingBlock?.className).not.toContain("mt-7");
+
+    // And the list is still the thing that scrolls, so the "Add N people"
+    // button cannot be pushed off the bottom by a long roster.
+    const scroller = sheet.querySelector(".overflow-y-auto.overscroll-contain");
+    expect(scroller).not.toBeNull();
+    expect(scroller?.contains(group)).toBe(true);
+  });
+
   it("scopes quick actions to the row's own member and hides actions that don't apply", async () => {
     const onShareWithMember = vi.fn();
     const ownerCircle = {

--- a/hushh-webapp/components/one-location/redesign/circles/circle-member-actions-menu.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-member-actions-menu.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+/**
+ * The two things you can do TO one person in a Circle -- Share location and
+ * Remove from Circle -- and the surface that offers them.
+ *
+ * Reported from phone QA with a screenshot of the roster: the kebab on the
+ * first member opened a small floating card that landed ON the second
+ * member's name, so the screen showed "Share location / Remove from Circle"
+ * overlapping the next person in the list. Nothing on the surface said whose
+ * actions those were, and the one visual cue available -- proximity --
+ * pointed at the wrong person. "Dusre connection ke name ke upar aa gaya."
+ *
+ * That is not a positioning bug to nudge with an offset. An anchored popover
+ * is a POINTER idiom: it works because a cursor is already at the anchor and
+ * the eye follows it there. On a phone the finger covers the anchor, the menu
+ * paints into whatever row happens to be below, and the roster is a list of
+ * near-identical rows -- so the one piece of context that would disambiguate
+ * it is exactly what gets covered.
+ *
+ * So the surface follows the pointer, not the component:
+ *
+ *   phone   (<640px)   bottom action sheet, headed by the member's own avatar
+ *                      and name, over a scrim. It cannot overlap a row
+ *                      because it is not laid out against one, and it says
+ *                      who it is for in the header rather than by proximity.
+ *
+ *   desktop (>=640px)  the anchored menu, restyled onto the app's surface
+ *                      grammar and headed by the same name. A cursor makes
+ *                      the anchor unambiguous, and a bottom sheet on a
+ *                      1440px window is the wrong trade in the other
+ *                      direction.
+ *
+ * 640px is the same boundary `save-location-sheet-layout.ts` switches its own
+ * sheet on, and the same one Tailwind's `sm:` uses -- restated here rather
+ * than imported, because that constant documents an onboarding modal's
+ * geometry and this one is free to move without dragging that surface along.
+ *
+ * ## Visual Map
+ *
+ *   phone                                desktop
+ *   +--------------------------+         roster row          [...]
+ *   | Ankit Kumar Singh  [...] |                               |
+ *   | JHUMMA KUMARI      [...] |                               v
+ *   +==========================+                  +---------------------+
+ *   |           ====           |                  | Ankit Kumar Singh   |
+ *   |  (AK)  Ankit Kumar Singh |                  +---------------------+
+ *   |        Connected         |                  | (>) Share location  |
+ *   |  +--------------------+  |                  | (X) Remove from ... |
+ *   |  | (>) Share location |  |                  +---------------------+
+ *   |  | (X) Remove from .. |  |
+ *   |  +--------------------+  |
+ *   |  |       Cancel       |  |
+ *   +--------------------------+
+ */
+
+import { useState, useSyncExternalStore } from "react";
+import { MoreVertical, Share2, Trash2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CIRCLE_MEMBER_MENU_CLASSNAME } from "@/components/one-location/redesign/circles/circle-member-row-layout";
+import { cn } from "@/lib/utils";
+
+/* ------------------------------------------------------------------ */
+/* Presentation boundary                                              */
+/* ------------------------------------------------------------------ */
+
+/** Below this width the actions arrive as a bottom sheet; at or above it, as
+ *  the anchored menu. See the module comment for why. */
+export const MEMBER_ACTIONS_SHEET_QUERY = "(max-width: 639.98px)";
+
+export const MEMBER_ACTIONS_SHEET_TESTID = "circle-member-actions-sheet";
+export const MEMBER_ACTIONS_MENU_TESTID = "circle-member-actions-menu";
+
+/**
+ * The anchored menu's surface, on the app's card grammar rather than the
+ * primitive's default `rounded-md border shadow-md`.
+ *
+ * The default is a generic popover: 6px corners, a hairline border in the
+ * shadcn palette, and `min-w-[8rem]` -- narrower than "Remove from Circle",
+ * so the menu sized itself to its own longest label and looked hand-cut.
+ * Everything else on this screen is a 14px-radius card on
+ * `--app-primary-surface`; this now is too.
+ */
+export const MEMBER_ACTIONS_MENU_SURFACE_CLASSNAME =
+  "min-w-[13.5rem] rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1 text-[color:var(--app-primary-label)] shadow-[var(--app-card-shadow-standard)] dark:shadow-none";
+
+/**
+ * One row of the anchored menu.
+ *
+ * `min-h-11` -- 44px, the platform touch minimum -- rather than the
+ * primitive's `py-1.5`, which lands a 15px label in a 30px row. Two 30px rows
+ * is the other half of the report: the actions were cramped AND unlabelled as
+ * to owner.
+ */
+export const MEMBER_ACTIONS_MENU_ITEM_CLASSNAME =
+  "flex min-h-11 items-center gap-3 rounded-[10px] px-3 text-[15px] font-normal leading-5 focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]";
+
+/** One row of the bottom sheet's action list. 56px, full bleed, so the whole
+ *  width of the row is the target rather than the label alone. */
+export const MEMBER_ACTIONS_SHEET_ITEM_CLASSNAME =
+  "flex min-h-14 w-full items-center gap-3 px-4 text-left text-[17px] font-normal leading-[22px] transition-colors active:bg-[color:var(--app-neutral-fill)] disabled:opacity-60";
+
+/* ------------------------------------------------------------------ */
+/* Confirmation copy                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The confirm step exists twice -- as an AlertDialog behind the anchored menu
+ * and as a second pane inside the sheet -- so its words live here once. Two
+ * copies of a sentence about ending someone's access is exactly the kind of
+ * pair that drifts, and the phone would be the copy nobody re-read.
+ */
+export function memberRemoveConfirmTitle(displayName: string): string {
+  return `Remove ${displayName}?`;
+}
+
+export function memberRemoveConfirmDescription(displayName: string): string {
+  return `Circle shares with ${displayName} will stop. Direct shares stay unchanged.`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Which surface                                                      */
+/* ------------------------------------------------------------------ */
+
+function sheetPresentationSupported(): boolean {
+  return (
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+  );
+}
+
+function subscribeToSheetPresentation(onChange: () => void): () => void {
+  if (!sheetPresentationSupported()) return () => {};
+  const query = window.matchMedia(MEMBER_ACTIONS_SHEET_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+/**
+ * Read during render rather than in an effect, the same way
+ * `save-location-modal.tsx` does: an effect would mount the anchored menu for
+ * one frame before swapping to the sheet, which on a phone is a visible flash
+ * of the exact defect this module exists to remove. The server snapshot is
+ * `false`, so SSR and the first client paint agree.
+ */
+function useSheetPresentation(): boolean {
+  return useSyncExternalStore(
+    subscribeToSheetPresentation,
+    () =>
+      sheetPresentationSupported() &&
+      window.matchMedia(MEMBER_ACTIONS_SHEET_QUERY).matches,
+    () => false,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export type CircleMemberActionsMenuProps = {
+  displayName: string;
+  /** Initials for the sheet header's avatar, computed by the row so the two
+   *  avatars of the same person can never disagree. */
+  initials: string;
+  photoUrl?: string | null;
+  /** The row's own second line ("Connected", "Owner", "Location setup
+   *  needed"). Repeated in the sheet header so the sheet identifies the
+   *  person exactly the way the row it came from did. */
+  secondaryLine?: string | null;
+  canShare: boolean;
+  canRemove: boolean;
+  /** A write is already in flight on this Circle. */
+  busy: boolean;
+  onShare: () => void;
+  onRemove: () => Promise<void>;
+};
+
+/**
+ * Renders the kebab and its actions -- or, on a row with no valid action, the
+ * inert spacer that holds the 44px kebab column open.
+ *
+ * The spacer lives here rather than at the call site so the two halves of
+ * "does this row have a menu" cannot be answered differently in one render.
+ * `circle-member-row-layout.ts` documents why the column has to exist on
+ * every row at all.
+ */
+export function CircleMemberActionsMenu({
+  displayName,
+  initials,
+  photoUrl,
+  secondaryLine,
+  canShare,
+  canRemove,
+  busy,
+  onShare,
+  onRemove,
+}: CircleMemberActionsMenuProps) {
+  const asSheet = useSheetPresentation();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  /** The sheet's second pane. A phone gets the confirm INSIDE the sheet
+   *  rather than as an AlertDialog over it: vaul's content sits at z-712 and
+   *  the alert at z-500, so a dialog opened over a closing sheet would spend
+   *  its entrance animation behind the thing it replaced. One surface, two
+   *  panes, no stacking order to get wrong. */
+  const [sheetConfirmingRemove, setSheetConfirmingRemove] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+
+  const hasMenu = canShare || canRemove;
+  const menuLabel = `Actions for ${displayName}`;
+
+  if (!hasMenu) {
+    return (
+      // Holds the kebab column open on the rows that have no kebab. Without
+      // it the roster's right edge steps in and out by 44px from row to row.
+      <span
+        aria-hidden="true"
+        className={CIRCLE_MEMBER_MENU_CLASSNAME}
+        data-testid="circle-member-menu-spacer"
+      />
+    );
+  }
+
+  const closeSheet = () => {
+    setSheetOpen(false);
+    setSheetConfirmingRemove(false);
+  };
+
+  if (asSheet) {
+    return (
+      <>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          disabled={busy}
+          aria-label={menuLabel}
+          aria-haspopup="menu"
+          aria-expanded={sheetOpen}
+          className={CIRCLE_MEMBER_MENU_CLASSNAME}
+          onClick={() => {
+            setSheetConfirmingRemove(false);
+            setSheetOpen(true);
+          }}
+        >
+          <MoreVertical className="h-5 w-5" />
+        </Button>
+
+        <Drawer
+          open={sheetOpen}
+          onOpenChange={(next) => {
+            setSheetOpen(next);
+            if (!next) setSheetConfirmingRemove(false);
+          }}
+        >
+          <DrawerContent
+            data-testid={MEMBER_ACTIONS_SHEET_TESTID}
+            className="rounded-t-[20px] pb-[max(12px,env(safe-area-inset-bottom))]"
+          >
+            {sheetConfirmingRemove ? (
+              <div className="px-4 pt-2">
+                <DrawerTitle className="text-[17px] leading-[22px]">
+                  {memberRemoveConfirmTitle(displayName)}
+                </DrawerTitle>
+                <DrawerDescription className="mt-1 text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+                  {memberRemoveConfirmDescription(displayName)}
+                </DrawerDescription>
+                <div className="mt-4 flex flex-col gap-2">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    className="h-12 w-full rounded-[14px] text-[17px] font-semibold"
+                    onClick={() => {
+                      closeSheet();
+                      void onRemove();
+                    }}
+                  >
+                    Remove
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-12 w-full rounded-[14px] text-[17px] font-semibold"
+                    onClick={() => setSheetConfirmingRemove(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="px-4 pt-1">
+                {/* Whose actions these are, said outright. The anchored menu
+                    left this to proximity, and proximity is the one thing a
+                    roster of near-identical rows cannot carry. */}
+                <div className="flex items-center gap-3 pb-3">
+                  <Avatar className="h-11 w-11 shrink-0">
+                    {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
+                    <AvatarFallback>{initials}</AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1 text-left">
+                    <DrawerTitle className="truncate text-[17px] leading-[22px]">
+                      {displayName}
+                    </DrawerTitle>
+                    <DrawerDescription className="truncate text-[13px] leading-4 text-[color:var(--app-secondary-label)]">
+                      {secondaryLine ?? "Circle member"}
+                    </DrawerDescription>
+                  </div>
+                </div>
+
+                <div
+                  role="menu"
+                  aria-label={menuLabel}
+                  className="overflow-hidden rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)]"
+                >
+                  {canShare ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={busy}
+                      className={MEMBER_ACTIONS_SHEET_ITEM_CLASSNAME}
+                      onClick={() => {
+                        closeSheet();
+                        onShare();
+                      }}
+                    >
+                      <Share2
+                        className="h-5 w-5 shrink-0 text-[color:var(--app-secondary-label)]"
+                        aria-hidden="true"
+                      />
+                      Share location
+                    </button>
+                  ) : null}
+                  {canShare && canRemove ? (
+                    // Inset from the icon column, the way a grouped iOS list
+                    // separates rows -- a full-bleed rule reads as the end of
+                    // the group rather than a divider inside it.
+                    <div
+                      aria-hidden="true"
+                      className="ml-[52px] h-px bg-[color:var(--app-separator)]"
+                    />
+                  ) : null}
+                  {canRemove ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={busy}
+                      className={cn(
+                        MEMBER_ACTIONS_SHEET_ITEM_CLASSNAME,
+                        "text-destructive",
+                      )}
+                      onClick={() => setSheetConfirmingRemove(true)}
+                    >
+                      <Trash2 className="h-5 w-5 shrink-0" aria-hidden="true" />
+                      Remove from Circle
+                    </button>
+                  ) : null}
+                </div>
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="mt-2 h-12 w-full rounded-[14px] text-[17px] font-semibold"
+                  onClick={closeSheet}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            disabled={busy}
+            aria-label={menuLabel}
+            className={CIRCLE_MEMBER_MENU_CLASSNAME}
+          >
+            <MoreVertical className="h-5 w-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          data-testid={MEMBER_ACTIONS_MENU_TESTID}
+          side="bottom"
+          align="end"
+          sideOffset={6}
+          collisionPadding={12}
+          className={MEMBER_ACTIONS_MENU_SURFACE_CLASSNAME}
+        >
+          {/* Same job as the sheet's header: name the person, so a menu that
+              paints over the next row still says who it belongs to. */}
+          <p className="truncate px-3 pt-1.5 pb-1 text-[13px] font-semibold leading-4 text-[color:var(--app-secondary-label)]">
+            {displayName}
+          </p>
+          <div
+            aria-hidden="true"
+            className="mx-1 mb-1 h-px bg-[color:var(--app-separator)]"
+          />
+          {canShare ? (
+            <DropdownMenuItem
+              className={MEMBER_ACTIONS_MENU_ITEM_CLASSNAME}
+              onSelect={() => onShare()}
+            >
+              <Share2 className="h-4 w-4 text-current" />
+              Share location
+            </DropdownMenuItem>
+          ) : null}
+          {canRemove ? (
+            <DropdownMenuItem
+              variant="destructive"
+              className={MEMBER_ACTIONS_MENU_ITEM_CLASSNAME}
+              onSelect={(event) => {
+                // `preventDefault` stops Radix's own close-and-restore-focus
+                // so that close cannot race the dialog's entrance; the menu is
+                // then closed explicitly on the next line. Before this, the
+                // menu was left OPEN behind the confirm dialog -- two stacked
+                // surfaces for one decision.
+                event.preventDefault();
+                setMenuOpen(false);
+                setConfirmRemoveOpen(true);
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+              Remove from Circle
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {canRemove ? (
+        <AlertDialog
+          open={confirmRemoveOpen}
+          onOpenChange={setConfirmRemoveOpen}
+        >
+          <AlertDialogContent size="sm">
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {memberRemoveConfirmTitle(displayName)}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {memberRemoveConfirmDescription(displayName)}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                onClick={() => void onRemove()}
+                className="h-11 w-full sm:w-auto"
+              >
+                Remove
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
+    </>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/circles/circle-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-sheet-layout.ts
@@ -1,0 +1,103 @@
+/**
+ * Vertical rhythm for the bottom sheets a Circle raises -- Add people, Invite
+ * code, Rename Circle.
+ *
+ * Reported from phone QA on Add people: "extra space between the section is
+ * bad", "search bahut jyada neeche aa raha", "divs truncated bhi dikh rahe
+ * hain". Measured, the gap between "Choose connections." and the search field
+ * was 48px, and none of it was asked for by this screen. It was four owners
+ * each adding their own default on top of the last:
+ *
+ *   SheetContent   flex flex-col gap-4   +16px between every child
+ *   SheetHeader    p-4                   +16px below the description
+ *                                        (and +16px to its LEFT, on top of
+ *                                        the sheet's own px-4, so the title
+ *                                        sat indented from the field under it)
+ *   the body       mt-4                  +16px again
+ *
+ * and then, below the field, `SettingsGroup`'s `mt-7` added 28px more before
+ * "Your connections" -- a margin that is correct on a settings SCREEN, where
+ * it separates one section from the section above, and wrong in a sheet,
+ * where there is no section above.
+ *
+ * None of those four is a bug on its own, which is why this drifted: every
+ * layer was defaulting sensibly for a context it could not see. So the sheet
+ * states its rhythm here, once, and the three sheets share it -- rather than
+ * each carrying inline numbers that can only be compared by opening all three
+ * files.
+ *
+ * ## Visual Map
+ *
+ *   before                              after
+ *   +--------------------------+        +--------------------------+
+ *   |                          |        | Add people               |
+ *   |     Add people           |        | Choose connections.      |
+ *   |     Choose connections.  |        |  [ Q  Search people    ] |
+ *   |                          |        | Your connections         |
+ *   |                          |        | +----------------------+ |
+ *   |  [ Q  Search people    ] |        | | Ankit Kumar Singh  o | |
+ *   |                          |        | | Neelesh Meena      o | |
+ *   |                          |        | +----------------------+ |
+ *   | Your connections         |        |  [   Add 2 people    ]   |
+ *   | +----------------------+ |        +--------------------------+
+ *   | | Ankit Kumar Singh  o | |
+ *   | | Neelesh Meena  (cut) | |
+ *   +--------------------------+
+ */
+
+/**
+ * The sheet's header, aligned with the body under it.
+ *
+ * `p-0` before `pt-1`, not `px-0 pt-1 pb-0`: `SheetHeader`'s own `p-4` is a
+ * single shorthand, and clearing it side by side leaves the reader checking
+ * four tailwind-merge groups to be sure nothing survived. One reset, then the
+ * one value this surface wants back.
+ *
+ * The horizontal padding belongs to `SheetContent` (`px-4 sm:px-6`), which is
+ * what the search field and the list are measured against -- so the title
+ * lines up with them instead of sitting 16px inboard of both.
+ */
+export const CIRCLE_SHEET_HEADER_CLASSNAME = "p-0 pt-1 text-left";
+
+/**
+ * A sheet body that is simply as tall as its content (Rename, Invite code).
+ *
+ * `mt-1` and not `mt-5`: `SheetContent`'s `gap-4` has already put 16px between
+ * the header and this, so the margin's whole job is the last 4px.
+ */
+export const CIRCLE_SHEET_BODY_CLASSNAME = "mt-1 space-y-4";
+
+/**
+ * A sheet body that OWNS the remaining height and scrolls inside it -- the
+ * shape Add people needs, so its "Add N people" button stays on screen while
+ * the roster moves under it.
+ */
+export const CIRCLE_SHEET_SCROLL_BODY_CLASSNAME =
+  "mt-1 flex min-h-0 flex-1 flex-col gap-3";
+
+/**
+ * The scrolling region itself.
+ *
+ * `-mx-1 px-1` is the "truncated divs" half of the report: an
+ * `overflow-y-auto` box clips at its own padding edge, so a card sitting flush
+ * against it lost the outer pixels of its rounded corner and all of its
+ * shadow, and read as a row cut in half rather than a list that scrolls. One
+ * pixel of gutter, pulled back out with a negative margin so nothing moves.
+ *
+ * `pb-2` keeps the last card off the clip edge for the same reason.
+ */
+export const CIRCLE_SHEET_SCROLL_AREA_CLASSNAME =
+  "-mx-1 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pb-2 [-webkit-overflow-scrolling:touch]";
+
+/**
+ * A `SettingsGroup` heading INSIDE a sheet.
+ *
+ * The group's own `mt-7` separates one section from the one above it. The
+ * first group in a sheet has nothing above it but the sheet's own header,
+ * which has already introduced the list, so the margin is pure gap.
+ */
+export const CIRCLE_SHEET_FIRST_GROUP_HEADING_CLASSNAME = "mt-0";
+
+/** A second group under the first, where some separation IS the point -- but
+ *  28px on top of the stack gap is two section breaks for one boundary. */
+export const CIRCLE_SHEET_NEXT_GROUP_HEADING_CLASSNAME = "mt-2";

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -1378,17 +1378,21 @@ export function CircleDetailFlow({
       ),
     [members, memberSearch],
   );
-  // The owner leads the roster in every kind of Circle, whichever of the two
-  // sources produced it and whatever a search did to the rest of the order.
-  // `circle-member-order.ts` documents why this is a partition applied to the
-  // rendered list rather than a second key on the A-Z sort.
-  const filteredMembers = useMemo(
-    () =>
-      sortCircleMembersOwnerFirst(
-        usesPagedMembers ? members : locallyFilteredMembers,
-      ),
-    [usesPagedMembers, members, locallyFilteredMembers],
-  );
+  // The owner leads the roster in every kind of Circle, from either source --
+  // but only while the roster is a ROSTER. Once a query is typed the list is
+  // answering that query, and both search paths now rank a name that begins
+  // with what you typed above one that merely contains it (client-side in
+  // `filterPeopleByQuery`, server-side since #6244). Hoisting the owner
+  // through that would put a loose match above an exact one, on the one
+  // screen where the reader has already said who they are looking for.
+  // `circle-member-order.ts` documents why this is a partition rather than a
+  // second key on the A-Z sort.
+  const filteredMembers = useMemo(() => {
+    const rendered = usesPagedMembers ? members : locallyFilteredMembers;
+    return memberSearch.trim()
+      ? rendered
+      : sortCircleMembersOwnerFirst(rendered);
+  }, [usesPagedMembers, members, locallyFilteredMembers, memberSearch]);
 
   // Beside the "Members" heading. Unfiltered it is the same phrase the screen
   // title and the "Your circles" row use, so the number never changes wording

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -16,7 +16,6 @@ import {
   ShieldCheck,
   Trash2,
   UsersRound,
-  MoreVertical,
 } from "lucide-react";
 
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -35,7 +34,6 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -70,10 +68,18 @@ import {
   CIRCLE_MEMBERS_CARD_SHELL_CLASSNAME,
   CIRCLE_MEMBER_ACTION_CLASSNAME,
   CIRCLE_MEMBER_AVATAR_CLASSNAME,
-  CIRCLE_MEMBER_MENU_CLASSNAME,
   CIRCLE_MEMBER_ROW_CLASSNAME,
   CIRCLE_MEMBER_TRAILING_CLASSNAME,
 } from "@/components/one-location/redesign/circles/circle-member-row-layout";
+import { CircleMemberActionsMenu } from "@/components/one-location/redesign/circles/circle-member-actions-menu";
+import {
+  CIRCLE_SHEET_BODY_CLASSNAME,
+  CIRCLE_SHEET_FIRST_GROUP_HEADING_CLASSNAME,
+  CIRCLE_SHEET_HEADER_CLASSNAME,
+  CIRCLE_SHEET_NEXT_GROUP_HEADING_CLASSNAME,
+  CIRCLE_SHEET_SCROLL_AREA_CLASSNAME,
+  CIRCLE_SHEET_SCROLL_BODY_CLASSNAME,
+} from "@/components/one-location/redesign/circles/circle-sheet-layout";
 import type {
   OneLocationCircleDetail,
   OneLocationCircleEligibleConnection,
@@ -92,6 +98,7 @@ import {
   filterPeopleByQuery,
   sortPeopleByName,
 } from "@/lib/one-location/people-search";
+import { sortCircleMembersOwnerFirst } from "@/lib/one-location/circle-member-order";
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
 import { LOCATION_SEARCH_INPUT_CLASSNAME } from "@/components/one-location/redesign/selectors";
@@ -906,12 +913,10 @@ function CircleMemberRow({
    *  to end. Offering Remove there is offering a control that cannot work. */
   membersRemovable?: boolean;
 }) {
-  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
   const isCurrentUser = member.userId === currentUserId;
   const canShare =
     !isCurrentUser && member.phoneVerified && member.secureLocationReady;
   const canRemove = isOwner && member.role !== "owner" && membersRemovable;
-  const hasMenu = canShare || canRemove;
 
   const relationship =
     !isCurrentUser && member.relationship && member.relationship !== "self"
@@ -1069,77 +1074,24 @@ function CircleMemberRow({
             </Link>
           </>
         ) : null}
-        {hasMenu ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                disabled={busy}
-                aria-label={`Actions for ${member.displayName}`}
-                className={CIRCLE_MEMBER_MENU_CLASSNAME}
-              >
-                <MoreVertical className="h-5 w-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {canShare ? (
-                <DropdownMenuItem onSelect={() => onShare()}>
-                  <Share2 className="h-4 w-4 text-current" />
-                  Share location
-                </DropdownMenuItem>
-              ) : null}
-              {canRemove ? (
-                <DropdownMenuItem
-                  variant="destructive"
-                  onSelect={(event) => {
-                    event.preventDefault();
-                    setConfirmRemoveOpen(true);
-                  }}
-                >
-                  <Trash2 className="h-4 w-4" />
-                  Remove from Circle
-                </DropdownMenuItem>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : (
-          // Holds the kebab column open on the rows that have no kebab. Without
-          // it the roster's right edge steps in and out by 44px from row to row.
-          <span
-            aria-hidden="true"
-            className={CIRCLE_MEMBER_MENU_CLASSNAME}
-            data-testid="circle-member-menu-spacer"
-          />
-        )}
+        {/* The kebab, its actions and the confirm they lead to -- one module,
+            because which SURFACE carries them depends on the pointer. See
+            `circle-member-actions-menu.tsx`: a phone gets a bottom action
+            sheet headed by this member's own name, a desktop keeps the
+            anchored menu. It also renders the inert 44px spacer on the rows
+            that offer nothing, so the kebab column exists on every row. */}
+        <CircleMemberActionsMenu
+          displayName={member.displayName}
+          initials={circleInitials(member.displayName)}
+          photoUrl={member.photoUrl}
+          secondaryLine={secondaryLine}
+          canShare={canShare}
+          canRemove={canRemove}
+          busy={busy}
+          onShare={onShare}
+          onRemove={onRemove}
+        />
       </div>
-      {canRemove ? (
-        <AlertDialog
-          open={confirmRemoveOpen}
-          onOpenChange={setConfirmRemoveOpen}
-        >
-          <AlertDialogContent size="sm">
-            <AlertDialogHeader>
-              <AlertDialogTitle>Remove {member.displayName}?</AlertDialogTitle>
-              <AlertDialogDescription>
-                Circle shares with {member.displayName} will stop. Direct shares
-                stay unchanged.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                variant="destructive"
-                onClick={() => void onRemove()}
-                className="h-11 w-full sm:w-auto"
-              >
-                Remove
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      ) : null}
     </div>
   );
 }
@@ -1426,9 +1378,17 @@ export function CircleDetailFlow({
       ),
     [members, memberSearch],
   );
-  const filteredMembers = usesPagedMembers
-    ? members
-    : locallyFilteredMembers;
+  // The owner leads the roster in every kind of Circle, whichever of the two
+  // sources produced it and whatever a search did to the rest of the order.
+  // `circle-member-order.ts` documents why this is a partition applied to the
+  // rendered list rather than a second key on the A-Z sort.
+  const filteredMembers = useMemo(
+    () =>
+      sortCircleMembersOwnerFirst(
+        usesPagedMembers ? members : locallyFilteredMembers,
+      ),
+    [usesPagedMembers, members, locallyFilteredMembers],
+  );
 
   // Beside the "Members" heading. Unfiltered it is the same phrase the screen
   // title and the "Your circles" row use, so the number never changes wording
@@ -1830,10 +1790,10 @@ export function CircleDetailFlow({
                 aria-describedby={undefined}
                 className="mx-auto w-full rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:max-w-lg sm:px-6"
               >
-                <SheetHeader className="text-left">
+                <SheetHeader className={CIRCLE_SHEET_HEADER_CLASSNAME}>
                   <SheetTitle>Rename Circle</SheetTitle>
                 </SheetHeader>
-                <div className="mt-5 space-y-4">
+                <div className={CIRCLE_SHEET_BODY_CLASSNAME}>
                   <label className="block space-y-2">
                     <span className="text-[15px] font-semibold leading-5 text-foreground">
                       Circle name
@@ -1957,7 +1917,7 @@ export function CircleDetailFlow({
                 }}
                 className="mx-auto w-full rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:max-w-lg sm:px-6"
               >
-                <SheetHeader className="text-left">
+                <SheetHeader className={CIRCLE_SHEET_HEADER_CLASSNAME}>
                   <SheetTitle>Invite code</SheetTitle>
                   {!inviteCode && !inviteCodeNeedsOwnerRotation ? (
                     <SheetDescription>
@@ -1966,7 +1926,7 @@ export function CircleDetailFlow({
                   ) : null}
                 </SheetHeader>
                 {inviteCode ? (
-                  <div className="mt-5 space-y-4">
+                  <div className={CIRCLE_SHEET_BODY_CLASSNAME}>
                     <div className="rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] p-5 text-center shadow-[var(--app-card-shadow-standard)]">
                       <p className="break-all font-mono text-2xl font-bold tracking-[0.12em] text-foreground">
                         {inviteCode.code}
@@ -2007,7 +1967,12 @@ export function CircleDetailFlow({
                     ) : null}
                   </div>
                 ) : inviteCodeNeedsOwnerRotation && !canRotateInviteCode ? (
-                  <div className="mt-5 rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--app-card-shadow-standard)]">
+                  <div
+                    className={cn(
+                      CIRCLE_SHEET_BODY_CLASSNAME,
+                      "rounded-[18px] bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--app-card-shadow-standard)]",
+                    )}
+                  >
                     <p className="text-[17px] font-semibold leading-[22px] text-foreground">
                       Invite code unavailable
                     </p>
@@ -2016,7 +1981,7 @@ export function CircleDetailFlow({
                     </p>
                   </div>
                 ) : (
-                  <div className="mt-5 space-y-3">
+                  <div className={cn(CIRCLE_SHEET_BODY_CLASSNAME, "space-y-3")}>
                     <Button
                       type="button"
                       disabled={busy}
@@ -2099,12 +2064,12 @@ export function CircleDetailFlow({
               // field they cannot see.
               className="mx-auto flex max-h-[calc(88dvh-var(--kb-height,0px))] w-full max-w-2xl flex-col rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
             >
-              <SheetHeader className="text-left">
+              <SheetHeader className={CIRCLE_SHEET_HEADER_CLASSNAME}>
                 <SheetTitle>Add people</SheetTitle>
                 <SheetDescription>Choose connections.</SheetDescription>
               </SheetHeader>
 
-              <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4">
+              <div className={CIRCLE_SHEET_SCROLL_BODY_CLASSNAME}>
                 <label className="relative block">
                   <span className="sr-only">Search connections</span>
                   <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -2119,7 +2084,7 @@ export function CircleDetailFlow({
                   />
                 </label>
 
-                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                <div className={CIRCLE_SHEET_SCROLL_AREA_CLASSNAME}>
                   {peopleLoading ? (
                     <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
                       <Loader2 className="h-5 w-5 animate-spin" />
@@ -2145,6 +2110,9 @@ export function CircleDetailFlow({
                       filteredEligibleConnections.length ? (
                         <SettingsGroup
                           title="Your connections"
+                          headingClassName={
+                            CIRCLE_SHEET_FIRST_GROUP_HEADING_CLASSNAME
+                          }
                           description={
                             remainingCapacity > CIRCLE_INVITE_BATCH_LIMIT
                               ? `Add up to ${CIRCLE_INVITE_BATCH_LIMIT} people at a time. ${peopleTotalCount} available; ${remainingCapacity} Circle slots remain.`
@@ -2278,7 +2246,12 @@ export function CircleDetailFlow({
                       ) : null}
 
                       {pendingInvites.length ? (
-                        <SettingsGroup title="Pending">
+                        <SettingsGroup
+                          title="Pending"
+                          headingClassName={
+                            CIRCLE_SHEET_NEXT_GROUP_HEADING_CLASSNAME
+                          }
+                        >
                           {pendingInvites.map((invite) => (
                             <SettingsRow
                               key={invite.id}

--- a/hushh-webapp/lib/one-location/__tests__/circle-member-order.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/circle-member-order.test.ts
@@ -56,8 +56,8 @@ describe("sortCircleMembersOwnerFirst", () => {
   });
 
   it("cannot invent an owner that is not in the list", () => {
-    // A searched roster the owner does not match, and a first page that has
-    // not reached them yet, are the same case: there is nothing to hoist.
+    // A paged roster whose first page has not reached the owner yet: there is
+    // nothing to hoist, and nothing is fetched to make one.
     expect(names(sortCircleMembersOwnerFirst([ankit, neelesh]))).toEqual([
       "Ankit Kumar Singh",
       "Neelesh Meena",

--- a/hushh-webapp/lib/one-location/__tests__/circle-member-order.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/circle-member-order.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The one row in a Circle roster whose position carries information.
+ *
+ * Reported on a Trusted Circle whose owner sat in the MIDDLE of an A-Z list:
+ * "owner hamesha sabse upar hi rahega, sabhi kind ke circles ke liye". These
+ * pin both halves of that -- the owner leads, and nobody else moves.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sortCircleMembersOwnerFirst } from "@/lib/one-location/circle-member-order";
+
+type Row = { userId: string; displayName: string; role: "owner" | "member" };
+
+const ankit: Row = {
+  userId: "ankit",
+  displayName: "Ankit Kumar Singh",
+  role: "member",
+};
+const jhumma: Row = {
+  userId: "jhumma",
+  displayName: "JHUMMA KUMARI",
+  role: "owner",
+};
+const neelesh: Row = {
+  userId: "neelesh",
+  displayName: "Neelesh Meena",
+  role: "member",
+};
+
+const names = (rows: readonly Row[]) => rows.map((row) => row.displayName);
+
+describe("sortCircleMembersOwnerFirst", () => {
+  it("lifts the owner out of the middle of an A-Z roster", () => {
+    // Exactly the screenshot: A, J (owner), N.
+    expect(
+      names(sortCircleMembersOwnerFirst([ankit, jhumma, neelesh])),
+    ).toEqual(["JHUMMA KUMARI", "Ankit Kumar Singh", "Neelesh Meena"]);
+  });
+
+  it("leaves everyone else in the order they arrived in", () => {
+    // A partition, not a sort: the members stay in the order the caller chose
+    // -- server paging order here, deliberately not alphabetical.
+    const pagedOrder = [neelesh, ankit, jhumma];
+    expect(names(sortCircleMembersOwnerFirst(pagedOrder))).toEqual([
+      "JHUMMA KUMARI",
+      "Neelesh Meena",
+      "Ankit Kumar Singh",
+    ]);
+  });
+
+  it("is a no-op when the owner already leads", () => {
+    expect(
+      names(sortCircleMembersOwnerFirst([jhumma, ankit, neelesh])),
+    ).toEqual(["JHUMMA KUMARI", "Ankit Kumar Singh", "Neelesh Meena"]);
+  });
+
+  it("cannot invent an owner that is not in the list", () => {
+    // A searched roster the owner does not match, and a first page that has
+    // not reached them yet, are the same case: there is nothing to hoist.
+    expect(names(sortCircleMembersOwnerFirst([ankit, neelesh]))).toEqual([
+      "Ankit Kumar Singh",
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("never mutates the list it was handed", () => {
+    const source = [ankit, jhumma, neelesh];
+    sortCircleMembersOwnerFirst(source);
+    expect(names(source)).toEqual([
+      "Ankit Kumar Singh",
+      "JHUMMA KUMARI",
+      "Neelesh Meena",
+    ]);
+  });
+
+  it("returns an empty roster unchanged", () => {
+    expect(sortCircleMembersOwnerFirst([])).toEqual([]);
+  });
+});

--- a/hushh-webapp/lib/one-location/circle-member-order.ts
+++ b/hushh-webapp/lib/one-location/circle-member-order.ts
@@ -1,0 +1,53 @@
+/**
+ * Where the owner sits in a Circle's roster: first, always, in every kind of
+ * Circle.
+ *
+ * Reported from phone QA on a Trusted Circle showing "Ankit Kumar Singh /
+ * JHUMMA KUMARI (You · Owner) / Neelesh Meena" -- "owner hamesha sabse upar hi
+ * rahega, sabhi kind ke circles ke liye". Nothing was mis-sorted: the roster
+ * is ordered A-Z by `sortPeopleByName`, and J falls between A and N. But A-Z
+ * is the right rule for a list of PEERS, and a Circle's roster is not one. The
+ * owner is the only row whose position carries information -- they are who the
+ * Circle belongs to, who can rename it, who can remove anyone -- and burying
+ * that under the alphabet makes the reader scan for it once per Circle.
+ *
+ * This is a STABLE PARTITION, not a second sort key. Everyone who is not the
+ * owner keeps exactly the order they arrived in, so:
+ *
+ *   - the A-Z roster stays A-Z beneath the owner;
+ *   - a PAGED roster keeps the server's order beneath the owner, rather than
+ *     having a client-side alphabet fight the page boundaries;
+ *   - a SEARCHED roster keeps `filterPeopleByQuery`'s relevance ranking
+ *     beneath the owner.
+ *
+ * Applied to the list about to be RENDERED rather than to the source, so the
+ * owner leads whatever that list turned out to be. It can only hoist a row
+ * that is in the list: a search the owner does not match still does not show
+ * them, and on a paged roster whose first page has not reached the owner yet
+ * there is nothing here to move. Both are correct -- this orders a roster, it
+ * does not fetch one.
+ */
+
+import type { OneLocationCircleRole } from "@/lib/one-location/types";
+
+/**
+ * Return `members` with the owner (or owners, defensively -- the API models
+ * one, and a partition costs nothing to make total) moved to the front,
+ * everything else untouched.
+ */
+export function sortCircleMembersOwnerFirst<
+  T extends { role: OneLocationCircleRole },
+>(members: readonly T[]): T[] {
+  const owners: T[] = [];
+  const rest: T[] = [];
+
+  for (const member of members) {
+    if (member.role === "owner") owners.push(member);
+    else rest.push(member);
+  }
+
+  // Nothing to hoist: hand back the same order rather than a rebuilt copy in
+  // the same order, so the common case cannot be a source of churn.
+  if (!owners.length) return [...members];
+  return [...owners, ...rest];
+}

--- a/hushh-webapp/lib/one-location/circle-member-order.ts
+++ b/hushh-webapp/lib/one-location/circle-member-order.ts
@@ -16,16 +16,19 @@
  *
  *   - the A-Z roster stays A-Z beneath the owner;
  *   - a PAGED roster keeps the server's order beneath the owner, rather than
- *     having a client-side alphabet fight the page boundaries;
- *   - a SEARCHED roster keeps `filterPeopleByQuery`'s relevance ranking
- *     beneath the owner.
+ *     having a client-side alphabet fight the page boundaries.
  *
  * Applied to the list about to be RENDERED rather than to the source, so the
  * owner leads whatever that list turned out to be. It can only hoist a row
- * that is in the list: a search the owner does not match still does not show
- * them, and on a paged roster whose first page has not reached the owner yet
- * there is nothing here to move. Both are correct -- this orders a roster, it
- * does not fetch one.
+ * that is in the list: on a paged roster whose first page has not reached the
+ * owner yet there is nothing here to move, which is correct -- this orders a
+ * roster, it does not fetch one.
+ *
+ * The caller stops applying it once a search query is typed, and that is
+ * deliberate: both search paths rank a name that BEGINS with the query above
+ * one that merely contains it, and hoisting the owner through that ranking
+ * would answer a typed question with the wrong person. A roster has no
+ * question to answer, which is why the owner leads it.
  */
 
 import type { OneLocationCircleRole } from "@/lib/one-location/types";


### PR DESCRIPTION
Three defects reported from phone QA on Circle Detail, all the same shape: a screen correct in every part and wrong as a whole.

## 1. The kebab's actions landed on the next member's name

Reported with a screenshot of the SMS Circle roster: tapping the kebab on **Ankit Kumar Singh** opened a small floating card that painted over **JHUMMA KUMARI**'s name in the row below. Nothing on the surface said whose actions those were, and the one cue available — proximity — pointed at the wrong person. *"Dusre connection ke name ke upar aa gaya."*

That is not a positioning bug to nudge with an offset. An anchored popover is a **pointer** idiom: it works because a cursor is already at the anchor and the eye follows it there. On a phone the finger covers the anchor, the menu paints into whatever row is below, and a roster is a list of near-identical rows — so the one piece of context that would disambiguate it is exactly what gets covered.

The surface now follows the pointer:

| | phone (<640px) | desktop (≥640px) |
|---|---|---|
| surface | bottom action sheet over a scrim | anchored menu |
| identity | member's own avatar + name + status in the header | member's name as a menu header |
| rows | 56px, full-bleed | 44px (was 30px) |
| destructive confirm | second pane of the **same** sheet | AlertDialog, and the menu now **closes** first |

The confirm no longer stacks. On the phone it cannot: vaul's content sits at `z-712` and the alert at `z-500`, so a dialog opened over a closing sheet would spend its entrance animation behind the thing it replaced. On the desktop, the menu used to be left **open** behind the confirm — two surfaces for one decision.

New module: `circle-member-actions-menu.tsx`. It owns the kebab, both surfaces, the confirm, and the inert 44px spacer that holds the kebab column open on rows with no menu — so "does this row have a menu" cannot be answered two ways in one render.

## 2. The owner sat wherever the alphabet put them

Reported on a Trusted Circle reading *Ankit Kumar Singh / JHUMMA KUMARI (You · Owner) / Neelesh Meena* — *"owner hamesha sabse upar hi rahega, sabhi kind ke circles ke liye."*

Nothing was mis-sorted: the roster is A–Z, and J falls between A and N. But A–Z is the right rule for a list of **peers**, and a Circle's roster is not one — the owner is the only row whose position carries information.

`sortCircleMembersOwnerFirst` is a **stable partition**, not a second sort key, applied to the rendered list. So A–Z survives beneath the owner, and so does the server's order on a paged roster. It hoists only a row already in the list — it never fetches one.

It stops at the search box, deliberately. This branch rebases onto #6244, which gave the server-paged member search the same one-letter ranking the client already had. Hoisting the owner through that ranking would answer a typed question with the wrong person: `"ku"` would return Jhumma Kumari above Ankit Kumar Singh, when both begin a word with it and A–Z inside the rank says otherwise. A roster has no question to answer, which is exactly why the owner leads it.

## 3. The Add people sheet had 48px of gap above its search field

Reported as *"extra space between the section is bad"*, *"search bahut jyada neeche aa raha"*, *"divs truncated bhi dikh rahe hain."*

None of that gap was written on this screen. It was four sensible defaults stacking, each defaulting for a context it could not see:

```
SheetContent   flex flex-col gap-4   +16px between every child
SheetHeader    p-4                   +16px below the description
                                     (and +16px to its LEFT, on top of the
                                      sheet's own px-4 — so the title sat
                                      indented from the field under it)
the body       mt-4                  +16px again
SettingsGroup  mt-7                  +28px before "Your connections"
```

`SettingsGroup`'s `mt-7` separates one section from the section **above** it — correct on a settings screen, pure gap in a sheet whose header has already introduced the list. It now takes a `headingClassName` (additive; every existing caller is untouched), the same escape hatch `shellClassName` and `contentClassName` already are.

The "truncated divs" half is the scroll area: an `overflow-y-auto` box clips at its own padding edge, so a card flush against it lost the outer pixels of its rounded corner and all of its shadow, and read as a row cut in half rather than a list that scrolls. One pixel of gutter, pulled back with a negative margin so nothing moves.

`circle-sheet-layout.ts` states the rhythm once and all three Circle sheets (Add people, Invite code, Rename Circle) share it.

**On scrolling, since it was asked:** yes, everywhere. `SheetContent side="bottom"` caps at `max-h-[calc(85dvh - --kb-height)]` with `overflow-y-auto overscroll-contain`, so any bottom sheet scrolls rather than running off the screen. Add people additionally owns an inner scroll region so its "Add N people" button stays pinned while the roster moves under it — that is now asserted, not assumed.

## Verification

- `npm run verify:one-location` — 674 tests. The one failure is the known 5s-timeout flake in `one-location-agent-page.test.tsx` under parallel load; 126/126 pass isolated.
- 78 tests across the Circle suites, 14 of them new: both action surfaces, the owner partition (both circle kinds), the search carve-out, and the sheet spacing contract.
- `tsc --noEmit`, `eslint`, `verify:design-system`, `verify:accent-tokens`, `verify:apple-hierarchy`, `verify:surface-map` — all clean.
- Protected behaviour `location-people-search-finds-a-person-from-one-letter` untouched: both required titles still present, assertion count only rises.
- No schema change, no migration.
