### PR TITLE
feat(one): tell an owner who opened their shared location

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 187,
+  "expected_migration_version": 188,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_pkm_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 187,
+  "expected_migration_version": 188,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 187,
+  "expected_migration_version": 188,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/migrations/188_feed_location_viewed_projection.sql
+++ b/consent-protocol/db/migrations/188_feed_location_viewed_projection.sql
@@ -1,0 +1,97 @@
+BEGIN;
+
+-- "Who actually looked at my location?"
+--
+-- `location_share_viewed` has been written on every envelope read since the
+-- feature shipped, and nothing has ever projected it: the event exists in the
+-- audit ledger and in the in-app Activity list, but never reaches the Feed. So
+-- the one question a person asks after sharing -- did they actually look? --
+-- had no answer on the screen built to answer it.
+--
+-- THE REASON IT COULD NOT SIMPLY BE PROJECTED
+--
+-- A viewer watching a live share polls for the envelope, so a single afternoon
+-- of watching writes hundreds of these events. Fanning one Feed row per event
+-- would bury every other kind of activity under one person refreshing a map.
+--
+-- So the row is deduplicated to one per grant, per viewer, per day, using the
+-- unique index migration 179 already added over
+-- (user_id, source_domain, event_type, source_row_id). `ON CONFLICT DO NOTHING`
+-- makes the second and four-hundredth view of the day free -- the Feed says
+-- "Ankit saw your location" once, which is the fact the owner wanted, rather
+-- than four hundred times, which is noise.
+--
+-- Only the OWNER gets a row. "You viewed their location" is not news to the
+-- person who did the viewing, and writing it would put every recipient's own
+-- polling back in their Feed.
+--
+-- The viewer's name is resolved HERE rather than stamped at write time,
+-- because the emitting path is a hot read that a recipient hits on a timer and
+-- it should not pay for an identity lookup it does not use.
+
+CREATE OR REPLACE FUNCTION feed_events_viewed_from_one_location_events()
+RETURNS TRIGGER AS $$
+DECLARE
+  viewer_label TEXT;
+BEGIN
+  IF NEW.event_type <> 'location_share_viewed' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Nothing to tell the owner about their own read.
+  IF NEW.actor_user_id IS NULL OR NEW.actor_user_id = NEW.owner_user_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Same sanitiser migration 179 uses for owner_label: never a raw user id, a
+  -- `ria:` handle, a bare UUID, or an unbroken 20+ character token.
+  SELECT CASE
+    WHEN NULLIF(BTRIM(display_name), '') IS NOT NULL
+     AND BTRIM(display_name) <> NEW.actor_user_id
+     AND BTRIM(display_name) !~* '^ria:'
+     AND BTRIM(display_name) !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+     AND NOT (
+       BTRIM(display_name) !~ '[@[:space:]]'
+       AND LENGTH(BTRIM(display_name)) >= 20
+     )
+    THEN LEFT(BTRIM(display_name), 160)
+  END
+    INTO viewer_label
+    FROM actor_identity_cache
+   WHERE user_id = NEW.actor_user_id;
+
+  INSERT INTO feed_events (
+    user_id, source_domain, event_type, actor_label, metadata, source_row_id
+  )
+  VALUES (
+    NEW.owner_user_id,
+    'location',
+    NEW.event_type,
+    viewer_label,
+    jsonb_strip_nulls(jsonb_build_object(
+      'counterpart_label', COALESCE(viewer_label, 'A trusted person')
+    )),
+    -- One row per grant, per viewer, per day.
+    CONCAT(
+      COALESCE(NEW.grant_id::TEXT, NEW.id::TEXT),
+      ':viewer:', NEW.actor_user_id,
+      ':', TO_CHAR(NEW.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+    )
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS one_location_viewed_events_feed_fanout
+  ON one_location_events;
+CREATE TRIGGER one_location_viewed_events_feed_fanout
+  AFTER INSERT ON one_location_events
+  FOR EACH ROW
+  EXECUTE FUNCTION feed_events_viewed_from_one_location_events();
+
+COMMENT ON FUNCTION feed_events_viewed_from_one_location_events() IS
+  'Tells an owner who opened their shared location, once per viewer per grant per day.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/188_feed_location_viewed_projection.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/188_feed_location_viewed_projection.rollback.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Stop telling owners who viewed their location. Rows already written stay:
+-- deleting them would remove the only record an owner has of who looked.
+
+DROP TRIGGER IF EXISTS one_location_viewed_events_feed_fanout
+  ON one_location_events;
+DROP FUNCTION IF EXISTS feed_events_viewed_from_one_location_events();
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -159,7 +159,8 @@
     "184_encrypted_one_adk_sessions.sql",
     "185_internal_access_request_id_text.sql",
     "186_feed_share_kind_projection.sql",
-    "187_one_location_sms_contact_events.sql"
+    "187_one_location_sms_contact_events.sql",
+    "188_feed_location_viewed_projection.sql"
   ],
   "environment_overlays": {
     "uat": [

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -7475,3 +7475,67 @@ def test_sms_contact_events_are_allowed_and_projected_to_both_audiences() -> Non
     ).read_text(encoding="utf-8")
     assert "DROP TRIGGER IF EXISTS one_location_sms_contact_events_feed_fanout" in rollback
     assert "location_sms_contact_added" not in rollback.split("ADD CONSTRAINT")[1]
+
+
+# ---------------------------------------------------------------------------
+# "Did they actually look?"
+# ---------------------------------------------------------------------------
+#
+# `location_share_viewed` has been written on every envelope read since the
+# feature shipped and was never projected into Feed. The reason it could not
+# simply be projected is volume: a viewer watching a live share polls, so one
+# afternoon writes hundreds of these events.
+
+
+def test_the_viewed_projection_tells_only_the_owner() -> None:
+    migrations = Path(one_location_agent_module.__file__).parents[2] / "db" / "migrations"
+    sql = (migrations / "188_feed_location_viewed_projection.sql").read_text(encoding="utf-8")
+
+    assert "location_share_viewed" in sql
+    # Exactly one row, and it belongs to the owner. "You viewed their location"
+    # is not news to the viewer, and would put their own polling in their Feed.
+    assert sql.count("INSERT INTO feed_events") == 1
+    assert "NEW.owner_user_id," in sql
+    assert "NEW.actor_user_id = NEW.owner_user_id" in sql
+    assert "feed_audience" not in sql
+
+
+def test_the_viewed_projection_collapses_polling_to_one_row_a_day() -> None:
+    migrations = Path(one_location_agent_module.__file__).parents[2] / "db" / "migrations"
+    sql = (migrations / "188_feed_location_viewed_projection.sql").read_text(encoding="utf-8")
+
+    # One row per grant, per viewer, per day, leaning on the unique index
+    # migration 179 added over (user_id, source_domain, event_type,
+    # source_row_id). Without this a single afternoon of watching a live share
+    # would bury every other kind of activity.
+    assert "':viewer:'" in sql
+    assert "'YYYY-MM-DD'" in sql
+    assert "ON CONFLICT DO NOTHING" in sql
+
+
+def test_the_viewer_name_is_resolved_in_the_trigger_not_the_read_path() -> None:
+    migrations = Path(one_location_agent_module.__file__).parents[2] / "db" / "migrations"
+    sql = (migrations / "188_feed_location_viewed_projection.sql").read_text(encoding="utf-8")
+    # The emitting path is a hot read a recipient hits on a timer; it must not
+    # pay for an identity lookup it does not use.
+    assert "FROM actor_identity_cache" in sql
+    viewed_block = _SERVICE_SOURCE[
+        _SERVICE_SOURCE.index('event_type="location_share_viewed"') - 600 :
+    ][:900]
+    assert "counterpart_label" not in viewed_block
+
+    # And the label is sanitised the same way every other projection does it:
+    # never a raw id, a `ria:` handle, a bare UUID, or a 20+ character token.
+    assert "!~* '^ria:'" in sql
+    assert "LENGTH(BTRIM(display_name)) >= 20" in sql
+
+
+def test_the_viewed_projection_can_be_rolled_back() -> None:
+    migrations = Path(one_location_agent_module.__file__).parents[2] / "db" / "migrations"
+    rollback = (
+        migrations / "rollback" / "188_feed_location_viewed_projection.rollback.sql"
+    ).read_text(encoding="utf-8")
+    assert "DROP TRIGGER IF EXISTS one_location_viewed_events_feed_fanout" in rollback
+    # Rows already written stay: they are the only record an owner has of who
+    # looked.
+    assert "DELETE FROM feed_events" not in rollback

--- a/hushh-webapp/__tests__/lib/feed/feed-location-viewed-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-location-viewed-lines.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { presentFeedItem } from "@/lib/feed/feed-item-renderers";
+import type { FeedItem } from "@/lib/services/feed-service";
+
+/**
+ * "Did they actually look?"
+ *
+ * It is the question a person asks after sharing their location, and the Feed
+ * could not answer it. `location_share_viewed` has been written on every
+ * envelope read since the feature shipped -- it reaches the audit ledger and
+ * the in-app Activity list -- but no trigger ever projected it, so it never
+ * reached either Feed.
+ *
+ * Only the OWNER gets this row. "You viewed their location" is not news to the
+ * person who did the viewing, and writing it would put a recipient's own
+ * polling back into their own Feed.
+ */
+
+function item(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: "feed_1",
+    source_domain: "location",
+    event_type: "location_share_viewed",
+    actor_label: "Ankit",
+    metadata: { counterpart_label: "Ankit" },
+    read: false,
+    created_at: "2026-08-30T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("the owner is told who looked", () => {
+  it("names the viewer and says what they did", () => {
+    const line = presentFeedItem(item());
+    expect(line.label).toBe("Ankit");
+    expect(line.description).toBe("Saw your location");
+  });
+
+  it("still renders when the backend could not resolve a name", () => {
+    const line = presentFeedItem(item({ metadata: {} }));
+    expect(line.label).toBe("Location");
+    expect(line.description).toBe("Saw your location");
+  });
+
+  it("opens One Location", () => {
+    expect(presentFeedItem(item()).href).toBeTruthy();
+  });
+
+  it("fits on one line", () => {
+    // ~30 characters is the description column at 375px.
+    expect(presentFeedItem(item()).description.length).toBeLessThanOrEqual(30);
+  });
+
+  it("does not borrow the share lifecycle's wording", () => {
+    // A view is not a share starting, stopping or expiring. Reusing any of
+    // those lines would report an ordinary read as a state change.
+    const line = presentFeedItem(item()).description;
+    for (const other of [
+      "You started sharing location",
+      "Shared location with you",
+      "Sharing stopped",
+      "Ended when time ran out",
+    ]) {
+      expect(line).not.toBe(other);
+    }
+  });
+});

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -254,6 +254,24 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
     // get a row: the owner sees what they changed, the contact learns what
     // changed about them. The row's title is already the other person, so
     // neither line needs to name a subject twice.
+    // "Did they actually look?" is the question a person asks after sharing,
+    // and until now the Feed could not answer it: `location_share_viewed` has
+    // been written on every envelope read since the feature shipped and was
+    // never projected. Only the owner gets this row -- "you viewed their
+    // location" is not news to the person who did the viewing -- and the
+    // projection collapses a whole afternoon of polling into one row per
+    // viewer per day, so watching a live share cannot bury everything else.
+    case "location_share_viewed": {
+      const hasWho = who !== "Someone";
+      return {
+        icon,
+        domainLabel,
+        label: hasWho ? who : "Location",
+        person: counterpartPerson(item.metadata, who),
+        description: "Saw your location",
+        href: ROUTES.ONE_LOCATION,
+      };
+    }
     case "location_sms_contact_added": {
       const hasWho = who !== "Someone";
       return {

--- a/hushh-webapp/lib/services/feed-service.ts
+++ b/hushh-webapp/lib/services/feed-service.ts
@@ -17,6 +17,7 @@ export type FeedEventType =
   | "location_share_shortened"
   | "location_share_duration_changed"
   | "location_share_expired"
+  | "location_share_viewed"
   | "location_access_request"
   | "location_access_approved"
   | "location_access_denied"


### PR DESCRIPTION
Closes #6250. Last of the gaps found in the Feed audit (#6234).

## The gap

"Did they actually look?" is the question a person asks after sharing their
location, and the Feed could not answer it.

`location_share_viewed` has been written on **every envelope read** since the
feature shipped. It reaches the audit ledger and the in-app Activity list — and
**no trigger ever projected it**, so it never reached either Feed. The event was
there the whole time with nothing reading it.

## Why it couldn't just be projected

A viewer watching a live share **polls** for the envelope, so one afternoon of
watching writes hundreds of these events. One Feed row per event would bury
every other kind of activity under a single person refreshing a map.

So the row is **deduplicated to one per grant, per viewer, per day**, using the
unique index migration 179 already added over
`(user_id, source_domain, event_type, source_row_id)`:

```sql
CONCAT(grant_id, ':viewer:', actor_user_id, ':', TO_CHAR(created_at, 'YYYY-MM-DD'))
… ON CONFLICT DO NOTHING
```

The second and the four-hundredth view of the day are free. The Feed says
**"Ankit — Saw your location"** once, which is the fact the owner wanted, rather
than four hundred times, which is noise.

## Only the owner

"You viewed their location" is not news to the person who did the viewing, and
writing it would put every recipient's own polling back into their own Feed. One
row, for the owner, and no `feed_audience`.

## The viewer's name

Resolved **in the trigger**, not stamped at write time: the emitting path is a
hot read a recipient hits on a timer and must not pay for an identity lookup it
does not use. The label goes through the same sanitiser migration 179 uses —
never a raw user id, a `ria:` handle, a bare UUID, or an unbroken 20+ character
token.

## Verification

| Check | Result |
|---|---|
| `ruff` check + format, `tsc`, `eslint` | clean |
| backend — `test_one_location_agent_service.py` | 194 passed (4 new) |
| webapp — 14 Feed test files | 102 passed (5 new) |
| `verify_release_migration_contract.py` | aligned at 188 |

The four new backend tests pin the things that would quietly break this:
owner-only, the daily dedup, the label resolved in the trigger rather than the
read path, and a rollback that drops the trigger **without** deleting rows an
owner may already be relying on.

## Platforms

One webapp serves web, iOS and Android through Capacitor, and the projection is
in Postgres — all three surfaces get this with no per-platform work.