### PR TITLE
fix(one): declutter the check-in drawer, and put the durations on one row

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -1504,9 +1504,17 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(screen.getByTestId("one-location-map-close")).toHaveAccessibleName(
       "Back to Location",
     );
+    // Check-in's own route opens the sheet on arrival, and while it is open
+    // the pill is the one control on screen with nothing to do -- its whole
+    // job is getting back INTO the sheet. Dismiss first, then it is here.
+    expect(
+      screen.queryByTestId("one-location-map-nearby-check-in"),
+    ).toBeNull();
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
     expect(
       screen.getByTestId("one-location-map-nearby-check-in"),
     ).toHaveAccessibleName("Check in nearby");
+
     expect(screen.getByTestId("one-location-map-locate")).toHaveAccessibleName(
       "Show my location",
     );
@@ -2386,10 +2394,22 @@ describe("LocationImmersiveMap reported map defects", () => {
     ).toBe(true);
   });
 
-  it("keeps Check in in the header on check-in's own route", async () => {
-    // That surface renders no tray at all, and this pill is the only way back
-    // into the sheet after dismissing it. Removing it everywhere strands the
-    // person on a map with nothing to do.
+  it("hides the Check in pill while the sheet is up, and brings it back on dismiss", async () => {
+    /**
+     * Reported from the check-in drawer: "Check in ka icon and text, Sharing
+     * with 1 ka text, You are here wala block ... yeh sb ek sath dikh rha,
+     * bahut hi bheed bhaad jesa lag rha hai." On a phone the sheet takes about
+     * three quarters of the screen, and five floating controls were competing
+     * for the strip left above it.
+     *
+     * The pill is the clearest thing to drop: while the sheet is open it is
+     * the one control on screen that does nothing, because its only job is
+     * getting back IN after a dismiss.
+     *
+     * Which is why the second half of this matters as much as the first. That
+     * surface renders no tray at all, so removing the pill outright would
+     * strand somebody on a map with no way back into the sheet.
+     */
     serviceHarness.getState.mockResolvedValue({
       recipients: [],
       ownerGrants: [],
@@ -2400,9 +2420,37 @@ describe("LocationImmersiveMap reported map defects", () => {
     const header = screen.getByRole("banner", {
       name: "Check in map controls",
     });
+
+    // The sheet opens with the route.
+    expect(
+      screen.getByTestId("nearby-check-in-sheet-mock"),
+    ).toHaveAttribute("data-open", "true");
+    expect(
+      header.querySelector('[data-testid="one-location-map-nearby-check-in"]'),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByTestId("dismiss-nearby-check-in"));
+
     expect(
       header.querySelector('[data-testid="one-location-map-nearby-check-in"]'),
     ).not.toBeNull();
+  });
+
+  it("keeps the way out and the search-area legend while the sheet is up", async () => {
+    // Decluttering must not take the two things up there that are still doing
+    // a job. Close is the way out. The legend is the only explanation of what
+    // the blue dot is and how far "nearby" reaches -- the sheet states
+    // neither, so cutting it would have tidied the screen by removing the part
+    // that was answering a question.
+    serviceHarness.getState.mockResolvedValue({
+      recipients: [],
+      ownerGrants: [],
+    });
+
+    await renderReadyMap({ surface: "check-in" });
+
+    expect(screen.getByTestId("one-location-map-close")).toBeInTheDocument();
+    expect(screen.getByTestId("one-location-map-locate")).toBeInTheDocument();
   });
 
   it("answers Everyone instead of sitting disabled when no one shares with you", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -49,6 +49,7 @@ import {
   type NearbyCheckInPlaceFocus,
 } from "@/components/one-location/nearby-check-in/nearby-check-in-sheet";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import {
@@ -2762,7 +2763,31 @@ export function LocationImmersiveMap({
             <X className="h-5 w-5 stroke-[2.25]" />
           </ShellActionSurface>
         </div>
-        <div className="col-span-2 col-start-1 row-start-2 flex min-w-0 items-center justify-center sm:col-span-1 sm:col-start-2 sm:row-start-1">
+        {/*
+          Hidden on a phone while the check-in sheet is open.
+
+          Reported from the check-in drawer: "Check in ka icon and text,
+          Sharing with 1 ka text, You are here wala block ... yeh sb ek sath
+          dikh rha, bahut hi bheed bhaad jesa lag rha hai." On a phone that
+          sheet takes roughly three quarters of the screen, so five floating
+          controls compete for the ~250px strip left above it.
+
+          This one goes because it is about a DIFFERENT audience. "Sharing
+          with 1" counts people watching your live location; check-in is a
+          separate one-time share to whoever is nearby. It answers a question
+          nobody is asking mid-check-in, and its popover opens over the sheet.
+
+          `max-md:hidden` rather than an unmount: `display:none` takes it out
+          of the accessibility tree and out of tab order too, and it costs no
+          state to bring back when the sheet closes. From `md` up the sheet is
+          a side panel with the map beside it, so there is nothing to declutter.
+        */}
+        <div
+          className={cn(
+            "col-span-2 col-start-1 row-start-2 flex min-w-0 items-center justify-center sm:col-span-1 sm:col-start-2 sm:row-start-1",
+            nearbyCheckInOpen && "max-md:hidden",
+          )}
+        >
           {!demoMode && (activeShareCount ?? 0) > 0 ? (
             <Popover
               open={sharingPopoverOpen}
@@ -2871,10 +2896,20 @@ export function LocationImmersiveMap({
               tray (see the `!isCheckInSurface` gate on the tray section), and
               this pill is the only way back into the sheet after dismissing it.
             */}
+            {/*
+              `!nearbyCheckInOpen`: while the sheet is open this pill is the
+              one control on screen that does nothing. Its whole reason for
+              being here is stated below -- a way back INTO the sheet after
+              dismissing it -- so it has no job while the sheet is up, and on a
+              phone it was taking a third of the only strip of map still
+              visible. Hidden at every width, because it is redundant at every
+              width; the crowding is just where it was noticed.
+            */}
             {rendererReady &&
             nearbyCheckInAvailable &&
             !demoMode &&
-            isCheckInSurface ? (
+            isCheckInSurface &&
+            !nearbyCheckInOpen ? (
               <ShellActionSurface
                 variant="pill"
                 // ShellActionSurface's own wrapper is shrink-0 by default (a
@@ -2934,6 +2969,12 @@ export function LocationImmersiveMap({
         Two pins on one map need naming, or the owner cannot tell which is
         "me" and which is "the place I'm checking in to" -- and those are
         routinely a street apart.
+
+        This one STAYS when the sheet is open, and it is the only thing up
+        there that does. It is the sole explanation of what the blue dot is
+        and how far "nearby" reaches -- 500 m -- and the sheet below states
+        neither. Cutting it with the other two would have tidied the screen by
+        removing the only part of it that was answering a question.
       */}
       {rendererReady &&
       (nearbyCheckInOpen || nearbyPlaceFocus?.active) &&

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -305,6 +305,56 @@ describe("NearbyCheckInSheet", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("puts the three visible-for lengths on one row, abbreviated to match", async () => {
+    /**
+     * Reported: "Visible for ke jo times hain inko one row mai dikhao ...
+     * looking scattered."
+     *
+     * They were. The shared `DURATION_GRID_CLASS` is two columns because the
+     * ladders that use it carry FOUR cells and land as an even 2x2. This
+     * control has three, so the same class stranded one on a row of its own,
+     * under a heading that reads as a single choice.
+     *
+     * The labels are abbreviated for consistency rather than for width --
+     * "30 min" beside "1 hour" and "2 hours" mixes two registers in one row.
+     */
+    render(
+      <NearbyCheckInSheet
+        open
+        ownerId="user-1"
+        vaultOwnerToken="owner-token"
+        captureCurrentPosition={vi.fn().mockResolvedValue(point)}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("radio", { name: /Stanford University/ });
+    const panel = screen.getByTestId("nearby-presence-setup");
+    const heading = within(panel).getByRole("heading", { name: "Visible for" });
+    const ladder = heading.nextElementSibling as HTMLElement;
+
+    expect(
+      within(ladder)
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim()),
+    ).toEqual(["30 min", "1 hr", "2 hr"]);
+
+    // Three across on a phone, so nothing wraps to a half-empty second row.
+    // Asserted on the class because JSDOM lays nothing out -- the browser
+    // layout spec is where geometry is proved.
+    expect(ladder.className).toContain("grid-cols-3");
+    expect(ladder.className).not.toContain("grid-cols-2");
+
+    // Still a working ladder, not just a tidier one.
+    fireEvent.click(within(ladder).getByRole("button", { name: "2 hr" }));
+    expect(
+      within(ladder).getByRole("button", { name: "2 hr" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(ladder).getByRole("button", { name: "1 hr" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("keeps the required consent visible and drops the optional preference a level", async () => {
     render(
       <NearbyCheckInSheet

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -26,7 +26,6 @@ import {
   DURATION_CELL_CLASS,
   DURATION_CELL_OFF_CLASS,
   DURATION_CELL_ON_CLASS,
-  DURATION_GRID_CLASS,
 } from "@/components/one-location/redesign/duration-presets";
 import {
   CHECK_IN_CATEGORY_ROW_CLASSNAME,
@@ -89,11 +88,38 @@ import { cn } from "@/lib/utils";
 
 const SUCCESS_ROLE = SEMANTIC_ROLE_CLASSES.success;
 
+/**
+ * Three lengths, and they have to fit one row.
+ *
+ * Reported: "Visible for ke jo times hain inko one row mai dikhao ... looking
+ * scattered". They were, and the cause was the shared `DURATION_GRID_CLASS`:
+ * two columns on a phone, which lays three cells out as 2 + 1 and leaves a
+ * half-empty second row under a heading that reads as a single choice.
+ *
+ * Abbreviated so the set is consistent rather than to buy width -- "30 min"
+ * beside "1 hour" and "2 hours" mixes two registers in one row, and at three
+ * across the long forms fit anyway. See CHECK_IN_DURATION_GRID_CLASS for why
+ * the grid is local rather than a change to the shared one.
+ */
 const DURATIONS = [
   { value: 30 as const, label: "30 min" },
-  { value: 60 as const, label: "1 hour" },
-  { value: 120 as const, label: "2 hours" },
+  { value: 60 as const, label: "1 hr" },
+  { value: 120 as const, label: "2 hr" },
 ];
+
+/**
+ * Three across on a phone, not the shared ladder's two.
+ *
+ * `DURATION_GRID_CLASS` is two columns because the ladders that use it carry
+ * four cells and land as an even 2x2. This control has three, so the same
+ * class strands one on a row of its own. Local rather than a fourth variant in
+ * `duration-presets`: the cells themselves stay identical, which is the part
+ * that has to agree across the product.
+ *
+ * At 320px this is ~90px a cell against a widest label of ~64px, so nothing
+ * truncates on the narrowest phone the app supports.
+ */
+const CHECK_IN_DURATION_GRID_CLASS = "grid grid-cols-3 gap-2 sm:flex sm:flex-wrap";
 
 /**
  * Chip labels only. The `value` on each row is the backend category and is
@@ -2739,7 +2765,7 @@ export function NearbyCheckInSheet({
                     duration ladder uses for the identical role (44px, 15px),
                     so the two duration controls in this product can no longer
                     disagree about how big a duration choice is. */}
-                <div className={cn("mt-3", DURATION_GRID_CLASS)}>
+                <div className={cn("mt-3", CHECK_IN_DURATION_GRID_CLASS)}>
                   {DURATIONS.map((duration) => (
                     <button
                       key={duration.value}


### PR DESCRIPTION
Two reports from the same screenshot of the check-in drawer on a phone.

---

## 1 · "Visible for" was scattered

> "Visible for ke jo times hain inko one row mai dikhao … looking scattered"

It was, and the cause was mechanical: the shared `DURATION_GRID_CLASS` is **two columns**, because the ladders that use it carry **four** cells and land as an even 2×2. This control has **three**, so the same class stranded one on a row of its own — under a heading that reads as a single choice.

**Before**

```
Visible for
[  30 min  ] [  1 hour  ]
[ 2 hours  ]
```

**After**

```
Visible for
[ 30 min ] [ 1 hr ] [ 2 hr ]
```

Three across, from a **local** grid rather than a fourth variant in `duration-presets`. The *cells* stay byte-identical — that is the part that has to agree across the product — and only the column count differs, because the cell count differs. At 320px that's ~90px per cell against a widest label of ~64px, so nothing truncates on the narrowest phone the app supports.

Labels abbreviated **for consistency, not for width**: "30 min" beside "1 hour" and "2 hours" mixes two registers in one row, and at three across the long forms fit anyway.

---

## 2 · The top was crowded

> "Check in ka icon and text, Sharing with 1 ka text, You are here wala block … yeh sb ek sath dikh rha, bahut hi bheed bhaad jesa lag rha hai"

On a phone the sheet takes about **three quarters of the screen**, so five floating controls were competing for the ~250px strip left above it. Two of them weren't earning it.

### Removed

| Control | Why |
|---|---|
| **"Check in" pill** | While the sheet is open it is the one control on screen that **does nothing** — its only stated job is getting back *into* the sheet after a dismiss. Hidden at every width, because it is redundant at every width; the crowding is just where it was noticed. |
| **"Sharing with N" chip** | Phones only. It counts people watching your **live location** — check-in is a separate one-time share to whoever is nearby. It answers a question nobody is asking mid-check-in, and its popover opens *over* the sheet. |

The pill **returns the moment the sheet is dismissed**, and that is not optional: the check-in surface renders no tray, so removing it outright would strand somebody on a map with no way back in. That half is tested as carefully as the removal.

`max-md:hidden` rather than an unmount for the chip — `display:none` takes it out of the accessibility tree and tab order too, and costs no state to bring back. From `md` up the sheet is a side panel with the map beside it, so there is nothing to declutter.

### Deliberately kept

**"You are here / 500 m around you"**, plus Close and Locate.

The legend is the **only** explanation of what the blue dot is and how far "nearby" reaches — and the sheet below states neither. Cutting it with the other two would have tidied the screen by removing the one part of it that was answering a question.

With the other two gone it is no longer crowded: three controls, each doing a different job.

```
Before (5 things)                After (3 things)
┌────────────────────────┐       ┌────────────────────────┐
│ ✕   [Check in]     ⊕   │       │ ✕                  ⊕   │
│ ┌─────────┐ (Sharing 1)│       │ ┌──────────────┐       │
│ │You are  │            │       │ │ You are here │       │
│ │here 500m│            │       │ │ 500 m        │       │
│ └─────────┘            │       │ └──────────────┘       │
├════ drawer ════════════┤       ├════ drawer ════════════┤
```

---

## Coverage

The two existing header cases asserted the pill **unconditionally**. They now assert the real contract rather than being deleted:

- absent while the sheet is up, **present again after dismiss**
- Close and Locate survive the declutter
- the ladder's contents, order, column count, and that it still selects

## Verification

| | |
|---|---|
| webapp typecheck + eslint | clean |
| vitest — one-location | **1369 / 1370** |
| runtime topology index | current |

The single failure is the known load flake (`resets every abandoned share field`) — it fails identically on a clean tree and passes isolated; confirmed both ways here.

## Still needs a human

On a phone: open **Location → Map → Check in**. The top strip should hold only ✕, Locate, and the "You are here" legend. Dismiss the sheet — the **Check in** pill should come back. And "Visible for" should be one tidy row of three.
