### PR TITLE
fix(one): a section's "+" no longer opens on top of that section's list

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -129,17 +129,41 @@ describe("One Location — hub tab naming", () => {
 });
 
 describe("One Location — People actions stay reachable and single-flight", () => {
-  it("keeps Find contacts mounted for action routing and disabled while syncing", () => {
-    const start = HUB_SOURCE.indexOf(
-      'data-voice-control-id="one-location-find-contacts"',
-    );
-    expect(start).toBeGreaterThan(-1);
-    const addPeopleMenu = HUB_SOURCE.slice(start - 600, start + 900);
+  // The "+" menus moved to the shared `ActionMenu`, which is a bottom sheet on
+  // a phone and an anchored menu on a pointer -- an anchored menu opened
+  // straight down ONTO the very list it belongs to. The properties this test
+  // was written for did not change; where they are declared did.
+  const ACTION_MENU_SOURCE = repoFile("components/app-ui/action-menu.tsx");
 
-    expect(addPeopleMenu).toContain("<DropdownMenuContent");
-    expect(addPeopleMenu).toContain("forceMount");
-    expect(addPeopleMenu).toContain('disabled={vm.busy === "contactSync"}');
-    expect(addPeopleMenu).toContain('aria-busy={vm.busy === "contactSync"');
+  it("keeps Find contacts listed and merely disabled while syncing", () => {
+    const start = HUB_SOURCE.indexOf('voiceControlId: "one-location-find-contacts"');
+    expect(start).toBeGreaterThan(-1);
+    const addPeopleMenu = HUB_SOURCE.slice(start - 900, start + 200);
+
+    // Present in the item list unconditionally -- a row that disappears
+    // mid-action is not a disabled control, it is a missing one.
+    expect(addPeopleMenu).toContain('id: "find-contacts"');
+    expect(addPeopleMenu).toContain('disabled: vm.busy === "contactSync"');
+    expect(addPeopleMenu).toContain('busy: vm.busy === "contactSync"');
+  });
+
+  it("refuses a second tap rather than queueing it, in both presentations", () => {
+    // Single-flight is the point: the sheet returns early and the menu
+    // preventDefaults, so a disabled row can never fire its action.
+    expect(ACTION_MENU_SOURCE).toContain("if (item.disabled) return;");
+    expect(ACTION_MENU_SOURCE).toContain("event.preventDefault();");
+    // The pointer lane keeps the content mounted, as it always did.
+    expect(ACTION_MENU_SOURCE).toContain("forceMount");
+  });
+
+  it("does not open a section's menu on top of that section's own list", () => {
+    // The reported defect, pinned: on a phone the surface is a bottom sheet,
+    // not a menu anchored under a "+" that sits above the list.
+    expect(ACTION_MENU_SOURCE).toContain('side="bottom"');
+    expect(ACTION_MENU_SOURCE).toContain("useIsMobile");
+    // And the presentation is frozen while open, so a rotation cannot remount
+    // the menu under the hand using it.
+    expect(ACTION_MENU_SOURCE).toContain("if (!open) setSheetPresentation(isMobile);");
   });
 });
 

--- a/hushh-webapp/components/app-ui/action-menu.tsx
+++ b/hushh-webapp/components/app-ui/action-menu.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+
+/**
+ * A section's "+" and the short list of things it can add.
+ *
+ * QA, three times, on three sections: "yeh + wala button open jab ho raha hai
+ * tab neeche aa raha hai dusre tab pe". A dropdown anchored under a "+" that
+ * sits at the top-right of a section opens straight down ONTO that section's
+ * own list -- so "Create Circle / Join with code" landed on top of the Circles
+ * rows, and it stopped being obvious which section the menu even belonged to.
+ * On a phone it also puts the choices at the top of the screen, furthest from
+ * the thumb that just tapped the button.
+ *
+ * So the surface follows the platform instead of the anchor:
+ *
+ *   phone   a sheet from the bottom, titled with the section it acts on. It
+ *           covers nothing the reader was mid-way through, it is where the
+ *           thumb already is, and the title says what these actions are for.
+ *   desktop the anchored menu, which is correct there -- a pointer is already
+ *           at the trigger and there is room beside the list.
+ *
+ * The presentation is frozen while the menu is open, for the same reason
+ * `SaveLocationModal` freezes its own: swapping Sheet for DropdownMenu swaps
+ * the parent element, React remounts everything inside, and a rotation
+ * mid-choice would tear the menu down under the hand using it.
+ */
+export type ActionMenuItem = {
+  /** Stable key. Also the test id, as `${testId}-item-${id}`. */
+  id: string;
+  label: ReactNode;
+  icon?: LucideIcon;
+  onSelect: () => void;
+  disabled?: boolean;
+  /** Marks the row busy without unmounting it, so a repeat tap is refused
+   *  rather than queued -- single-flight, visibly. */
+  busy?: boolean;
+  voiceControlId?: string;
+};
+
+const ITEM_CLASSNAME =
+  "flex min-h-11 w-full items-center gap-3 rounded-[10px] px-3 text-[15px] font-normal leading-5 text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]";
+
+export function ActionMenu({
+  label,
+  title,
+  items,
+  triggerIcon: TriggerIcon,
+  testId,
+  contentClassName,
+}: {
+  /** The trigger's accessible name, e.g. "Add Circle". */
+  label: string;
+  /** The sheet's heading on a phone. Defaults to `label`. */
+  title?: string;
+  items: ActionMenuItem[];
+  triggerIcon: LucideIcon;
+  testId?: string;
+  contentClassName?: string;
+}) {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
+  // Frozen for the lifetime of one opening. See the note above.
+  const [sheetPresentation, setSheetPresentation] = useState(isMobile);
+  useEffect(() => {
+    if (!open) setSheetPresentation(isMobile);
+  }, [isMobile, open]);
+
+  const trigger = (
+    <Button
+      type="button"
+      size="icon"
+      variant="ghost"
+      aria-label={label}
+      data-testid={testId}
+      className="h-11 w-11 rounded-full text-[color:var(--app-accent)] hover:bg-[color:var(--app-neutral-fill)] hover:text-[color:var(--app-accent-hover)]"
+    >
+      <TriggerIcon className="h-[21px] w-[21px]" aria-hidden="true" />
+    </Button>
+  );
+
+  if (sheetPresentation) {
+    return (
+      <>
+        <span onClick={() => setOpen(true)}>{trigger}</span>
+        <Sheet open={open} onOpenChange={setOpen} modal>
+          <SheetContent
+            side="bottom"
+            showCloseButton={false}
+            data-testid={testId ? `${testId}-sheet` : undefined}
+            className="gap-0 rounded-t-[24px] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-2"
+          >
+            <SheetHeader className="px-1 pb-2 pt-1 text-left">
+              <SheetTitle className="text-[15px] font-medium leading-5 text-[color:var(--app-secondary-label)]">
+                {title ?? label}
+              </SheetTitle>
+            </SheetHeader>
+            <div className="space-y-1">
+              {items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    disabled={item.disabled}
+                    aria-busy={item.busy || undefined}
+                    data-voice-control-id={item.voiceControlId}
+                    data-testid={testId ? `${testId}-item-${item.id}` : undefined}
+                    onClick={() => {
+                      if (item.disabled) return;
+                      setOpen(false);
+                      item.onSelect();
+                    }}
+                    className={cn(
+                      ITEM_CLASSNAME,
+                      "text-left disabled:opacity-50",
+                    )}
+                  >
+                    {Icon ? (
+                      <Icon
+                        className="h-4 w-4 shrink-0 text-[color:var(--app-secondary-label)]"
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+            {/* An explicit way out. A sheet a thumb opened by accident should
+                not need a reach to the scrim at the top of the screen. */}
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="mt-2 min-h-11 w-full rounded-[10px] text-[15px] font-medium text-[color:var(--app-secondary-label)]"
+            >
+              Cancel
+            </button>
+          </SheetContent>
+        </Sheet>
+      </>
+    );
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        forceMount
+        data-testid={testId ? `${testId}-menu` : undefined}
+        className={cn(
+          "min-w-52 rounded-2xl border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1.5 shadow-[var(--app-card-shadow-standard)] dark:shadow-none",
+          contentClassName,
+        )}
+      >
+        {items.map((item) => {
+          const Icon = item.icon;
+          return (
+            <DropdownMenuItem
+              key={item.id}
+              disabled={item.disabled}
+              aria-busy={item.busy || undefined}
+              data-voice-control-id={item.voiceControlId}
+              data-testid={testId ? `${testId}-item-${item.id}` : undefined}
+              onSelect={(event) => {
+                if (item.disabled) {
+                  event.preventDefault();
+                  return;
+                }
+                item.onSelect();
+              }}
+              className={ITEM_CLASSNAME}
+            >
+              {Icon ? (
+                <Icon
+                  className="h-4 w-4 shrink-0 text-[color:var(--app-secondary-label)]"
+                  aria-hidden="true"
+                />
+              ) : null}
+              {item.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import {
   Check,
   Copy,
@@ -32,11 +31,6 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   SheetClose,
   Sheet,
@@ -104,6 +98,7 @@ import { ContactSourceBadge } from "@/components/connections/contact-source-badg
 import { LOCATION_SEARCH_INPUT_CLASSNAME } from "@/components/one-location/redesign/selectors";
 import { relationshipCta } from "@/lib/connections/relationship-label";
 import { othersCountLabel } from "@/lib/one-location/circle-member-count";
+import { ActionMenu } from "@/components/app-ui/action-menu";
 import { cn } from "@/lib/utils";
 import {
   CIRCLE_INVITE_BATCH_LIMIT,
@@ -389,51 +384,28 @@ export function CirclesSection({
             "[&_[data-radix-popper-content-wrapper]]:!transform-none",
           )}
         >
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                aria-label="Add Circle"
-                className="h-11 w-11 rounded-full text-[color:var(--app-accent)] hover:bg-[color:var(--app-neutral-fill)] hover:text-[color:var(--app-accent-hover)]"
-              >
-                <Plus className="h-[21px] w-[21px]" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuPrimitive.Content
-              data-slot="dropdown-menu-content"
-              side="bottom"
-              align="end"
-              alignOffset={0}
-              sideOffset={0}
-              collisionPadding={12}
-              className="z-[212] min-w-[12rem] rounded-[14px] border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1 text-[color:var(--app-primary-label)] shadow-[var(--app-card-shadow-standard)] outline-none dark:shadow-none"
-            >
-              <DropdownMenuItem
-                onSelect={onCreate}
-                data-voice-control-id="one-location-action-create-circle"
-                className="flex min-h-11 items-center gap-3 rounded-[10px] px-3 text-[15px] font-normal leading-5 text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]"
-              >
-                <Plus
-                  className="h-4 w-4 text-[color:var(--app-secondary-label)]"
-                  aria-hidden="true"
-                />
-                Create Circle
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={onJoin}
-                data-voice-control-id="one-location-action-join-circle"
-                className="flex min-h-11 items-center gap-3 rounded-[10px] px-3 text-[15px] font-normal leading-5 text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]"
-              >
-                <KeyRound
-                  className="h-4 w-4 text-[color:var(--app-secondary-label)]"
-                  aria-hidden="true"
-                />
-                Join with code
-              </DropdownMenuItem>
-            </DropdownMenuPrimitive.Content>
-          </DropdownMenu>
+          <ActionMenu
+            label="Add Circle"
+            title="Circles"
+            triggerIcon={Plus}
+            testId="one-location-add-circle"
+            items={[
+              {
+                id: "create",
+                label: "Create Circle",
+                icon: Plus,
+                onSelect: onCreate,
+                voiceControlId: "one-location-action-create-circle",
+              },
+              {
+                id: "join",
+                label: "Join with code",
+                icon: KeyRound,
+                onSelect: onJoin,
+                voiceControlId: "one-location-action-join-circle",
+              },
+            ]}
+          />
         </div>
       </div>
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -71,15 +71,10 @@ import {
   resolveShareDurationHours,
   shareReplacementsLosingTime,
 } from "@/lib/one-location/share-replacement";
+import { ActionMenu } from "@/components/app-ui/action-menu";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { TopShellTabs } from "@/components/app-ui/top-shell-tabs";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -3389,63 +3384,51 @@ export function PeopleHub({
     </Button>
   );
   const addConnectionsMenu = (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          aria-label="Add people"
-          className="h-11 w-11 rounded-full text-[color:var(--app-accent)] hover:bg-[color:var(--app-neutral-fill)] hover:text-[color:var(--app-accent-hover)]"
-        >
-          <Plus className="h-[21px] w-[21px]" aria-hidden="true" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        forceMount
-        className="min-w-52 rounded-2xl border border-[color:var(--app-separator)] bg-[color:var(--app-primary-surface)] p-1.5 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
-      >
-        <DropdownMenuItem
-          data-voice-control-id="one-location-find-contacts"
-          aria-busy={vm.busy === "contactSync" || undefined}
-          disabled={vm.busy === "contactSync"}
-          onSelect={(event) => {
-            if (vm.busy === "contactSync") {
-              event.preventDefault();
-              return;
-            }
-            vm.onSyncContacts();
-          }}
-          className="flex items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-[15px] font-medium text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]"
-        >
-          {vm.busy === "contactSync"
+    <ActionMenu
+      label="Add people"
+      title="Connections"
+      triggerIcon={Plus}
+      testId="one-location-add-people"
+      items={[
+        {
+          id: "find-contacts",
+          // Kept mounted and merely DISABLED while a sync is in flight, so a
+          // second tap is refused rather than queued -- single-flight, and
+          // visibly so. Removing the row instead would make the control
+          // disappear mid-action.
+          label: vm.busy === "contactSync"
             ? "Finding contacts…"
             : vm.contactSyncSummary
               ? "Sync contacts again"
-              : "Find contacts"}
-        </DropdownMenuItem>
-        {vm.contactSyncSummary && vm.onViewContactSyncResults ? (
-          <DropdownMenuItem onSelect={() => vm.onViewContactSyncResults?.()}>
-            View contact sync results
-          </DropdownMenuItem>
-        ) : null}
-        <DropdownMenuItem
-          onSelect={() => onInvite()}
-          data-voice-control-id="one-location-action-invite"
-          className="flex items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-[15px] font-medium text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]"
-        >
-          Invite to One
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => onAddConnections()}
-          data-voice-control-id="one-location-add-connections"
-          className="flex items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-[15px] font-medium text-[color:var(--app-primary-label)] focus:bg-[color:var(--app-neutral-fill)] dark:focus:bg-[color:var(--app-neutral-fill-strong)]"
-        >
-          Manage connections
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              : "Find contacts",
+          onSelect: () => vm.onSyncContacts(),
+          disabled: vm.busy === "contactSync",
+          busy: vm.busy === "contactSync",
+          voiceControlId: "one-location-find-contacts",
+        },
+        ...(vm.contactSyncSummary && vm.onViewContactSyncResults
+          ? [
+              {
+                id: "sync-results",
+                label: "View contact sync results",
+                onSelect: () => vm.onViewContactSyncResults?.(),
+              },
+            ]
+          : []),
+        {
+          id: "invite",
+          label: "Invite to One",
+          onSelect: () => onInvite(),
+          voiceControlId: "one-location-action-invite",
+        },
+        {
+          id: "manage",
+          label: "Manage connections",
+          onSelect: () => onAddConnections(),
+          voiceControlId: "one-location-add-connections",
+        },
+      ]}
+    />
   );
 
   return (


### PR DESCRIPTION
Closes #6257.

## The report

Tapping the **+** beside "Circles" opened its menu straight down **onto the
Circles list**:

```
Circles                              +
┌──────────────────────┌──────────────────────┐
│ JC  JHUMMA's Circle  │ +  Create Circle     │
│     2 people         │ 🔑 Join with code    │
│ 👥  Trusted          └──────────────────────┘
│ SMS SMS Circle
```

Reported as **repetitive** — the Connections `+` on the same screen does it too.
A dropdown anchored under a "+" that sits at the top-right of a section can only
open onto that section, so it stops being obvious which section the menu is even
for. On a phone it also puts the choices at the *top* of the screen, furthest
from the thumb that just tapped the button.

## The surface now follows the platform, not the anchor

| | surface | why |
|---|---|---|
| **phone** | bottom sheet, titled with the section, with Cancel | covers nothing the reader was part-way through, and it is where the thumb already is |
| **desktop** | the anchored menu | correct there — the pointer is at the trigger and there is room beside the list |

Both menus now come from one `ActionMenu`
(`components/app-ui/action-menu.tsx`) instead of each hand-rolling a
`DropdownMenu` — so the next section that grows a `+` inherits the fixed
behaviour rather than becoming the third copy of the old one.

## Care taken

- **Presentation is frozen while open.** Same reason `SaveLocationModal` freezes
  its own: swapping Sheet for DropdownMenu swaps the parent element, React
  remounts everything inside, and a rotation mid-choice would tear the menu down
  under the hand using it.
- **"Find contacts" stays listed and merely disabled** while a sync is in
  flight, in *both* presentations — a row that disappears mid-action is not a
  disabled control, it is a missing one. Single-flight is enforced in both
  lanes: the sheet returns early, the menu `preventDefault`s.
- Every `data-voice-control-id` is carried into both lanes, so voice keeps
  seeing the same controls.
- The sheet has an explicit **Cancel**; a sheet a thumb opened by accident
  should not need a reach to the scrim at the top of the screen.

## The contract test

`one-location-copy-pass` asserted the old shape by grepping the hub for
`<DropdownMenuContent` and `forceMount`. The properties it was written for did
not change — *where they are declared* did — so it now checks the same things at
the new location, plus two more: that a disabled row cannot fire in either lane,
and that the phone surface is a bottom sheet rather than a menu anchored above
the list.

## Verification

| Check | Result |
|---|---|
| `tsc`, `eslint` | clean |
| copy-pass + agent-page suites | 141 passed |
| Circle/Connect picker suites | 231 passed |
| full `web-targeted` CI lane, run locally | 679 One Location flow tests |
| layout contracts (chromium) | 20 passed |
| `verify:voice-gateway` | current |

One webapp serves **web, iOS and Android** through Capacitor, so all three get
the same behaviour from the same component.