### PR TITLE
fix(one): confirm a sent request with the toast that already fires, not a banner

### DIFF
--- a/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
+++ b/hushh-webapp/__tests__/components/feed-live-and-cta.contract.test.ts
@@ -93,8 +93,10 @@ describe("the ask flow's primary action keeps the action colour", () => {
       )?.[0] ?? "";
     expect(sendButton.length).toBeGreaterThan(0);
     expect(sendButton).toContain("bg-[color:var(--app-accent)]");
-    // Green is a status, and this screen already says it twice — in the banner
-    // above and in each person's row turning to "Asked".
+    // Green is a status, and the outcome is already said twice elsewhere —
+    // the Sonner toast the send raises, and each person's row turning to
+    // "Asked". A third telling on the button would be the one that cannot be
+    // dismissed.
     expect(sendButton).not.toContain("--app-success");
   });
 
@@ -103,14 +105,24 @@ describe("the ask flow's primary action keeps the action colour", () => {
       "components/one-location/redesign/location-redesign-hub.tsx",
     );
 
-    expect(hub).toContain("sentSelectionRef");
-    expect(hub).toContain("const sent = await vm.onSendRequest(reason)");
-    expect(hub).toContain("setJustSent(sent)");
-    // The latch must not be part of what disables the button, or one send
-    // retires the control for the life of the screen.
-    expect(hub).not.toContain(
-      "disabled={!isRequestFormValid || sendingRequest || justSent}",
+    // Reported from the field as "can't send req to rest after 1 cycle".
+    // The guarantee used to be "the latch is cleared when a new person is
+    // picked"; it is now the stronger "there is no latch". `justSent` and the
+    // `sentSelectionRef` that retired it went with the confirmation banner —
+    // see the Request-sent contract in one-location-copy-pass.
+    expect(hub).not.toMatch(/const \[justSent/);
+    expect(hub).not.toMatch(/setJustSent\(/);
+    expect(hub).not.toContain("sentSelectionRef");
+
+    // What Send is allowed to depend on: the current selection, and whether a
+    // send is already in flight. Nothing that outlives one round.
+    expect(hub).toContain(
+      "disabled={!isRequestFormValid || sendingRequest}",
     );
+    // And the step still advances only on a resolved success, so a failed send
+    // cannot present as a completed one.
+    expect(hub).toContain("const sent = await vm.onSendRequest(reason)");
+    expect(hub).toContain("if (sent) setStep(\"person\")");
   });
 });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -4790,9 +4790,16 @@ describe("OneLocationAgentPage", () => {
         has_note: false,
       }),
     );
+    // The confirmation is a toast, not a banner. It used to be both, on a
+    // screen whose rows already say "Asked just now ... waiting on them" --
+    // three tellings of one fact, one of them holding permanent layout to say
+    // something that stopped being news a second later.
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringContaining("Request sent."),
+      ),
     );
+    expect(screen.queryByText("Request sent.")).toBeNull();
   });
 
   // Reported from the field: "can't send req to rest after 1 cycle". Asking
@@ -4815,7 +4822,9 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Send request/i }));
     await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringContaining("Request sent."),
+      ),
     );
 
     // Sending clears the composer, so with nobody chosen there is nothing to
@@ -4876,7 +4885,9 @@ describe("OneLocationAgentPage", () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("Request sent."),
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringContaining("Request sent."),
+      ),
     );
     expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 
@@ -4916,7 +4927,13 @@ describe("OneLocationAgentPage", () => {
           .hasAttribute("disabled"),
       ).toBe(false),
     );
-    expect(screen.queryByRole("status")).toBeNull();
+    // Asserted on the toast, not on the absence of a banner: with the banner
+    // gone, `queryByRole("status")` is null whether the send worked or not, so
+    // it would pass for the wrong reason. The channel that DOES carry a
+    // success is the one that has to stay silent.
+    expect(toast.success).not.toHaveBeenCalledWith(
+      expect.stringContaining("Request sent."),
+    );
   });
 
   it("renders my requests with safe labels instead of raw owner ids", async () => {

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -13,6 +13,8 @@ const HUB_SOURCE = repoFile(
   "components/one-location/redesign/location-redesign-hub.tsx",
 );
 const CONNECT_SOURCE = repoFile("app/connect/page-client.tsx");
+/** The route that owns the send, and therefore the toast that confirms it. */
+const PAGE_SOURCE = repoFile("app/one/location/page.tsx");
 
 /**
  * The duration ceiling is owned by the consent protocol, not by the web app.
@@ -112,6 +114,36 @@ describe("One Location — link durations stay inside the server's ceiling", () 
     expect(HUB_SOURCE).not.toContain("<WarningCard");
     // The surviving statement, on the live link's own card.
     expect(HUB_SOURCE).toContain("Anyone with this link can see your location.");
+  });
+
+  it("drops the Request sent banner in favour of the toast that already fired", () => {
+    // Reported on the Ask screen: "request sent is not looking cool, do you
+    // really think we want a bar for this only". The screen was telling the
+    // same fact three times -- a toast raised by `handleRequestAccess`, an
+    // "Asked" pill and an "Asked just now ... waiting on them" line on every
+    // row it applied to, and then a banner pinned above the search field to
+    // announce something that stopped being news a second later.
+    //
+    // `frontend-pattern-catalog.md`: "Do not create inline route banners for
+    // row-level saves... Inline errors are for stable page-blocking states
+    // only." A sent request is neither, so the banner and the `justSent` latch
+    // that drove it are both gone.
+    // Matched on the constructs, not on the words: the code comment that
+    // explains WHY the banner went is worth keeping, and a bare
+    // `not.toContain("justSent")` would forbid writing it down.
+    expect(HUB_SOURCE).not.toMatch(/const \[justSent/);
+    expect(HUB_SOURCE).not.toMatch(/setJustSent\(/);
+    expect(HUB_SOURCE).not.toMatch(/\{justSent \?/);
+    // A line that is nothing but the words is a JSX text node -- i.e. a banner
+    // rendering them. In a comment they are always preceded by `//` or `*`.
+    expect(HUB_SOURCE).not.toMatch(/^\s*Request sent\.\s*$/m);
+
+    // The channel that survives, and the durable per-row telling that made the
+    // banner redundant in the first place.
+    expect(PAGE_SOURCE).toContain(
+      "Request sent. We'll notify you here when they respond.",
+    );
+    expect(HUB_SOURCE).toContain("waiting on them");
   });
 });
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -5059,25 +5059,23 @@ function AskFlow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch]);
 
-  // Keep the person on this screen after sending so the confirmation is tied to
-  // the specific request they just made, rather than popping straight back to
-  // the hub.
+  // Keep the person on this screen after sending, so the roster they just acted
+  // on is still the thing in front of them and the next ask is one tap away
+  // rather than a trip back through the hub.
   //
-  // `justSent` is a confirmation, NOT a one-shot lock. It used to latch true
-  // forever the moment the button was tapped, which meant (a) a failed send
-  // still said "Request sent." and (b) after one round the button stayed
-  // disabled, so somebody who asked three people could not then ask the rest
-  // without leaving the screen and coming back. Now it is set from the resolved
-  // result, and choosing the next person clears it and re-arms Send.
-  const [justSent, setJustSent] = useState(false);
-  // Who the last send was for. Anyone selected who is NOT in it is a person
-  // being lined up for a new ask, which is what retires the confirmation and
-  // re-arms Send.
+  // There is no `justSent` banner any more. `handleRequestAccess` already
+  // raises a Sonner toast on a resolved success ("Request sent. We'll notify
+  // you here when they respond."), and every person asked already carries the
+  // outcome durably in their own row -- an "Asked" pill and "Asked just now for
+  // 1 hour, waiting on them". So the banner was the third telling of the same
+  // fact, and the only one that took permanent layout at the top of the screen
+  // to say something that stopped being news a second later. Reported as
+  // exactly that: "request sent is not looking cool, do you really think we
+  // want a bar for this only".
   //
-  // Compared as a set rather than counted: sending subtracts only the people it
-  // actually asked, so a person tapped mid-send survives into a non-empty
-  // selection, and a count would read that leftover as "nothing new here".
-  const sentSelectionRef = useRef<readonly string[]>([]);
+  // `frontend-pattern-catalog.md` has said so since before this screen existed:
+  // "Do not create inline route banners for row-level saves... Inline errors
+  // are for stable page-blocking states only." A sent request is neither.
   const selectedRequestOwnerIds = vm.selectedRequestOwnerIds;
   const selectedRequestRecipients = useMemo(() => {
     const byId = new globalThis.Map(
@@ -5089,12 +5087,6 @@ function AskFlow({
         Boolean(recipient),
       );
   }, [selectedRequestOwnerIds, vm.recipients]);
-  useEffect(() => {
-    const hasNewPick = selectedRequestOwnerIds.some(
-      (id) => !sentSelectionRef.current.includes(id),
-    );
-    if (hasNewPick) setJustSent(false);
-  }, [selectedRequestOwnerIds]);
   // Guards a double-tap inside the same frame, where `vm.busy` has not yet
   // re-rendered the button as disabled.
   const sendInFlightRef = useRef(false);
@@ -5249,14 +5241,13 @@ function AskFlow({
     if (!isRequestFormValid || sendingRequest || sendInFlightRef.current)
       return;
     sendInFlightRef.current = true;
-    sentSelectionRef.current = vm.selectedRequestOwnerIds;
     void (async () => {
       try {
-        // Confirm only what actually happened: the banner appears on a
-        // resolved success, and a failure leaves the composer intact with its
-        // own error toast.
+        // Confirm only what actually happened. `onSendRequest` resolves true
+        // only once at least one request reached the server, and raises the
+        // toast itself; a failure leaves the composer intact with its own error
+        // toast and never moves the step.
         const sent = await vm.onSendRequest(reason);
-        setJustSent(sent);
         if (sent) setStep("person");
       } finally {
         sendInFlightRef.current = false;
@@ -5399,18 +5390,8 @@ function AskFlow({
         )}
       />
 
-      {justSent ? (
-        <div
-          role="status"
-          className="flex items-start gap-2.5 rounded-[20px] border border-[color:var(--app-success)]/25 bg-[color:var(--app-primary-surface)] px-4 py-4 shadow-[var(--app-card-shadow-standard)] dark:shadow-none"
-        >
-          <ShieldCheck className="mt-0.5 h-[19px] w-[19px] shrink-0 text-[color:var(--app-success)]" />
-          <p className="text-[17px] font-medium leading-[22px] text-foreground">
-            Request sent.
-          </p>
-        </div>
-      ) : null}
-
+      {/* No confirmation banner here. The send raises a toast, and each person
+          asked says so in their own row -- see the note beside `sendRequest`. */}
       <section className="space-y-3">
         <PersonSearchInput
           value={searchDraft}


### PR DESCRIPTION
Reported from phone QA on **One → Location → Request location**: *"request sent is not looking cool — do you really think we want a bar for this only"*, and *"shayad yeh yahin ruk ja raha"*.

## The screen was telling one fact three times

| channel | lifetime | still there after this PR |
|---|---|---|
| Sonner toast — "Request sent. We'll notify you here when they respond." | ~3s, dismissible | ✅ unchanged |
| each asked person's row — "Asked" pill + "Asked just now for 1 hour, waiting on them" | durable, per-person | ✅ unchanged |
| **a bordered card pinned above the search field saying "Request sent."** | **forever** | ❌ removed |

The toast already existed — `handleRequestAccess` in [page.tsx](hushh-webapp/app/one/location/page.tsx) has always raised it on a resolved success. So this isn't "replace the banner with a toast"; the toast was already firing *underneath* the banner. The banner was a third telling, and the only one that took permanent layout to announce something that stopped being news a second later.

**And it did not leave.** The latch behind it cleared only when a *new* person was picked:

```js
const hasNewPick = selectedRequestOwnerIds.some(
  (id) => !sentSelectionRef.current.includes(id),
);
if (hasNewPick) setJustSent(false);
```

But sending clears the composer, so the selection went **empty** — nothing counts as "new" in an empty list — and the card sat there until you chose somebody else or left the screen. That is the "yahin ruk ja raha" exactly.

The repo's own [frontend-pattern-catalog.md](docs/reference/quality/frontend-pattern-catalog.md) has said this since before this screen existed:

> Do not create inline route banners for row-level saves, deletes, refreshes, or short-lived failures. Inline errors are for stable page-blocking states only.

A sent request is neither.

## What went

The banner, `justSent`, and the `sentSelectionRef` that existed only to retire it. Nothing else read either of them — Send is disabled by `!isRequestFormValid || sendingRequest` and always was.

So the guarantee behind the old field report *"can't send req to rest after 1 cycle"* gets **stronger**, not weaker. It used to be "the latch is cleared when a new person is picked". It is now "there is no latch". The step still advances only on a resolved success, so a failed send still cannot present as a completed one.

## Tests

Three source-level contracts pinned the latch **by name**, so they moved with it:

- `feed-live-and-cta` asserted `sentSelectionRef` and `setJustSent(sent)` exist. It now asserts their **absence**, plus what Send is allowed to depend on — a tighter statement of the same invariant.
- `one-location-copy-pass` gains the banner's own removal contract. Matched on the constructs (`const [justSent`, `{justSent ?`, a bare `Request sent.` JSX text line) rather than the words, so the comment explaining *why* it went can stay in the source.
- The three agent-page tests read the confirmation off `getByRole("status")` — which was the banner. They now assert `toast.success`. That matters most on the failure path: with the banner gone, the old `expect(queryByRole("status")).toBeNull()` would have passed for the wrong reason, so it now asserts the channel that *does* carry a success stays silent.

**Verified:** `npm run verify:one-location` — 678 tests across 32 files, all green. `tsc --noEmit`, `eslint`, `verify:design-system`, `verify:accent-tokens`, `verify:apple-hierarchy` clean. No schema change, no migration, no copy change to the surviving toast.
