### PR TITLE
fix(one): stop putting a possessive pronoun next to the name it stands for

### DIFF
--- a/hushh-webapp/__tests__/lib/feed/feed-sms-contact-lines.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/feed-sms-contact-lines.test.ts
@@ -46,7 +46,7 @@ describe("SMS Circle membership reaches both people", () => {
   it("tells the contact they were added", () => {
     // The whole point: this row is the only way they find out.
     expect(presentFeedItem(item({ metadata: contact })).description).toBe(
-      "Added you to their SMS",
+      "Added you to SMS Circle",
     );
   });
 
@@ -65,7 +65,7 @@ describe("SMS Circle membership reaches both people", () => {
       presentFeedItem(
         item({ event_type: "location_sms_contact_removed", metadata: contact }),
       ).description,
-    ).toBe("Removed you from their SMS");
+    ).toBe("Removed you from SMS Circle");
   });
 
   it("names the other person as the row's title, on both sides", () => {
@@ -81,6 +81,21 @@ describe("SMS Circle membership reaches both people", () => {
       const a = presentFeedItem(item({ event_type, metadata: owner }));
       const b = presentFeedItem(item({ event_type, metadata: contact }));
       expect(a.description).not.toBe(b.description);
+    }
+  });
+
+  it("never puts a possessive pronoun next to the name on the row", () => {
+    // The row's title is already the other person, so "added you to THEIR SMS"
+    // reads as a name followed immediately by a pronoun for that same name.
+    // Dropping the pronoun is shorter and says exactly as much.
+    for (const event_type of [
+      "location_sms_contact_added",
+      "location_sms_contact_removed",
+    ] as const) {
+      for (const metadata of [owner, contact]) {
+        const line = presentFeedItem(item({ event_type, metadata })).description;
+        expect(line).not.toMatch(/their/i);
+      }
     }
   });
 

--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -226,13 +226,16 @@ describe("One-Location workflow deep-link sections", () => {
       }).description,
     ).toBe("Neelesh added you to Family.");
 
-    // Without the Circle name it still names the person.
+    // Without the Circle name it still names the person -- and stops there.
+    // "Neelesh added you to THEIR Circle" put a possessive pronoun directly
+    // after the name it stands for, which is the thing QA read as wrong. The
+    // name has already said whose Circle it is.
     expect(
       locationWorkflowNotificationCopy({
         type: "location_circle_member_added",
         networkLabel: "Neelesh",
       }).description,
-    ).toBe("Neelesh added you to their Circle.");
+    ).toBe("Neelesh added you to a Circle.");
 
     // And with nothing resolvable it degrades to the same neutral label every
     // other One Location line uses -- not to "Someone".

--- a/hushh-webapp/components/app-ui/action-menu.tsx
+++ b/hushh-webapp/components/app-ui/action-menu.tsx
@@ -162,7 +162,12 @@ export function ActionMenu({
   }
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    // Deliberately UNCONTROLLED, with only a callback for the freeze above.
+    // Passing `open` puts a React state round-trip between the keypress and
+    // the menu appearing; Radix otherwise opens inside the same event. A test
+    // that presses Enter and reads the menu on the next line then fails under
+    // load while passing in isolation -- which is exactly what it did.
+    <DropdownMenu onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"

--- a/hushh-webapp/lib/feed/feed-item-renderers.tsx
+++ b/hushh-webapp/lib/feed/feed-item-renderers.tsx
@@ -280,7 +280,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         label: hasWho ? who : "Location",
         person: counterpartPerson(item.metadata, who),
         description: sharedWithMe
-          ? "Added you to their SMS"
+          ? "Added you to SMS Circle"
           : "Added to your SMS Circle",
         href: ROUTES.ONE_LOCATION,
       };
@@ -293,7 +293,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         label: hasWho ? who : "Location",
         person: counterpartPerson(item.metadata, who),
         description: sharedWithMe
-          ? "Removed you from their SMS"
+          ? "Removed you from SMS Circle"
           : "Removed from your SMS",
         href: ROUTES.ONE_LOCATION,
       };
@@ -523,7 +523,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         label: who !== "Someone" ? who : "One Network",
         person: counterpartPerson(item.metadata, who),
         description: sharedWithMe
-          ? "You joined their One Network"
+          ? "You joined the One Network"
           : "Joined your One Network",
         href: buildOneLocationWorkflowHref({ section: "people" }),
       };
@@ -590,7 +590,7 @@ export function presentFeedItem(item: FeedItem): FeedItemPresentation {
         description: addedBy
           ? circleName
             ? `${addedBy} added you to ${circleName}.`
-            : `${addedBy} added you to their Circle.`
+            : `${addedBy} added you to a Circle.`
           : circleName
             ? `You were added to ${circleName}.`
             : "You were added to a Circle.",

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -120,7 +120,7 @@ const WORKFLOW_COPY: Record<
   },
   location_circle_member_invite: {
     title: "Circle invitation",
-    fallbackDescription: "A connection invited you to join their Circle.",
+    fallbackDescription: "A connection invited you to join a Circle.",
   },
   location_circle_member_invite_accepted: {
     title: "Circle invitation accepted",
@@ -131,7 +131,7 @@ const WORKFLOW_COPY: Record<
     // moment the person learns about it. The fallback still says a human did
     // it -- "You were added to a Circle" reads as an intrusion by nobody.
     title: "Added to a Circle",
-    fallbackDescription: "A connection added you to their Circle.",
+    fallbackDescription: "A connection added you to a Circle.",
   },
   location_circle_code_joined: {
     title: "Someone joined your Circle",
@@ -816,7 +816,7 @@ export function locationWorkflowNotificationCopy(params: {
         title: copy.title,
         description: circleName
           ? `${networkLabel} added you to ${circleName}.`
-          : `${networkLabel} added you to their Circle.`,
+          : `${networkLabel} added you to a Circle.`,
       };
     }
     case "location_circle_code_joined":


### PR DESCRIPTION
Closes #6262.

## The report

QA, reading the Feed: *"usage of their with singular subject"*.

A Feed row is **titled with the other person's name**, so a line underneath that
says "added you to **their** Circle" repeats that same person as a pronoun
immediately after naming them. The name has already said whose. Dropping the
pronoun is shorter and says exactly as much.

## Most of this was already done

`8ba80040f` fixed the location-sharing lines — "Shared their location with you"
→ "Shared location with you", "You asked to see their location" → "You asked to
see location". **That is what the screenshot shows**, it is on `main`, and it is
on UAT, so those two rows already read correctly on a current build.

What it did not reach is the Circle and SMS lines — including two this
workstream added last week:

| before | after |
|---|---|
| Added you to their SMS | **Added you to SMS Circle** |
| Removed you from their SMS | **Removed you from SMS Circle** |
| You joined their One Network | **You joined the One Network** |
| `<name>` added you to their Circle. | **`<name>` added you to a Circle.** |
| A connection invited you to join their Circle. | **…to join a Circle.** |
| A connection added you to their Circle. | **…to a Circle.** |

## Deliberately left alone

- **"You'll get their SMS"** on the SMS Circle row. It is the one line where the
  other person is *not* named — the row is titled "SMS Circle" — so the
  possessive is carrying the meaning rather than repeating it.
- **"You gave them more time"**, **"Sharing until they stop"**, **"as long as
  they need"**. Object and subject pronouns, not a possessive sitting beside the
  name; the alternatives lose either the person or the tense.

Singular *they/their* is perfectly good English — the problem here is only that
the pronoun is redundant next to the name. A test now pins the rule for the SMS
rows in both directions, so it cannot come back on the lines that just lost it.

## Also in here

`ActionMenu`'s pointer lane is **uncontrolled** again. Passing Radix an `open`
prop put a React state round-trip between the keypress and the menu appearing,
where Radix otherwise opens inside the same event — a needless delay on the one
path that has to feel instant. The freeze that needs the open state keeps
working through `onOpenChange` alone.

## Verification

| Check | Result |
|---|---|
| `tsc`, `eslint` | clean |
| 14 Feed test files | 103 passed |
| notification suites | 126 passed |
| `verify:one-location` | **710 passed** |
| `verify:feed-notifications` | 183 passed |

Copy-only on the frontend, so **web, iOS and Android** all pick it up from the
same renderer.