### PR TITLE
Refine One Location My Location tab

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1,5 +1,6 @@
 import {
   act,
+  cleanup,
   fireEvent,
   render,
   screen,
@@ -868,7 +869,7 @@ async function openLocationPermissionsStep() {
 }
 
 async function switchLocationTab(
-  name: "Now" | "People" | "Links",
+  name: "My location" | "People" | "Links",
   expectedHeading: string,
 ) {
   fireEvent.click(screen.getByRole("button", { name }));
@@ -953,10 +954,21 @@ describe("OneLocationAgentPage", () => {
     // and every test after it hangs on a clock that never moves -- three
     // unrelated failures from one. Cheap to make impossible.
     vi.useRealTimers();
+    cleanup();
+    document.body.style.pointerEvents = "";
+    document.body.removeAttribute("data-scroll-locked");
+    document
+      .querySelectorAll("[data-radix-focus-guard], [data-aria-hidden]")
+      .forEach((node) => node.remove());
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    document.body.style.pointerEvents = "";
+    document.body.removeAttribute("data-scroll-locked");
+    document
+      .querySelectorAll("[data-radix-focus-guard], [data-aria-hidden]")
+      .forEach((node) => node.remove());
     // The shared store, holding a fix measured now — what a session with a
     // live movement watch looks like, and the precondition for the publisher.
     const busSnapshot = {
@@ -1363,8 +1375,8 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Map$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
     expect(
       screen.getByRole("button", { name: /^Share location$/i }),
     ).toBeTruthy();
@@ -1444,7 +1456,7 @@ describe("OneLocationAgentPage", () => {
 
     expect(screen.queryByText("Active shares")).toBeNull();
     expect(await toneOf("Sharing with you")).toBeUndefined();
-    expect(await toneOf("Needs review")).toBeUndefined();
+    expect(await toneOf("Location requests")).toBeUndefined();
   });
 
   it("renders Needs review with compact request cards and clear approval copy", async () => {
@@ -1472,7 +1484,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     fireEvent.click(
-      await screen.findByRole("button", { name: /Needs review/i }),
+      await screen.findByRole("button", { name: /Location requests/i }),
     );
 
     const flow = await screen.findByTestId("one-location-needs-review");
@@ -1548,7 +1560,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     fireEvent.click(
-      await screen.findByRole("button", { name: /Needs review/i }),
+      await screen.findByRole("button", { name: /Location requests/i }),
     );
 
     const flow = await screen.findByTestId("one-location-needs-review");
@@ -1640,10 +1652,10 @@ describe("OneLocationAgentPage", () => {
       }),
     ).toBeTruthy();
     expect(within(actions).getByText("Ask for location")).toBeTruthy();
-    expect(within(actions).getByText("Check in")).toBeTruthy();
+    expect(within(actions).getByText("Confirm arrival")).toBeTruthy();
     const retiredActionLabel = ["Their", "Location"].join(" ");
     expect(actions.textContent).not.toContain(retiredActionLabel);
-    expect(within(actions).queryByText("Confirm Arrival")).toBeNull();
+    expect(within(actions).queryByText("Check in")).toBeNull();
     expect(within(actions).getByText("Save My Soul")).toBeTruthy();
     expect(within(actions).getByText("Emergency alert")).toBeTruthy();
 
@@ -1658,16 +1670,15 @@ describe("OneLocationAgentPage", () => {
     actionCells?.forEach((cell) => {
       expect(cell.className).toContain("items-center");
       expect(cell.className).toContain("text-center");
-      expect(cell.className).toContain("rounded-[16px]");
-      expect(cell.className).toContain("min-h-[96px]");
-      expect(cell.className).toContain("px-5");
+      expect(cell.className).toContain("min-h-[58px]");
+      expect(cell.className).toContain("px-3");
     });
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("text-[color:var(--app-accent)]");
+    ).toContain("text-[color:var(--app-accent-deep)]");
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("[&>svg]:h-8");
+    ).toContain("[&>svg]:h-6");
     expect(
       actionGrid?.querySelectorAll("[data-one-location-action-icon] svg"),
     ).toHaveLength(2);
@@ -1684,21 +1695,24 @@ describe("OneLocationAgentPage", () => {
     expect(actions.textContent).not.toContain("location_on");
     expect(actions.textContent).not.toContain("where_to_vote");
     expect(actions.querySelector("[data-one-location-sms-row]")).toBeTruthy();
+    expect(
+      actions
+        .querySelector("[data-one-location-sms-row]")
+        ?.querySelector("[data-one-location-action-icon]")?.className,
+    ).toContain("bg-[color:var(--app-destructive)]");
 
     const activity = screen.getByTestId("one-location-now-activity");
     expect(within(activity).getByText("Sharing with you")).toBeTruthy();
-    expect(within(activity).getByText("Needs review")).toBeTruthy();
+    expect(within(activity).getByText("Location requests")).toBeTruthy();
     expect(within(activity).queryByText("Active shares")).toBeNull();
 
     expect(within(activity).queryByText("Share")).toBeNull();
-    const more = screen.getByTestId("one-location-now-more");
-    expect(within(more).getByText("Map")).toBeTruthy();
-    expect(within(more).getByText("Settings")).toBeTruthy();
+    expect(screen.queryByTestId("one-location-now-more")).toBeNull();
     expect(screen.queryByRole("heading", { name: "Activity" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "More" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Map$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
     expect(screen.queryByText("Check-In")).toBeNull();
     expect(screen.queryByText("Quick actions")).toBeNull();
   });
@@ -1735,7 +1749,7 @@ describe("OneLocationAgentPage", () => {
       "leading-[18px]",
       "font-normal",
     );
-    expect(status.textContent).toBe("Location off");
+    expect(status.textContent).toBe("Off");
     // Still the switch's description wherever it renders.
     expect(
       screen
@@ -1747,16 +1761,12 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     const heading = screen.getByRole("heading", { name: "Location" });
-    const headerRow = heading.closest('[data-slot="page-header-row"]');
-    expect(headerRow).toBeTruthy();
-    expect(headerRow).toHaveClass("flex", "justify-between");
-    expect(screen.getByTestId("page-header").className).toContain(
-      "[&_[data-slot=page-header-row]]:!items-center",
-    );
-    expect(heading).toHaveClass("ui-text-agent-title");
+    expect(heading).toHaveClass("sr-only");
+    expect(screen.queryByTestId("page-header")).toBeNull();
+    const accessRow = screen.getByTestId("one-location-access-row");
     expect(screen.getByTestId("one-location-header-icon")).toBeTruthy();
     expect(
-      headerRow?.contains(
+      accessRow.contains(
         screen.getByRole("switch", { name: "Turn location on" }),
       ),
     ).toBe(true);
@@ -1780,7 +1790,7 @@ describe("OneLocationAgentPage", () => {
     // keeps meaning visible without wrapping the title.
     expect(locationStatus.querySelector(".sm\\:hidden")).toBeNull();
     expect(locationStatus.querySelector(".hidden.sm\\:inline")).toBeNull();
-    expect(locationStatus.textContent).toBe("Location off");
+    expect(locationStatus.textContent).toBe("Off");
     expect(locationStatus).not.toHaveAttribute("aria-hidden");
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
@@ -1799,7 +1809,7 @@ describe("OneLocationAgentPage", () => {
       name: "Turn location off",
     });
     expect(locationOnSwitch).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByText("Location on")).toBeTruthy();
+    expect(screen.getByText("On")).toBeTruthy();
 
     fireEvent.click(locationOnSwitch);
     await waitFor(() =>
@@ -1807,7 +1817,7 @@ describe("OneLocationAgentPage", () => {
         screen.getByRole("switch", { name: "Turn location on" }),
       ).toHaveAttribute("aria-checked", "false"),
     );
-    expect(screen.getByText("Location off")).toBeTruthy();
+    expect(screen.getByText("Off")).toBeTruthy();
     expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
@@ -2041,7 +2051,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(
       await screen.findByRole("switch", { name: "Turn location off" }),
     );
-    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
 
     await act(async () => {
       resolveApproval?.({
@@ -2087,9 +2097,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     fireEvent.click(screen.getByRole("switch", { name: "Turn location on" }));
-    await waitFor(() =>
-      expect(screen.getByText("Location limited")).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("Limited")).toBeTruthy());
     expect(
       screen.getByRole("switch", { name: "Turn location off" }),
     ).toHaveAttribute("aria-checked", "true");
@@ -2126,7 +2134,7 @@ describe("OneLocationAgentPage", () => {
     await act(async () => {
       releaseFix();
     });
-    await waitFor(() => expect(screen.getByText("Location on")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("On")).toBeTruthy());
   });
 
   it("does not let a late fix undo a pause made while it was in flight", async () => {
@@ -2143,7 +2151,7 @@ describe("OneLocationAgentPage", () => {
       name: "Turn location off",
     });
     fireEvent.click(onSwitch);
-    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
 
     // The fix belongs to an intent the person has already replaced. Applying it
     // would silently turn location back on after they turned it off.
@@ -2153,7 +2161,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
     ).toHaveAttribute("aria-checked", "false");
-    expect(screen.getByText("Location off")).toBeTruthy();
+    expect(screen.getByText("Off")).toBeTruthy();
   });
 
   it("pauses the device without waiting on, or first probing, nearby presence", async () => {
@@ -2193,7 +2201,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(onSwitch);
 
-    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
     await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalledTimes(1));
     // Still in flight while the device already reads as paused.
     expect(releaseCheckout).not.toBeNull();
@@ -2538,7 +2546,7 @@ describe("OneLocationAgentPage", () => {
     expect(await screen.findByPlaceholderText(/Search people/i)).toHaveValue(
       "Investor",
     );
-    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+    fireEvent.click(screen.getByRole("button", { name: "My location" }));
     fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
@@ -3666,7 +3674,7 @@ describe("OneLocationAgentPage", () => {
     // The header agrees with what the person just did.
     await waitFor(() =>
       expect(screen.getByTestId("one-location-header-status").textContent).toBe(
-        "Location on",
+        "On",
       ),
     );
     expect(
@@ -3777,7 +3785,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText("TB").className).toContain("text-[#6E6E73]");
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+    fireEvent.click(screen.getByRole("button", { name: "My location" }));
     expect(screen.queryByRole("button", { name: /Active shares/i })).toBeNull();
     await openSharePersonStep();
     fireEvent.change(screen.getByPlaceholderText("Search people"), {
@@ -4736,8 +4744,12 @@ describe("OneLocationAgentPage", () => {
     ).toEqual(["15 min", "1 hour", "2 hours", "Custom"]);
 
     // Removed from the face of the ladder, not from the lane.
-    expect(within(ladder).queryByRole("button", { name: "4 hours" })).toBeNull();
-    expect(within(ladder).queryByRole("button", { name: "8 hours" })).toBeNull();
+    expect(
+      within(ladder).queryByRole("button", { name: "4 hours" }),
+    ).toBeNull();
+    expect(
+      within(ladder).queryByRole("button", { name: "8 hours" }),
+    ).toBeNull();
 
     // And Custom still reaches them: one deliberate tap, then the wheel.
     fireEvent.click(within(ladder).getByRole("button", { name: "Custom" }));
@@ -6376,6 +6388,16 @@ describe("OneLocationAgentPage", () => {
         fireEvent.click(change);
       });
 
+      const sheet = await screen.findByTestId(
+        "one-location-live-share-duration-sheet",
+      );
+
+      await act(async () => {
+        fireEvent.click(
+          within(sheet).getByRole("button", { name: "Choose an end time…" }),
+        );
+      });
+
       const editor = await screen.findByTestId(
         "one-location-live-share-duration-editor",
       );
@@ -6415,8 +6437,8 @@ describe("OneLocationAgentPage", () => {
           within(card).getByTestId("one-location-live-share-change-time"),
         );
       });
-      const editor = await screen.findByTestId(
-        "one-location-live-share-duration-editor",
+      const sheet = await screen.findByTestId(
+        "one-location-live-share-duration-sheet",
       );
 
       // "Until I stop" is the largest increase there is, and the direction the
@@ -6425,12 +6447,7 @@ describe("OneLocationAgentPage", () => {
       // a scroll position JSDOM cannot lay out.
       await act(async () => {
         fireEvent.click(
-          within(editor).getByRole("button", { name: "Until I stop" }),
-        );
-      });
-      await act(async () => {
-        fireEvent.click(
-          within(editor).getByTestId("one-location-live-share-duration-save"),
+          within(sheet).getByRole("button", { name: "Until I stop" }),
         );
       });
 
@@ -6452,12 +6469,12 @@ describe("OneLocationAgentPage", () => {
     }
   }, 15000);
 
-  it("offers four common lengths and the open-ended row, one tap each", async () => {
-    // The report (issue #6228): Change time showed too many near-identical
-    // choices -- 15 min / 1 hour / 2 hours / 4 hours / 8 hours / Custom /
-    // Until I stop -- wrapped and left-hugging under the live clock. It is
-    // trimmed to the four common lengths plus the open-ended row; `8 hours`
-    // and the `Custom` wheel are gone.
+  it("offers the common lengths as one tap, with custom time behind a row", async () => {
+    // The report: Change time opened straight onto a two-column scroll wheel.
+    // Almost every change to a running share is one of five lengths, so those
+    // are now always visible and cost one tap each. The wheel is still
+    // reachable for anything in between -- removed from the default view, not
+    // removed.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
     try {
@@ -6471,37 +6488,34 @@ describe("OneLocationAgentPage", () => {
           within(card).getByTestId("one-location-live-share-change-time"),
         );
       });
-      const editor = await screen.findByTestId(
-        "one-location-live-share-duration-editor",
+      const sheet = await screen.findByTestId(
+        "one-location-live-share-duration-sheet",
+      );
+      const quickOptions = within(sheet).getByTestId(
+        "one-location-live-share-duration-quick-options",
       );
 
-      for (const label of [
-        "15 min",
-        "1 hour",
-        "2 hours",
-        "4 hours",
-        "Until I stop",
-      ]) {
+      for (const label of ["30 min", "2 hours", "Until I stop"]) {
         expect(
-          within(editor).getByRole("button", { name: label }),
+          within(quickOptions).getByRole("button", {
+            name: new RegExp(`^${label}`),
+          }),
         ).toBeInTheDocument();
       }
-      // The two choices the issue asked to drop.
       expect(
-        within(editor).queryByRole("button", { name: "8 hours" }),
-      ).toBeNull();
+        within(quickOptions).getByRole("button", {
+          name: "Choose an end time…",
+        }),
+      ).toBeInTheDocument();
       expect(
-        within(editor).queryByRole("button", { name: "Custom" }),
+        within(sheet).queryByTestId("one-location-live-share-duration-save"),
       ).toBeNull();
 
       // One tap on a rung is the whole interaction -- no drag, no confirm
-      // step of its own before Save.
-      await act(async () => {
-        fireEvent.click(within(editor).getByRole("button", { name: "2 hours" }));
-      });
+      // step of its own before the backend update.
       await act(async () => {
         fireEvent.click(
-          within(editor).getByTestId("one-location-live-share-duration-save"),
+          within(quickOptions).getByRole("button", { name: /^2 hours/ }),
         );
       });
 

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -45,8 +45,9 @@ function serverMaxShareHours(): number {
 
 /** Every `{ value: "…", label: "…" }` duration option authored in the hub. */
 function durationOptionsIn(source: string): { value: string; label: string }[] {
-  return [...source.matchAll(/\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)"\s*\}/g)]
-    .map((m) => ({ value: m[1], label: m[2] }));
+  return [
+    ...source.matchAll(/\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)"\s*\}/g),
+  ].map((m) => ({ value: m[1], label: m[2] }));
 }
 
 describe("One Location — link durations stay inside the server's ceiling", () => {
@@ -109,11 +110,15 @@ describe("One Location — link durations stay inside the server's ceiling", () 
     // buttons state how long the link lives, and the card that replaces this
     // block once a link exists carries the concise link visibility line on the
     // object it is about.
-    expect(HUB_SOURCE).not.toContain('title="Anyone with this link can see you"');
+    expect(HUB_SOURCE).not.toContain(
+      'title="Anyone with this link can see you"',
+    );
     expect(HUB_SOURCE).not.toContain("The link stops on its own.");
     expect(HUB_SOURCE).not.toContain("<WarningCard");
     // The surviving statement, on the live link's own card.
-    expect(HUB_SOURCE).toContain("Anyone with this link can see your location.");
+    expect(HUB_SOURCE).toContain(
+      "Anyone with this link can see your location.",
+    );
   });
 
   it("drops the Request sent banner in favour of the toast that already fired", () => {
@@ -150,9 +155,9 @@ describe("One Location — link durations stay inside the server's ceiling", () 
 describe("One Location — hub tab naming", () => {
   const locationTabs = TOP_SHELL_TAB_REGISTRY.location;
 
-  it("labels the first tab Now while keeping its `now` query value", () => {
+  it("labels the first tab My location while keeping its `now` query value", () => {
     const first = locationTabs.tabs[0];
-    expect(first.label).toBe("Now");
+    expect(first.label).toBe("My location");
     // The value is the deep-link contract (`?view=now`, Kai's
     // `location.open_now`). Renaming the label must not move it.
     expect(first.value).toBe("now");
@@ -168,7 +173,9 @@ describe("One Location — People actions stay reachable and single-flight", () 
   const ACTION_MENU_SOURCE = repoFile("components/app-ui/action-menu.tsx");
 
   it("keeps Find contacts listed and merely disabled while syncing", () => {
-    const start = HUB_SOURCE.indexOf('voiceControlId: "one-location-find-contacts"');
+    const start = HUB_SOURCE.indexOf(
+      'voiceControlId: "one-location-find-contacts"',
+    );
     expect(start).toBeGreaterThan(-1);
     const addPeopleMenu = HUB_SOURCE.slice(start - 900, start + 200);
 
@@ -195,7 +202,9 @@ describe("One Location — People actions stay reachable and single-flight", () 
     expect(ACTION_MENU_SOURCE).toContain("useIsMobile");
     // And the presentation is frozen while open, so a rotation cannot remount
     // the menu under the hand using it.
-    expect(ACTION_MENU_SOURCE).toContain("if (!open) setSheetPresentation(isMobile);");
+    expect(ACTION_MENU_SOURCE).toContain(
+      "if (!open) setSheetPresentation(isMobile);",
+    );
   });
 });
 
@@ -308,7 +317,7 @@ describe("One Location — the Share confirm step is a measured column", () => {
 
     // The nested branch inherits the container's rounding rather than
     // asserting one of its own.
-    expect(page).toContain('nested');
+    expect(page).toContain("nested");
     expect(page).toContain('"rounded-[inherit]"');
     // ...and the standalone branch keeps the card it is.
     expect(page).toContain(

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -26,9 +26,9 @@ describe("One Location settings placement", () => {
   });
 
   it("offers Ask for location inside the compact Now actions", () => {
-    // Request location is an action, not status or utility. The compact Now
-    // tab shows Ask, Check in, SMS, count-backed Activity rows, and the quiet
-    // More rows without dashboard section labels or the old active-shares row.
+    // Request location is an action, not status or utility. The My Location
+    // tab shows Ask, Confirm arrival, SMS, and only count-backed incoming rows
+    // without dashboard section labels or the old active-shares row.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
@@ -36,6 +36,7 @@ describe("One Location settings placement", () => {
     expect(nowSource).toContain('data-testid="one-location-now-actions"');
     expect(nowSource).toContain('testId: "one-location-request-row"');
     expect(nowSource).toContain('title: "Ask for location"');
+    expect(nowSource).toContain('title: "Confirm arrival"');
     expect(nowSource).toContain('title: "Save My Soul"');
 
     const actionsIndex = nowSource.indexOf("LocationActionGrid");
@@ -45,9 +46,9 @@ describe("One Location settings placement", () => {
     expect(actionsIndex).toBeGreaterThan(-1);
     expect(requestIndex).toBeGreaterThan(actionsIndex);
     expect(activityIndex).toBeGreaterThan(requestIndex);
-    expect(moreIndex).toBeGreaterThan(activityIndex);
-    expect(nowSource).toContain('title: "Map"');
-    expect(nowSource).toContain('title: "Settings"');
+    expect(moreIndex).toBe(-1);
+    expect(nowSource).not.toContain('title: "Map"');
+    expect(nowSource).not.toContain('title: "Settings"');
     expect(nowSource).not.toContain('title: "Active shares"');
     expect(nowSource).not.toContain("LocationNowGroupLabel");
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -678,7 +678,8 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
 // cap and lose ties to whichever SUBVIEW_ACTION_BOOST entry matches the
 // current subview) -- this only changes what becomes a CANDIDATE, not how
 // candidates are ranked once the list is bigger.
-export const LOCATION_VOICE_ACTIONS = deriveLocationVoiceActions("one_location");
+export const LOCATION_VOICE_ACTIONS =
+  deriveLocationVoiceActions("one_location");
 
 const LOCATION_VOICE_CONTROLS = [
   {
@@ -2636,6 +2637,7 @@ export function OneLocationAgentPageContent({
   const savedLocationSessionEpochRef = useRef(0);
   const savedLocationPointUserIdRef = useRef<string | null>(null);
   const locationOnboardingRetryOnResumeRef = useRef(false);
+  const locationPermissionRefreshTimeoutRef = useRef<number | null>(null);
   const notificationOnboardingAttemptRef = useRef(false);
 
   useEffect(() => {
@@ -3172,8 +3174,8 @@ export function OneLocationAgentPageContent({
   );
   const rankedRecipients = useMemo(() => {
     const ranked = rankRecipientsForRecommendation(
-        contactSignalRecipients,
-        contactMatchedUserIds,
+      contactSignalRecipients,
+      contactMatchedUserIds,
     );
     // Every paged row came through the same vault-authorized recipient route.
     // Retain it by user id so selecting page 2, then changing search, does not
@@ -3184,7 +3186,7 @@ export function OneLocationAgentPageContent({
         [...pagedRecipientsByUserId.values()],
         contactMatchedUserIds,
       ),
-  );
+    );
   }, [contactMatchedUserIds, contactSignalRecipients, pagedRecipientsByUserId]);
   const shareRecipientPool = useMemo(
     () =>
@@ -3243,9 +3245,9 @@ export function OneLocationAgentPageContent({
             contactMatchedUserIds,
           )
         : filterPeopleByQuery(
-        rankedRecipients,
-        shareRecipientSearch,
-        recipientLabel,
+            rankedRecipients,
+            shareRecipientSearch,
+            recipientLabel,
           ).slice(0, 50),
     [
       contactMatchedUserIds,
@@ -4059,6 +4061,25 @@ export function OneLocationAgentPageContent({
     return nextPermission;
   }, []);
 
+  const clearDelayedLocationPermissionRefresh = useCallback(() => {
+    if (locationPermissionRefreshTimeoutRef.current === null) return;
+    window.clearTimeout(locationPermissionRefreshTimeoutRef.current);
+    locationPermissionRefreshTimeoutRef.current = null;
+  }, []);
+
+  const scheduleDelayedLocationPermissionRefresh = useCallback(() => {
+    clearDelayedLocationPermissionRefresh();
+    locationPermissionRefreshTimeoutRef.current = window.setTimeout(() => {
+      locationPermissionRefreshTimeoutRef.current = null;
+      void refreshLocationPermission();
+    }, 1200);
+  }, [clearDelayedLocationPermissionRefresh, refreshLocationPermission]);
+
+  useEffect(
+    () => () => clearDelayedLocationPermissionRefresh(),
+    [clearDelayedLocationPermissionRefresh],
+  );
+
   const handleOpenLocationSettings = useCallback(async () => {
     setBusy("locationSettings");
     try {
@@ -4076,9 +4097,9 @@ export function OneLocationAgentPageContent({
       );
     } finally {
       setBusy(null);
-      window.setTimeout(() => void refreshLocationPermission(), 1200);
+      scheduleDelayedLocationPermissionRefresh();
     }
-  }, [refreshLocationPermission]);
+  }, [scheduleDelayedLocationPermissionRefresh]);
 
   const ensureForegroundLocationReady = useCallback(
     async (options?: {
@@ -6532,58 +6553,64 @@ export function OneLocationAgentPageContent({
     setLiveShareDurationEditing(true);
   }, [activeOwnerGrants, liveShareStatus?.stoppableGrantId]);
 
-  const handleSaveLiveShareDuration = useCallback(async () => {
-    const grantId = liveShareStatus?.stoppableGrantId;
-    if (!vaultOwnerToken || !grantId) return;
-    const grant = activeOwnerGrants.find((row) => row.id === grantId);
-    const untilStopped = liveShareDurationHours === "until_stopped";
-    const durationHours = untilStopped ? null : Number(liveShareDurationHours);
+  const handleSaveLiveShareDuration = useCallback(
+    async (nextValue?: string) => {
+      const grantId = liveShareStatus?.stoppableGrantId;
+      if (!vaultOwnerToken || !grantId) return;
+      const grant = activeOwnerGrants.find((row) => row.id === grantId);
+      const effectiveDurationHours = nextValue ?? liveShareDurationHours;
+      const untilStopped = effectiveDurationHours === "until_stopped";
+      const durationHours = untilStopped
+        ? null
+        : Number(effectiveDurationHours);
 
-    // Save on a wheel still showing what the share already has left is not a
-    // change. Sending it anyway spends a round trip, writes an audit row, and
-    // pushes the recipient an alert about a time that did not move.
-    if (
-      durationHours !== null &&
-      grant?.durationMode !== "until_stopped" &&
-      grantDurationEditIntent({
-        grant,
-        durationHours,
-        nowMs: Date.now(),
-      }) === "unchanged"
-    ) {
-      setLiveShareDurationEditing(false);
-      return;
-    }
+      // Save on a wheel still showing what the share already has left is not a
+      // change. Sending it anyway spends a round trip, writes an audit row, and
+      // pushes the recipient an alert about a time that did not move.
+      if (
+        durationHours !== null &&
+        grant?.durationMode !== "until_stopped" &&
+        grantDurationEditIntent({
+          grant,
+          durationHours,
+          nowMs: Date.now(),
+        }) === "unchanged"
+      ) {
+        setLiveShareDurationEditing(false);
+        return;
+      }
 
-    setLiveShareDurationSaving(true);
-    try {
-      await OneLocationService.setGrantDuration({
-        vaultOwnerToken,
-        grantId,
-        durationHours,
-        durationMode: untilStopped ? "until_stopped" : "timed",
-      });
-      toast.success("Time updated.");
-      setLiveShareDurationEditing(false);
-      // Held until the list has reconciled, so the card's countdown is already
-      // reading the new expiry when the editor closes.
-      await refresh({ background: true }).catch(() => null);
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Couldn't change the time. Try again.",
-      );
-    } finally {
-      setLiveShareDurationSaving(false);
-    }
-  }, [
-    activeOwnerGrants,
-    liveShareDurationHours,
-    liveShareStatus?.stoppableGrantId,
-    refresh,
-    vaultOwnerToken,
-  ]);
+      setLiveShareDurationSaving(true);
+      try {
+        await OneLocationService.setGrantDuration({
+          vaultOwnerToken,
+          grantId,
+          durationHours,
+          durationMode: untilStopped ? "until_stopped" : "timed",
+        });
+        toast.success("Time updated.");
+        setLiveShareDurationEditing(false);
+        // Held until the list has reconciled, so the card's countdown is already
+        // reading the new expiry when the editor closes.
+        await refresh({ background: true }).catch(() => null);
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Couldn't change the time. Try again.",
+        );
+      } finally {
+        setLiveShareDurationSaving(false);
+      }
+    },
+    [
+      activeOwnerGrants,
+      liveShareDurationHours,
+      liveShareStatus?.stoppableGrantId,
+      refresh,
+      vaultOwnerToken,
+    ],
+  );
 
   // A share that ends, or a second share starting, takes the single grant this
   // editor was opened against out from under it. Closing is the honest answer:
@@ -7087,25 +7114,25 @@ export function OneLocationAgentPageContent({
                     onClick: () => void handleSyncContactSignalRef.current?.(),
                   },
                 }
-            : outcome.remedy === "invite"
-              ? {
-                  action: {
-                    label: "Invite them",
-                    // The other half of a contact scan. Until now the count of
-                    // people who are NOT on One was computed on every sync and
-                    // read by nothing but an analytics dimension — the product
-                    // learned who was missing, recorded it, and offered the
-                    // person no way to act on it.
-                    //
-                    // Reuses the existing invite share rather than minting a
-                    // second one, and deliberately carries no pre-authorized
-                    // connection: `buildInviteToOneShare` documents why, and
-                    // an invite that consents on the recipient's behalf is not
-                    // an invite.
-                    onClick: () => void handleInviteContactCandidates(),
-                  },
-                }
-              : {}),
+              : outcome.remedy === "invite"
+                ? {
+                    action: {
+                      label: "Invite them",
+                      // The other half of a contact scan. Until now the count of
+                      // people who are NOT on One was computed on every sync and
+                      // read by nothing but an analytics dimension — the product
+                      // learned who was missing, recorded it, and offered the
+                      // person no way to act on it.
+                      //
+                      // Reuses the existing invite share rather than minting a
+                      // second one, and deliberately carries no pre-authorized
+                      // connection: `buildInviteToOneShare` documents why, and
+                      // an invite that consents on the recipient's behalf is not
+                      // an invite.
+                      onClick: () => void handleInviteContactCandidates(),
+                    },
+                  }
+                : {}),
       };
       if (result.matchedUserIds.length > 0) {
         toast.success(outcome.title, outcomeOptions);
@@ -7228,7 +7255,9 @@ export function OneLocationAgentPageContent({
             vaultOwnerToken: activeVaultOwnerToken,
             ownerUserId: owner.userId,
             message: buildOneLocationRequestMessage(reason, requestMessage),
-            requestedDurationHours: Number(durationHoursOverride ?? durationHours),
+            requestedDurationHours: Number(
+              durationHoursOverride ?? durationHours,
+            ),
             requestedDurationMode: "timed",
           });
           successCount += 1;
@@ -12297,9 +12326,9 @@ export function OneLocationAgentPageContent({
       try {
         const preference = await OneLocationService.updateAutoApprovePreference(
           {
-          vaultOwnerToken,
-          enabled,
-          scope: enabled ? (input.scope ?? null) : null,
+            vaultOwnerToken,
+            enabled,
+            scope: enabled ? (input.scope ?? null) : null,
           },
         );
         // The PATCH result is the authority. Keep it visible even when the
@@ -12423,8 +12452,8 @@ export function OneLocationAgentPageContent({
         ? "Allow location in your browser's site settings (lock icon in the address bar), then try again."
         : "Turn on phone Location, then return to continue.",
     );
-    window.setTimeout(() => void refreshLocationPermission(), 1200);
-  }, [refreshLocationPermission]);
+    scheduleDelayedLocationPermissionRefresh();
+  }, [scheduleDelayedLocationPermissionRefresh]);
 
   const openAppSettingsForOnboarding = useCallback(async () => {
     locationOnboardingRetryOnResumeRef.current = true;
@@ -12434,8 +12463,8 @@ export function OneLocationAgentPageContent({
         ? "Allow location for this site in your browser settings, then try again."
         : "Allow Location for One in Settings, then return.",
     );
-    window.setTimeout(() => void refreshLocationPermission(), 1200);
-  }, [refreshLocationPermission]);
+    scheduleDelayedLocationPermissionRefresh();
+  }, [scheduleDelayedLocationPermissionRefresh]);
 
   // The "Save this place" step must appear on EVERY Location onboarding run once
   // access is ready — even if the owner discarded a previous onboarding or has
@@ -13404,7 +13433,7 @@ export function OneLocationAgentPageContent({
     liveShareDurationSaving,
     onEditLiveShareDurationStart: handleEditLiveShareDurationStart,
     onEditLiveShareDurationCancel: () => setLiveShareDurationEditing(false),
-    onSaveLiveShareDuration: () => void handleSaveLiveShareDuration(),
+    onSaveLiveShareDuration: handleSaveLiveShareDuration,
     onRequestMoreTime: handleRequestMoreTime,
     onCreatePublicInvite: () => void handleCreatePublicInvite(),
     onCopyPublicInvite: handleCopyPublicInvite,

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -22,7 +22,9 @@ function status(overrides: Partial<LiveShareStatus> = {}): LiveShareStatus {
 }
 
 function countdown(): string {
-  return screen.getByTestId("one-location-live-share-countdown").textContent ?? "";
+  return (
+    screen.getByTestId("one-location-live-share-countdown").textContent ?? ""
+  );
 }
 
 describe("LiveShareStatusCard", () => {
@@ -170,7 +172,11 @@ describe("LiveShareStatusCard", () => {
 
     rerender(
       <LiveShareStatusCard
-        status={status({ count: 3, names: ["A", "B", "C"], stoppableGrantId: null })}
+        status={status({
+          count: 3,
+          names: ["A", "B", "C"],
+          stoppableGrantId: null,
+        })}
         onManage={onManage}
       />,
     );
@@ -230,7 +236,8 @@ describe("LiveShareStatusCard", () => {
     expect(screen.getByText(/^Ends /)).toBeTruthy();
     const shareMore = screen.getByRole("button", { name: "Share with more" });
     expect(
-      (shareMore.compareDocumentPosition(change) & Node.DOCUMENT_POSITION_FOLLOWING) !==
+      (shareMore.compareDocumentPosition(change) &
+        Node.DOCUMENT_POSITION_FOLLOWING) !==
         0,
     ).toBe(true);
   });
@@ -280,7 +287,11 @@ describe("LiveShareStatusCard", () => {
     // referent, and the card must not offer to act on an unnamed one.
     render(
       <LiveShareStatusCard
-        status={status({ count: 3, names: ["A", "B", "C"], stoppableGrantId: null })}
+        status={status({
+          count: 3,
+          names: ["A", "B", "C"],
+          stoppableGrantId: null,
+        })}
         onManage={vi.fn()}
       />,
     );

--- a/hushh-webapp/components/one-location/redesign/live-share-card-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/live-share-card-layout.ts
@@ -11,8 +11,8 @@
  * control inside a 320px phone without clipping any of them.
  */
 
-/** Card body. The running-share card stays compact on the Now hub. */
-export const LIVE_SHARE_CARD_CLASSNAME = "overflow-hidden p-4";
+/** Card body. `overflow-hidden` clips the progress fill to the rounded corner. */
+export const LIVE_SHARE_CARD_CLASSNAME = "overflow-hidden p-4 sm:p-5";
 
 /**
  * Badge on the left, the one action on the right, sharing a centreline — the
@@ -33,15 +33,21 @@ export const LIVE_SHARE_ACTION_CLASSNAME =
  * hides the one fact the card exists to state.
  */
 export const LIVE_SHARE_TITLE_CLASSNAME =
-  "mt-3 text-[17px] font-semibold leading-[22px] text-foreground [overflow-wrap:anywhere]";
+  "text-[17px] font-semibold leading-[22px] text-foreground [overflow-wrap:anywhere]";
 
-/** The remaining time and wall-clock end read as one sentence. */
+/** Compact metadata row: the timer is information, not the whole screen. */
 export const LIVE_SHARE_CLOCK_ROW_CLASSNAME =
-  "mt-1 flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[15px] leading-[20px] text-[color:var(--app-secondary-label)]";
+  "mt-0.5 flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[15px] leading-5 text-[color:var(--app-secondary-label)]";
 
 /** `tabular-nums` keeps the width fixed as the digits change, so it cannot jitter. */
 export const LIVE_SHARE_CLOCK_CLASSNAME =
-  "font-semibold text-foreground tabular-nums";
+  "font-medium text-[color:var(--app-primary-label)] tabular-nums";
+
+export const LIVE_SHARE_PROGRESS_TRACK_CLASSNAME =
+  "mt-3 h-1 w-full overflow-hidden rounded-full bg-black/[0.07] dark:bg-white/[0.12]";
+
+export const LIVE_SHARE_PROGRESS_FILL_CLASSNAME =
+  "h-full rounded-full bg-emerald-500 transition-[width] duration-500 ease-linear";
 
 export const LIVE_SHARE_FOOTER_CLASSNAME = "min-w-0 [overflow-wrap:anywhere]";
 
@@ -50,4 +56,4 @@ export const LIVE_SHARE_FOOTER_CLASSNAME = "min-w-0 [overflow-wrap:anywhere]";
  * one obvious next action and one quieter editing affordance.
  */
 export const LIVE_SHARE_FOOTER_ROW_CLASSNAME =
-  "mt-3 flex flex-col gap-2";
+  "mt-3 flex flex-wrap items-center justify-end gap-x-3 gap-y-1";

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -36,6 +36,8 @@ import {
   LIVE_SHARE_FOOTER_CLASSNAME,
   LIVE_SHARE_FOOTER_ROW_CLASSNAME,
   LIVE_SHARE_HEADER_CLASSNAME,
+  LIVE_SHARE_PROGRESS_FILL_CLASSNAME,
+  LIVE_SHARE_PROGRESS_TRACK_CLASSNAME,
   LIVE_SHARE_TITLE_CLASSNAME,
 } from "./live-share-card-layout";
 import { CARD_SURFACE } from "./tokens";
@@ -70,7 +72,10 @@ export function ShareCountdownText({
 }) {
   const endsAtMs = parseTimestamp(expiresAt ?? null);
   const rough = endsAtMs === null ? 0 : endsAtMs - Date.now();
-  const nowMs = useShareClock(endsAtMs !== null, rough > HOUR_MS ? 15_000 : 1_000);
+  const nowMs = useShareClock(
+    endsAtMs !== null,
+    rough > HOUR_MS ? 15_000 : 1_000,
+  );
 
   if (endsAtMs === null) return <span className={className}>Active</span>;
   const remainingMs = endsAtMs - nowMs;
@@ -93,6 +98,55 @@ export function liveShareTitle(status: LiveShareStatus): string {
   const count = Math.max(status.names.length, status.count, 1);
   if (count === 1) return "Sharing with 1 person";
   return `Sharing with ${count} people`;
+}
+
+function initialsForName(name: string): string {
+  return (
+    name
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase())
+      .join("") || "1"
+  );
+}
+
+function LiveShareIdentity({ status }: { status: LiveShareStatus }) {
+  const names = status.names.filter(Boolean);
+  if (status.count > 1 || names.length > 1) {
+    const visibleNames = names.slice(0, 3);
+    const fallbackCount = Math.min(status.count, 3);
+    const slots = visibleNames.length
+      ? visibleNames
+      : Array.from({ length: fallbackCount }, (_, index) => `${index + 1}`);
+    const remaining = Math.max(status.count - slots.length, 0);
+    return (
+      <span aria-hidden="true" className="flex h-10 w-14 shrink-0 items-center">
+        {slots.map((name, index) => (
+          <span
+            key={`${name}-${index}`}
+            className="-ml-2 first:ml-0 inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-secondary-surface)] text-[12px] font-semibold text-[color:var(--app-secondary-label)] ring-2 ring-[color:var(--app-primary-surface)]"
+          >
+            {initialsForName(name)}
+          </span>
+        ))}
+        {remaining > 0 ? (
+          <span className="-ml-2 inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-secondary-surface)] text-[11px] font-semibold text-[color:var(--app-secondary-label)] ring-2 ring-[color:var(--app-primary-surface)]">
+            +{remaining}
+          </span>
+        ) : null}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-secondary-surface)] text-[13px] font-semibold text-[color:var(--app-secondary-label)] ring-1 ring-inset ring-[color:var(--app-separator)]"
+    >
+      {initialsForName(names[0] ?? "1")}
+    </span>
+  );
 }
 
 export function LiveShareStatusCard({
@@ -131,11 +185,21 @@ export function LiveShareStatusCard({
   // Seconds only matter inside the last hour. Above that they are noise, and a
   // once-a-second re-render for a 24-hour share is waste.
   const rough = endsAtMs !== null ? endsAtMs - Date.now() : 0;
-  const nowMs = useShareClock(true, !openEnded && rough > HOUR_MS ? 15_000 : 1_000);
+  const nowMs = useShareClock(
+    true,
+    !openEnded && rough > HOUR_MS ? 15_000 : 1_000,
+  );
 
   const remainingMs = endsAtMs === null ? null : endsAtMs - nowMs;
   const elapsedMs = startedAtMs === null ? 0 : Math.max(0, nowMs - startedAtMs);
   const ended = remainingMs !== null && remainingMs <= 0;
+  const progress =
+    startedAtMs !== null && endsAtMs !== null && endsAtMs > startedAtMs
+      ? Math.min(
+          1,
+          Math.max(0, (nowMs - startedAtMs) / (endsAtMs - startedAtMs)),
+        )
+      : null;
 
   // Fires once per share window. The page reconciles against the server from
   // here, so a share that runs out while the screen is open clears itself
@@ -252,54 +316,69 @@ export function LiveShareStatusCard({
         )}
       </div>
 
-      <p
-        data-ui-contract="required-copy"
-        data-ui-id="location-live-share-title"
-        data-ui-truncation="forbid"
-        data-ui-role="label"
-        className={LIVE_SHARE_TITLE_CLASSNAME}
-      >
-        {title}
-      </p>
+      <div className="mt-3 flex items-start gap-3">
+        <LiveShareIdentity status={status} />
+        <div className="min-w-0 flex-1">
+          <p
+            data-ui-contract="required-copy"
+            data-ui-id="location-live-share-title"
+            data-ui-truncation="forbid"
+            data-ui-role="label"
+            className={LIVE_SHARE_TITLE_CLASSNAME}
+          >
+            {title}
+          </p>
 
-      <p
-        className={LIVE_SHARE_CLOCK_ROW_CLASSNAME}
-        data-ui-contract="required-copy"
-        data-ui-id="location-live-share-time-summary"
-        data-ui-truncation="forbid"
-      >
-        <span
-          // The visible clock changes every second; a live region here would
-          // announce it every second too. The sentence below carries the value
-          // for assistive tech instead, at a pace a person can follow.
-          aria-hidden="true"
-          data-ui-contract="required-copy"
-          data-ui-id="location-live-share-countdown"
-          data-ui-truncation="forbid"
-          data-testid="one-location-live-share-countdown"
-          className={LIVE_SHARE_CLOCK_CLASSNAME}
-        >
-          {clock}
-        </span>
-        <span aria-hidden="true" className="shrink-0">
-          {openEnded ? "so far" : "left"}
-        </span>
-        {footer ? (
-          <>
-            <span aria-hidden="true" className="shrink-0">
-              ·
-            </span>
+          <p className={LIVE_SHARE_CLOCK_ROW_CLASSNAME}>
             <span
+              // The visible clock changes every second; a live region here would
+              // announce it every second too. The sentence below carries the value
+              // for assistive tech instead, at a pace a person can follow.
               aria-hidden="true"
-              data-ui-id="location-live-share-ends"
-              className={cn(LIVE_SHARE_FOOTER_CLASSNAME, "min-w-0")}
+              data-ui-contract="required-copy"
+              data-ui-id="location-live-share-countdown"
+              data-ui-truncation="forbid"
+              data-testid="one-location-live-share-countdown"
+              className={LIVE_SHARE_CLOCK_CLASSNAME}
             >
-              {footer}
+              {clock}
             </span>
-          </>
-        ) : null}
-        <span className="sr-only">{spoken}</span>
-      </p>
+            <span aria-hidden="true" className="shrink-0">
+              {openEnded ? "so far" : "left"}
+            </span>
+            {footer ? (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="text-[color:var(--app-tertiary-label)]"
+                >
+                  ·
+                </span>
+                <span
+                  data-ui-contract="required-copy"
+                  data-ui-id="location-live-share-ends"
+                  data-ui-truncation="forbid"
+                  data-ui-role="description"
+                  className={LIVE_SHARE_FOOTER_CLASSNAME}
+                >
+                  {footer}
+                </span>
+              </>
+            ) : null}
+            <span className="sr-only">{spoken}</span>
+          </p>
+        </div>
+      </div>
+
+      {progress !== null ? (
+        <div aria-hidden="true" className={LIVE_SHARE_PROGRESS_TRACK_CLASSNAME}>
+          <div
+            data-testid="one-location-live-share-progress"
+            className={LIVE_SHARE_PROGRESS_FILL_CLASSNAME}
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
+        </div>
+      ) : null}
 
       {onShareMore ? (
         <Button

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -74,7 +74,6 @@ import {
 import { ActionMenu } from "@/components/app-ui/action-menu";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { TopShellTabs } from "@/components/app-ui/top-shell-tabs";
 import {
   Dialog,
   DialogContent,
@@ -85,13 +84,11 @@ import {
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
-import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   ButtonLabel,
   CardTitle,
   FormLabel,
   MediumRowLabel,
-  PageTitle,
   PageSubtitle,
   RowDescription,
   RowLabel,
@@ -117,7 +114,6 @@ import type {
   OneLocationShareDurationMode,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
-import { locationStatusLabel } from "@/lib/one-location/location-readiness";
 import {
   isCircleSelectionFullySelected,
   type CircleRecipientSelection,
@@ -132,7 +128,7 @@ import {
   TaskFlowHeader,
   TrustNoteCard,
 } from "./primitives";
-import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
+import { MUTED_TEXT } from "./tokens";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
 import {
   initialsFrom,
@@ -165,10 +161,7 @@ import {
   REQUEST_DURATION_LADDER,
 } from "./duration-presets";
 import { approveShorterDurationOptions } from "@/lib/one-location/approve-duration-options";
-import {
-  AskForMoreTime,
-  type RequestMoreTimeHours,
-} from "./request-more-time";
+import { AskForMoreTime, type RequestMoreTimeHours } from "./request-more-time";
 import {
   LiveShareStatusCard,
   ShareCountdownText,
@@ -490,7 +483,7 @@ export type LocationHubViewModel = {
    * block above asks someone else for more of location, this one revises
    * your own, so it applies straight away and never turns into a request.
    */
-  /** True while the live share card's inline time editor is open. */
+  /** True while the live share card's compact time sheet is open. */
   liveShareDurationEditing: boolean;
   /** Wheel value, in decimal hours, or "until_stopped". */
   liveShareDurationHours: string;
@@ -498,7 +491,7 @@ export type LocationHubViewModel = {
   liveShareDurationSaving: boolean;
   onEditLiveShareDurationStart: () => void;
   onEditLiveShareDurationCancel: () => void;
-  onSaveLiveShareDuration: () => void;
+  onSaveLiveShareDuration: (nextValue?: string) => void | Promise<void>;
   onCreatePublicInvite: () => void;
   onCopyPublicInvite: () => boolean | Promise<boolean>;
   onSharePublicInvite: () => void;
@@ -836,16 +829,11 @@ const LOCATION_HEADER_STATUS_ID = "one-location-header-status";
 /** What the header switch currently means, in words. */
 function locationHeaderStatusText(vm: LocationHubViewModel): string {
   if (vm.locationAcquiring) return "Finding you\u2026";
-  return locationStatusLabel({
-    readiness: vm.locationBlocked
-      ? ("blocked" as const)
-      : vm.locationEnabled
-        ? ("ready" as const)
-        : ("askable" as const),
-    previewOn: vm.locationEnabled,
-    paused: vm.locationPaused,
-    accuracyLimited: vm.locationAccuracyLimited,
-  });
+  if (vm.locationBlocked) return "Blocked";
+  if (!vm.locationEnabled) return "Off";
+  if (vm.locationPaused) return "Paused";
+  if (vm.locationAccuracyLimited && vm.locationEnabled) return "Limited";
+  return "On";
 }
 
 /** The header switch status sits under the switch without becoming a page subtitle. */
@@ -1539,41 +1527,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   /* ----------------------------------------------------------------- */
   return (
     <div className="space-y-4 sm:space-y-5">
-      <PageHeader
-        title={
-          <PageTitle as="span">
-            Location
-          </PageTitle>
-        }
-        leading={<LocationHeaderIconTile />}
-        accent="location"
-        titleRole="agent"
-        actionsInlineMobile
-        actions={<LocationHeaderActions vm={vm} />}
-        className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center"
-      />
-
-      {/*
-        Directly under the header, above the tabs, because a blocked permission
-        is not a detail of one tab — it is the reason every Location feature
-        below is inert. It used to be announced only by the word "blocked" in
-        the header status and a toast that had already gone, which is how
-        someone ended up on this screen with nothing to act on.
-      */}
-      <LocationPermissionRecoveryCard
-        blocked={vm.locationBlocked}
-        busy={vm.locationAcquiring}
-        onRetry={vm.onShowMyLocation}
-        onOpenSettings={vm.onOpenLocationSettings}
-      />
-
-      <TopShellTabs
-        tabSet={{
-          ...LOCATION_TAB_DEFINITION,
-          activeValue: tab,
-        }}
-      />
-
+      <h1 className="sr-only">Location</h1>
       <div className="-mx-[var(--page-inline-gutter-standard)]">
         <SwipeViews
           tabSetId={LOCATION_TAB_DEFINITION.id}
@@ -1590,21 +1544,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                 vm.clearNamedCircleShareContext();
                 openShareFlow();
               }}
-              onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
-              // The app's own Location settings, not the OS permission
-              // screen. This tile carries voiceActionId
-              // "location.open_settings", a route action to
-              // ?action=settings -- so asking for it by voice already
-              // opened the right screen while tapping it left the app
-              // entirely. onOpenLocationSettings stays where it belongs:
-              // the permission recovery cards, whose whole job is sending
-              // someone to the OS to grant access.
-              onOpenSettings={() => openFlow("settings")}
-              onCheckIn={() =>
-                nearbyCheckInAvailable
-                  ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)
-                  : openFlow("check-in")
-              }
+              onCheckIn={() => openFlow("check-in")}
               onSos={() => openFlow("sos")}
               onOpenActiveShares={() => openFlow("active-shares")}
               onOpenSharedWithMe={() => openFlow("shared-with-me")}
@@ -1666,8 +1606,6 @@ function NowHub({
   onStartShare,
   onCheckIn,
   onSos,
-  onOpenMap,
-  onOpenSettings,
   onOpenActiveShares,
   onOpenSharedWithMe,
   onOpenNeedsReview,
@@ -1677,8 +1615,6 @@ function NowHub({
   onStartShare: () => void;
   onCheckIn: () => void;
   onSos: () => void;
-  onOpenMap: () => void;
-  onOpenSettings: () => void;
   onOpenActiveShares: () => void;
   onOpenSharedWithMe: () => void;
   onOpenNeedsReview: () => void;
@@ -1696,35 +1632,24 @@ function NowHub({
     },
     {
       leading: <LocationMenuListIcon name="review" />,
-      title: "Needs review",
+      title: "Location requests",
       value: vm.pendingOwnerRequests.length,
-      ariaLabel: "Needs review",
+      ariaLabel: "Location requests",
       onClick: onOpenNeedsReview,
       voiceControlId: "one-location-action-needs-review",
       voiceActionId: "location.open_needs_review",
     },
   ].filter((row) => row.value > 0);
-  const moreRows = [
-    {
-      leading: <LocationMenuListIcon name="map" />,
-      title: "Map",
-      ariaLabel: "Map",
-      onClick: onOpenMap,
-      voiceControlId: "one-location-action-map",
-      voiceActionId: "location.open_map",
-    },
-    {
-      leading: <LocationMenuListIcon name="settings" />,
-      title: "Settings",
-      ariaLabel: "Settings",
-      onClick: onOpenSettings,
-      voiceControlId: "one-location-action-settings",
-      voiceActionId: "location.open_settings",
-    },
-  ];
 
   return (
     <div className="space-y-3" data-testid="one-location-now-hub">
+      <LocationAccessRow vm={vm} />
+      <LocationPermissionRecoveryCard
+        blocked={vm.locationBlocked}
+        busy={vm.locationAcquiring}
+        onRetry={vm.onShowMyLocation}
+        onOpenSettings={vm.onOpenLocationSettings}
+      />
       {/* Sharing is the one thing on this screen that keeps running after you
           leave it, so it reports itself first and keeps its own clock. */}
       {vm.liveShare ? (
@@ -1751,34 +1676,16 @@ function NowHub({
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
-      <Dialog
-        open={Boolean(vm.liveShare && vm.liveShareDurationEditing)}
-        onOpenChange={(open) => {
-          if (!open) vm.onEditLiveShareDurationCancel();
-        }}
-      >
-        <DialogContent
-          className="max-w-[min(420px,calc(100%-2rem))] gap-4 rounded-[24px] p-4 sm:max-w-[420px]"
-          showCloseButton={!vm.liveShareDurationSaving}
-        >
-          <DialogHeader className="gap-1 text-left">
-            <DialogTitle className="text-[20px] font-semibold leading-[25px] text-[color:var(--app-primary-label)]">
-              Change time
-            </DialogTitle>
-            <DialogDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
-              Set a new end time for this share.
-            </DialogDescription>
-          </DialogHeader>
-          <LiveShareDurationEditor
-            value={vm.liveShareDurationHours}
-            onChange={vm.setLiveShareDurationHours}
-            onCancel={vm.onEditLiveShareDurationCancel}
-            onSave={vm.onSaveLiveShareDuration}
-            saving={vm.liveShareDurationSaving}
-            surface={false}
-          />
-        </DialogContent>
-      </Dialog>
+      {vm.liveShare && vm.liveShareDurationEditing ? (
+        <LiveShareDurationSheet
+          open={vm.liveShareDurationEditing}
+          value={vm.liveShareDurationHours}
+          onChange={vm.setLiveShareDurationHours}
+          onCancel={vm.onEditLiveShareDurationCancel}
+          onSave={vm.onSaveLiveShareDuration}
+          saving={vm.liveShareDurationSaving}
+        />
+      ) : null}
       {/* Every row and cell below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
@@ -1799,8 +1706,8 @@ function NowHub({
             testId: "one-location-request-row",
           },
           {
-            title: "Check in",
-            ariaLabel: "Check in",
+            title: "Confirm arrival",
+            ariaLabel: "Confirm arrival",
             icon: <LocationMenuGlyph name="checkIn" size={34} />,
             tone: "blue",
             onClick: onCheckIn,
@@ -1838,22 +1745,170 @@ function NowHub({
           </LocationMenuListGroup>
         </div>
       ) : null}
-      <div className="pt-1">
-        <LocationMenuListGroup testId="one-location-now-more">
-          {moreRows.map((row) => (
-            <LocationMenuListRow
-              key={row.voiceControlId}
-              leading={row.leading}
-              title={row.title}
-              ariaLabel={row.ariaLabel}
-              onClick={row.onClick}
-              voiceControlId={row.voiceControlId}
-              voiceActionId={row.voiceActionId}
-            />
-          ))}
-        </LocationMenuListGroup>
-      </div>
     </div>
+  );
+}
+
+function LiveShareDurationSheet({
+  open,
+  value,
+  onChange,
+  onCancel,
+  onSave,
+  saving,
+}: {
+  open: boolean;
+  value: string;
+  onChange: (next: string) => void;
+  onCancel: () => void;
+  onSave: (nextValue?: string) => void | Promise<void>;
+  saving: boolean;
+}) {
+  const [customOpen, setCustomOpen] = useState(false);
+  const [quickSavingValue, setQuickSavingValue] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setCustomOpen(false);
+    setQuickSavingValue(null);
+  }, [open]);
+
+  const quickOptions = [
+    { value: "0.5", label: "30 min", hint: shareEndsAtLabel("0.5", nowMs) },
+    { value: "2", label: "2 hours", hint: shareEndsAtLabel("2", nowMs) },
+    { value: "until_stopped", label: "Until I stop", hint: "" },
+  ];
+
+  const handleQuickSave = async (nextValue: string) => {
+    if (saving || quickSavingValue) return;
+    setQuickSavingValue(nextValue);
+    onChange(nextValue);
+    try {
+      await Promise.resolve(onSave(nextValue));
+    } finally {
+      setQuickSavingValue(null);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="one-location-live-share-duration-title"
+      aria-describedby="one-location-live-share-duration-description"
+      data-testid="one-location-live-share-duration-sheet"
+      className={cn(
+        LOCATION_GROUP_SURFACE,
+        "p-4 shadow-[0_18px_48px_rgba(0,0,0,0.08)] dark:shadow-none",
+      )}
+    >
+      <div className="space-y-1 text-left">
+        <h2
+          id="one-location-live-share-duration-title"
+          className="text-[20px] font-semibold leading-[25px] tracking-[-0.02em] text-[color:var(--app-primary-label)]"
+        >
+          {customOpen ? "Choose an end time" : "Change sharing time"}
+        </h2>
+        <p
+          id="one-location-live-share-duration-description"
+          className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]"
+        >
+          {customOpen
+            ? "Use the existing custom picker."
+            : value === "until_stopped"
+              ? "Currently shared until you stop."
+              : `Currently ${shareEndsAtLabel(value, nowMs)}`}
+        </p>
+      </div>
+      {customOpen ? (
+        <LiveShareDurationEditor
+          value={value}
+          onChange={onChange}
+          onCancel={onCancel}
+          onSave={onSave}
+          saving={saving}
+        />
+      ) : (
+        <>
+          <div
+            className={cn(
+              LOCATION_GROUP_SURFACE,
+              "mt-3 divide-y divide-[color:var(--app-separator)]",
+            )}
+            data-testid="one-location-live-share-duration-quick-options"
+          >
+            {quickOptions.map((option) => {
+              const optionSaving = quickSavingValue === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className="flex min-h-[52px] w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] disabled:opacity-60"
+                  onClick={() => void handleQuickSave(option.value)}
+                  disabled={saving || Boolean(quickSavingValue)}
+                >
+                  <RowLabel as="span" className="min-w-0">
+                    {optionSaving ? "Updating…" : option.label}
+                  </RowLabel>
+                  {option.hint ? (
+                    <RowDescription as="span" className="shrink-0">
+                      {option.hint}
+                    </RowDescription>
+                  ) : null}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              className="flex min-h-[52px] w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]"
+              onClick={() => setCustomOpen(true)}
+            >
+              <RowLabel as="span">Choose an end time…</RowLabel>
+              <ChevronRight
+                aria-hidden="true"
+                className="h-5 w-5 text-[color:var(--app-tertiary-label)]"
+              />
+            </button>
+          </div>
+          <Button
+            variant="ghost"
+            className="mt-3 h-11 w-full rounded-full"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function LocationAccessRow({ vm }: { vm: LocationHubViewModel }) {
+  return (
+    <section
+      aria-label="Location access"
+      className={cn(
+        LOCATION_GROUP_SURFACE,
+        "flex min-h-[72px] items-center gap-3 px-4 py-3",
+      )}
+      data-testid="one-location-access-row"
+    >
+      <LocationHeaderIconTile />
+      <div className="min-w-0 flex-1">
+        <RowLabel as="h2" className="text-[color:var(--app-primary-label)]">
+          Location access
+        </RowLabel>
+      </div>
+      <LocationHeaderActions vm={vm} />
+    </section>
   );
 }
 
@@ -1931,14 +1986,11 @@ function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
     <section aria-label="Share location" data-testid="one-location-now-primary">
       <div
         data-testid="one-location-share-row"
-        className={cn(
-          LOCATION_INTERACTIVE_SURFACE,
-          "grid w-full gap-4 rounded-[20px] px-5 py-5 text-left sm:grid-cols-[auto_minmax(0,1fr)_194px] sm:items-center sm:gap-5 sm:px-6 sm:py-5",
-        )}
+        className={cn(LOCATION_GROUP_SURFACE, "w-full text-left")}
       >
-        <div className="flex min-w-0 items-center gap-4">
+        <div className="flex min-w-0 items-center gap-3 px-4 py-4 sm:px-5">
           <LocationSharePulseIcon />
-          <span className="min-w-0 space-y-1">
+          <span className="min-w-0 space-y-0.5">
             <CardTitle as="span" className="block">
               You&apos;re not sharing
             </CardTitle>
@@ -1947,17 +1999,19 @@ function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
             </PageSubtitle>
           </span>
         </div>
-        <button
-          type="button"
-          data-voice-control-id="one-location-action-share"
-          data-voice-action-id="location.open_share"
-          data-voice-label="Share location"
-          aria-label="Share location"
-          onClick={onClick}
-          className="inline-flex min-h-[47px] w-full items-center justify-center rounded-[15px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:col-start-3"
-        >
-          <ButtonLabel as="span">Share location</ButtonLabel>
-        </button>
+        <div className="border-t border-[color:var(--app-separator)] px-4 py-3 sm:px-5">
+          <button
+            type="button"
+            data-voice-control-id="one-location-action-share"
+            data-voice-action-id="location.open_share"
+            data-voice-label="Share location"
+            aria-label="Share location"
+            onClick={onClick}
+            className="inline-flex min-h-[48px] w-full items-center justify-center rounded-[16px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
+          >
+            <ButtonLabel as="span">Share location</ButtonLabel>
+          </button>
+        </div>
       </div>
     </section>
   );
@@ -1967,10 +2021,10 @@ function LocationHeaderIconTile() {
   return (
     <span
       aria-hidden="true"
-      className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-[12px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
+      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)]"
       data-testid="one-location-header-icon"
     >
-      <MapPin className="h-6 w-6" strokeWidth={2} />
+      <MapPin className="h-5 w-5" strokeWidth={2} />
     </span>
   );
 }
@@ -1980,7 +2034,7 @@ function LocationSharePulseIcon() {
     <span
       aria-hidden="true"
       data-location-share-pulse-icon=""
-      className="relative inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-16 sm:w-16"
+      className="relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-12 sm:w-12"
     >
       <span className="absolute inset-[13%] rounded-full bg-[color:var(--app-accent-surface)]" />
       <span className="absolute inset-[28%] rounded-full bg-[color:var(--app-accent)]/20" />
@@ -2013,7 +2067,7 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
     >
       <div
         data-one-location-action-grid=""
-        className="grid w-full grid-cols-1 gap-3 min-[360px]:grid-cols-2 sm:gap-4"
+        className="grid w-full grid-cols-1 gap-3 min-[360px]:grid-cols-2"
       >
         {regularItems.map((item) => (
           <button
@@ -2028,18 +2082,18 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             onClick={item.onClick}
             className={cn(
               LOCATION_INTERACTIVE_SURFACE,
-              "group flex min-h-[96px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[16px] px-5 py-4 text-center transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-secondary-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]",
+              "group flex min-h-[58px] min-w-0 items-center justify-center gap-2 rounded-[16px] px-3 py-3 text-center transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]",
             )}
           >
             <span
               aria-hidden
               data-one-location-action-icon=""
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center text-[color:var(--app-accent)] transition-transform group-active:scale-95 [&>svg]:h-8 [&>svg]:w-8"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center text-[color:var(--app-accent-deep)] transition-transform group-active:scale-95 [&>svg]:h-6 [&>svg]:w-6"
             >
               {item.icon}
             </span>
             <span className="min-w-0">
-              <ButtonLabel as="span" className="block min-w-0">
+              <ButtonLabel as="span" className="block min-w-0 break-words">
                 {item.title}
               </ButtonLabel>
             </span>
@@ -2058,23 +2112,29 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
           data-voice-label={emergencyItem.ariaLabel}
           aria-label={emergencyItem.ariaLabel}
           onClick={emergencyItem.onClick}
-          className="group mt-3 flex min-h-[68px] w-full items-center justify-between gap-4 rounded-[16px] bg-[color:var(--app-destructive-tint)] px-5 py-3 text-left ring-1 ring-inset ring-[color:var(--app-destructive-border)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-destructive-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]"
+          className={cn(
+            LOCATION_GROUP_SURFACE,
+            "group mt-3 flex min-h-16 w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--app-destructive-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]",
+          )}
         >
-          <span className="flex min-w-0 items-center gap-4">
+          <span className="flex min-w-0 items-center gap-3">
             <span
               aria-hidden
               data-one-location-action-icon=""
-              className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
             >
               {emergencyItem.icon}
             </span>
             <span className="min-w-0">
-              <RowLabel as="span" className="block min-w-0 font-semibold">
+              <RowLabel
+                as="span"
+                className="block min-w-0 break-words font-semibold"
+              >
                 {emergencyItem.title}
               </RowLabel>
               <RowDescription
                 as="span"
-                className="mt-0.5 block min-w-0 !text-[color:var(--app-destructive)]"
+                className="mt-0.5 block min-w-0 break-words !text-[color:var(--app-destructive)]"
               >
                 {emergencyItem.subtitle}
               </RowDescription>
@@ -2886,9 +2946,7 @@ function LocationSettingsFlow({
           <SettingsRow
             title="Emergency contacts"
             trailing={
-              <TrailingValue as="span">
-                {smsContactCount}
-              </TrailingValue>
+              <TrailingValue as="span">{smsContactCount}</TrailingValue>
             }
             onClick={onManageSmsContacts}
             chevron
@@ -3396,11 +3454,12 @@ export function PeopleHub({
           // second tap is refused rather than queued -- single-flight, and
           // visibly so. Removing the row instead would make the control
           // disappear mid-action.
-          label: vm.busy === "contactSync"
-            ? "Finding contacts…"
-            : vm.contactSyncSummary
-              ? "Sync contacts again"
-              : "Find contacts",
+          label:
+            vm.busy === "contactSync"
+              ? "Finding contacts…"
+              : vm.contactSyncSummary
+                ? "Sync contacts again"
+                : "Find contacts",
           onSelect: () => vm.onSyncContacts(),
           disabled: vm.busy === "contactSync",
           busy: vm.busy === "contactSync",
@@ -4058,9 +4117,7 @@ function LinksHub({ vm }: { vm: LocationHubViewModel }) {
                 data-voice-control-id="one-location-action-temp-link"
                 className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
               >
-                {vm.busy === "publicInvite"
-                  ? "Creating link…"
-                  : "Create link"}
+                {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
               </Button>
             </div>
           </>
@@ -4285,7 +4342,9 @@ function ShareFlow({
             ? `${selected ? "Deselect" : "Select"} ${label} for private sharing`
             : undefined
         }
-        leading={<Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />}
+        leading={
+          <Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />
+        }
         title={
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -4336,33 +4395,32 @@ function ShareFlow({
    * Reuses the `nowMs` this step already ticks every 30 seconds, so a screen
    * left open cannot quote a remaining time that has since run out.
    */
-  const shareReplacementRows: ShareReplacementRow[] = shareReplacementsLosingTime(
-    {
+  const shareReplacementRows: ShareReplacementRow[] =
+    shareReplacementsLosingTime({
       recipientUserIds: selectedReady.map((recipient) => recipient.userId),
       activeOwnerGrants: vm.activeOwnerGrants,
       durationValue: vm.shareDurationHours,
       nowMs,
-    },
-  ).map(({ recipientUserId, grant, untilStopped }) => {
-    const recipient = recipientById.get(recipientUserId);
-    return {
-      recipientUserId,
-      label: recipient ? vm.recipientLabel(recipient) : "This person",
-      untilStopped,
-      // The two vocabularies this app already owns for the two kinds of live
-      // share: "Until you stop" is what every surface that lists a share calls
-      // an open-ended one, and `formatLocationRemaining` is what the approvals
-      // card, the feed and the Consent Manager call the time left on a timed
-      // one. A warning about a share must not be the one place that words it
-      // differently.
-      remainingLabel: untilStopped
-        ? "Until you stop"
-        : (formatLocationRemaining(
-            parseTimestamp(grant.expiresAt) ?? nowMs,
-            nowMs,
-          ) ?? "less than a minute more"),
-    };
-  });
+    }).map(({ recipientUserId, grant, untilStopped }) => {
+      const recipient = recipientById.get(recipientUserId);
+      return {
+        recipientUserId,
+        label: recipient ? vm.recipientLabel(recipient) : "This person",
+        untilStopped,
+        // The two vocabularies this app already owns for the two kinds of live
+        // share: "Until you stop" is what every surface that lists a share calls
+        // an open-ended one, and `formatLocationRemaining` is what the approvals
+        // card, the feed and the Consent Manager call the time left on a timed
+        // one. A warning about a share must not be the one place that words it
+        // differently.
+        remainingLabel: untilStopped
+          ? "Until you stop"
+          : (formatLocationRemaining(
+              parseTimestamp(grant.expiresAt) ?? nowMs,
+              nowMs,
+            ) ?? "less than a minute more"),
+      };
+    });
   const shareReplacementDurationLabel = formatLocationDurationLabel(
     resolveShareDurationHours(vm.shareDurationHours),
   );
@@ -4451,10 +4509,7 @@ function ShareFlow({
                 8px gap under one and 10px under the other reads as a
                 mistake. */}
             <div className="space-y-2.5">
-              <FormLabel
-                as="label"
-                htmlFor="one-location-share-note"
-              >
+              <FormLabel as="label" htmlFor="one-location-share-note">
                 Optional note
               </FormLabel>
               <div className="relative">
@@ -4603,43 +4658,45 @@ function ShareFlow({
           className="[&>div:first-child]:mt-0"
         >
           {[...shareableCircles]
-            .sort((a, b) => (a.name === "SMS Circle" ? 1 : b.name === "SMS Circle" ? -1 : 0))
+            .sort((a, b) =>
+              a.name === "SMS Circle" ? 1 : b.name === "SMS Circle" ? -1 : 0,
+            )
             .map((circle) => {
-            const selected =
-              vm.selectedShareCircleSelection?.circle.id === circle.id &&
-              shareCircleFullySelected;
-            const circleRole = roleClasses("people");
-            return (
-              <SettingsRow
-                key={circle.id}
-                density="compact"
-                disabled={vm.busy === "shareCircle"}
-                onClick={() => void vm.onSelectShareCircle(circle.id)}
-                ariaPressed={selected}
-                ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
-                leading={
-                  <span
-                    className={cn(
-                      "flex h-9 w-9 shrink-0 items-center justify-center rounded-full",
-                      circleRole.tile,
-                      circleRole.glyph,
-                    )}
-                  >
-                    <UsersRound className="h-[18px] w-[18px]" />
-                  </span>
-                }
-                title={circle.name}
-                description={
-                  vm.busy === "shareCircle"
-                    ? "Loading…"
-                    : selected
-                      ? `${selectedReady.length} selected`
-                      : circleMemberCountLabel(circle.memberCount)
-                }
-                trailing={<SelectionDot selected={selected} />}
-              />
-            );
-          })}
+              const selected =
+                vm.selectedShareCircleSelection?.circle.id === circle.id &&
+                shareCircleFullySelected;
+              const circleRole = roleClasses("people");
+              return (
+                <SettingsRow
+                  key={circle.id}
+                  density="compact"
+                  disabled={vm.busy === "shareCircle"}
+                  onClick={() => void vm.onSelectShareCircle(circle.id)}
+                  ariaPressed={selected}
+                  ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
+                  leading={
+                    <span
+                      className={cn(
+                        "flex h-9 w-9 shrink-0 items-center justify-center rounded-full",
+                        circleRole.tile,
+                        circleRole.glyph,
+                      )}
+                    >
+                      <UsersRound className="h-[18px] w-[18px]" />
+                    </span>
+                  }
+                  title={circle.name}
+                  description={
+                    vm.busy === "shareCircle"
+                      ? "Loading…"
+                      : selected
+                        ? `${selectedReady.length} selected`
+                        : circleMemberCountLabel(circle.memberCount)
+                  }
+                  trailing={<SelectionDot selected={selected} />}
+                />
+              );
+            })}
         </SettingsGroup>
       ) : null}
       <PersonSearchInput
@@ -4723,13 +4780,11 @@ function ShareFlow({
 }
 
 /**
- * The new-end-time editor opened from the live share card.
+ * The new-end-time editor that opens from the live share card's compact sheet.
  *
- * A short preset ladder (15 min / 1 hour / 2 hours / 4 hours / Until I stop),
- * not the received-shares editor's select and not the scroll wheel this used
- * to open on. It still opens on what the share actually has left, so the
- * "Ends …" read-back stays honest even when that value matches no rung; the
- * person then picks the length they want in one tap.
+ * The wheel, not the four-option select the received-shares editor uses. This
+ * one opens on what the share actually has left, and 32 minutes snapped to
+ * "1 hour" would silently offer to double a share the person meant to trim.
  */
 function LiveShareDurationEditor({
   value,
@@ -4737,14 +4792,12 @@ function LiveShareDurationEditor({
   onCancel,
   onSave,
   saving,
-  surface = true,
 }: {
   value: string;
   onChange: (next: string) => void;
   onCancel: () => void;
-  onSave: () => void;
+  onSave: (nextValue?: string) => void | Promise<void>;
   saving: boolean;
-  surface?: boolean;
 }) {
   // Same 30-second tick as the share confirm step: an editor left open must
   // not keep quoting an end time that has already gone past.
@@ -4756,11 +4809,7 @@ function LiveShareDurationEditor({
 
   return (
     <div
-      className={cn(
-        surface ? SUBCARD_SURFACE : null,
-        "space-y-4",
-        surface ? "p-4" : null,
-      )}
+      className="space-y-4 pt-2"
       data-testid="one-location-live-share-duration-editor"
       data-ui-contract="control-group"
       data-ui-id="location-live-share-duration-editor"
@@ -4810,7 +4859,7 @@ function LiveShareDurationEditor({
         </Button>
         <Button
           className="h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-          onClick={onSave}
+          onClick={() => void onSave()}
           isLoading={saving}
           data-testid="one-location-live-share-duration-save"
         >
@@ -4821,7 +4870,6 @@ function LiveShareDurationEditor({
   );
 }
 
-/**
 /**
  * "Ends 4:35 PM" — the read-back under a duration picker.
  *
@@ -5294,10 +5342,7 @@ function AskFlow({
             />
             {reason === "Other" ? (
               <div className="space-y-2.5">
-                <FormLabel
-                  as="label"
-                  htmlFor="one-location-ask-other-reason"
-                >
+                <FormLabel as="label" htmlFor="one-location-ask-other-reason">
                   Add reason
                 </FormLabel>
                 <textarea

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -87,7 +87,7 @@ export const TOP_SHELL_TAB_REGISTRY = {
     tabs: [
       // Keep the authored value `now` so existing links and Kai's
       // `location.open_now` action continue resolving.
-      { value: "now", label: "Now", href: "/one/location" },
+      { value: "now", label: "My location", href: "/one/location" },
       {
         value: "people",
         label: "People",


### PR DESCRIPTION
## Summary
- Rename the visible Location hub tab from Now to My location while preserving the internal `view=now` route value.
- Remove duplicate body Location identity from the redesigned hub and move readiness into a compact Location access row.
- Simplify My Location actions, keep Confirm arrival on the private flow, and replace inline Change Time editing with a compact quick-choice sheet.
- Tighten one-person and multi-person active-share presentation without changing sharing APIs, grant semantics, or deep links.

## Validation
- `git diff --check HEAD~1 HEAD`
- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx components/one-location/redesign/__tests__/live-share-status-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/one-location-tab-strip.layout.spec.ts e2e/one-location-live-share.layout.spec.ts e2e/app-shell-top-clearance.layout.spec.ts e2e/app-shell-bottom-clearance.layout.spec.ts --project=chromium`