### PR TITLE
Refine One Location share recipient picker

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2476,7 +2476,9 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search people")).toHaveValue("");
+    expect(screen.getByPlaceholderText("Search Circles or people")).toHaveValue(
+      "",
+    );
     expect(
       screen.getByRole("button", {
         name: /Deselect Investor D for private sharing/i,
@@ -2497,7 +2499,7 @@ describe("OneLocationAgentPage", () => {
     mockUseSearchParams.mockReturnValue(shareParams);
     rerender(<OneLocationAgentPage />);
 
-    fireEvent.change(screen.getByPlaceholderText("Search people"), {
+    fireEvent.change(screen.getByPlaceholderText("Search Circles or people"), {
       target: { value: "Trusted" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
@@ -2563,7 +2565,9 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search people")).toHaveValue("");
+    expect(screen.getByPlaceholderText("Search Circles or people")).toHaveValue(
+      "",
+    );
     expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
     expect(
       screen.getByRole("button", {
@@ -3788,7 +3792,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "My location" }));
     expect(screen.queryByRole("button", { name: /Active shares/i })).toBeNull();
     await openSharePersonStep();
-    fireEvent.change(screen.getByPlaceholderText("Search people"), {
+    fireEvent.change(screen.getByPlaceholderText("Search Circles or people"), {
       target: { value: "advisor" },
     });
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/share-circle-sections.test.ts
+++ b/hushh-webapp/components/one-location/redesign/__tests__/share-circle-sections.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { shareCircleSections } from "@/components/one-location/redesign/location-redesign-hub";
+import type { OneLocationCircleSummary } from "@/lib/one-location/types";
+
+function circle(
+  overrides: Partial<OneLocationCircleSummary>,
+): OneLocationCircleSummary {
+  return {
+    id: overrides.id ?? "circle",
+    name: overrides.name ?? "Circle",
+    kind: "general",
+    role: overrides.role ?? "owner",
+    memberCount: overrides.memberCount ?? 2,
+    memberLimit: overrides.memberLimit ?? 12,
+    canModerateInvites: true,
+    ...overrides,
+  } as OneLocationCircleSummary;
+}
+
+describe("shareCircleSections", () => {
+  it("separates created and joined Circles for ordinary Share", () => {
+    const sections = shareCircleSections(
+      [
+        circle({ id: "mine", name: "Family", role: "owner" }),
+        circle({ id: "joined", name: "Office", role: "member" }),
+      ],
+      "",
+    );
+
+    expect(sections).toEqual([
+      {
+        id: "created",
+        title: "Created by you",
+        circles: [expect.objectContaining({ id: "mine" })],
+      },
+      {
+        id: "joined",
+        title: "Joined Circles",
+        circles: [expect.objectContaining({ id: "joined" })],
+      },
+    ]);
+  });
+
+  it("excludes system Circles from ordinary Share", () => {
+    const sections = shareCircleSections(
+      [
+        circle({ id: "trusted", name: "Trusted", systemKind: "trusted" }),
+        circle({
+          id: "sms",
+          name: "SMS Circle",
+          isSystem: true,
+          systemKind: "sms",
+        }),
+        circle({ id: "manual", name: "Team", role: "owner" }),
+      ],
+      "",
+    );
+
+    expect(
+      sections.flatMap((section) => section.circles.map((row) => row.id)),
+    ).toEqual(["manual"]);
+  });
+
+  it("filters Circle sections with the same Share search query", () => {
+    const sections = shareCircleSections(
+      [
+        circle({ id: "family", name: "Family", role: "owner" }),
+        circle({ id: "office", name: "Office", role: "member" }),
+      ],
+      "off",
+    );
+
+    expect(sections).toEqual([
+      {
+        id: "joined",
+        title: "Joined Circles",
+        circles: [expect.objectContaining({ id: "office" })],
+      },
+    ]);
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -941,6 +941,43 @@ function selectedCountCopy(count: number, emptyCopy: string) {
   return `${count} selected`;
 }
 
+export type ShareCircleSection = {
+  id: "created" | "joined";
+  title: string;
+  circles: OneLocationCircleSummary[];
+};
+
+function isUserManagedShareCircle(circle: OneLocationCircleSummary): boolean {
+  return !circle.isSystem && circle.systemKind == null;
+}
+
+function circleMatchesQuery(
+  circle: OneLocationCircleSummary,
+  query: string,
+): boolean {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return true;
+  return circle.name.toLocaleLowerCase().includes(normalizedQuery);
+}
+
+export function shareCircleSections(
+  circles: readonly OneLocationCircleSummary[],
+  query: string,
+): ShareCircleSection[] {
+  const ordered = circles
+    .filter(isUserManagedShareCircle)
+    .filter((circle) => circleMatchesQuery(circle, query));
+  const created = ordered.filter((circle) => circle.role === "owner");
+  const joined = ordered.filter((circle) => circle.role === "member");
+
+  const sections: ShareCircleSection[] = [
+    { id: "created", title: "Created by you", circles: created },
+    { id: "joined", title: "Joined Circles", circles: joined },
+  ];
+
+  return sections.filter((section) => section.circles.length > 0);
+}
+
 export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -4280,6 +4317,10 @@ function ShareFlow({
   }, [onEnterShareConfirm, step]);
 
   const filtered = vm.visibleShareRecipients;
+  const circleSections = useMemo(
+    () => shareCircleSections(vm.circles, vm.shareRecipientSearch),
+    [vm.circles, vm.shareRecipientSearch],
+  );
   /**
    * Who can already see you, by recipient — the same `activeOwnerGrants` the
    * Active shares screen lists, read here for the first time.
@@ -4444,13 +4485,6 @@ function ShareFlow({
     shareNoteLength > 0 ||
     shareNoteLength >= ONE_LOCATION_SHARE_NOTE_MAX_LENGTH - 20 ||
     shareNoteLimitExceeded;
-  // Picking a Circle selects its ready members in the list below, and those
-  // rows remain individually deselectable. Once one is turned off the recipients
-  // are no longer that Circle, so the Circle row stops reading as selected.
-  const shareableCircles = useMemo(
-    () => vm.circles.filter((circle) => circle.systemKind !== "trusted"),
-    [vm.circles],
-  );
   const shareCircleFullySelected = isCircleSelectionFullySelected(
     vm.selectedShareCircleSelection,
     vm.selectedRecipientIds,
@@ -4637,74 +4671,66 @@ function ShareFlow({
           "Choose a Circle or contact.",
         )}
       />
-      {/* Trusted is not a group you share with.
-       *
-       * It listed here with the same glyph and count as a Circle somebody
-       * made, and one tap pre-selected every location-ready person in it --
-       * which, for a Circle whose roster IS the connection graph, is
-       * "everyone you know" behind a single press. The share then succeeded,
-       * because those people satisfy the connection arm anyway, so nothing
-       * refused it: this is the only place that says no.
-       *
-       * The eligibility SQL puts it plainly -- "Trusted records who you are
-       * connected to; it never decides who can see you" -- and the onboarding
-       * invite step already filters the same way. Only this picker is
-       * narrowed: the People tab, SOS contacts and the SMS flow still list
-       * every Circle. */}
-      {shareableCircles.length ? (
-        <SettingsGroup
-          title="Circles"
-          separatorInset
-          className="[&>div:first-child]:mt-0"
-        >
-          {[...shareableCircles]
-            .sort((a, b) =>
-              a.name === "SMS Circle" ? 1 : b.name === "SMS Circle" ? -1 : 0,
-            )
-            .map((circle) => {
-              const selected =
-                vm.selectedShareCircleSelection?.circle.id === circle.id &&
-                shareCircleFullySelected;
-              const circleRole = roleClasses("people");
-              return (
-                <SettingsRow
-                  key={circle.id}
-                  density="compact"
-                  disabled={vm.busy === "shareCircle"}
-                  onClick={() => void vm.onSelectShareCircle(circle.id)}
-                  ariaPressed={selected}
-                  ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
-                  leading={
-                    <span
-                      className={cn(
-                        "flex h-9 w-9 shrink-0 items-center justify-center rounded-full",
-                        circleRole.tile,
-                        circleRole.glyph,
-                      )}
-                    >
-                      <UsersRound className="h-[18px] w-[18px]" />
-                    </span>
-                  }
-                  title={circle.name}
-                  description={
-                    vm.busy === "shareCircle"
-                      ? "Loading…"
-                      : selected
-                        ? `${selectedReady.length} selected`
-                        : circleMemberCountLabel(circle.memberCount)
-                  }
-                  trailing={<SelectionDot selected={selected} />}
-                />
-              );
-            })}
-        </SettingsGroup>
-      ) : null}
       <PersonSearchInput
         value={vm.shareRecipientSearch}
         onChange={vm.setShareRecipientSearch}
-        placeholder="Search people"
+        placeholder="Search Circles or people"
         voiceControlId="one-location-share-recipient-search"
       />
+      {/* Product-managed Circles are deliberately excluded from ordinary Share:
+          Trusted is the connection graph, and SMS belongs to Save My Soul. */}
+      {circleSections.map((section) => (
+        <SettingsGroup
+          key={section.id}
+          title={
+            <span className="flex w-full items-center justify-between gap-4">
+              <span>{section.title}</span>
+              <span className="font-normal text-muted-foreground">
+                {section.circles.length}
+              </span>
+            </span>
+          }
+          separatorInset
+          className="[&>div:first-child]:mt-0"
+        >
+          {section.circles.map((circle) => {
+            const selected =
+              vm.selectedShareCircleSelection?.circle.id === circle.id &&
+              shareCircleFullySelected;
+            const circleRole = roleClasses("people");
+            return (
+              <SettingsRow
+                key={circle.id}
+                density="compact"
+                disabled={vm.busy === "shareCircle"}
+                onClick={() => void vm.onSelectShareCircle(circle.id)}
+                ariaPressed={selected}
+                ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
+                leading={
+                  <span
+                    className={cn(
+                      "flex h-9 w-9 shrink-0 items-center justify-center rounded-full",
+                      circleRole.tile,
+                      circleRole.glyph,
+                    )}
+                  >
+                    <UsersRound className="h-[18px] w-[18px]" />
+                  </span>
+                }
+                title={circle.name}
+                description={
+                  vm.busy === "shareCircle"
+                    ? "Loading…"
+                    : selected
+                      ? `${selectedReady.length} selected`
+                      : circleMemberCountLabel(circle.memberCount)
+                }
+                trailing={<SelectionDot selected={selected} />}
+              />
+            );
+          })}
+        </SettingsGroup>
+      ))}
       {filtered.length ? (
         // ONE scroll region around BOTH groups, not one per group. The list had
         // a 340px budget and a single scrolling surface; two capped groups
@@ -4752,14 +4778,13 @@ function ShareFlow({
         // A typo used to be reported as "you have no contacts", which sends a
         // person with twenty of them off to invite people they already have.
         // The list being empty and the QUERY being empty are different facts.
-        <EmptyState
-          title="No matching people"
-          description="Try a different name."
-        />
+        circleSections.length ? null : (
+          <EmptyState title="No matches" description="Try a different name." />
+        )
       ) : (
         <EmptyState
-          title="No trusted people yet"
-          description="Invite someone first."
+          title="No one to share with"
+          description="Create a Circle or invite someone first."
         />
       )}
       {/* A plain step change. Advancing must not depend on device permission:


### PR DESCRIPTION
## Summary
- separate Share Location Circle choices into Created by you and Joined Circles
- exclude product-managed/system Circles from ordinary Share Location selection
- make Share Location search cover Circle names and people, with clearer empty states
- add focused coverage for Circle section eligibility/filtering and update existing flow expectations

## Verification
- npm run test -- components/one-location/redesign/__tests__/share-circle-sections.test.ts __tests__/components/one-location-agent-page.test.tsx
- npm run verify:one-location
- npm run typecheck
- npm run build