### PR TITLE
Fix avatar consistency across Connect and Circle invites

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -32,6 +32,7 @@ from hushh_mcp.services.contact_sync_contract import (
 )
 from hushh_mcp.services.people_search_sql import people_query_match_params
 from hushh_mcp.services.requester_identity import label_from_identity_row
+from hushh_mcp.services.ria_status import RIA_VERIFIED_STATUS_SQL
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ def _iso(value: Any) -> str | None:
 #
 # Static text under our control, never user input -- it is interpolated, not
 # bound, because a bound array would erase those literals from the SQL text.
-_RIA_VERIFIED_STATUS_SQL = "verification_status IN ('active', 'verified', 'finra_verified')"
+_RIA_VERIFIED_STATUS_SQL = RIA_VERIFIED_STATUS_SQL
 
 # Who a directory search is asking about.
 #

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -30,6 +30,7 @@ from hushh_mcp.services.connection_graph_service import (
     revoke_circle_origins,
 )
 from hushh_mcp.services.people_search_sql import people_query_match_params
+from hushh_mcp.services.ria_status import RIA_VERIFIED_STATUS_SQL
 from mcp_modules.log_redaction import redact_log_field
 
 logger = logging.getLogger(__name__)
@@ -653,6 +654,7 @@ class OneLocationCircleService:
             "photoUrl": str(row.get("custom_photo_url") or row.get("photo_url") or "") or None,
             "connectedAt": _iso(row.get("connected_at")),
             "connectedFromContacts": bool(row.get("connected_from_contacts")),
+            "isRia": bool(row.get("is_ria")),
         }
 
     @staticmethod
@@ -2749,7 +2751,7 @@ class OneLocationCircleService:
                     status_code=403,
                 )
             result = self._db.execute_raw(
-                """
+                f"""
                 SELECT DISTINCT
                   connection.id AS connection_id,
                   CASE
@@ -2767,7 +2769,17 @@ class OneLocationCircleService:
                       AND contact_origin.status = 'active'
                       AND contact_origin.origin_kind = 'contact_sync'
                       AND contact_origin.source_ref = :actor_user_id
-                  ) AS connected_from_contacts
+                  ) AS connected_from_contacts,
+                  EXISTS (
+                    SELECT 1
+                    FROM ria_profiles ria_annotation
+                    WHERE ria_annotation.user_id = CASE
+                      WHEN connection.user_a_id = :actor_user_id
+                      THEN connection.user_b_id
+                      ELSE connection.user_a_id
+                    END
+                      AND {RIA_VERIFIED_STATUS_SQL}
+                  ) AS is_ria
                 FROM one_location_circles circle
                 JOIN one_location_circle_memberships actor_membership
                   ON actor_membership.circle_id = circle.id
@@ -2824,7 +2836,7 @@ class OneLocationCircleService:
                       AND invite.expires_at > NOW()
                   )
                 ORDER BY identity.display_name NULLS LAST
-                """,
+                """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
                 {
                     "circle_id": cleaned_circle_id,
                     "actor_user_id": actor_user_id,
@@ -2859,7 +2871,7 @@ class OneLocationCircleService:
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(
-                """
+                f"""
                 WITH authorized_circle AS (
                   SELECT circle.id, circle.owner_user_id
                   FROM one_location_circles circle
@@ -2977,11 +2989,17 @@ class OneLocationCircleService:
                            AND contact_origin.status = 'active'
                            AND contact_origin.origin_kind = 'contact_sync'
                            AND contact_origin.source_ref = :actor_user_id
-                       ) END AS connected_from_contacts
+                       ) END AS connected_from_contacts,
+                       CASE WHEN page_rows.connection_id IS NULL THEN FALSE ELSE EXISTS (
+                         SELECT 1
+                         FROM ria_profiles ria_annotation
+                         WHERE ria_annotation.user_id = page_rows.user_id
+                           AND {RIA_VERIFIED_STATUS_SQL}
+                       ) END AS is_ria
                 FROM total LEFT JOIN page_rows ON TRUE
                 ORDER BY page_rows.match_rank, page_rows.normalized_name,
                          page_rows.user_id, page_rows.connection_id
-                """,
+                """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
                 {
                     "circle_id": cleaned_circle_id,
                     "actor_user_id": actor_user_id,

--- a/consent-protocol/hushh_mcp/services/ria_status.py
+++ b/consent-protocol/hushh_mcp/services/ria_status.py
@@ -1,0 +1,9 @@
+"""Shared RIA status predicates for relationship-facing reads."""
+
+from __future__ import annotations
+
+# The SQL predicate for "this RIA profile is real enough to carry a capability".
+#
+# Static text under our control, never user input. Query builders interpolate it
+# so tests can assert every status literal remains aligned with RIAIAMService.
+RIA_VERIFIED_STATUS_SQL = "verification_status IN ('active', 'verified', 'finra_verified')"

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -115,6 +115,30 @@ def test_a_person_with_no_profile_name_is_still_named_in_a_circle() -> None:
     )
 
 
+def test_eligible_connection_payload_marks_verified_ria_status() -> None:
+    assert (
+        OneLocationCircleService._eligible_connection_payload(
+            {
+                "connection_id": "connection-1",
+                "user_id": "advisor-user",
+                "display_name": "Ada Advisor",
+                "is_ria": True,
+            }
+        )["isRia"]
+        is True
+    )
+    assert (
+        OneLocationCircleService._eligible_connection_payload(
+            {
+                "connection_id": "connection-2",
+                "user_id": "person-user",
+                "display_name": "Pat Person",
+            }
+        )["isRia"]
+        is False
+    )
+
+
 def test_the_roster_and_picker_queries_read_the_email_the_ladder_needs() -> None:
     """A ladder with no rung to stand on resolves nothing.
 
@@ -132,6 +156,24 @@ def test_the_roster_and_picker_queries_read_the_email_the_ladder_needs() -> None
 
     source = inspect.getsource(OneLocationCircleService.list_eligible_direct_connections)
     assert "identity.email" in source
+
+
+def test_eligible_connection_queries_use_the_shared_verified_ria_gate() -> None:
+    import inspect
+
+    from hushh_mcp.services.ria_iam_service import RIAIAMService
+    from hushh_mcp.services.ria_status import RIA_VERIFIED_STATUS_SQL
+
+    for status in RIAIAMService._RIA_VERIFIED_STATUSES:
+        assert f"'{status}'" in RIA_VERIFIED_STATUS_SQL
+
+    source = inspect.getsource(OneLocationCircleService.list_eligible_direct_connections)
+    assert "RIA_VERIFIED_STATUS_SQL" in source
+    assert "ria_profiles ria_annotation" in source
+
+    source = inspect.getsource(OneLocationCircleService.list_eligible_direct_connections_page)
+    assert "RIA_VERIFIED_STATUS_SQL" in source
+    assert "ria_profiles ria_annotation" in source
 
 
 def test_circle_summary_uses_canonical_owner_instead_of_membership_role() -> None:
@@ -2499,6 +2541,7 @@ def test_invitable_connections_are_not_narrowed_to_directly_requested_ones() -> 
                 "display_name": "Circle Only Peer",
                 "photo_url": None,
                 "custom_photo_url": None,
+                "is_ria": True,
             }
         ],
     )
@@ -2510,12 +2553,14 @@ def test_invitable_connections_are_not_narrowed_to_directly_requested_ones() -> 
     )
 
     assert [row["userId"] for row in eligible] == ["circle-only-peer"]
+    assert eligible[0]["isRia"] is True
     listing_sql = next(
         sql for sql in db.sql if "FROM connection_origins" in sql or "connection_origins" in sql
     )
     assert "origin.status = 'active'" in listing_sql
     # The guard: provenance must not be filtered down to direct requests.
     assert "origin_kind = 'direct_request'" not in listing_sql
+    assert "ria_profiles ria_annotation" in listing_sql
 
 
 def test_every_aggregating_circle_query_groups_by_the_owner_name_it_selects() -> None:

--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -33,12 +33,17 @@ describe("Connect canonical surface contract", () => {
     // says who and the badge says what, instead of one replacing the other.
     // Asserted as behaviour rather than an exact ternary so a later refactor
     // of the avatar is not blocked by the shape of this line.
-    expect(source).toContain("<ConnectPersonAvatar");
+    expect(source).toContain("ConnectionPersonAvatar");
     expect(source).toContain("photoUrl={connection.photoUrl ?? null}");
     expect(source).toContain("photoUrl={person.photoUrl}");
     expect(source).toContain("verified={Boolean(person.isRia)}");
-    expect(source).toContain("BadgeCheck");
-    expect(source).toContain('aria-label="Verified advisor"');
+
+    const avatarSource = readFileSync(
+      join(process.cwd(), "components/connections/connection-person-avatar.tsx"),
+      "utf8",
+    );
+    expect(avatarSource).toContain("BadgeCheck");
+    expect(avatarSource).toContain('aria-label="Verified advisor"');
     expect(source).toContain("separatorInset");
   });
 

--- a/hushh-webapp/__tests__/services/one-location-circle-member-invites-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-location-circle-member-invites-service.test.ts
@@ -39,6 +39,13 @@ describe("OneLocationService Circle member invitations", () => {
           displayName: "Asha",
           photoUrl: null,
           connectedAt: "2026-07-24T00:00:00Z",
+          isRia: true,
+        },
+        {
+          connectionId: "connection-2",
+          userId: "friend-2",
+          displayName: "Neel",
+          photoUrl: null,
         },
       ],
       pendingInvites: [],
@@ -56,6 +63,8 @@ describe("OneLocationService Circle member invitations", () => {
       { headers: { Authorization: "Bearer vault-token" } },
     );
     expect(result.eligibleConnections[0]?.userId).toBe("friend-1");
+    expect(result.eligibleConnections[0]?.isRia).toBe(true);
+    expect(result.eligibleConnections[1]?.isRia).toBe(false);
     expect(result.remainingCapacity).toBe(3);
   });
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/lib/voice/voice-action-card";
 import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
 import { getDirectoryPersonDescription } from "./directory-person-label";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import {
   CONNECT_PAGER_BUTTON_CLASSNAME,
   CONNECT_SEARCH_INPUT_CLASSNAME,
@@ -82,7 +83,6 @@ import {
 } from "./connect-search-layout";
 import { cn } from "@/lib/utils";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 type ConnectTab = "people" | "advisors" | "nearby";
 
@@ -466,64 +466,6 @@ async function resolveConnectionForVoice({
   // A name may have another duplicate beyond the bounded window. Choosing one
   // would make pagination an authority decision, so voice refuses safely.
   return { matches: [], complete: false };
-}
-
-/**
- * Two-letter fallback for someone with no Google photo. Mirrors the
- * contact-sync sheet, which already draws people this way.
- */
-function connectAvatarInitials(label: string): string {
-  const parts = label.trim().split(/\s+/).filter(Boolean);
-  if (!parts.length) return "?";
-  const first = parts[0] ?? "";
-  if (parts.length === 1) return (first.slice(0, 2) || "?").toUpperCase();
-  const last = parts[parts.length - 1] ?? "";
-  return ((first[0] ?? "") + (last[0] ?? "")).toUpperCase() || "?";
-}
-
-/**
- * A person's real Google picture where we have one, initials otherwise.
- *
- * Connect used to draw everyone with the same static UserRound glyph even
- * though the directory payload has carried `photoUrl` all along -- so the
- * one screen that exists to tell people apart made them all look alike.
- * The RIA check stays a badge on verified advisors rather than a photo,
- * since that mark means something the picture cannot.
- */
-function ConnectPersonAvatar({
-  photoUrl,
-  label,
-  verified,
-}: {
-  photoUrl: string | null;
-  label: string;
-  /** A capability-bearing RIA. Kept as a mark ON the avatar, never instead
-   *  of it: the photo says who, the badge says what, and swapping one for
-   *  the other loses whichever it replaced. */
-  verified: boolean;
-}) {
-  return (
-    <Avatar
-      className="relative h-[34px] w-[34px] shrink-0"
-      data-photo-url={photoUrl ?? undefined}
-    >
-      {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-      <AvatarFallback className="text-xs">
-        {connectAvatarInitials(label)}
-      </AvatarFallback>
-      {verified ? (
-        <span
-          className="absolute -right-0.5 -bottom-0.5 z-10 inline-flex size-[15px] items-center justify-center rounded-full bg-background"
-          aria-label="Verified advisor"
-        >
-          <BadgeCheck
-            className="size-[13px] text-[color:var(--app-success,#16a34a)]"
-            aria-hidden="true"
-          />
-        </span>
-      ) : null}
-    </Avatar>
-  );
 }
 
 export default function ConnectPageClient() {
@@ -2542,7 +2484,7 @@ export default function ConnectPageClient() {
                           <SettingsRow
                             key={connection.connectionId}
                             leading={
-                              <ConnectPersonAvatar
+                              <ConnectionPersonAvatar
                                 photoUrl={connection.photoUrl ?? null}
                                 label={
                                   connection.displayName || connection.userId
@@ -2914,7 +2856,7 @@ export default function ConnectPageClient() {
                                 // row rather than on the tab so the mark still means
                                 // something in a search that spans both.
                                 leading={
-                                  <ConnectPersonAvatar
+                                  <ConnectionPersonAvatar
                                     photoUrl={person.photoUrl}
                                     label={title}
                                     verified={Boolean(person.isRia)}
@@ -3305,7 +3247,7 @@ export default function ConnectPageClient() {
                     <SettingsRow
                       key={`batch-${person.userId}`}
                       leading={
-                        <ConnectPersonAvatar
+                        <ConnectionPersonAvatar
                           photoUrl={person.photoUrl}
                           label={title}
                           verified={Boolean(person.isRia)}

--- a/hushh-webapp/components/connections/connection-person-avatar.tsx
+++ b/hushh-webapp/components/connections/connection-person-avatar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { BadgeCheck } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+export function connectionAvatarInitials(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return "?";
+  const first = parts[0] ?? "";
+  if (parts.length === 1) return (first.slice(0, 2) || "?").toUpperCase();
+  const last = parts[parts.length - 1] ?? "";
+  return ((first[0] ?? "") + (last[0] ?? "")).toUpperCase() || "?";
+}
+
+/**
+ * Canonical avatar for connection rows.
+ *
+ * The photo says who the person is; the verified badge says what status the row
+ * carries. Keep them together so Connect and Location invite sheets cannot
+ * drift into different person identities.
+ */
+export function ConnectionPersonAvatar({
+  photoUrl,
+  label,
+  verified = false,
+  className,
+}: {
+  photoUrl?: string | null;
+  label: string;
+  verified?: boolean;
+  className?: string;
+}) {
+  return (
+    <Avatar
+      className={cn("relative h-[34px] w-[34px] shrink-0", className)}
+      data-photo-url={photoUrl ?? undefined}
+    >
+      {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
+      <AvatarFallback className="text-xs">
+        {connectionAvatarInitials(label)}
+      </AvatarFallback>
+      {verified ? (
+        <span
+          className="absolute -right-0.5 -bottom-0.5 z-10 inline-flex size-[15px] items-center justify-center rounded-full bg-background"
+          aria-label="Verified advisor"
+        >
+          <BadgeCheck
+            className="size-[13px] text-[color:var(--app-success,#16a34a)]"
+            aria-hidden="true"
+          />
+        </span>
+      ) : null}
+    </Avatar>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-grow-actions.test.tsx
@@ -221,7 +221,9 @@ describe("CircleInvitePeopleSheet", () => {
                 connectionId: "conn-asha",
                 userId: "asha-user",
                 displayName: "Same Name",
+                photoUrl: "https://cdn.example.test/asha.jpg",
                 connectedFromContacts: true,
+                isRia: true,
               },
         ],
         pendingInvites: [],
@@ -245,13 +247,18 @@ describe("CircleInvitePeopleSheet", () => {
       />,
     );
 
-    fireEvent.click(
-      within(
-        await screen.findByTestId(
-          "one-location-circle-grow-eligible-asha-user",
-        ),
-      ).getByRole("button"),
+    const ashaRow = await screen.findByTestId(
+      "one-location-circle-grow-eligible-asha-user",
     );
+    expect(
+      ashaRow.querySelector('[data-photo-url="https://cdn.example.test/asha.jpg"]'),
+    ).toBeTruthy();
+    expect(within(ashaRow).getByLabelText("Verified advisor")).toBeTruthy();
+    expect(
+      within(ashaRow).getByLabelText("Connected from your contacts"),
+    ).toBeTruthy();
+
+    fireEvent.click(within(ashaRow).getByRole("button"));
     fireEvent.change(screen.getByLabelText("Search connections"), {
       target: { value: "neel" },
     });

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -251,8 +251,10 @@ describe("named Circle flows", () => {
             {
               userId: "conn-1",
               displayName: "Asha Meena",
+              photoUrl: "https://cdn.example.test/asha-circle.jpg",
               connectionOrigin: "one" as const,
               connectedFromContacts: true,
+              isRia: true,
             },
             {
               userId: "conn-2",
@@ -268,7 +270,16 @@ describe("named Circle flows", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Add people" }));
     expect(await screen.findByText("Asha Meena")).toBeTruthy();
-    expect(screen.getByLabelText("Connected from your contacts")).toBeTruthy();
+    const ashaRow = screen.getByTestId("one-location-circle-eligible-conn-1");
+    expect(
+      ashaRow.querySelector(
+        '[data-photo-url="https://cdn.example.test/asha-circle.jpg"]',
+      ),
+    ).toBeTruthy();
+    expect(within(ashaRow).getByLabelText("Verified advisor")).toBeTruthy();
+    expect(
+      within(ashaRow).getByLabelText("Connected from your contacts"),
+    ).toBeTruthy();
 
     // "Asha Meena" and "Neel Shah" BOTH contain an "n", so a substring filter
     // returned both and one-letter search looked broken. Only Neel's name

--- a/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-grow-actions.tsx
@@ -20,7 +20,6 @@ import { toast } from "sonner";
 import { Check, Loader2, Search, Send, Share2, UserPlus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Sheet,
   SheetContent,
@@ -44,20 +43,11 @@ import {
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { cn } from "@/lib/utils";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import {
   CIRCLE_INVITE_BATCH_LIMIT,
   circleInviteSelectionLimit,
 } from "@/lib/one-location/circle-invite-contract";
-
-function circleInitials(value: string): string {
-  return value
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
-}
 
 function growErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message.trim()
@@ -358,14 +348,11 @@ export function CircleInvitePeopleSheet({
                         <SettingsRow
                           key={connection.userId}
                           leading={
-                            <Avatar className="h-10 w-10 rounded-xl">
-                              {connection.photoUrl ? (
-                                <AvatarImage src={connection.photoUrl} alt="" />
-                              ) : null}
-                              <AvatarFallback className="rounded-xl">
-                                {circleInitials(connection.displayName)}
-                              </AvatarFallback>
-                            </Avatar>
+                            <ConnectionPersonAvatar
+                              photoUrl={connection.photoUrl ?? null}
+                              label={connection.displayName}
+                              verified={Boolean(connection.isRia)}
+                            />
                           }
                           title={
                             <span className="flex min-w-0 items-center gap-1.5">

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -95,6 +95,7 @@ import {
 import { sortCircleMembersOwnerFirst } from "@/lib/one-location/circle-member-order";
 import { BLOCKED_CTA } from "@/components/one-location/redesign/circles/blocked-cta";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import { LOCATION_SEARCH_INPUT_CLASSNAME } from "@/components/one-location/redesign/selectors";
 import { relationshipCta } from "@/lib/connections/relationship-label";
 import { othersCountLabel } from "@/lib/one-location/circle-member-count";
@@ -2108,17 +2109,11 @@ export function CircleDetailFlow({
                               <SettingsRow
                                 key={connection.userId}
                                 leading={
-                                  <Avatar className="h-10 w-10 rounded-xl">
-                                    {connection.photoUrl ? (
-                                      <AvatarImage
-                                        src={connection.photoUrl}
-                                        alt=""
-                                      />
-                                    ) : null}
-                                    <AvatarFallback className="rounded-xl">
-                                      {circleInitials(connection.displayName)}
-                                    </AvatarFallback>
-                                  </Avatar>
+                                  <ConnectionPersonAvatar
+                                    photoUrl={connection.photoUrl ?? null}
+                                    label={connection.displayName}
+                                    verified={Boolean(connection.isRia)}
+                                  />
                                 }
                                 title={
                                   <span className="flex min-w-0 items-center gap-1.5">

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -19,6 +19,7 @@ import type {
   OneLocationAutoApprovePreference,
   OneLocationCircleInvite,
   OneLocationCircleDetail,
+  OneLocationCircleEligibleConnection,
   OneLocationCircleEligibleConnections,
   OneLocationCircleEligibleConnectionsPage,
   OneLocationCircleInviteCode,
@@ -52,6 +53,29 @@ import type {
   DriveDestination,
   RouteEta,
 } from "@/lib/one-location/types";
+
+type OneLocationCircleEligibleConnectionApiRow = Omit<
+  OneLocationCircleEligibleConnection,
+  "isRia"
+> & {
+  isRia?: boolean | null;
+};
+
+type OneLocationCircleEligibleConnectionsApiResponse = {
+  eligibleConnections?: OneLocationCircleEligibleConnectionApiRow[];
+  connections?: OneLocationCircleEligibleConnectionApiRow[];
+  pendingInvites?: OneLocationCircleMemberInvite[];
+  remainingCapacity?: number;
+};
+
+function normalizeEligibleConnection(
+  connection: OneLocationCircleEligibleConnectionApiRow,
+): OneLocationCircleEligibleConnection {
+  return {
+    ...connection,
+    isRia: Boolean(connection.isRia),
+  };
+}
 
 function authHeaders(vaultOwnerToken: string): Record<string, string> {
   return { Authorization: `Bearer ${vaultOwnerToken}` };
@@ -849,24 +873,23 @@ export class OneLocationService {
     vaultOwnerToken: string;
     circleId: string;
   }): Promise<OneLocationCircleEligibleConnections> {
-    const response = await apiJson<{
-      eligibleConnections?: OneLocationCircleEligibleConnections["eligibleConnections"];
-      connections?: OneLocationCircleEligibleConnections["eligibleConnections"];
-      pendingInvites?: OneLocationCircleMemberInvite[];
-      remainingCapacity?: number;
-    }>(
+    const response = await apiJson<OneLocationCircleEligibleConnectionsApiResponse>(
       `/api/one/location/circles/${encodeURIComponent(params.circleId)}/eligible-connections`,
       { headers: authHeaders(params.vaultOwnerToken) },
     );
+    const eligibleConnections = (
+      response.eligibleConnections ??
+      response.connections ??
+      []
+    ).map(normalizeEligibleConnection);
     return {
-      eligibleConnections:
-        response.eligibleConnections ?? response.connections ?? [],
+      eligibleConnections,
       pendingInvites: response.pendingInvites ?? [],
       remainingCapacity: Math.max(
         0,
         Number.isFinite(response.remainingCapacity)
           ? Number(response.remainingCapacity)
-          : (response.eligibleConnections ?? response.connections ?? []).length,
+          : eligibleConnections.length,
       ),
     };
   }
@@ -883,20 +906,21 @@ export class OneLocationService {
       limit: String(params.limit ?? 50),
     });
     if (params.query?.trim()) search.set("query", params.query.trim());
-    const response = await apiJson<{
-      eligibleConnections?: OneLocationCircleEligibleConnections["eligibleConnections"];
-      connections?: OneLocationCircleEligibleConnections["eligibleConnections"];
-      pendingInvites?: OneLocationCircleMemberInvite[];
-      remainingCapacity?: number;
+    const response = await apiJson<
+      OneLocationCircleEligibleConnectionsApiResponse & {
       page?: number;
       hasMore?: boolean;
       totalCount?: number;
-    }>(
+      }
+    >(
       `/api/one/location/circles/${encodeURIComponent(params.circleId)}/eligible-connections?${search.toString()}`,
       { headers: authHeaders(params.vaultOwnerToken) },
     );
-    const eligibleConnections =
-      response.eligibleConnections ?? response.connections ?? [];
+    const eligibleConnections = (
+      response.eligibleConnections ??
+      response.connections ??
+      []
+    ).map(normalizeEligibleConnection);
     return {
       eligibleConnections,
       pendingInvites: response.pendingInvites ?? [],

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -456,6 +456,7 @@ export type OneLocationCircleEligibleConnection = {
   photoUrl?: string | null;
   connectedAt?: string | null;
   connectedFromContacts?: boolean;
+  isRia: boolean;
 };
 
 export type OneLocationCircleMemberInviteStatus =


### PR DESCRIPTION
## Summary

- Make Connect and Circle Invite People use the same avatar component and rendering logic.
- Keep verified/RIA status consistent across both surfaces.
- Normalize missing `isRia` values to false for backward compatibility.
- Add/update focused tests for avatar and `isRia` behavior.

## Verification

- Backend avatar/status tests: 5 passed
- Frontend avatar/service tests: 154 passed
- Frontend typecheck: passed
- Targeted ESLint: passed
- git diff --check: passed
