### PR TITLE
Revert My Location to prior working layout

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1,6 +1,5 @@
 import {
   act,
-  cleanup,
   fireEvent,
   render,
   screen,
@@ -869,7 +868,7 @@ async function openLocationPermissionsStep() {
 }
 
 async function switchLocationTab(
-  name: "My location" | "People" | "Links",
+  name: "Now" | "People" | "Links",
   expectedHeading: string,
 ) {
   fireEvent.click(screen.getByRole("button", { name }));
@@ -879,28 +878,9 @@ async function switchLocationTab(
 }
 
 async function openSharePersonStep() {
-  let shareEntry =
-    screen.queryByRole("button", { name: /^Share location$/i }) ??
-    screen.queryByRole("button", { name: /^Share with more$/i });
-
-  if (!shareEntry) {
-    const enableLocation = screen.queryByRole("button", {
-      name: /^Turn on location$/i,
-    });
-    if (enableLocation) {
-      fireEvent.click(enableLocation);
-      await waitFor(() =>
-        expect(mockCaptureCurrentPosition).toHaveBeenCalled(),
-      );
-      mockCaptureCurrentPosition.mockClear();
-      shareEntry = await screen.findByRole("button", {
-        name: /^Share location$/i,
-      });
-    }
-  }
-
   fireEvent.click(
-    shareEntry ?? screen.getByRole("button", { name: /^Share with more$/i }),
+    screen.queryByRole("button", { name: /^Share location$/i }) ??
+      screen.getByRole("button", { name: /^Share with more$/i }),
   );
   expect(
     await screen.findByRole("heading", { name: "Who can see you?" }),
@@ -973,21 +953,10 @@ describe("OneLocationAgentPage", () => {
     // and every test after it hangs on a clock that never moves -- three
     // unrelated failures from one. Cheap to make impossible.
     vi.useRealTimers();
-    cleanup();
-    document.body.style.pointerEvents = "";
-    document.body.removeAttribute("data-scroll-locked");
-    document
-      .querySelectorAll("[data-radix-focus-guard], [data-aria-hidden]")
-      .forEach((node) => node.remove());
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    document.body.style.pointerEvents = "";
-    document.body.removeAttribute("data-scroll-locked");
-    document
-      .querySelectorAll("[data-radix-focus-guard], [data-aria-hidden]")
-      .forEach((node) => node.remove());
     // The shared store, holding a fix measured now — what a session with a
     // live movement watch looks like, and the precondition for the publisher.
     const busSnapshot = {
@@ -1394,8 +1363,8 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Map$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /^Share location$/i }),
     ).toBeTruthy();
@@ -1475,7 +1444,7 @@ describe("OneLocationAgentPage", () => {
 
     expect(screen.queryByText("Active shares")).toBeNull();
     expect(await toneOf("Sharing with you")).toBeUndefined();
-    expect(await toneOf("Location requests")).toBeUndefined();
+    expect(await toneOf("Needs review")).toBeUndefined();
   });
 
   it("renders Needs review with compact request cards and clear approval copy", async () => {
@@ -1503,7 +1472,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     fireEvent.click(
-      await screen.findByRole("button", { name: /Location requests/i }),
+      await screen.findByRole("button", { name: /Needs review/i }),
     );
 
     const flow = await screen.findByTestId("one-location-needs-review");
@@ -1579,7 +1548,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     fireEvent.click(
-      await screen.findByRole("button", { name: /Location requests/i }),
+      await screen.findByRole("button", { name: /Needs review/i }),
     );
 
     const flow = await screen.findByTestId("one-location-needs-review");
@@ -1612,9 +1581,9 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("uses a compact sharing-first Now composition without dashboard groups", async () => {
-    // Now is a sharing surface, not a management dashboard. The access state
-    // decides the primary CTA, then secondary actions and utility rows stay in
-    // two quiet grouped surfaces.
+    // Now is a sharing surface, not a management dashboard. Idle state leads
+    // with Share location, then secondary actions, then only the positive-count
+    // activity rows that need attention.
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -1649,15 +1618,11 @@ describe("OneLocationAgentPage", () => {
 
     const primary = await screen.findByTestId("one-location-now-primary");
     expect(
-      within(primary).getByRole("button", { name: "Turn on location" }),
+      within(primary).getByRole("button", { name: "Share location" }),
     ).toBeTruthy();
+    expect(within(primary).getByText("You're not sharing")).toBeTruthy();
     expect(
-      within(primary).getByText("Turn on location to start sharing"),
-    ).toBeTruthy();
-    expect(
-      within(primary).getByText(
-        "Location is required for sharing and arrival confirmation.",
-      ),
+      within(primary).getByText("Choose a Circle or contact."),
     ).toBeTruthy();
 
     const actions = await screen.findByTestId("one-location-now-actions");
@@ -1670,28 +1635,21 @@ describe("OneLocationAgentPage", () => {
       within(actions).getByRole("button", { name: "Request location" }),
     ).toBeTruthy();
     expect(
-      within(actions).queryByRole("button", {
-        name: "Save My Soul emergency alert",
-      }),
-    ).toBeNull();
-    expect(
-      screen.getByRole("button", {
+      within(actions).getByRole("button", {
         name: "Save My Soul emergency alert",
       }),
     ).toBeTruthy();
     expect(within(actions).getByText("Ask for location")).toBeTruthy();
-    expect(within(actions).getByText("Confirm arrival")).toBeTruthy();
+    expect(within(actions).getByText("Check in")).toBeTruthy();
     const retiredActionLabel = ["Their", "Location"].join(" ");
     expect(actions.textContent).not.toContain(retiredActionLabel);
-    expect(within(actions).queryByText("Check in")).toBeNull();
-    expect(within(actions).queryByText("Save My Soul")).toBeNull();
-    expect(within(actions).queryByText("Emergency alert")).toBeNull();
+    expect(within(actions).queryByText("Confirm Arrival")).toBeNull();
+    expect(within(actions).getByText("Save My Soul")).toBeTruthy();
+    expect(within(actions).getByText("Emergency alert")).toBeTruthy();
 
     const actionGrid = actions.querySelector("[data-one-location-action-grid]");
     expect(actionGrid?.className).toContain("grid-cols-1");
     expect(actionGrid?.className).toContain("min-[360px]:grid-cols-2");
-    expect(actionGrid?.className).toContain("divide-y");
-    expect(actionGrid?.className).toContain("min-[360px]:divide-x");
 
     const actionCells = actionGrid?.querySelectorAll(
       "[data-one-location-action-cell]",
@@ -1700,15 +1658,16 @@ describe("OneLocationAgentPage", () => {
     actionCells?.forEach((cell) => {
       expect(cell.className).toContain("items-center");
       expect(cell.className).toContain("text-center");
-      expect(cell.className).toContain("min-h-[68px]");
-      expect(cell.className).toContain("px-3");
+      expect(cell.className).toContain("rounded-[16px]");
+      expect(cell.className).toContain("min-h-[96px]");
+      expect(cell.className).toContain("px-5");
     });
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("text-[color:var(--app-accent-deep)]");
+    ).toContain("text-[color:var(--app-accent)]");
     expect(
       actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("[&>svg]:h-6");
+    ).toContain("[&>svg]:h-8");
     expect(
       actionGrid?.querySelectorAll("[data-one-location-action-icon] svg"),
     ).toHaveLength(2);
@@ -1720,30 +1679,26 @@ describe("OneLocationAgentPage", () => {
     ).toBeTruthy();
     expect(
       actions.querySelector("[data-one-location-emergency-cell]"),
-    ).toBeNull();
+    ).toBeTruthy();
     expect(actions.textContent).not.toContain("near_me");
     expect(actions.textContent).not.toContain("location_on");
     expect(actions.textContent).not.toContain("where_to_vote");
+    expect(actions.querySelector("[data-one-location-sms-row]")).toBeTruthy();
 
     const activity = screen.getByTestId("one-location-now-activity");
-    expect(
-      activity
-        .querySelector("[data-one-location-sms-row]")
-        ?.querySelector("[data-one-location-action-icon]")?.className,
-    ).toContain("bg-[color:var(--app-destructive)]");
-    expect(activity.querySelector("[data-one-location-sms-row]")).toBeTruthy();
-
     expect(within(activity).getByText("Sharing with you")).toBeTruthy();
-    expect(within(activity).getByText("Location requests")).toBeTruthy();
+    expect(within(activity).getByText("Needs review")).toBeTruthy();
     expect(within(activity).queryByText("Active shares")).toBeNull();
 
     expect(within(activity).queryByText("Share")).toBeNull();
-    expect(screen.queryByTestId("one-location-now-more")).toBeNull();
+    const more = screen.getByTestId("one-location-now-more");
+    expect(within(more).getByText("Map")).toBeTruthy();
+    expect(within(more).getByText("Settings")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Activity" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "More" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Map$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Settings$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(screen.queryByText("Check-In")).toBeNull();
     expect(screen.queryByText("Quick actions")).toBeNull();
   });
@@ -1780,7 +1735,7 @@ describe("OneLocationAgentPage", () => {
       "leading-[18px]",
       "font-normal",
     );
-    expect(status.textContent).toBe("Off");
+    expect(status.textContent).toBe("Location off");
     // Still the switch's description wherever it renders.
     expect(
       screen
@@ -1792,16 +1747,19 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     const heading = screen.getByRole("heading", { name: "Location" });
-    expect(heading).toHaveClass("ui-text-page-title");
-    expect(screen.getByTestId("page-header")).toBeTruthy();
-    const accessRow = screen.getByTestId("one-location-access-row");
+    const headerRow = heading.closest('[data-slot="page-header-row"]');
+    expect(headerRow).toBeTruthy();
+    expect(headerRow).toHaveClass("flex", "justify-between");
+    expect(screen.getByTestId("page-header").className).toContain(
+      "[&_[data-slot=page-header-row]]:!items-center",
+    );
+    expect(heading).toHaveClass("ui-text-agent-title");
     expect(screen.getByTestId("one-location-header-icon")).toBeTruthy();
     expect(
-      accessRow.contains(
+      headerRow?.contains(
         screen.getByRole("switch", { name: "Turn location on" }),
       ),
-    ).toBe(false);
-    expect(within(accessRow).getByText("Access off")).toBeTruthy();
+    ).toBe(true);
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
     ).toHaveAttribute("data-size", "ios");
@@ -1822,7 +1780,7 @@ describe("OneLocationAgentPage", () => {
     // keeps meaning visible without wrapping the title.
     expect(locationStatus.querySelector(".sm\\:hidden")).toBeNull();
     expect(locationStatus.querySelector(".hidden.sm\\:inline")).toBeNull();
-    expect(locationStatus.textContent).toBe("Off");
+    expect(locationStatus.textContent).toBe("Location off");
     expect(locationStatus).not.toHaveAttribute("aria-hidden");
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
@@ -1841,7 +1799,7 @@ describe("OneLocationAgentPage", () => {
       name: "Turn location off",
     });
     expect(locationOnSwitch).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByText("On")).toBeTruthy();
+    expect(screen.getByText("Location on")).toBeTruthy();
 
     fireEvent.click(locationOnSwitch);
     await waitFor(() =>
@@ -1849,7 +1807,7 @@ describe("OneLocationAgentPage", () => {
         screen.getByRole("switch", { name: "Turn location on" }),
       ).toHaveAttribute("aria-checked", "false"),
     );
-    expect(screen.getByText("Off")).toBeTruthy();
+    expect(screen.getByText("Location off")).toBeTruthy();
     expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
@@ -2083,7 +2041,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(
       await screen.findByRole("switch", { name: "Turn location off" }),
     );
-    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
 
     await act(async () => {
       resolveApproval?.({
@@ -2129,7 +2087,9 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     fireEvent.click(screen.getByRole("switch", { name: "Turn location on" }));
-    await waitFor(() => expect(screen.getByText("Limited")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText("Location limited")).toBeTruthy(),
+    );
     expect(
       screen.getByRole("switch", { name: "Turn location off" }),
     ).toHaveAttribute("aria-checked", "true");
@@ -2166,7 +2126,7 @@ describe("OneLocationAgentPage", () => {
     await act(async () => {
       releaseFix();
     });
-    await waitFor(() => expect(screen.getByText("On")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Location on")).toBeTruthy());
   });
 
   it("does not let a late fix undo a pause made while it was in flight", async () => {
@@ -2183,7 +2143,7 @@ describe("OneLocationAgentPage", () => {
       name: "Turn location off",
     });
     fireEvent.click(onSwitch);
-    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
 
     // The fix belongs to an intent the person has already replaced. Applying it
     // would silently turn location back on after they turned it off.
@@ -2193,7 +2153,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("switch", { name: "Turn location on" }),
     ).toHaveAttribute("aria-checked", "false");
-    expect(screen.getByText("Off")).toBeTruthy();
+    expect(screen.getByText("Location off")).toBeTruthy();
   });
 
   it("pauses the device without waiting on, or first probing, nearby presence", async () => {
@@ -2233,7 +2193,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(onSwitch);
 
-    await waitFor(() => expect(screen.getByText("Off")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Location off")).toBeTruthy());
     await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalledTimes(1));
     // Still in flight while the device already reads as paused.
     expect(releaseCheckout).not.toBeNull();
@@ -2508,9 +2468,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search Circles or people")).toHaveValue(
-      "",
-    );
+    expect(screen.getByPlaceholderText("Search people")).toHaveValue("");
     expect(
       screen.getByRole("button", {
         name: /Deselect Investor D for private sharing/i,
@@ -2531,7 +2489,7 @@ describe("OneLocationAgentPage", () => {
     mockUseSearchParams.mockReturnValue(shareParams);
     rerender(<OneLocationAgentPage />);
 
-    fireEvent.change(screen.getByPlaceholderText("Search Circles or people"), {
+    fireEvent.change(screen.getByPlaceholderText("Search people"), {
       target: { value: "Trusted" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
@@ -2580,7 +2538,7 @@ describe("OneLocationAgentPage", () => {
     expect(await screen.findByPlaceholderText(/Search people/i)).toHaveValue(
       "Investor",
     );
-    fireEvent.click(screen.getByRole("button", { name: "My location" }));
+    fireEvent.click(screen.getByRole("button", { name: "Now" }));
     fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
@@ -2597,9 +2555,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search Circles or people")).toHaveValue(
-      "",
-    );
+    expect(screen.getByPlaceholderText("Search people")).toHaveValue("");
     expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
     expect(
       screen.getByRole("button", {
@@ -3710,7 +3666,7 @@ describe("OneLocationAgentPage", () => {
     // The header agrees with what the person just did.
     await waitFor(() =>
       expect(screen.getByTestId("one-location-header-status").textContent).toBe(
-        "On",
+        "Location on",
       ),
     );
     expect(
@@ -3821,10 +3777,10 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText("TB").className).toContain("text-[#6E6E73]");
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "My location" }));
+    fireEvent.click(screen.getByRole("button", { name: "Now" }));
     expect(screen.queryByRole("button", { name: /Active shares/i })).toBeNull();
     await openSharePersonStep();
-    fireEvent.change(screen.getByPlaceholderText("Search Circles or people"), {
+    fireEvent.change(screen.getByPlaceholderText("Search people"), {
       target: { value: "advisor" },
     });
 
@@ -4780,12 +4736,8 @@ describe("OneLocationAgentPage", () => {
     ).toEqual(["15 min", "1 hour", "2 hours", "Custom"]);
 
     // Removed from the face of the ladder, not from the lane.
-    expect(
-      within(ladder).queryByRole("button", { name: "4 hours" }),
-    ).toBeNull();
-    expect(
-      within(ladder).queryByRole("button", { name: "8 hours" }),
-    ).toBeNull();
+    expect(within(ladder).queryByRole("button", { name: "4 hours" })).toBeNull();
+    expect(within(ladder).queryByRole("button", { name: "8 hours" })).toBeNull();
 
     // And Custom still reaches them: one deliberate tap, then the wheel.
     fireEvent.click(within(ladder).getByRole("button", { name: "Custom" }));
@@ -6059,11 +6011,11 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    expect(screen.getByText("Location is blocked in Settings")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open Settings" })).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: /^Share location$/i }),
-    ).toBeNull();
+    await openShareConfirmStep();
+    const shareButton = screen.getByRole("button", {
+      name: /Start sharing/i,
+    }) as HTMLButtonElement;
+    expect(shareButton.disabled).toBe(true);
     expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 
@@ -6424,16 +6376,6 @@ describe("OneLocationAgentPage", () => {
         fireEvent.click(change);
       });
 
-      const sheet = await screen.findByTestId(
-        "one-location-live-share-duration-sheet",
-      );
-
-      await act(async () => {
-        fireEvent.click(
-          within(sheet).getByRole("button", { name: "Choose an end time…" }),
-        );
-      });
-
       const editor = await screen.findByTestId(
         "one-location-live-share-duration-editor",
       );
@@ -6473,8 +6415,8 @@ describe("OneLocationAgentPage", () => {
           within(card).getByTestId("one-location-live-share-change-time"),
         );
       });
-      const sheet = await screen.findByTestId(
-        "one-location-live-share-duration-sheet",
+      const editor = await screen.findByTestId(
+        "one-location-live-share-duration-editor",
       );
 
       // "Until I stop" is the largest increase there is, and the direction the
@@ -6483,7 +6425,12 @@ describe("OneLocationAgentPage", () => {
       // a scroll position JSDOM cannot lay out.
       await act(async () => {
         fireEvent.click(
-          within(sheet).getByRole("button", { name: "Until I stop" }),
+          within(editor).getByRole("button", { name: "Until I stop" }),
+        );
+      });
+      await act(async () => {
+        fireEvent.click(
+          within(editor).getByTestId("one-location-live-share-duration-save"),
         );
       });
 
@@ -6505,12 +6452,12 @@ describe("OneLocationAgentPage", () => {
     }
   }, 15000);
 
-  it("offers the common lengths as one tap, with custom time behind a row", async () => {
-    // The report: Change time opened straight onto a two-column scroll wheel.
-    // Almost every change to a running share is one of five lengths, so those
-    // are now always visible and cost one tap each. The wheel is still
-    // reachable for anything in between -- removed from the default view, not
-    // removed.
+  it("offers four common lengths and the open-ended row, one tap each", async () => {
+    // The report (issue #6228): Change time showed too many near-identical
+    // choices -- 15 min / 1 hour / 2 hours / 4 hours / 8 hours / Custom /
+    // Until I stop -- wrapped and left-hugging under the live clock. It is
+    // trimmed to the four common lengths plus the open-ended row; `8 hours`
+    // and the `Custom` wheel are gone.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
     try {
@@ -6524,34 +6471,37 @@ describe("OneLocationAgentPage", () => {
           within(card).getByTestId("one-location-live-share-change-time"),
         );
       });
-      const sheet = await screen.findByTestId(
-        "one-location-live-share-duration-sheet",
-      );
-      const quickOptions = within(sheet).getByTestId(
-        "one-location-live-share-duration-quick-options",
+      const editor = await screen.findByTestId(
+        "one-location-live-share-duration-editor",
       );
 
-      for (const label of ["30 min", "2 hours", "Until I stop"]) {
+      for (const label of [
+        "15 min",
+        "1 hour",
+        "2 hours",
+        "4 hours",
+        "Until I stop",
+      ]) {
         expect(
-          within(quickOptions).getByRole("button", {
-            name: new RegExp(`^${label}`),
-          }),
+          within(editor).getByRole("button", { name: label }),
         ).toBeInTheDocument();
       }
+      // The two choices the issue asked to drop.
       expect(
-        within(quickOptions).getByRole("button", {
-          name: "Choose an end time…",
-        }),
-      ).toBeInTheDocument();
+        within(editor).queryByRole("button", { name: "8 hours" }),
+      ).toBeNull();
       expect(
-        within(sheet).queryByTestId("one-location-live-share-duration-save"),
+        within(editor).queryByRole("button", { name: "Custom" }),
       ).toBeNull();
 
       // One tap on a rung is the whole interaction -- no drag, no confirm
-      // step of its own before the backend update.
+      // step of its own before Save.
+      await act(async () => {
+        fireEvent.click(within(editor).getByRole("button", { name: "2 hours" }));
+      });
       await act(async () => {
         fireEvent.click(
-          within(quickOptions).getByRole("button", { name: /^2 hours/ }),
+          within(editor).getByTestId("one-location-live-share-duration-save"),
         );
       });
 

--- a/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-copy-pass.contract.test.ts
@@ -45,9 +45,8 @@ function serverMaxShareHours(): number {
 
 /** Every `{ value: "…", label: "…" }` duration option authored in the hub. */
 function durationOptionsIn(source: string): { value: string; label: string }[] {
-  return [
-    ...source.matchAll(/\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)"\s*\}/g),
-  ].map((m) => ({ value: m[1], label: m[2] }));
+  return [...source.matchAll(/\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)"\s*\}/g)]
+    .map((m) => ({ value: m[1], label: m[2] }));
 }
 
 describe("One Location — link durations stay inside the server's ceiling", () => {
@@ -110,15 +109,11 @@ describe("One Location — link durations stay inside the server's ceiling", () 
     // buttons state how long the link lives, and the card that replaces this
     // block once a link exists carries the concise link visibility line on the
     // object it is about.
-    expect(HUB_SOURCE).not.toContain(
-      'title="Anyone with this link can see you"',
-    );
+    expect(HUB_SOURCE).not.toContain('title="Anyone with this link can see you"');
     expect(HUB_SOURCE).not.toContain("The link stops on its own.");
     expect(HUB_SOURCE).not.toContain("<WarningCard");
     // The surviving statement, on the live link's own card.
-    expect(HUB_SOURCE).toContain(
-      "Anyone with this link can see your location.",
-    );
+    expect(HUB_SOURCE).toContain("Anyone with this link can see your location.");
   });
 
   it("drops the Request sent banner in favour of the toast that already fired", () => {
@@ -155,9 +150,9 @@ describe("One Location — link durations stay inside the server's ceiling", () 
 describe("One Location — hub tab naming", () => {
   const locationTabs = TOP_SHELL_TAB_REGISTRY.location;
 
-  it("labels the first tab My location while keeping its `now` query value", () => {
+  it("labels the first tab Now while keeping its `now` query value", () => {
     const first = locationTabs.tabs[0];
-    expect(first.label).toBe("My location");
+    expect(first.label).toBe("Now");
     // The value is the deep-link contract (`?view=now`, Kai's
     // `location.open_now`). Renaming the label must not move it.
     expect(first.value).toBe("now");
@@ -173,9 +168,7 @@ describe("One Location — People actions stay reachable and single-flight", () 
   const ACTION_MENU_SOURCE = repoFile("components/app-ui/action-menu.tsx");
 
   it("keeps Find contacts listed and merely disabled while syncing", () => {
-    const start = HUB_SOURCE.indexOf(
-      'voiceControlId: "one-location-find-contacts"',
-    );
+    const start = HUB_SOURCE.indexOf('voiceControlId: "one-location-find-contacts"');
     expect(start).toBeGreaterThan(-1);
     const addPeopleMenu = HUB_SOURCE.slice(start - 900, start + 200);
 
@@ -202,9 +195,7 @@ describe("One Location — People actions stay reachable and single-flight", () 
     expect(ACTION_MENU_SOURCE).toContain("useIsMobile");
     // And the presentation is frozen while open, so a rotation cannot remount
     // the menu under the hand using it.
-    expect(ACTION_MENU_SOURCE).toContain(
-      "if (!open) setSheetPresentation(isMobile);",
-    );
+    expect(ACTION_MENU_SOURCE).toContain("if (!open) setSheetPresentation(isMobile);");
   });
 });
 
@@ -317,7 +308,7 @@ describe("One Location — the Share confirm step is a measured column", () => {
 
     // The nested branch inherits the container's rounding rather than
     // asserting one of its own.
-    expect(page).toContain("nested");
+    expect(page).toContain('nested');
     expect(page).toContain('"rounded-[inherit]"');
     // ...and the standalone branch keeps the card it is.
     expect(page).toContain(

--- a/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-hub-hierarchy.contract.test.ts
@@ -25,7 +25,8 @@ describe("Location hub hierarchy", () => {
   it("keeps exactly one Location title before the local tab strip and content", () => {
     const body = functionBody("LocationRedesignHub");
     const headerIndex = body.indexOf("<PageHeader");
-    const titleMatches = body.match(/title="Location"/g) ?? [];
+    const titleMatches =
+      body.match(/<PageTitle\s+as="span">\s*Location\s*<\/PageTitle>/g) ?? [];
     const tabsIndex = body.indexOf("<TopShellTabs");
     const swipeIndex = body.indexOf("<SwipeViews");
     const linksIndex = body.indexOf("<LinksHub");
@@ -82,10 +83,8 @@ describe("Location hub hierarchy", () => {
       body.indexOf("</SwipeViews>"),
     );
 
-    expect(body).toContain("const locationTabSet = useMemo");
-    expect(body).toContain("...LOCATION_TAB_DEFINITION");
-    expect(body).toContain("activeValue: tab");
-    expect(tabsWindow).toContain("tabSet={locationTabSet}");
+    expect(tabsWindow).toContain("LOCATION_TAB_DEFINITION");
+    expect(tabsWindow).toContain("activeValue: tab");
     expect(swipeWindow).toContain("tabSetId={LOCATION_TAB_DEFINITION.id}");
     expect(swipeWindow).toContain("options={LOCATION_SWIPE_OPTIONS}");
   });

--- a/hushh-webapp/__tests__/components/one-location-recovery-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-recovery-placement.contract.test.ts
@@ -39,25 +39,18 @@ describe("blocked-location recovery placement", () => {
     expect(functionBody("SosFlow")).toContain("LocationPermissionRecoveryCard");
   });
 
-  it("is folded into the Location hub primary state", () => {
-    const nowBody = functionBody("NowHub");
-    const stateBody = functionBody("currentLocationStateCopy");
-
-    expect(nowBody).toContain("LocationCurrentStateSurface");
-    expect(stateBody).toContain("Location is blocked in Settings");
-    expect(stateBody).toContain("Open Settings to share or confirm arrival.");
-    expect(stateBody).toContain("vm.onOpenLocationSettings");
+  it("is rendered by the Location hub", () => {
+    expect(functionBody("LocationRedesignHub")).toContain(
+      "LocationPermissionRecoveryCard",
+    );
   });
 
   it("is gated on an observed block, never shown unconditionally", () => {
     // Telling someone their browser is blocking location when it is not sends
     // them into settings for no reason and teaches them to ignore the message.
-    for (const fn of ["SosFlow", "currentLocationStateCopy"]) {
+    for (const fn of ["SosFlow", "LocationRedesignHub"]) {
       const body = functionBody(fn);
-      const index =
-        fn === "SosFlow"
-          ? body.indexOf("LocationPermissionRecoveryCard")
-          : body.indexOf("Location is blocked in Settings");
+      const index = body.indexOf("LocationPermissionRecoveryCard");
       const around = body.slice(Math.max(0, index - 400), index + 400);
       expect(around, `${fn} must gate the card on locationBlocked`).toMatch(
         /locationBlocked/,

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -26,10 +26,9 @@ describe("One Location settings placement", () => {
   });
 
   it("offers Ask for location inside the compact Now actions", () => {
-    // Request location is an action, not status or utility. The My Location
-    // tab shows Ask and Confirm arrival as quick actions, then SMS and only
-    // count-backed incoming rows in the utility group. No dashboard labels or
-    // old active-shares row.
+    // Request location is an action, not status or utility. The compact Now
+    // tab shows Ask, Check in, SMS, count-backed Activity rows, and the quiet
+    // More rows without dashboard section labels or the old active-shares row.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
@@ -37,21 +36,18 @@ describe("One Location settings placement", () => {
     expect(nowSource).toContain('data-testid="one-location-now-actions"');
     expect(nowSource).toContain('testId: "one-location-request-row"');
     expect(nowSource).toContain('title: "Ask for location"');
-    expect(nowSource).toContain('title: "Confirm arrival"');
-    expect(nowSource).toContain("<LocationSmsUtilityRow");
+    expect(nowSource).toContain('title: "Save My Soul"');
 
     const actionsIndex = nowSource.indexOf("LocationActionGrid");
     const requestIndex = nowSource.indexOf('title: "Ask for location"');
-    const smsIndex = nowSource.indexOf("<LocationSmsUtilityRow");
     const activityIndex = nowSource.indexOf("one-location-now-activity");
     const moreIndex = nowSource.indexOf("one-location-now-more");
     expect(actionsIndex).toBeGreaterThan(-1);
     expect(requestIndex).toBeGreaterThan(actionsIndex);
-    expect(activityIndex).toBeGreaterThan(actionsIndex);
-    expect(smsIndex).toBeGreaterThan(activityIndex);
-    expect(moreIndex).toBe(-1);
-    expect(nowSource).not.toContain('title: "Map"');
-    expect(nowSource).not.toContain('title: "Settings"');
+    expect(activityIndex).toBeGreaterThan(requestIndex);
+    expect(moreIndex).toBeGreaterThan(activityIndex);
+    expect(nowSource).toContain('title: "Map"');
+    expect(nowSource).toContain('title: "Settings"');
     expect(nowSource).not.toContain('title: "Active shares"');
     expect(nowSource).not.toContain("LocationNowGroupLabel");
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -678,8 +678,7 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
 // cap and lose ties to whichever SUBVIEW_ACTION_BOOST entry matches the
 // current subview) -- this only changes what becomes a CANDIDATE, not how
 // candidates are ranked once the list is bigger.
-export const LOCATION_VOICE_ACTIONS =
-  deriveLocationVoiceActions("one_location");
+export const LOCATION_VOICE_ACTIONS = deriveLocationVoiceActions("one_location");
 
 const LOCATION_VOICE_CONTROLS = [
   {
@@ -2637,7 +2636,6 @@ export function OneLocationAgentPageContent({
   const savedLocationSessionEpochRef = useRef(0);
   const savedLocationPointUserIdRef = useRef<string | null>(null);
   const locationOnboardingRetryOnResumeRef = useRef(false);
-  const locationPermissionRefreshTimeoutRef = useRef<number | null>(null);
   const notificationOnboardingAttemptRef = useRef(false);
 
   useEffect(() => {
@@ -3174,8 +3172,8 @@ export function OneLocationAgentPageContent({
   );
   const rankedRecipients = useMemo(() => {
     const ranked = rankRecipientsForRecommendation(
-      contactSignalRecipients,
-      contactMatchedUserIds,
+        contactSignalRecipients,
+        contactMatchedUserIds,
     );
     // Every paged row came through the same vault-authorized recipient route.
     // Retain it by user id so selecting page 2, then changing search, does not
@@ -3186,7 +3184,7 @@ export function OneLocationAgentPageContent({
         [...pagedRecipientsByUserId.values()],
         contactMatchedUserIds,
       ),
-    );
+  );
   }, [contactMatchedUserIds, contactSignalRecipients, pagedRecipientsByUserId]);
   const shareRecipientPool = useMemo(
     () =>
@@ -3245,9 +3243,9 @@ export function OneLocationAgentPageContent({
             contactMatchedUserIds,
           )
         : filterPeopleByQuery(
-            rankedRecipients,
-            shareRecipientSearch,
-            recipientLabel,
+        rankedRecipients,
+        shareRecipientSearch,
+        recipientLabel,
           ).slice(0, 50),
     [
       contactMatchedUserIds,
@@ -4061,25 +4059,6 @@ export function OneLocationAgentPageContent({
     return nextPermission;
   }, []);
 
-  const clearDelayedLocationPermissionRefresh = useCallback(() => {
-    if (locationPermissionRefreshTimeoutRef.current === null) return;
-    window.clearTimeout(locationPermissionRefreshTimeoutRef.current);
-    locationPermissionRefreshTimeoutRef.current = null;
-  }, []);
-
-  const scheduleDelayedLocationPermissionRefresh = useCallback(() => {
-    clearDelayedLocationPermissionRefresh();
-    locationPermissionRefreshTimeoutRef.current = window.setTimeout(() => {
-      locationPermissionRefreshTimeoutRef.current = null;
-      void refreshLocationPermission();
-    }, 1200);
-  }, [clearDelayedLocationPermissionRefresh, refreshLocationPermission]);
-
-  useEffect(
-    () => () => clearDelayedLocationPermissionRefresh(),
-    [clearDelayedLocationPermissionRefresh],
-  );
-
   const handleOpenLocationSettings = useCallback(async () => {
     setBusy("locationSettings");
     try {
@@ -4097,9 +4076,9 @@ export function OneLocationAgentPageContent({
       );
     } finally {
       setBusy(null);
-      scheduleDelayedLocationPermissionRefresh();
+      window.setTimeout(() => void refreshLocationPermission(), 1200);
     }
-  }, [scheduleDelayedLocationPermissionRefresh]);
+  }, [refreshLocationPermission]);
 
   const ensureForegroundLocationReady = useCallback(
     async (options?: {
@@ -6553,64 +6532,58 @@ export function OneLocationAgentPageContent({
     setLiveShareDurationEditing(true);
   }, [activeOwnerGrants, liveShareStatus?.stoppableGrantId]);
 
-  const handleSaveLiveShareDuration = useCallback(
-    async (nextValue?: string) => {
-      const grantId = liveShareStatus?.stoppableGrantId;
-      if (!vaultOwnerToken || !grantId) return;
-      const grant = activeOwnerGrants.find((row) => row.id === grantId);
-      const effectiveDurationHours = nextValue ?? liveShareDurationHours;
-      const untilStopped = effectiveDurationHours === "until_stopped";
-      const durationHours = untilStopped
-        ? null
-        : Number(effectiveDurationHours);
+  const handleSaveLiveShareDuration = useCallback(async () => {
+    const grantId = liveShareStatus?.stoppableGrantId;
+    if (!vaultOwnerToken || !grantId) return;
+    const grant = activeOwnerGrants.find((row) => row.id === grantId);
+    const untilStopped = liveShareDurationHours === "until_stopped";
+    const durationHours = untilStopped ? null : Number(liveShareDurationHours);
 
-      // Save on a wheel still showing what the share already has left is not a
-      // change. Sending it anyway spends a round trip, writes an audit row, and
-      // pushes the recipient an alert about a time that did not move.
-      if (
-        durationHours !== null &&
-        grant?.durationMode !== "until_stopped" &&
-        grantDurationEditIntent({
-          grant,
-          durationHours,
-          nowMs: Date.now(),
-        }) === "unchanged"
-      ) {
-        setLiveShareDurationEditing(false);
-        return;
-      }
+    // Save on a wheel still showing what the share already has left is not a
+    // change. Sending it anyway spends a round trip, writes an audit row, and
+    // pushes the recipient an alert about a time that did not move.
+    if (
+      durationHours !== null &&
+      grant?.durationMode !== "until_stopped" &&
+      grantDurationEditIntent({
+        grant,
+        durationHours,
+        nowMs: Date.now(),
+      }) === "unchanged"
+    ) {
+      setLiveShareDurationEditing(false);
+      return;
+    }
 
-      setLiveShareDurationSaving(true);
-      try {
-        await OneLocationService.setGrantDuration({
-          vaultOwnerToken,
-          grantId,
-          durationHours,
-          durationMode: untilStopped ? "until_stopped" : "timed",
-        });
-        toast.success("Time updated.");
-        setLiveShareDurationEditing(false);
-        // Held until the list has reconciled, so the card's countdown is already
-        // reading the new expiry when the editor closes.
-        await refresh({ background: true }).catch(() => null);
-      } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Couldn't change the time. Try again.",
-        );
-      } finally {
-        setLiveShareDurationSaving(false);
-      }
-    },
-    [
-      activeOwnerGrants,
-      liveShareDurationHours,
-      liveShareStatus?.stoppableGrantId,
-      refresh,
-      vaultOwnerToken,
-    ],
-  );
+    setLiveShareDurationSaving(true);
+    try {
+      await OneLocationService.setGrantDuration({
+        vaultOwnerToken,
+        grantId,
+        durationHours,
+        durationMode: untilStopped ? "until_stopped" : "timed",
+      });
+      toast.success("Time updated.");
+      setLiveShareDurationEditing(false);
+      // Held until the list has reconciled, so the card's countdown is already
+      // reading the new expiry when the editor closes.
+      await refresh({ background: true }).catch(() => null);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Couldn't change the time. Try again.",
+      );
+    } finally {
+      setLiveShareDurationSaving(false);
+    }
+  }, [
+    activeOwnerGrants,
+    liveShareDurationHours,
+    liveShareStatus?.stoppableGrantId,
+    refresh,
+    vaultOwnerToken,
+  ]);
 
   // A share that ends, or a second share starting, takes the single grant this
   // editor was opened against out from under it. Closing is the honest answer:
@@ -7114,25 +7087,25 @@ export function OneLocationAgentPageContent({
                     onClick: () => void handleSyncContactSignalRef.current?.(),
                   },
                 }
-              : outcome.remedy === "invite"
-                ? {
-                    action: {
-                      label: "Invite them",
-                      // The other half of a contact scan. Until now the count of
-                      // people who are NOT on One was computed on every sync and
-                      // read by nothing but an analytics dimension — the product
-                      // learned who was missing, recorded it, and offered the
-                      // person no way to act on it.
-                      //
-                      // Reuses the existing invite share rather than minting a
-                      // second one, and deliberately carries no pre-authorized
-                      // connection: `buildInviteToOneShare` documents why, and
-                      // an invite that consents on the recipient's behalf is not
-                      // an invite.
-                      onClick: () => void handleInviteContactCandidates(),
-                    },
-                  }
-                : {}),
+            : outcome.remedy === "invite"
+              ? {
+                  action: {
+                    label: "Invite them",
+                    // The other half of a contact scan. Until now the count of
+                    // people who are NOT on One was computed on every sync and
+                    // read by nothing but an analytics dimension — the product
+                    // learned who was missing, recorded it, and offered the
+                    // person no way to act on it.
+                    //
+                    // Reuses the existing invite share rather than minting a
+                    // second one, and deliberately carries no pre-authorized
+                    // connection: `buildInviteToOneShare` documents why, and
+                    // an invite that consents on the recipient's behalf is not
+                    // an invite.
+                    onClick: () => void handleInviteContactCandidates(),
+                  },
+                }
+              : {}),
       };
       if (result.matchedUserIds.length > 0) {
         toast.success(outcome.title, outcomeOptions);
@@ -7255,9 +7228,7 @@ export function OneLocationAgentPageContent({
             vaultOwnerToken: activeVaultOwnerToken,
             ownerUserId: owner.userId,
             message: buildOneLocationRequestMessage(reason, requestMessage),
-            requestedDurationHours: Number(
-              durationHoursOverride ?? durationHours,
-            ),
+            requestedDurationHours: Number(durationHoursOverride ?? durationHours),
             requestedDurationMode: "timed",
           });
           successCount += 1;
@@ -12326,9 +12297,9 @@ export function OneLocationAgentPageContent({
       try {
         const preference = await OneLocationService.updateAutoApprovePreference(
           {
-            vaultOwnerToken,
-            enabled,
-            scope: enabled ? (input.scope ?? null) : null,
+          vaultOwnerToken,
+          enabled,
+          scope: enabled ? (input.scope ?? null) : null,
           },
         );
         // The PATCH result is the authority. Keep it visible even when the
@@ -12452,8 +12423,8 @@ export function OneLocationAgentPageContent({
         ? "Allow location in your browser's site settings (lock icon in the address bar), then try again."
         : "Turn on phone Location, then return to continue.",
     );
-    scheduleDelayedLocationPermissionRefresh();
-  }, [scheduleDelayedLocationPermissionRefresh]);
+    window.setTimeout(() => void refreshLocationPermission(), 1200);
+  }, [refreshLocationPermission]);
 
   const openAppSettingsForOnboarding = useCallback(async () => {
     locationOnboardingRetryOnResumeRef.current = true;
@@ -12463,8 +12434,8 @@ export function OneLocationAgentPageContent({
         ? "Allow location for this site in your browser settings, then try again."
         : "Allow Location for One in Settings, then return.",
     );
-    scheduleDelayedLocationPermissionRefresh();
-  }, [scheduleDelayedLocationPermissionRefresh]);
+    window.setTimeout(() => void refreshLocationPermission(), 1200);
+  }, [refreshLocationPermission]);
 
   // The "Save this place" step must appear on EVERY Location onboarding run once
   // access is ready — even if the owner discarded a previous onboarding or has
@@ -13433,7 +13404,7 @@ export function OneLocationAgentPageContent({
     liveShareDurationSaving,
     onEditLiveShareDurationStart: handleEditLiveShareDurationStart,
     onEditLiveShareDurationCancel: () => setLiveShareDurationEditing(false),
-    onSaveLiveShareDuration: handleSaveLiveShareDuration,
+    onSaveLiveShareDuration: () => void handleSaveLiveShareDuration(),
     onRequestMoreTime: handleRequestMoreTime,
     onCreatePublicInvite: () => void handleCreatePublicInvite(),
     onCopyPublicInvite: handleCopyPublicInvite,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -74,7 +74,6 @@ import {
 import { ActionMenu } from "@/components/app-ui/action-menu";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/app-ui/page-sections";
 import { TopShellTabs } from "@/components/app-ui/top-shell-tabs";
 import {
   Dialog,
@@ -86,11 +85,13 @@ import {
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
+import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   ButtonLabel,
   CardTitle,
   FormLabel,
   MediumRowLabel,
+  PageTitle,
   PageSubtitle,
   RowDescription,
   RowLabel,
@@ -116,6 +117,7 @@ import type {
   OneLocationShareDurationMode,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
+import { locationStatusLabel } from "@/lib/one-location/location-readiness";
 import {
   isCircleSelectionFullySelected,
   type CircleRecipientSelection,
@@ -130,7 +132,7 @@ import {
   TaskFlowHeader,
   TrustNoteCard,
 } from "./primitives";
-import { MUTED_TEXT } from "./tokens";
+import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
 import {
   initialsFrom,
@@ -163,7 +165,10 @@ import {
   REQUEST_DURATION_LADDER,
 } from "./duration-presets";
 import { approveShorterDurationOptions } from "@/lib/one-location/approve-duration-options";
-import { AskForMoreTime, type RequestMoreTimeHours } from "./request-more-time";
+import {
+  AskForMoreTime,
+  type RequestMoreTimeHours,
+} from "./request-more-time";
 import {
   LiveShareStatusCard,
   ShareCountdownText,
@@ -485,7 +490,7 @@ export type LocationHubViewModel = {
    * block above asks someone else for more of location, this one revises
    * your own, so it applies straight away and never turns into a request.
    */
-  /** True while the live share card's compact time sheet is open. */
+  /** True while the live share card's inline time editor is open. */
   liveShareDurationEditing: boolean;
   /** Wheel value, in decimal hours, or "until_stopped". */
   liveShareDurationHours: string;
@@ -493,7 +498,7 @@ export type LocationHubViewModel = {
   liveShareDurationSaving: boolean;
   onEditLiveShareDurationStart: () => void;
   onEditLiveShareDurationCancel: () => void;
-  onSaveLiveShareDuration: (nextValue?: string) => void | Promise<void>;
+  onSaveLiveShareDuration: () => void;
   onCreatePublicInvite: () => void;
   onCopyPublicInvite: () => boolean | Promise<boolean>;
   onSharePublicInvite: () => void;
@@ -831,11 +836,16 @@ const LOCATION_HEADER_STATUS_ID = "one-location-header-status";
 /** What the header switch currently means, in words. */
 function locationHeaderStatusText(vm: LocationHubViewModel): string {
   if (vm.locationAcquiring) return "Finding you\u2026";
-  if (vm.locationBlocked) return "Blocked";
-  if (!vm.locationEnabled) return "Off";
-  if (vm.locationPaused) return "Paused";
-  if (vm.locationAccuracyLimited && vm.locationEnabled) return "Limited";
-  return "On";
+  return locationStatusLabel({
+    readiness: vm.locationBlocked
+      ? ("blocked" as const)
+      : vm.locationEnabled
+        ? ("ready" as const)
+        : ("askable" as const),
+    previewOn: vm.locationEnabled,
+    paused: vm.locationPaused,
+    accuracyLimited: vm.locationAccuracyLimited,
+  });
 }
 
 /** The header switch status sits under the switch without becoming a page subtitle. */
@@ -941,43 +951,6 @@ const STICKY_FLOW_ACTION_CLASSNAME =
 function selectedCountCopy(count: number, emptyCopy: string) {
   if (count <= 0) return emptyCopy;
   return `${count} selected`;
-}
-
-export type ShareCircleSection = {
-  id: "created" | "joined";
-  title: string;
-  circles: OneLocationCircleSummary[];
-};
-
-function isUserManagedShareCircle(circle: OneLocationCircleSummary): boolean {
-  return !circle.isSystem && circle.systemKind == null;
-}
-
-function circleMatchesQuery(
-  circle: OneLocationCircleSummary,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-  if (!normalizedQuery) return true;
-  return circle.name.toLocaleLowerCase().includes(normalizedQuery);
-}
-
-export function shareCircleSections(
-  circles: readonly OneLocationCircleSummary[],
-  query: string,
-): ShareCircleSection[] {
-  const ordered = circles
-    .filter(isUserManagedShareCircle)
-    .filter((circle) => circleMatchesQuery(circle, query));
-  const created = ordered.filter((circle) => circle.role === "owner");
-  const joined = ordered.filter((circle) => circle.role === "member");
-
-  const sections: ShareCircleSection[] = [
-    { id: "created", title: "Created by you", circles: created },
-    { id: "joined", title: "Joined Circles", circles: joined },
-  ];
-
-  return sections.filter((section) => section.circles.length > 0);
 }
 
 export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
@@ -1124,13 +1097,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const activeFlowRef = useRef<FlowKind>("none");
   const resetShareComposer = vm.resetShareComposer;
   const startShareComposer = vm.startShareComposer;
-  const locationTabSet = useMemo(
-    () => ({
-      ...LOCATION_TAB_DEFINITION,
-      activeValue: tab,
-    }),
-    [tab],
-  );
 
   const resetShareLocalState = useCallback(() => {
     setShareStep("person");
@@ -1574,13 +1540,40 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   return (
     <div className="space-y-4 sm:space-y-5">
       <PageHeader
-        title="Location"
-        icon={MapPin}
-        accent="default"
+        title={
+          <PageTitle as="span">
+            Location
+          </PageTitle>
+        }
+        leading={<LocationHeaderIconTile />}
+        accent="location"
+        titleRole="agent"
         actionsInlineMobile
         actions={<LocationHeaderActions vm={vm} />}
+        className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center"
       />
-      <TopShellTabs tabSet={locationTabSet} />
+
+      {/*
+        Directly under the header, above the tabs, because a blocked permission
+        is not a detail of one tab — it is the reason every Location feature
+        below is inert. It used to be announced only by the word "blocked" in
+        the header status and a toast that had already gone, which is how
+        someone ended up on this screen with nothing to act on.
+      */}
+      <LocationPermissionRecoveryCard
+        blocked={vm.locationBlocked}
+        busy={vm.locationAcquiring}
+        onRetry={vm.onShowMyLocation}
+        onOpenSettings={vm.onOpenLocationSettings}
+      />
+
+      <TopShellTabs
+        tabSet={{
+          ...LOCATION_TAB_DEFINITION,
+          activeValue: tab,
+        }}
+      />
+
       <div className="-mx-[var(--page-inline-gutter-standard)]">
         <SwipeViews
           tabSetId={LOCATION_TAB_DEFINITION.id}
@@ -1597,7 +1590,21 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
                 vm.clearNamedCircleShareContext();
                 openShareFlow();
               }}
-              onCheckIn={() => openFlow("check-in")}
+              onOpenMap={() => router.push(ROUTES.ONE_LOCATION_MAP)}
+              // The app's own Location settings, not the OS permission
+              // screen. This tile carries voiceActionId
+              // "location.open_settings", a route action to
+              // ?action=settings -- so asking for it by voice already
+              // opened the right screen while tapping it left the app
+              // entirely. onOpenLocationSettings stays where it belongs:
+              // the permission recovery cards, whose whole job is sending
+              // someone to the OS to grant access.
+              onOpenSettings={() => openFlow("settings")}
+              onCheckIn={() =>
+                nearbyCheckInAvailable
+                  ? router.push(ROUTES.ONE_LOCATION_CHECK_IN)
+                  : openFlow("check-in")
+              }
               onSos={() => openFlow("sos")}
               onOpenActiveShares={() => openFlow("active-shares")}
               onOpenSharedWithMe={() => openFlow("shared-with-me")}
@@ -1634,10 +1641,13 @@ const PEOPLE_HEADER_ACTION =
   "relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]";
 
 const LOCATION_GROUP_SURFACE =
-  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-none ring-1 ring-inset ring-[color:var(--app-separator)]";
+  "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
 
 const LOCATION_GROUP_SHELL_CLASSNAME =
-  "[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-none ring-1 ring-inset ring-[color:var(--app-separator)]";
+  "[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:!shadow-none";
+
+const LOCATION_INTERACTIVE_SURFACE =
+  "bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
 
 function LocationHubPanel({ children }: { children: ReactNode }) {
   return (
@@ -1656,6 +1666,8 @@ function NowHub({
   onStartShare,
   onCheckIn,
   onSos,
+  onOpenMap,
+  onOpenSettings,
   onOpenActiveShares,
   onOpenSharedWithMe,
   onOpenNeedsReview,
@@ -1665,6 +1677,8 @@ function NowHub({
   onStartShare: () => void;
   onCheckIn: () => void;
   onSos: () => void;
+  onOpenMap: () => void;
+  onOpenSettings: () => void;
   onOpenActiveShares: () => void;
   onOpenSharedWithMe: () => void;
   onOpenNeedsReview: () => void;
@@ -1682,18 +1696,35 @@ function NowHub({
     },
     {
       leading: <LocationMenuListIcon name="review" />,
-      title: "Location requests",
+      title: "Needs review",
       value: vm.pendingOwnerRequests.length,
-      ariaLabel: "Location requests",
+      ariaLabel: "Needs review",
       onClick: onOpenNeedsReview,
       voiceControlId: "one-location-action-needs-review",
       voiceActionId: "location.open_needs_review",
     },
   ].filter((row) => row.value > 0);
+  const moreRows = [
+    {
+      leading: <LocationMenuListIcon name="map" />,
+      title: "Map",
+      ariaLabel: "Map",
+      onClick: onOpenMap,
+      voiceControlId: "one-location-action-map",
+      voiceActionId: "location.open_map",
+    },
+    {
+      leading: <LocationMenuListIcon name="settings" />,
+      title: "Settings",
+      ariaLabel: "Settings",
+      onClick: onOpenSettings,
+      voiceControlId: "one-location-action-settings",
+      voiceActionId: "location.open_settings",
+    },
+  ];
 
   return (
     <div className="space-y-3" data-testid="one-location-now-hub">
-      <LocationAccessRow vm={vm} />
       {/* Sharing is the one thing on this screen that keeps running after you
           leave it, so it reports itself first and keeps its own clock. */}
       {vm.liveShare ? (
@@ -1720,22 +1751,40 @@ function NowHub({
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
-      {vm.liveShare && vm.liveShareDurationEditing ? (
-        <LiveShareDurationSheet
-          open={vm.liveShareDurationEditing}
-          value={vm.liveShareDurationHours}
-          onChange={vm.setLiveShareDurationHours}
-          onCancel={vm.onEditLiveShareDurationCancel}
-          onSave={vm.onSaveLiveShareDuration}
-          saving={vm.liveShareDurationSaving}
-        />
-      ) : null}
+      <Dialog
+        open={Boolean(vm.liveShare && vm.liveShareDurationEditing)}
+        onOpenChange={(open) => {
+          if (!open) vm.onEditLiveShareDurationCancel();
+        }}
+      >
+        <DialogContent
+          className="max-w-[min(420px,calc(100%-2rem))] gap-4 rounded-[24px] p-4 sm:max-w-[420px]"
+          showCloseButton={!vm.liveShareDurationSaving}
+        >
+          <DialogHeader className="gap-1 text-left">
+            <DialogTitle className="text-[20px] font-semibold leading-[25px] text-[color:var(--app-primary-label)]">
+              Change time
+            </DialogTitle>
+            <DialogDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+              Set a new end time for this share.
+            </DialogDescription>
+          </DialogHeader>
+          <LiveShareDurationEditor
+            value={vm.liveShareDurationHours}
+            onChange={vm.setLiveShareDurationHours}
+            onCancel={vm.onEditLiveShareDurationCancel}
+            onSave={vm.onSaveLiveShareDuration}
+            saving={vm.liveShareDurationSaving}
+            surface={false}
+          />
+        </DialogContent>
+      </Dialog>
       {/* Every row and cell below carries the `control_ids` / `action_id` pair
           it was authored with in the Location voice action contract, so One and
           the search bar can name the individual control a person is asking for
           rather than only the screen it lives on. */}
       {!vm.liveShare ? (
-        <LocationCurrentStateSurface vm={vm} onStartShare={onStartShare} />
+        <LocationPrimaryShareCard onClick={onStartShare} />
       ) : null}
       <LocationActionGrid
         items={[
@@ -1743,216 +1792,68 @@ function NowHub({
             title: "Ask for location",
             ariaLabel: "Request location",
             icon: <LocationMenuGlyph name="ask" size={34} />,
+            tone: "blue",
             onClick: onRequestLocation,
             controlId: "one-location-action-ask",
             actionId: "location.open_ask",
             testId: "one-location-request-row",
           },
           {
-            title: "Confirm arrival",
-            ariaLabel: "Confirm arrival",
+            title: "Check in",
+            ariaLabel: "Check in",
             icon: <LocationMenuGlyph name="checkIn" size={34} />,
+            tone: "blue",
             onClick: onCheckIn,
             controlId: "one-location-action-check-in",
             actionId: "location.open_check_in",
           },
+          {
+            title: "Save My Soul",
+            subtitle: "Emergency alert",
+            ariaLabel: "Save My Soul emergency alert",
+            icon: <SmsTextIcon />,
+            tone: "red",
+            onClick: onSos,
+            controlId: "one-location-action-sos",
+            actionId: "location.open_sos",
+          },
         ]}
       />
 
+      {activityRows.length ? (
+        <div className="pt-1">
+          <LocationMenuListGroup testId="one-location-now-activity">
+            {activityRows.map((row) => (
+              <LocationMenuListRow
+                key={row.voiceControlId}
+                leading={row.leading}
+                title={row.title}
+                trailingValue={row.value}
+                ariaLabel={row.ariaLabel}
+                onClick={row.onClick}
+                voiceControlId={row.voiceControlId}
+                voiceActionId={row.voiceActionId}
+              />
+            ))}
+          </LocationMenuListGroup>
+        </div>
+      ) : null}
       <div className="pt-1">
-        <LocationMenuListGroup
-          testId={
-            activityRows.length
-              ? "one-location-now-activity"
-              : "one-location-now-utility"
-          }
-        >
-          <LocationSmsUtilityRow onClick={onSos} />
-          {activityRows.length
-            ? activityRows.map((row) => (
-                <LocationMenuListRow
-                  key={row.voiceControlId}
-                  leading={row.leading}
-                  title={row.title}
-                  trailingValue={row.value}
-                  ariaLabel={row.ariaLabel}
-                  onClick={row.onClick}
-                  voiceControlId={row.voiceControlId}
-                  voiceActionId={row.voiceActionId}
-                />
-              ))
-            : null}
+        <LocationMenuListGroup testId="one-location-now-more">
+          {moreRows.map((row) => (
+            <LocationMenuListRow
+              key={row.voiceControlId}
+              leading={row.leading}
+              title={row.title}
+              ariaLabel={row.ariaLabel}
+              onClick={row.onClick}
+              voiceControlId={row.voiceControlId}
+              voiceActionId={row.voiceActionId}
+            />
+          ))}
         </LocationMenuListGroup>
       </div>
     </div>
-  );
-}
-
-function LiveShareDurationSheet({
-  open,
-  value,
-  onChange,
-  onCancel,
-  onSave,
-  saving,
-}: {
-  open: boolean;
-  value: string;
-  onChange: (next: string) => void;
-  onCancel: () => void;
-  onSave: (nextValue?: string) => void | Promise<void>;
-  saving: boolean;
-}) {
-  const [customOpen, setCustomOpen] = useState(false);
-  const [quickSavingValue, setQuickSavingValue] = useState<string | null>(null);
-  const [nowMs, setNowMs] = useState(() => Date.now());
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => setNowMs(Date.now()), 30_000);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-    setCustomOpen(false);
-    setQuickSavingValue(null);
-  }, [open]);
-
-  const quickOptions = [
-    { value: "0.5", label: "30 min", hint: shareEndsAtLabel("0.5", nowMs) },
-    { value: "2", label: "2 hours", hint: shareEndsAtLabel("2", nowMs) },
-    { value: "until_stopped", label: "Until I stop", hint: "" },
-  ];
-
-  const handleQuickSave = async (nextValue: string) => {
-    if (saving || quickSavingValue) return;
-    setQuickSavingValue(nextValue);
-    onChange(nextValue);
-    try {
-      await Promise.resolve(onSave(nextValue));
-    } finally {
-      setQuickSavingValue(null);
-    }
-  };
-
-  if (!open) return null;
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="false"
-      aria-labelledby="one-location-live-share-duration-title"
-      aria-describedby="one-location-live-share-duration-description"
-      data-testid="one-location-live-share-duration-sheet"
-      className={cn(
-        LOCATION_GROUP_SURFACE,
-        "p-4 shadow-[0_18px_48px_rgba(0,0,0,0.08)] dark:shadow-none",
-      )}
-    >
-      <div className="space-y-1 text-left">
-        <h2
-          id="one-location-live-share-duration-title"
-          className="text-[20px] font-semibold leading-[25px] tracking-[-0.02em] text-[color:var(--app-primary-label)]"
-        >
-          {customOpen ? "Choose an end time" : "Change sharing time"}
-        </h2>
-        <p
-          id="one-location-live-share-duration-description"
-          className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]"
-        >
-          {customOpen
-            ? "Use the existing custom picker."
-            : value === "until_stopped"
-              ? "Currently shared until you stop."
-              : `Currently ${shareEndsAtLabel(value, nowMs)}`}
-        </p>
-      </div>
-      {customOpen ? (
-        <LiveShareDurationEditor
-          value={value}
-          onChange={onChange}
-          onCancel={onCancel}
-          onSave={onSave}
-          saving={saving}
-        />
-      ) : (
-        <>
-          <div
-            className={cn(
-              LOCATION_GROUP_SURFACE,
-              "mt-3 divide-y divide-[color:var(--app-separator)]",
-            )}
-            data-testid="one-location-live-share-duration-quick-options"
-          >
-            {quickOptions.map((option) => {
-              const optionSaving = quickSavingValue === option.value;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  className="flex min-h-[52px] w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)] disabled:opacity-60"
-                  onClick={() => void handleQuickSave(option.value)}
-                  disabled={saving || Boolean(quickSavingValue)}
-                >
-                  <RowLabel as="span" className="min-w-0">
-                    {optionSaving ? "Updating…" : option.label}
-                  </RowLabel>
-                  {option.hint ? (
-                    <RowDescription as="span" className="shrink-0">
-                      {option.hint}
-                    </RowDescription>
-                  ) : null}
-                </button>
-              );
-            })}
-            <button
-              type="button"
-              className="flex min-h-[52px] w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]"
-              onClick={() => setCustomOpen(true)}
-            >
-              <RowLabel as="span">Choose an end time…</RowLabel>
-              <ChevronRight
-                aria-hidden="true"
-                className="h-5 w-5 text-[color:var(--app-tertiary-label)]"
-              />
-            </button>
-          </div>
-          <Button
-            variant="ghost"
-            className="mt-3 h-11 w-full rounded-full"
-            onClick={onCancel}
-          >
-            Cancel
-          </Button>
-        </>
-      )}
-    </div>
-  );
-}
-
-function LocationAccessRow({ vm }: { vm: LocationHubViewModel }) {
-  return (
-    <section
-      aria-label="Location access"
-      className={cn(
-        LOCATION_GROUP_SURFACE,
-        "flex min-h-[72px] items-center gap-3 px-4 py-3",
-      )}
-      data-testid="one-location-access-row"
-    >
-      <LocationHeaderIconTile />
-      <div className="min-w-0 flex-1">
-        <RowLabel as="h2" className="text-[color:var(--app-primary-label)]">
-          Location access
-        </RowLabel>
-        <RowDescription
-          as="p"
-          className="mt-0.5 text-[color:var(--app-secondary-label)]"
-        >
-          {locationAccessRowStatusText(vm)}
-        </RowDescription>
-      </div>
-    </section>
   );
 }
 
@@ -2025,176 +1926,40 @@ function LocationMenuListRow({
   );
 }
 
-function locationAccessRowStatusText(vm: LocationHubViewModel): string {
-  const status = locationHeaderStatusText(vm).toLocaleLowerCase();
-  return `Access ${status}`;
-}
-
-function LocationCurrentStateSurface({
-  vm,
-  onStartShare,
-}: {
-  vm: LocationHubViewModel;
-  onStartShare: () => void;
-}) {
-  const state = currentLocationStateCopy(vm, onStartShare);
-
+function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
   return (
     <section aria-label="Share location" data-testid="one-location-now-primary">
       <div
         data-testid="one-location-share-row"
-        className={cn(LOCATION_GROUP_SURFACE, "w-full text-left")}
+        className={cn(
+          LOCATION_INTERACTIVE_SURFACE,
+          "grid w-full gap-4 rounded-[20px] px-5 py-5 text-left sm:grid-cols-[auto_minmax(0,1fr)_194px] sm:items-center sm:gap-5 sm:px-6 sm:py-5",
+        )}
       >
-        <div className="flex min-w-0 items-center gap-3 px-4 py-4 sm:px-5">
+        <div className="flex min-w-0 items-center gap-4">
           <LocationSharePulseIcon />
-          <span className="min-w-0 space-y-0.5">
+          <span className="min-w-0 space-y-1">
             <CardTitle as="span" className="block">
-              {state.title}
+              You&apos;re not sharing
             </CardTitle>
             <PageSubtitle as="span" className="block">
-              {state.description}
+              Choose a Circle or contact.
             </PageSubtitle>
           </span>
         </div>
-        {state.actionLabel ? (
-          <div className="border-t border-[color:var(--app-separator)] px-4 py-3 sm:px-5">
-            <button
-              type="button"
-              data-voice-control-id={state.controlId}
-              data-voice-action-id={state.actionId}
-              data-voice-label={state.actionLabel}
-              aria-label={state.actionLabel}
-              onClick={state.onClick}
-              disabled={state.busy}
-              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-[16px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] disabled:cursor-wait disabled:opacity-65"
-            >
-              {state.busy ? (
-                <Loader2
-                  aria-hidden="true"
-                  className="mr-2 h-4 w-4 animate-spin"
-                />
-              ) : null}
-              <ButtonLabel as="span">{state.actionLabel}</ButtonLabel>
-            </button>
-          </div>
-        ) : null}
+        <button
+          type="button"
+          data-voice-control-id="one-location-action-share"
+          data-voice-action-id="location.open_share"
+          data-voice-label="Share location"
+          aria-label="Share location"
+          onClick={onClick}
+          className="inline-flex min-h-[47px] w-full items-center justify-center rounded-[15px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:col-start-3"
+        >
+          <ButtonLabel as="span">Share location</ButtonLabel>
+        </button>
       </div>
     </section>
-  );
-}
-
-function currentLocationStateCopy(
-  vm: LocationHubViewModel,
-  onStartShare: () => void,
-): {
-  title: string;
-  description: string;
-  actionLabel: string | null;
-  onClick: () => void;
-  busy: boolean;
-  controlId: string;
-  actionId: string;
-} {
-  if (vm.locationBlocked) {
-    return {
-      title: "Location is blocked in Settings",
-      description: "Open Settings to share or confirm arrival.",
-      actionLabel: "Open Settings",
-      onClick: vm.onOpenLocationSettings,
-      busy: false,
-      controlId: "one-location-action-open-settings",
-      actionId: "location.open_settings",
-    };
-  }
-
-  if (vm.locationAcquiring) {
-    return {
-      title: "Finding your location…",
-      description: "This usually takes a moment.",
-      actionLabel: null,
-      onClick: vm.onShowMyLocation,
-      busy: true,
-      controlId: "one-location-action-find-location",
-      actionId: "location.refresh",
-    };
-  }
-
-  if (!vm.locationEnabled) {
-    return {
-      title: "Turn on location to start sharing",
-      description: "Location is required for sharing and arrival confirmation.",
-      actionLabel: "Turn on location",
-      onClick: vm.onShowMyLocation,
-      busy: false,
-      controlId: "one-location-action-enable-location",
-      actionId: "location.resume_updates",
-    };
-  }
-
-  if (vm.locationPaused) {
-    return {
-      title: "Location updates are paused",
-      description: "Resume to share or confirm arrival.",
-      actionLabel: "Resume updates",
-      onClick: vm.onResumeMyLocation,
-      busy: false,
-      controlId: "one-location-action-resume-location",
-      actionId: "location.resume_updates",
-    };
-  }
-
-  return {
-    title: "You’re not sharing",
-    description: "Choose a Circle or person.",
-    actionLabel: "Share location",
-    onClick: onStartShare,
-    busy: false,
-    controlId: "one-location-action-share",
-    actionId: "location.open_share",
-  };
-}
-
-function LocationSmsUtilityRow({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      data-one-location-sms-row=""
-      data-one-location-emergency-cell=""
-      data-voice-control-id="one-location-action-sos"
-      data-voice-action-id="location.open_sos"
-      data-voice-label="Save My Soul emergency alert"
-      aria-label="Save My Soul emergency alert"
-      onClick={onClick}
-      className="group flex min-h-16 w-full cursor-pointer items-center justify-between border-b border-[color:var(--app-separator)] px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-[color:var(--app-destructive-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]"
-    >
-      <span className="flex min-w-0 items-center gap-3">
-        <span
-          aria-hidden
-          data-one-location-action-icon=""
-          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
-        >
-          <SmsTextIcon />
-        </span>
-        <span className="min-w-0">
-          <RowLabel
-            as="span"
-            className="block min-w-0 break-words font-semibold"
-          >
-            Save My Soul
-          </RowLabel>
-          <RowDescription
-            as="span"
-            className="mt-0.5 block min-w-0 break-words !text-[color:var(--app-destructive)]"
-          >
-            Emergency alert
-          </RowDescription>
-        </span>
-      </span>
-      <ChevronRight
-        aria-hidden="true"
-        className="h-5 w-5 shrink-0 text-[color:var(--app-destructive)]/45"
-      />
-    </button>
   );
 }
 
@@ -2202,10 +1967,10 @@ function LocationHeaderIconTile() {
   return (
     <span
       aria-hidden="true"
-      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent-deep)]"
+      className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-[12px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
       data-testid="one-location-header-icon"
     >
-      <MapPin className="h-5 w-5" strokeWidth={2} />
+      <MapPin className="h-6 w-6" strokeWidth={2} />
     </span>
   );
 }
@@ -2215,7 +1980,7 @@ function LocationSharePulseIcon() {
     <span
       aria-hidden="true"
       data-location-share-pulse-icon=""
-      className="relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-12 sm:w-12"
+      className="relative inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-16 sm:w-16"
     >
       <span className="absolute inset-[13%] rounded-full bg-[color:var(--app-accent-surface)]" />
       <span className="absolute inset-[28%] rounded-full bg-[color:var(--app-accent)]/20" />
@@ -2226,8 +1991,10 @@ function LocationSharePulseIcon() {
 
 type LocationActionGridItem = {
   title: string;
+  subtitle?: string;
   ariaLabel: string;
   icon: ReactNode;
+  tone: "blue" | "red";
   onClick: () => void;
   controlId: string;
   actionId: string;
@@ -2235,6 +2002,9 @@ type LocationActionGridItem = {
 };
 
 function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
+  const regularItems = items.filter((item) => item.tone !== "red");
+  const emergencyItem = items.find((item) => item.tone === "red");
+
   return (
     <section
       aria-label="Actions"
@@ -2243,12 +2013,9 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
     >
       <div
         data-one-location-action-grid=""
-        className={cn(
-          LOCATION_GROUP_SURFACE,
-          "grid w-full grid-cols-1 divide-y divide-[color:var(--app-separator)] min-[360px]:grid-cols-2 min-[360px]:divide-x min-[360px]:divide-y-0",
-        )}
+        className="grid w-full grid-cols-1 gap-3 min-[360px]:grid-cols-2 sm:gap-4"
       >
-        {items.map((item) => (
+        {regularItems.map((item) => (
           <button
             key={item.controlId}
             type="button"
@@ -2259,23 +2026,66 @@ function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
             data-voice-label={item.ariaLabel}
             aria-label={item.ariaLabel}
             onClick={item.onClick}
-            className="group flex min-h-[68px] min-w-0 items-center justify-center gap-2 px-3 py-3 text-center transition-colors hover:bg-[color:var(--app-secondary-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]"
+            className={cn(
+              LOCATION_INTERACTIVE_SURFACE,
+              "group flex min-h-[96px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[16px] px-5 py-4 text-center transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-secondary-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]",
+            )}
           >
             <span
               aria-hidden
               data-one-location-action-icon=""
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center text-[color:var(--app-accent-deep)] transition-transform group-active:scale-95 [&>svg]:h-6 [&>svg]:w-6"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center text-[color:var(--app-accent)] transition-transform group-active:scale-95 [&>svg]:h-8 [&>svg]:w-8"
             >
               {item.icon}
             </span>
             <span className="min-w-0">
-              <ButtonLabel as="span" className="block min-w-0 break-words">
+              <ButtonLabel as="span" className="block min-w-0">
                 {item.title}
               </ButtonLabel>
             </span>
           </button>
         ))}
       </div>
+      {emergencyItem ? (
+        <button
+          key={emergencyItem.controlId}
+          type="button"
+          data-testid={emergencyItem.testId}
+          data-one-location-sms-row=""
+          data-one-location-emergency-cell=""
+          data-voice-control-id={emergencyItem.controlId}
+          data-voice-action-id={emergencyItem.actionId}
+          data-voice-label={emergencyItem.ariaLabel}
+          aria-label={emergencyItem.ariaLabel}
+          onClick={emergencyItem.onClick}
+          className="group mt-3 flex min-h-[68px] w-full items-center justify-between gap-4 rounded-[16px] bg-[color:var(--app-destructive-tint)] px-5 py-3 text-left ring-1 ring-inset ring-[color:var(--app-destructive-border)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-destructive-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]"
+        >
+          <span className="flex min-w-0 items-center gap-4">
+            <span
+              aria-hidden
+              data-one-location-action-icon=""
+              className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
+            >
+              {emergencyItem.icon}
+            </span>
+            <span className="min-w-0">
+              <RowLabel as="span" className="block min-w-0 font-semibold">
+                {emergencyItem.title}
+              </RowLabel>
+              <RowDescription
+                as="span"
+                className="mt-0.5 block min-w-0 !text-[color:var(--app-destructive)]"
+              >
+                {emergencyItem.subtitle}
+              </RowDescription>
+            </span>
+          </span>
+          <ChevronRight
+            aria-hidden="true"
+            className="h-5 w-5 shrink-0 text-[color:var(--app-destructive)]/45"
+          />
+        </button>
+      ) : null}
     </section>
   );
 }
@@ -3076,7 +2886,9 @@ function LocationSettingsFlow({
           <SettingsRow
             title="Emergency contacts"
             trailing={
-              <TrailingValue as="span">{smsContactCount}</TrailingValue>
+              <TrailingValue as="span">
+                {smsContactCount}
+              </TrailingValue>
             }
             onClick={onManageSmsContacts}
             chevron
@@ -3584,12 +3396,11 @@ export function PeopleHub({
           // second tap is refused rather than queued -- single-flight, and
           // visibly so. Removing the row instead would make the control
           // disappear mid-action.
-          label:
-            vm.busy === "contactSync"
-              ? "Finding contacts…"
-              : vm.contactSyncSummary
-                ? "Sync contacts again"
-                : "Find contacts",
+          label: vm.busy === "contactSync"
+            ? "Finding contacts…"
+            : vm.contactSyncSummary
+              ? "Sync contacts again"
+              : "Find contacts",
           onSelect: () => vm.onSyncContacts(),
           disabled: vm.busy === "contactSync",
           busy: vm.busy === "contactSync",
@@ -4247,7 +4058,9 @@ function LinksHub({ vm }: { vm: LocationHubViewModel }) {
                 data-voice-control-id="one-location-action-temp-link"
                 className="h-12 min-h-12 w-full rounded-[15px] bg-[color:var(--app-accent)] text-[17px] font-semibold leading-[22px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
               >
-                {vm.busy === "publicInvite" ? "Creating link…" : "Create link"}
+                {vm.busy === "publicInvite"
+                  ? "Creating link…"
+                  : "Create link"}
               </Button>
             </div>
           </>
@@ -4410,10 +4223,6 @@ function ShareFlow({
   }, [onEnterShareConfirm, step]);
 
   const filtered = vm.visibleShareRecipients;
-  const circleSections = useMemo(
-    () => shareCircleSections(vm.circles, vm.shareRecipientSearch),
-    [vm.circles, vm.shareRecipientSearch],
-  );
   /**
    * Who can already see you, by recipient — the same `activeOwnerGrants` the
    * Active shares screen lists, read here for the first time.
@@ -4476,9 +4285,7 @@ function ShareFlow({
             ? `${selected ? "Deselect" : "Select"} ${label} for private sharing`
             : undefined
         }
-        leading={
-          <Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />
-        }
+        leading={<Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />}
         title={
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -4529,32 +4336,33 @@ function ShareFlow({
    * Reuses the `nowMs` this step already ticks every 30 seconds, so a screen
    * left open cannot quote a remaining time that has since run out.
    */
-  const shareReplacementRows: ShareReplacementRow[] =
-    shareReplacementsLosingTime({
+  const shareReplacementRows: ShareReplacementRow[] = shareReplacementsLosingTime(
+    {
       recipientUserIds: selectedReady.map((recipient) => recipient.userId),
       activeOwnerGrants: vm.activeOwnerGrants,
       durationValue: vm.shareDurationHours,
       nowMs,
-    }).map(({ recipientUserId, grant, untilStopped }) => {
-      const recipient = recipientById.get(recipientUserId);
-      return {
-        recipientUserId,
-        label: recipient ? vm.recipientLabel(recipient) : "This person",
-        untilStopped,
-        // The two vocabularies this app already owns for the two kinds of live
-        // share: "Until you stop" is what every surface that lists a share calls
-        // an open-ended one, and `formatLocationRemaining` is what the approvals
-        // card, the feed and the Consent Manager call the time left on a timed
-        // one. A warning about a share must not be the one place that words it
-        // differently.
-        remainingLabel: untilStopped
-          ? "Until you stop"
-          : (formatLocationRemaining(
-              parseTimestamp(grant.expiresAt) ?? nowMs,
-              nowMs,
-            ) ?? "less than a minute more"),
-      };
-    });
+    },
+  ).map(({ recipientUserId, grant, untilStopped }) => {
+    const recipient = recipientById.get(recipientUserId);
+    return {
+      recipientUserId,
+      label: recipient ? vm.recipientLabel(recipient) : "This person",
+      untilStopped,
+      // The two vocabularies this app already owns for the two kinds of live
+      // share: "Until you stop" is what every surface that lists a share calls
+      // an open-ended one, and `formatLocationRemaining` is what the approvals
+      // card, the feed and the Consent Manager call the time left on a timed
+      // one. A warning about a share must not be the one place that words it
+      // differently.
+      remainingLabel: untilStopped
+        ? "Until you stop"
+        : (formatLocationRemaining(
+            parseTimestamp(grant.expiresAt) ?? nowMs,
+            nowMs,
+          ) ?? "less than a minute more"),
+    };
+  });
   const shareReplacementDurationLabel = formatLocationDurationLabel(
     resolveShareDurationHours(vm.shareDurationHours),
   );
@@ -4578,6 +4386,13 @@ function ShareFlow({
     shareNoteLength > 0 ||
     shareNoteLength >= ONE_LOCATION_SHARE_NOTE_MAX_LENGTH - 20 ||
     shareNoteLimitExceeded;
+  // Picking a Circle selects its ready members in the list below, and those
+  // rows remain individually deselectable. Once one is turned off the recipients
+  // are no longer that Circle, so the Circle row stops reading as selected.
+  const shareableCircles = useMemo(
+    () => vm.circles.filter((circle) => circle.systemKind !== "trusted"),
+    [vm.circles],
+  );
   const shareCircleFullySelected = isCircleSelectionFullySelected(
     vm.selectedShareCircleSelection,
     vm.selectedRecipientIds,
@@ -4636,7 +4451,10 @@ function ShareFlow({
                 8px gap under one and 10px under the other reads as a
                 mistake. */}
             <div className="space-y-2.5">
-              <FormLabel as="label" htmlFor="one-location-share-note">
+              <FormLabel
+                as="label"
+                htmlFor="one-location-share-note"
+              >
                 Optional note
               </FormLabel>
               <div className="relative">
@@ -4764,29 +4582,29 @@ function ShareFlow({
           "Choose a Circle or contact.",
         )}
       />
-      <PersonSearchInput
-        value={vm.shareRecipientSearch}
-        onChange={vm.setShareRecipientSearch}
-        placeholder="Search Circles or people"
-        voiceControlId="one-location-share-recipient-search"
-      />
-      {/* Product-managed Circles are deliberately excluded from ordinary Share:
-          Trusted is the connection graph, and SMS belongs to Save My Soul. */}
-      {circleSections.map((section) => (
+      {/* Trusted is not a group you share with.
+       *
+       * It listed here with the same glyph and count as a Circle somebody
+       * made, and one tap pre-selected every location-ready person in it --
+       * which, for a Circle whose roster IS the connection graph, is
+       * "everyone you know" behind a single press. The share then succeeded,
+       * because those people satisfy the connection arm anyway, so nothing
+       * refused it: this is the only place that says no.
+       *
+       * The eligibility SQL puts it plainly -- "Trusted records who you are
+       * connected to; it never decides who can see you" -- and the onboarding
+       * invite step already filters the same way. Only this picker is
+       * narrowed: the People tab, SOS contacts and the SMS flow still list
+       * every Circle. */}
+      {shareableCircles.length ? (
         <SettingsGroup
-          key={section.id}
-          title={
-            <span className="flex w-full items-center justify-between gap-4">
-              <span>{section.title}</span>
-              <span className="font-normal text-muted-foreground">
-                {section.circles.length}
-              </span>
-            </span>
-          }
+          title="Circles"
           separatorInset
           className="[&>div:first-child]:mt-0"
         >
-          {section.circles.map((circle) => {
+          {[...shareableCircles]
+            .sort((a, b) => (a.name === "SMS Circle" ? 1 : b.name === "SMS Circle" ? -1 : 0))
+            .map((circle) => {
             const selected =
               vm.selectedShareCircleSelection?.circle.id === circle.id &&
               shareCircleFullySelected;
@@ -4823,7 +4641,13 @@ function ShareFlow({
             );
           })}
         </SettingsGroup>
-      ))}
+      ) : null}
+      <PersonSearchInput
+        value={vm.shareRecipientSearch}
+        onChange={vm.setShareRecipientSearch}
+        placeholder="Search people"
+        voiceControlId="one-location-share-recipient-search"
+      />
       {filtered.length ? (
         // ONE scroll region around BOTH groups, not one per group. The list had
         // a 340px budget and a single scrolling surface; two capped groups
@@ -4871,13 +4695,14 @@ function ShareFlow({
         // A typo used to be reported as "you have no contacts", which sends a
         // person with twenty of them off to invite people they already have.
         // The list being empty and the QUERY being empty are different facts.
-        circleSections.length ? null : (
-          <EmptyState title="No matches" description="Try a different name." />
-        )
+        <EmptyState
+          title="No matching people"
+          description="Try a different name."
+        />
       ) : (
         <EmptyState
-          title="No one to share with"
-          description="Create a Circle or invite someone first."
+          title="No trusted people yet"
+          description="Invite someone first."
         />
       )}
       {/* A plain step change. Advancing must not depend on device permission:
@@ -4898,11 +4723,13 @@ function ShareFlow({
 }
 
 /**
- * The new-end-time editor that opens from the live share card's compact sheet.
+ * The new-end-time editor opened from the live share card.
  *
- * The wheel, not the four-option select the received-shares editor uses. This
- * one opens on what the share actually has left, and 32 minutes snapped to
- * "1 hour" would silently offer to double a share the person meant to trim.
+ * A short preset ladder (15 min / 1 hour / 2 hours / 4 hours / Until I stop),
+ * not the received-shares editor's select and not the scroll wheel this used
+ * to open on. It still opens on what the share actually has left, so the
+ * "Ends …" read-back stays honest even when that value matches no rung; the
+ * person then picks the length they want in one tap.
  */
 function LiveShareDurationEditor({
   value,
@@ -4910,12 +4737,14 @@ function LiveShareDurationEditor({
   onCancel,
   onSave,
   saving,
+  surface = true,
 }: {
   value: string;
   onChange: (next: string) => void;
   onCancel: () => void;
-  onSave: (nextValue?: string) => void | Promise<void>;
+  onSave: () => void;
   saving: boolean;
+  surface?: boolean;
 }) {
   // Same 30-second tick as the share confirm step: an editor left open must
   // not keep quoting an end time that has already gone past.
@@ -4927,7 +4756,11 @@ function LiveShareDurationEditor({
 
   return (
     <div
-      className="space-y-4 pt-2"
+      className={cn(
+        surface ? SUBCARD_SURFACE : null,
+        "space-y-4",
+        surface ? "p-4" : null,
+      )}
       data-testid="one-location-live-share-duration-editor"
       data-ui-contract="control-group"
       data-ui-id="location-live-share-duration-editor"
@@ -4977,7 +4810,7 @@ function LiveShareDurationEditor({
         </Button>
         <Button
           className="h-11 rounded-full bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
-          onClick={() => void onSave()}
+          onClick={onSave}
           isLoading={saving}
           data-testid="one-location-live-share-duration-save"
         >
@@ -4988,6 +4821,7 @@ function LiveShareDurationEditor({
   );
 }
 
+/**
 /**
  * "Ends 4:35 PM" — the read-back under a duration picker.
  *
@@ -5460,7 +5294,10 @@ function AskFlow({
             />
             {reason === "Other" ? (
               <div className="space-y-2.5">
-                <FormLabel as="label" htmlFor="one-location-ask-other-reason">
+                <FormLabel
+                  as="label"
+                  htmlFor="one-location-ask-other-reason"
+                >
                   Add reason
                 </FormLabel>
                 <textarea

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -87,7 +87,7 @@ export const TOP_SHELL_TAB_REGISTRY = {
     tabs: [
       // Keep the authored value `now` so existing links and Kai's
       // `location.open_now` action continue resolving.
-      { value: "now", label: "My location", href: "/one/location" },
+      { value: "now", label: "Now", href: "/one/location" },
       {
         value: "people",
         label: "People",


### PR DESCRIPTION
## Summary
- Restore the One Location / My Location implementation to the working state from commit `56eb0ebe` (`2026-08-31 02:08 IST`).
- Reverts only the Location page implementation/tests touched by the later My Location simplification.
- Brings back the earlier working hierarchy/actions instead of the stripped page where functionality was hidden or obscured.

## Verification
- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts __tests__/components/one-location-hub-hierarchy.contract.test.ts __tests__/components/one-location-recovery-placement.contract.test.ts __tests__/components/one-location-settings-placement.contract.test.ts` (154 passed, 1 timeout)
- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx -t "keeps Settings focused on auto approval and Saved Locations" --testTimeout 20000` (passed)
- `npm run verify:one-location` (35 files, 710 tests passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`