### PR TITLE
Refine One Location nearby check-in

### DIFF
--- a/config/protected-behaviors.json
+++ b/config/protected-behaviors.json
@@ -426,7 +426,7 @@
             "states the checked-in fact in three lines and nothing more",
             "ends the check-in with a neutral action, not a destructive one",
             "keeps the pre-check-in panel to where, how long, and check in",
-            "keeps the required consent visible and drops the optional preference a level"
+            "keeps the required consent and connection preference visible"
           ]
         }
       ]

--- a/hushh-webapp/app/one/location/check-in/page.tsx
+++ b/hushh-webapp/app/one/location/check-in/page.tsx
@@ -50,7 +50,7 @@ export default function OneLocationCheckInPage() {
           screenId: "one_location_check_in",
           title: "Check in nearby",
           purpose:
-            "Shows nearby places and confirms an arrival once one is picked.",
+            "Temporarily shows you to people checked in at the same public place.",
           spokenSubject: "Location, Check in nearby",
           actions: LOCATION_CHECK_IN_VOICE_ACTIONS,
           availableActions: LOCATION_CHECK_IN_VOICE_ACTIONS.map(

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -440,9 +440,7 @@ function radiusBounds(
   radiusMeters: number,
 ) {
   const latitudeDelta = radiusMeters / 111_320;
-  const longitudeScale = Math.abs(
-    Math.cos((point.latitude * Math.PI) / 180),
-  );
+  const longitudeScale = Math.abs(Math.cos((point.latitude * Math.PI) / 180));
   const longitudeDelta = Math.min(
     180,
     radiusMeters / (111_320 * Math.max(longitudeScale, 0.000001)),
@@ -941,7 +939,9 @@ export function LocationImmersiveMap({
         },
       );
       return request;
-    }, []);
+    },
+    [],
+  );
 
   // Forwards `options` deliberately. Declared with no parameters, this silently
   // dropped a caller's `maxAgeMs: 0` — TypeScript accepts the narrower arity, so
@@ -1076,7 +1076,10 @@ export function LocationImmersiveMap({
         (item): item is RenderMarker => item !== null,
       );
       setPreferences(state.preferences);
-      if (Number.isFinite(state.freshnessSeconds) && state.freshnessSeconds > 0) {
+      if (
+        Number.isFinite(state.freshnessSeconds) &&
+        state.freshnessSeconds > 0
+      ) {
         setFreshnessSeconds(state.freshnessSeconds);
       }
       const nextSignature = markerSignature(nextMarkers);
@@ -1262,8 +1265,7 @@ export function LocationImmersiveMap({
     const cachedPoint = rendererReady
       ? readLocationWorkspaceMemory(auth.userId).myLocationPoint
       : null;
-    const superseded = () =>
-      cancelled || isNativeMapSuperseded(MAP_ID, claim);
+    const superseded = () => cancelled || isNativeMapSuperseded(MAP_ID, claim);
 
     void withNativeMapLock(MAP_ID, async () => {
       // Never touch the bridge on behalf of a mount that is already gone: the
@@ -1646,7 +1648,10 @@ export function LocationImmersiveMap({
           )
         : null;
       const mobileSheetInset = checkInSheet
-        ? Math.max(0, window.innerHeight - checkInSheet.getBoundingClientRect().top)
+        ? Math.max(
+            0,
+            window.innerHeight - checkInSheet.getBoundingClientRect().top,
+          )
         : 0;
       const padding = {
         top: Math.ceil(top + 12),
@@ -1737,8 +1742,7 @@ export function LocationImmersiveMap({
           )
         : null;
       const desktopCheckInOpen =
-        nearbyCheckInOpen &&
-        window.matchMedia("(min-width: 768px)").matches;
+        nearbyCheckInOpen && window.matchMedia("(min-width: 768px)").matches;
       const mobileSheetInset =
         checkInSheet && !desktopCheckInOpen
           ? Math.max(0, rect.bottom - checkInSheet.getBoundingClientRect().top)
@@ -1996,7 +2000,9 @@ export function LocationImmersiveMap({
     const generation = ++markerGenerationRef.current;
     let cancelled = false;
     const enqueue = (command: () => Promise<void>): Promise<void> => {
-      const next = markerCommandRef.current.catch(() => undefined).then(command);
+      const next = markerCommandRef.current
+        .catch(() => undefined)
+        .then(command);
       markerCommandRef.current = next.catch(() => undefined);
       return next;
     };
@@ -2045,11 +2051,14 @@ export function LocationImmersiveMap({
           // per-pin styling this bridge exposes -- `title` cannot carry it,
           // because the web renderer paints titles across the map as a glyph
           // (see above) -- so the colour is where staleness has to be said.
-          tintColor: isStaleAt(marker.capturedAt, freshnessSeconds, staleClockMs)
+          tintColor: isStaleAt(
+            marker.capturedAt,
+            freshnessSeconds,
+            staleClockMs,
+          )
             ? STALE_TINT
             : marker.tint,
-          zIndex:
-            marker.kind === "self" ? 10 : marker.kind === "place" ? 9 : 1,
+          zIndex: marker.kind === "self" ? 10 : marker.kind === "place" ? 9 : 1,
         };
       });
       const ids = mapMarkers.length ? await map.addMarkers(mapMarkers) : [];
@@ -2338,10 +2347,10 @@ export function LocationImmersiveMap({
     }
     return markers.length > 0
       ? `${markers.length} on your map`
-      // "No one sharing yet" beside a subtitle reading "Sharing with 1" was
-      // the reported contradiction. Naming the audience resolves it without
-      // making the row any longer.
-      : "No one sharing with you yet";
+      : // "No one sharing yet" beside a subtitle reading "Sharing with 1" was
+        // the reported contradiction. Naming the audience resolves it without
+        // making the row any longer.
+        "No one sharing with you yet";
   }, [markers.length, nearbyAttendees.length, nearbyPresenceState.presence]);
 
   // Only when it adds something the title cannot. Restating the title in
@@ -2755,7 +2764,10 @@ export function LocationImmersiveMap({
             disabled={closing}
             onClick={closeMap}
             onPointerUp={(event) => {
-              if (event.pointerType === "touch" || event.pointerType === "pen") {
+              if (
+                event.pointerType === "touch" ||
+                event.pointerType === "pen"
+              ) {
                 closeMap();
               }
             }}
@@ -2827,7 +2839,10 @@ export function LocationImmersiveMap({
                 <p className="px-2 py-1 text-[13px] font-semibold leading-[18px] text-muted-foreground">
                   Sharing with
                 </p>
-                <ul className="grid gap-1" aria-label="People you are sharing with">
+                <ul
+                  className="grid gap-1"
+                  aria-label="People you are sharing with"
+                >
                   {activeShareNames.map((name, index) => {
                     const pin = markerForSharedPerson(name);
                     return (
@@ -2927,7 +2942,11 @@ export function LocationImmersiveMap({
                 }`}
                 aria-label={
                   nearbyPresenceState.presence
-                    ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
+                    ? `Checked in${
+                        nearbyPresenceState.attendees.length > 0
+                          ? `, ${nearbyPresenceState.attendees.length} nearby`
+                          : ""
+                      }`
                     : "Check in nearby"
                 }
                 data-testid="one-location-map-nearby-check-in"
@@ -2936,8 +2955,8 @@ export function LocationImmersiveMap({
                 <UsersRound className="h-4 w-4 shrink-0" />
                 <span className="truncate">
                   {nearbyPresenceState.presence
-                    ? `Nearby ${nearbyPresenceState.attendees.length}`
-                    : "Check in"}
+                    ? "Checked in"
+                    : "Check in nearby"}
                 </span>
               </ShellActionSurface>
             ) : null}
@@ -2945,7 +2964,9 @@ export function LocationImmersiveMap({
               <ShellActionSurface
                 className={`pointer-events-auto !h-14 !w-14 touch-manipulation border shadow-lg backdrop-blur-md ${MAP_ACCENT_CONTROL_CLASSNAME}`}
                 aria-label={
-                  busy === "locate" ? "Finding your location" : "Show my location"
+                  busy === "locate"
+                    ? "Finding your location"
+                    : "Show my location"
                 }
                 aria-busy={busy === "locate"}
                 data-testid="one-location-map-locate"
@@ -3059,7 +3080,11 @@ export function LocationImmersiveMap({
             className="pointer-events-none absolute inset-0 opacity-[0.5] [background-image:linear-gradient(to_right,color-mix(in_srgb,var(--foreground)_8%,transparent)_1px,transparent_1px),linear-gradient(to_bottom,color-mix(in_srgb,var(--foreground)_8%,transparent)_1px,transparent_1px)] [background-size:32px_32px]"
           />
           <span className="relative flex h-14 w-14 items-center justify-center rounded-full bg-background text-[color:var(--app-accent)] shadow-lg">
-            <Loader2 className="h-7 w-7 animate-spin" strokeWidth={2} aria-hidden />
+            <Loader2
+              className="h-7 w-7 animate-spin"
+              strokeWidth={2}
+              aria-hidden
+            />
           </span>
           <p className="relative text-sm font-medium text-muted-foreground">
             Loading your map…
@@ -3357,232 +3382,237 @@ export function LocationImmersiveMap({
                   so its offsetHeight is the content's true natural size,
                   padding included since that padding lives here now. */}
               <div ref={trayContentRef} className="px-3 pb-3 pt-1">
-              <label className="relative block">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <span className="sr-only">Find a person</span>
-                <Input
-                  className="h-11 rounded-full border-border/60 bg-muted/80 pl-9 pr-4"
-                  data-testid="one-location-map-search"
-                  inputMode="search"
-                  placeholder="Search"
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                />
-              </label>
+                <label className="relative block">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <span className="sr-only">Find a person</span>
+                  <Input
+                    className="h-11 rounded-full border-border/60 bg-muted/80 pl-9 pr-4"
+                    data-testid="one-location-map-search"
+                    inputMode="search"
+                    placeholder="Search"
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                  />
+                </label>
 
-              {nearbyPresenceState.presence ? (
-                <section
-                  className="mt-2"
-                  data-testid="one-location-map-nearby-people"
-                  aria-label="People checked in nearby"
-                >
-                  {filteredNearbyAttendees.length > 0 ? (
-                    <div className="space-y-1">
-                      {filteredNearbyAttendees.map((attendee) => {
-                        const connectionBusy =
-                          nearbyConnectionBusyAlias ===
-                          attendee.participantAlias;
-                        return (
-                          <div
-                            key={attendee.participantAlias}
-                            className="flex min-h-11 items-center gap-1 rounded-xl px-1.5 transition-colors hover:bg-muted/70 focus-within:ring-2 focus-within:ring-accent/70"
-                            data-testid="one-location-map-nearby-person"
-                          >
-                            <button
-                              type="button"
-                              className="flex min-h-11 min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none"
-                              aria-label={`Open nearby actions for ${attendee.displayName}`}
-                              onClick={openNearbyCheckIn}
+                {nearbyPresenceState.presence ? (
+                  <section
+                    className="mt-2"
+                    data-testid="one-location-map-nearby-people"
+                    aria-label="People checked in nearby"
+                  >
+                    {filteredNearbyAttendees.length > 0 ? (
+                      <div className="space-y-1">
+                        {filteredNearbyAttendees.map((attendee) => {
+                          const connectionBusy =
+                            nearbyConnectionBusyAlias ===
+                            attendee.participantAlias;
+                          return (
+                            <div
+                              key={attendee.participantAlias}
+                              className="flex min-h-11 items-center gap-1 rounded-xl px-1.5 transition-colors hover:bg-muted/70 focus-within:ring-2 focus-within:ring-accent/70"
+                              data-testid="one-location-map-nearby-person"
                             >
-                              <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[var(--app-accent)] text-[11px] font-semibold text-[var(--app-accent-fg)]">
-                                {personInitials(attendee.displayName)}
-                              </span>
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-sm font-medium">
-                                  {attendee.displayName}
-                                </span>
-                                <span className="block truncate text-xs text-muted-foreground">
-                                  {nearbyRelationshipLabel(attendee)}
-                                </span>
-                              </span>
-                            </button>
-                            {attendee.canConnect &&
-                            attendee.relationship === "none" ? (
-                              <Button
+                              <button
                                 type="button"
-                                size="sm"
-                                variant="secondary"
-                                className="h-8 shrink-0 rounded-full px-3"
-                                aria-label={`Connect with ${attendee.displayName}`}
-                                disabled={nearbyConnectionBusyAlias !== null}
-                                onClick={() =>
-                                  void connectNearbyAttendee(attendee)
-                                }
-                              >
-                                {connectionBusy ? (
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                ) : (
-                                  "Connect"
-                                )}
-                              </Button>
-                            ) : attendee.relationship === "pending_outgoing" ? (
-                              <span className="shrink-0 px-2 text-xs font-medium text-muted-foreground">
-                                Requested
-                              </span>
-                            ) : attendee.relationship === "pending_incoming" ? (
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="secondary"
-                                className="h-8 shrink-0 rounded-full px-3"
-                                aria-label={`Respond to ${attendee.displayName}`}
+                                className="flex min-h-11 min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none"
+                                aria-label={`Open nearby actions for ${attendee.displayName}`}
                                 onClick={openNearbyCheckIn}
                               >
-                                Respond
-                              </Button>
-                            ) : (
-                              <ChevronDown className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground" />
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <p className="px-1 py-2 text-sm text-muted-foreground">
-                      {nearbyAttendees.length > 0
-                        ? "No matches."
-                        : "No one else here yet."}
-                    </p>
-                  )}
-                </section>
-              ) : null}
+                                <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[var(--app-accent)] text-[11px] font-semibold text-[var(--app-accent-fg)]">
+                                  {personInitials(attendee.displayName)}
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate text-sm font-medium">
+                                    {attendee.displayName}
+                                  </span>
+                                  <span className="block truncate text-xs text-muted-foreground">
+                                    {nearbyRelationshipLabel(attendee)}
+                                  </span>
+                                </span>
+                              </button>
+                              {attendee.canConnect &&
+                              attendee.relationship === "none" ? (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="secondary"
+                                  className="h-8 shrink-0 rounded-full px-3"
+                                  aria-label={`Connect with ${attendee.displayName}`}
+                                  disabled={nearbyConnectionBusyAlias !== null}
+                                  onClick={() =>
+                                    void connectNearbyAttendee(attendee)
+                                  }
+                                >
+                                  {connectionBusy ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  ) : (
+                                    "Connect"
+                                  )}
+                                </Button>
+                              ) : attendee.relationship ===
+                                "pending_outgoing" ? (
+                                <span className="shrink-0 px-2 text-xs font-medium text-muted-foreground">
+                                  Requested
+                                </span>
+                              ) : attendee.relationship ===
+                                "pending_incoming" ? (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="secondary"
+                                  className="h-8 shrink-0 rounded-full px-3"
+                                  aria-label={`Respond to ${attendee.displayName}`}
+                                  onClick={openNearbyCheckIn}
+                                >
+                                  Respond
+                                </Button>
+                              ) : (
+                                <ChevronDown className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground" />
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <p className="px-1 py-2 text-sm text-muted-foreground">
+                        {nearbyAttendees.length > 0
+                          ? "No matches."
+                          : "No one else here yet."}
+                      </p>
+                    )}
+                  </section>
+                ) : null}
 
-              {/* The heading, the count badge and the two-sentence pin rule
+                {/* The heading, the count badge and the two-sentence pin rule
                   all used to sit here, and all three said what the row above
                   already says: how many people are on this map. What survives
                   is the list itself, plus the pin rule in the one state where
                   it answers a real question -- "why is this list empty when
                   people are checked in nearby?" -- phrased once, in a line. */}
-              <section className="mt-3" aria-label="Live locations shared with you">
-                <div
-                  className="mt-2 flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                  data-testid="one-location-map-people"
+                <section
+                  className="mt-3"
+                  aria-label="Live locations shared with you"
                 >
-                  {filteredPeople.map((person) => {
-                    const selectedPerson = selected?.key === person.key;
-                    // The tray is where identity lives, because it is the only
-                    // part of this screen that is real DOM. Map pins come from
-                    // the Capacitor bridge, which offers a tint and nothing
-                    // else -- no avatar, no badge, and no hover at all on a
-                    // touch device.
-                    const personStale = isStaleAt(
-                      person.capturedAt,
-                      freshnessSeconds,
-                      staleClockMs,
-                    );
-                    const lastSeen = personStale
-                      ? lastSeenLabel(person.capturedAt, staleClockMs)
-                      : null;
-                    return (
-                      <button
-                        key={person.key}
-                        type="button"
-                        className={`flex h-11 shrink-0 items-center gap-2 rounded-full border px-2.5 pr-3 text-left text-sm transition-colors ${
-                          selectedPerson
-                            ? MAP_ACCENT_ACTIVE_CLASSNAME
-                            : "border-border/60 bg-muted/70 text-foreground hover:bg-muted"
-                        }`}
-                        // The live case keeps its original name exactly. Only a
-                        // person who has gone quiet has anything extra worth
-                        // announcing, and saying "sharing live" on every other
-                        // row would be noise in a screen reader.
-                        aria-label={
-                          lastSeen
-                            ? `Show ${person.label} on the map. Last seen ${lastSeen}.`
-                            : `Show ${person.label} on the map`
-                        }
-                        title={
-                          lastSeen
-                            ? `${person.label} — last seen ${lastSeen}`
-                            : `${person.label} — live now`
-                        }
-                        data-testid="one-location-map-person"
-                        data-stale={personStale ? "true" : "false"}
-                        onClick={() => void focusMarker(person)}
-                      >
-                        <span className="relative shrink-0">
-                          <span
-                            className={`grid h-7 w-7 place-items-center rounded-full text-[11px] font-semibold text-white transition-[filter,opacity] ${
-                              personStale ? "opacity-70 grayscale" : ""
-                            }`}
-                            style={{
-                              backgroundColor: person.tint
-                                ? `rgba(${person.tint.r}, ${person.tint.g}, ${person.tint.b}, ${person.tint.a / 255})`
-                                : "var(--app-accent)",
-                            }}
-                          >
-                            {personInitials(person.label)}
-                          </span>
-                          {/* Bottom-right, over the avatar's own edge. Shape as
+                  <div
+                    className="mt-2 flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    data-testid="one-location-map-people"
+                  >
+                    {filteredPeople.map((person) => {
+                      const selectedPerson = selected?.key === person.key;
+                      // The tray is where identity lives, because it is the only
+                      // part of this screen that is real DOM. Map pins come from
+                      // the Capacitor bridge, which offers a tint and nothing
+                      // else -- no avatar, no badge, and no hover at all on a
+                      // touch device.
+                      const personStale = isStaleAt(
+                        person.capturedAt,
+                        freshnessSeconds,
+                        staleClockMs,
+                      );
+                      const lastSeen = personStale
+                        ? lastSeenLabel(person.capturedAt, staleClockMs)
+                        : null;
+                      return (
+                        <button
+                          key={person.key}
+                          type="button"
+                          className={`flex h-11 shrink-0 items-center gap-2 rounded-full border px-2.5 pr-3 text-left text-sm transition-colors ${
+                            selectedPerson
+                              ? MAP_ACCENT_ACTIVE_CLASSNAME
+                              : "border-border/60 bg-muted/70 text-foreground hover:bg-muted"
+                          }`}
+                          // The live case keeps its original name exactly. Only a
+                          // person who has gone quiet has anything extra worth
+                          // announcing, and saying "sharing live" on every other
+                          // row would be noise in a screen reader.
+                          aria-label={
+                            lastSeen
+                              ? `Show ${person.label} on the map. Last seen ${lastSeen}.`
+                              : `Show ${person.label} on the map`
+                          }
+                          title={
+                            lastSeen
+                              ? `${person.label} — last seen ${lastSeen}`
+                              : `${person.label} — live now`
+                          }
+                          data-testid="one-location-map-person"
+                          data-stale={personStale ? "true" : "false"}
+                          onClick={() => void focusMarker(person)}
+                        >
+                          <span className="relative shrink-0">
+                            <span
+                              className={`grid h-7 w-7 place-items-center rounded-full text-[11px] font-semibold text-white transition-[filter,opacity] ${
+                                personStale ? "opacity-70 grayscale" : ""
+                              }`}
+                              style={{
+                                backgroundColor: person.tint
+                                  ? `rgba(${person.tint.r}, ${person.tint.g}, ${person.tint.b}, ${person.tint.a / 255})`
+                                  : "var(--app-accent)",
+                              }}
+                            >
+                              {personInitials(person.label)}
+                            </span>
+                            {/* Bottom-right, over the avatar's own edge. Shape as
                               well as colour, so it survives being read on a
                               greyscale avatar by someone who cannot rely on
                               the grey itself. */}
-                          {personStale ? (
-                            <span
-                              className="absolute -bottom-0.5 -right-0.5 grid h-3.5 w-3.5 place-items-center rounded-full bg-background ring-1 ring-border"
-                              aria-hidden="true"
-                            >
-                              <WifiOff className="h-2.5 w-2.5 text-muted-foreground" />
-                            </span>
-                          ) : null}
-                        </span>
-                        <span className="flex min-w-0 flex-col leading-tight">
-                          <span className="max-w-28 truncate font-medium">
-                            {person.label}
+                            {personStale ? (
+                              <span
+                                className="absolute -bottom-0.5 -right-0.5 grid h-3.5 w-3.5 place-items-center rounded-full bg-background ring-1 ring-border"
+                                aria-hidden="true"
+                              >
+                                <WifiOff className="h-2.5 w-2.5 text-muted-foreground" />
+                              </span>
+                            ) : null}
                           </span>
-                          {lastSeen ? (
-                            <span className="max-w-28 truncate text-[11px] text-muted-foreground">
-                              {lastSeen}
+                          <span className="flex min-w-0 flex-col leading-tight">
+                            <span className="max-w-28 truncate font-medium">
+                              {person.label}
                             </span>
-                          ) : null}
-                        </span>
-                      </button>
-                    );
-                  })}
-                  {filteredPeople.length === 0 ? (
-                    <p className="py-2 pl-1 text-sm text-muted-foreground">
-                      {markers.length > 0
-                        ? "No matches."
-                        : // The header already says no one is sharing. This
-                          // line spends itself on the part the header cannot:
-                          // what it takes to appear here.
-                          "Pins appear once they share with maps on."}
-                    </p>
-                  ) : null}
-                </div>
-              </section>
-
-              {selected ? (
-                <div
-                  className="mt-3 flex min-h-11 items-center justify-between gap-3 rounded-2xl bg-muted/80 px-3"
-                  data-testid="one-location-map-selection"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium">
-                      {selected.label}
-                    </p>
-                    {/* The self marker is already labelled "You"; captioning it
-                        "Your current location" was the same fact twice. */}
-                    {selected.kind === "self" ? null : (
-                      <p className="text-xs text-muted-foreground">
-                        Sharing now
+                            {lastSeen ? (
+                              <span className="max-w-28 truncate text-[11px] text-muted-foreground">
+                                {lastSeen}
+                              </span>
+                            ) : null}
+                          </span>
+                        </button>
+                      );
+                    })}
+                    {filteredPeople.length === 0 ? (
+                      <p className="py-2 pl-1 text-sm text-muted-foreground">
+                        {markers.length > 0
+                          ? "No matches."
+                          : // The header already says no one is sharing. This
+                            // line spends itself on the part the header cannot:
+                            // what it takes to appear here.
+                            "Pins appear once they share with maps on."}
                       </p>
-                    )}
+                    ) : null}
                   </div>
-                </div>
-              ) : null}
+                </section>
 
-              {/*
+                {selected ? (
+                  <div
+                    className="mt-3 flex min-h-11 items-center justify-between gap-3 rounded-2xl bg-muted/80 px-3"
+                    data-testid="one-location-map-selection"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {selected.label}
+                      </p>
+                      {/* The self marker is already labelled "You"; captioning it
+                        "Your current location" was the same fact twice. */}
+                      {selected.kind === "self" ? null : (
+                        <p className="text-xs text-muted-foreground">
+                          Sharing now
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+
+                {/*
                 Three audiences, three rows, in the order a person asks about
                 them. Reported as "this interface gives an illusion of a
                 check-in page and creates a little bit of confusion", and it
@@ -3618,159 +3648,163 @@ export function LocationImmersiveMap({
                 `list_map_state` and in this file's `locateMe`, and is gone
                 from both.
               */}
-              <section
-                className="mt-3 space-y-2"
-                aria-label="Who can see you, and who you can see"
-                data-testid="one-location-map-visibility"
-              >
-                {/* Incoming. Keeps the `show-everyone` id: this IS the old
-                    Everyone control, finally saying what it frames. */}
-                <button
-                  type="button"
-                  className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-                  data-testid="one-location-map-show-everyone"
-                  aria-label={
-                    markers.length > 0
-                      ? `${incomingShareLabel}. Fit them all on the map.`
-                      : incomingShareLabel
-                  }
-                  onClick={() => void showEveryone()}
+                <section
+                  className="mt-3 space-y-2"
+                  aria-label="Who can see you, and who you can see"
+                  data-testid="one-location-map-visibility"
                 >
-                  <span
-                    className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
-                    aria-hidden="true"
+                  {/* Incoming. Keeps the `show-everyone` id: this IS the old
+                    Everyone control, finally saying what it frames. */}
+                  <button
+                    type="button"
+                    className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                    data-testid="one-location-map-show-everyone"
+                    aria-label={
+                      markers.length > 0
+                        ? `${incomingShareLabel}. Fit them all on the map.`
+                        : incomingShareLabel
+                    }
+                    onClick={() => void showEveryone()}
                   >
-                    <UsersRound className="h-[18px] w-[18px]" />
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm font-medium">
-                      {incomingShareLabel}
-                    </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {markers.length > 0
-                        ? "Tap to fit everyone on the map"
-                        : "Ghost Mode never hides them from you"}
-                    </span>
-                  </span>
-                  <ChevronDown
-                    className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                </button>
-
-                {/* Outgoing. Hidden in demo, where the count is never fetched
-                    and a number would be fiction. */}
-                {!demoMode ? (
-                  <div className="rounded-2xl bg-muted/70">
-                    <button
-                      type="button"
-                      className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default disabled:hover:bg-transparent"
-                      data-testid="one-location-map-private-shares"
-                      aria-expanded={privateSharesExpanded}
-                      disabled={privateShareCount === 0}
-                      aria-label={privateShareLabel}
-                      onClick={() => setPrivateSharesExpanded((open) => !open)}
+                    <span
+                      className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
+                      aria-hidden="true"
                     >
-                      <span
-                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
-                        aria-hidden="true"
+                      <UsersRound className="h-[18px] w-[18px]" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {incomingShareLabel}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {markers.length > 0
+                          ? "Tap to fit everyone on the map"
+                          : "Ghost Mode never hides them from you"}
+                      </span>
+                    </span>
+                    <ChevronDown
+                      className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                  </button>
+
+                  {/* Outgoing. Hidden in demo, where the count is never fetched
+                    and a number would be fiction. */}
+                  {!demoMode ? (
+                    <div className="rounded-2xl bg-muted/70">
+                      <button
+                        type="button"
+                        className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default disabled:hover:bg-transparent"
+                        data-testid="one-location-map-private-shares"
+                        aria-expanded={privateSharesExpanded}
+                        disabled={privateShareCount === 0}
+                        aria-label={privateShareLabel}
+                        onClick={() =>
+                          setPrivateSharesExpanded((open) => !open)
+                        }
                       >
-                        <LocateFixed className="h-[18px] w-[18px]" />
-                      </span>
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium">
-                          {privateShareLabel}
-                        </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {privateShareHint}
-                        </span>
-                      </span>
-                      {privateShareCount > 0 ? (
-                        <ChevronDown
-                          className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
-                            privateSharesExpanded ? "" : "-rotate-90"
-                          }`}
+                        <span
+                          className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
                           aria-hidden="true"
-                        />
-                      ) : null}
-                    </button>
-                    {privateSharesExpanded && privateShareCount > 0 ? (
-                      <ul
-                        className="grid gap-0.5 px-2 pb-2"
-                        aria-label="People you are sharing with privately"
-                      >
-                        {activeShareNames.map((name, index) => {
-                          const pin = markerForSharedPerson(name);
-                          return (
-                            <li key={`${name}-${index}`}>
-                              {/* Same two destinations as the header popover,
+                        >
+                          <LocateFixed className="h-[18px] w-[18px]" />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">
+                            {privateShareLabel}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {privateShareHint}
+                          </span>
+                        </span>
+                        {privateShareCount > 0 ? (
+                          <ChevronDown
+                            className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
+                              privateSharesExpanded ? "" : "-rotate-90"
+                            }`}
+                            aria-hidden="true"
+                          />
+                        ) : null}
+                      </button>
+                      {privateSharesExpanded && privateShareCount > 0 ? (
+                        <ul
+                          className="grid gap-0.5 px-2 pb-2"
+                          aria-label="People you are sharing with privately"
+                        >
+                          {activeShareNames.map((name, index) => {
+                            const pin = markerForSharedPerson(name);
+                            return (
+                              <li key={`${name}-${index}`}>
+                                {/* Same two destinations as the header popover,
                                   for the same reason: a row that names a person
                                   has to go to that person. */}
-                              <button
-                                type="button"
-                                data-testid="one-location-map-private-share-person"
-                                data-has-pin={pin ? "true" : "false"}
-                                aria-label={
-                                  pin
-                                    ? `Show ${name} on your map`
-                                    : `Manage your location share with ${name}`
-                                }
-                                className="flex min-h-11 w-full items-center gap-2 rounded-xl px-2 text-left text-sm transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-                                onClick={() => void openSharedPerson(name)}
-                              >
-                                <span
-                                  className="h-2 w-2 shrink-0 rounded-full bg-[var(--app-accent)]"
-                                  aria-hidden="true"
-                                />
-                                <span className="min-w-0 flex-1 truncate">
-                                  {name}
-                                </span>
-                              </button>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    ) : null}
-                  </div>
-                ) : null}
+                                <button
+                                  type="button"
+                                  data-testid="one-location-map-private-share-person"
+                                  data-has-pin={pin ? "true" : "false"}
+                                  aria-label={
+                                    pin
+                                      ? `Show ${name} on your map`
+                                      : `Manage your location share with ${name}`
+                                  }
+                                  className="flex min-h-11 w-full items-center gap-2 rounded-xl px-2 text-left text-sm transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                                  onClick={() => void openSharedPerson(name)}
+                                >
+                                  <span
+                                    className="h-2 w-2 shrink-0 rounded-full bg-[var(--app-accent)]"
+                                    aria-hidden="true"
+                                  />
+                                  <span className="min-w-0 flex-1 truncate">
+                                    {name}
+                                  </span>
+                                </button>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : null}
+                    </div>
+                  ) : null}
 
-                {/* General visibility. A switch, not a pill in a pair: it is a
+                  {/* General visibility. A switch, not a pill in a pair: it is a
                     standing setting with an on and an off, and it is the only
                     control here that changes what anyone else sees. */}
-                <div
-                  className="flex min-h-[52px] items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2"
-                  data-testid="one-location-map-ghost"
-                >
-                  <span
-                    className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
-                    aria-hidden="true"
+                  <div
+                    className="flex min-h-[52px] items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2"
+                    data-testid="one-location-map-ghost"
                   >
-                    {isGhostMode ? (
-                      <EyeOff className="h-[18px] w-[18px]" />
-                    ) : (
-                      <Eye className="h-[18px] w-[18px]" />
-                    )}
-                  </span>
-                  <label
-                    className="min-w-0 flex-1 cursor-pointer"
-                    htmlFor="one-location-map-ghost-toggle"
-                  >
-                    <span className="block text-sm font-medium">Ghost Mode</span>
-                    <span className="block text-xs text-muted-foreground">
-                      {ghostModeExplainer}
+                    <span
+                      className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
+                      aria-hidden="true"
+                    >
+                      {isGhostMode ? (
+                        <EyeOff className="h-[18px] w-[18px]" />
+                      ) : (
+                        <Eye className="h-[18px] w-[18px]" />
+                      )}
                     </span>
-                  </label>
-                  <Switch
-                    id="one-location-map-ghost-toggle"
-                    data-testid="one-location-map-ghost-toggle"
-                    checked={isGhostMode}
-                    disabled={busy === "presence"}
-                    onCheckedChange={() => void setPresence()}
-                  />
-                </div>
-              </section>
+                    <label
+                      className="min-w-0 flex-1 cursor-pointer"
+                      htmlFor="one-location-map-ghost-toggle"
+                    >
+                      <span className="block text-sm font-medium">
+                        Ghost Mode
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {ghostModeExplainer}
+                      </span>
+                    </label>
+                    <Switch
+                      id="one-location-map-ghost-toggle"
+                      data-testid="one-location-map-ghost-toggle"
+                      checked={isGhostMode}
+                      disabled={busy === "presence"}
+                      onCheckedChange={() => void setPresence()}
+                    />
+                  </div>
+                </section>
 
-              {/*
+                {/*
                 Check in and Demo: occasional actions, not map state.
 
                 Check-in used to be the filled full-width button at the bottom
@@ -3780,57 +3814,61 @@ export function LocationImmersiveMap({
                 Mode -- so it sits with Demo as a secondary action, and the
                 sheet above it is now the part that answers "who can see me".
               */}
-              {checkInActionAvailable || demoAvailable ? (
-                <div
-                  className={`mt-2 grid gap-2 ${
-                    checkInActionAvailable && demoAvailable
-                      ? "grid-cols-2"
-                      : "grid-cols-1"
-                  }`}
-                >
-                  {demoAvailable ? (
-                    <Button
-                      className={`h-11 min-w-0 rounded-2xl px-2 ${
-                        demoMode ? MAP_ACCENT_ACTIVE_CLASSNAME : ""
-                      }`}
-                      variant="secondary"
-                      aria-pressed={demoMode}
-                      data-testid="one-location-map-demo-toggle"
-                      onClick={toggleDemoPeople}
-                    >
-                      <UsersRound className="h-4 w-4 shrink-0" />
-                      {/* Pressed state is already carried by the accent fill and
+                {checkInActionAvailable || demoAvailable ? (
+                  <div
+                    className={`mt-2 grid gap-2 ${
+                      checkInActionAvailable && demoAvailable
+                        ? "grid-cols-2"
+                        : "grid-cols-1"
+                    }`}
+                  >
+                    {demoAvailable ? (
+                      <Button
+                        className={`h-11 min-w-0 rounded-2xl px-2 ${
+                          demoMode ? MAP_ACCENT_ACTIVE_CLASSNAME : ""
+                        }`}
+                        variant="secondary"
+                        aria-pressed={demoMode}
+                        data-testid="one-location-map-demo-toggle"
+                        onClick={toggleDemoPeople}
+                      >
+                        <UsersRound className="h-4 w-4 shrink-0" />
+                        {/* Pressed state is already carried by the accent fill and
                           aria-pressed; the label need not say it too. */}
-                      <span className="truncate">Demo</span>
-                    </Button>
-                  ) : null}
-                  {checkInActionAvailable ? (
-                    <Button
-                      className="h-11 min-w-0 rounded-2xl px-2"
-                      variant="secondary"
-                      aria-label={
-                        nearbyPresenceState.presence
-                          ? `Nearby check-in active with ${nearbyPresenceState.attendees.length} people`
-                          : "Check in nearby"
-                      }
-                      data-testid="one-location-map-nearby-check-in"
-                      onClick={openNearbyCheckIn}
-                    >
-                      <UsersRound className="h-4 w-4 shrink-0" />
-                      <span className="truncate">
-                        {nearbyPresenceState.presence
-                          ? `Nearby ${nearbyPresenceState.attendees.length}`
-                          : "Check in"}
-                      </span>
-                    </Button>
-                  ) : null}
-                </div>
-              ) : null}
-              {status === "error" ? (
-                <p className="mt-2 text-center text-xs text-destructive">
-                  Some locations didn&apos;t refresh.
-                </p>
-              ) : null}
+                        <span className="truncate">Demo</span>
+                      </Button>
+                    ) : null}
+                    {checkInActionAvailable ? (
+                      <Button
+                        className="h-11 min-w-0 rounded-2xl px-2"
+                        variant="secondary"
+                        aria-label={
+                          nearbyPresenceState.presence
+                            ? `Checked in${
+                                nearbyPresenceState.attendees.length > 0
+                                  ? `, ${nearbyPresenceState.attendees.length} nearby`
+                                  : ""
+                              }`
+                            : "Check in nearby"
+                        }
+                        data-testid="one-location-map-nearby-check-in"
+                        onClick={openNearbyCheckIn}
+                      >
+                        <UsersRound className="h-4 w-4 shrink-0" />
+                        <span className="truncate">
+                          {nearbyPresenceState.presence
+                            ? "Checked in"
+                            : "Check in nearby"}
+                        </span>
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : null}
+                {status === "error" ? (
+                  <p className="mt-2 text-center text-xs text-destructive">
+                    Some locations didn&apos;t refresh.
+                  </p>
+                ) : null}
               </div>
             </div>
           </div>

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -215,7 +215,9 @@ describe("NearbyCheckInSheet", () => {
     // which is a fact about the roadmap, not about the person's decision.
     expect(screen.queryByText("Preview")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Choose a real place within 500 m of your current location."),
+      screen.queryByText(
+        "Choose a real place within 500 m of your current location.",
+      ),
     ).not.toBeInTheDocument();
 
     const longName = await screen.findByText(
@@ -233,11 +235,17 @@ describe("NearbyCheckInSheet", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Stay visible for")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "See all 4" }),
+      screen.getByRole("button", { name: "See all places" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "See all 4" }));
-    expect(await screen.findByRole("radio", { name: /Place Four/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Food" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
+    expect(
+      await screen.findByRole("radio", { name: /Place Four/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Food" })).toBeInTheDocument();
     // Attribution only. The place count that used to lead this line is
     // already on the expansion control and in the list itself.
     expect(screen.getByText("Google Maps")).toBeInTheDocument();
@@ -292,11 +300,16 @@ describe("NearbyCheckInSheet", () => {
       within(panel)
         .getAllByRole("heading")
         .map((heading) => heading.textContent?.trim()),
-    ).toEqual(["Nearby places", "Visible for"]);
+    ).toEqual(["Nearby places", "Visible for", "Visibility"]);
 
-    // Two one-word chips replace the two that could not fit one.
-    expect(screen.getByRole("button", { name: "Food" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Shops" })).toBeInTheDocument();
+    // Compact setup keeps categories out of the first decision. They appear
+    // only after the person asks for the full chooser.
+    expect(
+      screen.queryByRole("button", { name: "Food" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Shops" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Food & drink" }),
     ).not.toBeInTheDocument();
@@ -337,7 +350,7 @@ describe("NearbyCheckInSheet", () => {
       within(ladder)
         .getAllByRole("button")
         .map((button) => button.textContent?.trim()),
-    ).toEqual(["30 min", "1 hr", "2 hr"]);
+    ).toEqual(["30 min", "1 hour", "2 hours"]);
 
     // Three across on a phone, so nothing wraps to a half-empty second row.
     // Asserted on the class because JSDOM lays nothing out -- the browser
@@ -346,16 +359,16 @@ describe("NearbyCheckInSheet", () => {
     expect(ladder.className).not.toContain("grid-cols-2");
 
     // Still a working ladder, not just a tidier one.
-    fireEvent.click(within(ladder).getByRole("button", { name: "2 hr" }));
+    fireEvent.click(within(ladder).getByRole("button", { name: "2 hours" }));
     expect(
-      within(ladder).getByRole("button", { name: "2 hr" }),
+      within(ladder).getByRole("button", { name: "2 hours" }),
     ).toHaveAttribute("aria-pressed", "true");
     expect(
-      within(ladder).getByRole("button", { name: "1 hr" }),
+      within(ladder).getByRole("button", { name: "1 hour" }),
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("keeps the required consent visible and drops the optional preference a level", async () => {
+  it("keeps the required consent and connection preference visible", async () => {
     render(
       <NearbyCheckInSheet
         open
@@ -368,25 +381,18 @@ describe("NearbyCheckInSheet", () => {
 
     // Consent gates the Check in button, so hiding it would leave a disabled
     // primary action with no visible reason. It stays in the open.
-    await screen.findByRole("checkbox", { name: /Appear nearby/ });
-    expect(screen.getByText("Your name only")).toBeInTheDocument();
+    await screen.findByRole("checkbox", { name: /Show my name here/ });
+    expect(
+      screen.getByText("Only people checked in at this place can see it."),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText("People see your name only."),
     ).not.toBeInTheDocument();
 
-    // Connection requests defaults off, changes nothing about who can see the
-    // person, and does not need answering before every check-in.
-    const options = screen.getByRole("button", { name: "Options" });
-    expect(options).toHaveAttribute("aria-expanded", "false");
     expect(
-      screen.queryByRole("switch", {
-        name: "Allow nearby connection requests",
-      }),
+      screen.queryByRole("button", { name: "Options" }),
     ).not.toBeInTheDocument();
-
-    fireEvent.click(options);
-    expect(options).toHaveAttribute("aria-expanded", "true");
-    // Same control, same default — only its prominence changed.
+    // Same control, same default, now readable without a disclosure detour.
     expect(
       screen.getByRole("switch", {
         name: "Allow nearby connection requests",
@@ -424,7 +430,9 @@ describe("NearbyCheckInSheet", () => {
       lng: point.longitude,
       category: "all",
     });
-    expect(screen.queryByText("Stanford Shopping Center")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Stanford Shopping Center"),
+    ).not.toBeInTheDocument();
     // One supporting line: what kind of place it is. The postal address always
     // truncated, and the tail it cut was the disambiguating half — so it cost
     // a line and answered nothing. It survives in the title attribute.
@@ -455,7 +463,7 @@ describe("NearbyCheckInSheet", () => {
     ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
     expect(submit).toBeDisabled();
@@ -464,7 +472,7 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.click(submit);
 
     await waitFor(() => {
-    expect(service.checkInNearby).toHaveBeenCalledWith({
+      expect(service.checkInNearby).toHaveBeenCalledWith({
         vaultOwnerToken: "owner-token",
         placeId: "stanford-main",
         point: confirmationPoint,
@@ -499,12 +507,10 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     expect(
       await screen.findByText(/couldn't confirm where you are/i),
@@ -573,12 +579,10 @@ describe("NearbyCheckInSheet", () => {
 
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     await waitFor(() => {
       expect(service.checkInNearby).toHaveBeenCalledWith(
@@ -720,7 +724,7 @@ describe("NearbyCheckInSheet", () => {
     ).toBeDisabled();
   });
 
-  it("prepares a fresh check-in when an active presence expires while open", async () => {
+  it("keeps a clear completed state when an active presence ends while open", async () => {
     service.getNearbyPresence
       .mockResolvedValueOnce({
         presence: {
@@ -751,19 +755,16 @@ describe("NearbyCheckInSheet", () => {
     await screen.findByTestId("nearby-presence-active");
     document.dispatchEvent(new Event("visibilitychange"));
 
-    await screen.findByTestId("nearby-presence-setup");
-    await waitFor(() => {
-      expect(capture).toHaveBeenCalledTimes(1);
-      expect(service.nearbyPlaces).toHaveBeenCalledWith({
-        vaultOwnerToken: "owner-token",
-        lat: point.latitude,
-        lng: point.longitude,
-        category: "all",
-      });
-    });
+    const completed = await screen.findByTestId("nearby-presence-completed");
+    expect(completed).toHaveTextContent("Check-in ended");
+    expect(completed).toHaveTextContent("Stanford University");
+    expect(completed).toHaveTextContent("This check-in has ended.");
+    expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+    expect(capture).not.toHaveBeenCalled();
+    expect(service.nearbyPlaces).not.toHaveBeenCalled();
     expect(
-      screen.getByRole("radio", { name: /Stanford University/ }),
-    ).toHaveAttribute("aria-checked", "false");
+      screen.queryByRole("radio", { name: /Stanford University/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("states the checked-in fact in three lines and nothing more", async () => {
@@ -808,9 +809,7 @@ describe("NearbyCheckInSheet", () => {
 
     // The privacy mechanism is unchanged and is no longer narrated twice on a
     // screen whose subject is a roster of names.
-    expect(
-      screen.queryByText(/not as map pins/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/not as map pins/i)).not.toBeInTheDocument();
     expect(
       screen.queryByText(/never pinned on your map/i),
     ).not.toBeInTheDocument();
@@ -877,7 +876,9 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.click(
       await screen.findByRole("radio", { name: /Stanford University/ }),
     );
-    fireEvent.click(screen.getByRole("checkbox", { name: /Appear nearby/ }));
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /Show my name here/ }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Check in" }));
     await screen.findByTestId("nearby-presence-active");
   };
@@ -885,9 +886,7 @@ describe("NearbyCheckInSheet", () => {
   it("says nothing about a gap the owner cannot act on", async () => {
     // ~11 m north of the place: inside the building, not a different one.
     await checkInFrom(37.4277);
-    expect(
-      screen.queryByTestId("nearby-active-drift"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("nearby-active-drift")).not.toBeInTheDocument();
   });
 
   it("says so plainly once the owner has actually left the place", async () => {
@@ -1034,9 +1033,8 @@ describe("NearbyCheckInSheet", () => {
       attendees: [],
       checkedOut: true,
     };
-    let resolveCheckout:
-      | ((value: typeof checkedOutState) => void)
-      | null = null;
+    let resolveCheckout: ((value: typeof checkedOutState) => void) | null =
+      null;
     service.getNearbyPresence.mockResolvedValue(activeState);
     service.checkoutNearby.mockImplementationOnce(
       () =>
@@ -1069,7 +1067,9 @@ describe("NearbyCheckInSheet", () => {
     await act(async () => {
       resolveCheckout?.(checkedOutState);
     });
-    expect(await screen.findByTestId("nearby-presence-completed")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("nearby-presence-completed"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "I'm leaving" }),
     ).not.toBeInTheDocument();
@@ -1128,7 +1128,9 @@ describe("NearbyCheckInSheet", () => {
         incrementMinutes: 30,
       });
     });
-    expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("nearby-presence-setup"),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("nearby-presence-active")).toBeInTheDocument();
   });
 
@@ -1221,9 +1223,11 @@ describe("NearbyCheckInSheet", () => {
     service.nearbyPlaces.mockClear();
 
     fireEvent.click(screen.getByPlaceholderText("Search places"));
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
+    const allPlaces = await screen.findByRole("button", { name: "All" });
     await act(async () => {
       // A failed refresh must degrade the drawer, not blank it.
-      fireEvent.click(screen.getByRole("button", { name: "All" }));
+      fireEvent.click(allPlaces);
     });
 
     // Force the failing refresh through the recovery button.
@@ -1359,7 +1363,9 @@ describe("NearbyCheckInSheet", () => {
       />,
     );
 
-    expect(await screen.findByText("Previous Owner Person")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Previous Owner Person"),
+    ).toBeInTheDocument();
 
     rerender(
       <NearbyCheckInSheet
@@ -1372,7 +1378,9 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText("Previous Owner Person")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Previous Owner Person"),
+      ).not.toBeInTheDocument();
     });
     expect(service.getNearbyPresence).toHaveBeenLastCalledWith({
       vaultOwnerToken: "owner-token-2",
@@ -1415,6 +1423,7 @@ describe("NearbyCheckInSheet", () => {
       category: "all",
     });
 
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1451,16 +1460,14 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.change(screen.getByPlaceholderText("Search places"), {
       target: { value: "" },
     });
-    expect(await screen.findByRole("button", { name: "Health" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(
+      await screen.findByRole("button", { name: "Health" }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("cannot submit an old place while typed search is unresolved", async () => {
     let resolveSearch:
-      | ((value: Array<{ placeId: string; text: string }>) => void)
-      | null = null;
+      ((value: Array<{ placeId: string; text: string }>) => void) | null = null;
     service.placesAutocomplete.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -1483,7 +1490,7 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
     const submit = screen.getByRole("button", {
@@ -1534,6 +1541,7 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.click(
       await screen.findByRole("radio", { name: /Stanford University/ }),
     );
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1546,12 +1554,10 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
     await waitFor(() => {
@@ -1644,7 +1650,8 @@ describe("NearbyCheckInSheet", () => {
     const capture = vi.fn().mockResolvedValue(point);
     service.checkInNearby.mockRejectedValueOnce(new Error("invalid place"));
     service.nearbyCheckInErrorDetails.mockReturnValueOnce({
-      message: "This place is no longer available. Choose another nearby place.",
+      message:
+        "This place is no longer available. Choose another nearby place.",
       retryLocation: false,
       openAppSettings: false,
       retryPlaces: true,
@@ -1661,6 +1668,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByRole("radio", { name: /Stanford University/ });
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1673,12 +1681,10 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     // The area is re-swept once when the chosen place turns out to be
     // unavailable; the chip the owner was browsing is preserved.
@@ -1707,7 +1713,8 @@ describe("NearbyCheckInSheet", () => {
       .mockResolvedValueOnce(movedPoint);
     service.checkInNearby.mockRejectedValueOnce(new Error("outside radius"));
     service.nearbyCheckInErrorDetails.mockReturnValueOnce({
-      message: "You moved outside that place's range. Choose a nearby place again.",
+      message:
+        "You moved outside that place's range. Choose a nearby place again.",
       retryLocation: false,
       openAppSettings: false,
       retryPlaces: true,
@@ -1728,12 +1735,10 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     await waitFor(() => {
       expect(service.nearbyPlaces).toHaveBeenLastCalledWith({
@@ -1815,12 +1820,10 @@ describe("NearbyCheckInSheet", () => {
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /Appear nearby/,
+        name: /Show my name here/,
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Check in" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Check in" }));
 
     await waitFor(() => {
       expect(onPlaceFocusChange).toHaveBeenLastCalledWith(
@@ -1871,6 +1874,7 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByRole("radio", { name: /Stanford University/ });
+    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Transit" }));
 
     const empty = await screen.findByTestId("nearby-category-empty");
@@ -2062,7 +2066,9 @@ describe("NearbyCheckInSheet", () => {
       // fix was being written here while the grant was not, because the grant
       // was only recorded by the bus, which this surface never attaches.
       await waitFor(() => {
-        expect(locationMemory.rememberLocationGrant).toHaveBeenCalledWith("user-1");
+        expect(locationMemory.rememberLocationGrant).toHaveBeenCalledWith(
+          "user-1",
+        );
       });
     });
 
@@ -2279,11 +2285,17 @@ describe("NearbyCheckInSheet", () => {
       const completed = await screen.findByTestId("nearby-presence-completed");
       expect(completed.textContent).toContain("Check-in ended");
       expect(completed.textContent).toContain("Blue Bottle Coffee");
-      expect(completed.textContent).toContain("You're no longer visible nearby.");
-      expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+      expect(completed.textContent).toContain(
+        "You're no longer visible nearby.",
+      );
+      expect(
+        screen.queryByTestId("nearby-presence-setup"),
+      ).not.toBeInTheDocument();
       expect(screen.queryByText("Checked out from")).not.toBeInTheDocument();
       expect(
-        await screen.findByRole("button", { name: "Save for faster check-ins" }),
+        await screen.findByRole("button", {
+          name: "Save for faster check-ins",
+        }),
       ).toBeInTheDocument();
     });
 
@@ -2344,7 +2356,9 @@ describe("NearbyCheckInSheet", () => {
           longitude: -122.1697,
         },
       });
-      expect(await screen.findByText("Saved for next time.")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Saved for next time."),
+      ).toBeInTheDocument();
     });
 
     it("finishes without saving", async () => {

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import {
   Check,
-  ChevronDown,
+  ChevronRight,
   Compass,
   Loader2,
   LocateFixed,
@@ -103,8 +103,8 @@ const SUCCESS_ROLE = SEMANTIC_ROLE_CLASSES.success;
  */
 const DURATIONS = [
   { value: 30 as const, label: "30 min" },
-  { value: 60 as const, label: "1 hr" },
-  { value: 120 as const, label: "2 hr" },
+  { value: 60 as const, label: "1 hour" },
+  { value: 120 as const, label: "2 hours" },
 ];
 
 /**
@@ -119,7 +119,8 @@ const DURATIONS = [
  * At 320px this is ~90px a cell against a widest label of ~64px, so nothing
  * truncates on the narrowest phone the app supports.
  */
-const CHECK_IN_DURATION_GRID_CLASS = "grid grid-cols-3 gap-2 sm:flex sm:flex-wrap";
+const CHECK_IN_DURATION_GRID_CLASS =
+  "grid grid-cols-3 gap-2 sm:flex sm:flex-wrap";
 
 /**
  * Chip labels only. The `value` on each row is the backend category and is
@@ -170,8 +171,10 @@ type PresenceLoadResult = OneLocationNearbyPresenceState | "error" | null;
  */
 type PointOrigin = "fresh" | "last-known";
 type NearbyCheckInViewState = "loading" | "setup" | "active" | "completed";
+type NearbyCheckInCompletionReason = "left" | "expired" | "ended";
 type CompletedCheckIn = {
   placeLabel: string | null;
+  reason: NearbyCheckInCompletionReason;
   saved: boolean;
   saveError: string | null;
 };
@@ -261,7 +264,8 @@ function normalizeAutomaticPlaces(
       return true;
     })
     .sort((left, right) => {
-      const distance = Number(left.distanceMeters) - Number(right.distanceMeters);
+      const distance =
+        Number(left.distanceMeters) - Number(right.distanceMeters);
       if (distance !== 0) return distance;
       return (left.name || left.text).localeCompare(right.name || right.text);
     });
@@ -413,6 +417,12 @@ function peopleNearbyLabel(count: number): string | null {
   return `${count} ${count === 1 ? "person" : "people"} nearby`;
 }
 
+function completionCopy(reason: NearbyCheckInCompletionReason | undefined) {
+  if (reason === "expired") return "Your time ran out.";
+  if (reason === "ended") return "This check-in has ended.";
+  return "You're no longer visible nearby.";
+}
+
 function initials(label: string): string {
   return (
     label
@@ -444,10 +454,9 @@ function NearbyPersonRow({
   const buttonLabel = connectionUnavailable
     ? "Not accepting requests"
     : cta.label;
-  const accessibleLabel =
-    connectionUnavailable
-      ? `${attendee.displayName} is not accepting connection requests`
-      : cta.action === "respond"
+  const accessibleLabel = connectionUnavailable
+    ? `${attendee.displayName} is not accepting connection requests`
+    : cta.action === "respond"
       ? `Respond to ${attendee.displayName}'s connection request`
       : `${cta.label} with ${attendee.displayName}`;
   return (
@@ -463,7 +472,7 @@ function NearbyPersonRow({
           {attendee.displayName}
         </span>
         <span className="block text-xs text-muted-foreground">
-          Checked in nearby
+          At this place
         </span>
       </span>
       <Button
@@ -472,11 +481,7 @@ function NearbyPersonRow({
         className="shrink-0"
         variant={cta.action === "connect" ? "default" : "secondary"}
         aria-label={accessibleLabel}
-        disabled={
-          interactionDisabled ||
-          cta.disabled ||
-          connectionUnavailable
-        }
+        disabled={interactionDisabled || cta.disabled || connectionUnavailable}
         onClick={cta.action === "respond" ? onRespond : onConnect}
       >
         {busy ? (
@@ -595,15 +600,13 @@ export function NearbyCheckInSheet({
   const [searching, setSearching] = useState(false);
   const [capturing, setCapturing] = useState(false);
   const [loadingPresence, setLoadingPresence] = useState(false);
-  const [viewState, setViewState] =
-    useState<NearbyCheckInViewState>("loading");
+  const [viewState, setViewState] = useState<NearbyCheckInViewState>("loading");
   const [state, setState] =
     useState<OneLocationNearbyPresenceState>(EMPTY_NEARBY_STATE);
   const [durationMinutes, setDurationMinutes] = useState<30 | 60 | 120>(60);
   const [consentAccepted, setConsentAccepted] = useState(false);
   const [allowConnectionRequests, setAllowConnectionRequests] = useState(false);
-  /** Whether the secondary preference row is revealed. Presentation only. */
-  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [showAllPlaces, setShowAllPlaces] = useState(false);
   const [addTimeOpen, setAddTimeOpen] = useState(false);
   const [addTimeBusy, setAddTimeBusy] = useState<30 | 60 | null>(null);
   const [busy, setBusy] = useState<"check-in" | "checkout" | string | null>(
@@ -627,9 +630,8 @@ export function NearbyCheckInSheet({
   );
   const [placesError, setPlacesError] = useState<string | null>(null);
   const [accuracyNotice, setAccuracyNotice] = useState<string | null>(null);
-  const [visiblePlacesCount, setVisiblePlacesCount] = useState(3);
-
   const typedSearchActive = search.trim().length >= 2;
+  const fullPlaceChooserOpen = showAllPlaces || typedSearchActive;
 
   /**
    * The rows on screen. Derived rather than stored: the merged nearby sweep is
@@ -639,7 +641,9 @@ export function NearbyCheckInSheet({
   const places = useMemo(() => {
     const visible = typedSearchActive
       ? searchResults
-      : placesInCategory(automaticPlaces, category);
+      : fullPlaceChooserOpen
+        ? placesInCategory(automaticPlaces, category)
+        : automaticPlaces;
     // Coordinates resolved on demand for searched places, which arrive without
     // them, so the map can pin whatever the owner is looking at.
     return visible.map((place) => {
@@ -650,6 +654,7 @@ export function NearbyCheckInSheet({
   }, [
     automaticPlaces,
     category,
+    fullPlaceChooserOpen,
     resolvedPlacePoints,
     searchResults,
     typedSearchActive,
@@ -772,7 +777,9 @@ export function NearbyCheckInSheet({
         const boundedSuggestions = normalizeAutomaticPlaces(suggestions);
         setAutomaticPlaces(boundedSuggestions);
         if (boundedSuggestions.length === 0) {
-          setPlacesError("No places found within 500 m.");
+          setPlacesError(
+            "No places found. Search another place or update your location.",
+          );
         }
       } catch (error) {
         if (
@@ -809,7 +816,10 @@ export function NearbyCheckInSheet({
    * no longer owns the screen.
    */
   const adoptLastKnownPoint = useCallback(
-    async (generation: number, expectedOwnerEpoch: number): Promise<boolean> => {
+    async (
+      generation: number,
+      expectedOwnerEpoch: number,
+    ): Promise<boolean> => {
       const superseded = () =>
         ownerEpochRef.current !== expectedOwnerEpoch ||
         requestGenerationRef.current !== generation;
@@ -847,13 +857,17 @@ export function NearbyCheckInSheet({
   );
 
   const captureAndLoadPlaces = useCallback(
-    async (nextCategory: OneLocationNearbyPlaceCategory = "all") => {
+    async (
+      nextCategory: OneLocationNearbyPlaceCategory = "all",
+      options: { preserveChooser?: boolean } = {},
+    ) => {
       if (!ownerId || !vaultOwnerToken) return;
       const expectedOwnerEpoch = ownerEpochRef.current;
       const generation = ++requestGenerationRef.current;
       searchGenerationRef.current += 1;
       setCapturing(true);
       setCategory(nextCategory);
+      if (!options.preserveChooser) setShowAllPlaces(false);
       setSearch("");
       setSearchResults([]);
       setSearching(false);
@@ -1029,11 +1043,11 @@ export function NearbyCheckInSheet({
   const selectCategory = useCallback(
     (nextCategory: OneLocationNearbyPlaceCategory) => {
       setCategory(nextCategory);
+      setShowAllPlaces(true);
       setSearch("");
       setSearchResults([]);
       setSearching(false);
       setPlacesError(null);
-      setVisiblePlacesCount(5);
       searchGenerationRef.current += 1;
     },
     [],
@@ -1062,11 +1076,10 @@ export function NearbyCheckInSheet({
     setViewState("loading");
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
-    setOptionsOpen(false);
+    setShowAllPlaces(false);
     setAddTimeOpen(false);
     setAddTimeBusy(null);
     setDurationMinutes(60);
-    setVisiblePlacesCount(3);
     setBusy(null);
     setCompletedCheckIn(null);
     setSavePlaceCandidateState(null);
@@ -1101,11 +1114,10 @@ export function NearbyCheckInSheet({
     setSearching(false);
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
-    setOptionsOpen(false);
+    setShowAllPlaces(false);
     setAddTimeOpen(false);
     setAddTimeBusy(null);
     setDurationMinutes(60);
-    setVisiblePlacesCount(3);
     setCompletedCheckIn(null);
     setSavePlaceCandidateState(null);
     setLocationError(null);
@@ -1114,10 +1126,7 @@ export function NearbyCheckInSheet({
     setPlacesError(null);
     if (open) setViewState("loading");
     void loadPresence(!open, expectedOwnerEpoch).then((next) => {
-      if (
-        next === "error" ||
-        ownerEpochRef.current !== expectedOwnerEpoch
-      ) {
+      if (next === "error" || ownerEpochRef.current !== expectedOwnerEpoch) {
         return;
       }
       if (next?.presence) {
@@ -1133,13 +1142,7 @@ export function NearbyCheckInSheet({
       presenceReadGenerationRef.current += 1;
       searchGenerationRef.current += 1;
     };
-  }, [
-    captureAndLoadPlaces,
-    loadPresence,
-    open,
-    ownerId,
-    vaultOwnerToken,
-  ]);
+  }, [captureAndLoadPlaces, loadPresence, open, ownerId, vaultOwnerToken]);
 
   useEffect(() => {
     onSearchAreaChange?.(
@@ -1164,6 +1167,7 @@ export function NearbyCheckInSheet({
         return;
       }
       inFlight = true;
+      const previousPresence = state.presence;
       try {
         const next = await loadPresence(true, expectedOwnerEpoch);
         if (
@@ -1173,10 +1177,24 @@ export function NearbyCheckInSheet({
           !next.presence &&
           ownerEpochRef.current === expectedOwnerEpoch
         ) {
-          setViewState((current) =>
-            current === "completed" ? current : "setup",
-          );
-          void captureAndLoadPlaces();
+          setViewState((current) => {
+            if (current === "completed") return current;
+            return previousPresence ? "completed" : "setup";
+          });
+          if (previousPresence) {
+            const expiresMs = Date.parse(previousPresence.expiresAt);
+            setCompletedCheckIn({
+              placeLabel: previousPresence.placeLabel ?? null,
+              reason:
+                Number.isFinite(expiresMs) && expiresMs <= Date.now()
+                  ? "expired"
+                  : "ended",
+              saved: false,
+              saveError: null,
+            });
+          } else {
+            void captureAndLoadPlaces();
+          }
         }
       } finally {
         inFlight = false;
@@ -1212,9 +1230,7 @@ export function NearbyCheckInSheet({
     // — the tab becoming visible and the app returning to the foreground —
     // which is where a stale presence would otherwise be noticed. Nothing is
     // lost except requests nobody was waiting for.
-    const timer = open
-      ? window.setInterval(() => void poll(), 15_000)
-      : null;
+    const timer = open ? window.setInterval(() => void poll(), 15_000) : null;
     document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
       if (timer !== null) window.clearInterval(timer);
@@ -1233,9 +1249,7 @@ export function NearbyCheckInSheet({
   useEffect(() => {
     if (!open || state.presence || !locationRecovery) return;
     return appInteractionCoordinator.subscribeLifecycle(() => {
-      if (
-        appInteractionCoordinator.getLifecycleSnapshot().state === "active"
-      ) {
+      if (appInteractionCoordinator.getLifecycleSnapshot().state === "active") {
         void captureAndLoadPlaces();
       }
     });
@@ -1302,9 +1316,7 @@ export function NearbyCheckInSheet({
   // owner must intentionally choose another place before checking in.
   useEffect(() => {
     setSelectedPlaceId((current) =>
-      places.some((place) => place.placeId === current)
-        ? current
-        : "",
+      places.some((place) => place.placeId === current) ? current : "",
     );
   }, [places]);
 
@@ -1388,7 +1400,10 @@ export function NearbyCheckInSheet({
    * resurface a decision the person already walked away from.
    */
   useEffect(() => {
-    if (!open) setSavePlaceCandidateState(null);
+    if (!open) {
+      setAddTimeOpen(false);
+      setSavePlaceCandidateState(null);
+    }
   }, [open]);
 
   useEffect(() => {
@@ -1578,11 +1593,11 @@ export function NearbyCheckInSheet({
             }
           });
         } else {
-          void captureAndLoadPlaces(category);
+          void captureAndLoadPlaces(category, {
+            preserveChooser: fullPlaceChooserOpen,
+          });
         }
-      } else if (
-        details.message.toLowerCase().includes("closer place")
-      ) {
+      } else if (details.message.toLowerCase().includes("closer place")) {
         setPlacesError(details.message);
       }
       toast.error(details.message);
@@ -1635,8 +1650,9 @@ export function NearbyCheckInSheet({
       }
       const ambiguous = unresolved.find((entry) => entry.kind === "ambiguous");
       if (ambiguous && ambiguous.kind === "ambiguous") {
-        const names = ambiguousMatchNames(ambiguous.matches, (place) =>
-          place.name ?? place.text,
+        const names = ambiguousMatchNames(
+          ambiguous.matches,
+          (place) => place.name ?? place.text,
         );
         return {
           status: "blocked" as const,
@@ -1711,8 +1727,9 @@ export function NearbyCheckInSheet({
           (entry) => entry.kind === "ambiguous",
         );
         if (ambiguous && ambiguous.kind === "ambiguous") {
-          const names = ambiguousMatchNames(ambiguous.matches, (place) =>
-            place.name ?? place.text,
+          const names = ambiguousMatchNames(
+            ambiguous.matches,
+            (place) => place.name ?? place.text,
           );
           return {
             status: "blocked" as const,
@@ -1753,9 +1770,7 @@ export function NearbyCheckInSheet({
       let allowConnectionRequestsDefault: boolean;
       try {
         const preferences =
-          await OneLocationService.getNearbyCheckInPreferences(
-            vaultOwnerToken,
-          );
+          await OneLocationService.getNearbyCheckInPreferences(vaultOwnerToken);
         visibilityDefault = preferences.visible;
         allowConnectionRequestsDefault = preferences.allowConnectionRequests;
       } catch {
@@ -1793,7 +1808,9 @@ export function NearbyCheckInSheet({
           };
         }
         setAccuracyNotice(
-          isCoarseAccuracy(freshPoint) ? coarseAccuracyNotice(freshPoint) : null,
+          isCoarseAccuracy(freshPoint)
+            ? coarseAccuracyNotice(freshPoint)
+            : null,
         );
         setPoint(freshPoint);
         const next = await OneLocationService.checkInNearby({
@@ -1935,7 +1952,17 @@ export function NearbyCheckInSheet({
         return;
       }
       publishState(next);
-      setViewState(next.presence ? "active" : "setup");
+      if (next.presence) {
+        setViewState("active");
+      } else {
+        setViewState("completed");
+        setCompletedCheckIn({
+          placeLabel: state.presence?.placeLabel ?? null,
+          reason: "ended",
+          saved: false,
+          saveError: null,
+        });
+      }
       setAddTimeOpen(false);
       toast.success(
         incrementMinutes === 60 ? "1 hour added." : "30 minutes added.",
@@ -1989,13 +2016,15 @@ export function NearbyCheckInSheet({
       publishState(next);
       setViewState("completed");
       setCompletedCheckIn({
-        placeLabel: savedPlaceOffer?.label ?? state.presence?.placeLabel ?? null,
+        placeLabel:
+          savedPlaceOffer?.label ?? state.presence?.placeLabel ?? null,
+        reason: "left",
         saved: false,
         saveError: null,
       });
       setConsentAccepted(false);
       setAllowConnectionRequests(false);
-      setOptionsOpen(false);
+      setShowAllPlaces(false);
       setAddTimeOpen(false);
       setAddTimeBusy(null);
       toast.success("Check-in ended.");
@@ -2123,213 +2152,251 @@ export function NearbyCheckInSheet({
   // close X the dismissal, which is why it needed a real 44px target (see
   // SheetContent).
   return (
-    <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="bottom"
-        // Handle-only, not the whole body.
-        //
-        // This sheet owns an inner scroll container (see below), so its own
-        // `scrollTop` never leaves 0 — and the body-drag rule engages on
-        // exactly that condition. Enabled for the body, every downward swipe
-        // over the place list would have dismissed the sheet instead of
-        // scrolling it. `contentDragDismiss={false}` leaves the handle as the
-        // only drag surface: the phone gets the native grab-and-pull it
-        // expects, the list scrolls, and dismissal still leaves the map
-        // standing with its "Check in" pill to re-open.
-        //
-        // The panel used to pass `dragDismiss={false}`, which switched the
-        // gesture off AND took the grab handle with it — a phone bottom sheet
-        // with no affordance to put it away.
-        contentDragDismiss={false}
-        showOverlay={false}
-        onInteractOutside={(event) => event.preventDefault()}
-        // The map is a native view below the WebView, so a tap that lands on it
-        // never reaches Radix as a normal outside-pointer event on some
-        // platforms and does on others. Refusing both keeps dismissal identical
-        // on web and on device instead of platform-dependent.
-        onPointerDownOutside={(event) => event.preventDefault()}
-        // Stop short of the map header instead of the default 85dvh. With the
-        // scrim gone the controls behind are live again, so the sheet must not
-        // be the thing covering them: 8.5rem clears the header's real stack
-        // (56px control row + 8px gap + the Sharing row + its 16px padding)
-        // plus the top safe area, and leaves a visible strip of map between the
-        // two. Phone-only; the md rail is a side sheet and sets max-h-none.
-        //
-        // The desktop rail width comes from the shared constant so the browser
-        // contract that asserts the map keeps the majority of the viewport is
-        // measuring the number that actually ships.
-        style={
-          {
-            "--check-in-rail-width": `${CHECK_IN_PANEL_DESKTOP_WIDTH_REM}rem`,
-          } as CSSProperties
-        }
-        className="max-h-[calc(100dvh-env(safe-area-inset-top)-8.5rem-var(--kb-height,0px))] gap-0 overflow-hidden px-0 pb-[max(1rem,env(safe-area-inset-bottom))] md:inset-y-0 md:left-auto md:right-0 md:h-full md:max-h-none md:w-[var(--check-in-rail-width)] md:rounded-none md:rounded-l-[var(--app-card-radius-feature)] md:border-l md:border-t-0 md:data-[state=closed]:slide-out-to-right md:data-[state=open]:slide-in-from-right"
-        data-testid="one-location-nearby-check-in-sheet"
-        data-one-location-nearby-check-in-sheet=""
-      >
-        {/* No build-stage badge. "Preview" reported how finished the FEATURE
+    <>
+      <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          // Handle-only, not the whole body.
+          //
+          // This sheet owns an inner scroll container (see below), so its own
+          // `scrollTop` never leaves 0 — and the body-drag rule engages on
+          // exactly that condition. Enabled for the body, every downward swipe
+          // over the place list would have dismissed the sheet instead of
+          // scrolling it. `contentDragDismiss={false}` leaves the handle as the
+          // only drag surface: the phone gets the native grab-and-pull it
+          // expects, the list scrolls, and dismissal still leaves the map
+          // standing with its "Check in" pill to re-open.
+          //
+          // The panel used to pass `dragDismiss={false}`, which switched the
+          // gesture off AND took the grab handle with it — a phone bottom sheet
+          // with no affordance to put it away.
+          contentDragDismiss={false}
+          showOverlay={false}
+          onInteractOutside={(event) => event.preventDefault()}
+          // The map is a native view below the WebView, so a tap that lands on it
+          // never reaches Radix as a normal outside-pointer event on some
+          // platforms and does on others. Refusing both keeps dismissal identical
+          // on web and on device instead of platform-dependent.
+          onPointerDownOutside={(event) => event.preventDefault()}
+          // Stop short of the map header instead of the default 85dvh. With the
+          // scrim gone the controls behind are live again, so the sheet must not
+          // be the thing covering them: 8.5rem clears the header's real stack
+          // (56px control row + 8px gap + the Sharing row + its 16px padding)
+          // plus the top safe area, and leaves a visible strip of map between the
+          // two. Phone-only; the md rail is a side sheet and sets max-h-none.
+          //
+          // The desktop rail width comes from the shared constant so the browser
+          // contract that asserts the map keeps the majority of the viewport is
+          // measuring the number that actually ships.
+          style={
+            {
+              "--check-in-rail-width": `${CHECK_IN_PANEL_DESKTOP_WIDTH_REM}rem`,
+            } as CSSProperties
+          }
+          className="max-h-[calc(100dvh-env(safe-area-inset-top)-8.5rem-var(--kb-height,0px))] gap-0 overflow-hidden px-0 pb-[max(1rem,env(safe-area-inset-bottom))] md:inset-y-0 md:left-auto md:right-0 md:h-full md:max-h-none md:w-[var(--check-in-rail-width)] md:rounded-none md:rounded-l-[var(--app-card-radius-feature)] md:border-l md:border-t-0 md:data-[state=closed]:slide-out-to-right md:data-[state=open]:slide-in-from-right"
+          data-testid="one-location-nearby-check-in-sheet"
+          data-one-location-nearby-check-in-sheet=""
+        >
+          {/* No build-stage badge. "Preview" reported how finished the FEATURE
             is, which is a fact about our roadmap, not about the person or the
             decision in front of them — and it sat in the highest-priority slot
             on the screen, beside the title. Admission to nearby check-in is
             already gated by a build flag and a server cohort, so nobody
             reaches this sheet who was not meant to. */}
-        <SheetHeader className="gap-0 border-b border-border/60 px-5 py-4 text-left">
-          <div className="flex min-h-9 items-center gap-2 pr-10">
-            <SheetTitle className="text-[17px] leading-6">
-              Check in nearby
-            </SheetTitle>
-          </div>
-        </SheetHeader>
-
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4">
-          <p className="sr-only" aria-live="polite" aria-atomic="true">
-            {state.presence
-              ? `Nearby check-in active. ${state.attendees.length} ${
-                  state.attendees.length === 1 ? "person" : "people"
-                } nearby.`
-              : "Nearby check-in is not active."}
-          </p>
-          {loadingPresence && !state.presence ? (
-            <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Checking your current status…
-            </div>
-          ) : null}
-
-          {presenceLoadError && !state.presence ? (
-            <div
-              className="mb-4 rounded-2xl border border-destructive/20 bg-destructive/10 p-3"
-              role="alert"
-            >
-              <p className="text-sm text-destructive">{presenceLoadError}</p>
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                className="mt-2"
-                disabled={loadingPresence}
-                onClick={() => void retryPresenceLoad()}
-              >
-                {loadingPresence ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : null}
-                Retry status
-              </Button>
-            </div>
-          ) : null}
-
-          {viewState === "completed" ? (
-            <div className="space-y-4" data-testid="nearby-presence-completed">
-              <section className="rounded-[18px] border border-border/60 bg-card p-4">
-                <div className="flex items-start gap-3">
-                  <span
-                    className={cn(
-                      "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
-                      SUCCESS_ROLE.tile,
-                      SUCCESS_ROLE.glyph,
-                    )}
-                    aria-hidden="true"
-                  >
-                    <Check className="h-4 w-4" />
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="font-semibold">Check-in ended</p>
-                    {completedCheckIn?.placeLabel ? (
-                      <p className="mt-0.5 truncate text-sm font-medium">
-                        {completedCheckIn.placeLabel}
-                      </p>
-                    ) : null}
-                    <p className="mt-0.5 text-sm text-muted-foreground">
-                      You're no longer visible nearby.
-                    </p>
-                    {completedCheckIn?.saved ? (
-                      <p className="mt-2 text-xs font-medium text-muted-foreground">
-                        Saved for next time.
-                      </p>
-                    ) : null}
-                    {completedCheckIn?.saveError ? (
-                      <p
-                        className="mt-2 text-xs font-medium text-destructive"
-                        role="alert"
-                      >
-                        {completedCheckIn.saveError}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              </section>
-              <Button
-                type="button"
-                className="h-[52px] min-h-[52px] w-full rounded-2xl"
-                onClick={finishCompletedCheckIn}
-              >
-                Done
-              </Button>
-              {savePlaceCandidateState && !completedCheckIn?.saved ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-11 min-h-11 w-full text-muted-foreground"
-                  isLoading={savingPlace}
-                  onClick={() => void saveCheckedOutPlace()}
-                >
-                  <Star className="h-4 w-4" />
-                  Save for faster check-ins
-                </Button>
+          <SheetHeader className="gap-0 border-b border-border/60 px-5 py-4 text-left">
+            <div className="flex min-h-9 flex-col justify-center gap-1 pr-10">
+              <SheetTitle className="text-[17px] leading-6">
+                Check in nearby
+              </SheetTitle>
+              {!state.presence && viewState !== "completed" ? (
+                <p className="text-sm leading-5 text-muted-foreground">
+                  Let people at the same place know you&apos;re there.
+                </p>
               ) : null}
             </div>
-          ) : viewState === "loading" ||
-            (loadingPresence && !state.presence) ? null : state.presence ? (
-            <div className="space-y-4" data-testid="nearby-presence-active">
-              <section className="rounded-[18px] border border-border/60 bg-card p-4">
-                <div className="flex items-start gap-3">
-                  <span
-                    className={cn(
-                      "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
-                      SUCCESS_ROLE.tile,
-                      SUCCESS_ROLE.glyph,
-                    )}
-                    aria-hidden="true"
-                  >
-                    <Check className="h-4 w-4" />
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="font-semibold">Checked in</p>
-                    <p
-                      className="mt-0.5 truncate text-sm font-medium"
-                      title={state.presence.placeLabel || undefined}
-                    >
-                      {state.presence.placeLabel || "Your place"}
-                    </p>
-                    <p className="mt-0.5 text-sm text-muted-foreground">
-                      {[
-                        timeLeftLabel(state.presence.expiresAt),
-                        peopleNearbyLabel(state.attendees.length),
-                      ]
-                        .filter(Boolean)
-                        .join(" · ")}
-                    </p>
-                    {activeDriftMeters !== null &&
-                    activeDriftMeters > NEARBY_DRIFT_NUDGE_METERS ? (
-                      <p
-                        className="mt-2 flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
-                        data-testid="nearby-active-drift"
-                      >
-                        <LocateFixed
-                          className="mt-px h-3.5 w-3.5 shrink-0"
-                          aria-hidden="true"
-                        />
-                        <span>
-                          You’ve moved away. People still see you here.
-                        </span>
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              </section>
+          </SheetHeader>
 
-              <section aria-labelledby="nearby-people-title">
-                {/* The privacy mechanism used to be spelled out here in two
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4">
+            <p className="sr-only" aria-live="polite" aria-atomic="true">
+              {state.presence
+                ? `Checked in. ${state.attendees.length} ${
+                    state.attendees.length === 1 ? "person" : "people"
+                  } nearby.`
+                : "Not checked in nearby."}
+            </p>
+            {loadingPresence && !state.presence ? (
+              <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Checking your current status…
+              </div>
+            ) : null}
+
+            {presenceLoadError && !state.presence ? (
+              <div
+                className="mb-4 rounded-2xl border border-destructive/20 bg-destructive/10 p-3"
+                role="alert"
+              >
+                <p className="text-sm text-destructive">{presenceLoadError}</p>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="mt-2"
+                  disabled={loadingPresence}
+                  onClick={() => void retryPresenceLoad()}
+                >
+                  {loadingPresence ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : null}
+                  Retry status
+                </Button>
+              </div>
+            ) : null}
+
+            {viewState === "completed" ? (
+              <div
+                className="space-y-4"
+                data-testid="nearby-presence-completed"
+              >
+                <section className="rounded-[18px] border border-border/60 bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <span
+                      className={cn(
+                        "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
+                        SUCCESS_ROLE.tile,
+                        SUCCESS_ROLE.glyph,
+                      )}
+                      aria-hidden="true"
+                    >
+                      <Check className="h-4 w-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold">Check-in ended</p>
+                      {completedCheckIn?.placeLabel ? (
+                        <p className="mt-0.5 truncate text-sm font-medium">
+                          {completedCheckIn.placeLabel}
+                        </p>
+                      ) : null}
+                      <p className="mt-0.5 text-sm text-muted-foreground">
+                        {completionCopy(completedCheckIn?.reason)}
+                      </p>
+                      {completedCheckIn?.saved ? (
+                        <p className="mt-2 text-xs font-medium text-muted-foreground">
+                          Saved for next time.
+                        </p>
+                      ) : null}
+                      {completedCheckIn?.saveError ? (
+                        <p
+                          className="mt-2 text-xs font-medium text-destructive"
+                          role="alert"
+                        >
+                          {completedCheckIn.saveError}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </section>
+                <Button
+                  type="button"
+                  className="h-[52px] min-h-[52px] w-full rounded-2xl"
+                  onClick={finishCompletedCheckIn}
+                >
+                  Done
+                </Button>
+                {savePlaceCandidateState && !completedCheckIn?.saved ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-11 min-h-11 w-full text-muted-foreground"
+                    isLoading={savingPlace}
+                    onClick={() => void saveCheckedOutPlace()}
+                  >
+                    <Star className="h-4 w-4" />
+                    Save for faster check-ins
+                  </Button>
+                ) : null}
+              </div>
+            ) : viewState === "loading" ||
+              (loadingPresence && !state.presence) ? null : state.presence ? (
+              <div className="space-y-4" data-testid="nearby-presence-active">
+                <section className="rounded-[18px] border border-border/60 bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <span
+                      className={cn(
+                        "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full",
+                        SUCCESS_ROLE.tile,
+                        SUCCESS_ROLE.glyph,
+                      )}
+                      aria-hidden="true"
+                    >
+                      <Check className="h-4 w-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold">Checked in</p>
+                      <p
+                        className="mt-0.5 truncate text-sm font-medium"
+                        title={state.presence.placeLabel || undefined}
+                      >
+                        {state.presence.placeLabel || "Your place"}
+                      </p>
+                      <p className="mt-0.5 text-sm text-muted-foreground">
+                        {[
+                          timeLeftLabel(state.presence.expiresAt),
+                          peopleNearbyLabel(state.attendees.length),
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {state.presence.allowConnectionRequests
+                          ? "Name shown · Requests allowed"
+                          : "Name shown · Requests off"}
+                      </p>
+                      {activeDriftMeters !== null &&
+                      activeDriftMeters > NEARBY_DRIFT_NUDGE_METERS ? (
+                        <p
+                          className="mt-2 flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
+                          data-testid="nearby-active-drift"
+                        >
+                          <LocateFixed
+                            className="mt-px h-3.5 w-3.5 shrink-0"
+                            aria-hidden="true"
+                          />
+                          <span>
+                            You’ve moved away. People still see you here.
+                          </span>
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </section>
+
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="h-12 min-h-12"
+                    disabled={busy !== null}
+                    onClick={() => setAddTimeOpen(true)}
+                  >
+                    Add time
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={CHECK_OUT_BUTTON_VARIANT}
+                    className="h-12 min-h-12"
+                    disabled={busy !== null}
+                    onClick={() => void checkout()}
+                  >
+                    {busy === "checkout" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : null}
+                    {busy === "checkout" ? "Leaving..." : "I'm leaving"}
+                  </Button>
+                </div>
+
+                <section aria-labelledby="nearby-people-title">
+                  {/* The privacy mechanism used to be spelled out here in two
                     sentences, every time. The behaviour is unchanged — an
                     attendee object carries a name and nothing else, never a
                     coordinate — but a person reading a roster of names is not
@@ -2337,427 +2404,402 @@ export function NearbyCheckInSheet({
                     only once there is a count worth reading; beside an empty
                     state that already says "nobody", a "0" is the same word
                     twice. */}
-                <div className="flex items-center justify-between gap-3">
-                  <h2 id="nearby-people-title" className="font-semibold">
-                    People nearby
-                  </h2>
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 id="nearby-people-title" className="font-semibold">
+                      People nearby
+                    </h2>
+                    {state.attendees.length ? (
+                      <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold">
+                        {state.attendees.length}
+                      </span>
+                    ) : null}
+                  </div>
                   {state.attendees.length ? (
-                    <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold">
-                      {state.attendees.length}
-                    </span>
-                  ) : null}
-                </div>
-                {state.attendees.length ? (
-                  <ul className="mt-2" data-testid="nearby-attendee-roster">
-                    {state.attendees.map((attendee) => (
-                      <NearbyPersonRow
-                        key={attendee.participantAlias}
-                        attendee={attendee}
-                        busy={busy === `connect:${attendee.participantAlias}`}
-                        interactionDisabled={busy !== null}
-                        onConnect={() => void connect(attendee)}
-                        onRespond={() =>
-                          // Back from Consent Center returns to the screen this
-                          // was opened from -- check-in's own route. Naming Your
-                          // Map here sent the person to a screen that withholds
-                          // the check-in sheet, which then redirected on to the
-                          // same place: the flow they had left visibly rebuilt
-                          // itself twice before reappearing.
-                          router.push(
-                            buildConsentCenterHref("pending", {
-                              from: ROUTES.ONE_LOCATION_CHECK_IN,
-                            }),
-                          )
-                        }
-                      />
-                    ))}
-                  </ul>
-                ) : (
-                  <div className="mt-3 rounded-2xl bg-muted/70 px-4 py-5 text-center">
-                    <UsersRound className="mx-auto h-5 w-5 text-muted-foreground" />
-                    {/* The auto-refresh line is gone. The list refreshes on a
+                    <ul className="mt-2" data-testid="nearby-attendee-roster">
+                      {state.attendees.map((attendee) => (
+                        <NearbyPersonRow
+                          key={attendee.participantAlias}
+                          attendee={attendee}
+                          busy={busy === `connect:${attendee.participantAlias}`}
+                          interactionDisabled={busy !== null}
+                          onConnect={() => void connect(attendee)}
+                          onRespond={() =>
+                            // Back from Consent Center returns to the screen this
+                            // was opened from -- check-in's own route. Naming Your
+                            // Map here sent the person to a screen that withholds
+                            // the check-in sheet, which then redirected on to the
+                            // same place: the flow they had left visibly rebuilt
+                            // itself twice before reappearing.
+                            router.push(
+                              buildConsentCenterHref("pending", {
+                                from: ROUTES.ONE_LOCATION_CHECK_IN,
+                              }),
+                            )
+                          }
+                        />
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="mt-3 rounded-2xl bg-muted/70 px-4 py-5 text-center">
+                      <UsersRound className="mx-auto h-5 w-5 text-muted-foreground" />
+                      {/* The auto-refresh line is gone. The list refreshes on a
                         timer whether or not it is advertised, and telling
                         someone their empty list will keep checking itself is
                         an implementation detail dressed as reassurance. */}
-                    <p className="mt-2 text-sm font-medium">Nobody nearby yet</p>
-                  </div>
-                )}
-              </section>
-
-              {addTimeOpen ? (
-                <section
-                  className="rounded-[18px] border border-border/60 bg-card p-3"
-                  aria-label="Add time"
-                >
-                  <div className="grid grid-cols-2 gap-2">
-                    {([30, 60] as const).map((increment) => (
-                      <Button
-                        key={increment}
-                        type="button"
-                        variant="secondary"
-                        className="h-11 min-h-11"
-                        disabled={busy !== null}
-                        onClick={() => void addTime(increment)}
-                      >
-                        {addTimeBusy === increment ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : null}
-                        {increment === 60 ? "1 hour more" : "30 min more"}
-                      </Button>
-                    ))}
-                  </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="mt-2 h-10 min-h-10 w-full text-muted-foreground"
-                    disabled={busy !== null}
-                    onClick={() => setAddTimeOpen(false)}
-                  >
-                    Cancel
-                  </Button>
+                      <p className="mt-2 text-sm font-medium">
+                        Nobody nearby yet
+                      </p>
+                    </div>
+                  )}
                 </section>
-              ) : null}
-
-              <div className="grid grid-cols-2 gap-2">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="h-12 min-h-12"
-                  disabled={busy !== null}
-                  onClick={() => setAddTimeOpen((current) => !current)}
-                >
-                  Add time
-                </Button>
-                <Button
-                  type="button"
-                  variant={CHECK_OUT_BUTTON_VARIANT}
-                  className="h-12 min-h-12"
-                  disabled={busy !== null}
-                  onClick={() => void checkout()}
-                >
-                  {busy === "checkout" ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : null}
-                  {busy === "checkout" ? "Leaving..." : "I'm leaving"}
-                </Button>
               </div>
-            </div>
-          ) : (
-            <div className="space-y-5" data-testid="nearby-presence-setup">
-              <section>
-                {/* "Places within 500 m" restated the circle the map is
+            ) : (
+              <div className="space-y-5" data-testid="nearby-presence-setup">
+                <section>
+                  {/* "Places within 500 m" restated the circle the map is
                     already drawing directly behind this panel, in the units
                     the backend happens to use. The radius is unchanged and
                     still named on the map's own legend; the heading only has
                     to say what the list is. */}
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <h2 className="font-semibold">Nearby places</h2>
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h2 className="font-semibold">
+                        {fullPlaceChooserOpen
+                          ? "All nearby places"
+                          : "Nearby places"}
+                      </h2>
+                    </div>
+                    {capturing ? (
+                      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                    ) : null}
                   </div>
-                  {capturing ? (
-                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                  ) : null}
-                </div>
 
-                {/*
+                  {/*
                   A location problem is a state to work through, not a failure
                   to alarm about: the owner has done nothing wrong and can
                   usually resolve it in one tap. It is therefore rendered in the
                   neutral surface style with the recovery actions attached,
                   never as a destructive alert.
                 */}
-                {locationError ? (
-                  <div
-                    className="mt-3 rounded-2xl border border-border/60 bg-muted/50 p-4"
-                    role="status"
-                    data-testid="nearby-location-fallback"
-                  >
-                    <div className="flex items-start gap-3">
-                      <span
-                        className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full bg-background text-muted-foreground"
-                        aria-hidden="true"
-                      >
-                        <Compass className="h-4 w-4" />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-semibold">
-                          Still finding you
-                        </p>
-                        <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
-                          {locationError}
-                        </p>
+                  {locationError ? (
+                    <div
+                      className="mt-3 rounded-2xl border border-border/60 bg-muted/50 p-4"
+                      role="status"
+                      data-testid="nearby-location-fallback"
+                    >
+                      <div className="flex items-start gap-3">
+                        <span
+                          className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full bg-background text-muted-foreground"
+                          aria-hidden="true"
+                        >
+                          <Compass className="h-4 w-4" />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-semibold">
+                            Still finding you
+                          </p>
+                          <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
+                            {locationError}
+                          </p>
+                        </div>
                       </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        size="sm"
-                        disabled={capturing || busy === "settings"}
-                        onClick={() => void captureAndLoadPlaces(category)}
-                      >
-                        {capturing ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : null}
-                        Try again
-                      </Button>
-                      {locationRecovery && isNative() ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
                         <Button
                           type="button"
                           size="sm"
-                          variant="secondary"
-                          disabled={busy === "settings"}
-                          onClick={() => void openRecoverySettings()}
+                          disabled={capturing || busy === "settings"}
+                          onClick={() =>
+                            void captureAndLoadPlaces(category, {
+                              preserveChooser: fullPlaceChooserOpen,
+                            })
+                          }
                         >
-                          {busy === "settings" ? (
+                          {capturing ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           ) : null}
-                          Open settings
+                          Try again
                         </Button>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    {pointOrigin === "last-known" && point ? (
-                      <p
-                        className="mt-3 flex items-start gap-2 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs leading-4 text-muted-foreground"
-                        role="status"
-                        data-testid="nearby-last-known-notice"
-                      >
-                        <LocateFixed
-                          className="mt-px h-3.5 w-3.5 shrink-0"
-                          aria-hidden="true"
-                        />
-                        <span>
-                          Showing places around your last known position
-                          {restoredPointAgeLabel(point.capturedAt)} — we
-                          couldn’t refresh it just now. Pick where you actually
-                          are, or{" "}
-                          <button
-                            type="button"
-                            className="font-semibold underline underline-offset-2"
-                            disabled={capturing}
-                            onClick={() => void captureAndLoadPlaces(category)}
-                          >
-                            update your location
-                          </button>
-                          .
-                        </span>
-                      </p>
-                    ) : null}
-                    {accuracyNotice ? (
-                      <p
-                        className="mt-3 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs text-muted-foreground"
-                        role="status"
-                      >
-                        {accuracyNotice}
-                      </p>
-                    ) : null}
-                    <label className="relative mt-3 block">
-                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                      <span className="sr-only">Search</span>
-                      <Input
-                        value={search}
-                        onChange={(event) => {
-                          const nextSearch = event.target.value;
-                          searchGenerationRef.current += 1;
-                          setSearch(nextSearch);
-                          setPlacesError(null);
-                          if (nextSearch.trim().length >= 2) {
-                            setSearching(true);
-                            setSearchResults([]);
-                          } else {
-                            setSearching(false);
-                          }
-                        }}
-                        disabled={!point || capturing}
-                        placeholder="Search places"
-                        className="h-11 rounded-full pl-9"
-                      />
-                      {searching ? (
-                        <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
-                      ) : null}
-                    </label>
-
-                    <div
-                      className={CHECK_IN_CATEGORY_ROW_CLASSNAME}
-                      aria-label="Nearby place categories"
-                    >
-                      {typedSearchActive ? (
-                        <span className="inline-flex h-9 shrink-0 items-center rounded-full bg-primary px-3 text-sm font-medium text-primary-foreground">
-                          Search results
-                        </span>
-                      ) : null}
-                      {PLACE_CATEGORIES.map((option) => (
-                        <Button
-                          key={option.value}
-                          type="button"
-                          size="sm"
-                          variant={
-                            !typedSearchActive && category === option.value
-                              ? "default"
-                              : "secondary"
-                          }
-                          className="shrink-0 rounded-full"
-                          aria-pressed={
-                            !typedSearchActive && category === option.value
-                          }
-                          disabled={!point || capturing || typedSearchActive}
-                          onClick={() => selectCategory(option.value)}
-                        >
-                          {option.label}
-                        </Button>
-                      ))}
-                    </div>
-
-                    <div
-                      className={cn(
-                        "mt-3 space-y-2",
-                        visiblePlacesCount > 3 && "max-h-[35vh] overflow-y-auto pr-2"
-                      )}
-                      role="radiogroup"
-                      aria-label="Nearby places"
-                    >
-                      {places.slice(0, visiblePlacesCount).map((place) => {
-                        const selected = place.placeId === selectedPlaceId;
-                        const name = place.name?.trim() || place.text;
-                        // One supporting line, not two joined by a middot.
-                        //
-                        // The row is a choice between venues the person can
-                        // see out of the window, so the useful cue is what
-                        // kind of place it is. A postal address is longer than
-                        // the row, always truncates, and the tail that gets
-                        // cut is the part that would have disambiguated it —
-                        // so it cost a line and answered nothing. The address
-                        // still shows when there is no category to show
-                        // instead, and the full pair stays in the title
-                        // attribute for a pointer and for assistive tech.
-                        const category = place.category?.trim() || "";
-                        const address = place.address?.trim() || "";
-                        const metadataLabel = category || address;
-                        const metadataTitle = Array.from(
-                          new Set([category, address].filter(Boolean)),
-                        ).join(" · ");
-                        return (
-                          <button
-                            key={place.placeId}
-                            type="button"
-                            role="radio"
-                            aria-checked={selected}
-                            className={cn(
-                              CHECK_IN_PLACE_ROW_CLASSNAME,
-                              selected
-                                ? CHECK_IN_PLACE_ROW_ON_CLASSNAME
-                                : CHECK_IN_PLACE_ROW_OFF_CLASSNAME,
-                            )}
-                            onClick={() => setSelectedPlaceId(place.placeId)}
-                          >
-                            <MapPin className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
-                            <span className="min-w-0 flex-1">
-                              <span
-                                title={name}
-                                className={CHECK_IN_PLACE_NAME_CLASSNAME}
-                              >
-                                {name}
-                              </span>
-                              {metadataLabel ? (
-                                <span
-                                  title={metadataTitle}
-                                  className={CHECK_IN_PLACE_META_CLASSNAME}
-                                >
-                                  {metadataLabel}
-                                </span>
-                              ) : null}
-                            </span>
-                            <span className={CHECK_IN_PLACE_DISTANCE_CLASSNAME}>
-                              {compactDistanceLabel(place.distanceMeters)}
-                            </span>
-                            {selected ? (
-                              <Check className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
-                            ) : null}
-                          </button>
-                        );
-                      })}
-                      {places.length > visiblePlacesCount ? (
-                        <div className="pt-1 pb-2">
+                        {locationRecovery && isNative() ? (
                           <Button
                             type="button"
-                            variant="ghost"
                             size="sm"
-                            className="w-full text-muted-foreground"
-                            onClick={() => setVisiblePlacesCount(places.length)}
+                            variant="secondary"
+                            disabled={busy === "settings"}
+                            onClick={() => void openRecoverySettings()}
                           >
-                            See all {places.length}
+                            {busy === "settings" ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : null}
+                            Open settings
                           </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      {pointOrigin === "last-known" && point ? (
+                        <p
+                          className="mt-3 flex items-start gap-2 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs leading-4 text-muted-foreground"
+                          role="status"
+                          data-testid="nearby-last-known-notice"
+                        >
+                          <LocateFixed
+                            className="mt-px h-3.5 w-3.5 shrink-0"
+                            aria-hidden="true"
+                          />
+                          <span>
+                            Showing places around your last known position
+                            {restoredPointAgeLabel(point.capturedAt)} — we
+                            couldn’t refresh it just now. Pick where you
+                            actually are, or{" "}
+                            <button
+                              type="button"
+                              className="font-semibold underline underline-offset-2"
+                              disabled={capturing}
+                              onClick={() =>
+                                void captureAndLoadPlaces(category, {
+                                  preserveChooser: fullPlaceChooserOpen,
+                                })
+                              }
+                            >
+                              update your location
+                            </button>
+                            .
+                          </span>
+                        </p>
+                      ) : null}
+                      {accuracyNotice ? (
+                        <p
+                          className="mt-3 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs text-muted-foreground"
+                          role="status"
+                        >
+                          {accuracyNotice}
+                        </p>
+                      ) : null}
+                      <label className="relative mt-3 block">
+                        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                        <span className="sr-only">Search</span>
+                        <Input
+                          value={search}
+                          onChange={(event) => {
+                            const nextSearch = event.target.value;
+                            searchGenerationRef.current += 1;
+                            setSearch(nextSearch);
+                            setPlacesError(null);
+                            if (nextSearch.trim().length >= 2) {
+                              setSearching(true);
+                              setSearchResults([]);
+                            } else {
+                              setSearching(false);
+                            }
+                          }}
+                          disabled={!point || capturing}
+                          placeholder="Search places"
+                          className="h-11 rounded-full pl-9"
+                        />
+                        {searching ? (
+                          <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+                        ) : null}
+                      </label>
+
+                      {fullPlaceChooserOpen ? (
+                        <div
+                          className={CHECK_IN_CATEGORY_ROW_CLASSNAME}
+                          aria-label="Nearby place categories"
+                        >
+                          {typedSearchActive ? (
+                            <span className="inline-flex h-9 shrink-0 items-center rounded-full bg-primary px-3 text-sm font-medium text-primary-foreground">
+                              Search results
+                            </span>
+                          ) : null}
+                          {PLACE_CATEGORIES.map((option) => (
+                            <Button
+                              key={option.value}
+                              type="button"
+                              size="sm"
+                              variant={
+                                !typedSearchActive && category === option.value
+                                  ? "default"
+                                  : "secondary"
+                              }
+                              className="shrink-0 rounded-full"
+                              aria-pressed={
+                                !typedSearchActive && category === option.value
+                              }
+                              disabled={
+                                !point || capturing || typedSearchActive
+                              }
+                              onClick={() => selectCategory(option.value)}
+                            >
+                              {option.label}
+                            </Button>
+                          ))}
                         </div>
                       ) : null}
-                    </div>
-                    {/*
+
+                      <div
+                        className={cn(
+                          "mt-3 space-y-2",
+                          fullPlaceChooserOpen &&
+                            "max-h-[35vh] overflow-y-auto pr-2",
+                        )}
+                        role="radiogroup"
+                        aria-label="Nearby places"
+                      >
+                        {places
+                          .slice(0, fullPlaceChooserOpen ? places.length : 3)
+                          .map((place) => {
+                            const selected = place.placeId === selectedPlaceId;
+                            const name = place.name?.trim() || place.text;
+                            // One supporting line, not two joined by a middot.
+                            //
+                            // The row is a choice between venues the person can
+                            // see out of the window, so the useful cue is what
+                            // kind of place it is. A postal address is longer than
+                            // the row, always truncates, and the tail that gets
+                            // cut is the part that would have disambiguated it —
+                            // so it cost a line and answered nothing. The address
+                            // still shows when there is no category to show
+                            // instead, and the full pair stays in the title
+                            // attribute for a pointer and for assistive tech.
+                            const category = place.category?.trim() || "";
+                            const address = place.address?.trim() || "";
+                            const metadataLabel = category || address;
+                            const metadataTitle = Array.from(
+                              new Set([category, address].filter(Boolean)),
+                            ).join(" · ");
+                            return (
+                              <button
+                                key={place.placeId}
+                                type="button"
+                                role="radio"
+                                aria-checked={selected}
+                                className={cn(
+                                  CHECK_IN_PLACE_ROW_CLASSNAME,
+                                  selected
+                                    ? CHECK_IN_PLACE_ROW_ON_CLASSNAME
+                                    : CHECK_IN_PLACE_ROW_OFF_CLASSNAME,
+                                )}
+                                onClick={() =>
+                                  setSelectedPlaceId(place.placeId)
+                                }
+                              >
+                                <MapPin className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+                                <span className="min-w-0 flex-1">
+                                  <span
+                                    title={name}
+                                    className={CHECK_IN_PLACE_NAME_CLASSNAME}
+                                  >
+                                    {name}
+                                  </span>
+                                  {metadataLabel ? (
+                                    <span
+                                      title={metadataTitle}
+                                      className={CHECK_IN_PLACE_META_CLASSNAME}
+                                    >
+                                      {metadataLabel}
+                                    </span>
+                                  ) : null}
+                                </span>
+                                <span
+                                  className={CHECK_IN_PLACE_DISTANCE_CLASSNAME}
+                                >
+                                  {compactDistanceLabel(place.distanceMeters)}
+                                </span>
+                                {selected ? (
+                                  <Check className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+                                ) : null}
+                              </button>
+                            );
+                          })}
+                      {!fullPlaceChooserOpen && automaticPlaces.length > 0 ? (
+                          <div className="pt-1 pb-2">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="flex w-full items-center justify-between text-muted-foreground"
+                              onClick={() => setShowAllPlaces(true)}
+                            >
+                              <span>See all places</span>
+                              <ChevronRight
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+                      {/*
                       The owner's point and their venue are two different places
                       and can be a street apart. Naming the gap is what lets
                       them tell the hotel they are in from the one behind it.
                     */}
-                    {selectedPlace && offsetNotice(selectedPlaceOffsetMeters) ? (
-                      <p
-                        className="mt-2 flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
-                        data-testid="nearby-selected-place-offset"
-                      >
-                        <LocateFixed
-                          className="mt-px h-3.5 w-3.5 shrink-0"
-                          aria-hidden="true"
-                        />
-                        <span>{offsetNotice(selectedPlaceOffsetMeters)}</span>
-                      </p>
-                    ) : null}
-                    {!places.length &&
-                    !capturing &&
-                    !searching &&
-                    !typedSearchActive &&
-                    automaticPlaces.length ? (
-                      <div
-                        className="mt-3 rounded-2xl bg-muted/60 px-4 py-5 text-center"
-                        data-testid="nearby-category-empty"
-                      >
-                        <p className="text-sm font-medium">Nothing here</p>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="secondary"
-                          className="mt-3"
-                          onClick={() => selectCategory("all")}
+                      {selectedPlace &&
+                      offsetNotice(selectedPlaceOffsetMeters) ? (
+                        <p
+                          className="mt-2 flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
+                          data-testid="nearby-selected-place-offset"
                         >
-                          See all {automaticPlaces.length}
-                        </Button>
-                      </div>
-                    ) : null}
-                    {/* Attribution only. The count that used to lead this line
+                          <LocateFixed
+                            className="mt-px h-3.5 w-3.5 shrink-0"
+                            aria-hidden="true"
+                          />
+                          <span>{offsetNotice(selectedPlaceOffsetMeters)}</span>
+                        </p>
+                      ) : null}
+                      {!places.length &&
+                      !capturing &&
+                      !searching &&
+                      !typedSearchActive &&
+                      automaticPlaces.length ? (
+                        <div
+                          className="mt-3 rounded-2xl bg-muted/60 px-4 py-5 text-center"
+                          data-testid="nearby-category-empty"
+                        >
+                          <p className="text-sm font-medium">Nothing here</p>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            className="mt-3"
+                            onClick={() => selectCategory("all")}
+                          >
+                            See all {automaticPlaces.length}
+                          </Button>
+                        </div>
+                      ) : null}
+                      {/* Attribution only. The count that used to lead this line
                         is already on the "See all N" control and in the list
                         itself, and "N places · Google Maps" read as one fact
                         when it was two. The provider name stays because the
                         Places terms require it wherever their data is shown. */}
-                    {places.length ? (
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        <span translate="no" className="whitespace-nowrap font-normal">
-                          Google Maps
-                        </span>
-                      </p>
-                    ) : null}
-                    {placesError ? (
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        {placesError}
-                      </p>
-                    ) : null}
-                  </>
-                )}
-              </section>
+                      {places.length ? (
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          <span
+                            translate="no"
+                            className="whitespace-nowrap font-normal"
+                          >
+                            Google Maps
+                          </span>
+                        </p>
+                      ) : null}
+                      {placesError ? (
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {placesError}
+                        </p>
+                      ) : null}
+                    </>
+                  )}
+                </section>
 
-              <section>
-                {/* Matches the "Nearby places" heading above it: a plain word
+                <section>
+                  {/* Matches the "Nearby places" heading above it: a plain word
                     pair, no leading glyph. One of the two section headings
                     carrying an icon and the other not was the only reason
                     they did not read as a pair. */}
-                <h2 className="font-semibold">Visible for</h2>
-                {/* Raw <button>, not the morphy <Button>: at `size="default"`
+                  <h2 className="font-semibold">Visible for</h2>
+                  {/* Raw <button>, not the morphy <Button>: at `size="default"`
                     that component carries min-h-[50px] in a different
                     tailwind-merge group from h-*, and `.ui-text-button-label`
                     forces 17px !important — so it cannot be made compact from
@@ -2765,119 +2807,126 @@ export function NearbyCheckInSheet({
                     duration ladder uses for the identical role (44px, 15px),
                     so the two duration controls in this product can no longer
                     disagree about how big a duration choice is. */}
-                <div className={cn("mt-3", CHECK_IN_DURATION_GRID_CLASS)}>
-                  {DURATIONS.map((duration) => (
-                    <button
-                      key={duration.value}
-                      type="button"
-                      aria-pressed={durationMinutes === duration.value}
-                      onClick={() => setDurationMinutes(duration.value)}
-                      className={cn(
-                        DURATION_CELL_CLASS,
-                        durationMinutes === duration.value
-                          ? DURATION_CELL_ON_CLASS
-                          : DURATION_CELL_OFF_CLASS,
-                      )}
-                    >
-                      {duration.label}
-                    </button>
-                  ))}
-                </div>
-              </section>
-
-              {/*
-                Two preferences, one of them load-bearing.
-
-                "Appear nearby" stays in the open because it is the consent the
-                server requires and the condition the Check in button is
-                disabled on. Hiding the only reason a primary action is greyed
-                out behind a disclosure would make the button look broken.
-
-                "Connection requests" is genuinely a preference: it defaults
-                off, changes nothing about who can see the person, and only
-                decides whether someone already looking at their name may ask
-                to connect. It does not need answering before every check-in,
-                so it drops one level. Same state, same default, same value
-                sent — only its prominence changes.
-              */}
-              <section className="rounded-2xl border border-border/60">
-                <label className="flex cursor-pointer items-start gap-3 p-4">
-                  <Checkbox
-                    className="mt-0.5"
-                    checked={consentAccepted}
-                    onCheckedChange={(checked) =>
-                      setConsentAccepted(checked === true)
-                    }
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-sm font-semibold">
-                      Appear nearby
-                    </span>
-                    <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">
-                      Your name only
-                    </span>
-                  </span>
-                </label>
-
-                <button
-                  type="button"
-                  className="flex min-h-11 w-full items-center justify-between gap-4 border-t border-border/60 px-4 py-2.5 text-left"
-                  aria-expanded={optionsOpen}
-                  aria-controls="nearby-check-in-options"
-                  onClick={() => setOptionsOpen((current) => !current)}
-                >
-                  <span className="text-sm font-semibold">Options</span>
-                  <ChevronDown
-                    className={cn(
-                      "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                      optionsOpen && "rotate-180",
-                    )}
-                    aria-hidden="true"
-                  />
-                </button>
-                <div
-                  id="nearby-check-in-options"
-                  hidden={!optionsOpen}
-                  className="px-4 pb-4"
-                >
-                  <div className="flex min-h-11 items-center justify-between gap-4">
-                    <p className="text-sm">Connection requests</p>
-                    <Switch
-                      checked={allowConnectionRequests}
-                      onCheckedChange={setAllowConnectionRequests}
-                      aria-label="Allow nearby connection requests"
-                    />
+                  <div className={cn("mt-3", CHECK_IN_DURATION_GRID_CLASS)}>
+                    {DURATIONS.map((duration) => (
+                      <button
+                        key={duration.value}
+                        type="button"
+                        aria-pressed={durationMinutes === duration.value}
+                        onClick={() => setDurationMinutes(duration.value)}
+                        className={cn(
+                          DURATION_CELL_CLASS,
+                          durationMinutes === duration.value
+                            ? DURATION_CELL_ON_CLASS
+                            : DURATION_CELL_OFF_CLASS,
+                        )}
+                      >
+                        {duration.label}
+                      </button>
+                    ))}
                   </div>
-                </div>
-              </section>
+                </section>
 
+                <section>
+                  <h2 className="font-semibold">Visibility</h2>
+                  <div className="mt-3 rounded-2xl border border-border/60">
+                    <label className="flex cursor-pointer items-start gap-3 p-4">
+                      <Checkbox
+                        className="mt-0.5"
+                        checked={consentAccepted}
+                        onCheckedChange={(checked) =>
+                          setConsentAccepted(checked === true)
+                        }
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-sm font-semibold">
+                          Show my name here
+                        </span>
+                        <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">
+                          Only people checked in at this place can see it.
+                        </span>
+                      </span>
+                    </label>
+
+                    <div className="flex min-h-14 items-center justify-between gap-4 border-t border-border/60 p-4">
+                      <span className="min-w-0">
+                        <span className="block text-sm font-semibold">
+                          Allow connection requests
+                        </span>
+                        <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">
+                          People here can ask to connect.
+                        </span>
+                      </span>
+                      <Switch
+                        checked={allowConnectionRequests}
+                        onCheckedChange={setAllowConnectionRequests}
+                        aria-label="Allow nearby connection requests"
+                      />
+                    </div>
+                  </div>
+                </section>
+
+                <Button
+                  type="button"
+                  // Both halves, or neither lands: `h-12` alone loses to the
+                  // size variant's own min-h-[50px], which is why this button has
+                  // been 50px the whole time its class said 48.
+                  className="h-12 min-h-12 w-full disabled:!bg-muted disabled:!text-muted-foreground disabled:!opacity-100"
+                  disabled={
+                    busy !== null ||
+                    capturing ||
+                    searching ||
+                    !point ||
+                    !selectedPlace ||
+                    !consentAccepted
+                  }
+                  onClick={() => void checkIn()}
+                >
+                  {busy === "check-in" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <UsersRound className="h-4 w-4" />
+                  )}
+                  Check in
+                </Button>
+              </div>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+      <Sheet
+        open={addTimeOpen}
+        onOpenChange={(nextOpen) => {
+          if (busy === null) setAddTimeOpen(nextOpen);
+        }}
+      >
+      <SheetContent
+        side="bottom"
+        className="mx-auto w-full gap-0 rounded-t-[var(--app-card-radius-feature)] px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:max-w-md md:left-auto md:right-6 md:max-w-sm md:rounded-[var(--app-card-radius-feature)]"
+        aria-describedby={undefined}
+      >
+          <SheetHeader className="px-0 pb-3 text-left">
+            <SheetTitle className="text-[17px] leading-6">Add time</SheetTitle>
+          </SheetHeader>
+          <div className="grid grid-cols-2 gap-2">
+            {([30, 60] as const).map((increment) => (
               <Button
+                key={increment}
                 type="button"
-                // Both halves, or neither lands: `h-12` alone loses to the
-                // size variant's own min-h-[50px], which is why this button has
-                // been 50px the whole time its class said 48.
-                className="h-12 min-h-12 w-full disabled:!bg-muted disabled:!text-muted-foreground disabled:!opacity-100"
-                disabled={
-                  busy !== null ||
-                  capturing ||
-                  searching ||
-                  !point ||
-                  !selectedPlace ||
-                  !consentAccepted
-                }
-                onClick={() => void checkIn()}
+                variant="secondary"
+                className="h-11 min-h-11"
+                disabled={busy !== null}
+                onClick={() => void addTime(increment)}
               >
-                {busy === "check-in" ? (
+                {addTimeBusy === increment ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <UsersRound className="h-4 w-4" />
-                )}
-                Check in
+                ) : null}
+                {increment === 60 ? "1 hour more" : "30 min more"}
               </Button>
-            </div>
-          )}
-        </div>
-      </SheetContent>
-    </Sheet>
+            ))}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Refines `/one/location/check-in` as a public-place Check in nearby flow, preserving the existing map, sheet, search, categories, duration, consent, active presence, attendee, connect/respond, add-time, leave, and saved-place behavior.
- Keeps compact setup to nearby places, duration, visibility consent, and one primary Check in action, with categories available through the full chooser.
- Moves active Add time into a compact sheet, keeps I'm leaving immediately visible, and shows explicit completion states for left/expired/ended outcomes.
- Updates the map affordance and voice metadata to use Check in nearby / Checked in language instead of arrival-style meaning.

## Validation
- `npm test -- --run components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx __tests__/components/location-immersive-map.test.tsx app/one/location/__tests__/check-in-page-voice-publish.test.tsx` — 114 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run verify:one-location` — 710 passed
- `git diff --check` — passed